### PR TITLE
fix(ui): make root chrome responsive on narrow desktops

### DIFF
--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -87,8 +87,9 @@ mod tests {
         detached_workspace_ids,
     };
     use super::{align_attached_workspaces, inherit_workspace_cwd, update_workspace_cwd, workspace_cwd};
+    use crate::app::TOOLBAR_HEIGHT;
+    use crate::app::root_chrome::effective_sidebar_width;
     use crate::app::settings::SETTINGS_BAR_HEIGHT;
-    use crate::app::{SIDEBAR_WIDTH, TOOLBAR_HEIGHT};
 
     #[test]
     fn inherit_workspace_cwd_populates_missing_panel_cwd() {
@@ -211,10 +212,11 @@ mod tests {
         let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1200.0, 800.0));
         let settings_panel = Rect::from_min_max(Pos2::new(840.0, TOOLBAR_HEIGHT), Pos2::new(1200.0, 752.0));
         let settings_bar = Rect::from_min_max(Pos2::new(0.0, 800.0 - SETTINGS_BAR_HEIGHT), Pos2::new(1200.0, 800.0));
+        let sidebar_width = effective_sidebar_width(viewport.width());
 
-        let rect = canvas_rect_for_layout(viewport, true, Some(settings_panel), Some(settings_bar));
+        let rect = canvas_rect_for_layout(viewport, sidebar_width, Some(settings_panel), Some(settings_bar));
 
-        assert_eq!(rect.min, Pos2::new(SIDEBAR_WIDTH, TOOLBAR_HEIGHT));
+        assert_eq!(rect.min, Pos2::new(sidebar_width, TOOLBAR_HEIGHT));
         assert_eq!(rect.max, Pos2::new(840.0, 800.0 - SETTINGS_BAR_HEIGHT));
     }
 

--- a/crates/horizon-ui/src/app/actions/layout.rs
+++ b/crates/horizon-ui/src/app/actions/layout.rs
@@ -6,9 +6,10 @@ use egui::{Context, Id, Pos2, Rect, Vec2};
 use horizon_core::{PanelId, WorkspaceId};
 
 use crate::app::attention_feed::estimated_outer_rect;
+use crate::app::root_chrome::effective_sidebar_width;
 use crate::app::settings::{SETTINGS_BAR_HEIGHT, SETTINGS_BAR_ID, SETTINGS_PANEL_ID, settings_panel_default_width};
 use crate::app::util::{OverlayExclusion, viewport_local_rect};
