### PR TITLE
fix(board): preserve sessions when panel restore fails

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -14,11 +14,11 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::attention::AttentionItem;
+use crate::attention::{AttentionItem, AttentionSeverity};
 use crate::config::Config;
 use crate::error::{Error, Result};
-use crate::panel::{Panel, PanelId, PanelKind, PanelProcessOutput};
-use crate::runtime_state::RuntimeState;
+use crate::panel::{Panel, PanelId, PanelKind, PanelOptions, PanelProcessOutput};
+use crate::runtime_state::{PanelState, RuntimeState};
 use crate::workspace::{Workspace, WorkspaceId};
 
 const PANEL_CHROME_PAD: f32 = 8.0;
@@ -27,6 +27,21 @@ const TERMINAL_PANEL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const READY_FOR_INPUT_AUTO_DISMISS_AFTER: Duration = Duration::from_secs(45);
 fn vec2_eq(left: [f32; 2], right: [f32; 2]) -> bool {
     (left[0] - right[0]).abs() <= f32::EPSILON && (left[1] - right[1]).abs() <= f32::EPSILON
+}
+
+fn panel_restore_options(panel_state: &PanelState, transcript_root: Option<&Path>) -> PanelOptions {
+    let mut options = panel_state.to_panel_options();
+    options.transcript_root = transcript_root.map(Path::to_path_buf);
+    options.restore_as_disconnected_snapshot = transcript_root.is_some() && panel_state.kind == PanelKind::Ssh;
+    options
+}
+
+fn panel_restore_label(panel_state: &PanelState) -> String {
+    if panel_state.name.is_empty() {
+        panel_state.kind.display_name().to_string()
+    } else {
+        format!("'{}'", panel_state.name)
+    }
 }
 
 /// Predefined layout arrangements for panels inside a workspace.
