### PR TITLE
fix(ci): add timeout-minutes to prevent indefinite job hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -74,6 +75,7 @@ jobs:
   clippy-strict:
     name: Clippy (strict)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -85,6 +87,7 @@ jobs:
   clippy-pedantic:
     name: Clippy (pedantic — advisory)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -100,6 +103,7 @@ jobs:
   rust-test:
     name: Tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -125,6 +129,7 @@ jobs:
   windows-smoke:
     name: Windows test build
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -138,6 +143,7 @@ jobs:
     name: Artifacts (${{ matrix.name }})
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -190,6 +196,7 @@ jobs:
   cargo-publish:
     name: Publish Cargo (crates.io)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [version, clippy, clippy-strict, rust-test, rust-artifacts]
     if: >-
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (


### PR DESCRIPTION
## Summary

- Add `timeout-minutes` to all CI jobs to prevent indefinite hangs
- Test/lint/publish jobs: 15 minutes (normally complete in ~1-2 minutes)
- Artifact build jobs: 30 minutes (release builds take longer)

## Root Cause

Run [23241728580](https://github.com/peters/horizon/actions/runs/23241728580/job/67559707342) had the "Tests (macOS x64)" job stuck for 40+ minutes on `cargo test --workspace`. Investigation showed:

- All tests are pure unit tests (no process spawning, GPU init, or I/O that could hang)
- The same code passed macOS x64 tests on the immediately preceding run
- The only change was a docs-only commit (AGENTS.md)
- All other jobs in the same run passed (including macOS arm64 tests and macOS x64 artifact build)

This was a transient `macos-15-intel` runner infrastructure issue. Without `timeout-minutes`, jobs default to GitHub's 6-hour maximum, causing the entire workflow to hang indefinitely and block the publish/release pipeline.

## Test Plan

- [ ] Verify CI passes on this PR branch (all jobs should complete well within timeouts)
- [ ] Confirm the stuck run was cancelled