### PR TITLE
Publish undocumented shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,13 @@ Duplicate or overlapping bindings are rejected, including near-conflicts such as
 | **Ctrl+Shift+W** | Focus the active workspace at the current zoom |
 | **Ctrl+Shift+9** | Fit the active workspace into view |
 | **Ctrl+Shift+H** | Open Remote Hosts overlay |
+| **Ctrl+Shift+J** | Open the sessions picker |
 | **Ctrl+Shift+B** | Toggle sidebar |
 | **Ctrl+Shift+U** | Toggle HUD |
 | **Ctrl+Shift+M** | Toggle minimap |
 | **Ctrl+Shift+A** | Align visible attached workspaces into a horizontal row |
 | **Ctrl+Shift+,** | Open settings editor |
+| **Ctrl+Shift+F** | Focus the terminal search bar |
 | **Ctrl+0** | Reset canvas zoom to 100% |
 | **Ctrl+Plus** | Zoom canvas in |
 | **Ctrl+Minus** | Zoom canvas out |
@@ -209,6 +211,9 @@ Duplicate or overlapping bindings are rejected, including near-conflicts such as
 | **Escape** | Exit active panel fullscreen |
 | **Ctrl+Shift+F11** | Toggle window fullscreen |
 | **Ctrl+Shift+S** | Save the active Markdown editor |
+| **Ctrl+Shift+C** | Copy the current terminal selection |
+| **Ctrl+Shift+V** | Paste into the focused terminal |
+| **Ctrl+Shift+R** | Reconnect the focused disconnected SSH panel |
 
 ### Structured Workflow
 
@@ -232,7 +237,7 @@ If you do not want to start by dragging panels around the canvas, use Horizon li
 | **Ctrl+double-click** canvas | Create a new workspace |
 | **Ctrl+double-click** inside a workspace | Add a new terminal |
 
-<sub>On macOS, substitute Cmd for Ctrl.</sub>
+<sub>On macOS, substitute Cmd for Ctrl. Copy and paste use the standard Cmd+C / Cmd+V bindings, and on Windows you can also use Ctrl+Insert / Shift+Insert. The SSH reconnect shortcut is contextual and is disabled if another global shortcut overlaps with Ctrl+Shift+R.</sub>
 
 ---
 

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -15,6 +15,7 @@ mod root_chrome;
 mod session;
 mod session_manager;
 mod settings;
+mod shortcut_inventory;
 pub(crate) mod shortcuts;
 mod sidebar;
 mod ssh_upload;

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -1,20 +1,19 @@
 use egui::{Align, Color32, Context, Id, Layout, Order, Pos2, Rect, Sense, UiBuilder, Vec2};
-use horizon_core::{
-    AppShortcuts, AttentionSeverity, Panel, PanelId, PanelKind, ShortcutBinding, SshConnectionStatus, WorkspaceId,
-};
+use horizon_core::{AttentionSeverity, Panel, PanelId, PanelKind, ShortcutBinding, SshConnectionStatus, WorkspaceId};
 
 use super::super::editor_widget::{MarkdownEditorView, MarkdownPreviewCache};
 use super::super::git_changes_widget::GitChangesView;
 use super::super::input::TerminalInputEvent;
 use super::super::primary_selection::PrimarySelection;
 use super::super::terminal_widget::{
-    SSH_RECONNECT_SHORTCUT, TerminalGridCache, TerminalKeyboardContext, TerminalView, viewport_for_available_space,
+    TerminalGridCache, TerminalKeyboardContext, TerminalView, viewport_for_available_space,
 };
 use super::super::theme;
 use super::super::usage_widget::UsageDashboardView;
 pub(super) use super::panel_chrome::{
     PanelChrome, paint_panel_chrome, panel_kind_icon, panel_title_content_rect, show_inline_rename_editor,
 };
+use super::shortcut_inventory::ssh_reconnect_shortcut_conflicts;
 use super::util::clamp_panel_size;
 use super::{HorizonApp, PANEL_PADDING, PANEL_TITLEBAR_HEIGHT, RESIZE_HANDLE_SIZE, RenameEditAction};
 