@@ -104,7 +119,7 @@ impl Board {
     ///
     /// # Errors
     ///
-    /// Returns an error if any configured panel fails to spawn.
+    /// Returns an error if the generated runtime state cannot be restored.
     pub fn from_config(config: &Config) -> Result<Self> {
         Self::from_runtime_state(&RuntimeState::from_config(config))
     }
@@ -113,7 +128,7 @@ impl Board {
     ///
     /// # Errors
     ///
-    /// Returns an error if any configured panel fails to spawn.
+    /// Returns an error if the runtime state cannot be restored.
     pub fn from_runtime_state(state: &RuntimeState) -> Result<Self> {
         Self::from_runtime_state_with_transcripts(state, None)
     }
@@ -122,18 +137,23 @@ impl Board {
     ///
     /// # Errors
     ///
-    /// Returns an error if any configured panel fails to spawn.
+    /// Returns an error if the runtime state cannot be restored.
     pub fn from_runtime_state_with_transcripts(state: &RuntimeState, transcript_root: Option<&Path>) -> Result<Self> {
         let mut board = Self::new();
 
         for workspace_state in &state.workspaces {
             let ws_id = board.create_workspace_record(workspace_state);
             for panel_state in &workspace_state.panels {
-                let mut options = panel_state.to_panel_options();
-                options.transcript_root = transcript_root.map(Path::to_path_buf);
-                options.restore_as_disconnected_snapshot =
-                    transcript_root.is_some() && panel_state.kind == PanelKind::Ssh;
-                board.create_panel(options, ws_id)?;
+                let options = panel_restore_options(panel_state, transcript_root);
+                if let Err(error) = board.create_panel(options, ws_id) {
+                    board.handle_panel_restore_failure(
+                        &workspace_state.name,
+                        panel_state,
+                        ws_id,
+                        transcript_root,
+                        &error,
+                    );
+                }
             }
             if let Some(workspace) = board.workspace_mut(ws_id) {
                 workspace.layout = workspace_state.layout;
@@ -156,6 +176,54 @@ impl Board {
         }
 
         Ok(board)
+    }
+
+    fn handle_panel_restore_failure(
+        &mut self,
+        workspace_name: &str,
+        panel_state: &PanelState,
+        workspace_id: WorkspaceId,
+        transcript_root: Option<&Path>,
+        error: &Error,
+    ) {
+        let panel_label = panel_restore_label(panel_state);
+        let error_message = error.to_string();
+        tracing::error!(
+            workspace = %workspace_name,
+            panel = %panel_label,
+            error = %error_message,
+            "failed to restore panel"
+        );
+
+        let options = panel_restore_options(panel_state, transcript_root);
+        match self.create_failed_restore_panel(options, workspace_id, &error_message) {
+            Ok(panel_id) => {
+                self.create_attention(
+                    workspace_id,
+                    Some(panel_id),
+                    "restore",
+                    format!("Failed to restore {panel_label}: {error_message}"),
+                    AttentionSeverity::High,
+                );
+            }
+            Err(placeholder_error) => {
+                tracing::error!(
+                    workspace = %workspace_name,
+                    panel = %panel_label,
+                    error = %placeholder_error,
+                    "failed to create restore failure placeholder"
+                );
+                self.create_attention(
+                    workspace_id,
+                    None,
+                    "restore",
+                    format!(
+                        "Failed to restore {panel_label}: {error_message}. Also failed to show a placeholder: {placeholder_error}"
+                    ),
+                    AttentionSeverity::High,
+                );
+            }
+        }
     }
 
     /// Restart a panel's terminal process in-place, preserving identity and

--- a/crates/horizon-core/src/board/tests/workspace.rs
+++ b/crates/horizon-core/src/board/tests/workspace.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
-use crate::config::WorkspaceConfig;
+use crate::config::{WindowConfig, WorkspaceConfig};
 use crate::layout::{TILE_GAP, WS_COLLISION_GAP, WS_INNER_PAD};
 use crate::panel::{DEFAULT_PANEL_SIZE, PanelKind, PanelOptions, PanelResume};
 use crate::runtime_state::{PanelState, RuntimeState, WorkspaceState, WorkspaceTemplateRef};
 use crate::ssh::{SshConnection, SshConnectionStatus};
+use crate::view::CanvasViewState;
 
 use super::super::*;
 use super::editor_panel_options;
@@ -621,6 +622,91 @@ fn persisted_ssh_panels_restore_as_disconnected_snapshots() {
         panel.terminal().expect("terminal").last_lines_text(1),
         "restored ssh prompt"
     );
+}
+
+#[test]
+fn runtime_restore_keeps_remaining_panels_when_one_spawn_fails() {
+    let invalid_command = "bad\0codex";
+    let state = RuntimeState {
+        active_workspace_local_id: Some("workspace".to_string()),
+        focused_panel_local_id: Some("broken-codex".to_string()),
+        workspaces: vec![WorkspaceState {
+            local_id: "workspace".to_string(),
+            name: "Workspace".to_string(),
+            cwd: None,
+            position: Some([0.0, 40.0]),
+            template: None,
+            layout: Some(WorkspaceLayout::Grid),
+            panels: vec![
+                PanelState {
+                    local_id: "notes".to_string(),
+                    name: "Notes".to_string(),
+                    kind: PanelKind::Editor,
+                    command: None,
+                    args: Vec::new(),
+                    cwd: None,
+                    ssh_connection: None,
+                    rows: 24,
+                    cols: 80,
+                    resume: PanelResume::Fresh,
+                    position: Some([0.0, 40.0]),
+                    size: Some([320.0, 220.0]),
+                    session_binding: None,
+                    template: None,
+                    editor_content: None,
+                },
+                PanelState {
+                    local_id: "broken-codex".to_string(),
+                    name: "Broken Codex".to_string(),
+                    kind: PanelKind::Codex,
+                    command: Some(invalid_command.to_string()),
+                    args: vec!["--no-alt-screen".to_string()],
+                    cwd: None,
+                    ssh_connection: None,
+                    rows: 24,
+                    cols: 80,
+                    resume: PanelResume::Fresh,
+                    position: Some([360.0, 40.0]),
+                    size: Some([320.0, 220.0]),
+                    session_binding: None,
+                    template: None,
+                    editor_content: None,
+                },
+            ],
+        }],
+        ..RuntimeState::default()
+    };
+
+    let mut board = Board::from_runtime_state(&state).expect("board");
+
+    assert_eq!(board.panels.len(), 2);
+    assert!(board.panel_id_by_local_id("notes").is_some());
+    let failed_panel_id = board
+        .panel_id_by_local_id("broken-codex")
+        .expect("failed panel placeholder");
+    let failed_panel = board.panel(failed_panel_id).expect("failed panel");
+    assert_eq!(failed_panel.kind, PanelKind::Codex);
+    assert_eq!(failed_panel.launch_command.as_deref(), Some(invalid_command));
+    assert_eq!(failed_panel.launch_args, vec!["--no-alt-screen".to_string()]);
+    assert_eq!(board.focused, Some(failed_panel_id));
+    let placeholder_text = failed_panel
+        .terminal()
+        .expect("placeholder terminal")
+        .last_lines_text(24);
+    assert!(placeholder_text.contains("Horizon could not restore this panel"));
+    assert!(board.unresolved_attention_for_panel(failed_panel_id).is_some());
+
+    let saved_state = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    let saved_failed_panel = saved_state
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.panels)
+        .find(|panel| panel.local_id == "broken-codex")
+        .expect("saved failed panel");
+    assert_eq!(saved_failed_panel.command.as_deref(), Some(invalid_command));
+    assert_eq!(saved_failed_panel.kind, PanelKind::Codex);
+
+    board.shutdown_terminal_panels();
 }
 
 #[test]

--- a/crates/horizon-core/src/board/workspaces.rs
+++ b/crates/horizon-core/src/board/workspaces.rs
@@ -59,7 +59,27 @@ impl Board {
     /// # Errors
     ///
     /// Returns an error if the underlying PTY-backed panel cannot be spawned.
-    pub fn create_panel(&mut self, mut opts: PanelOptions, workspace: WorkspaceId) -> Result<PanelId> {
+    pub fn create_panel(&mut self, opts: PanelOptions, workspace: WorkspaceId) -> Result<PanelId> {
+        self.create_panel_with(opts, workspace, Panel::spawn)
+    }
+
+    pub(super) fn create_failed_restore_panel(
+        &mut self,
+        opts: PanelOptions,
+        workspace: WorkspaceId,
+        error_message: &str,
+    ) -> Result<PanelId> {
+        self.create_panel_with(opts, workspace, |id, workspace, opts| {
+            Panel::restore_failure(id, workspace, opts, error_message)
+        })
+    }
+
+    fn create_panel_with(
+        &mut self,
+        mut opts: PanelOptions,
+        workspace: WorkspaceId,
+        spawn_panel: impl FnOnce(PanelId, WorkspaceId, PanelOptions) -> Result<Panel>,
+    ) -> Result<PanelId> {
         let id = PanelId(self.next_panel_id);
         self.next_panel_id += 1;
         let explicit_position = opts.position.is_some();
@@ -80,7 +100,7 @@ impl Board {
 
         let layout_position = opts.position.unwrap_or_else(|| self.default_panel_position(workspace));
         let layout_size = opts.size.unwrap_or(DEFAULT_PANEL_SIZE);
-        let mut panel = Panel::spawn(id, workspace, opts)?;
+        let mut panel = spawn_panel(id, workspace, opts)?;
         panel.move_to(layout_position);
         panel.resize_layout(layout_size);
         self.panels.push(panel);

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -243,6 +243,20 @@ impl Panel {
         spawn_panel(id, workspace_id, opts)
     }
 
+    /// Build a terminal-backed placeholder for a panel that failed to restore.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the placeholder terminal runtime cannot be created.
+    pub(crate) fn restore_failure(
+        id: PanelId,
+        workspace_id: WorkspaceId,
+        opts: PanelOptions,
+        error_message: &str,
+    ) -> Result<Self> {
+        spawn::restore_failure_panel(id, workspace_id, opts, error_message)
+    }
+
     /// Drain pending terminal events. Returns `true` if any output was processed.
     #[profiling::function]
     pub fn process_output(&mut self) -> PanelProcessOutput {

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -170,6 +170,64 @@ pub(super) fn spawn_panel(id: PanelId, workspace_id: WorkspaceId, opts: PanelOpt
     }
 }
 
+pub(super) fn restore_failure_panel(
+    id: PanelId,
+    workspace_id: WorkspaceId,
+    opts: PanelOptions,
+    error_message: &str,
+) -> Result<Panel> {
+    let local_id = opts.local_id.clone().unwrap_or_else(new_local_id);
+    let PanelOptions {
+        name,
+        command,
+        args,
+        cwd,
+        ssh_connection,
+        rows,
+        cols,
+        kind,
+        resume,
+        position,
+        size,
+        session_binding,
+        template,
+        ..
+    } = opts;
+
+    let saved_ssh_connection = ssh_connection.clone();
+    let has_custom_name = name.is_some();
+    let title = name.unwrap_or_else(|| default_terminal_title(id, saved_ssh_connection.as_ref()));
+    let replay_bytes = restore_failure_replay_bytes(&title, error_message);
+    let terminal = spawn_restore_failure_snapshot_terminal(id, kind, rows, cols, replay_bytes)?;
+    let ssh_status = if kind == PanelKind::Ssh {
+        Some(SshConnectionStatus::Disconnected)
+    } else {
+        None
+    };
+
+    Ok(build_terminal_panel(
+        TerminalPanelBuildArgs {
+            id,
+            local_id,
+            title,
+            kind,
+            resume,
+            position,
+            size,
+            workspace_id,
+            session_binding,
+            template,
+            has_custom_name,
+            launch_command: command,
+            launch_args: args,
+            launch_cwd: cwd,
+            ssh_connection: saved_ssh_connection,
+        },
+        terminal,
+        ssh_status,
+    ))
+}
+
 fn spawn_terminal(id: PanelId, workspace_id: WorkspaceId, local_id: String, opts: PanelOptions) -> Result<Panel> {
     let PanelOptions {
         name,
@@ -256,6 +314,44 @@ fn spawn_terminal(id: PanelId, workspace_id: WorkspaceId, local_id: String, opts
     })?;
     tracing::info!("created panel '{}' (id={})", panel_args.title, panel_args.id.0);
     Ok(build_terminal_panel(panel_args, terminal, initial_ssh_status))
+}
+
+fn spawn_restore_failure_snapshot_terminal(
+    id: PanelId,
+    kind: PanelKind,
+    rows: u16,
+    cols: u16,
+    replay_bytes: Vec<u8>,
+) -> Result<Terminal> {
+    let (program, args) = disconnected_snapshot_launch_command();
+    Terminal::spawn(TerminalSpawnOptions {
+        program,
+        args,
+        cwd: None,
+        rows,
+        cols,
+        cell_width: DEFAULT_CELL_WIDTH,
+        cell_height: DEFAULT_CELL_HEIGHT,
+        scrollback_limit: scrollback_limit_for_kind(kind),
+        window_id: id.0,
+        replay_bytes,
+        env: HashMap::new(),
+        kitty_keyboard: kitty_keyboard_for_kind(kind),
+    })
+}
+
+fn restore_failure_replay_bytes(title: &str, error_message: &str) -> Vec<u8> {
+    format!(
+        concat!(
+            "Horizon could not restore this panel.\r\n\r\n",
+            "Panel: {title}\r\n",
+            "Error: {error_message}\r\n\r\n",
+            "Fix the command or binary, then restart the panel.\r\n"
+        ),
+        title = title,
+        error_message = error_message
+    )
+    .into_bytes()
 }
 
 fn spawn_disconnected_snapshot_terminal(id: PanelId, rows: u16, cols: u16, replay_bytes: Vec<u8>) -> Result<Terminal> {


### PR DESCRIPTION
## Summary

Fixes #174 by making runtime-state restoration tolerant of individual panel spawn failures.

When one panel cannot be restored, Horizon now:

- keeps restoring the remaining panels in the session
- creates a terminal-backed placeholder for the failed panel with the restore error
- preserves the failed panel original kind, command, args, cwd, layout, local id, and session metadata so it can be restarted after the underlying problem is fixed
- adds a high-severity attention item for the failed restore instead of silently falling back to an empty board

## Root Cause

Board::from_runtime_state_with_transcripts() used ? while restoring each panel, so any single create_panel() failure aborted the whole board restore. The UI then caught that board-level error and replaced the session with Board::new(), making every panel appear lost even though runtime.yaml still existed.

## Validation

- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings

Note: while investigating corrupt or missing Codex binaries, I found that some executable failures can surface as fast child exits instead of parent-side PTY spawn errors on macOS. This PR fixes the board-abort path described in the issue: any restore-time create_panel() error no longer takes down the full session.
