### PR TITLE
Fix rustfmt failure on main

### DIFF
--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -350,5 +350,4 @@ mod tests {
         assert!((zoomed_out - MIN_CANVAS_ZOOM).abs() <= f32::EPSILON);
         assert!((zoomed_in - MAX_CANVAS_ZOOM).abs() <= f32::EPSILON);
     }
-
 }


### PR DESCRIPTION
## Summary
- remove the stray blank line in `crates/horizon-ui/src/app/view.rs`
- restore a rustfmt-clean tree for the failing `main` workflow

## Why
The `Format` job on `main` is the only failing check in workflow run `24277383109`. Rustfmt reports a one-line diff in `app/view.rs`.

## Validation
- `cargo fmt --all -- --check`