### PR TITLE
fix(ui): prevent settings from overlapping canvas overlays

### DIFF
--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::path::PathBuf;
 
+use egui::containers::panel::PanelState;
 use egui::{Button, Color32, Context, Id, Margin, Order, Pos2, Rect, Stroke, Vec2};
 use horizon_core::{PanelId, PanelKind, PanelOptions, PanelTranscript, PresetConfig, WorkspaceId};
 
@@ -8,6 +9,7 @@ use crate::dir_picker::{DirPicker, DirPickerAction, DirPickerPurpose};
 use crate::quick_nav::{QuickNav, QuickNavAction, WorkspaceEntry};
 use crate::theme;
 
+use super::settings::{SETTINGS_BAR_HEIGHT, SETTINGS_BAR_ID, SETTINGS_PANEL_ID, settings_panel_default_width};
 use super::util::{OverlayExclusion, editor_panel_size_for_file, primary_shortcut_modifier, viewport_local_rect};
 use super::{HorizonApp, MINIMAP_MARGIN, MINIMAP_PAD, SIDEBAR_WIDTH, TOOLBAR_HEIGHT, WS_BG_PAD, WS_TITLE_HEIGHT};
 
@@ -24,14 +26,31 @@ impl HorizonApp {
             .map(|workspace| workspace.id)
     }
 
-    pub(super) fn canvas_rect(ctx: &Context, sidebar_visible: bool) -> Rect {
-        let rect = viewport_local_rect(ctx);
-        let left = if sidebar_visible {
-            rect.min.x + SIDEBAR_WIDTH
-        } else {
-            rect.min.x
-        };
-        Rect::from_min_max(Pos2::new(left, rect.min.y + TOOLBAR_HEIGHT), rect.max)
+    pub(super) fn canvas_rect(&self, ctx: &Context) -> Rect {
+        let viewport = viewport_local_rect(ctx);
+        let settings_panel_rect = self.settings_panel_rect(ctx, viewport);
+        let settings_bar_rect = self.settings_bar_rect(ctx, viewport);
+        canvas_rect_for_layout(viewport, self.sidebar_visible, settings_panel_rect, settings_bar_rect)
+    }
+
+    pub(super) fn fixed_overlays_visible(&self) -> bool {
+        self.settings.is_none()
+    }
+
+    fn settings_panel_rect(&self, ctx: &Context, viewport: Rect) -> Option<Rect> {
+        estimated_settings_panel_rect(
+            viewport,
+            self.settings.is_some(),
+            PanelState::load(ctx, Id::new(SETTINGS_PANEL_ID)).map(|state| state.rect),
+        )
+    }
+
+    fn settings_bar_rect(&self, ctx: &Context, viewport: Rect) -> Option<Rect> {
+        estimated_settings_bar_rect(
+            viewport,
+            self.settings.is_some(),
+            PanelState::load(ctx, Id::new(SETTINGS_BAR_ID)).map(|state| state.rect),
+        )
     }
 
     /// Screen-space rectangles occupied by fixed overlay widgets.  Compute
@@ -48,20 +67,29 @@ impl HorizonApp {
             ));
         }
 
-        let minimap_height = if self.minimap_visible && !self.board.workspaces.is_empty() {
-            let overlays = &self.template_config.overlays;
-            let w = overlays.minimap_width.max(120.0) + MINIMAP_PAD * 2.0;
-            let h = overlays.minimap_height.max(120.0) + MINIMAP_PAD * 2.0;
-            zones.push(Rect::from_min_size(
-                Pos2::new(viewport.max.x - MINIMAP_MARGIN - w, viewport.max.y - MINIMAP_MARGIN - h),
-                Vec2::new(w, h),
-            ));
-            h
-        } else {
-            0.0
-        };
+        if let Some(rect) = self.settings_panel_rect(ctx, viewport) {
+            zones.push(rect);
+        }
+        if let Some(rect) = self.settings_bar_rect(ctx, viewport) {
+            zones.push(rect);
+        }
 
