### PR TITLE
fix(search): dropdown interactivity, live refresh, full scrollback

### DIFF
--- a/crates/horizon-core/src/terminal/content.rs
+++ b/crates/horizon-core/src/terminal/content.rs
@@ -1,3 +1,5 @@
+use alacritty_terminal::term::cell::{Cell, Flags};
+
 use super::{
     Column, Dimensions, PathBuf, RenderableContent, Scroll, TermDamage, Terminal, current_cwd_for_pid,
     find_file_path_at_column, find_url_at_column,
@@ -49,6 +51,7 @@ impl Terminal {
         let rows = usize::from(self.rows);
         let mut lines: Vec<String> = Vec::with_capacity(max_lines);
         let mut current_line = String::with_capacity(cols);
+        let mut current_line_columns = 0;
         let mut current_row: Option<usize> = None;
 
         for indexed in content.display_iter {
@@ -64,13 +67,14 @@ impl Terminal {
                 }
                 current_row = Some(row);
                 current_line.clear();
+                current_line_columns = 0;
             }
-            if indexed.cell.c != ' ' || indexed.cell.zerowidth().is_some() {
-                while current_line.len() < indexed.point.column.0 {
-                    current_line.push(' ');
-                }
-                current_line.push(indexed.cell.c);
-            }
+            append_cell_text(
+                &mut current_line,
+                &mut current_line_columns,
+                indexed.point.column.0,
+                indexed.cell,
+            );
         }
         if !current_line.is_empty() {
             lines.push(current_line);
@@ -112,16 +116,10 @@ impl Terminal {
             };
 
             let mut line = String::with_capacity(cols);
+            let mut occupied_columns = 0;
             for col in 0..cols {
                 let cell = &grid[line_idx][Column(col)];
-                let ch = cell.c;
-                if ch != ' ' {
-                    // Pad with spaces up to this column if needed.
-                    while line.len() < col {
-                        line.push(' ');
-                    }
-                    line.push(ch);
-                }
+                append_cell_text(&mut line, &mut occupied_columns, col, cell);
             }
             let trimmed_len = line.trim_end().len();
             line.truncate(trimmed_len);
@@ -205,5 +203,82 @@ impl Terminal {
         }
 
         find_url_at_column(&line_chars, col).or_else(|| find_file_path_at_column(&line_chars, col))
+    }
+}
+
+fn append_cell_text(line: &mut String, occupied_columns: &mut usize, target_column: usize, cell: &Cell) {
+    if cell
+        .flags
+        .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+        || (cell.c == ' ' && cell.zerowidth().is_none())
+    {
+        return;
+    }
+
+    // Terminal columns are not the same as UTF-8 bytes, so track occupied
+    // columns separately to preserve spacing after multibyte and wide glyphs.
+    while *occupied_columns < target_column {
+        line.push(' ');
+        *occupied_columns += 1;
+    }
+
+    line.push(cell.c);
+    if let Some(chars) = cell.zerowidth() {
+        for ch in chars {
+            line.push(*ch);
+        }
+    }
+
+    *occupied_columns = target_column + if cell.flags.contains(Flags::WIDE_CHAR) { 2 } else { 1 };
+}
+
+#[cfg(test)]
+mod tests {
+    use alacritty_terminal::term::cell::{Cell, Flags};
+
+    use super::append_cell_text;
+
+    fn reconstruct_line(cells: &[(usize, Cell)]) -> String {
+        let mut line = String::new();
+        let mut occupied_columns = 0;
+
+        for (column, cell) in cells {
+            append_cell_text(&mut line, &mut occupied_columns, *column, cell);
+        }
+
+        line
+    }
+
+    #[test]
+    fn multibyte_glyphs_preserve_following_padding() {
+        let accent_cell = Cell {
+            c: 'é',
+            ..Cell::default()
+        };
+        let x_cell = Cell {
+            c: 'x',
+            ..Cell::default()
+        };
+
+        let line = reconstruct_line(&[(0, accent_cell), (2, x_cell)]);
+
+        assert_eq!(line, "é x");
+    }
+
+    #[test]
+    fn wide_glyphs_consume_two_terminal_columns() {
+        let wide_cell = Cell {
+            c: '你',
+            flags: Flags::WIDE_CHAR,
+            ..Cell::default()
+        };
+        let x_cell = Cell {
+            c: 'x',
+            ..Cell::default()
+        };
+
+        let line = reconstruct_line(&[(0, wide_cell), (2, x_cell)]);
+
+        assert_eq!(line, "你x");
     }
 }