@@ -139,35 +138,6 @@ fn show_panel_body_contents(
     }
 }
 
-fn global_shortcut_bindings(shortcuts: &AppShortcuts) -> [ShortcutBinding; 18] {
-    [
-        shortcuts.command_palette,
-        shortcuts.new_terminal,
-        shortcuts.focus_active_workspace,
-        shortcuts.fit_active_workspace,
-        shortcuts.open_remote_hosts,
-        shortcuts.toggle_sidebar,
-        shortcuts.toggle_hud,
-        shortcuts.toggle_minimap,
-        shortcuts.align_workspaces_horizontally,
-        shortcuts.toggle_settings,
-        shortcuts.zoom_reset,
-        shortcuts.zoom_in,
-        shortcuts.zoom_out,
-        shortcuts.fullscreen_panel,
-        shortcuts.exit_fullscreen_panel,
-        shortcuts.fullscreen_window,
-        shortcuts.save_editor,
-        shortcuts.search,
-    ]
-}
-
-fn local_ssh_reconnect_shortcut_conflicts(shortcuts: &AppShortcuts) -> bool {
-    global_shortcut_bindings(shortcuts)
-        .into_iter()
-        .any(|binding| binding.overlaps(SSH_RECONNECT_SHORTCUT))
-}
-
 fn clip_screen_rect_to_canvas(raw_rect: Rect, canvas_rect: Rect) -> Option<Rect> {
     let clipped = raw_rect.intersect(canvas_rect);
     (clipped.is_positive()
@@ -180,7 +150,7 @@ fn clip_screen_rect_to_canvas(raw_rect: Rect, canvas_rect: Rect) -> Option<Rect>
 
 impl HorizonApp {
     fn local_ssh_reconnect_shortcut_enabled(&self) -> bool {
-        !local_ssh_reconnect_shortcut_conflicts(&self.shortcuts)
+        !ssh_reconnect_shortcut_conflicts(&self.shortcuts)
     }
 
     pub(in crate::app) fn visible_panel_geometry_for_canvas_view(
@@ -721,61 +691,8 @@ impl HorizonApp {
 
 #[cfg(test)]
 mod tests {
+    use super::clip_screen_rect_to_canvas;
     use egui::{Pos2, Rect, Vec2};
-    use horizon_core::{AppShortcuts, ShortcutBinding, ShortcutKey, ShortcutModifiers};
-
-    use super::{
-        SSH_RECONNECT_SHORTCUT, clip_screen_rect_to_canvas, global_shortcut_bindings,
-        local_ssh_reconnect_shortcut_conflicts,
-    };
-
-    #[test]
-    fn default_global_shortcuts_leave_local_ssh_reconnect_available() {
-        assert!(!local_ssh_reconnect_shortcut_conflicts(&AppShortcuts::default()));
-    }
-
-    #[test]
-    fn matching_global_shortcut_disables_local_ssh_reconnect() {
-        let shortcuts = AppShortcuts {
-            open_remote_hosts: SSH_RECONNECT_SHORTCUT,
-            ..AppShortcuts::default()
-        };
-
-        assert!(local_ssh_reconnect_shortcut_conflicts(&shortcuts));
-    }
-
-    #[test]
-    fn overlapping_mac_command_shortcut_disables_local_ssh_reconnect() {
-        let shortcuts = AppShortcuts {
-            open_remote_hosts: ShortcutBinding::new(
-                ShortcutModifiers::MAC_CMD.plus(ShortcutModifiers::SHIFT),
-                ShortcutKey::Letter('R'),
-            ),
-            ..AppShortcuts::default()
-        };
-
-        assert!(local_ssh_reconnect_shortcut_conflicts(&shortcuts));
-    }
-
-    #[test]
-    fn save_editor_shortcut_conflict_disables_local_ssh_reconnect() {
-        let shortcuts = AppShortcuts {
-            save_editor: SSH_RECONNECT_SHORTCUT,
-            ..AppShortcuts::default()
-        };
-
-        assert!(local_ssh_reconnect_shortcut_conflicts(&shortcuts));
-    }
-
-    #[test]
-    fn global_shortcut_bindings_include_command_palette_bindings() {
-        let shortcuts = AppShortcuts {
-            command_palette: ShortcutBinding::new(ShortcutModifiers::PRIMARY_SHIFT, ShortcutKey::Letter('P')),
-            ..AppShortcuts::default()
-        };
-
-        assert!(global_shortcut_bindings(&shortcuts).contains(&shortcuts.command_palette));
-    }
 
     #[test]
     fn clip_screen_rect_to_canvas_intersects_with_canvas_bounds() {

--- a/crates/horizon-ui/src/app/settings/shortcuts.rs
+++ b/crates/horizon-ui/src/app/settings/shortcuts.rs
@@ -1,14 +1,114 @@
-use egui::Ui;
-use horizon_core::{Config, ShortcutBinding};
+use egui::{Color32, Ui};
+use horizon_core::{Config, ShortcutBinding, ShortcutsConfig};
 
+use crate::app::shortcut_inventory::{
+    copy_selection_shortcut_label, paste_shortcut_label, ssh_reconnect_shortcut_conflicts,
+};
+use crate::app::util;
+use crate::terminal_widget::SSH_RECONNECT_SHORTCUT;
 use crate::theme;
 
 const LABEL_WIDTH: f32 = 130.0;
 const ERROR_INDICATOR_WIDTH: f32 = 20.0;
 
-/// Render the Shortcuts settings tab.  Each keyboard binding is shown as
-/// an editable text field with inline validation.  Returns `true` when
-/// any binding changed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EditableShortcut {
+    CommandPalette,
+    NewTerminal,
+    FocusWorkspace,
+    FitWorkspace,
+    RemoteHosts,
+    Sessions,
+    ToggleSidebar,
+    ToggleHud,
+    ToggleMinimap,
+    AlignWorkspaces,
+    ToggleSettings,
+    ResetZoom,
+    ZoomIn,
+    ZoomOut,
+    FullscreenPanel,
+    ExitFullscreen,
+    FullscreenWindow,
+    SaveEditor,
+    SearchTerminals,
+}
+
+impl EditableShortcut {
+    const ALL: [Self; 19] = [
+        Self::CommandPalette,
+        Self::NewTerminal,
+        Self::FocusWorkspace,
+        Self::FitWorkspace,
+        Self::RemoteHosts,
+        Self::Sessions,
+        Self::ToggleSidebar,
+        Self::ToggleHud,
+        Self::ToggleMinimap,
+        Self::AlignWorkspaces,
+        Self::ToggleSettings,
+        Self::ResetZoom,
+        Self::ZoomIn,
+        Self::ZoomOut,
+        Self::FullscreenPanel,
+        Self::ExitFullscreen,
+        Self::FullscreenWindow,
+        Self::SaveEditor,
+        Self::SearchTerminals,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::CommandPalette => "Command Palette",
+            Self::NewTerminal => "New Terminal",
+            Self::FocusWorkspace => "Focus Workspace",
+            Self::FitWorkspace => "Fit Workspace",
+            Self::RemoteHosts => "Remote Hosts",
+            Self::Sessions => "Sessions",
+            Self::ToggleSidebar => "Toggle Sidebar",
+            Self::ToggleHud => "Toggle HUD",
+            Self::ToggleMinimap => "Toggle Minimap",
+            Self::AlignWorkspaces => "Align Workspaces",
+            Self::ToggleSettings => "Toggle Settings",
+            Self::ResetZoom => "Reset Zoom",
+            Self::ZoomIn => "Zoom In",
+            Self::ZoomOut => "Zoom Out",
+            Self::FullscreenPanel => "Fullscreen Panel",
+            Self::ExitFullscreen => "Exit Fullscreen",
+            Self::FullscreenWindow => "Fullscreen Window",
+            Self::SaveEditor => "Save Editor",
+            Self::SearchTerminals => "Search Terminals",
+        }
+    }
+
+    fn value_mut(self, shortcuts: &mut ShortcutsConfig) -> &mut String {
+        match self {
+            Self::CommandPalette => &mut shortcuts.command_palette,
+            Self::NewTerminal => &mut shortcuts.new_terminal,
+            Self::FocusWorkspace => &mut shortcuts.focus_active_workspace,
+            Self::FitWorkspace => &mut shortcuts.fit_active_workspace,
+            Self::RemoteHosts => &mut shortcuts.open_remote_hosts,
+            Self::Sessions => &mut shortcuts.toggle_sessions,
+            Self::ToggleSidebar => &mut shortcuts.toggle_sidebar,
+            Self::ToggleHud => &mut shortcuts.toggle_hud,
+            Self::ToggleMinimap => &mut shortcuts.toggle_minimap,
+            Self::AlignWorkspaces => &mut shortcuts.align_workspaces_horizontally,
+            Self::ToggleSettings => &mut shortcuts.toggle_settings,
+            Self::ResetZoom => &mut shortcuts.zoom_reset,
+            Self::ZoomIn => &mut shortcuts.zoom_in,
+            Self::ZoomOut => &mut shortcuts.zoom_out,
+            Self::FullscreenPanel => &mut shortcuts.fullscreen_panel,
+            Self::ExitFullscreen => &mut shortcuts.exit_fullscreen_panel,
+            Self::FullscreenWindow => &mut shortcuts.fullscreen_window,
+            Self::SaveEditor => &mut shortcuts.save_editor,
+            Self::SearchTerminals => &mut shortcuts.search,
+        }
+    }
+}
+
+/// Render the Shortcuts settings tab. Each configurable keyboard binding is
+/// shown as an editable text field with inline validation. Returns `true`
+/// when any binding changed.
 pub(super) fn render(ui: &mut Ui, config: &mut Config) -> bool {
     let mut changed = false;
     let mut all_valid = true;
@@ -18,81 +118,16 @@ pub(super) fn render(ui: &mut Ui, config: &mut Config) -> bool {
         super::dim_label(ui, "Key bindings use modifier+key syntax (e.g. Ctrl+K, Ctrl+Shift+A).");
         ui.add_space(8.0);
 
-        changed |= shortcut_row(
-            ui,
-            "Command Palette",
-            &mut config.shortcuts.command_palette,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(ui, "New Terminal", &mut config.shortcuts.new_terminal, &mut all_valid);
-        changed |= shortcut_row(
-            ui,
-            "Focus Workspace",
-            &mut config.shortcuts.focus_active_workspace,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(
-            ui,
-            "Fit Workspace",
-            &mut config.shortcuts.fit_active_workspace,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(
-            ui,
-            "Remote Hosts",
-            &mut config.shortcuts.open_remote_hosts,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(ui, "Sessions", &mut config.shortcuts.toggle_sessions, &mut all_valid);
-        changed |= shortcut_row(
-            ui,
-            "Toggle Sidebar",
-            &mut config.shortcuts.toggle_sidebar,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(ui, "Toggle HUD", &mut config.shortcuts.toggle_hud, &mut all_valid);
-        changed |= shortcut_row(
-            ui,
-            "Toggle Minimap",
-            &mut config.shortcuts.toggle_minimap,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(
-            ui,
-            "Align Workspaces",
-            &mut config.shortcuts.align_workspaces_horizontally,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(
-            ui,
-            "Toggle Settings",
-            &mut config.shortcuts.toggle_settings,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(ui, "Reset Zoom", &mut config.shortcuts.zoom_reset, &mut all_valid);
-        changed |= shortcut_row(ui, "Zoom In", &mut config.shortcuts.zoom_in, &mut all_valid);
-        changed |= shortcut_row(ui, "Zoom Out", &mut config.shortcuts.zoom_out, &mut all_valid);
-        changed |= shortcut_row(
-            ui,
-            "Fullscreen Panel",
-            &mut config.shortcuts.fullscreen_panel,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(
-            ui,
-            "Exit Fullscreen",
-            &mut config.shortcuts.exit_fullscreen_panel,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(
-            ui,
-            "Fullscreen Window",
-            &mut config.shortcuts.fullscreen_window,
-            &mut all_valid,
-        );
-        changed |= shortcut_row(ui, "Save Editor", &mut config.shortcuts.save_editor, &mut all_valid);
+        for shortcut in EditableShortcut::ALL {
+            changed |= shortcut_row(
+                ui,
+                shortcut.label(),
+                shortcut.value_mut(&mut config.shortcuts),
+                &mut all_valid,
+            );
+        }
 
-        // Cross-field validation for duplicates/overlaps.  Skip if any
+        // Cross-field validation for duplicates/overlaps. Skip if any
         // individual binding failed to parse (those errors are shown inline
         // and resolve() would just repeat them).
         if all_valid && let Err(error) = config.shortcuts.resolve() {
@@ -103,7 +138,60 @@ pub(super) fn render(ui: &mut Ui, config: &mut Config) -> bool {
         }
     });
 
+    render_contextual_shortcuts(ui, config);
+
     changed
+}
+
+fn render_contextual_shortcuts(ui: &mut Ui, config: &Config) {
+    let primary_label = util::primary_shortcut_label();
+    let (reconnect_note, reconnect_note_color) = reconnect_shortcut_note(config);
+
+    super::section_heading(ui, "Built-In Shortcuts");
+    super::section_card(ui, |ui| {
+        super::dim_label(ui, contextual_shortcuts_hint());
+        ui.add_space(8.0);
+
+        static_shortcut_row(
+            ui,
+            "Copy Selection",
+            &copy_selection_shortcut_label(primary_label),
+            None,
+            theme::FG(),
+        );
+        static_shortcut_row(ui, "Paste", &paste_shortcut_label(primary_label), None, theme::FG());
+        static_shortcut_row(
+            ui,
+            "Reconnect SSH Panel",
+            &SSH_RECONNECT_SHORTCUT.display_label(primary_label),
+            Some(reconnect_note),
+            reconnect_note_color,
+        );
+    });
+}
+
+fn reconnect_shortcut_note(config: &Config) -> (&'static str, Color32) {
+    match config.shortcuts.resolve() {
+        Ok(shortcuts) if ssh_reconnect_shortcut_conflicts(&shortcuts) => (
+            "Disabled while another global shortcut uses the same binding.",
+            theme::PALETTE_RED(),
+        ),
+        Ok(_) => ("Available when a disconnected SSH panel is focused.", theme::FG_DIM()),
+        Err(_) => (
+            "Fix shortcut validation errors to confirm whether this shortcut is available.",
+            theme::PALETTE_RED(),
+        ),
+    }
+}
+
+fn contextual_shortcuts_hint() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "These shortcuts use macOS clipboard conventions and are shown here for reference; they are not editable."
+    } else if cfg!(target_os = "windows") {
+        "These shortcuts are shown here for reference; they are not editable. Plain Ctrl+C still reaches the terminal, and Windows also accepts Ctrl+Insert / Shift+Insert for copy and paste."
+    } else {
+        "These shortcuts are shown here for reference; they are not editable. Plain Ctrl+C still reaches the terminal, so copy uses Ctrl+Shift+C."
+    }
 }
 
 fn shortcut_row(ui: &mut Ui, label: &str, value: &mut String, all_valid: &mut bool) -> bool {
@@ -144,4 +232,51 @@ fn shortcut_row(ui: &mut Ui, label: &str, value: &mut String, all_valid: &mut bo
     });
 
     row_changed
+}
+
+fn static_shortcut_row(ui: &mut Ui, label: &str, value: &str, note: Option<&str>, note_color: Color32) {
+    ui.vertical(|ui| {
+        ui.horizontal(|ui| {
+            let label_response = ui.label(egui::RichText::new(label).color(theme::FG_SOFT()).size(12.0));
+            let used = label_response.rect.width();
+            if used < LABEL_WIDTH {
+                ui.add_space(LABEL_WIDTH - used);
+            }
+
+            ui.label(
+                egui::RichText::new(value)
+                    .color(theme::FG())
+                    .size(12.0)
+                    .family(egui::FontFamily::Monospace),
+            );
+        });
+
+        if let Some(note) = note {
+            ui.add_space(2.0);
+            ui.horizontal(|ui| {
+                ui.add_space(LABEL_WIDTH);
+                ui.label(egui::RichText::new(note).color(note_color).size(11.0));
+            });
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use horizon_core::ShortcutsConfig;
+
+    use super::EditableShortcut;
+
+    #[test]
+    fn editable_shortcuts_include_search_terminals() {
+        assert!(EditableShortcut::ALL.contains(&EditableShortcut::SearchTerminals));
+    }
+
+    #[test]
+    fn editable_shortcut_rows_update_the_expected_config_field() {
+        let mut shortcuts = ShortcutsConfig::default();
+        *EditableShortcut::SearchTerminals.value_mut(&mut shortcuts) = "Alt+F".to_string();
+
+        assert_eq!(shortcuts.search, "Alt+F");
+    }
 }

--- a/crates/horizon-ui/src/app/shortcut_inventory.rs
+++ b/crates/horizon-ui/src/app/shortcut_inventory.rs
@@ -1,0 +1,134 @@
+use horizon_core::{AppShortcuts, ShortcutBinding};
+
+use crate::terminal_widget::SSH_RECONNECT_SHORTCUT;
+
+const GLOBAL_SHORTCUT_COUNT: usize = 19;
+
+pub(crate) fn global_shortcut_bindings(shortcuts: &AppShortcuts) -> [ShortcutBinding; GLOBAL_SHORTCUT_COUNT] {
+    [
+        shortcuts.command_palette,
+        shortcuts.new_terminal,
+        shortcuts.focus_active_workspace,
+        shortcuts.fit_active_workspace,
+        shortcuts.open_remote_hosts,
+        shortcuts.toggle_sessions,
+        shortcuts.toggle_sidebar,
+        shortcuts.toggle_hud,
+        shortcuts.toggle_minimap,
+        shortcuts.align_workspaces_horizontally,
+        shortcuts.toggle_settings,
+        shortcuts.zoom_reset,
+        shortcuts.zoom_in,
+        shortcuts.zoom_out,
+        shortcuts.fullscreen_panel,
+        shortcuts.exit_fullscreen_panel,
+        shortcuts.fullscreen_window,
+        shortcuts.save_editor,
+        shortcuts.search,
+    ]
+}
+
+pub(crate) fn ssh_reconnect_shortcut_conflicts(shortcuts: &AppShortcuts) -> bool {
+    global_shortcut_bindings(shortcuts)
+        .into_iter()
+        .any(|binding| binding.overlaps(SSH_RECONNECT_SHORTCUT))
+}
+
+pub(crate) fn copy_selection_shortcut_label(primary_label: &str) -> String {
+    if cfg!(target_os = "macos") {
+        format!("{primary_label}+C")
+    } else if cfg!(target_os = "windows") {
+        format!("{primary_label}+Shift+C / {primary_label}+Insert")
+    } else {
+        format!("{primary_label}+Shift+C")
+    }
+}
+
+pub(crate) fn paste_shortcut_label(primary_label: &str) -> String {
+    if cfg!(target_os = "macos") {
+        format!("{primary_label}+V")
+    } else if cfg!(target_os = "windows") {
+        format!("{primary_label}+Shift+V / Shift+Insert")
+    } else {
+        format!("{primary_label}+Shift+V")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use horizon_core::{ShortcutBinding, ShortcutKey, ShortcutModifiers};
+
+    use super::{
+        copy_selection_shortcut_label, global_shortcut_bindings, paste_shortcut_label, ssh_reconnect_shortcut_conflicts,
+    };
+    use crate::terminal_widget::SSH_RECONNECT_SHORTCUT;
+
+    #[test]
+    fn default_global_shortcuts_leave_local_ssh_reconnect_available() {
+        assert!(!ssh_reconnect_shortcut_conflicts(&horizon_core::AppShortcuts::default()));
+    }
+
+    #[test]
+    fn matching_global_shortcut_disables_local_ssh_reconnect() {
+        let shortcuts = horizon_core::AppShortcuts {
+            open_remote_hosts: SSH_RECONNECT_SHORTCUT,
+            ..horizon_core::AppShortcuts::default()
+        };
+
+        assert!(ssh_reconnect_shortcut_conflicts(&shortcuts));
+    }
+
+    #[test]
+    fn overlapping_mac_command_shortcut_disables_local_ssh_reconnect() {
+        let shortcuts = horizon_core::AppShortcuts {
+            open_remote_hosts: ShortcutBinding::new(
+                ShortcutModifiers::MAC_CMD.plus(ShortcutModifiers::SHIFT),
+                ShortcutKey::Letter('R'),
+            ),
+            ..horizon_core::AppShortcuts::default()
+        };
+
+        assert!(ssh_reconnect_shortcut_conflicts(&shortcuts));
+    }
+
+    #[test]
+    fn save_editor_shortcut_conflict_disables_local_ssh_reconnect() {
+        let shortcuts = horizon_core::AppShortcuts {
+            save_editor: SSH_RECONNECT_SHORTCUT,
+            ..horizon_core::AppShortcuts::default()
+        };
+
+        assert!(ssh_reconnect_shortcut_conflicts(&shortcuts));
+    }
+
+    #[test]
+    fn global_shortcut_bindings_include_command_palette_and_search_bindings() {
+        let shortcuts = horizon_core::AppShortcuts {
+            command_palette: ShortcutBinding::new(ShortcutModifiers::PRIMARY_SHIFT, ShortcutKey::Letter('P')),
+            search: ShortcutBinding::new(ShortcutModifiers::PRIMARY_SHIFT, ShortcutKey::Letter('G')),
+            ..horizon_core::AppShortcuts::default()
+        };
+
+        let bindings = global_shortcut_bindings(&shortcuts);
+        assert!(bindings.contains(&shortcuts.command_palette));
+        assert!(bindings.contains(&shortcuts.search));
+    }
+
+    #[test]
+    fn copy_and_paste_shortcut_labels_match_platform_conventions() {
+        let primary_label = if cfg!(target_os = "macos") { "Cmd" } else { "Ctrl" };
+        let copy = copy_selection_shortcut_label(primary_label);
+        let paste = paste_shortcut_label(primary_label);
+
+        if cfg!(target_os = "macos") {
+            assert_eq!(copy, "Cmd+C");
+            assert_eq!(paste, "Cmd+V");
+        } else if cfg!(target_os = "windows") {
+            assert_eq!(copy, "Ctrl+Shift+C / Ctrl+Insert");
+            assert_eq!(paste, "Ctrl+Shift+V / Shift+Insert");
+        } else {
+            assert_eq!(copy, "Ctrl+Shift+C");
+            assert_eq!(paste, "Ctrl+Shift+V");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- publish the missing documented shortcuts in the README, including the existing sessions shortcut and the built-in copy, paste, search, and SSH reconnect flows
- add the missing editable `Search Terminals` binding to the Settings UI and add a read-only built-in section for contextual shortcuts
- centralize SSH reconnect conflict detection so the panel behavior and Settings copy stay in sync

## Why
Issue #164 called out several shortcuts that already existed in the app but were not published anywhere users would discover them. The audit also found the sessions shortcut was missing from the README table and the settings editor had no row for the configurable search binding.

## Validation
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- launched `target/debug/horizon` with an isolated `HOME`, opened Settings -> Shortcuts, and captured live screenshots before and after resizing the window during the smoke pass

Closes #164.
