### PR TITLE
fix(shell): use login shell and BSD script flags on macOS

### DIFF
--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -305,7 +305,15 @@ pub(super) fn resolve_launch_command(
 ) -> (String, Vec<String>) {
     match kind {
         PanelKind::Editor | PanelKind::GitChanges | PanelKind::Usage => (String::new(), Vec::new()),
-        PanelKind::Shell => (command.unwrap_or_else(default_shell), args),
+        PanelKind::Shell => {
+            let program = command.unwrap_or_else(default_shell);
+            let shell_args = if args.is_empty() {
+                vec!["-l".to_string()]
+            } else {
+                args
+            };
+            (program, shell_args)
+        }
         PanelKind::Command => {
             if let Some(program) = command {
                 (program, args)

--- a/crates/horizon-core/src/transcript.rs
+++ b/crates/horizon-core/src/transcript.rs
@@ -43,24 +43,33 @@ impl PanelTranscript {
             return (program, args);
         };
 
-        let mut parts = vec![program];
-        parts.extend(args);
-        let command = parts
-            .iter()
-            .map(|part| shell_escape(part))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let session_path = self.session_path().display().to_string();
 
-        (
-            script_program,
-            vec![
-                "-qef".to_string(),
-                "--log-out".to_string(),
-                self.session_path().display().to_string(),
-                "--command".to_string(),
-                command,
-            ],
-        )
+        if cfg!(target_os = "macos") {
+            // BSD script: script [-flags] <file> <command...>
+            let mut script_args = vec!["-qeF".to_string(), session_path, program];
+            script_args.extend(args);
+            (script_program, script_args)
+        } else {
+            // GNU script: script [-flags] --log-out <file> --command "<command>"
+            let mut parts = vec![program];
+            parts.extend(args);
+            let command = parts
+                .iter()
+                .map(|part| shell_escape(part))
+                .collect::<Vec<_>>()
+                .join(" ");
+            (
+                script_program,
+                vec![
+                    "-qef".to_string(),
+                    "--log-out".to_string(),
+                    session_path,
+                    "--command".to_string(),
+                    command,
+                ],
+            )
+        }
     }
 
     /// Finalize any previous in-flight capture and return the retained replay bytes.


### PR DESCRIPTION
## Summary

- **Shell panels exit immediately on macOS** because `script` is invoked with GNU-style long flags (`--log-out`, `--command`) that BSD `script` doesn't support. Uses positional args (`script -qeF <file> <command...>`) on macOS instead.
- **Shell panels don't initialize properly** because the shell is spawned without `-l` (login), so fish/zsh/bash skip environment setup and may exit immediately. Adds `-l` when no custom args are provided.

## Test plan

- [ ] `cargo run --release` on macOS, create a Shell workspace → terminal should start and show a prompt
- [ ] Verify Codex/Claude panels still work (unaffected — they use `wrap_in_login_shell`)
- [ ] Verify Linux behavior unchanged (GNU `script` path is untouched)