### PR TITLE
fix(opencode): resolve sqlite path via platform data dir

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod git_status;
 pub mod git_watcher;
 mod horizon_home;
 mod layout;
+mod opencode_paths;
 mod panel;
 mod remote_hosts;
 mod runtime_state;

--- a/crates/horizon-core/src/opencode_paths.rs
+++ b/crates/horizon-core/src/opencode_paths.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+pub(crate) fn opencode_db_path() -> Option<PathBuf> {
+    opencode_db_path_with_env(
+        std::env::consts::OS,
+        env_path("HOME"),
+        env_path("USERPROFILE"),
+        env_path("XDG_DATA_HOME"),
+        env_path("APPDATA"),
+    )
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn opencode_db_path_with_env(
+    target_os: &str,
+    home: Option<PathBuf>,
+    user_profile: Option<PathBuf>,
+    xdg_data_home: Option<PathBuf>,
+    appdata: Option<PathBuf>,
+) -> Option<PathBuf> {
+    let data_dir = match target_os {
+        "macos" => home.map(|path| path.join("Library").join("Application Support")),
+        "windows" => appdata.or_else(|| user_profile.map(|path| path.join("AppData").join("Roaming"))),
+        _ => xdg_data_home.or_else(|| home.map(|path| path.join(".local").join("share"))),
+    }?;
+
+    Some(data_dir.join("opencode").join("opencode.db"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::opencode_db_path_with_env;
+
+    #[test]
+    fn linux_prefers_xdg_data_home() {
+        let path = opencode_db_path_with_env(
+            "linux",
+            Some(PathBuf::from("/home/tester")),
+            None,
+            Some(PathBuf::from("/tmp/data-home")),
+            None,
+        );
+
+        assert_eq!(path, Some(PathBuf::from("/tmp/data-home/opencode/opencode.db")));
+    }
+
+    #[test]
+    fn linux_falls_back_to_local_share() {
+        let path = opencode_db_path_with_env("linux", Some(PathBuf::from("/home/tester")), None, None, None);
+
+        assert_eq!(
+            path,
+            Some(PathBuf::from("/home/tester/.local/share/opencode/opencode.db"))
+        );
+    }
+
+    #[test]
+    fn macos_uses_application_support() {
+        let path = opencode_db_path_with_env("macos", Some(PathBuf::from("/Users/tester")), None, None, None);
+
+        assert_eq!(
+            path,
+            Some(PathBuf::from(
+                "/Users/tester/Library/Application Support/opencode/opencode.db"
+            ))
+        );
+    }
+
+    #[test]
+    fn windows_uses_appdata() {
+        let appdata = PathBuf::from(r"C:\Users\tester\AppData\Roaming");
+        let path = opencode_db_path_with_env(
+            "windows",
+            None,
+            Some(PathBuf::from(r"C:\Users\tester")),
+            None,
+            Some(appdata.clone()),
+        );
+
+        assert_eq!(path, Some(appdata.join("opencode").join("opencode.db")));
+    }
+
+    #[test]
+    fn windows_falls_back_to_userprofile_appdata() {
+        let user_profile = PathBuf::from(r"C:\Users\tester");
+        let path = opencode_db_path_with_env("windows", None, Some(user_profile.clone()), None, None);
+
+        assert_eq!(
+            path,
+            Some(
+                user_profile
+                    .join("AppData")
+                    .join("Roaming")
+                    .join("opencode")
+                    .join("opencode.db")
+            )
+        );
+    }
+}

--- a/crates/horizon-core/src/runtime_state/agent_sessions.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions.rs
@@ -7,6 +7,7 @@ use rusqlite::Connection;
 use serde_json::Value;
 
 use crate::error::{Error, Result};
+use crate::opencode_paths::opencode_db_path;
 
 use super::{AgentSessionBinding, PanelKind, normalize_cwd};
 
@@ -311,10 +312,9 @@ fn load_codex_sessions() -> Result<Vec<AgentSessionRecord>> {
 }
 
 fn load_opencode_sessions() -> Result<Vec<AgentSessionRecord>> {
-    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+    let Some(sqlite_path) = opencode_db_path() else {
         return Ok(Vec::new());
     };
-    let sqlite_path = home.join(".local").join("share").join("opencode").join("opencode.db");
     if !sqlite_path.exists() {
         return Ok(Vec::new());
     }

--- a/crates/horizon-core/src/usage_stats.rs
+++ b/crates/horizon-core/src/usage_stats.rs
@@ -4,6 +4,8 @@ use std::time::Instant;
 
 use serde::Deserialize;
 
+use crate::opencode_paths::opencode_db_path;
+
 const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Snapshot of usage statistics for Claude Code, Codex CLI, and `OpenCode`.
@@ -388,7 +390,7 @@ struct OpenCodeDayRow {
 }
 
 fn load_opencode_stats() -> Vec<OpenCodeDayRow> {
-    let Some(path) = home_dir().map(|h| h.join(".local/share/opencode/opencode.db")) else {
+    let Some(path) = opencode_db_path() else {
         return Vec::new();
     };
     if !path.exists() {


### PR DESCRIPTION
## Summary
- resolve the OpenCode SQLite path from the platform data directory instead of a Linux-only default path
- share that resolver between agent session discovery and usage stats polling
- add regression coverage for Linux XDG, macOS Application Support, and Windows AppData paths

## Testing
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic