### PR TITLE
fix(workspace): ignore detached workspaces when aligning

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -922,6 +922,57 @@ mod tests {
     }
 
     #[test]
+    fn align_workspaces_horizontally_arranges_in_row() {
+        let mut board = Board::new();
+        let ws1 = board.create_workspace("first");
+        let ws2 = board.create_workspace("second");
+        let ws3 = board.create_workspace("third");
+
+        board.move_workspace(ws1, [100.0, 200.0]);
+        board.move_workspace(ws2, [500.0, 50.0]);
+        board.move_workspace(ws3, [300.0, 400.0]);
+
+        board.align_workspaces_horizontally(&[ws1, ws2, ws3]);
+
+        // After alignment, sorted by original x: ws1 (100), ws3 (300), ws2 (500)
+        let p1 = board.workspace(ws1).expect("ws1").position;
+        let p3 = board.workspace(ws3).expect("ws3").position;
+        let p2 = board.workspace(ws2).expect("ws2").position;
+
+        // All y positions should match (aligned to leftmost workspace frame top).
+        assert!((p1[1] - p3[1]).abs() <= f32::EPSILON);
+        assert!((p3[1] - p2[1]).abs() <= f32::EPSILON);
+
+        // X positions should be in sorted order with gaps.
+        assert!(p3[0] > p1[0], "ws3 should be right of ws1");
+        assert!(p2[0] > p3[0], "ws2 should be right of ws3");
+    }
+
+    #[test]
+    fn align_workspaces_horizontally_only_moves_selected_workspaces() {
+        let mut board = Board::new();
+        let ws1 = board.create_workspace("first");
+        let ws2 = board.create_workspace("second");
+        let ws3 = board.create_workspace("third");
+
+        board.move_workspace(ws1, [100.0, 200.0]);
+        board.move_workspace(ws2, [500.0, 50.0]);
+        board.move_workspace(ws3, [20.0, 20.0]);
+
+        let original_ws3 = board.workspace(ws3).expect("ws3").position;
+        let leftmost = board
+            .align_workspaces_horizontally(&[ws1, ws2])
+            .expect("aligned workspace");
+
+        assert_eq!(leftmost, ws1);
+        let current_ws3 = board.workspace(ws3).expect("ws3").position;
+        assert!(
+            vec2_eq(current_ws3, original_ws3),
+            "expected detached workspace position {original_ws3:?}, got {current_ws3:?}"
+        );
+    }
+
+    #[test]
     fn resize_panel_pushes_sibling() {
         let mut board = Board::new();
         let ws_id = board.create_workspace("test");

--- a/crates/horizon-core/src/board/arrangement.rs
+++ b/crates/horizon-core/src/board/arrangement.rs
@@ -1,6 +1,6 @@
 use crate::layout::{
-    TILE_GAP, WS_COLLISION_GAP, WS_EMPTY_FRAME_SIZE, WS_FRAME_PAD, WS_FRAME_TOP_EXTRA, WS_INNER_PAD, ceil_sqrt_usize,
-    tiled_panel_position, usize_to_f32, workspace_slot_width,
+    TILE_GAP, WORKSPACE_GAP, WS_COLLISION_GAP, WS_EMPTY_FRAME_SIZE, WS_FRAME_PAD, WS_FRAME_TOP_EXTRA, WS_INNER_PAD,
+    ceil_sqrt_usize, tiled_panel_position, usize_to_f32, workspace_slot_width,
 };
 use crate::panel::{DEFAULT_PANEL_SIZE, PanelId};
 use crate::workspace::{Workspace, WorkspaceId};
@@ -152,6 +152,55 @@ impl Board {
 
         self.set_workspace_layout(id, None);
         true
+    }
+
+    /// Align the selected workspaces side by side in a horizontal row,
+    /// sorted by their current x position, with consistent vertical
+    /// alignment and [`WORKSPACE_GAP`] spacing between frames. Returns the
+    /// leftmost workspace ID after alignment, or `None` when fewer than two
+    /// selected workspaces exist.
+    pub fn align_workspaces_horizontally(&mut self, workspace_ids: &[WorkspaceId]) -> Option<WorkspaceId> {
+        if workspace_ids.len() < 2 {
+            return None;
+        }
+
+        let bounds_map = self.workspace_bounds_map();
+        let mut entries: Vec<(WorkspaceId, [f32; 4])> = workspace_ids
+            .iter()
+            .filter_map(|workspace_id| {
+                let ws = self.workspace(*workspace_id)?;
+                let rect = if let Some((min, max)) = bounds_map.get(&ws.id) {
+                    [
+                        min[0] - WS_FRAME_PAD,
+                        min[1] - WS_FRAME_PAD - WS_FRAME_TOP_EXTRA,
+                        max[0] + WS_FRAME_PAD,
+                        max[1] + WS_FRAME_PAD,
+                    ]
+                } else {
+                    let p = ws.position;
+                    [p[0], p[1], p[0] + WS_EMPTY_FRAME_SIZE[0], p[1] + WS_EMPTY_FRAME_SIZE[1]]
+                };
+                Some((ws.id, rect))
+            })
+            .collect();
+
+        if entries.len() < 2 {
+            return None;
+        }
+
+        entries.sort_by(|a, b| a.1[0].total_cmp(&b.1[0]));
+
+        let leftmost_id = entries[0].0;
+        let anchor_y = entries[0].1[1];
+        let mut cursor_x = entries[0].1[0];
+
+        for (ws_id, frame) in &entries {
+            let frame_width = frame[2] - frame[0];
+            self.translate_workspace(*ws_id, [cursor_x - frame[0], anchor_y - frame[1]]);
+            cursor_x += frame_width + WORKSPACE_GAP;
+        }
+
+        Some(leftmost_id)
     }
 
     /// Compute the canvas position for the next workspace so it doesn't

--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -373,6 +373,24 @@ impl HorizonApp {
             let _ = self.zoom_canvas_at(canvas_rect, canvas_rect.center(), self.canvas_view.zoom / 1.1);
         }
 
+        if ctx.input(|input| {
+            input.key_pressed(egui::Key::A) && primary_shortcut_modifier(input.modifiers) && input.modifiers.shift
+        }) {
+            let workspace_ids: Vec<_> = self
+                .board
+                .workspaces
+                .iter()
+                .filter(|workspace| !self.workspace_is_detached(workspace.id))
+                .map(|workspace| workspace.id)
+                .collect();
+            if let Some(ws_id) = self.board.align_workspaces_horizontally(&workspace_ids)
+                && let Some((min, max)) = self.board.workspace_bounds(ws_id)
+            {
+                self.focus_workspace_bounds(ctx, min, max, true);
+            }
+            self.mark_runtime_dirty();
+        }
+
         if self.terminal_accepts_keyboard_input(ctx) {
             return;
         }

--- a/docs/testing/2026-03-19-align-workspaces-shortcut-smoke.md
+++ b/docs/testing/2026-03-19-align-workspaces-shortcut-smoke.md
@@ -1,0 +1,59 @@
+# Align Workspaces Shortcut Smoke Test
+
+## Scope
+
+Validate `Ctrl/Cmd+Shift+A` for the main-window workspace alignment flow, with
+specific attention to detached workspaces being excluded from both alignment and
+focus targeting.
+
+## Environment
+
+- Build from the current checkout.
+- Run Horizon with a temporary `HOME` so the test does not mutate real session
+  data.
+- Use a config with at least two workspaces where the workspace that will be
+  detached starts left of the visible main-window workspace.
+
+## Baseline
+
+1. Launch Horizon and confirm the root window renders normally.
+2. Confirm the sidebar lists both workspaces.
+3. Confirm both workspaces are initially visible in the main canvas.
+4. Confirm panning and zooming still work before any detach/align action.
+
+## Primary Flow
+
+1. Detach the leftmost workspace into a native window.
+2. Confirm the root window now renders only the remaining attached workspace.
+3. Focus the root window.
+4. Trigger `Ctrl/Cmd+Shift+A`.
+5. Confirm the root canvas stays centered on the attached workspace instead of
+   empty space.
+6. Confirm the detached window remains open and its workspace content is still
+   rendered in that detached window.
+7. Confirm the attached workspace moves only relative to other attached
+   workspaces.
+
+## Edge Cases
+
+1. Trigger the shortcut when only one attached workspace remains and confirm it
+   is a no-op.
+2. Reattach the detached workspace and trigger the shortcut again; confirm both
+   visible workspaces align in the root window.
+3. Repeat after zooming in and zooming out to ensure focus targeting still
+   lands on visible content.
+
+## Persistence
+
+1. Detach a workspace, close Horizon, and relaunch.
+2. Confirm detached workspace state restores correctly.
+3. Trigger the shortcut and confirm detached workspaces still do not pull the
+   root viewport to empty space.
+
+## Visual Checks
+
+1. Capture a screenshot after launch showing both workspaces before detaching.
+2. Capture a screenshot after detaching the leftmost workspace and triggering
+   the shortcut.
+3. Confirm the root-window screenshot still shows a visible workspace frame and
+   panel content after alignment.


### PR DESCRIPTION
## Summary
- align only an explicit workspace subset in the board helper instead of every workspace on the board
- have `Ctrl/Cmd+Shift+A` pass only attached workspaces so detached windows are neither moved nor chosen as the main-canvas focus target
- add regression coverage for alignment ordering and for leaving unselected workspaces untouched
- add a temporary UI smoke-test handoff plan for the detached-workspace shortcut path

## Behavior Impact
`Ctrl/Cmd+Shift+A` no longer pans the main window to empty space when a detached workspace sits left of the visible canvas. Detached workspace positions also remain unchanged until they are reattached.

## Testing
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Follow-up
- Live UI smoketest is being handled separately.
- Temporary validation artifact: `docs/testing/2026-03-19-align-workspaces-shortcut-smoke.md`
- Delete that smoke plan after the validation pass completes.
