### PR TITLE
ci: disable Snap Build and Snap Store publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,9 @@ jobs:
   snap-build:
     name: Snap Build
     needs: snap-build-inputs
-    if: needs.snap-build-inputs.outputs.run_snap_build == 'true'
+    # Disabled: Snap packaging paused. Re-enable by restoring the previous
+    # condition: needs.snap-build-inputs.outputs.run_snap_build == 'true'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,7 +519,9 @@ jobs:
 
   publish-snap:
     name: Publish Snap
-    if: ${{ needs.validate-release.outputs.release_prerelease == 'false' && (github.event_name == 'release' || inputs.publish_snap) }}
+    # Disabled: Snap Store publication paused. Re-enable by restoring the previous
+    # condition: ${{ needs.validate-release.outputs.release_prerelease == 'false' && (github.event_name == 'release' || inputs.publish_snap) }}
+    if: false
     needs: [validate-release]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Hard-disables the `publish-snap` job in `.github/workflows/release.yml` by setting `if: false`.
- Hard-disables the `snap-build` job in `.github/workflows/ci.yml` the same way.
- Both original conditions are preserved in comments so the jobs can be re-enabled with one-line edits once Snap packaging resumes.
- No other infrastructure is touched: `snap/snapcraft.yaml`, `snap-build-inputs`, and the `publish_snap` workflow_dispatch input all remain in place.

## Test plan

- [x] CI green on this branch with both jobs reporting `skipping`.
- [ ] On the next stable release run, confirm the `Publish Snap` job appears as skipped (not pending or running).