### PR TITLE
fix: keep panel focus and scroll routing aligned after pan and zoom

### DIFF
--- a/crates/horizon-ui/src/app/actions/interaction.rs
+++ b/crates/horizon-ui/src/app/actions/interaction.rs
@@ -1,6 +1,7 @@
 use std::mem;
 
 use egui::{Context, Event, Key, Modifiers, Rect, Vec2};
+use horizon_core::WorkspaceId;
 
 use super::super::super::input::{TerminalInputEvent, terminal_input_events};
 use super::super::shortcuts::shortcut_pressed;
@@ -150,11 +151,16 @@ impl HorizonApp {
 
     #[profiling::function]
     pub(in super::super) fn handle_canvas_pan(&mut self, ctx: &Context) {
-        self.handle_canvas_pan_in_rect(ctx, self.canvas_rect(ctx));
+        self.handle_canvas_pan_in_rect(ctx, self.canvas_rect(ctx), None);
     }
 
     #[profiling::function]
-    pub(in super::super) fn handle_canvas_pan_in_rect(&mut self, ctx: &Context, canvas_rect: Rect) {
+    pub(in super::super) fn handle_canvas_pan_in_rect(
+        &mut self,
+        ctx: &Context,
+        canvas_rect: Rect,
+        visible_workspace: Option<WorkspaceId>,
+    ) {
         let (
             events,
             pointer_position,
@@ -178,14 +184,16 @@ impl HorizonApp {
                 input.zoom_delta(),
             )
         });
+        let panel_geometry = self.visible_panel_geometry_for_canvas_view(canvas_rect, visible_workspace);
         let pointer_in_canvas = pointer_position.is_some_and(|position| canvas_rect.contains(position));
         let space_drag_claimed =
             pointer_in_canvas && primary_down && space_down && space_drag_modifier_active(modifiers);
         let ctrl_or_cmd = modifiers.ctrl || modifiers.command;
         let pointer_over_terminal_body = primary_selection_routing_active()
             && pointer_position.is_some_and(|position| {
-                self.terminal_body_screen_rects
-                    .values()
+                panel_geometry
+                    .iter()
+                    .filter_map(|(_, geometry)| geometry.terminal_body_screen_rect)
                     .any(|rect| rect.contains(position))
             });
         let terminal_events = self.terminal_events_for_viewport(ctx.viewport_id(), &events);
@@ -225,7 +233,9 @@ impl HorizonApp {
                 && !drag_panning
                 && scroll != Vec2::ZERO
                 && !ctrl_or_cmd
-                && self.panel_screen_rects.values().any(|rect| rect.contains(position))
+                && panel_geometry
+                    .iter()
+                    .any(|(_, geometry)| geometry.screen_rect.contains(position))
         });
         let pan_delta = if drag_panning {
             pointer_delta

--- a/crates/horizon-ui/src/app/actions/layout.rs
+++ b/crates/horizon-ui/src/app/actions/layout.rs
@@ -147,16 +147,15 @@ impl HorizonApp {
             return;
         };
 
-        let panel_order: Vec<_> = self
-            .board
-            .panels
-            .iter()
-            .filter(|panel| !self.workspace_is_detached(panel.workspace_id))
-            .map(|panel| panel.id)
+        let panel_geometry = self.visible_panel_geometry_for_canvas_view(self.canvas_rect(ctx), None);
+        let panel_order: Vec<_> = panel_geometry.iter().map(|(panel_id, _)| *panel_id).collect();
+        let panel_rects: HashMap<_, _> = panel_geometry
+            .into_iter()
+            .map(|(panel_id, geometry)| (panel_id, geometry.screen_rect))
             .collect();
 
         if let Some(panel_id) =
-            panel_focus_target_at_pointer_press(&panel_order, &self.panel_screen_rects, self.board.focused, pointer_pos)
+            panel_focus_target_at_pointer_press(&panel_order, &panel_rects, self.board.focused, pointer_pos)
         {
             self.board.focus(panel_id);
         }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -172,7 +172,7 @@ impl HorizonApp {
 
         let canvas_rect = detached_canvas_rect(ctx);
         let workspace_bounds = self.board.workspace_bounds_map();
-        self.handle_canvas_pan_in_rect(ctx, canvas_rect);
+        self.handle_canvas_pan_in_rect(ctx, canvas_rect, Some(workspace_id));
         self.render_canvas(ctx);
         self.render_detached_workspace_backgrounds(ctx, &workspace_bounds, canvas_rect, workspace_id);
         self.render_panels_for_workspace(ctx, workspace_id);

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -18,6 +18,12 @@ pub(super) use super::panel_chrome::{
 use super::util::clamp_panel_size;
 use super::{HorizonApp, PANEL_PADDING, PANEL_TITLEBAR_HEIGHT, RESIZE_HANDLE_SIZE, RenameEditAction};
 
+#[derive(Clone, Copy)]
+pub(in crate::app) struct PanelScreenGeometry {
+    pub(in crate::app) screen_rect: Rect,
+    pub(in crate::app) terminal_body_screen_rect: Option<Rect>,
+}
+
 struct PanelSnapshot {
     screen_rect: Rect,
     terminal_body_screen_rect: Option<Rect>,
@@ -162,9 +168,66 @@ fn local_ssh_reconnect_shortcut_conflicts(shortcuts: &AppShortcuts) -> bool {
         .any(|binding| binding.overlaps(SSH_RECONNECT_SHORTCUT))
 }
 
+fn clip_screen_rect_to_canvas(raw_rect: Rect, canvas_rect: Rect) -> Option<Rect> {
+    let clipped = raw_rect.intersect(canvas_rect);
+    (clipped.is_positive()
+        && clipped.min.x.is_finite()
+        && clipped.min.y.is_finite()
+        && clipped.max.x.is_finite()
+        && clipped.max.y.is_finite())
+    .then_some(clipped)
+}
+
 impl HorizonApp {
     fn local_ssh_reconnect_shortcut_enabled(&self) -> bool {
         !local_ssh_reconnect_shortcut_conflicts(&self.shortcuts)
+    }
+
+    pub(in crate::app) fn visible_panel_geometry_for_canvas_view(
+        &self,
+        canvas_rect: Rect,
+        visible_workspace: Option<WorkspaceId>,
+    ) -> Vec<(PanelId, PanelScreenGeometry)> {
+        self.board
+            .panels
+            .iter()
+            .filter(|panel| match visible_workspace {
+                Some(workspace_id) => panel.workspace_id == workspace_id,
+                None => !self.workspace_is_detached(panel.workspace_id),
+            })
+            .filter_map(|panel| {
+                self.panel_screen_geometry(panel, canvas_rect)
+                    .map(|geometry| (panel.id, geometry))
+            })
+            .collect()
+    }
+
+    fn panel_screen_geometry(&self, panel: &Panel, canvas_rect: Rect) -> Option<PanelScreenGeometry> {
+        let canvas_position = Pos2::new(panel.layout.position[0], panel.layout.position[1]);
+        let canvas_size = Vec2::new(panel.layout.size[0], panel.layout.size[1]);
+        let screen_rect = clip_screen_rect_to_canvas(
+            Rect::from_min_size(
+                self.canvas_to_screen(canvas_rect, canvas_position),
+                self.canvas_size_to_screen(canvas_size),
+            ),
+            canvas_rect,
+        )?;
+        let terminal_body_screen_rect = panel.terminal().and_then(|_| {
+            let panel_rect = Rect::from_min_size(canvas_position, canvas_size);
+            let body_rect = PanelFrame::new(panel_rect).body;
+            clip_screen_rect_to_canvas(
+                Rect::from_min_size(
+                    self.canvas_to_screen(canvas_rect, body_rect.min),
+                    self.canvas_size_to_screen(body_rect.size()),
+                ),
+                canvas_rect,
+            )
+        });
+
+        Some(PanelScreenGeometry {
+            screen_rect,
+            terminal_body_screen_rect,
+        })
     }
 
     #[profiling::function]
@@ -291,27 +354,10 @@ impl HorizonApp {
         workspaces: &[(WorkspaceId, String, Color32)],
     ) -> Option<PanelSnapshot> {
         self.board.panel(panel_id).and_then(|panel| {
+            let geometry = self.panel_screen_geometry(panel, canvas_rect)?;
             let terminal = panel.terminal();
             let canvas_position = Pos2::new(panel.layout.position[0], panel.layout.position[1]);
             let canvas_size = Vec2::new(panel.layout.size[0], panel.layout.size[1]);
-            let screen_rect = Rect::from_min_size(
-                self.canvas_to_screen(canvas_rect, canvas_position),
-                self.canvas_size_to_screen(canvas_size),
-            );
-            let terminal_body_screen_rect = terminal.and_then(|_| {
-                let panel_rect = Rect::from_min_size(canvas_position, canvas_size);
-                let body_rect = PanelFrame::new(panel_rect).body;
-                let screen_body_rect = Rect::from_min_size(
-                    self.canvas_to_screen(canvas_rect, body_rect.min),
-                    self.canvas_size_to_screen(body_rect.size()),
-                );
-                screen_body_rect.is_positive().then_some(screen_body_rect)
-            });
-
-            // Cull off-screen panels — skip chrome, snapshot, and rendering.
-            if !canvas_rect.intersects(screen_rect) {
-                return None;
-            }
 
             let workspace_accent = workspaces
                 .iter()
@@ -327,8 +373,8 @@ impl HorizonApp {
             };
 
             Some(PanelSnapshot {
-                screen_rect,
-                terminal_body_screen_rect,
+                screen_rect: geometry.screen_rect,
+                terminal_body_screen_rect: geometry.terminal_body_screen_rect,
                 canvas_position,
                 canvas_size,
                 current_workspace_id: panel.workspace_id,
@@ -671,9 +717,13 @@ impl HorizonApp {
 
 #[cfg(test)]
 mod tests {
+    use egui::{Pos2, Rect, Vec2};
     use horizon_core::{AppShortcuts, ShortcutBinding, ShortcutKey, ShortcutModifiers};
 
-    use super::{SSH_RECONNECT_SHORTCUT, global_shortcut_bindings, local_ssh_reconnect_shortcut_conflicts};
+    use super::{
+        SSH_RECONNECT_SHORTCUT, clip_screen_rect_to_canvas, global_shortcut_bindings,
+        local_ssh_reconnect_shortcut_conflicts,
+    };
 
     #[test]
     fn default_global_shortcuts_leave_local_ssh_reconnect_available() {
@@ -721,5 +771,24 @@ mod tests {
         };
 
         assert!(global_shortcut_bindings(&shortcuts).contains(&shortcuts.command_palette));
+    }
+
+    #[test]
+    fn clip_screen_rect_to_canvas_intersects_with_canvas_bounds() {
+        let canvas_rect = Rect::from_min_max(Pos2::new(100.0, 80.0), Pos2::new(420.0, 320.0));
+        let raw_rect = Rect::from_min_max(Pos2::new(60.0, 40.0), Pos2::new(180.0, 180.0));
+
+        assert_eq!(
+            clip_screen_rect_to_canvas(raw_rect, canvas_rect),
+            Some(Rect::from_min_max(Pos2::new(100.0, 80.0), Pos2::new(180.0, 180.0)))
+        );
+    }
+
+    #[test]
+    fn clip_screen_rect_to_canvas_rejects_non_positive_intersections() {
+        let canvas_rect = Rect::from_min_size(Pos2::new(100.0, 80.0), Vec2::new(320.0, 240.0));
+        let raw_rect = Rect::from_min_size(Pos2::new(430.0, 90.0), Vec2::new(80.0, 80.0));
+
+        assert_eq!(clip_screen_rect_to_canvas(raw_rect, canvas_rect), None);
     }
 }

--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -118,7 +118,7 @@ impl HorizonApp {
     pub(super) fn apply_canvas_layer_transform(&self, ui: &mut Ui, canvas_rect: Rect) {
         let transform = canvas_scene_transform(canvas_rect, self.canvas_view);
         ui.ctx().set_transform_layer(ui.layer_id(), transform);
-        ui.set_clip_rect(transform.inverse() * canvas_rect);
+        ui.set_clip_rect(canvas_layer_clip_rect(ui.clip_rect(), transform, canvas_rect));
     }
 
     pub(super) fn zoom_canvas_at(&mut self, canvas_rect: Rect, screen_anchor: Pos2, zoom: f32) -> bool {
@@ -280,6 +280,15 @@ pub(super) fn canvas_scene_transform(canvas_rect: Rect, canvas_view: horizon_cor
 }
 
 #[must_use]
+pub(in crate::app) fn canvas_layer_clip_rect(
+    existing_clip_rect: Rect,
+    canvas_transform: TSTransform,
+    canvas_rect: Rect,
+) -> Rect {
+    existing_clip_rect.intersect(canvas_transform.inverse() * canvas_rect)
+}
+
+#[must_use]
 fn canvas_origin(canvas_rect: Rect) -> [f32; 2] {
     [canvas_rect.min.x, canvas_rect.min.y]
 }
@@ -289,7 +298,9 @@ mod tests {
     use egui::{Pos2, Rect, Vec2};
     use horizon_core::{CanvasViewState, MAX_CANVAS_ZOOM, MIN_CANVAS_ZOOM};
 
-    use super::{aligned_pan_offset, canvas_scene_transform, fit_zoom_for_frame, panel_focus_frame};
+    use super::{
+        aligned_pan_offset, canvas_layer_clip_rect, canvas_scene_transform, fit_zoom_for_frame, panel_focus_frame,
+    };
 
     #[test]
     fn canvas_scene_transform_matches_canvas_view_mapping() {
@@ -349,5 +360,16 @@ mod tests {
 
         assert!((zoomed_out - MIN_CANVAS_ZOOM).abs() <= f32::EPSILON);
         assert!((zoomed_in - MAX_CANVAS_ZOOM).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn canvas_layer_clip_rect_preserves_existing_clip_bounds() {
+        let canvas_rect = Rect::from_min_size(Pos2::new(120.0, 64.0), Vec2::new(640.0, 480.0));
+        let existing = Rect::from_min_size(Pos2::new(0.0, 0.0), Vec2::new(520.0, 360.0));
+        let transform = canvas_scene_transform(canvas_rect, CanvasViewState::new([24.0, -18.0], 1.25));
+        let clip_rect = canvas_layer_clip_rect(existing, transform, canvas_rect);
+
+        assert!(existing.contains(clip_rect.min));
+        assert!(existing.contains(clip_rect.max - Vec2::splat(0.01)));
     }
 }

--- a/crates/horizon-ui/src/app/workspace/render.rs
+++ b/crates/horizon-ui/src/app/workspace/render.rs
@@ -2,6 +2,7 @@ use egui::emath::TSTransform;
 use egui::{Context, CursorIcon, Id, Pos2, Rect, Sense, Vec2};
 
 use crate::app::panels::show_inline_rename_editor;
+use crate::app::view::canvas_layer_clip_rect;
 use crate::app::{RenameEditAction, util::OverlayExclusion};
 
 use super::paint::{
@@ -129,5 +130,9 @@ pub(super) fn render_workspace_visual(
 
 pub(super) fn apply_canvas_transform(ui: &mut egui::Ui, canvas_transform: TSTransform, canvas_clip_rect: Rect) {
     ui.ctx().set_transform_layer(ui.layer_id(), canvas_transform);
-    ui.set_clip_rect(canvas_clip_rect);
+    ui.set_clip_rect(canvas_layer_clip_rect(
+        ui.clip_rect(),
+        canvas_transform,
+        canvas_clip_rect,
+    ));
 }


### PR DESCRIPTION
## Summary
- use live current-frame panel geometry for panel hit testing and middle-pan routing instead of previous-frame cached rects
- clip panel and terminal-body screen rects to the active canvas before using them for focus and input bookkeeping
- preserve existing layer clipping by intersecting the canvas clip with the current layer clip for panel and workspace rendering

## Root cause
The main window mixed stale geometry and unclipped bounds in a few places:
- input routing during canvas pan/zoom decisions and pointer-focus sync relied on cached panel rects from the previous frame
- cached panel rects were not clipped to the current canvas bounds, so panels could still appear present across settings-panel space
- canvas rendering replaced the current layer clip instead of intersecting with it

After pan/zoom or layout changes like opening settings, focus ownership, wheel routing, and visible panel chrome could drift out of sync and produce ghost focus outlines or settings overlap.

## Impact
Focused-panel chrome, wheel routing, and canvas clipping now use the live visible geometry for the current frame, which keeps the blue focus ring and terminal scroll behavior aligned with what is actually on screen.

## Validation
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`

## Smoke testing
- macOS UI smoke is pending with a separate agent
