### PR TITLE
fix(render): suppress transient sparse alt-screen frames

### DIFF
--- a/crates/horizon-ui/src/terminal_widget/mod.rs
+++ b/crates/horizon-ui/src/terminal_widget/mod.rs
@@ -3,6 +3,7 @@ mod layout;
 mod render;
 mod scrollbar;
 
+use alacritty_terminal::term::TermMode;
 use egui::FontId;
 use horizon_core::Panel;
 
@@ -83,6 +84,13 @@ impl<'a> TerminalView<'a> {
             && self.panel.terminal().is_some_and(|terminal| !terminal.has_selection())
             && !interaction.body.dragged()
             && !interaction.scrollbar.dragged();
+        let allow_sparse_frame_reuse = self.panel.had_recent_output()
+            && self
+                .panel
+                .terminal()
+                .is_some_and(|terminal| !terminal.has_selection() && terminal.mode().contains(TermMode::ALT_SCREEN))
+            && !interaction.body.dragged()
+            && !interaction.scrollbar.dragged();
 
         if ui.is_rect_visible(interaction.layout.outer)
             && let Some(terminal) = self.panel.terminal_mut()
@@ -100,6 +108,7 @@ impl<'a> TerminalView<'a> {
                     &metrics,
                     grid_cache.as_deref_mut(),
                     allow_grid_cache,
+                    allow_sparse_frame_reuse,
                 );
                 render_cursor(
                     ui,

--- a/crates/horizon-ui/src/terminal_widget/render.rs
+++ b/crates/horizon-ui/src/terminal_widget/render.rs
@@ -8,6 +8,8 @@ use crate::theme;
 
 use super::layout::{GridMetrics, usize_to_f32};
 
+const MAX_SPARSE_FRAME_REUSE: u8 = 2;
+
 struct TextRun {
     line: usize,
     next_column: usize,
@@ -42,10 +44,32 @@ impl GridCacheKey {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct GridContentStats {
+    occupied_cells: usize,
+    non_empty_rows: usize,
+}
+
+impl GridContentStats {
+    fn should_reuse_for_sparse_frame(self, previous: Self) -> bool {
+        previous.non_empty_rows >= 8
+            && previous.occupied_cells >= 160
+            && self.non_empty_rows.saturating_mul(2) < previous.non_empty_rows
+            && self.occupied_cells.saturating_mul(3) < previous.occupied_cells
+    }
+}
+
+struct BuiltGrid {
+    shapes: Vec<Shape>,
+    stats: GridContentStats,
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct TerminalGridCache {
     key: Option<GridCacheKey>,
     shapes: Vec<Shape>,
+    stats: GridContentStats,
+    suppressed_sparse_frames: u8,
 }
 
 #[profiling::function]
@@ -56,6 +80,7 @@ pub(super) fn render_grid(
     metrics: &GridMetrics,
     grid_cache: Option<&mut TerminalGridCache>,
     allow_grid_cache: bool,
+    allow_sparse_frame_reuse: bool,
 ) {
     let painter = ui.painter_at(rect);
     let key = GridCacheKey::new(rect, content.display_offset, metrics);
@@ -63,21 +88,37 @@ pub(super) fn render_grid(
     if let Some(grid_cache) = grid_cache {
         if allow_grid_cache && grid_cache.key == Some(key) {
             painter.extend(grid_cache.shapes.iter().cloned());
+            grid_cache.suppressed_sparse_frames = 0;
             return;
         }
 
-        let shapes = build_grid_shapes(ui, rect, content, metrics);
-        painter.extend(shapes.iter().cloned());
+        let built_grid = build_grid_shapes(ui, rect, content, metrics);
+        if allow_sparse_frame_reuse
+            && grid_cache.key == Some(key)
+            && grid_cache.suppressed_sparse_frames < MAX_SPARSE_FRAME_REUSE
+            && built_grid.stats.should_reuse_for_sparse_frame(grid_cache.stats)
+        {
+            painter.extend(grid_cache.shapes.iter().cloned());
+            grid_cache.suppressed_sparse_frames += 1;
+            return;
+        }
+
+        painter.extend(built_grid.shapes.iter().cloned());
         grid_cache.key = Some(key);
-        grid_cache.shapes = shapes;
+        grid_cache.shapes = built_grid.shapes;
+        grid_cache.stats = built_grid.stats;
+        grid_cache.suppressed_sparse_frames = 0;
         return;
     }
 
-    painter.extend(build_grid_shapes(ui, rect, content, metrics));
+    painter.extend(build_grid_shapes(ui, rect, content, metrics).shapes);
 }
 
-fn build_grid_shapes(ui: &egui::Ui, rect: Rect, content: RenderableContent<'_>, metrics: &GridMetrics) -> Vec<Shape> {
+fn build_grid_shapes(ui: &egui::Ui, rect: Rect, content: RenderableContent<'_>, metrics: &GridMetrics) -> BuiltGrid {
     let mut shapes = Vec::new();
+    let mut occupied_cells = 0usize;
+    let mut non_empty_rows = 0usize;
+    let mut last_non_empty_row = None;
 
     ui.fonts_mut(|fonts| {
         let mut text_run: Option<TextRun> = None;
@@ -100,6 +141,14 @@ fn build_grid_shapes(ui: &egui::Ui, rect: Rect, content: RenderableContent<'_>, 
             let (fg, bg) = cell_colors(indexed.cell, selected, content.colors);
             let batchable_char = batchable_cell_char(indexed.cell, selected)
                 .filter(|_| bg == theme::PANEL_BG && !has_cell_decoration(indexed.cell));
+            let visible_cell = cell_has_visible_content(indexed.cell, bg, selected);
+            if visible_cell {
+                occupied_cells += 1;
+                if last_non_empty_row != Some(point.line) {
+                    non_empty_rows += 1;
+                    last_non_empty_row = Some(point.line);
+                }
+            }
 
             if let Some(ch) = batchable_char {
                 let can_continue = text_run
@@ -155,7 +204,13 @@ fn build_grid_shapes(ui: &egui::Ui, rect: Rect, content: RenderableContent<'_>, 
         flush_text_run(fonts, &mut shapes, metrics, &mut text_run);
     });
 
-    shapes
+    BuiltGrid {
+        shapes,
+        stats: GridContentStats {
+            occupied_cells,
+            non_empty_rows,
+        },
+    }
 }
 
 #[profiling::function]
@@ -271,6 +326,13 @@ fn cell_text(cell: &Cell) -> Option<String> {
     Some(text)
 }
 
+fn cell_has_text(cell: &Cell) -> bool {
+    !cell
+        .flags
+        .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER | Flags::HIDDEN)
+        && (cell.c != ' ' || cell.zerowidth().is_some())
+}
+
 fn batchable_cell_char(cell: &Cell, selected: bool) -> Option<char> {
     if selected
         || cell
@@ -282,6 +344,14 @@ fn batchable_cell_char(cell: &Cell, selected: bool) -> Option<char> {
     }
 
     Some(cell.c)
+}
+
+fn cell_has_visible_content(cell: &Cell, bg: Color32, selected: bool) -> bool {
+    if selected || bg != theme::PANEL_BG || has_cell_decoration(cell) {
+        return true;
+    }
+
+    cell_has_text(cell)
 }
 
 fn flush_text_run(
@@ -348,5 +418,38 @@ fn append_cell_decoration(
             [Pos2::new(cell_rect.min.x, y), Pos2::new(cell_rect.max.x, y)],
             egui::Stroke::new(1.0, color),
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GridContentStats;
+
+    #[test]
+    fn sparse_frame_detection_prefers_previous_dense_grid() {
+        let previous = GridContentStats {
+            occupied_cells: 420,
+            non_empty_rows: 18,
+        };
+        let current = GridContentStats {
+            occupied_cells: 72,
+            non_empty_rows: 4,
+        };
+
+        assert!(current.should_reuse_for_sparse_frame(previous));
+    }
+
+    #[test]
+    fn sparse_frame_detection_ignores_similar_density_updates() {
+        let previous = GridContentStats {
+            occupied_cells: 420,
+            non_empty_rows: 18,
+        };
+        let current = GridContentStats {
+            occupied_cells: 360,
+            non_empty_rows: 16,
+        };
+
+        assert!(!current.should_reuse_for_sparse_frame(previous));
     }
 }

--- a/scripts/repro-issue-19-redraw.sh
+++ b/scripts/repro-issue-19-redraw.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+set -eu
+
+cycles="${HORIZON_REPRO_CYCLES:-120}"
+visible_rows="${HORIZON_REPRO_ROWS:-18}"
+blank_delay="${HORIZON_REPRO_BLANK_DELAY:-0.012}"
+frame_delay="${HORIZON_REPRO_FRAME_DELAY:-0.045}"
+sync_updates="${HORIZON_REPRO_SYNC_UPDATES:-0}"
+
+begin_sync() {
+    if [ "$sync_updates" = "1" ]; then
+        printf '\033[?2026h'
+    fi
+}
+
+end_sync() {
+    if [ "$sync_updates" = "1" ]; then
+        printf '\033[?2026l'
+    fi
+}
+
+cleanup() {
+    printf '\033[0m\033[?25h\033[?1049l'
+}
+
+trap cleanup EXIT INT TERM HUP
+
+printf '\033[?1049h\033[?25l'
+
+step=1
+while [ "$step" -le "$cycles" ]; do
+    begin_sync
+
+    # Clear first, then redraw the prompt/footer before the candidate list.
+    printf '\033[H\033[2J'
+    printf '\033[1;1H issue-19 redraw repro\033[K'
+    printf '\033[2;1H sync-updates=%s  blank-delay=%ss  frame-delay=%ss\033[K' \
+        "$sync_updates" "$blank_delay" "$frame_delay"
+    printf '\033[22;1H query> redraw-cycle-%03d\033[K' "$step"
+    printf '\033[23;1H %02d matches  macOS shell panel  transcript wrapper active\033[K' "$visible_rows"
+    printf '\033[24;1H ctrl-c exits\033[K'
+
+    sleep "$blank_delay"
+
+    highlight_row=$((step % visible_rows + 1))
+    row=1
+    while [ "$row" -le "$visible_rows" ]; do
+        screen_row=$((row + 3))
+        if [ "$row" -eq "$highlight_row" ]; then
+            printf '\033[%d;1H\033[7m %02d  candidate %02d for redraw cycle %03d                       \033[0m\033[K' \
+                "$screen_row" "$row" "$row" "$step"
+        else
+            printf '\033[%d;1H %02d  candidate %02d for redraw cycle %03d                         \033[K' \
+                "$screen_row" "$row" "$row" "$step"
+        fi
+        row=$((row + 1))
+    done
+
+    end_sync
+    sleep "$frame_delay"
+    step=$((step + 1))
+done
+
+sleep 1


### PR DESCRIPTION
## Summary

- detect the transient sparse alt-screen frame that causes most of the viewport to blank during rapid fullscreen redraws
- temporarily reuse the previous stable grid for up to two frames instead of painting the sparse intermediate state
- add `scripts/repro-issue-19-redraw.sh` to the repository as a deterministic repro for future regressions

Closes #19.

## Behavior Impact

Rapid fullscreen redraws in alternate-screen TUIs no longer flash a mostly blank middle viewport. The committed repro script can be used later with or without synchronized updates if this regresses.

## Test Evidence

- `cargo test -p horizon-ui`
- live macOS check with `target/release/horizon --new-session --config /tmp/horizon-issue-19-unsynced.yaml`
  - verified the session-backed repro process stayed alive
- live macOS check with the unsynchronized redraw repro showed the candidate list staying populated instead of flashing a blank middle frame after the patch
