### PR TITLE
feat(release): add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,10 @@ jobs:
   upload-release-assets:
     name: Upload Release Assets
     needs: [build-artifacts]
+    outputs:
+      linux_x64_sha256: ${{ steps.checksums.outputs.linux_x64_sha256 }}
+      macos_arm64_sha256: ${{ steps.checksums.outputs.macos_arm64_sha256 }}
+      macos_x64_sha256: ${{ steps.checksums.outputs.macos_x64_sha256 }}
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -143,6 +147,36 @@ jobs:
           mkdir -p release-assets
           find artifacts -maxdepth 2 -type f -exec cp {} release-assets/ \;
 
+      - id: checksums
+        name: Generate release checksums
+        shell: bash
+        run: |
+          cd release-assets
+
+          required_assets=(
+            horizon-linux-x64.tar.gz
+            horizon-osx-arm64.tar.gz
+            horizon-osx-x64.tar.gz
+            horizon-windows-x64.exe
+          )
+
+          for asset in "${required_assets[@]}"; do
+            if [ ! -f "$asset" ]; then
+              echo "::error::Missing required release asset: $asset"
+              exit 1
+            fi
+          done
+
+          sha256sum "${required_assets[@]}" | tee SHA256SUMS.txt
+
+          linux_x64_sha256="$(awk '$2 == "horizon-linux-x64.tar.gz" { print $1 }' SHA256SUMS.txt)"
+          macos_arm64_sha256="$(awk '$2 == "horizon-osx-arm64.tar.gz" { print $1 }' SHA256SUMS.txt)"
+          macos_x64_sha256="$(awk '$2 == "horizon-osx-x64.tar.gz" { print $1 }' SHA256SUMS.txt)"
+
+          echo "linux_x64_sha256=${linux_x64_sha256}" >> "$GITHUB_OUTPUT"
+          echo "macos_arm64_sha256=${macos_arm64_sha256}" >> "$GITHUB_OUTPUT"
+          echo "macos_x64_sha256=${macos_x64_sha256}" >> "$GITHUB_OUTPUT"
+
       - name: Upload assets to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -150,3 +184,56 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" release-assets/* \
             --repo "${{ github.repository }}" \
             --clobber
+
+  update-homebrew-tap:
+    name: Update Homebrew Tap
+    if: ${{ !github.event.release.prerelease }}
+    needs: [validate-release, upload-release-assets]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Homebrew tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN secret is required for stable release packaging."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          lfs: true
+
+      - name: Checkout Homebrew tap repository
+        uses: actions/checkout@v6
+        with:
+          repository: peters/homebrew-horizon
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-horizon
+
+      - name: Update Homebrew tap files
+        shell: bash
+        run: |
+          ./scripts/update-homebrew-tap.sh \
+            --tap-dir homebrew-horizon \
+            --version "${{ needs.validate-release.outputs.release_version }}" \
+            --macos-arm64-sha "${{ needs.upload-release-assets.outputs.macos_arm64_sha256 }}" \
+            --macos-x64-sha "${{ needs.upload-release-assets.outputs.macos_x64_sha256 }}" \
+            --linux-x64-sha "${{ needs.upload-release-assets.outputs.linux_x64_sha256 }}"
+
+      - name: Commit and push Homebrew tap update
+        working-directory: homebrew-horizon
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if git diff --quiet; then
+            echo "Homebrew tap already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/horizon.rb README.md
+          git commit -m "horizon ${RELEASE_TAG}"
+          git push

