### PR TITLE
fix(presets): start a fresh session for every menu launch of Codex / Claude Code

### DIFF
--- a/crates/horizon-core/src/config.rs
+++ b/crates/horizon-core/src/config.rs
@@ -211,7 +211,8 @@ pub(crate) fn insert_missing_kilo_presets(presets: &mut Vec<PresetConfig>) {
 
 /// Single Codex preset. Codex 0.128's default invocation is auto mode
 /// (`--sandbox workspace-write --ask-for-approval on-request`), so
-/// `--no-alt-screen` is the only flag we need to set.
+/// `--no-alt-screen` is the only flag we need to set. Menu launches always
+/// start a fresh session — same as every other coding-agent default.
 pub(crate) fn default_codex_preset() -> PresetConfig {
     PresetConfig {
         name: "Codex".to_string(),
@@ -219,7 +220,7 @@ pub(crate) fn default_codex_preset() -> PresetConfig {
         kind: PanelKind::Codex,
         command: None,
         args: vec!["--no-alt-screen".to_string()],
-        resume: PanelResume::Last,
+        resume: PanelResume::Fresh,
         ssh_connection: None,
     }
 }
@@ -227,6 +228,7 @@ pub(crate) fn default_codex_preset() -> PresetConfig {
 /// Single Claude Code preset. `--permission-mode auto` (Claude Code v2.1.83+)
 /// routes actions through a separate classifier model; safer than the old
 /// `--dangerously-skip-permissions` and the right default for hands-off use.
+/// Menu launches always start a fresh session.
 pub(crate) fn default_claude_preset() -> PresetConfig {
     PresetConfig {
         name: "Claude Code".to_string(),
@@ -234,7 +236,7 @@ pub(crate) fn default_claude_preset() -> PresetConfig {
         kind: PanelKind::Claude,
         command: None,
         args: vec!["--permission-mode".to_string(), "auto".to_string()],
-        resume: PanelResume::Last,
+        resume: PanelResume::Fresh,
         ssh_connection: None,
     }
 }

--- a/crates/horizon-core/src/config_migration.rs
+++ b/crates/horizon-core/src/config_migration.rs
@@ -537,7 +537,7 @@ presets:
         assert_eq!(codex_presets[0].name, "Codex");
         assert_eq!(codex_presets[0].alias.as_deref(), Some("cx"));
         assert_eq!(codex_presets[0].args, vec!["--no-alt-screen".to_string()]);
-        assert_eq!(codex_presets[0].resume, PanelResume::Last);
+        assert_eq!(codex_presets[0].resume, PanelResume::Fresh);
 
         let claude_presets: Vec<_> = config
             .presets
@@ -551,7 +551,7 @@ presets:
             claude_presets[0].args,
             vec!["--permission-mode".to_string(), "auto".to_string()]
         );
-        assert_eq!(claude_presets[0].resume, PanelResume::Last);
+        assert_eq!(claude_presets[0].resume, PanelResume::Fresh);
 
         let opencode_presets: Vec<_> = config
             .presets


### PR DESCRIPTION
## Summary

Stacks on #178.

After the consolidation, Gemini / OpenCode / KiloCode all default to `resume: fresh` from the menu but Codex and Claude Code still defaulted to `resume: last`. Inconsistent — and surprising when a user picks `Codex` from the new-panel menu and gets dropped into an old session instead of a clean one. Switch both to `resume: fresh` so every coding agent behaves the same way out of the box.

Users who want to resume a previous session can use the agent's own resume flow (`codex resume`, `claude --continue`) or customise the preset's `resume` field.

## Test plan

- [x] `cargo test -p horizon-core` — 243 passed, 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p horizon-core --all-targets --all-features -- -D warnings` clean
- [x] `./scripts/check-maintainability.sh` clean
- [ ] Manual: rebuild + launch `Codex` from menu → starts a fresh session, not a resumed one
- [ ] Manual: same for `Claude Code`

## Note on PR base

This PR targets `fix/consolidate-agent-presets` so the diff shows only the new work. When #178 merges to `main`, GitHub will auto-retarget this PR to `main`.