### PR TITLE
fix(ui): inherit workspace cwd for new panels

### DIFF
--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -192,12 +192,25 @@ impl HorizonApp {
             }
             self.mark_runtime_dirty();
         } else {
-            self.dir_picker = Some(DirPicker::new(DirPickerPurpose::AddPanel {
+            self.open_panel_dir_picker(workspace_id, preset, canvas_pos);
+        }
+    }
+
+    pub(super) fn open_panel_dir_picker(
+        &mut self,
+        workspace_id: WorkspaceId,
+        preset: PresetConfig,
+        canvas_pos: Option<[f32; 2]>,
+    ) {
+        let workspace_cwd = workspace_cwd(&self.board, workspace_id);
+        self.dir_picker = Some(DirPicker::with_seed(
+            DirPickerPurpose::AddPanel {
                 workspace_id,
                 preset,
                 canvas_pos,
-            }));
-        }
+            },
+            workspace_cwd.as_deref(),
+        ));
     }
 
     pub(super) fn render_quick_nav(&mut self, ctx: &Context) {
@@ -429,7 +442,7 @@ impl HorizonApp {
         let popup_id = Id::new("canvas_preset_picker");
         let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
         let screen_pos = self.canvas_to_screen(canvas_rect, Pos2::new(canvas_pos[0], canvas_pos[1]));
-        let mut open_dir_picker: Option<DirPickerPurpose> = None;
+        let mut selected_action: Option<PresetPickerAction> = None;
 
         let area_response = egui::Area::new(popup_id)
             .fixed_pos(screen_pos)
@@ -457,37 +470,59 @@ impl HorizonApp {
                             } else {
                                 preset.name.clone()
                             };
-                            let text = egui::RichText::new(label).size(12.5).color(theme::FG_SOFT);
-                            if ui.add(Button::new(text).frame(false)).clicked() {
-                                open_dir_picker = Some(if let Some(workspace_id) = target_workspace {
-                                    DirPickerPurpose::AddPanel {
-                                        workspace_id,
-                                        preset: preset.clone(),
-                                        canvas_pos: Some(canvas_pos),
+                            if let Some(workspace_id) = target_workspace {
+                                ui.horizontal(|ui| {
+                                    let create_text =
+                                        egui::RichText::new(label.clone()).size(12.5).color(theme::FG_SOFT);
+                                    if ui.add(Button::new(create_text).frame(false)).clicked() {
+                                        selected_action = Some(PresetPickerAction::CreatePanel {
+                                            workspace_id,
+                                            preset: preset.clone(),
+                                            canvas_pos: Some(canvas_pos),
+                                        });
                                     }
-                                } else {
-                                    DirPickerPurpose::NewWorkspace {
-                                        canvas_pos,
-                                        preset: preset.clone(),
+
+                                    let dir_text = egui::RichText::new("Dir").size(11.0).color(theme::FG_DIM);
+                                    if ui.add(Button::new(dir_text).frame(false)).clicked() {
+                                        selected_action = Some(PresetPickerAction::ChooseDirectory {
+                                            workspace_id,
+                                            preset: preset.clone(),
+                                            canvas_pos: Some(canvas_pos),
+                                        });
                                     }
                                 });
+                            } else {
+                                let create_text = egui::RichText::new(label).size(12.5).color(theme::FG_SOFT);
+                                if ui.add(Button::new(create_text).frame(false)).clicked() {
+                                    selected_action = Some(PresetPickerAction::CreateWorkspace {
+                                        canvas_pos,
+                                        preset: preset.clone(),
+                                    });
+                                }
                             }
                         }
                     });
             });
 
-        if let Some(purpose) = open_dir_picker {
+        if let Some(action) = selected_action {
             self.pending_preset_pick = None;
-            match purpose {
-                DirPickerPurpose::AddPanel {
+            match action {
+                PresetPickerAction::CreatePanel {
                     workspace_id,
                     preset,
                     canvas_pos,
                 } => {
                     self.add_panel_to_workspace(workspace_id, preset, canvas_pos);
                 }
-                purpose @ DirPickerPurpose::NewWorkspace { .. } => {
-                    self.dir_picker = Some(DirPicker::new(purpose));
+                PresetPickerAction::ChooseDirectory {
+                    workspace_id,
+                    preset,
+                    canvas_pos,
+                } => {
+                    self.open_panel_dir_picker(workspace_id, preset, canvas_pos);
+                }
+                PresetPickerAction::CreateWorkspace { canvas_pos, preset } => {
+                    self.dir_picker = Some(DirPicker::new(DirPickerPurpose::NewWorkspace { canvas_pos, preset }));
                 }
             }
         } else if opened_at.elapsed() > std::time::Duration::from_millis(150) {
@@ -562,6 +597,23 @@ fn workspace_cwd(board: &horizon_core::Board, workspace_id: WorkspaceId) -> Opti
     board
         .workspace(workspace_id)
         .and_then(|workspace| workspace.cwd.clone())
+}
+
+enum PresetPickerAction {
+    CreatePanel {
+        workspace_id: WorkspaceId,
+        preset: PresetConfig,
+        canvas_pos: Option<[f32; 2]>,
+    },
+    ChooseDirectory {
+        workspace_id: WorkspaceId,
+        preset: PresetConfig,
+        canvas_pos: Option<[f32; 2]>,
+    },
+    CreateWorkspace {
+        canvas_pos: [f32; 2],
+        preset: PresetConfig,
+    },
 }
 
 fn inherit_workspace_cwd(options: &mut PanelOptions, workspace_cwd: Option<&PathBuf>) {

--- a/crates/horizon-ui/src/dir_picker.rs
+++ b/crates/horizon-ui/src/dir_picker.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Instant;
 
@@ -64,14 +64,19 @@ struct PickerLayout {
 
 impl DirPicker {
     pub fn new(purpose: DirPickerPurpose) -> Self {
-        let rx = dir_search::spawn_lookup(String::new());
+        Self::with_seed(purpose, None)
+    }
+
+    pub fn with_seed(purpose: DirPickerPurpose, path: Option<&Path>) -> Self {
+        let query = seed_query(path);
+        let rx = dir_search::spawn_lookup(query.clone());
         Self {
-            query: String::new(),
+            query: query.clone(),
             results: Vec::new(),
             selected: 0,
             purpose: Some(purpose),
             search_rx: Some(rx),
-            last_query_sent: String::new(),
+            last_query_sent: query,
             last_query_time: Instant::now(),
             opened_at: Instant::now(),
             initial_results_loaded: false,
@@ -215,15 +220,12 @@ impl DirPicker {
                 .max_rect(text_rect)
                 .layout(Layout::left_to_right(Align::Center)),
         );
-        child.label(egui::RichText::new("~").monospace().size(16.0).color(theme::ACCENT));
-        child.add_space(4.0);
-
         let response = child.add(
             egui::TextEdit::singleline(&mut self.query)
                 .font(egui::FontId::monospace(14.0))
                 .text_color(theme::FG)
                 .frame(false)
-                .desired_width(text_rect.width() - 30.0)
+                .desired_width(text_rect.width())
                 .hint_text(
                     egui::RichText::new("Type a path or search...")
                         .color(theme::FG_DIM)
@@ -511,7 +513,34 @@ fn expand_tilde_simple(input: &str) -> PathBuf {
     }
 }
 
+fn seed_query(path: Option<&Path>) -> String {
+    let Some(path) = path else {
+        return String::new();
+    };
+
+    let mut query = dir_search::abbreviate_home(path);
+    if !query.ends_with('/') {
+        query.push('/');
+    }
+    query
+}
+
 fn usize_to_f32(v: usize) -> f32 {
     let clamped = u16::try_from(v).unwrap_or(u16::MAX);
     f32::from(clamped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::seed_query;
+
+    #[test]
+    fn seed_query_appends_trailing_separator() {
+        assert_eq!(seed_query(Some(std::path::Path::new("/repo"))), "/repo/");
+    }
+
+    #[test]
+    fn seed_query_is_empty_without_workspace_directory() {
+        assert!(seed_query(None).is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- keep new panels inheriting `workspace.cwd` instead of storing ad hoc cwd overrides
- promote a directory selected for an existing workspace into `workspace.cwd` before creating the panel
- add an explicit seeded directory-override path in the canvas preset picker while keeping `Ctrl+N` on the fast inherited path

## Behavior
- creating a panel in a workspace with a cwd now launches directly in that workspace directory
- when an existing workspace has no cwd, picking one for a new panel sets the workspace default so later panels inherit it
- the directory picker can be opened seeded from the current workspace directory when the user wants to override it

## Test Evidence
- `cargo test --workspace`
- `cargo clippy -p horizon-ui --all-targets -- -D warnings`