-use crate::app::{HorizonApp, MINIMAP_MARGIN, MINIMAP_PAD, SIDEBAR_WIDTH, TOOLBAR_HEIGHT};
+use crate::app::{HorizonApp, MINIMAP_MARGIN, MINIMAP_PAD, TOOLBAR_HEIGHT};
 
 pub(super) fn panel_focus_target_at_pointer_press(
     panel_order: &[PanelId],
@@ -49,7 +50,12 @@ impl HorizonApp {
         let viewport = viewport_local_rect(ctx);
         let settings_panel_rect = self.settings_panel_rect(ctx, viewport);
         let settings_bar_rect = self.settings_bar_rect(ctx, viewport);
-        canvas_rect_for_layout(viewport, self.sidebar_visible, settings_panel_rect, settings_bar_rect)
+        let sidebar_width = if self.sidebar_visible {
+            effective_sidebar_width(viewport.width())
+        } else {
+            0.0
+        };
+        canvas_rect_for_layout(viewport, sidebar_width, settings_panel_rect, settings_bar_rect)
     }
 
     pub(in crate::app) fn fixed_overlays_visible(&self) -> bool {
@@ -78,11 +84,16 @@ impl HorizonApp {
     pub(in crate::app) fn overlay_exclusion_zones(&self, ctx: &Context) -> OverlayExclusion {
         let viewport = viewport_local_rect(ctx);
         let mut zones = Vec::new();
+        let sidebar_width = if self.sidebar_visible {
+            effective_sidebar_width(viewport.width())
+        } else {
+            0.0
+        };
 
-        if self.sidebar_visible {
+        if sidebar_width > 0.0 {
             zones.push(Rect::from_min_max(
                 Pos2::new(viewport.min.x, viewport.min.y + TOOLBAR_HEIGHT),
-                Pos2::new(viewport.min.x + SIDEBAR_WIDTH, viewport.max.y),
+                Pos2::new(viewport.min.x + sidebar_width, viewport.max.y),
             ));
         }
 
@@ -154,15 +165,11 @@ impl HorizonApp {
 
 pub(super) fn canvas_rect_for_layout(
     viewport: Rect,
-    sidebar_visible: bool,
+    sidebar_width: f32,
     settings_panel_rect: Option<Rect>,
     settings_bar_rect: Option<Rect>,
 ) -> Rect {
-    let left = if sidebar_visible {
-        viewport.min.x + SIDEBAR_WIDTH
-    } else {
-        viewport.min.x
-    };
+    let left = viewport.min.x + sidebar_width;
     let right = settings_panel_rect.map_or(viewport.max.x, |rect| rect.min.x);
     let bottom = settings_bar_rect.map_or(viewport.max.y, |rect| rect.min.y);
 

--- a/crates/horizon-ui/src/app/canvas.rs
+++ b/crates/horizon-ui/src/app/canvas.rs
@@ -8,8 +8,9 @@ use horizon_core::WorkspaceId;
 
 use crate::theme;
 
-use super::util::{format_grid_position, paint_canvas_glow, rounded_i32};
-use super::{HorizonApp, MINIMAP_MARGIN, MINIMAP_PAD, SIDEBAR_WIDTH, WS_BG_PAD, WS_EMPTY_SIZE, WS_TITLE_HEIGHT};
+use super::root_chrome::effective_sidebar_width;
+use super::util::{format_grid_position, paint_canvas_glow, rounded_i32, viewport_local_rect};
+use super::{HorizonApp, MINIMAP_MARGIN, MINIMAP_PAD, WS_BG_PAD, WS_EMPTY_SIZE, WS_TITLE_HEIGHT};
 
 const GRID_SPACING: f32 = 22.0;
 const GRID_DOT_DIAMETER: f32 = 2.3;
@@ -245,7 +246,7 @@ impl HorizonApp {
             );
 
         let hud_left = if self.sidebar_visible {
-            SIDEBAR_WIDTH + 16.0
+            effective_sidebar_width(viewport_local_rect(ctx).width()) + 16.0
         } else {
             16.0
         };

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -8,6 +8,7 @@ mod panel_chrome;
 mod panels;
 mod persistence;
 mod remote_hosts;
+mod root_chrome;
 mod session;
 mod settings;
 pub(crate) mod shortcuts;

--- a/crates/horizon-ui/src/app/root_chrome.rs
+++ b/crates/horizon-ui/src/app/root_chrome.rs
@@ -1,0 +1,248 @@
+use egui::{Pos2, Rect, Vec2};
+
+use super::{SIDEBAR_WIDTH, TOOLBAR_HEIGHT};
+
+pub(super) const ROOT_TOOLBAR_BUTTON_HEIGHT: f32 = 30.0;
+pub(super) const ROOT_TOOLBAR_BUTTON_GAP: f32 = 8.0;
+
+const ROOT_TOOLBAR_HORIZONTAL_PAD: f32 = 14.0;
+const ROOT_TOOLBAR_VERTICAL_PAD: f32 = 8.0;
+const ROOT_TOOLBAR_CLUSTER_GAP: f32 = 12.0;
+const ROOT_TOOLBAR_SEARCH_MIN_WIDTH: f32 = 180.0;
+const ROOT_TOOLBAR_SEARCH_MAX_WIDTH: f32 = 420.0;
+const ROOT_TOOLBAR_MORE_WIDTH: f32 = 72.0;
+const ROOT_TOOLBAR_NAME_WIDTH: f32 = 72.0;
+const ROOT_TOOLBAR_TAGLINE_WIDTH: f32 = 324.0;
+const SIDEBAR_WIDTH_RATIO: f32 = 0.18;
+
+pub(super) const SIDEBAR_MIN_WIDTH: f32 = 168.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ToolbarAction {
+    NewWorkspace,
+    QuickNav,
+    FitWorkspace,
+    RemoteHosts,
+    Settings,
+}
+
+impl ToolbarAction {
+    const SECONDARY: [Self; 2] = [Self::FitWorkspace, Self::RemoteHosts];
+
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::NewWorkspace => "New Workspace",
+            Self::QuickNav => "Quick Nav",
+            Self::FitWorkspace => "Fit Workspace",
+            Self::RemoteHosts => "Remote Hosts",
+            Self::Settings => "Settings",
+        }
+    }
+
+    fn estimated_width(self) -> f32 {
+        estimated_toolbar_button_width(self.label())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ToolbarItem {
+    Action(ToolbarAction),
+    OverflowMenu,
+}
+
+impl ToolbarItem {
+    fn estimated_width(self) -> f32 {
+        match self {
+            Self::Action(action) => action.estimated_width(),
+            Self::OverflowMenu => ROOT_TOOLBAR_MORE_WIDTH,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct RootToolbarLayout {
+    pub(super) brand_rect: Rect,
+    pub(super) search_rect: Rect,
+    pub(super) actions_rect: Rect,
+    pub(super) visible_items: Vec<ToolbarItem>,
+    pub(super) overflow_actions: Vec<ToolbarAction>,
+    pub(super) show_tagline: bool,
+}
+
+struct RootToolbarCandidate {
+    layout: RootToolbarLayout,
+    search_available: f32,
+}
+
+pub(super) fn effective_sidebar_width(viewport_width: f32) -> f32 {
+    (viewport_width * SIDEBAR_WIDTH_RATIO).clamp(SIDEBAR_MIN_WIDTH, SIDEBAR_WIDTH)
+}
+
+pub(super) fn root_toolbar_layout(viewport: Rect) -> RootToolbarLayout {
+    let content_rect = Rect::from_min_max(
+        Pos2::new(
+            viewport.min.x + ROOT_TOOLBAR_HORIZONTAL_PAD,
+            viewport.min.y + ROOT_TOOLBAR_VERTICAL_PAD,
+        ),
+        Pos2::new(
+            viewport.max.x - ROOT_TOOLBAR_HORIZONTAL_PAD,
+            viewport.min.y + TOOLBAR_HEIGHT - ROOT_TOOLBAR_VERTICAL_PAD,
+        ),
+    );
+
+    let states = [(true, 2_usize), (false, 2_usize), (false, 1_usize), (false, 0_usize)];
+    let mut fallback = layout_candidate(viewport, content_rect, false, 0);
+
+    for (show_tagline, secondary_visible) in states {
+        let candidate = layout_candidate(viewport, content_rect, show_tagline, secondary_visible);
+        if candidate.search_available >= ROOT_TOOLBAR_SEARCH_MIN_WIDTH {
+            return candidate.layout;
+        }
+        fallback = candidate;
+    }
+
+    fallback.layout
+}
+
+fn layout_candidate(
+    viewport: Rect,
+    content_rect: Rect,
+    show_tagline: bool,
+    secondary_visible: usize,
+) -> RootToolbarCandidate {
+    let brand_width = ROOT_TOOLBAR_NAME_WIDTH
+        + if show_tagline {
+            ROOT_TOOLBAR_BUTTON_GAP + ROOT_TOOLBAR_TAGLINE_WIDTH
+        } else {
+            0.0
+        };
+    let brand_rect = Rect::from_min_size(content_rect.min, Vec2::new(brand_width, content_rect.height()));
+
+    let mut visible_items = vec![
+        ToolbarItem::Action(ToolbarAction::NewWorkspace),
+        ToolbarItem::Action(ToolbarAction::QuickNav),
+    ];
+    for action in ToolbarAction::SECONDARY.iter().take(secondary_visible).copied() {
+        visible_items.push(ToolbarItem::Action(action));
+    }
+
+    let overflow_actions = ToolbarAction::SECONDARY
+        .iter()
+        .skip(secondary_visible)
+        .copied()
+        .collect::<Vec<_>>();
+    if !overflow_actions.is_empty() {
+        visible_items.push(ToolbarItem::OverflowMenu);
+    }
+    visible_items.push(ToolbarItem::Action(ToolbarAction::Settings));
+
+    let actions_width = visible_items_width(&visible_items);
+    let actions_left = content_rect.max.x - actions_width;
+    let actions_rect = Rect::from_min_size(
+        Pos2::new(actions_left, content_rect.min.y),
+        Vec2::new(actions_width, content_rect.height()),
+    );
+
+    let search_left_bound = brand_rect.max.x + ROOT_TOOLBAR_CLUSTER_GAP;
+    let search_right_bound = actions_rect.min.x - ROOT_TOOLBAR_CLUSTER_GAP;
+    let search_available = (search_right_bound - search_left_bound).max(0.0);
+    let search_width = search_available.min(ROOT_TOOLBAR_SEARCH_MAX_WIDTH);
+    let search_left = search_left_bound + ((search_available - search_width) * 0.5);
+    let search_rect = Rect::from_center_size(
+        Pos2::new(search_left + search_width * 0.5, viewport.min.y + TOOLBAR_HEIGHT * 0.5),
+        Vec2::new(search_width, TOOLBAR_HEIGHT - 14.0),
+    );
+
+    RootToolbarCandidate {
+        layout: RootToolbarLayout {
+            brand_rect,
+            search_rect,
+            actions_rect,
+            visible_items,
+            overflow_actions,
+            show_tagline,
+        },
+        search_available,
+    }
+}
+
+fn visible_items_width(items: &[ToolbarItem]) -> f32 {
+    let gaps = items
+        .len()
+        .saturating_sub(1)
+        .try_into()
+        .map_or(0.0, |count: u16| f32::from(count) * ROOT_TOOLBAR_BUTTON_GAP);
+    items.iter().map(|item| item.estimated_width()).sum::<f32>() + gaps
+}
+
+fn estimated_toolbar_button_width(label: &str) -> f32 {
+    let chars = u16::try_from(label.chars().count()).map_or(f32::from(u16::MAX), f32::from);
+    34.0 + chars * 7.2
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::{Pos2, Rect};
+
+    use super::{ToolbarAction, ToolbarItem, effective_sidebar_width, root_toolbar_layout};
+    use crate::app::{SIDEBAR_WIDTH, TOOLBAR_HEIGHT};
+
+    #[test]
+    fn sidebar_width_shrinks_on_narrow_desktop_viewports() {
+        assert!((effective_sidebar_width(1600.0) - SIDEBAR_WIDTH).abs() <= f32::EPSILON);
+        assert!(effective_sidebar_width(1024.0) < SIDEBAR_WIDTH);
+        assert!((effective_sidebar_width(800.0) - super::SIDEBAR_MIN_WIDTH).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn toolbar_hides_tagline_before_collapsing_actions() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1024.0, 768.0));
+        let layout = root_toolbar_layout(viewport);
+
+        assert!(!layout.show_tagline);
+        assert!(layout.overflow_actions.is_empty());
+        assert!(
+            layout
+                .visible_items
+                .contains(&ToolbarItem::Action(ToolbarAction::RemoteHosts))
+        );
+        assert!(layout.search_rect.width() >= 180.0);
+    }
+
+    #[test]
+    fn toolbar_moves_secondary_actions_into_overflow_on_tighter_widths() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(900.0, 768.0));
+        let layout = root_toolbar_layout(viewport);
+
+        assert!(!layout.show_tagline);
+        assert_eq!(layout.overflow_actions, vec![ToolbarAction::RemoteHosts]);
+        assert!(layout.visible_items.contains(&ToolbarItem::OverflowMenu));
+        assert!((layout.search_rect.center().y - TOOLBAR_HEIGHT * 0.5).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn toolbar_keeps_primary_actions_visible_at_min_window_width() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(800.0, 600.0));
+        let layout = root_toolbar_layout(viewport);
+
+        assert_eq!(
+            layout.overflow_actions,
+            vec![ToolbarAction::FitWorkspace, ToolbarAction::RemoteHosts]
+        );
+        assert!(
+            layout
+                .visible_items
+                .contains(&ToolbarItem::Action(ToolbarAction::NewWorkspace))
+        );
+        assert!(
+            layout
+                .visible_items
+                .contains(&ToolbarItem::Action(ToolbarAction::QuickNav))
+        );
+        assert!(
+            layout
+                .visible_items
+                .contains(&ToolbarItem::Action(ToolbarAction::Settings))
+        );
+    }
+}

--- a/crates/horizon-ui/src/app/sidebar.rs
+++ b/crates/horizon-ui/src/app/sidebar.rs
@@ -1,13 +1,14 @@
-use egui::{
-    Align, Button, Color32, Context, CornerRadius, Id, Layout, Order, Pos2, Rect, Sense, Stroke, UiBuilder, Vec2,
-};
+mod toolbar;
+
+use egui::{Button, Color32, Context, CornerRadius, Id, Order, Pos2, Rect, Sense, Stroke, Vec2};
 use horizon_core::{AttentionSeverity, PanelId, WorkspaceId, WorkspaceLayout};
 
-use crate::{branding, theme};
+use crate::theme;
 
 use super::panels::panel_kind_icon;
+use super::root_chrome::effective_sidebar_width;
 use super::util;
-use super::{HorizonApp, SIDEBAR_WIDTH, TOOLBAR_HEIGHT, WS_BG_PAD, WS_TITLE_HEIGHT};
+use super::{HorizonApp, TOOLBAR_HEIGHT, WS_BG_PAD, WS_TITLE_HEIGHT};
 
 struct WorkspaceSidebarEntry {
     id: WorkspaceId,
@@ -33,114 +34,6 @@ struct SidebarActions {
 }
 
 impl HorizonApp {
-    pub(super) fn render_toolbar(&mut self, ctx: &Context) {
-        let viewport = util::viewport_local_rect(ctx);
-        egui::Area::new(Id::new("toolbar"))
-            .fixed_pos(viewport.min)
-            .constrain(false)
-            .order(Order::Tooltip)
-            .show(ctx, |ui| {
-                ui.set_min_size(Vec2::new(viewport.width(), TOOLBAR_HEIGHT));
-                ui.set_max_size(Vec2::new(viewport.width(), TOOLBAR_HEIGHT));
-                ui.painter().rect_filled(
-                    Rect::from_min_size(viewport.min, Vec2::new(viewport.width(), TOOLBAR_HEIGHT)),
-                    CornerRadius::ZERO,
-                    theme::TITLEBAR_BG,
-                );
-                ui.painter().line_segment(
-                    [
-                        Pos2::new(viewport.min.x, viewport.min.y + TOOLBAR_HEIGHT),
-                        Pos2::new(viewport.max.x, viewport.min.y + TOOLBAR_HEIGHT),
-                    ],
-                    Stroke::new(1.0, theme::alpha(theme::BORDER_SUBTLE, 170)),
-                );
-
-                let content_rect = Rect::from_min_max(
-                    Pos2::new(viewport.min.x + 14.0, viewport.min.y + 8.0),
-                    Pos2::new(viewport.max.x - 14.0, viewport.min.y + TOOLBAR_HEIGHT - 8.0),
-                );
-                ui.scope_builder(
-                    UiBuilder::new()
-                        .max_rect(content_rect)
-                        .layout(Layout::left_to_right(Align::Center)),
-                    |ui| {
-                        ui.label(
-                            egui::RichText::new(branding::APP_NAME)
-                                .color(theme::FG)
-                                .size(14.0)
-                                .strong(),
-                        );
-                        ui.label(
-                            egui::RichText::new(branding::APP_TAGLINE)
-                                .color(theme::FG_DIM)
-                                .size(10.5),
-                        );
-                        self.render_toolbar_actions(ui);
-                    },
-                );
-
-                // Search bar centered inside the toolbar area.
-                let search_width = (viewport.width() * 0.28).clamp(220.0, 520.0);
-                let search_rect = Rect::from_center_size(
-                    Pos2::new(
-                        viewport.min.x + viewport.width() * 0.5,
-                        viewport.min.y + TOOLBAR_HEIGHT * 0.5,
-                    ),
-                    Vec2::new(search_width, TOOLBAR_HEIGHT - 14.0),
-                );
-                let mut search_ui = ui.new_child(
-                    UiBuilder::new()
-                        .max_rect(search_rect)
-                        .layout(Layout::left_to_right(Align::Center)),
-                );
-                self.render_toolbar_search(&mut search_ui);
-            });
-    }
-
-    fn render_toolbar_actions(&mut self, ui: &mut egui::Ui) {
-        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-            ui.add_space(8.0);
-            if ui.add(util::chrome_button("Settings")).clicked() {
-                self.toggle_settings();
-            }
-            ui.add_space(8.0);
-            let remote_hosts_button = ui.add(util::chrome_button("Remote Hosts")).on_hover_text(
-                self.shortcuts
-                    .open_remote_hosts
-                    .display_label(util::primary_shortcut_label()),
-            );
-            if remote_hosts_button.clicked() {
-                self.toggle_remote_hosts_overlay(ui.ctx());
-            }
-            ui.add_space(8.0);
-            let fit_workspace_button =
-                ui.add_enabled(self.has_attached_workspace(), util::chrome_button("Fit Workspace"));
-            let fit_workspace_button = fit_workspace_button.on_hover_text(
-                self.shortcuts
-                    .fit_active_workspace
-                    .display_label(util::primary_shortcut_label()),
-            );
-            if fit_workspace_button.clicked() {
-                self.execute_command(ui.ctx(), &crate::command_registry::CommandId::FitActiveWorkspace);
-            }
-            ui.add_space(8.0);
-            let quick_nav_button = ui.add(util::chrome_button("Quick Nav")).on_hover_text(
-                self.shortcuts
-                    .command_palette
-                    .display_label(util::primary_shortcut_label()),
-            );
-            if quick_nav_button.clicked() {
-                self.open_command_palette();
-            }
-            ui.add_space(8.0);
-            if ui.add(util::chrome_button("New Workspace")).clicked() {
-                let name = format!("Workspace {}", self.board.workspaces.len() + 1);
-                self.create_workspace_visible(ui.ctx(), &name);
-            }
-            ui.add_space(8.0);
-        });
-    }
-
     fn has_attached_workspace(&self) -> bool {
         self.board
             .workspaces
@@ -155,7 +48,8 @@ impl HorizonApp {
 
         let viewport = util::viewport_local_rect(ctx);
         let sidebar_origin = Pos2::new(viewport.min.x, viewport.min.y + TOOLBAR_HEIGHT);
-        let sidebar_size = Vec2::new(SIDEBAR_WIDTH, viewport.height() - TOOLBAR_HEIGHT);
+        let sidebar_width = effective_sidebar_width(viewport.width());
+        let sidebar_size = Vec2::new(sidebar_width, viewport.height() - TOOLBAR_HEIGHT);
         let workspace_data = self.sidebar_workspace_data();
         let mut actions = SidebarActions::default();
 
@@ -164,7 +58,7 @@ impl HorizonApp {
             .constrain(false)
             .order(Order::Tooltip)
             .show(ctx, |ui| {
-                Self::paint_sidebar_frame(ui, sidebar_origin, sidebar_size);
+                Self::paint_sidebar_frame(ui, sidebar_origin, sidebar_size, sidebar_width);
                 self.render_sidebar_contents(ui, &workspace_data, &mut actions);
             });
 
@@ -201,7 +95,7 @@ impl HorizonApp {
             .collect()
     }
 
-    fn paint_sidebar_frame(ui: &mut egui::Ui, sidebar_origin: Pos2, sidebar_size: Vec2) {
+    fn paint_sidebar_frame(ui: &mut egui::Ui, sidebar_origin: Pos2, sidebar_size: Vec2, sidebar_width: f32) {
         ui.set_min_size(sidebar_size);
         ui.set_max_size(sidebar_size);
         ui.painter().rect_filled(
@@ -211,8 +105,8 @@ impl HorizonApp {
         );
         ui.painter().line_segment(
             [
-                Pos2::new(sidebar_origin.x + SIDEBAR_WIDTH, sidebar_origin.y),
-                Pos2::new(sidebar_origin.x + SIDEBAR_WIDTH, sidebar_origin.y + sidebar_size.y),
+                Pos2::new(sidebar_origin.x + sidebar_width, sidebar_origin.y),
+                Pos2::new(sidebar_origin.x + sidebar_width, sidebar_origin.y + sidebar_size.y),
             ],
             Stroke::new(1.0, theme::BORDER_SUBTLE),
         );

--- a/crates/horizon-ui/src/app/sidebar/toolbar.rs
+++ b/crates/horizon-ui/src/app/sidebar/toolbar.rs
@@ -1,0 +1,195 @@
+use egui::{Align, Context, CornerRadius, Id, Layout, Order, Pos2, Rect, Stroke, UiBuilder, Vec2};
+
+use crate::app::root_chrome::{
+    ROOT_TOOLBAR_BUTTON_GAP, ROOT_TOOLBAR_BUTTON_HEIGHT, RootToolbarLayout, ToolbarAction, ToolbarItem,
+    root_toolbar_layout,
+};
+use crate::app::util;
+use crate::app::{HorizonApp, TOOLBAR_HEIGHT};
+use crate::{branding, theme};
+
+impl HorizonApp {
+    pub(in crate::app) fn render_toolbar(&mut self, ctx: &Context) {
+        let viewport = util::viewport_local_rect(ctx);
+        let layout = root_toolbar_layout(viewport);
+
+        egui::Area::new(Id::new("toolbar"))
+            .fixed_pos(viewport.min)
+            .constrain(false)
+            .order(Order::Tooltip)
+            .show(ctx, |ui| {
+                ui.set_min_size(Vec2::new(viewport.width(), TOOLBAR_HEIGHT));
+                ui.set_max_size(Vec2::new(viewport.width(), TOOLBAR_HEIGHT));
+                ui.painter().rect_filled(
+                    Rect::from_min_size(viewport.min, Vec2::new(viewport.width(), TOOLBAR_HEIGHT)),
+                    CornerRadius::ZERO,
+                    theme::TITLEBAR_BG,
+                );
+                ui.painter().line_segment(
+                    [
+                        Pos2::new(viewport.min.x, viewport.min.y + TOOLBAR_HEIGHT),
+                        Pos2::new(viewport.max.x, viewport.min.y + TOOLBAR_HEIGHT),
+                    ],
+                    Stroke::new(1.0, theme::alpha(theme::BORDER_SUBTLE, 170)),
+                );
+
+                Self::render_toolbar_brand(ui, &layout);
+                self.render_toolbar_search_rect(ui, &layout);
+                self.render_toolbar_actions(ui, &layout);
+            });
+    }
+
+    fn render_toolbar_brand(ui: &mut egui::Ui, layout: &RootToolbarLayout) {
+        ui.scope_builder(
+            UiBuilder::new()
+                .max_rect(layout.brand_rect)
+                .layout(Layout::left_to_right(Align::Center)),
+            |ui| {
+                ui.label(
+                    egui::RichText::new(branding::APP_NAME)
+                        .color(theme::FG)
+                        .size(14.0)
+                        .strong(),
+                );
+                if layout.show_tagline {
+                    ui.add_space(ROOT_TOOLBAR_BUTTON_GAP);
+                    ui.label(
+                        egui::RichText::new(branding::APP_TAGLINE)
+                            .color(theme::FG_DIM)
+                            .size(10.5),
+                    );
+                }
+            },
+        );
+    }
+
+    fn render_toolbar_search_rect(&mut self, ui: &mut egui::Ui, layout: &RootToolbarLayout) {
+        let mut search_ui = ui.new_child(
+            UiBuilder::new()
+                .max_rect(layout.search_rect)
+                .layout(Layout::left_to_right(Align::Center)),
+        );
+        self.render_toolbar_search(&mut search_ui);
+    }
+
+    fn render_toolbar_actions(&mut self, ui: &mut egui::Ui, layout: &RootToolbarLayout) {
+        ui.scope_builder(
+            UiBuilder::new()
+                .max_rect(layout.actions_rect)
+                .layout(Layout::left_to_right(Align::Center)),
+            |ui| {
+                ui.spacing_mut().item_spacing.x = ROOT_TOOLBAR_BUTTON_GAP;
+
+                for item in &layout.visible_items {
+                    match *item {
+                        ToolbarItem::Action(action) => self.render_toolbar_action_button(ui, action),
+                        ToolbarItem::OverflowMenu => self.render_toolbar_overflow_menu(ui, &layout.overflow_actions),
+                    }
+                }
+            },
+        );
+    }
+
+    fn render_toolbar_action_button(&mut self, ui: &mut egui::Ui, action: ToolbarAction) {
+        let response = match action {
+            ToolbarAction::FitWorkspace => ui
+                .add_enabled(
+                    self.has_attached_workspace(),
+                    util::chrome_button(action.label())
+                        .min_size(Vec2::new(action_button_width(action), ROOT_TOOLBAR_BUTTON_HEIGHT)),
+                )
+                .on_hover_text(
+                    self.shortcuts
+                        .fit_active_workspace
+                        .display_label(util::primary_shortcut_label()),
+                ),
+            ToolbarAction::QuickNav => ui
+                .add(
+                    util::chrome_button(action.label())
+                        .min_size(Vec2::new(action_button_width(action), ROOT_TOOLBAR_BUTTON_HEIGHT)),
+                )
+                .on_hover_text(
+                    self.shortcuts
+                        .command_palette
+                        .display_label(util::primary_shortcut_label()),
+                ),
+            ToolbarAction::RemoteHosts => ui
+                .add(
+                    util::chrome_button(action.label())
+                        .min_size(Vec2::new(action_button_width(action), ROOT_TOOLBAR_BUTTON_HEIGHT)),
+                )
+                .on_hover_text(
+                    self.shortcuts
+                        .open_remote_hosts
+                        .display_label(util::primary_shortcut_label()),
+                ),
+            ToolbarAction::NewWorkspace | ToolbarAction::Settings => ui.add(
+                util::chrome_button(action.label())
+                    .min_size(Vec2::new(action_button_width(action), ROOT_TOOLBAR_BUTTON_HEIGHT)),
+            ),
+        };
+
+        if response.clicked() {
+            self.perform_toolbar_action(ui.ctx(), action);
+        }
+    }
+
+    fn render_toolbar_overflow_menu(&mut self, ui: &mut egui::Ui, overflow_actions: &[ToolbarAction]) {
+        ui.scope(|ui| {
+            ui.style_mut().spacing.button_padding = Vec2::new(12.0, 7.0);
+            ui.menu_button(egui::RichText::new("More").size(11.0).color(theme::FG_SOFT), |ui| {
+                ui.set_min_width(160.0);
+
+                for action in overflow_actions {
+                    let mut button =
+                        egui::Button::new(egui::RichText::new(action.label()).size(12.0).color(theme::FG_SOFT))
+                            .frame(false);
+
+                    if *action == ToolbarAction::FitWorkspace {
+                        button = button.sense(if self.has_attached_workspace() {
+                            egui::Sense::click()
+                        } else {
+                            egui::Sense::hover()
+                        });
+                    }
+
+                    let response = if *action == ToolbarAction::FitWorkspace {
+                        ui.add_enabled(self.has_attached_workspace(), button)
+                    } else {
+                        ui.add(button)
+                    };
+
+                    if response.clicked() {
+                        self.perform_toolbar_action(ui.ctx(), *action);
+                        ui.close();
+                    }
+                }
+            });
+        });
+    }
+
+    fn perform_toolbar_action(&mut self, ctx: &Context, action: ToolbarAction) {
+        match action {
+            ToolbarAction::NewWorkspace => {
+                let name = format!("Workspace {}", self.board.workspaces.len() + 1);
+                self.create_workspace_visible(ctx, &name);
+            }
+            ToolbarAction::QuickNav => self.open_command_palette(),
+            ToolbarAction::FitWorkspace => {
+                self.execute_command(ctx, &crate::command_registry::CommandId::FitActiveWorkspace);
+            }
+            ToolbarAction::RemoteHosts => self.toggle_remote_hosts_overlay(ctx),
+            ToolbarAction::Settings => self.toggle_settings(),
+        }
+    }
+}
+
+fn action_button_width(action: ToolbarAction) -> f32 {
+    match action {
+        ToolbarAction::NewWorkspace => 128.0,
+        ToolbarAction::QuickNav => 102.0,
+        ToolbarAction::FitWorkspace => 126.0,
+        ToolbarAction::RemoteHosts => 120.0,
+        ToolbarAction::Settings => 92.0,
+    }
+}


### PR DESCRIPTION
## Summary

Closes #82.

- add a responsive root-chrome layout model for the toolbar and sidebar reservation math
- keep the root toolbar on one row while hiding the tagline and then overflowing secondary actions as width shrinks
- make the sidebar reservation adaptive so the canvas, HUD, and overlay exclusion zones track the real sidebar width

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- live root-window screenshots captured after launch at about `1480x920`, after resize at `1024x768`, and at `800x600` to confirm overflow behavior
