### PR TITLE
fix terminal panel IME activation on Windows

### DIFF
--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -373,11 +373,10 @@ fn configure_fonts() -> egui::FontDefinitions {
         include_bytes!("../../assets/fonts/NotoSansSymbols2-Regular.ttf"),
     );
 
-    fonts
-        .families
-        .entry(egui::FontFamily::Proportional)
-        .or_default()
-        .insert(0, FONT_INTER.to_owned());
+    let proportional = fonts.families.entry(egui::FontFamily::Proportional).or_default();
+    proportional.insert(0, FONT_INTER.to_owned());
+    proportional.insert(1, FONT_NOTO_CJK.to_owned());
+    proportional.insert(2, FONT_NOTO_SYMBOLS.to_owned());
 
     let monospace = fonts.families.entry(egui::FontFamily::Monospace).or_default();
     monospace.insert(0, FONT_JETBRAINS_MONO.to_owned());
@@ -477,7 +476,7 @@ mod tests {
     use super::{FONT_INTER, FONT_JETBRAINS_MONO, FONT_NOTO_CJK, FONT_NOTO_SYMBOLS, configure_fonts};
 
     #[test]
-    fn configure_fonts_registers_terminal_fallback_stack() {
+    fn configure_fonts_registers_ui_and_terminal_fallback_stacks() {
         let fonts = configure_fonts();
         let proportional = fonts
             .families
@@ -489,6 +488,8 @@ mod tests {
             .expect("monospace font family");
 
         assert_eq!(proportional.first().map(String::as_str), Some(FONT_INTER));
+        assert_eq!(proportional.get(1).map(String::as_str), Some(FONT_NOTO_CJK));
+        assert_eq!(proportional.get(2).map(String::as_str), Some(FONT_NOTO_SYMBOLS));
         assert_eq!(monospace.first().map(String::as_str), Some(FONT_JETBRAINS_MONO));
         assert_eq!(monospace.get(1).map(String::as_str), Some(FONT_NOTO_CJK));
         assert_eq!(monospace.get(2).map(String::as_str), Some(FONT_NOTO_SYMBOLS));

--- a/crates/horizon-ui/src/terminal_widget/ime.rs
+++ b/crates/horizon-ui/src/terminal_widget/ime.rs
@@ -1,0 +1,226 @@
+use alacritty_terminal::term::point_to_viewport;
+use alacritty_terminal::vte::ansi::CursorShape;
+use egui::{Id, Pos2, Rect, Vec2};
+use horizon_core::Panel;
+
+use crate::input::TerminalInputEvent;
+
+use super::layout::{GridMetrics, TerminalInteraction, usize_to_f32};
+
+#[derive(Clone, Copy, Default)]
+struct TerminalImeState {
+    enabled: bool,
+}
+
+pub(super) fn publish_terminal_ime_output(
+    ui: &egui::Ui,
+    panel: &Panel,
+    interaction: &TerminalInteraction,
+    metrics: &GridMetrics,
+) {
+    let to_global = ui.ctx().layer_transform_to_global(ui.layer_id()).unwrap_or_default();
+    let body_rect = interaction.layout.body;
+    let cursor_rect = terminal_cursor_rect(panel, body_rect, metrics).unwrap_or(body_rect);
+
+    ui.ctx().output_mut(|output| {
+        output.ime = Some(egui::output::IMEOutput {
+            rect: to_global * body_rect,
+            cursor_rect: to_global * cursor_rect,
+        });
+    });
+}
+
+pub(super) fn clear_terminal_ime_state(ui: &egui::Ui, terminal_id: Id) {
+    ui.data_mut(|data| {
+        data.remove_temp::<TerminalImeState>(terminal_id);
+    });
+}
+
+pub(super) fn terminal_ime_enabled(ui: &egui::Ui, terminal_id: Id) -> bool {
+    ui.data(|data| data.get_temp::<TerminalImeState>(terminal_id))
+        .unwrap_or_default()
+        .enabled
+}
+
+pub(super) fn store_terminal_ime_enabled(ui: &egui::Ui, terminal_id: Id, enabled: bool) {
+    ui.data_mut(|data| {
+        if enabled {
+            data.insert_temp(terminal_id, TerminalImeState { enabled });
+        } else {
+            data.remove_temp::<TerminalImeState>(terminal_id);
+        }
+    });
+}
+
+pub(super) fn prepare_terminal_keyboard_events(
+    events: &[TerminalInputEvent],
+    ime_enabled: bool,
+) -> Vec<TerminalInputEvent> {
+    let ime_events_present = events.iter().any(|event| matches!(event.event, egui::Event::Ime(_)));
+    if !ime_enabled && !ime_events_present {
+        return events.to_vec();
+    }
+
+    let mut filtered = events.to_vec();
+    filtered.retain(|event| !is_ime_incompatible_event(&event.event));
+    filtered.sort_by_key(|event| !matches!(event.event, egui::Event::Ime(_)));
+    filtered
+}
+
+fn is_ime_incompatible_event(event: &egui::Event) -> bool {
+    matches!(
+        event,
+        egui::Event::Key { repeat: true, .. }
+            | egui::Event::Key {
+                key: egui::Key::Backspace
+                    | egui::Key::ArrowUp
+                    | egui::Key::ArrowDown
+                    | egui::Key::ArrowLeft
+                    | egui::Key::ArrowRight,
+                ..
+            }
+    )
+}
+
+fn terminal_cursor_rect(panel: &Panel, body_rect: Rect, metrics: &GridMetrics) -> Option<Rect> {
+    let terminal = panel.terminal()?;
+    terminal.with_renderable_content(|content| {
+        let point = point_to_viewport(content.display_offset, content.cursor.point)?;
+        Some(cursor_rect_for_viewport_point(
+            body_rect,
+            metrics,
+            point.line,
+            point.column.0,
+            content.cursor.shape,
+        ))
+    })
+}
+
+fn cursor_rect_for_viewport_point(
+    body_rect: Rect,
+    metrics: &GridMetrics,
+    line: usize,
+    column: usize,
+    shape: CursorShape,
+) -> Rect {
+    let min = Pos2::new(
+        body_rect.min.x + usize_to_f32(column) * metrics.char_width,
+        body_rect.min.y + usize_to_f32(line) * metrics.line_height,
+    );
+
+    match shape {
+        CursorShape::Underline => Rect::from_min_size(
+            Pos2::new(min.x, min.y + metrics.line_height - 2.0),
+            Vec2::new(metrics.char_width, 2.0),
+        ),
+        CursorShape::Beam => Rect::from_min_size(min, Vec2::new(2.0, metrics.line_height)),
+        CursorShape::Block | CursorShape::HollowBlock | CursorShape::Hidden => {
+            Rect::from_min_size(min, Vec2::new(metrics.char_width, metrics.line_height))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cursor_rect_for_viewport_point, prepare_terminal_keyboard_events};
+    use crate::input::TerminalInputEvent;
+    use crate::terminal_widget::layout::GridMetrics;
+    use alacritty_terminal::vte::ansi::CursorShape;
+    use egui::{Event, FontId, Key, Modifiers, Rect, pos2, vec2};
+
+    fn metrics() -> GridMetrics {
+        GridMetrics {
+            char_width: 8.0,
+            line_height: 16.0,
+            font_id: FontId::monospace(13.0),
+        }
+    }
+
+    fn terminal_event(event: Event) -> TerminalInputEvent {
+        TerminalInputEvent {
+            event,
+            key_without_modifiers_text: None,
+            observed_key: None,
+        }
+    }
+
+    #[test]
+    fn prepare_terminal_keyboard_events_filters_ime_incompatible_keys() {
+        let events = vec![
+            terminal_event(Event::Key {
+                key: Key::ArrowLeft,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: Modifiers::NONE,
+            }),
+            terminal_event(Event::Ime(egui::ImeEvent::Commit("中".to_owned()))),
+            terminal_event(Event::Key {
+                key: Key::A,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: Modifiers::NONE,
+            }),
+            terminal_event(Event::Key {
+                key: Key::B,
+                physical_key: None,
+                pressed: true,
+                repeat: true,
+                modifiers: Modifiers::NONE,
+            }),
+        ];
+
+        let filtered = prepare_terminal_keyboard_events(&events, true);
+
+        assert!(matches!(
+            filtered.first(),
+            Some(TerminalInputEvent {
+                event: Event::Ime(egui::ImeEvent::Commit(text)),
+                ..
+            }) if text == "中"
+        ));
+        assert!(filtered.iter().all(|event| !matches!(
+            event.event,
+            Event::Key {
+                key: Key::ArrowLeft,
+                ..
+            } | Event::Key { repeat: true, .. }
+        )));
+        assert!(
+            filtered
+                .iter()
+                .any(|event| matches!(event.event, Event::Key { key: Key::A, .. }))
+        );
+    }
+
+    #[test]
+    fn prepare_terminal_keyboard_events_leaves_regular_input_untouched() {
+        let events = vec![
+            terminal_event(Event::Text("a".to_owned())),
+            terminal_event(Event::Key {
+                key: Key::Enter,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: Modifiers::NONE,
+            }),
+        ];
+
+        assert_eq!(prepare_terminal_keyboard_events(&events, false), events);
+    }
+
+    #[test]
+    fn cursor_rect_tracks_viewport_cell_position() {
+        let rect = cursor_rect_for_viewport_point(
+            Rect::from_min_size(pos2(10.0, 20.0), vec2(320.0, 240.0)),
+            &metrics(),
+            2,
+            3,
+            CursorShape::Block,
+        );
+
+        assert_eq!(rect.min, pos2(34.0, 52.0));
+        assert_eq!(rect.size(), vec2(8.0, 16.0));
+    }
+}

--- a/crates/horizon-ui/src/terminal_widget/input.rs
+++ b/crates/horizon-ui/src/terminal_widget/input.rs
@@ -11,6 +11,7 @@ use super::super::input::{self, TerminalInputEvent};
 use super::super::primary_selection::PrimarySelection;
 use crate::app::shortcuts::shortcut_event_matches;
 
+use super::ime::{prepare_terminal_keyboard_events, store_terminal_ime_enabled, terminal_ime_enabled};
 use super::layout::{GridMetrics, TerminalInteraction, cell_side, grid_point_from_position};
 use super::scrollbar::{scrollbar_pointer_to_scrollback, scrollbar_thumb_height};
 
@@ -465,6 +466,7 @@ fn handle_pointer_selection_drag(
 
 pub(super) fn handle_terminal_keyboard_input(
     ui: &egui::Ui,
+    terminal_id: egui::Id,
     panel: &mut Panel,
     events: &[TerminalInputEvent],
     primary_selection: &PrimarySelection,
@@ -479,10 +481,21 @@ pub(super) fn handle_terminal_keyboard_input(
     };
     let mode = terminal.mode();
     let mut forwarder = KeyboardInputForwarder::default();
+    let mut ime_enabled = terminal_ime_enabled(ui, terminal_id);
+    let events = prepare_terminal_keyboard_events(events, ime_enabled);
 
-    for event in events {
+    for event in &events {
         match &event.event {
+            egui::Event::Ime(egui::ImeEvent::Enabled | egui::ImeEvent::Preedit(_)) => {
+                ime_enabled = true;
+            }
+            egui::Event::Ime(egui::ImeEvent::Disabled) => {
+                ime_enabled = false;
+            }
             egui::Event::Text(text) | egui::Event::Ime(egui::ImeEvent::Commit(text)) => {
+                if matches!(&event.event, egui::Event::Ime(egui::ImeEvent::Commit(_))) {
+                    ime_enabled = false;
+                }
                 let emission = forwarder.on_text(text, mode);
                 if emission.clears_selection {
                     terminal.clear_selection();
@@ -527,6 +540,8 @@ pub(super) fn handle_terminal_keyboard_input(
     if !emission.bytes.is_empty() {
         terminal.write_input(&emission.bytes);
     }
+
+    store_terminal_ime_enabled(ui, terminal_id, ime_enabled);
 
     false
 }

--- a/crates/horizon-ui/src/terminal_widget/mod.rs
+++ b/crates/horizon-ui/src/terminal_widget/mod.rs
@@ -1,3 +1,4 @@
+mod ime;
 mod input;
 mod layout;
 mod render;
@@ -6,6 +7,7 @@ mod scrollbar;
 use egui::{Context, FontId, Vec2};
 use horizon_core::Panel;
 
+use self::ime::{clear_terminal_ime_state, publish_terminal_ime_output};
 pub(crate) use self::input::SSH_RECONNECT_SHORTCUT;
 use self::input::{PointerSupport, handle_terminal_keyboard_input, handle_terminal_pointer_input};
 use self::layout::{GridMetrics, terminal_interaction, terminal_layout, terminal_viewport_size};
@@ -89,6 +91,9 @@ impl<'a> TerminalView<'a> {
                     },
                 );
             });
+            publish_terminal_ime_output(ui, self.panel, &interaction, &metrics);
+        } else {
+            clear_terminal_ime_state(ui, interaction.body.id);
         }
 
         let allow_grid_cache = !self.panel.had_recent_output()
@@ -136,6 +141,7 @@ impl<'a> TerminalView<'a> {
         if interactive && has_terminal_focus {
             *keyboard.reconnect_requested |= handle_terminal_keyboard_input(
                 ui,
+                interaction.body.id,
                 self.panel,
                 keyboard.keyboard_events,
                 keyboard.primary_selection,


### PR DESCRIPTION
## Summary
- emit egui IME output for focused terminal panels so the native window backend enables IME and positions the candidate UI
- track terminal-local IME composition state and filter IME-incompatible key events while composition is active
- add focused unit coverage for terminal IME event ordering and cursor rect calculation

## Root Cause
The terminal widget handled committed IME text, but it never published `PlatformOutput.ime` while focused. With `egui-winit`, that leaves `set_ime_allowed(false)` in effect, so Windows does not activate IME for the terminal panel.

## Impact
This gives terminal panels the same IME activation signal that egui text widgets already provide, which should allow Windows IME candidate windows to appear and commit text into the PTY.

## Validation
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`

Refs #154
