### PR TITLE
fix(view): auto-pan workspace collision chains

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -53,6 +53,12 @@ impl WorkspaceLayout {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceTranslationOutcome {
+    pub moved: bool,
+    pub affected_workspaces: Vec<WorkspaceId>,
+}
+
 pub struct Board {
     pub panels: Vec<Panel>,
     pub workspaces: Vec<Workspace>,

--- a/crates/horizon-core/src/board/arrangement.rs
+++ b/crates/horizon-core/src/board/arrangement.rs
@@ -51,9 +51,9 @@ impl Board {
 
     /// After the workspace `source` was moved, push every overlapping
     /// workspace along `drag_dir`, cascading until nothing overlaps.
-    pub(super) fn resolve_workspace_collisions(&mut self, source: WorkspaceId, drag_dir: [f32; 2]) {
+    pub(super) fn resolve_workspace_collisions(&mut self, source: WorkspaceId, drag_dir: [f32; 2]) -> Vec<WorkspaceId> {
         let workspace_ids: Vec<_> = self.workspaces.iter().map(|workspace| workspace.id).collect();
-        self.resolve_workspace_collisions_with_push(source, drag_dir, &workspace_ids, collision_push);
+        self.resolve_workspace_collisions_with_push(source, drag_dir, &workspace_ids, collision_push)
     }
 
     /// Resolve collisions for `source` against an explicit workspace scope.
@@ -62,8 +62,8 @@ impl Board {
         source: WorkspaceId,
         drag_dir: [f32; 2],
         workspace_ids: &[WorkspaceId],
-    ) {
-        self.resolve_workspace_collisions_with_push(source, drag_dir, workspace_ids, collision_push);
+    ) -> Vec<WorkspaceId> {
+        self.resolve_workspace_collisions_with_push(source, drag_dir, workspace_ids, collision_push)
     }
 
     fn resolve_workspace_resize_collisions_in_scope(
@@ -81,7 +81,7 @@ impl Board {
         delta: [f32; 2],
         workspace_ids: &[WorkspaceId],
         push_fn: RectCollisionPush,
-    ) {
+    ) -> Vec<WorkspaceId> {
         let mut queue = vec![source];
         let mut settled = vec![source];
 
@@ -108,6 +108,8 @@ impl Board {
                 }
             }
         }
+
+        settled
     }
 
     pub fn move_panel(&mut self, id: PanelId, position: [f32; 2]) -> bool {

--- a/crates/horizon-core/src/board/tests/workspace.rs
+++ b/crates/horizon-core/src/board/tests/workspace.rs
@@ -119,11 +119,13 @@ fn translate_workspace_with_push_in_scope_ignores_out_of_scope_workspaces() {
     let beta_before = board.workspace(beta).expect("beta workspace").position;
     let gamma_before = board.workspace(gamma).expect("gamma workspace").position;
 
-    assert!(board.translate_workspace_with_push_in_scope(alpha, [500.0, 0.0], &[alpha, beta]));
+    let outcome = board.translate_workspace_with_push_in_scope(alpha, [500.0, 0.0], &[alpha, beta]);
 
     let beta_after = board.workspace(beta).expect("beta workspace").position;
     let gamma_after = board.workspace(gamma).expect("gamma workspace").position;
 
+    assert!(outcome.moved);
+    assert_eq!(outcome.affected_workspaces, vec![alpha, beta]);
     assert!(
         beta_after[0] > beta_before[0],
         "expected beta to move right from {beta_before:?}, got {beta_after:?}"
@@ -131,6 +133,33 @@ fn translate_workspace_with_push_in_scope_ignores_out_of_scope_workspaces() {
     assert!(
         vec2_eq(gamma_after, gamma_before),
         "expected out-of-scope gamma workspace to stay at {gamma_before:?}, got {gamma_after:?}"
+    );
+}
+
+#[test]
+fn translate_workspace_with_push_reports_full_collision_chain() {
+    let mut board = Board::new();
+    let alpha = board.create_workspace_at("alpha", [0.0, 40.0]);
+    let beta = board.create_workspace_at("beta", [250.0, 40.0]);
+    let gamma = board.create_workspace_at("gamma", [500.0, 40.0]);
+
+    let beta_before = board.workspace(beta).expect("beta workspace").position;
+    let gamma_before = board.workspace(gamma).expect("gamma workspace").position;
+
+    let outcome = board.translate_workspace_with_push(alpha, [80.0, 0.0]);
+
+    let beta_after = board.workspace(beta).expect("beta workspace").position;
+    let gamma_after = board.workspace(gamma).expect("gamma workspace").position;
+
+    assert!(outcome.moved);
+    assert_eq!(outcome.affected_workspaces, vec![alpha, beta, gamma]);
+    assert!(
+        beta_after[0] > beta_before[0],
+        "expected beta to move right from {beta_before:?}, got {beta_after:?}"
+    );
+    assert!(
+        gamma_after[0] > gamma_before[0],
+        "expected gamma to move right from {gamma_before:?}, got {gamma_after:?}"
     );
 }
 

--- a/crates/horizon-core/src/board/workspaces.rs
+++ b/crates/horizon-core/src/board/workspaces.rs
@@ -4,7 +4,7 @@ use crate::panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelOptions};
 use crate::runtime_state::WorkspaceState;
 use crate::workspace::{Workspace, WorkspaceId};
 
-use super::Board;
+use super::{Board, WorkspaceTranslationOutcome};
 
 impl Board {
     #[must_use]
@@ -307,12 +307,14 @@ impl Board {
 
     /// Translate a workspace and push any colliding workspaces further along
     /// the drag direction, cascading through the chain of collisions.
-    pub fn translate_workspace_with_push(&mut self, id: WorkspaceId, delta: [f32; 2]) -> bool {
+    pub fn translate_workspace_with_push(&mut self, id: WorkspaceId, delta: [f32; 2]) -> WorkspaceTranslationOutcome {
         if !self.translate_workspace(id, delta) {
-            return false;
+            return WorkspaceTranslationOutcome::default();
         }
-        self.resolve_workspace_collisions(id, delta);
-        true
+        WorkspaceTranslationOutcome {
+            moved: true,
+            affected_workspaces: self.resolve_workspace_collisions(id, delta),
+        }
     }
 
     /// Translate a workspace and push colliding workspaces within an explicit
@@ -322,12 +324,14 @@ impl Board {
         id: WorkspaceId,
         delta: [f32; 2],
         workspace_ids: &[WorkspaceId],
-    ) -> bool {
+    ) -> WorkspaceTranslationOutcome {
         if !self.translate_workspace(id, delta) {
-            return false;
+            return WorkspaceTranslationOutcome::default();
         }
-        self.resolve_workspace_collisions_in_scope(id, delta, workspace_ids);
-        true
+        WorkspaceTranslationOutcome {
+            moved: true,
+            affected_workspaces: self.resolve_workspace_collisions_in_scope(id, delta, workspace_ids),
+        }
     }
 
     pub(super) fn create_workspace_record(&mut self, workspace_state: &WorkspaceState) -> WorkspaceId {

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -32,7 +32,7 @@ pub use agents::{AgentDefinition, AgentIntegrationKind, AgentResumeMode, agent_d
 pub use alacritty_terminal::index::Side as TerminalSide;
 pub use alacritty_terminal::selection::SelectionType;
 pub use attention::{AttentionId, AttentionItem, AttentionSeverity, AttentionState};
-pub use board::{Board, ShutdownProgress, WorkspaceLayout};
+pub use board::{Board, ShutdownProgress, WorkspaceLayout, WorkspaceTranslationOutcome};
 pub use config::{
     Config, FeaturesConfig, OverlaysConfig, PresetConfig, ShortcutsConfig, TerminalConfig, WindowConfig,
     WorkspaceConfig,

--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -3,6 +3,8 @@ use horizon_core::{PanelId, WorkspaceId};
 
 use super::{HorizonApp, PANEL_PADDING, WS_BG_PAD, WS_TITLE_HEIGHT};
 
+const WORKSPACE_DRAG_AUTO_PAN_MARGIN: f32 = 64.0;
+
 impl HorizonApp {
     pub(super) fn ensure_workspace_visible(&mut self, ctx: &Context) -> WorkspaceId {
         let workspace_count_before = self.board.workspaces.len();
@@ -192,6 +194,31 @@ impl HorizonApp {
         true
     }
 
+    pub(super) fn auto_pan_workspace_drag_chain(
+        &mut self,
+        canvas_rect: Rect,
+        workspace_ids: &[WorkspaceId],
+        drag_delta: Vec2,
+    ) {
+        if workspace_ids.len() <= 1 {
+            return;
+        }
+
+        let Some(chain_rect) = self.workspace_chain_screen_rect(canvas_rect, workspace_ids) else {
+            return;
+        };
+        let pan_delta =
+            workspace_drag_autopan_delta(canvas_rect, chain_rect, drag_delta, WORKSPACE_DRAG_AUTO_PAN_MARGIN);
+        if pan_delta == Vec2::ZERO {
+            return;
+        }
+
+        self.pan_target = None;
+        let current = Vec2::new(self.canvas_view.pan_offset[0], self.canvas_view.pan_offset[1]);
+        let next = current + pan_delta;
+        self.canvas_view.set_pan_offset([next.x, next.y]);
+    }
+
     fn reveal_initial_workspace(&mut self, ctx: &Context, workspace_id: WorkspaceId, workspace_count_before: usize) {
         if workspace_count_before != 0 {
             return;
@@ -234,6 +261,22 @@ impl HorizonApp {
             .panel(panel_id)
             .map(|panel| panel_focus_frame(panel.layout.position, panel.layout.size))
     }
+
+    fn workspace_chain_screen_rect(&self, canvas_rect: Rect, workspace_ids: &[WorkspaceId]) -> Option<Rect> {
+        workspace_ids
+            .iter()
+            .copied()
+            .filter(|workspace_id| !self.workspace_is_detached(*workspace_id))
+            .filter_map(|workspace_id| {
+                self.workspace_focus_frame(workspace_id).map(|(pos, size)| {
+                    Rect::from_min_size(
+                        self.canvas_to_screen(canvas_rect, pos),
+                        self.canvas_size_to_screen(size),
+                    )
+                })
+            })
+            .reduce(Rect::union)
+    }
 }
 
 fn panel_focus_frame(position: [f32; 2], size: [f32; 2]) -> (Pos2, Vec2) {
@@ -267,6 +310,31 @@ fn aligned_pan_offset(canvas_rect: Rect, canvas_pos: Pos2, canvas_size: Vec2, zo
     Vec2::new(x, y)
 }
 
+fn workspace_drag_autopan_delta(canvas_rect: Rect, chain_rect: Rect, drag_delta: Vec2, margin: f32) -> Vec2 {
+    let left_limit = canvas_rect.min.x + margin;
+    let right_limit = canvas_rect.max.x - margin;
+    let top_limit = canvas_rect.min.y + margin;
+    let bottom_limit = canvas_rect.max.y - margin;
+
+    let x = if drag_delta.x > 0.0 && chain_rect.max.x > right_limit {
+        right_limit - chain_rect.max.x
+    } else if drag_delta.x < 0.0 && chain_rect.min.x < left_limit {
+        left_limit - chain_rect.min.x
+    } else {
+        0.0
+    };
+
+    let y = if drag_delta.y > 0.0 && chain_rect.max.y > bottom_limit {
+        bottom_limit - chain_rect.max.y
+    } else if drag_delta.y < 0.0 && chain_rect.min.y < top_limit {
+        top_limit - chain_rect.min.y
+    } else {
+        0.0
+    };
+
+    Vec2::new(x, y)
+}
+
 #[must_use]
 pub(super) fn canvas_scene_transform(canvas_rect: Rect, canvas_view: horizon_core::CanvasViewState) -> TSTransform {
     TSTransform::from_translation(
@@ -284,7 +352,9 @@ mod tests {
     use egui::{Pos2, Rect, Vec2};
     use horizon_core::{CanvasViewState, MAX_CANVAS_ZOOM, MIN_CANVAS_ZOOM};
 
-    use super::{aligned_pan_offset, canvas_scene_transform, fit_zoom_for_frame, panel_focus_frame};
+    use super::{
+        aligned_pan_offset, canvas_scene_transform, fit_zoom_for_frame, panel_focus_frame, workspace_drag_autopan_delta,
+    };
 
     #[test]
     fn canvas_scene_transform_matches_canvas_view_mapping() {
@@ -344,5 +414,25 @@ mod tests {
 
         assert!((zoomed_out - MIN_CANVAS_ZOOM).abs() <= f32::EPSILON);
         assert!((zoomed_in - MAX_CANVAS_ZOOM).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn workspace_drag_autopan_follows_rightward_chain_at_visible_edge() {
+        let canvas_rect = Rect::from_min_size(Pos2::new(0.0, 0.0), Vec2::new(1200.0, 800.0));
+        let chain_rect = Rect::from_min_max(Pos2::new(420.0, 120.0), Pos2::new(1180.0, 520.0));
+
+        let pan_delta = workspace_drag_autopan_delta(canvas_rect, chain_rect, Vec2::new(48.0, 0.0), 64.0);
+
+        assert_eq!(pan_delta, Vec2::new(-44.0, 0.0));
+    }
+
+    #[test]
+    fn workspace_drag_autopan_ignores_opposite_edge_when_drag_direction_changes() {
+        let canvas_rect = Rect::from_min_size(Pos2::new(0.0, 0.0), Vec2::new(1200.0, 800.0));
+        let chain_rect = Rect::from_min_max(Pos2::new(20.0, 120.0), Pos2::new(760.0, 520.0));
+
+        let pan_delta = workspace_drag_autopan_delta(canvas_rect, chain_rect, Vec2::new(36.0, 0.0), 64.0);
+
+        assert_eq!(pan_delta, Vec2::ZERO);
     }
 }

--- a/crates/horizon-ui/src/app/workspace.rs
+++ b/crates/horizon-ui/src/app/workspace.rs
@@ -224,11 +224,14 @@ impl HorizonApp {
 
         if !self.canvas_pan_input_claimed {
             for (workspace_id, delta) in pending_workspace_moves {
-                let _ = self.board.translate_workspace_with_push_in_scope(
+                let outcome = self.board.translate_workspace_with_push_in_scope(
                     workspace_id,
                     [delta.x, delta.y],
                     &workspace_collision_ids,
                 );
+                if visible_detached_workspace.is_none() {
+                    self.auto_pan_workspace_drag_chain(canvas_rect, &outcome.affected_workspaces, delta);
+                }
                 self.mark_runtime_dirty();
             }
         }


### PR DESCRIPTION
## Summary
- preserve the pushed workspace chain from board drag resolution so the UI can follow the actual collision cascade
- auto-pan the root canvas during attached workspace drags when the collision chain reaches the visible edge
- add regressions for collision-chain reporting and the directional auto-pan helper

Closes #103

## Validation
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic

## Smoke
- Launch + screenshot smoke completed in a disposable HOME using the seeded Alpha/Beta/Gamma workspace layout.
- Motion-sensitive drag automation was attempted from this terminal session with Quartz and cliclick, but the scripted coordinate drag did not reach Horizon's workspace label handler reliably enough to count as a trustworthy live pass. A manual live drag/relaunch check is still recommended before merge.

## Notes
- This PR is stacked on top of #109 (`fix/resize-collision-scope`) so the diff stays limited to issue #103.