### PR TITLE
fix(ci): set ContinuousDeployment mode on branch configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       semver: ${{ steps.gitversion.outputs.semVer }}
+      fullsemver: ${{ steps.gitversion.outputs.fullSemVer }}
       major: ${{ steps.gitversion.outputs.major }}
       minor: ${{ steps.gitversion.outputs.minor }}
       patch: ${{ steps.gitversion.outputs.patch }}
       prerelease: ${{ steps.gitversion.outputs.preReleaseLabel }}
+      commits_since_version_source: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -206,6 +208,21 @@ jobs:
         run: |
           if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
             echo "CARGO_REGISTRY_TOKEN secret is required for crates.io publish."
+            exit 1
+          fi
+      - name: Validate prerelease version
+        run: |
+          VERSION="${{ needs.version.outputs.semver }}"
+          echo "semVer: $VERSION"
+          echo "fullSemVer: ${{ needs.version.outputs.fullsemver }}"
+          echo "preReleaseLabel: ${{ needs.version.outputs.prerelease }}"
+          echo "commitsSinceVersionSource: ${{ needs.version.outputs.commits_since_version_source }}"
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]] && [[ "$VERSION" != *-alpha.* ]]; then
+            echo "::error::Expected alpha prerelease version for main branch, got: $VERSION"
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" == refs/heads/release/* ]] && [[ "$VERSION" != *-beta.* ]]; then
+            echo "::error::Expected beta prerelease version for release branch, got: $VERSION"
             exit 1
           fi
       - name: Set version

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,12 +3,14 @@ mode: ContinuousDeployment
 branches:
   main:
     regex: ^main$
+    mode: ContinuousDeployment
     increment: Minor
     label: alpha
     prevent-increment:
       when-current-commit-tagged: true
   release:
     regex: ^release/.*$
+    mode: ContinuousDeployment
     increment: Patch
     label: beta
     prevent-increment:


### PR DESCRIPTION
## Summary

- Fix GitVersion producing bare `0.1.0` instead of `0.1.0-alpha.N` on main branch pushes, which caused `cargo publish` to fail with "crate already exists"
- Root cause: GitVersion 6 branch-type defaults override top-level `mode`, so `label: alpha` was silently discarded. Added explicit `mode: ContinuousDeployment` to both `main` and `release` branch configs.
- Added a version validation step in `cargo-publish` that fails fast if the version doesn't match the expected prerelease pattern for the branch

## Test plan

- [ ] PR CI: `Version` job outputs include a prerelease semver (e.g. `0.1.0-alpha.N`)
- [ ] PR CI: All existing jobs (fmt, clippy, tests) still pass
- [ ] After merge: `Publish Cargo` job succeeds with alpha version
- [ ] After merge: `Release` job creates prerelease GitHub release tagged `v0.1.0-alpha.N`
- [ ] After merge: Delete stale `v0.1.0` draft release (`gh release delete v0.1.0 --yes`)