-        if self.template_config.features.attention_feed
+        let minimap_height =
+            if self.fixed_overlays_visible() && self.minimap_visible && !self.board.workspaces.is_empty() {
+                let overlays = &self.template_config.overlays;
+                let w = overlays.minimap_width.max(120.0) + MINIMAP_PAD * 2.0;
+                let h = overlays.minimap_height.max(120.0) + MINIMAP_PAD * 2.0;
+                zones.push(Rect::from_min_size(
+                    Pos2::new(viewport.max.x - MINIMAP_MARGIN - w, viewport.max.y - MINIMAP_MARGIN - h),
+                    Vec2::new(w, h),
+                ));
+                h
+            } else {
+                0.0
+            };
+
+        if self.fixed_overlays_visible()
+            && self.template_config.features.attention_feed
             && let Some(rect) = super::attention_feed::estimated_outer_rect(
                 viewport,
                 minimap_height,
@@ -284,7 +312,7 @@ impl HorizonApp {
             self.reset_view();
         }
 
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         if ctx.input(|input| {
             primary_shortcut_modifier(input.modifiers)
                 && (input.key_pressed(egui::Key::Plus) || input.key_pressed(egui::Key::Equals))
@@ -340,7 +368,7 @@ impl HorizonApp {
 
         let screen_pos = self.file_hover_pos.or(pointer_pos);
         self.file_hover_pos = None;
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let canvas_pos = screen_pos.map(|pos| self.screen_to_canvas(canvas_rect, pos));
 
         for file in dropped {
@@ -370,7 +398,7 @@ impl HorizonApp {
     }
 
     pub(super) fn handle_canvas_double_click(&mut self, ctx: &Context) {
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let ctrl_double_click = ctx.input(|input| {
             let ctrl = input.modifiers.ctrl || input.modifiers.command;
             let double = input.pointer.button_double_clicked(egui::PointerButton::Primary);
@@ -401,7 +429,7 @@ impl HorizonApp {
         };
 
         let popup_id = Id::new("canvas_preset_picker");
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let screen_pos = self.canvas_to_screen(canvas_rect, Pos2::new(canvas_pos[0], canvas_pos[1]));
         let mut selected_action: Option<PresetPickerAction> = None;
 
@@ -503,7 +531,7 @@ impl HorizonApp {
 
     #[profiling::function]
     pub(super) fn handle_canvas_pan(&mut self, ctx: &Context) {
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let (pointer_position, middle_down, primary_down, space_down, modifiers, scroll, pointer_delta, zoom_delta) =
             ctx.input(|input| {
                 (
@@ -568,6 +596,53 @@ impl HorizonApp {
     }
 }
 
+fn canvas_rect_for_layout(
+    viewport: Rect,
+    sidebar_visible: bool,
+    settings_panel_rect: Option<Rect>,
+    settings_bar_rect: Option<Rect>,
+) -> Rect {
+    let left = if sidebar_visible {
+        viewport.min.x + SIDEBAR_WIDTH
+    } else {
+        viewport.min.x
+    };
+    let right = settings_panel_rect.map_or(viewport.max.x, |rect| rect.min.x);
+    let bottom = settings_bar_rect.map_or(viewport.max.y, |rect| rect.min.y);
+
+    Rect::from_min_max(
+        Pos2::new(left, viewport.min.y + TOOLBAR_HEIGHT),
+        Pos2::new(right, bottom),
+    )
+}
+
+fn estimated_settings_panel_rect(viewport: Rect, settings_open: bool, remembered_rect: Option<Rect>) -> Option<Rect> {
+    if !settings_open {
+        return None;
+    }
+
+    remembered_rect.or_else(|| {
+        let width = settings_panel_default_width(viewport.width());
+        Some(Rect::from_min_max(
+            Pos2::new(viewport.max.x - width, viewport.min.y + TOOLBAR_HEIGHT),
+            Pos2::new(viewport.max.x, viewport.max.y - SETTINGS_BAR_HEIGHT),
+        ))
+    })
+}
+
+fn estimated_settings_bar_rect(viewport: Rect, settings_open: bool, remembered_rect: Option<Rect>) -> Option<Rect> {
+    if !settings_open {
+        return None;
+    }
+
+    remembered_rect.or_else(|| {
+        Some(Rect::from_min_max(
+            Pos2::new(viewport.min.x, viewport.max.y - SETTINGS_BAR_HEIGHT),
+            viewport.max,
+        ))
+    })
+}
+
 fn workspace_cwd(board: &horizon_core::Board, workspace_id: WorkspaceId) -> Option<PathBuf> {
     board
         .workspace(workspace_id)
@@ -611,9 +686,14 @@ fn update_workspace_cwd(workspace: Option<&mut horizon_core::Workspace>, path: O
 mod tests {
     use std::path::PathBuf;
 
+    use egui::{Pos2, Rect};
     use horizon_core::{Board, PanelOptions, Workspace, WorkspaceId};
 
-    use super::{inherit_workspace_cwd, update_workspace_cwd, workspace_cwd};
+    use super::{
+        SIDEBAR_WIDTH, TOOLBAR_HEIGHT, canvas_rect_for_layout, estimated_settings_bar_rect,
+        estimated_settings_panel_rect, inherit_workspace_cwd, update_workspace_cwd, workspace_cwd,
+    };
+    use crate::app::settings::SETTINGS_BAR_HEIGHT;
 
     #[test]
     fn inherit_workspace_cwd_populates_missing_panel_cwd() {
@@ -668,5 +748,55 @@ mod tests {
         board.workspace_mut(workspace_id).expect("workspace").cwd = Some(path.clone());
 
         assert_eq!(workspace_cwd(&board, workspace_id), Some(path));
+    }
+
+    #[test]
+    fn estimated_settings_panel_rect_uses_default_wide_fallback() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1200.0, 800.0));
+
+        let rect = estimated_settings_panel_rect(viewport, true, None).expect("settings rect");
+
+        assert_eq!(rect.min, Pos2::new(840.0, TOOLBAR_HEIGHT));
+        assert_eq!(rect.max, Pos2::new(1200.0, 752.0));
+    }
+
+    #[test]
+    fn estimated_settings_panel_rect_clamps_narrow_fallback_width() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(700.0, 800.0));
+
+        let rect = estimated_settings_panel_rect(viewport, true, None).expect("settings rect");
+
+        assert_eq!(rect.min, Pos2::new(360.0, TOOLBAR_HEIGHT));
+        assert_eq!(rect.max, Pos2::new(700.0, 752.0));
+    }
+
+    #[test]
+    fn estimated_settings_panel_rect_prefers_remembered_panel_state() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1200.0, 800.0));
+        let remembered = Rect::from_min_max(Pos2::new(900.0, 60.0), Pos2::new(1200.0, 720.0));
+
+        let rect = estimated_settings_panel_rect(viewport, true, Some(remembered)).expect("settings rect");
+
+        assert_eq!(rect, remembered);
+    }
+
+    #[test]
+    fn estimated_settings_rects_close_when_settings_are_hidden() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1200.0, 800.0));
+
+        assert_eq!(estimated_settings_panel_rect(viewport, false, None), None);
+        assert_eq!(estimated_settings_bar_rect(viewport, false, None), None);
+    }
+
+    #[test]
+    fn canvas_rect_for_layout_excludes_sidebar_settings_panel_and_bar() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1200.0, 800.0));
+        let settings_panel = Rect::from_min_max(Pos2::new(840.0, TOOLBAR_HEIGHT), Pos2::new(1200.0, 752.0));
+        let settings_bar = Rect::from_min_max(Pos2::new(0.0, 800.0 - SETTINGS_BAR_HEIGHT), Pos2::new(1200.0, 800.0));
+
+        let rect = canvas_rect_for_layout(viewport, true, Some(settings_panel), Some(settings_bar));
+
+        assert_eq!(rect.min, Pos2::new(SIDEBAR_WIDTH, TOOLBAR_HEIGHT));
+        assert_eq!(rect.max, Pos2::new(840.0, 800.0 - SETTINGS_BAR_HEIGHT));
     }
 }

--- a/crates/horizon-ui/src/app/canvas.rs
+++ b/crates/horizon-ui/src/app/canvas.rs
@@ -64,11 +64,11 @@ impl HorizonApp {
         ctx: &Context,
         workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
     ) -> f32 {
-        if !self.minimap_visible || self.board.workspaces.is_empty() {
+        if !self.fixed_overlays_visible() || !self.minimap_visible || self.board.workspaces.is_empty() {
             return 0.0;
         }
 
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let Some(model) = self.minimap_model(canvas_rect, workspace_bounds) else {
             return 0.0;
         };
@@ -220,7 +220,7 @@ impl HorizonApp {
             return;
         }
 
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let view_origin = self.screen_to_canvas(canvas_rect, canvas_rect.min);
         let focused_status = self
             .board

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -111,7 +111,7 @@ impl HorizonApp {
         if let Some(workspace_id) = self.leftmost_workspace_id() {
             self.board.focus_workspace(workspace_id);
             if let Some((min, _max)) = self.board.workspace_bounds(workspace_id) {
-                let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+                let canvas_rect = self.canvas_rect(ctx);
                 self.canvas_view.align_canvas_point_to_screen(
                     [canvas_rect.min.x, canvas_rect.min.y],
                     [min[0] - WS_BG_PAD, min[1] - WS_BG_PAD - WS_TITLE_HEIGHT],
@@ -307,7 +307,7 @@ impl HorizonApp {
         self.render_panels(ctx);
         self.render_preset_picker(ctx);
         let minimap_height = self.render_minimap(ctx, &workspace_bounds);
-        if self.template_config.features.attention_feed {
+        if self.fixed_overlays_visible() && self.template_config.features.attention_feed {
             let feed_result =
                 attention_feed::render_attention_feed(ctx, &self.board, minimap_height, &self.template_config.overlays);
             for attention_id in feed_result.dismissed_ids {

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -153,7 +153,7 @@ impl HorizonApp {
         let focused = self.board.focused;
         panel_order.sort_by_key(|(panel_id, _)| Some(*panel_id) == focused);
 
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let mut panels_to_close = Vec::new();
 
         for (panel_id, fallback_index) in panel_order {

--- a/crates/horizon-ui/src/app/settings.rs
+++ b/crates/horizon-ui/src/app/settings.rs
@@ -7,6 +7,10 @@ use super::util::{atomic_write, chrome_button, primary_button};
 use super::yaml_highlight::highlight_yaml;
 use super::{HorizonApp, SettingsEditor, SettingsStatus};
 
+pub(super) const SETTINGS_BAR_ID: &str = "settings_bar";
+pub(super) const SETTINGS_BAR_HEIGHT: f32 = 48.0;
+pub(super) const SETTINGS_PANEL_ID: &str = "settings_panel";
+
 #[derive(Clone, Copy)]
 enum SettingsAction {
     None,
@@ -92,8 +96,8 @@ impl HorizonApp {
     ) -> SettingsAction {
         let mut action = SettingsAction::None;
 
-        egui::TopBottomPanel::bottom("settings_bar")
-            .exact_height(48.0)
+        egui::TopBottomPanel::bottom(SETTINGS_BAR_ID)
+            .exact_height(SETTINGS_BAR_HEIGHT)
             .frame(
                 egui::Frame::default()
                     .fill(theme::BG_ELEVATED)
@@ -198,6 +202,10 @@ impl HorizonApp {
     }
 }
 
+pub(super) fn settings_panel_default_width(viewport_width: f32) -> f32 {
+    (viewport_width * 0.3).clamp(340.0, 900.0)
+}
+
 fn settings_status(status: &SettingsStatus) -> (String, Color32) {
     match status {
         SettingsStatus::None => (String::new(), theme::FG_DIM),
@@ -215,9 +223,9 @@ fn render_settings_editor(ctx: &Context, config_path: &str, buffer: &mut String)
     };
 
     let viewport_width = super::util::viewport_local_rect(ctx).width();
-    let default_width = (viewport_width * 0.3).clamp(340.0, 900.0);
+    let default_width = settings_panel_default_width(viewport_width);
 
-    egui::SidePanel::right("settings_panel")
+    egui::SidePanel::right(SETTINGS_PANEL_ID)
         .default_width(default_width)
         .min_width(viewport_width * 0.15)
         .max_width(viewport_width * 0.5)

--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -33,7 +33,7 @@ impl HorizonApp {
         canvas_size: Vec2,
         left_align: bool,
     ) {
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let zoom = self.canvas_view.zoom;
         let pan_margin = 40.0;
         let x = if left_align {

--- a/crates/horizon-ui/src/app/workspace.rs
+++ b/crates/horizon-ui/src/app/workspace.rs
@@ -57,7 +57,7 @@ impl HorizonApp {
         workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
         overlay_zones: &OverlayExclusion,
     ) {
-        let canvas_rect = Self::canvas_rect(ctx, self.sidebar_visible);
+        let canvas_rect = self.canvas_rect(ctx);
         let canvas_transform = super::view::canvas_scene_transform(canvas_rect, self.canvas_view);
         let canvas_clip_rect = canvas_transform.inverse() * canvas_rect;
         let visuals = self.workspace_visuals(canvas_rect, workspace_bounds, overlay_zones);

--- a/docs/testing/settings-overlay-smoketest.md
+++ b/docs/testing/settings-overlay-smoketest.md
@@ -1,0 +1,53 @@
+# Settings Overlay Smoke Test
+
+Use this checklist for issue `#14` and any future work that changes the settings panel, minimap, or attention feed layout.
+
+## Setup
+
+Launch Horizon with:
+
+- `features.attention_feed: true`
+- at least one workspace so the minimap is visible
+- at least one notification or attention item so the attention feed is visible
+- one non-terminal panel if you want to use global shortcuts during the smoke pass
+
+## Required Matrix
+
+Capture live screenshots for all four states:
+
+1. Wide window, settings closed
+2. Wide window, settings open
+3. Narrow window, settings closed
+4. Narrow window, settings open
+
+Suggested sizes:
+
+- Wide: about `1480x920`
+- Narrow: about `980x780`
+
+## Expected Results
+
+For `settings closed`:
+
+- minimap is visible
+- attention feed is visible when attention items exist
+- neither overlay is clipped off-screen
+- neither overlay overlaps the settings button or toolbar chrome
+
+For `settings open`:
+
+- settings editor is fully visible
+- minimap is not visible
+- attention feed is not visible
+- canvas panels and workspace chrome do not render under the settings side panel
+- the bottom settings action bar does not overlap canvas-space widgets
+
+## Edge Cases
+
+Check these before signing off:
+
+- open settings from a wide window, then resize to narrow while settings stays open
+- close settings after resizing back and forth at least once
+- repeat the open/close cycle more than once to confirm overlays return consistently
+- verify sidebar shown and sidebar hidden states if the touched code changes canvas reservation math
+- if using notification-based attention items, remember they can age out of the feed after their resolved-item grace window; regenerate attention before blaming layout


### PR DESCRIPTION
## Summary
- shrink the effective canvas rect while settings is open so the editor owns the right and bottom edge geometry
- suppress minimap and attention-feed rendering while settings is open, and include settings chrome in overlay exclusion math
- add unit coverage for the layout math plus a detailed smoke-test checklist for wide and narrow windows

## Testing
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `cargo test -p horizon-ui`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `RUSTFLAGS='-D warnings' cargo test --workspace` (intermittent pre-existing macOS PTY failures still reproduce in `horizon-core` board tests; reruns fail in different spawn tests with `Pty(\"Unknown error: -6\")`)
- live smoke: wide closed, wide open, narrow open, narrow closed screenshots on the rebased branch

Closes #14.