--- a/crates/horizon-ui/src/search_overlay/mod.rs
+++ b/crates/horizon-ui/src/search_overlay/mod.rs
@@ -126,6 +126,7 @@ impl SearchOverlay {
 
         if response.changed() {
             self.note_query_changed(Instant::now());
+            ui.ctx().request_repaint_after(Self::DEBOUNCE);
         }
 
         // Handle keyboard while the input has focus.
@@ -211,11 +212,25 @@ impl SearchOverlay {
     const DEBOUNCE: Duration = Duration::from_millis(150);
 
     fn maybe_refresh_results(&mut self, ctx: &Context, board: &Board) {
+        let terminal_output_changed = self.should_refresh_for_terminal_output(board);
+        self.maybe_refresh_results_at(ctx, board, terminal_output_changed, Instant::now());
+    }
+
+    fn should_refresh_for_terminal_output(&self, board: &Board) -> bool {
+        !self.query.is_empty() && board.panels.iter().any(horizon_core::Panel::had_recent_output)
+    }
+
+    fn note_query_changed(&mut self, now: Instant) {
+        self.selected = 0;
+        self.query_changed_at = Some(now);
+    }
+
+    fn maybe_refresh_results_at(&mut self, ctx: &Context, board: &Board, terminal_output_changed: bool, now: Instant) {
         let query_changed = self.query != self.last_query;
         let options_changed = self.options_dirty;
+        let query_or_options_changed = query_changed || options_changed;
 
-        if !query_changed && !options_changed {
-            // Nothing to do; clear any stale debounce timer.
+        if !query_changed && !options_changed && !terminal_output_changed {
             self.query_changed_at = None;
             return;
         }
@@ -224,10 +239,9 @@ impl SearchOverlay {
             // Option toggles fire immediately (no debounce needed).
             self.options_dirty = false;
             self.query_changed_at = None;
-        } else {
+        } else if query_changed {
             // Query text changed -- debounce to avoid searching on every
             // keystroke when many terminals are open.
-            let now = Instant::now();
             let changed_at = *self.query_changed_at.get_or_insert(now);
             let remaining = Self::DEBOUNCE.saturating_sub(now.duration_since(changed_at));
             if !remaining.is_zero() {
@@ -244,12 +258,11 @@ impl SearchOverlay {
         };
         self.cached_results = search_board(board, &self.query, &options);
         self.rebuild_display_rows();
-        self.selected = 0;
-    }
-
-    fn note_query_changed(&mut self, now: Instant) {
-        self.selected = 0;
-        self.query_changed_at = Some(now);
+        if query_or_options_changed {
+            self.selected = 0;
+        } else {
+            self.clamp_selection();
+        }
     }
 
     fn rebuild_display_rows(&mut self) {
@@ -364,9 +377,10 @@ impl SearchOverlay {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use egui::{Pos2, Rect, Vec2};
+    use egui::{Context, Pos2, Rect, Vec2};
+    use horizon_core::{Board, PanelId, PanelSearchResult, SearchMatch, SearchResults};
 
-    use super::SearchOverlay;
+    use super::{DisplayRow, SearchOverlay};
 
     #[test]
     fn note_query_changed_resets_debounce_anchor() {
@@ -399,7 +413,7 @@ mod tests {
             query: "workspace-beta-only".to_string(),
             ..SearchOverlay::new()
         };
-        let ctx = egui::Context::default();
+        let ctx = Context::default();
         let dropdown_rect = Rect::from_min_size(Pos2::new(10.0, 20.0), Vec2::new(120.0, 80.0));
 
         let pointer = dropdown_rect.center();
@@ -421,7 +435,7 @@ mod tests {
             query: "workspace-beta-only".to_string(),
             ..SearchOverlay::new()
         };
-        let ctx = egui::Context::default();
+        let ctx = Context::default();
         let dropdown_rect = Rect::from_min_size(Pos2::new(10.0, 20.0), Vec2::new(120.0, 80.0));
 
         let outside = Pos2::new(dropdown_rect.max.x + 20.0, dropdown_rect.max.y + 20.0);
@@ -435,5 +449,57 @@ mod tests {
         let _ = ctx.end_pass();
 
         assert!(!show_dropdown);
+    }
+
+    #[test]
+    fn terminal_output_refreshes_cached_results_without_query_change() {
+        let mut overlay = SearchOverlay::new_inactive();
+        overlay.query = "error".to_string();
+        overlay.last_query = overlay.query.clone();
+        overlay.selected = 1;
+        overlay.cached_results = SearchResults {
+            panels: vec![PanelSearchResult {
+                panel_id: PanelId(7),
+                panel_title: "build".to_string(),
+                lines: vec!["error: first failure".to_string()],
+                matches: vec![SearchMatch {
+                    line_index: 0,
+                    byte_offset: 0,
+                    byte_len: 5,
+                }],
+            }],
+            total_matches: 1,
+        };
+        overlay.display_rows = vec![DisplayRow {
+            panel_id: PanelId(7),
+            panel_title: "build".to_string(),
+            line_text: "error: first failure".to_string(),
+            match_count_label: None,
+        }];
+
+        overlay.maybe_refresh_results_at(&Context::default(), &Board::new(), true, Instant::now());
+
+        assert_eq!(overlay.cached_results.total_matches, 0);
+        assert!(overlay.cached_results.panels.is_empty());
+        assert!(overlay.display_rows.is_empty());
+    }
+
+    #[test]
+    fn debounce_fires_after_window_expires() {
+        let mut overlay = SearchOverlay::new_inactive();
+        let ctx = Context::default();
+        let board = Board::new();
+        let edit_time = Instant::now();
+
+        overlay.query = "error".to_string();
+        overlay.note_query_changed(edit_time);
+
+        // Before debounce expires: should not search.
+        overlay.maybe_refresh_results_at(&ctx, &board, false, edit_time + Duration::from_millis(50));
+        assert!(overlay.last_query.is_empty());
+
+        // After debounce expires: should search.
+        overlay.maybe_refresh_results_at(&ctx, &board, false, edit_time + SearchOverlay::DEBOUNCE);
+        assert_eq!(overlay.last_query, overlay.query);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fixes to #65 (cross-terminal search).

## Changes

- **Dropdown stays interactive during clicks**: result rows and toggle buttons (Aa, .*) no longer dismiss the dropdown when clicked, because pointer position is checked against the dropdown rect before hiding
- **Live terminal output refresh**: results auto-update when terminals produce new output while a search query is active
- **Full scrollback search**: `Terminal::full_text_lines()` reads the grid directly (scrollback + screen) instead of only visible display content; preserves column positions during extraction
- **Precise debounce timing**: uses `remaining = DEBOUNCE - elapsed` for exact repaint scheduling
- **Tests**: dropdown visibility, debounce expiry, live refresh, clear state

## Test plan

- [ ] Type a query, click a toggle button (Aa or .*) -- dropdown should stay open
- [ ] Click a result row -- should navigate to panel without dropdown flickering
- [ ] Run a command in a terminal while search is active -- results should update
- [ ] Type fast -- debounce should prevent lag (one search after typing stops)
- [ ] Search for text in scrollback history -- should find matches beyond visible screen