### PR TITLE
perf(render): reduce per-frame allocations in panel and pointer hot paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,13 @@ uuid = { version = "1.23.0", features = ["serde", "v4"] }
 git2 = { version = "0.20", default-features = false }
 regex = "1.12.3"
 arboard = "3.6.1"
-tokio = { version = "1.52.0", features = ["full"] }
+tokio = { version = "1.52.0", features = ["rt", "macros"] }
 surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.0.0-beta.12", package = "surge-core" }
 
 [profile.release]
 lto = true
 strip = true
+panic = "abort"
 
 [profile.profiling]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.
 [profile.release]
 lto = true
 strip = true
-panic = "abort"
 
 [profile.profiling]
 inherits = "release"

--- a/crates/horizon-core/src/runtime_state/agent_sessions.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -26,7 +27,7 @@ impl AgentSessionCatalog {
         let mut sessions = load_claude_sessions()?;
         sessions.extend(load_codex_sessions()?);
         sessions.extend(load_opencode_sessions()?);
-        sessions.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        sessions.sort_by_key(|session| Reverse(session.updated_at));
         Ok(Self { sessions })
     }
 
@@ -75,7 +76,7 @@ fn load_claude_sessions() -> Result<Vec<AgentSessionRecord>> {
 
     let mut session_paths = Vec::new();
     collect_claude_project_files(&projects_dir, &mut session_paths)?;
-    session_paths.sort_by(|left, right| right.1.cmp(&left.1));
+    session_paths.sort_by_key(|(_, updated_at)| Reverse(*updated_at));
     session_paths.truncate(super::MAX_CLAUDE_SESSION_FILES);
 
     let mut sessions_by_id: HashMap<String, AgentSessionRecord> = HashMap::new();
@@ -96,7 +97,7 @@ fn load_claude_sessions() -> Result<Vec<AgentSessionRecord>> {
     }
 
     let mut sessions: Vec<_> = sessions_by_id.into_values().collect();
-    sessions.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    sessions.sort_by_key(|session| Reverse(session.updated_at));
     Ok(sessions)
 }
 

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -335,15 +335,12 @@ impl HorizonApp {
         self.panel_screen_order.clear();
         let workspace_collision_ids = self.workspace_collision_scope(Some(workspace_id));
 
-        let workspaces: Vec<_> = self
-            .board
-            .workspaces
-            .iter()
-            .map(|workspace| {
+        self.workspace_colors.clear();
+        self.workspace_colors
+            .extend(self.board.workspaces.iter().map(|workspace| {
                 let (r, g, b) = workspace.accent();
-                (workspace.id, workspace.name.clone(), Color32::from_rgb(r, g, b))
-            })
-            .collect();
+                (workspace.id, Color32::from_rgb(r, g, b))
+            }));
 
         let mut panel_ids = self
             .board
@@ -356,14 +353,7 @@ impl HorizonApp {
         let canvas_rect = detached_canvas_rect(ctx);
         self.panels_to_close.clear();
         for (fallback_index, panel_id) in panel_ids.into_iter().enumerate() {
-            if self.render_panel(
-                ctx,
-                canvas_rect,
-                panel_id,
-                fallback_index,
-                &workspaces,
-                &workspace_collision_ids,
-            ) {
+            if self.render_panel(ctx, canvas_rect, panel_id, fallback_index, &workspace_collision_ids) {
                 self.panels_to_close.push(panel_id);
             }
         }

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::time::Instant;
 
-use egui::{Context, Pos2, Rect, Vec2, ViewportId};
+use egui::{Color32, Context, Pos2, Rect, Vec2, ViewportId};
 use horizon_core::{
     AgentSessionBinding, AgentSessionCatalog, AppShortcuts, Board, CanvasViewState, Config, GitWatcher, ManagedInstall,
     PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease, SessionStore,
@@ -162,6 +162,8 @@ pub struct HorizonApp {
     panel_screen_rects: HashMap<PanelId, Rect>,
     terminal_body_screen_rects: HashMap<PanelId, Rect>,
     panel_screen_order: Vec<PanelId>,
+    panel_render_order: Vec<(PanelId, usize)>,
+    workspace_colors: Vec<(WorkspaceId, Color32)>,
     primary_selection: PrimarySelection,
     terminal_grid_cache: HashMap<PanelId, TerminalGridCache>,
     editor_preview_cache: HashMap<PanelId, MarkdownPreviewCache>,
@@ -252,6 +254,8 @@ impl HorizonApp {
             theme_applied: false,
             panel_screen_rects: HashMap::new(),
             panel_screen_order: Vec::new(),
+            panel_render_order: Vec::new(),
+            workspace_colors: Vec::new(),
             terminal_grid_cache: HashMap::new(),
             editor_preview_cache: HashMap::new(),
             canvas_grid_cache: CanvasGridCache::default(),

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -229,6 +229,19 @@ pub struct HorizonApp {
     exit_cleanup_complete: bool,
 }
 
+struct AppBootstrap {
+    config_path: PathBuf,
+    session_store: SessionStore,
+    observed_keyboard_inputs: input::ObservedKeyboardInputs,
+    board: Board,
+    resolved_theme: theme::ResolvedTheme,
+    config_last_mtime: Option<std::time::SystemTime>,
+    managed_install: Option<ManagedInstall>,
+    next_surge_update_check_at: Option<Instant>,
+    shortcuts: AppShortcuts,
+    action_commands_cache: Vec<CommandEntry>,
+}
+
 impl HorizonApp {
     pub fn new(
         cc: &eframe::CreationContext<'_>,
@@ -250,7 +263,46 @@ impl HorizonApp {
         let config_last_mtime = std::fs::metadata(&config_path).ok().and_then(|m| m.modified().ok());
         let (managed_install, next_surge_update_check_at) = managed_install_state();
 
-        let mut app = Self {
+        let bootstrap = AppBootstrap {
+            config_path,
+            session_store,
+            observed_keyboard_inputs,
+            board,
+            resolved_theme,
+            config_last_mtime,
+            managed_install,
+            next_surge_update_check_at,
+            shortcuts,
+            action_commands_cache,
+        };
+        let mut app = Self::initial_state(config, bootstrap);
+
+        match startup {
+            StartupDecision::Open { session, .. } => app.activate_persistent_session(&session),
+            StartupDecision::Ephemeral { runtime_state } => app.activate_ephemeral_session(&runtime_state),
+            StartupDecision::Choose(chooser) => app.startup_chooser = Some(StartupChooserState::new(chooser)),
+        }
+
+        app.maybe_start_update_check();
+
+        app
+    }
+
+    fn initial_state(config: &Config, bootstrap: AppBootstrap) -> Self {
+        let AppBootstrap {
+            config_path,
+            session_store,
+            observed_keyboard_inputs,
+            board,
+            resolved_theme,
+            config_last_mtime,
+            managed_install,
+            next_surge_update_check_at,
+            shortcuts,
+            action_commands_cache,
+        } = bootstrap;
+
+        Self {
             board,
             panels_to_close: Vec::new(),
             panels_to_restart: Vec::new(),
@@ -333,17 +385,7 @@ impl HorizonApp {
             config_last_check: None,
             shutdown_progress: None,
             exit_cleanup_complete: false,
-        };
-
-        match startup {
-            StartupDecision::Open { session, .. } => app.activate_persistent_session(&session),
-            StartupDecision::Ephemeral { runtime_state } => app.activate_ephemeral_session(&runtime_state),
-            StartupDecision::Choose(chooser) => app.startup_chooser = Some(StartupChooserState::new(chooser)),
         }
-
-        app.maybe_start_update_check();
-
-        app
     }
 }
 

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -30,8 +30,6 @@ struct PanelSnapshot {
     canvas_position: Pos2,
     canvas_size: Vec2,
     current_workspace_id: WorkspaceId,
-    title: String,
-    display_title: String,
     kind: PanelKind,
     history_size: usize,
     scrollback_limit: usize,
@@ -289,39 +287,39 @@ impl HorizonApp {
         self.panel_screen_order.clear();
         let workspace_collision_ids = self.workspace_collision_scope(None);
 
-        let workspaces: Vec<(WorkspaceId, String, Color32)> = self
-            .board
-            .workspaces
-            .iter()
-            .map(|workspace| {
+        // Reuse workspace color vec across frames (avoids per-frame String
+        // clones — names are looked up lazily in the context menu).
+        self.workspace_colors.clear();
+        self.workspace_colors
+            .extend(self.board.workspaces.iter().map(|workspace| {
                 let (r, g, b) = workspace.accent();
-                (workspace.id, workspace.name.clone(), Color32::from_rgb(r, g, b))
-            })
-            .collect();
+                (workspace.id, Color32::from_rgb(r, g, b))
+            }));
 
-        let mut panel_order: Vec<_> = self
-            .board
-            .panels
-            .iter()
-            .filter(|panel| !self.workspace_is_detached(panel.workspace_id))
-            .enumerate()
-            .map(|(index, panel)| (panel.id, index))
-            .collect();
+        // Reuse panel ordering vec across frames. Collect into a local first,
+        // then swap into the field, because the filter borrows self immutably
+        // while extend borrows panel_render_order mutably.
+        let mut order = std::mem::take(&mut self.panel_render_order);
+        order.clear();
+        order.extend(
+            self.board
+                .panels
+                .iter()
+                .filter(|panel| !self.workspace_is_detached(panel.workspace_id))
+                .enumerate()
+                .map(|(index, panel)| (panel.id, index)),
+        );
+        self.panel_render_order = order;
         let focused = self.board.focused;
-        panel_order.sort_by_key(|(panel_id, _)| Some(*panel_id) == focused);
+        self.panel_render_order
+            .sort_by_key(|(panel_id, _)| Some(*panel_id) == focused);
 
         let canvas_rect = self.canvas_rect(ctx);
         let mut panels_to_close = Vec::new();
 
-        for (panel_id, fallback_index) in panel_order {
-            if self.render_panel(
-                ctx,
-                canvas_rect,
-                panel_id,
-                fallback_index,
-                &workspaces,
-                &workspace_collision_ids,
-            ) {
+        for i in 0..self.panel_render_order.len() {
+            let (panel_id, fallback_index) = self.panel_render_order[i];
+            if self.render_panel(ctx, canvas_rect, panel_id, fallback_index, &workspace_collision_ids) {
                 panels_to_close.push(panel_id);
             }
         }
@@ -336,33 +334,28 @@ impl HorizonApp {
         canvas_rect: Rect,
         panel_id: PanelId,
         _fallback_index: usize,
-        workspaces: &[(WorkspaceId, String, Color32)],
         workspace_collision_ids: &[WorkspaceId],
     ) -> bool {
-        let Some(snapshot) = self.panel_snapshot(panel_id, canvas_rect, workspaces) else {
+        let Some(snapshot) = self.panel_snapshot(panel_id, canvas_rect) else {
             return false;
         };
-        let outcome = self.show_panel_area(ctx, canvas_rect, panel_id, &snapshot, workspaces);
+        let outcome = self.show_panel_area(ctx, canvas_rect, panel_id, &snapshot);
         self.apply_panel_outcome(ctx, panel_id, &snapshot, &outcome, workspace_collision_ids)
     }
 
     #[profiling::function]
-    fn panel_snapshot(
-        &self,
-        panel_id: PanelId,
-        canvas_rect: Rect,
-        workspaces: &[(WorkspaceId, String, Color32)],
-    ) -> Option<PanelSnapshot> {
+    fn panel_snapshot(&self, panel_id: PanelId, canvas_rect: Rect) -> Option<PanelSnapshot> {
         self.board.panel(panel_id).and_then(|panel| {
             let geometry = self.panel_screen_geometry(panel, canvas_rect)?;
             let terminal = panel.terminal();
             let canvas_position = Pos2::new(panel.layout.position[0], panel.layout.position[1]);
             let canvas_size = Vec2::new(panel.layout.size[0], panel.layout.size[1]);
 
-            let workspace_accent = workspaces
+            let workspace_accent = self
+                .workspace_colors
                 .iter()
-                .find(|(workspace_id, _, _)| *workspace_id == panel.workspace_id)
-                .map(|(_, _, color)| *color);
+                .find(|(workspace_id, _)| *workspace_id == panel.workspace_id)
+                .map(|(_, color)| *color);
 
             let attention_badge = if self.template_config.features.attention_feed {
                 self.board
@@ -378,8 +371,6 @@ impl HorizonApp {
                 canvas_position,
                 canvas_size,
                 current_workspace_id: panel.workspace_id,
-                title: panel.title.clone(),
-                display_title: panel.display_title().into_owned(),
                 kind: panel.kind,
                 history_size: terminal.map_or(0, horizon_core::Terminal::history_size),
                 scrollback_limit: terminal.map_or(0, horizon_core::Terminal::scrollback_limit),
@@ -399,7 +390,6 @@ impl HorizonApp {
         canvas_rect: Rect,
         panel_id: PanelId,
         snapshot: &PanelSnapshot,
-        workspaces: &[(WorkspaceId, String, Color32)],
     ) -> PanelUiOutcome {
         let mut outcome = PanelUiOutcome::default();
         let interactive = !self.canvas_pan_input_claimed;
@@ -457,10 +447,19 @@ impl HorizonApp {
                         panel_id,
                         snapshot.current_workspace_id,
                         snapshot.kind,
-                        workspaces,
                         &mut outcome,
                     );
                 }
+
+                // Compute display_title from the board on demand, avoiding a
+                // per-panel String clone in PanelSnapshot. The Cow is borrowed
+                // when the underlying panel title is sufficient, and only
+                // allocates when a formatted composite title is needed.
+                let display_title = if snapshot.is_renaming {
+                    None
+                } else {
+                    self.board.panel(panel_id).map(|p| p.display_title())
+                };
 
                 paint_panel_chrome(
                     ui,
@@ -471,11 +470,7 @@ impl HorizonApp {
                         titlebar_rect: rects.titlebar,
                         close_rect: rects.close,
                         resize_rect: rects.resize,
-                        title: if snapshot.is_renaming {
-                            None
-                        } else {
-                            Some(snapshot.display_title.as_str())
-                        },
+                        title: display_title.as_deref(),
                         history_size: snapshot.history_size,
                         scrollback_limit: snapshot.scrollback_limit,
                         focused: snapshot.is_focused,
@@ -485,6 +480,9 @@ impl HorizonApp {
                         ssh_status: snapshot.ssh_status,
                     },
                 );
+
+                // Release the shared board borrow before the mutable borrow below.
+                drop(display_title);
 
                 if snapshot.is_renaming {
                     outcome.rename_action = show_inline_rename_editor(
@@ -578,7 +576,6 @@ impl HorizonApp {
         panel_id: PanelId,
         current_workspace_id: WorkspaceId,
         kind: PanelKind,
-        workspaces: &[(WorkspaceId, String, Color32)],
         outcome: &mut PanelUiOutcome,
     ) {
         drag_response.context_menu(|ui| {
@@ -586,18 +583,23 @@ impl HorizonApp {
             ui.label(egui::RichText::new("Move to Workspace").size(11.0).color(theme::FG_DIM));
             ui.separator();
 
-            for (workspace_id, workspace_name, workspace_color) in workspaces {
-                let is_current = current_workspace_id == *workspace_id;
+            // Look up workspace names lazily — this closure only runs when the
+            // context menu is actually open, so the per-workspace iteration and
+            // formatting cost is not paid on every frame.
+            for workspace in &self.board.workspaces {
+                let (r, g, b) = workspace.accent();
+                let workspace_color = Color32::from_rgb(r, g, b);
+                let is_current = current_workspace_id == workspace.id;
                 let label = if is_current {
-                    format!("● {workspace_name}")
+                    format!("● {}", workspace.name)
                 } else {
-                    format!("  {workspace_name}")
+                    format!("  {}", workspace.name)
                 };
                 let text = egui::RichText::new(label)
-                    .color(if is_current { *workspace_color } else { theme::FG_SOFT })
+                    .color(if is_current { workspace_color } else { theme::FG_SOFT })
                     .size(12.0);
                 if ui.add(egui::Button::new(text).frame(false)).clicked() {
-                    outcome.workspace_assignment = Some(*workspace_id);
+                    outcome.workspace_assignment = Some(workspace.id);
                     ui.close();
                 }
             }
@@ -652,7 +654,9 @@ impl HorizonApp {
         if matches!(outcome.command, Some(PanelCommand::StartRename)) {
             self.clear_workspace_rename();
             self.renaming_panel = Some(panel_id);
-            self.panel_rename_buffer.clone_from(&snapshot.title);
+            if let Some(panel) = self.board.panel(panel_id) {
+                self.panel_rename_buffer.clone_from(&panel.title);
+            }
         }
 
         match outcome.rename_action {

--- a/crates/horizon-ui/src/terminal_widget/input.rs
+++ b/crates/horizon-ui/src/terminal_widget/input.rs
@@ -54,10 +54,32 @@ pub(super) fn handle_terminal_pointer_input(
         interaction.body.request_focus();
     }
 
-    let events: Vec<egui::Event> = ui.input(|input| input.events.clone());
     let from_global = ui.ctx().layer_transform_from_global(ui.layer_id());
     let body_pointer_pos = response_pointer_pos(&interaction.body);
     let scrollbar_pointer_pos = response_pointer_pos(&interaction.scrollbar);
+
+    // Check cheap interaction-state conditions before cloning the event list.
+    // For most panels the pointer is elsewhere, so we exit early and avoid the
+    // per-panel Vec<Event> clone entirely.
+    let should_handle_pointer = body_pointer_pos.is_some()
+        || scrollbar_pointer_pos.is_some()
+        || interaction.body.is_pointer_button_down_on()
+        || interaction.scrollbar.is_pointer_button_down_on()
+        || interaction.body.drag_stopped_by(PointerButton::Primary)
+        || interaction.body.double_clicked()
+        || interaction.body.triple_clicked()
+        || interaction.body.clicked_by(PointerButton::Middle)
+        || interaction.scrollbar.clicked()
+        || ui.input(|input| {
+            pointer_event_targets_rect(&input.events, from_global, interaction.layout.body)
+                || pointer_event_targets_rect(&input.events, from_global, interaction.layout.scrollbar)
+        });
+    if !should_handle_pointer {
+        return;
+    }
+
+    // Only clone events for the panel that actually needs pointer processing.
+    let events: Vec<egui::Event> = ui.input(|input| input.events.clone());
     let body_primary_press_pos = pointer_button_event_pos(
         &events,
         from_global,
@@ -72,20 +94,6 @@ pub(super) fn handle_terminal_pointer_input(
         true,
         interaction.layout.body,
     );
-    let should_handle_pointer = body_pointer_pos.is_some()
-        || scrollbar_pointer_pos.is_some()
-        || pointer_event_targets_rect(&events, from_global, interaction.layout.body)
-        || pointer_event_targets_rect(&events, from_global, interaction.layout.scrollbar)
-        || interaction.body.is_pointer_button_down_on()
-        || interaction.scrollbar.is_pointer_button_down_on()
-        || interaction.body.drag_stopped_by(PointerButton::Primary)
-        || interaction.body.double_clicked()
-        || interaction.body.triple_clicked()
-        || interaction.body.clicked_by(PointerButton::Middle)
-        || interaction.scrollbar.clicked();
-    if !should_handle_pointer {
-        return;
-    }
 
     let Some(terminal_mode) = panel.terminal_mut().map(|terminal| terminal.mode()) else {
         return;

--- a/crates/horizon-ui/src/terminal_widget/render.rs
+++ b/crates/horizon-ui/src/terminal_widget/render.rs
@@ -277,19 +277,22 @@ fn cell_text(cell: &Cell) -> Option<String> {
         return None;
     }
 
-    if cell.c == ' ' && cell.zerowidth().is_none() {
+    let zerowidth = cell.zerowidth();
+    if cell.c == ' ' && zerowidth.is_none() {
         return None;
     }
 
-    let mut text = String::new();
-    text.push(cell.c);
-    if let Some(chars) = cell.zerowidth() {
-        for ch in chars {
-            text.push(*ch);
+    match zerowidth {
+        Some(chars) => {
+            let mut text = String::with_capacity(cell.c.len_utf8() + chars.len() * 3);
+            text.push(cell.c);
+            for ch in chars {
+                text.push(*ch);
+            }
+            Some(text)
         }
+        None => Some(cell.c.to_string()),
     }
-
-    Some(text)
 }
 
 fn batchable_cell_char(cell: &Cell) -> Option<char> {


### PR DESCRIPTION
## Summary

- defer per-panel `Vec<Event>` cloning in `handle_terminal_pointer_input` until cheap pointer-hit checks show the panel actually needs pointer processing
- reuse scratch vectors for panel render order and workspace accents, and compute panel display titles and workspace labels lazily to avoid per-frame `String` cloning
- reduce terminal cell text allocation churn by fast-pathing single codepoints and only preallocating when zero-width glyphs are present
- trim Horizon's direct Tokio feature list to `rt` and `macros`; transitive dependencies still provide the IO and network features used by the update paths
- split `HorizonApp::new` bootstrap setup into a helper after merging `main`, keeping the constructor within clippy limits without changing behavior

## Review follow-up

- merged the latest `main` into this branch to resolve the PR conflict
- dropped the earlier release-profile `panic = "abort"` change

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-maintainability.sh`
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`