### PR TITLE
fix(core): merge match arms with identical bodies

### DIFF
--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -574,13 +574,12 @@ fn scan_claude_session_reader<R: BufRead>(mut reader: R, limit: Option<usize>, s
         }
         buffer.clear();
         match reader.read_until(b'\n', &mut buffer) {
-            Ok(0) => break,
+            Ok(0) | Err(_) => break,
             Ok(_) => {
                 let line = String::from_utf8_lossy(&buffer);
                 summary.apply_line(line.trim_end_matches(['\r', '\n']));
                 index += 1;
             }
-            Err(_) => break,
         }
     }
 }

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -209,8 +209,7 @@ impl Terminal {
                 tracing::warn!("terminal event loop panicked during shutdown");
                 true
             }
-            Err(mpsc::RecvTimeoutError::Timeout) => false,
-            Err(mpsc::RecvTimeoutError::Disconnected) => false,
+            Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => false,
         }
     }
 


### PR DESCRIPTION
## Summary
- Merge `Ok(0) => break` and `Err(_) => break` into a single arm in `runtime_state.rs`
- Merge `Err(Timeout)` and `Err(Disconnected)` into a single arm in `terminal.rs`

Fixes `clippy::match_same_arms` errors that broke both the **Clippy (strict)** and **Clippy** CI jobs.

## Test plan
- [ ] CI passes (both Clippy jobs should go green)