### PR TITLE
fix(presets): consolidate agent presets and unbreak Codex launch

### DIFF
--- a/crates/horizon-core/src/config.rs
+++ b/crates/horizon-core/src/config.rs
@@ -211,7 +211,8 @@ pub(crate) fn insert_missing_kilo_presets(presets: &mut Vec<PresetConfig>) {
 
 /// Single Codex preset. Codex 0.128's default invocation is auto mode
 /// (`--sandbox workspace-write --ask-for-approval on-request`), so
-/// `--no-alt-screen` is the only flag we need to set.
+/// `--no-alt-screen` is the only flag we need to set. Menu launches always
+/// start a fresh session — same as every other coding-agent default.
 pub(crate) fn default_codex_preset() -> PresetConfig {
     PresetConfig {
         name: "Codex".to_string(),
@@ -219,7 +220,7 @@ pub(crate) fn default_codex_preset() -> PresetConfig {
         kind: PanelKind::Codex,
         command: None,
         args: vec!["--no-alt-screen".to_string()],
-        resume: PanelResume::Last,
+        resume: PanelResume::Fresh,
         ssh_connection: None,
     }
 }
@@ -227,6 +228,7 @@ pub(crate) fn default_codex_preset() -> PresetConfig {
 /// Single Claude Code preset. `--permission-mode auto` (Claude Code v2.1.83+)
 /// routes actions through a separate classifier model; safer than the old
 /// `--dangerously-skip-permissions` and the right default for hands-off use.
+/// Menu launches always start a fresh session.
 pub(crate) fn default_claude_preset() -> PresetConfig {
     PresetConfig {
         name: "Claude Code".to_string(),
@@ -234,7 +236,7 @@ pub(crate) fn default_claude_preset() -> PresetConfig {
         kind: PanelKind::Claude,
         command: None,
         args: vec!["--permission-mode".to_string(), "auto".to_string()],
-        resume: PanelResume::Last,
+        resume: PanelResume::Fresh,
         ssh_connection: None,
     }
 }

--- a/crates/horizon-core/src/config.rs
+++ b/crates/horizon-core/src/config.rs
@@ -132,27 +132,20 @@ impl Default for WindowConfig {
     }
 }
 
-pub(crate) fn default_opencode_presets() -> [PresetConfig; 2] {
-    [
-        PresetConfig {
-            name: "OpenCode".to_string(),
-            alias: Some("oc".to_string()),
-            kind: PanelKind::OpenCode,
-            command: None,
-            args: Vec::new(),
-            resume: PanelResume::Last,
-            ssh_connection: None,
-        },
-        PresetConfig {
-            name: "OpenCode (Fresh)".to_string(),
-            alias: Some("ocf".to_string()),
-            kind: PanelKind::OpenCode,
-            command: None,
-            args: Vec::new(),
-            resume: PanelResume::Fresh,
-            ssh_connection: None,
-        },
-    ]
+pub(crate) fn default_opencode_presets() -> [PresetConfig; 1] {
+    [default_opencode_preset()]
+}
+
+pub(crate) fn default_opencode_preset() -> PresetConfig {
+    PresetConfig {
+        name: "OpenCode".to_string(),
+        alias: Some("oc".to_string()),
+        kind: PanelKind::OpenCode,
+        command: None,
+        args: Vec::new(),
+        resume: PanelResume::Fresh,
+        ssh_connection: None,
+    }
 }
 
 pub(crate) fn default_gemini_presets() -> [PresetConfig; 1] {
@@ -167,27 +160,20 @@ pub(crate) fn default_gemini_presets() -> [PresetConfig; 1] {
     }]
 }
 
-pub(crate) fn default_kilo_presets() -> [PresetConfig; 2] {
-    [
-        PresetConfig {
-            name: "KiloCode".to_string(),
-            alias: Some("kc".to_string()),
-            kind: PanelKind::KiloCode,
-            command: None,
-            args: Vec::new(),
-            resume: PanelResume::Last,
-            ssh_connection: None,
-        },
-        PresetConfig {
-            name: "KiloCode (Fresh)".to_string(),
-            alias: Some("kcf".to_string()),
-            kind: PanelKind::KiloCode,
-            command: None,
-            args: Vec::new(),
-            resume: PanelResume::Fresh,
-            ssh_connection: None,
-        },
-    ]
+pub(crate) fn default_kilo_presets() -> [PresetConfig; 1] {
+    [default_kilo_preset()]
+}
+
+pub(crate) fn default_kilo_preset() -> PresetConfig {
+    PresetConfig {
+        name: "KiloCode".to_string(),
+        alias: Some("kc".to_string()),
+        kind: PanelKind::KiloCode,
+        command: None,
+        args: Vec::new(),
+        resume: PanelResume::Fresh,
+        ssh_connection: None,
+    }
 }
 
 fn insert_missing_agent_presets(presets: &mut Vec<PresetConfig>, defaults: impl IntoIterator<Item = PresetConfig>) {
@@ -223,6 +209,36 @@ pub(crate) fn insert_missing_kilo_presets(presets: &mut Vec<PresetConfig>) {
     insert_missing_agent_presets(presets, default_kilo_presets());
 }
 
+/// Single Codex preset. Codex 0.128's default invocation is auto mode
+/// (`--sandbox workspace-write --ask-for-approval on-request`), so
+/// `--no-alt-screen` is the only flag we need to set.
+pub(crate) fn default_codex_preset() -> PresetConfig {
+    PresetConfig {
+        name: "Codex".to_string(),
+        alias: Some("cx".to_string()),
+        kind: PanelKind::Codex,
+        command: None,
+        args: vec!["--no-alt-screen".to_string()],
+        resume: PanelResume::Last,
+        ssh_connection: None,
+    }
+}
+
+/// Single Claude Code preset. `--permission-mode auto` (Claude Code v2.1.83+)
+/// routes actions through a separate classifier model; safer than the old
+/// `--dangerously-skip-permissions` and the right default for hands-off use.
+pub(crate) fn default_claude_preset() -> PresetConfig {
+    PresetConfig {
+        name: "Claude Code".to_string(),
+        alias: Some("cc".to_string()),
+        kind: PanelKind::Claude,
+        command: None,
+        args: vec!["--permission-mode".to_string(), "auto".to_string()],
+        resume: PanelResume::Last,
+        ssh_connection: None,
+    }
+}
+
 fn default_presets() -> Vec<PresetConfig> {
     let mut presets = vec![
         PresetConfig {
@@ -234,42 +250,8 @@ fn default_presets() -> Vec<PresetConfig> {
             resume: PanelResume::Fresh,
             ssh_connection: None,
         },
-        PresetConfig {
-            name: "Codex".to_string(),
-            alias: Some("cx".to_string()),
-            kind: PanelKind::Codex,
-            command: None,
-            args: vec!["--no-alt-screen".to_string()],
-            resume: PanelResume::Last,
-            ssh_connection: None,
-        },
-        PresetConfig {
-            name: "Codex (YOLO)".to_string(),
-            alias: Some("cxy".to_string()),
-            kind: PanelKind::Codex,
-            command: None,
-            args: vec!["--full-auto".to_string(), "--no-alt-screen".to_string()],
-            resume: PanelResume::Fresh,
-            ssh_connection: None,
-        },
-        PresetConfig {
-            name: "Claude Code".to_string(),
-            alias: Some("cc".to_string()),
-            kind: PanelKind::Claude,
-            command: None,
-            args: Vec::new(),
-            resume: PanelResume::Last,
-            ssh_connection: None,
-        },
-        PresetConfig {
-            name: "Claude Code (Auto)".to_string(),
-            alias: Some("cca".to_string()),
-            kind: PanelKind::Claude,
-            command: None,
-            args: vec!["--permission-mode".to_string(), "auto".to_string()],
-            resume: PanelResume::Fresh,
-            ssh_connection: None,
-        },
+        default_codex_preset(),
+        default_claude_preset(),
     ];
     presets.extend(default_opencode_presets());
     presets.extend(default_gemini_presets());

--- a/crates/horizon-core/src/config_migration.rs
+++ b/crates/horizon-core/src/config_migration.rs
@@ -1,9 +1,11 @@
 use std::path::Path;
 
 use crate::config::{
-    Config, insert_missing_gemini_presets, insert_missing_kilo_presets, insert_missing_opencode_presets,
+    Config, PresetConfig, default_claude_preset, default_codex_preset, default_kilo_preset, default_opencode_preset,
+    insert_missing_gemini_presets, insert_missing_kilo_presets, insert_missing_opencode_presets,
 };
 use crate::error::{Error, Result};
+use crate::panel::{PanelKind, PanelResume};
 use crate::shortcuts::ShortcutBinding;
 
 pub const CURRENT_CONFIG_VERSION: u32 = 7;
@@ -93,28 +95,149 @@ fn migrate_v4_to_v5(config: &mut Config) {
 /// v5 -> v6: add the appearance block with the default auto theme.
 fn migrate_v5_to_v6(_config: &mut Config) {}
 
-/// v6 -> v7: switch the hands-off agent presets from yolo flags to the
-/// upstream auto modes.
+/// v6 -> v7: collapse the agent preset pairs that no longer carry meaningful
+/// distinctions in their default shape.
 ///
-/// Codex `--full-auto` enables `--ask-for-approval on-request` and
-/// `--sandbox workspace-write`; Claude Code `--permission-mode auto`
-/// (v2.1.83+) routes actions through a separate classifier model.
-/// Both replace the unrestricted yolo behavior with safer defaults.
-///
-/// Only rewrites presets that still match the v6 defaults exactly so that
-/// user-customised args are left untouched.
+/// codex-cli 0.128 boots into auto mode by default and Claude Code v2.1.83+
+/// has `--permission-mode auto`, so the old interactive/hands-off split has
+/// stopped buying anything for those two — auto mode is now the default
+/// behavior, and the single `Codex` / `Claude Code` preset uses it without
+/// further qualification. The `OpenCode` and `KiloCode` pairs only differed
+/// by resume mode, and we prefer always-fresh as the single default. Drop
+/// default-shaped variants of `Codex`, `Codex (YOLO)`, `Claude Code`,
+/// `Claude Code (Auto)`, `OpenCode`, `OpenCode (Fresh)`, `KiloCode`, and
+/// `KiloCode (Fresh)`, then insert each replacement at the position of the
+/// first removed entry from its agent. User-customised presets are preserved.
 fn migrate_v6_to_v7(config: &mut Config) {
-    for preset in &mut config.presets {
-        match (preset.name.as_str(), preset.args.as_slice()) {
-            ("Codex (YOLO)", [first, second]) if first == "--yolo" && second == "--no-alt-screen" => {
-                preset.args = vec!["--full-auto".to_string(), "--no-alt-screen".to_string()];
+    collapse_agent_presets(config, "Codex", default_codex_preset, |preset| {
+        matches_default_codex(preset) || matches_default_yolo(preset)
+    });
+    collapse_agent_presets(config, "Claude Code", default_claude_preset, |preset| {
+        matches_default_claude(preset) || matches_default_claude_auto(preset)
+    });
+    collapse_agent_presets(
+        config,
+        "OpenCode",
+        default_opencode_preset,
+        matches_default_opencode_pair,
+    );
+    collapse_agent_presets(config, "KiloCode", default_kilo_preset, matches_default_kilo_pair);
+}
+
+/// Remove every preset matching `should_remove`, then insert `replacement()`
+/// at the slot of the first removed preset (unless a preset named
+/// `replacement_name` already exists).
+fn collapse_agent_presets(
+    config: &mut Config,
+    replacement_name: &str,
+    replacement: fn() -> PresetConfig,
+    should_remove: impl Fn(&PresetConfig) -> bool,
+) {
+    let mut first_removed = None;
+    let mut index = 0;
+    while index < config.presets.len() {
+        if should_remove(&config.presets[index]) {
+            if first_removed.is_none() {
+                first_removed = Some(index);
             }
-            ("Claude Code (Auto)", [only]) if only == "--dangerously-skip-permissions" => {
-                preset.args = vec!["--permission-mode".to_string(), "auto".to_string()];
-            }
-            _ => {}
+            config.presets.remove(index);
+        } else {
+            index += 1;
         }
     }
+    if !config.presets.iter().any(|preset| preset.name == replacement_name) {
+        let position = first_removed.unwrap_or(config.presets.len()).min(config.presets.len());
+        config.presets.insert(position, replacement());
+    }
+}
+
+fn matches_default_codex(preset: &PresetConfig) -> bool {
+    preset.name == "Codex"
+        && preset.alias.as_deref() == Some("cx")
+        && preset.kind == PanelKind::Codex
+        && preset.command.is_none()
+        && preset.args.as_slice() == ["--no-alt-screen"]
+        && preset.resume == PanelResume::Last
+}
+
+/// Matches every `Codex (YOLO)` default that has shipped on `release/v0.2.6`:
+/// the original `--yolo`, the broken `--full-auto` from commit `eff9335`, and
+/// the explicit auto-mode args used in pre-release dev builds.
+fn matches_default_yolo(preset: &PresetConfig) -> bool {
+    if preset.name != "Codex (YOLO)"
+        || preset.alias.as_deref() != Some("cxy")
+        || preset.kind != PanelKind::Codex
+        || preset.command.is_some()
+        || preset.resume != PanelResume::Fresh
+    {
+        return false;
+    }
+    let args: Vec<&str> = preset.args.iter().map(String::as_str).collect();
+    matches!(
+        args.as_slice(),
+        ["--yolo" | "--full-auto", "--no-alt-screen"]
+            | [
+                "--sandbox",
+                "workspace-write",
+                "--ask-for-approval",
+                "on-request",
+                "--no-alt-screen"
+            ]
+    )
+}
+
+fn matches_default_claude(preset: &PresetConfig) -> bool {
+    preset.name == "Claude Code"
+        && preset.alias.as_deref() == Some("cc")
+        && preset.kind == PanelKind::Claude
+        && preset.command.is_none()
+        && preset.args.is_empty()
+        && preset.resume == PanelResume::Last
+}
+
+/// Matches the `Claude Code (Auto)` default with either of the two arg shapes
+/// it has shipped with: the original `--dangerously-skip-permissions` and the
+/// `--permission-mode auto` form added later in v6.
+fn matches_default_claude_auto(preset: &PresetConfig) -> bool {
+    if preset.name != "Claude Code (Auto)"
+        || preset.alias.as_deref() != Some("cca")
+        || preset.kind != PanelKind::Claude
+        || preset.command.is_some()
+        || preset.resume != PanelResume::Fresh
+    {
+        return false;
+    }
+    let args: Vec<&str> = preset.args.iter().map(String::as_str).collect();
+    matches!(
+        args.as_slice(),
+        ["--dangerously-skip-permissions"] | ["--permission-mode", "auto"]
+    )
+}
+
+/// Matches either of the two default `OpenCode` presets that shipped together
+/// up through v6: the resume-last `OpenCode` and the resume-fresh
+/// `OpenCode (Fresh)`. v7 collapses both into the single always-fresh form.
+fn matches_default_opencode_pair(preset: &PresetConfig) -> bool {
+    if preset.kind != PanelKind::OpenCode || preset.command.is_some() || !preset.args.is_empty() {
+        return false;
+    }
+    matches!(
+        (preset.name.as_str(), preset.alias.as_deref(), &preset.resume),
+        ("OpenCode", Some("oc"), PanelResume::Last) | ("OpenCode (Fresh)", Some("ocf"), PanelResume::Fresh)
+    )
+}
+
+/// Matches either of the two default `KiloCode` presets that shipped together
+/// up through v6: the resume-last `KiloCode` and the resume-fresh
+/// `KiloCode (Fresh)`. v7 collapses both into the single always-fresh form.
+fn matches_default_kilo_pair(preset: &PresetConfig) -> bool {
+    if preset.kind != PanelKind::KiloCode || preset.command.is_some() || !preset.args.is_empty() {
+        return false;
+    }
+    matches!(
+        (preset.name.as_str(), preset.alias.as_deref(), &preset.resume),
+        ("KiloCode", Some("kc"), PanelResume::Last) | ("KiloCode (Fresh)", Some("kcf"), PanelResume::Fresh)
+    )
 }
 
 fn rewrite(field: &mut String, old_default: &str, new_default: &str) {
@@ -281,8 +404,13 @@ presets:
 
         migrate_v2_to_v3(&mut config);
 
-        assert!(config.presets.iter().any(|preset| preset.name == "OpenCode"));
-        assert!(config.presets.iter().any(|preset| preset.name == "OpenCode (Fresh)"));
+        let opencode = config
+            .presets
+            .iter()
+            .find(|preset| preset.name == "OpenCode")
+            .expect("OpenCode preset");
+        assert_eq!(opencode.alias.as_deref(), Some("oc"));
+        assert_eq!(opencode.resume, PanelResume::Fresh);
     }
 
     #[test]
@@ -336,18 +464,215 @@ presets:
                 .iter()
                 .any(|preset| preset.kind == crate::panel::PanelKind::Gemini)
         );
+        let kilo = config
+            .presets
+            .iter()
+            .find(|preset| preset.kind == crate::panel::PanelKind::KiloCode)
+            .expect("KiloCode preset");
+        assert_eq!(kilo.name, "KiloCode");
+        assert_eq!(kilo.alias.as_deref(), Some("kc"));
+        assert_eq!(kilo.resume, PanelResume::Fresh);
+    }
+
+    const V6_DEFAULT_AGENT_PRESETS_YAML: &str = "\
+version: 6
+presets:
+  - name: Shell
+    alias: sh
+    kind: shell
+    resume: fresh
+  - name: Codex
+    alias: cx
+    kind: codex
+    args:
+      - --no-alt-screen
+    resume: last
+  - name: Codex (YOLO)
+    alias: cxy
+    kind: codex
+    args:
+      - --yolo
+      - --no-alt-screen
+    resume: fresh
+  - name: Claude Code
+    alias: cc
+    kind: claude
+    resume: last
+  - name: Claude Code (Auto)
+    alias: cca
+    kind: claude
+    args:
+      - --dangerously-skip-permissions
+    resume: fresh
+  - name: OpenCode
+    alias: oc
+    kind: open_code
+    resume: last
+  - name: OpenCode (Fresh)
+    alias: ocf
+    kind: open_code
+    resume: fresh
+  - name: KiloCode
+    alias: kc
+    kind: kilo_code
+    resume: last
+  - name: KiloCode (Fresh)
+    alias: kcf
+    kind: kilo_code
+    resume: fresh
+";
+
+    #[test]
+    fn migration_v6_to_v7_collapses_default_agent_pairs() {
+        let mut config: Config = serde_yaml::from_str(V6_DEFAULT_AGENT_PRESETS_YAML).expect("should deserialize");
+
+        migrate_v6_to_v7(&mut config);
+
+        let codex_presets: Vec<_> = config
+            .presets
+            .iter()
+            .filter(|preset| preset.kind == PanelKind::Codex)
+            .collect();
+        assert_eq!(codex_presets.len(), 1, "should collapse to a single codex preset");
+        assert_eq!(codex_presets[0].name, "Codex");
+        assert_eq!(codex_presets[0].alias.as_deref(), Some("cx"));
+        assert_eq!(codex_presets[0].args, vec!["--no-alt-screen".to_string()]);
+        assert_eq!(codex_presets[0].resume, PanelResume::Last);
+
+        let claude_presets: Vec<_> = config
+            .presets
+            .iter()
+            .filter(|preset| preset.kind == PanelKind::Claude)
+            .collect();
+        assert_eq!(claude_presets.len(), 1, "should collapse to a single claude preset");
+        assert_eq!(claude_presets[0].name, "Claude Code");
+        assert_eq!(claude_presets[0].alias.as_deref(), Some("cc"));
         assert_eq!(
-            config
-                .presets
-                .iter()
-                .filter(|preset| preset.kind == crate::panel::PanelKind::KiloCode)
-                .count(),
-            2
+            claude_presets[0].args,
+            vec!["--permission-mode".to_string(), "auto".to_string()]
+        );
+        assert_eq!(claude_presets[0].resume, PanelResume::Last);
+
+        let opencode_presets: Vec<_> = config
+            .presets
+            .iter()
+            .filter(|preset| preset.kind == PanelKind::OpenCode)
+            .collect();
+        assert_eq!(opencode_presets.len(), 1, "should collapse to a single opencode preset");
+        assert_eq!(opencode_presets[0].name, "OpenCode");
+        assert_eq!(opencode_presets[0].alias.as_deref(), Some("oc"));
+        assert!(opencode_presets[0].args.is_empty());
+        assert_eq!(opencode_presets[0].resume, PanelResume::Fresh);
+
+        let kilo_presets: Vec<_> = config
+            .presets
+            .iter()
+            .filter(|preset| preset.kind == PanelKind::KiloCode)
+            .collect();
+        assert_eq!(kilo_presets.len(), 1, "should collapse to a single kilo preset");
+        assert_eq!(kilo_presets[0].name, "KiloCode");
+        assert_eq!(kilo_presets[0].alias.as_deref(), Some("kc"));
+        assert!(kilo_presets[0].args.is_empty());
+        assert_eq!(kilo_presets[0].resume, PanelResume::Fresh);
+    }
+
+    #[test]
+    fn migration_v6_to_v7_inserts_replacements_at_first_removed_slot() {
+        let mut config: Config = serde_yaml::from_str(V6_DEFAULT_AGENT_PRESETS_YAML).expect("should deserialize");
+
+        migrate_v6_to_v7(&mut config);
+
+        let codex_position = config
+            .presets
+            .iter()
+            .position(|preset| preset.kind == PanelKind::Codex)
+            .expect("codex preset position");
+        assert_eq!(
+            codex_position, 1,
+            "Codex replacement should land at the first removed Codex slot"
+        );
+        let claude_position = config
+            .presets
+            .iter()
+            .position(|preset| preset.kind == PanelKind::Claude)
+            .expect("claude preset position");
+        assert_eq!(
+            claude_position, 2,
+            "Claude replacement should land at the first removed Claude slot"
+        );
+        let opencode_position = config
+            .presets
+            .iter()
+            .position(|preset| preset.kind == PanelKind::OpenCode)
+            .expect("opencode preset position");
+        assert_eq!(
+            opencode_position, 3,
+            "OpenCode replacement should land at the first removed OpenCode slot"
+        );
+        let kilo_position = config
+            .presets
+            .iter()
+            .position(|preset| preset.kind == PanelKind::KiloCode)
+            .expect("kilo preset position");
+        assert_eq!(
+            kilo_position, 4,
+            "KiloCode replacement should land at the first removed KiloCode slot"
         );
     }
 
     #[test]
-    fn migration_v6_to_v7_rewrites_default_yolo_presets() {
+    fn migration_v6_to_v7_preserves_customised_opencode_presets() {
+        let mut config: Config = serde_yaml::from_str(
+            "\
+version: 6
+presets:
+  - name: OpenCode
+    alias: oc
+    kind: open_code
+    args:
+      - --model
+      - gpt-5
+    resume: last
+  - name: OpenCode (Fresh)
+    alias: ocf
+    kind: open_code
+    resume: fresh
+",
+        )
+        .expect("should deserialize");
+
+        migrate_v6_to_v7(&mut config);
+
+        // Customised OpenCode (has args) is preserved with its original name.
+        let customised = config
+            .presets
+            .iter()
+            .find(|preset| preset.alias.as_deref() == Some("oc") && !preset.args.is_empty())
+            .expect("customised OpenCode preset should be preserved");
+        assert_eq!(customised.name, "OpenCode");
+        assert_eq!(customised.resume, PanelResume::Last);
+
+        // Default-shaped OpenCode (Fresh) is removed; replacement is inserted.
+        assert!(
+            !config.presets.iter().any(|preset| preset.name == "OpenCode (Fresh)"),
+            "default-shaped OpenCode (Fresh) should be removed"
+        );
+        // The replacement reuses the "OpenCode" name. Because the customised
+        // preset already has that name, the replacement is not inserted —
+        // collapse_agent_presets short-circuits when the target name exists.
+        let opencode_count = config
+            .presets
+            .iter()
+            .filter(|preset| preset.kind == PanelKind::OpenCode)
+            .count();
+        assert_eq!(opencode_count, 1, "only the customised preset should remain");
+    }
+
+    #[test]
+    fn migration_v6_to_v7_handles_broken_full_auto_yolo_preset() {
+        // Dev users who ran the broken commit (eff9335) ended up with
+        // --full-auto in their YOLO preset; v6→v7 must still recognise and
+        // replace it.
         let mut config: Config = serde_yaml::from_str(
             "\
 version: 6
@@ -356,14 +681,8 @@ presets:
     alias: cxy
     kind: codex
     args:
-      - --yolo
+      - --full-auto
       - --no-alt-screen
-    resume: fresh
-  - name: Claude Code (Auto)
-    alias: cca
-    kind: claude
-    args:
-      - --dangerously-skip-permissions
     resume: fresh
 ",
         )
@@ -371,26 +690,20 @@ presets:
 
         migrate_v6_to_v7(&mut config);
 
+        assert!(!config.presets.iter().any(|preset| preset.name == "Codex (YOLO)"));
         let codex = config
             .presets
             .iter()
-            .find(|preset| preset.name == "Codex (YOLO)")
+            .find(|preset| preset.name == "Codex")
             .expect("codex preset");
-        assert_eq!(
-            codex.args,
-            vec!["--full-auto".to_string(), "--no-alt-screen".to_string()]
-        );
-
-        let claude = config
-            .presets
-            .iter()
-            .find(|preset| preset.name == "Claude Code (Auto)")
-            .expect("claude preset");
-        assert_eq!(claude.args, vec!["--permission-mode".to_string(), "auto".to_string()]);
+        assert_eq!(codex.args, vec!["--no-alt-screen".to_string()]);
     }
 
     #[test]
-    fn migration_v6_to_v7_preserves_customised_args() {
+    fn migration_v6_to_v7_preserves_customised_yolo_and_claude_auto_presets() {
+        // User customised the Codex (YOLO) and Claude Code (Auto) presets with
+        // extra args. Neither matches the default predicate, so both are kept,
+        // and the new "Codex" / "Claude Code" replacements are inserted alongside.
         let mut config: Config = serde_yaml::from_str(
             "\
 version: 6
@@ -416,40 +729,65 @@ presets:
         )
         .expect("should deserialize");
 
-        let original_codex_args = config
-            .presets
-            .iter()
-            .find(|preset| preset.name == "Codex (YOLO)")
-            .map(|preset| preset.args.clone())
-            .expect("codex preset");
-        let original_claude_args = config
-            .presets
-            .iter()
-            .find(|preset| preset.name == "Claude Code (Auto)")
-            .map(|preset| preset.args.clone())
-            .expect("claude preset");
-
         migrate_v6_to_v7(&mut config);
 
-        let codex_args = config
-            .presets
-            .iter()
-            .find(|preset| preset.name == "Codex (YOLO)")
-            .map(|preset| preset.args.clone())
-            .expect("codex preset");
-        let claude_args = config
-            .presets
-            .iter()
-            .find(|preset| preset.name == "Claude Code (Auto)")
-            .map(|preset| preset.args.clone())
-            .expect("claude preset");
-
-        assert_eq!(codex_args, original_codex_args);
-        assert_eq!(claude_args, original_claude_args);
+        assert!(
+            config.presets.iter().any(|preset| preset.name == "Codex (YOLO)"),
+            "customised YOLO preset should be preserved"
+        );
+        assert!(
+            config.presets.iter().any(|preset| preset.name == "Codex"),
+            "Codex replacement should be inserted"
+        );
+        assert!(
+            config.presets.iter().any(|preset| preset.name == "Claude Code (Auto)"),
+            "customised Claude Code (Auto) preset should be preserved"
+        );
+        assert!(
+            config.presets.iter().any(|preset| preset.name == "Claude Code"),
+            "Claude Code replacement should be inserted"
+        );
     }
 
     #[test]
-    fn migration_v6_to_v7_bumps_version_via_migrate_if_needed() {
+    fn migration_v6_to_v7_skips_replacement_when_customised_codex_keeps_the_name() {
+        // User customised the plain "Codex" preset (extra args). It doesn't
+        // match the default predicate, so it stays. Because a preset named
+        // "Codex" already exists, the replacement is not inserted — we don't
+        // want two presets sharing the same name in the menu.
+        let mut config: Config = serde_yaml::from_str(
+            "\
+version: 6
+presets:
+  - name: Codex
+    alias: cx
+    kind: codex
+    args:
+      - --no-alt-screen
+      - --model
+      - gpt-5
+    resume: last
+",
+        )
+        .expect("should deserialize");
+
+        migrate_v6_to_v7(&mut config);
+
+        assert_eq!(
+            config.presets.iter().filter(|preset| preset.name == "Codex").count(),
+            1,
+            "exactly one Codex preset should remain (the customised one)"
+        );
+        let codex = config
+            .presets
+            .iter()
+            .find(|preset| preset.name == "Codex")
+            .expect("codex preset");
+        assert_eq!(codex.args.last().map(String::as_str), Some("gpt-5"));
+    }
+
+    #[test]
+    fn migration_from_v6_via_migrate_if_needed_lands_on_codex_preset() {
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("config.yaml");
         let v6_yaml = "\
@@ -470,15 +808,13 @@ presets:
 
         assert!(migrated);
         assert_eq!(config.version, CURRENT_CONFIG_VERSION);
-
+        assert!(!config.presets.iter().any(|preset| preset.name == "Codex (YOLO)"));
         let codex = config
             .presets
             .iter()
-            .find(|preset| preset.name == "Codex (YOLO)")
+            .find(|preset| preset.name == "Codex")
             .expect("codex preset");
-        assert_eq!(
-            codex.args,
-            vec!["--full-auto".to_string(), "--no-alt-screen".to_string()]
-        );
+        assert_eq!(codex.args, vec!["--no-alt-screen".to_string()]);
+        assert_eq!(codex.alias.as_deref(), Some("cx"));
     }
 }

--- a/crates/horizon-core/src/config_migration.rs
+++ b/crates/horizon-core/src/config_migration.rs
@@ -537,7 +537,7 @@ presets:
         assert_eq!(codex_presets[0].name, "Codex");
         assert_eq!(codex_presets[0].alias.as_deref(), Some("cx"));
         assert_eq!(codex_presets[0].args, vec!["--no-alt-screen".to_string()]);
-        assert_eq!(codex_presets[0].resume, PanelResume::Last);
+        assert_eq!(codex_presets[0].resume, PanelResume::Fresh);
 
         let claude_presets: Vec<_> = config
             .presets
@@ -551,7 +551,7 @@ presets:
             claude_presets[0].args,
             vec!["--permission-mode".to_string(), "auto".to_string()]
         );
-        assert_eq!(claude_presets[0].resume, PanelResume::Last);
+        assert_eq!(claude_presets[0].resume, PanelResume::Fresh);
 
         let opencode_presets: Vec<_> = config
             .presets


### PR DESCRIPTION
## Summary

- Fix `Codex (YOLO)` panels failing to launch with `error: unexpected argument '--full-auto' found` after codex-cli 0.128 deprecated and removed `--full-auto` from the top-level `codex` invocation (regression from eff9335).
- Codex 0.128 boots into auto mode by default and Claude Code v2.1.83+ has `--permission-mode auto`, so the interactive/hands-off preset split no longer buys anything for those two. Drop the qualifier — `Codex` and `Claude Code` now simply *are* the auto-mode preset.
- Collapse the resume-only `OpenCode (Fresh)` and `KiloCode (Fresh)` siblings into the base preset with `resume: fresh`.
- Default Codex and Claude Code presets now also use `resume: fresh` so every coding agent launched from the menu starts with a clean session — consistent with Gemini, OpenCode, KiloCode. Users who want to resume can use the agent's own resume flow (`codex resume`, `claude --continue`) or customise the preset.
- One `v6 → v7` migration handles the cleanup. The Codex (YOLO) matcher recognises every arg shape that landed on `release/v0.2.6` (`--yolo`, broken `--full-auto`, and the explicit auto-mode args from pre-release dev builds), so any dev who tested the broken intermediate self-heals on next launch. User-customised presets are preserved; replacements aren't inserted when a same-named preset already exists.

### Final menu

| Section | Entries |
|---|---|
| New Terminal | `Shell` |
| Agents | `Codex` (cx), `Claude Code` (cc), `OpenCode` (oc), `Gemini CLI` (gm), `KiloCode` (kc) |
| Tools | `Git Changes` (gc), `Markdown` (md), `Usage` (u) |

## Test plan

- [x] `cargo test -p horizon-core` — 243 passed, 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p horizon-core --all-targets --all-features -- -D warnings` clean
- [x] `./scripts/check-maintainability.sh` clean
- [x] Verified `codex --sandbox workspace-write --ask-for-approval on-request --no-alt-screen` parses against installed codex 0.128.0
- [ ] Manual: rebuild + relaunch with v6 config (or deleted config) → menu shows the consolidated agent list above
- [ ] Manual: launch `Codex` panel from menu → reaches the codex prompt instead of dying with the `--full-auto` error
- [ ] Manual: each agent launched from the menu starts a fresh session

## Migration coverage (config v6 → v7)

New tests in `config_migration.rs`:

- `migration_v6_to_v7_collapses_default_agent_pairs` — full-fixture collapse for Codex / Claude / OpenCode / KiloCode
- `migration_v6_to_v7_inserts_replacements_at_first_removed_slot` — replacement lands at the first-removed slot per agent
- `migration_v6_to_v7_handles_broken_full_auto_yolo_preset` — recovers configs from the broken eff9335 build
- `migration_v6_to_v7_preserves_customised_yolo_and_claude_auto_presets` — non-default-shaped presets survive
- `migration_v6_to_v7_skips_replacement_when_customised_codex_keeps_the_name` — no duplicate menu entries when user customised the plain `Codex`
- `migration_v6_to_v7_preserves_customised_opencode_presets` — same for OpenCode
- `migration_from_v6_via_migrate_if_needed_lands_on_codex_preset` — end-to-end via the public `migrate_if_needed` entry