### PR TITLE
fix(input): suppress leaked space during canvas pan drag

### DIFF
--- a/crates/horizon-ui/src/app/actions/interaction.rs
+++ b/crates/horizon-ui/src/app/actions/interaction.rs
@@ -1,7 +1,112 @@
-use egui::{Context, Rect, Vec2};
+use std::mem;
 
-use crate::app::HorizonApp;
+use egui::{Context, Event, Key, Modifiers, Rect, Vec2};
+
 use crate::app::shortcuts::shortcut_pressed;
+use crate::app::{CanvasPanSpaceKeyState, HorizonApp};
+
+impl CanvasPanSpaceKeyState {
+    fn filter_terminal_events(&mut self, events: &[Event], space_drag_claimed: bool) -> Vec<Event> {
+        let mut filtered = Vec::with_capacity(events.len());
+
+        if space_drag_claimed && matches!(self, Self::Pending(_)) {
+            *self = Self::Consumed;
+        }
+
+        for event in events {
+            if self.handle_space_event(event, space_drag_claimed, &mut filtered) {
+                continue;
+            }
+
+            if matches!(self, Self::Pending(_)) {
+                filtered.extend(self.flush_pending());
+            }
+
+            filtered.push(event.clone());
+        }
+
+        filtered
+    }
+
+    fn handle_space_event(&mut self, event: &Event, space_drag_claimed: bool, filtered: &mut Vec<Event>) -> bool {
+        match self {
+            Self::Idle => {
+                if is_space_pan_start_event(event) {
+                    if space_drag_claimed {
+                        *self = Self::Consumed;
+                    } else {
+                        *self = Self::Pending(vec![event.clone()]);
+                    }
+                    return true;
+                }
+            }
+            Self::Pending(pending) => {
+                if is_space_pan_related_event(event) {
+                    pending.push(event.clone());
+                    if space_drag_claimed {
+                        *self = Self::Consumed;
+                    } else if is_space_key_release(event) {
+                        filtered.extend(self.flush_pending());
+                    }
+                    return true;
+                }
+            }
+            Self::Consumed => {
+                if is_space_pan_related_event(event) {
+                    if is_space_key_release(event) {
+                        *self = Self::Idle;
+                    }
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    fn flush_pending(&mut self) -> Vec<Event> {
+        match mem::take(self) {
+            Self::Pending(events) => events,
+            state => {
+                *self = state;
+                Vec::new()
+            }
+        }
+    }
+}
+
+fn is_space_pan_start_event(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Key {
+            key: Key::Space,
+            pressed: true,
+            repeat: false,
+            modifiers,
+            ..
+        } if space_drag_modifier_active(*modifiers)
+    )
+}
+
+fn is_space_pan_related_event(event: &Event) -> bool {
+    matches!(event, Event::Key { key: Key::Space, .. })
+        || matches!(event, Event::Text(text) | Event::Ime(egui::ImeEvent::Commit(text)) if text == " ")
+}
+
+fn is_space_key_release(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Key {
+            key: Key::Space,
+            pressed: false,
+            ..
+        }
+    )
+}
+
+fn space_drag_modifier_active(modifiers: Modifiers) -> bool {
+    !modifiers.ctrl && !modifiers.command && !modifiers.alt
+}
 
 impl HorizonApp {
     pub(in crate::app) fn handle_fullscreen_toggle(&mut self, ctx: &Context) {
@@ -40,30 +145,49 @@ impl HorizonApp {
 
     #[profiling::function]
     pub(in crate::app) fn handle_canvas_pan_in_rect(&mut self, ctx: &Context, canvas_rect: Rect) {
-        let (pointer_position, middle_down, primary_down, space_down, modifiers, scroll, pointer_delta, zoom_delta) =
-            ctx.input(|input| {
-                (
-                    input.pointer.hover_pos(),
-                    input.pointer.middle_down(),
-                    input.pointer.primary_down(),
-                    input.key_down(egui::Key::Space),
-                    input.modifiers,
-                    input.smooth_scroll_delta + input.raw_scroll_delta,
-                    input.pointer.delta(),
-                    input.zoom_delta(),
-                )
-            });
+        let (
+            events,
+            pointer_position,
+            middle_down,
+            primary_down,
+            space_down,
+            modifiers,
+            scroll,
+            pointer_delta,
+            zoom_delta,
+        ) = ctx.input(|input| {
+            (
+                input.events.clone(),
+                input.pointer.interact_pos().or_else(|| input.pointer.hover_pos()),
+                input.pointer.middle_down(),
+                input.pointer.primary_down(),
+                input.key_down(egui::Key::Space),
+                input.modifiers,
+                input.smooth_scroll_delta + input.raw_scroll_delta,
+                input.pointer.delta(),
+                input.zoom_delta(),
+            )
+        });
         let pointer_in_canvas = pointer_position.is_some_and(|position| canvas_rect.contains(position));
+        let space_drag_claimed =
+            pointer_in_canvas && primary_down && space_down && space_drag_modifier_active(modifiers);
+        // Delay plain Space forwarding until we know whether the key becomes
+        // the canvas-pan modifier or an actual terminal keystroke.
+        self.terminal_keyboard_events = self
+            .pending_space_pan_key
+            .filter_terminal_events(&events, space_drag_claimed);
+        self.canvas_pan_input_claimed = pointer_in_canvas && (middle_down || space_drag_claimed);
         if pointer_in_canvas && (zoom_delta - 1.0).abs() > f32::EPSILON {
             let anchor = pointer_position.unwrap_or_else(|| canvas_rect.center());
             if self.zoom_canvas_at(canvas_rect, anchor, self.canvas_view.zoom * zoom_delta) {
                 self.clear_terminal_selections();
             }
+            self.canvas_pan_input_claimed = false;
             self.is_panning = false;
             return;
         }
 
-        let drag_panning = pointer_in_canvas && (middle_down || (space_down && primary_down));
+        let drag_panning = self.canvas_pan_input_claimed;
         let pointer_over_panel = pointer_position.is_some_and(|position| {
             pointer_in_canvas
                 && !drag_panning
@@ -100,6 +224,93 @@ impl HorizonApp {
             if let Some(terminal) = panel.terminal() {
                 terminal.clear_selection();
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::{Event, Key, Modifiers};
+
+    use crate::app::CanvasPanSpaceKeyState;
+
+    #[test]
+    fn plain_space_is_delayed_until_release() {
+        let mut state = CanvasPanSpaceKeyState::default();
+        let press = space_press();
+        let text = Event::Text(" ".to_owned());
+        let release = space_release();
+
+        assert!(
+            state
+                .filter_terminal_events(&[press.clone(), text.clone()], false)
+                .is_empty()
+        );
+
+        let filtered = state.filter_terminal_events(std::slice::from_ref(&release), false);
+        assert_eq!(filtered, vec![press, text, release]);
+        assert!(matches!(state, CanvasPanSpaceKeyState::Idle));
+    }
+
+    #[test]
+    fn space_candidate_is_dropped_once_drag_pan_claims_it() {
+        let mut state = CanvasPanSpaceKeyState::default();
+
+        assert!(
+            state
+                .filter_terminal_events(&[space_press(), Event::Text(" ".to_owned())], false)
+                .is_empty()
+        );
+        assert!(matches!(state, CanvasPanSpaceKeyState::Pending(_)));
+
+        assert!(state.filter_terminal_events(&[], true).is_empty());
+        assert!(matches!(state, CanvasPanSpaceKeyState::Consumed));
+
+        assert!(state.filter_terminal_events(&[space_release()], false).is_empty());
+        assert!(matches!(state, CanvasPanSpaceKeyState::Idle));
+    }
+
+    #[test]
+    fn pending_space_flushes_before_later_non_space_input() {
+        let mut state = CanvasPanSpaceKeyState::default();
+        let press = space_press();
+        let text = Event::Text(" ".to_owned());
+        let letter = Event::Key {
+            key: Key::A,
+            physical_key: Some(Key::A),
+            pressed: true,
+            repeat: false,
+            modifiers: Modifiers::NONE,
+        };
+
+        assert!(
+            state
+                .filter_terminal_events(&[press.clone(), text.clone()], false)
+                .is_empty()
+        );
+
+        let filtered = state.filter_terminal_events(std::slice::from_ref(&letter), false);
+        assert_eq!(filtered, vec![press, text, letter]);
+        assert!(matches!(state, CanvasPanSpaceKeyState::Idle));
+    }
+
+    fn space_press() -> Event {
+        Event::Key {
+            key: Key::Space,
+            physical_key: Some(Key::Space),
+            pressed: true,
+            repeat: false,
+            modifiers: Modifiers::NONE,
+        }
+    }
+
+    fn space_release() -> Event {
+        Event::Key {
+            key: Key::Space,
+            physical_key: Some(Key::Space),
+            pressed: false,
+            repeat: false,
+            modifiers: Modifiers::NONE,
         }
     }
 }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -131,6 +131,9 @@ impl HorizonApp {
         let saved_canvas_view = self.canvas_view;
         let saved_pan_target = self.pan_target;
         let saved_is_panning = self.is_panning;
+        let saved_canvas_pan_input_claimed = self.canvas_pan_input_claimed;
+        let saved_pending_space_pan_key = self.pending_space_pan_key.clone();
+        let saved_terminal_keyboard_events = std::mem::take(&mut self.terminal_keyboard_events);
         // Detached rendering must not overwrite root-window hit-testing or
         // close requests that were collected earlier in the frame.
         let saved_panel_screen_rects = std::mem::take(&mut self.panel_screen_rects);
@@ -170,6 +173,9 @@ impl HorizonApp {
         self.canvas_view = saved_canvas_view;
         self.pan_target = saved_pan_target;
         self.is_panning = saved_is_panning;
+        self.canvas_pan_input_claimed = saved_canvas_pan_input_claimed;
+        self.pending_space_pan_key = saved_pending_space_pan_key;
+        self.terminal_keyboard_events = saved_terminal_keyboard_events;
         self.panels_to_close = saved_panels_to_close;
         self.panel_screen_rects = saved_panel_screen_rects;
         self.panel_screen_order = saved_panel_screen_order;
@@ -273,6 +279,9 @@ impl HorizonApp {
         self.canvas_view = detached_state.canvas_view;
         self.pan_target = detached_state.pan_target;
         self.is_panning = detached_state.is_panning;
+        self.canvas_pan_input_claimed = detached_state.canvas_pan_input_claimed;
+        self.pending_space_pan_key = detached_state.pending_space_pan_key.clone();
+        self.terminal_keyboard_events.clear();
         self.panel_screen_rects = std::mem::take(&mut detached_state.panel_screen_rects);
         self.panel_screen_order = std::mem::take(&mut detached_state.panel_screen_order);
         true
@@ -286,6 +295,8 @@ impl HorizonApp {
         detached_state.canvas_view = self.canvas_view;
         detached_state.pan_target = self.pan_target;
         detached_state.is_panning = self.is_panning;
+        detached_state.canvas_pan_input_claimed = self.canvas_pan_input_claimed;
+        detached_state.pending_space_pan_key = self.pending_space_pan_key.clone();
         detached_state.panel_screen_rects = std::mem::take(&mut self.panel_screen_rects);
         detached_state.panel_screen_order = std::mem::take(&mut self.panel_screen_order);
     }

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -26,7 +26,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::time::Instant;
 
-use egui::{Context, Pos2, Rect, Vec2, ViewportId};
+use egui::{Context, Event, Pos2, Rect, Vec2, ViewportId};
 use horizon_core::{
     AgentSessionBinding, AgentSessionCatalog, AppShortcuts, Board, CanvasViewState, Config, GitWatcher, PanelId,
     PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease, SessionStore, ShutdownProgress,
@@ -66,6 +66,14 @@ enum RenameEditAction {
     Cancel,
 }
 
+#[derive(Clone, Default)]
+pub(in crate::app) enum CanvasPanSpaceKeyState {
+    #[default]
+    Idle,
+    Pending(Vec<Event>),
+    Consumed,
+}
+
 use self::frame_stats::FrameStats;
 use self::settings::SettingsEditor;
 
@@ -93,6 +101,8 @@ pub(in crate::app) struct DetachedWorkspaceViewportState {
     canvas_view: CanvasViewState,
     pan_target: Option<Vec2>,
     is_panning: bool,
+    canvas_pan_input_claimed: bool,
+    pending_space_pan_key: CanvasPanSpaceKeyState,
     initial_fit_pending: bool,
     panel_screen_rects: HashMap<PanelId, Rect>,
     panel_screen_order: Vec<PanelId>,
@@ -105,6 +115,8 @@ impl DetachedWorkspaceViewportState {
             canvas_view: CanvasViewState::default(),
             pan_target: None,
             is_panning: false,
+            canvas_pan_input_claimed: false,
+            pending_space_pan_key: CanvasPanSpaceKeyState::Idle,
             initial_fit_pending: true,
             panel_screen_rects: HashMap::new(),
             panel_screen_order: Vec::new(),
@@ -123,6 +135,9 @@ pub struct HorizonApp {
     canvas_view: CanvasViewState,
     pan_target: Option<Vec2>,
     is_panning: bool,
+    canvas_pan_input_claimed: bool,
+    pending_space_pan_key: CanvasPanSpaceKeyState,
+    terminal_keyboard_events: Vec<Event>,
     panel_screen_rects: HashMap<PanelId, Rect>,
     panel_screen_order: Vec<PanelId>,
     terminal_grid_cache: HashMap<PanelId, TerminalGridCache>,
@@ -273,6 +288,9 @@ impl HorizonApp {
             canvas_view: CanvasViewState::default(),
             pan_target: None,
             is_panning: false,
+            canvas_pan_input_claimed: false,
+            pending_space_pan_key: CanvasPanSpaceKeyState::Idle,
+            terminal_keyboard_events: Vec::new(),
             git_watchers: HashMap::new(),
             config_last_mtime,
             config_last_check: None,

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -88,22 +88,34 @@ impl PanelFrame {
     }
 }
 
+struct PanelBodyContext<'a> {
+    keyboard_events: &'a [egui::Event],
+    editor_save_shortcut: ShortcutBinding,
+    editor_preview_cache: Option<&'a mut MarkdownPreviewCache>,
+    terminal_grid_cache: Option<&'a mut TerminalGridCache>,
+}
+
 fn show_panel_body_contents(
     ui: &mut egui::Ui,
     panel: &mut Panel,
     is_focused: bool,
     interactive: bool,
-    editor_save_shortcut: ShortcutBinding,
-    editor_preview_cache: Option<&mut MarkdownPreviewCache>,
-    terminal_grid_cache: Option<&mut TerminalGridCache>,
+    body_context: PanelBodyContext<'_>,
 ) -> bool {
     match panel.kind {
-        PanelKind::Editor => {
-            MarkdownEditorView::new(panel, editor_preview_cache).show(ui, is_focused, editor_save_shortcut)
-        }
+        PanelKind::Editor => MarkdownEditorView::new(panel, body_context.editor_preview_cache).show(
+            ui,
+            is_focused,
+            body_context.editor_save_shortcut,
+        ),
         PanelKind::GitChanges => GitChangesView::new(panel).show(ui, is_focused),
         PanelKind::Usage => UsageDashboardView::new(panel).show(ui, is_focused),
-        _ => TerminalView::new(panel, terminal_grid_cache).show(ui, is_focused, interactive),
+        _ => TerminalView::new(panel, body_context.terminal_grid_cache).show(
+            ui,
+            is_focused,
+            interactive,
+            body_context.keyboard_events,
+        ),
     }
 }
 
@@ -139,9 +151,12 @@ impl HorizonApp {
                                 panel,
                                 true,
                                 true,
-                                self.shortcuts.save_editor,
-                                preview_cache,
-                                None,
+                                PanelBodyContext {
+                                    keyboard_events: &ui.input(|input| input.events.clone()),
+                                    editor_save_shortcut: self.shortcuts.save_editor,
+                                    editor_preview_cache: preview_cache,
+                                    terminal_grid_cache: None,
+                                },
                             );
                         }
                     },
@@ -266,7 +281,7 @@ impl HorizonApp {
         workspaces: &[(WorkspaceId, String, Color32)],
     ) -> PanelUiOutcome {
         let mut outcome = PanelUiOutcome::default();
-        let interactive = !self.is_panning;
+        let interactive = !self.canvas_pan_input_claimed;
 
         egui::Area::new(Id::new(("panel", panel_id.0)))
             .fixed_pos(snapshot.canvas_position)
@@ -382,9 +397,12 @@ impl HorizonApp {
                                 panel,
                                 snapshot.is_focused,
                                 interactive,
-                                self.shortcuts.save_editor,
-                                preview_cache,
-                                grid_cache,
+                                PanelBodyContext {
+                                    keyboard_events: &self.terminal_keyboard_events,
+                                    editor_save_shortcut: self.shortcuts.save_editor,
+                                    editor_preview_cache: preview_cache,
+                                    terminal_grid_cache: grid_cache,
+                                },
                             );
                         }
                     },
@@ -522,12 +540,12 @@ impl HorizonApp {
             RenameEditAction::None => {}
         }
 
-        if !self.is_panning && outcome.drag_delta != Vec2::ZERO {
+        if !self.canvas_pan_input_claimed && outcome.drag_delta != Vec2::ZERO {
             let new_position = snapshot.canvas_position + outcome.drag_delta;
             let _ = self.board.move_panel(panel_id, [new_position.x, new_position.y]);
             self.mark_runtime_dirty();
         }
-        if !self.is_panning && outcome.resize_delta != Vec2::ZERO {
+        if !self.canvas_pan_input_claimed && outcome.resize_delta != Vec2::ZERO {
             let new_size = clamp_panel_size(snapshot.canvas_size + outcome.resize_delta);
             let _ = self.board.resize_panel(panel_id, [new_size.x, new_size.y]);
             self.mark_runtime_dirty();

--- a/crates/horizon-ui/src/app/workspace.rs
+++ b/crates/horizon-ui/src/app/workspace.rs
@@ -221,7 +221,7 @@ impl HorizonApp {
             self.close_workspace_panels(workspace_id);
         }
 
-        if !self.is_panning {
+        if !self.canvas_pan_input_claimed {
             for (workspace_id, delta) in pending_workspace_moves {
                 let _ = self
                     .board

--- a/crates/horizon-ui/src/terminal_widget/input.rs
+++ b/crates/horizon-ui/src/terminal_widget/input.rs
@@ -291,15 +291,14 @@ fn handle_pointer_selection_drag(
     }
 }
 
-pub(super) fn handle_terminal_keyboard_input(ui: &egui::Ui, panel: &mut Panel) {
-    let events: Vec<egui::Event> = ui.input(|input| input.events.clone());
+pub(super) fn handle_terminal_keyboard_input(ui: &egui::Ui, panel: &mut Panel, events: &[egui::Event]) {
     let Some(terminal) = panel.terminal_mut() else {
         return;
     };
     let mode = terminal.mode();
     let mut forwarder = KeyboardInputForwarder::default();
 
-    for event in &events {
+    for event in events {
         match event {
             egui::Event::Text(text) | egui::Event::Ime(egui::ImeEvent::Commit(text)) => {
                 let emission = forwarder.on_text(text, mode);

--- a/crates/horizon-ui/src/terminal_widget/mod.rs
+++ b/crates/horizon-ui/src/terminal_widget/mod.rs
@@ -27,7 +27,13 @@ impl<'a> TerminalView<'a> {
 
     /// Renders the terminal panel. Returns `true` if clicked (for focus tracking).
     #[profiling::function]
-    pub fn show(&mut self, ui: &mut egui::Ui, is_active_panel: bool, interactive: bool) -> bool {
+    pub fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        is_active_panel: bool,
+        interactive: bool,
+        keyboard_events: &[egui::Event],
+    ) -> bool {
         let metrics = grid_metrics(ui.ctx());
         let char_width = metrics.char_width;
         let line_height = metrics.line_height;
@@ -116,7 +122,7 @@ impl<'a> TerminalView<'a> {
         }
 
         if interactive && has_terminal_focus {
-            handle_terminal_keyboard_input(ui, self.panel);
+            handle_terminal_keyboard_input(ui, self.panel, keyboard_events);
         }
 
         interaction.body.clicked()

--- a/docs/testing/windows-space-pan-smoke-test.md
+++ b/docs/testing/windows-space-pan-smoke-test.md
@@ -1,0 +1,98 @@
+# Windows Smoke Test: `Space + Left-Drag` Canvas Pan
+
+This is a temporary validation artifact for the fix that prevents `Space + left-click drag` from inserting a space into the focused terminal on Windows.
+
+Delete this file after the Windows validation pass is complete unless it is explicitly needed longer.
+
+## Target
+
+- Repository: `peters/horizon`
+- Branch/PR: fix for Windows `Space + left-click drag` leaking `Space` into the focused terminal
+- Platform: Windows 11 preferred, Windows 10 acceptable
+- Tester: separate agent or machine, not this Linux workstation
+
+## Build Or Install
+
+Choose one:
+
+1. Build from source on the PR branch
+   - Install Rust stable `>= 1.88`
+   - Clone the PR branch
+   - Run `cargo run --release`
+2. Use the PR CI artifact if one is attached
+   - Download the Windows build artifact for the PR
+   - Launch `horizon.exe`
+
+## Test Setup
+
+1. Start Horizon with a clean session if practical.
+2. Create one workspace and one terminal panel.
+3. In the terminal, run a command that makes inserted spaces obvious, for example:
+   - `python -q`
+   - `cmd`
+   - `powershell`
+4. Click inside the terminal so it is definitely the focused input target.
+
+## Baseline Checks
+
+1. Press `Space` once without dragging.
+   - Expected: one space is inserted into the terminal.
+2. Type `a`, `Space`, `b`.
+   - Expected: the terminal receives `a b` in that order.
+3. Hold `Space`, release it without clicking.
+   - Expected: one space is inserted, with no stuck input state afterward.
+
+## Primary Regression Checks
+
+1. Focus the terminal.
+2. Hold `Space`.
+3. Press and hold left mouse.
+4. Drag the canvas several hundred pixels.
+5. Release left mouse, then release `Space`.
+   - Expected: the canvas pans.
+   - Expected: no space is inserted into the terminal.
+   - Expected: no extra key-up escape sequence or visible artifact appears in the terminal.
+6. Repeat the same flow starting the drag from:
+   - terminal body
+   - panel titlebar
+   - empty canvas
+
+## Edge Cases
+
+1. Hold `Space`, then press another key such as `A` before releasing `Space`.
+   - Expected: if no drag occurred, input order remains sane and Horizon does not get stuck in pan mode.
+2. Hold `Space`, click without moving, then release.
+   - Expected: no accidental panel drag or resize.
+   - Expected: the terminal does not receive stray spaces from a click-only gesture.
+3. Hold middle mouse and drag.
+   - Expected: canvas panning still works.
+4. Use `Ctrl+click` or `Cmd+click` style terminal link interactions if available on the platform.
+   - Expected: the fix does not break existing modifier-based interactions.
+5. With multiple panels open, focus one terminal and perform the regression check.
+   - Expected: no other terminal receives the leaked space.
+
+## Persistence And Relaunch
+
+1. Pan the canvas after the fix.
+2. Close Horizon cleanly.
+3. Relaunch Horizon.
+   - Expected: normal persisted layout behavior remains unchanged.
+   - Expected: the fix does not introduce stuck pan state after relaunch.
+
+## Visual Regression Checks
+
+1. Capture a screenshot right after launch.
+2. Capture a screenshot after a successful `Space + left-drag` pan.
+3. Resize the main window and repeat the pan gesture once.
+   - Expected: panel chrome, workspace labels, and terminal rendering remain stable.
+   - Expected: no jitter, snap-back, or unexpected window movement occurs.
+
+## Report Back
+
+Include the following in the PR comment or test report:
+
+- Windows version
+- How Horizon was launched
+- Pass/fail for each primary regression check
+- Any additional bugs found during the gesture test
+- Launch screenshot and post-pan screenshot


### PR DESCRIPTION
## Summary
- suppress plain `Space` terminal input until Horizon can tell whether it becomes the canvas-pan modifier
- treat `Space + left-click` as a claimed canvas-pan gesture before pointer motion so panel/workspace interactions stop immediately
- add a temporary Windows smoke-test plan for an external machine/agent under `docs/testing/windows-space-pan-smoke-test.md`

Closes #88.

## Behavior Impact
On Windows, `Space + left-click drag` should keep panning the canvas without sending a stray space to the focused terminal. Plain `Space` typing without a pan gesture should continue to work normally.

## Test Evidence
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`

## Pending Validation
- Windows smoke test is still pending on another machine/agent.
- Temporary instructions live in `docs/testing/windows-space-pan-smoke-test.md` and should be deleted after that validation pass unless we decide to keep them.