--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ Grab the latest binary from [**Releases**](https://github.com/peters/horizon/rel
 | **macOS** x64 | `horizon-osx-x64.tar.gz` | Extract, `chmod +x`, run |
 | **Windows** x64 | `horizon-windows-x64.exe` | Download and run |
 
+### Homebrew
+
+Stable releases are available through the `peters/horizon` tap on macOS and Linux x64:
+
+```bash
+brew install peters/horizon/horizon
+```
+
+If you prefer to add the tap explicitly first:
+
+```bash
+brew tap peters/horizon
+brew install horizon
+```
+
+To update or remove it later:
+
+```bash
+brew upgrade horizon
+brew uninstall horizon
+brew untap peters/horizon
+```
+
 ### Build from source
 
 ```bash

--- a/crates/horizon-cursor/src/lib.rs
+++ b/crates/horizon-cursor/src/lib.rs
@@ -43,6 +43,18 @@ mod platform {
 
 #[cfg(target_os = "macos")]
 mod platform {
+    fn screen_coordinate(value: f64) -> Option<i32> {
+        if !value.is_finite() {
+            return None;
+        }
+
+        let rounded = value.round().clamp(f64::from(i32::MIN), f64::from(i32::MAX));
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            Some(rounded as i32)
+        }
+    }
+
     pub(crate) fn cursor_position() -> Option<(i32, i32)> {
         use core_graphics::event::CGEvent;
         use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
@@ -50,7 +62,21 @@ mod platform {
         let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
         let event = CGEvent::new(source).ok()?;
         let point = event.location();
-        Some((point.x as i32, point.y as i32))
+        Some((screen_coordinate(point.x)?, screen_coordinate(point.y)?))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::screen_coordinate;
+
+        #[test]
+        fn screen_coordinate_rounds_and_clamps_finite_values() {
+            assert_eq!(screen_coordinate(12.6), Some(13));
+            assert_eq!(screen_coordinate(-12.4), Some(-12));
+            assert_eq!(screen_coordinate(f64::INFINITY), None);
+            assert_eq!(screen_coordinate(f64::from(i32::MAX) + 512.0), Some(i32::MAX));
+            assert_eq!(screen_coordinate(f64::from(i32::MIN) - 512.0), Some(i32::MIN));
+        }
     }
 }
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -5,6 +5,7 @@ Horizon releases are tag-driven.
 - `vX.Y.Z-alpha.N` and `vX.Y.Z-beta.N` are prereleases.
 - `vX.Y.Z` is a stable release.
 - Publishing a GitHub Release with one of those tags triggers the release workflow, which publishes to crates.io and uploads the platform binaries to the same GitHub Release.
+- Stable releases also publish `SHA256SUMS.txt` and update the `peters/homebrew-horizon` tap.
 
 ## Source Of Truth
 
@@ -62,7 +63,8 @@ Then it:
 
 - rewrites the workspace version to the exact tag version in CI
 - builds the release binaries for Linux, macOS, and Windows
-- uploads those assets to the GitHub Release you just published
+- uploads those assets plus `SHA256SUMS.txt` to the GitHub Release you just published
+- for stable releases only, updates `peters/homebrew-horizon` so `brew install peters/horizon/horizon` tracks the latest stable release
 
 ## CLI Alternative
 
@@ -80,3 +82,17 @@ gh release create "$TAG" \
 `--target` accepts any branch, tag, or commit SHA. For beta or stable releases from a specific commit, replace `main` with the desired ref.
 
 For a stable release, omit `--prerelease`.
+
+## Stable Packaging Requirements
+
+Stable-release packaging assumes:
+
+- the release assets keep their current names:
+  - `horizon-linux-x64.tar.gz`
+  - `horizon-osx-arm64.tar.gz`
+  - `horizon-osx-x64.tar.gz`
+  - `horizon-windows-x64.exe`
+- the stable release uploads all four assets before the tap update runs
+- `HOMEBREW_TAP_TOKEN` is configured in the `peters/horizon` repository secrets with write access to `peters/homebrew-horizon`
+
+If a stable release is missing one of those assets or the tap token secret, the release workflow fails instead of publishing a partial Homebrew update.

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Render the Horizon Homebrew formula for a stable release.
+
+Usage:
+  render-homebrew-formula.sh \
+    --version <version> \
+    --macos-arm64-sha <sha256> \
+    --macos-x64-sha <sha256> \
+    --linux-x64-sha <sha256>
+EOF
+}
+
+version=""
+macos_arm64_sha=""
+macos_x64_sha=""
+linux_x64_sha=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --macos-arm64-sha)
+      macos_arm64_sha="${2:-}"
+      shift 2
+      ;;
+    --macos-x64-sha)
+      macos_x64_sha="${2:-}"
+      shift 2
+      ;;
+    --linux-x64-sha)
+      linux_x64_sha="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$version" ] || [ -z "$macos_arm64_sha" ] || [ -z "$macos_x64_sha" ] || [ -z "$linux_x64_sha" ]; then
+  printf 'The version and all SHA256 arguments are required.\n\n' >&2
+  usage >&2
+  exit 1
+fi
+
+cat <<EOF
+class Horizon < Formula
+  desc "GPU-accelerated terminal board on an infinite canvas"
+  homepage "https://github.com/peters/horizon"
+  url "https://github.com/peters/horizon/releases/download/v${version}/horizon-osx-arm64.tar.gz"
+  version "${version}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/peters/horizon/releases/download/v${version}/horizon-osx-arm64.tar.gz"
+      sha256 "${macos_arm64_sha}"
+    end
+
+    on_intel do
+      url "https://github.com/peters/horizon/releases/download/v${version}/horizon-osx-x64.tar.gz"
+      sha256 "${macos_x64_sha}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/peters/horizon/releases/download/v${version}/horizon-linux-x64.tar.gz"
+      sha256 "${linux_x64_sha}"
+    end
+  end
+
+  def install
+    bin.install "horizon"
+  end
+
+  test do
+    assert_path_exists bin/"horizon"
+    assert_predicate bin/"horizon", :executable?
+  end
+end
+EOF

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Update a checked-out Homebrew tap repo for a Horizon stable release.
+
+Usage:
+  update-homebrew-tap.sh \
+    --tap-dir <path> \
+    --version <version> \
+    --macos-arm64-sha <sha256> \
+    --macos-x64-sha <sha256> \
+    --linux-x64-sha <sha256>
+EOF
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+tap_dir=""
+version=""
+macos_arm64_sha=""
+macos_x64_sha=""
+linux_x64_sha=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tap-dir)
+      tap_dir="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --macos-arm64-sha)
+      macos_arm64_sha="${2:-}"
+      shift 2
+      ;;
+    --macos-x64-sha)
+      macos_x64_sha="${2:-}"
+      shift 2
+      ;;
+    --linux-x64-sha)
+      linux_x64_sha="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$tap_dir" ] || [ -z "$version" ] || [ -z "$macos_arm64_sha" ] || [ -z "$macos_x64_sha" ] || [ -z "$linux_x64_sha" ]; then
+  printf 'The tap dir, version, and all SHA256 arguments are required.\n\n' >&2
+  usage >&2
+  exit 1
+fi
+
+if [ ! -d "$tap_dir" ]; then
+  printf 'Tap directory not found: %s\n' "$tap_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$tap_dir/Formula"
+
+"$repo_root/scripts/render-homebrew-formula.sh" \
+  --version "$version" \
+  --macos-arm64-sha "$macos_arm64_sha" \
+  --macos-x64-sha "$macos_x64_sha" \
+  --linux-x64-sha "$linux_x64_sha" \
+  > "$tap_dir/Formula/horizon.rb"
+
+cat > "$tap_dir/README.md" <<EOF
+# homebrew-horizon
+
+Homebrew tap for [Horizon](https://github.com/peters/horizon), the GPU-accelerated terminal board on an infinite canvas.
+
+## Install
+
+\`\`\`bash
+brew tap peters/horizon
+brew install horizon
+\`\`\`
+
+Or install in one command:
+
+\`\`\`bash
+brew install peters/horizon/horizon
+\`\`\`
+
+## Upgrade
+
+\`\`\`bash
+brew upgrade horizon
+\`\`\`
+
+## Uninstall
+
+\`\`\`bash
+brew uninstall horizon
+brew untap peters/horizon
+\`\`\`
+
+## Release Source
+
+The formula installs the stable release assets published at:
+
+https://github.com/peters/horizon/releases/tag/v${version}
+EOF


### PR DESCRIPTION
## Summary
- add stable-release Homebrew tap automation, including `SHA256SUMS.txt` publishing and tap repo updates
- add tap rendering/update scripts plus README/release-flow install documentation
- fix the current `horizon-cursor` macOS clippy failure so the branch is CI-green on the current toolchain

## Homebrew
- created the public tap repo: https://github.com/peters/homebrew-horizon
- configured `HOMEBREW_TAP_TOKEN` in `peters/horizon` for the stable-release workflow
- seeded the tap with the current stable release `v0.2.0`

## Smoke Test
- `brew audit --strict peters/horizon/horizon`
- `brew install peters/horizon/horizon`
- `brew test peters/horizon/horizon`
- `brew upgrade horizon` on an already-current install
- launch the Homebrew-installed `horizon --blank` in isolated `HOME`s twice and verify the process/window comes up
- `brew uninstall horizon`
- `brew untap peters/horizon`

## Validation
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`

Refs #96
