### PR TITLE
fix(panel): keep panels open when child process fails or exits non-zero

### DIFF
--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -336,9 +336,18 @@ impl Panel {
         self.content.terminal().is_some_and(Terminal::child_exited)
     }
 
+    /// Returns `true` only when the panel should be auto-removed after its
+    /// child process exits.
+    ///
+    /// SSH panels never auto-close (the user often wants to see the
+    /// disconnection message). For every other kind we keep the panel open
+    /// unless the child reported a *successful* exit (status code `0`):
+    /// a missing binary, crash, or signal kill leaves the panel around so
+    /// the user can read the error instead of having it vanish silently.
     #[must_use]
     pub fn should_close_after_exit(&self) -> bool {
-        !matches!(self.kind, PanelKind::Ssh)
+        let exit_status = self.content.terminal().and_then(Terminal::child_exit_status);
+        should_close_for_exit_status(self.kind, exit_status)
     }
 
     /// Returns `true` if the terminal bell has fired since the last call.
@@ -588,6 +597,13 @@ impl Panel {
     }
 }
 
+fn should_close_for_exit_status(kind: PanelKind, exit_status: Option<std::process::ExitStatus>) -> bool {
+    if matches!(kind, PanelKind::Ssh) {
+        return false;
+    }
+    exit_status.is_some_and(|status| status.success())
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -595,7 +611,7 @@ mod tests {
     use super::{
         AGENT_PANEL_SCROLLBACK_LIMIT, AgentSessionBinding, DEFAULT_PANEL_SCROLLBACK_LIMIT, Panel, PanelContent,
         PanelId, PanelKind, PanelLayout, PanelResume, UsageDashboard, WorkspaceId, kitty_keyboard_for_kind,
-        platform_default_shell, resolve_launch_command, scrollback_limit_for_kind,
+        platform_default_shell, resolve_launch_command, scrollback_limit_for_kind, should_close_for_exit_status,
     };
     use crate::ssh::SshConnection;
 
@@ -664,6 +680,56 @@ mod tests {
         panel.kind = PanelKind::Ssh;
 
         assert!(!panel.should_close_after_exit());
+    }
+
+    #[cfg(unix)]
+    fn exit_status_with_code(code: i32) -> std::process::ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        // Wait status format on Unix: low 8 bits hold the signal (0 here),
+        // next 8 bits hold the exit code.
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(windows)]
+    fn exit_status_with_code(code: i32) -> std::process::ExitStatus {
+        use std::os::windows::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(code as u32)
+    }
+
+    #[test]
+    fn agent_panel_with_no_reported_exit_status_stays_open() {
+        // Mirrors the "binary not found" / "child still running" case where
+        // `Terminal::child_exit_status` returns `None`.
+        assert!(!should_close_for_exit_status(PanelKind::Codex, None));
+        assert!(!should_close_for_exit_status(PanelKind::Shell, None));
+    }
+
+    #[test]
+    fn agent_panel_with_failure_exit_stays_open() {
+        // 127 is the canonical "command not found" status from a shell — the
+        // exact case where we don't want the panel to vanish before the user
+        // can read the error.
+        let failure = exit_status_with_code(127);
+        assert!(!should_close_for_exit_status(PanelKind::Codex, Some(failure)));
+        assert!(!should_close_for_exit_status(PanelKind::Gemini, Some(failure)));
+        assert!(!should_close_for_exit_status(PanelKind::Shell, Some(failure)));
+    }
+
+    #[test]
+    fn agent_panel_with_clean_exit_auto_closes() {
+        let success = exit_status_with_code(0);
+        assert!(should_close_for_exit_status(PanelKind::Codex, Some(success)));
+        assert!(should_close_for_exit_status(PanelKind::Claude, Some(success)));
+        assert!(should_close_for_exit_status(PanelKind::Shell, Some(success)));
+    }
+
+    #[test]
+    fn ssh_panels_never_auto_close_regardless_of_exit_status() {
+        let success = exit_status_with_code(0);
+        let failure = exit_status_with_code(1);
+        assert!(!should_close_for_exit_status(PanelKind::Ssh, None));
+        assert!(!should_close_for_exit_status(PanelKind::Ssh, Some(success)));
+        assert!(!should_close_for_exit_status(PanelKind::Ssh, Some(failure)));
     }
 
     #[test]

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -131,6 +131,7 @@ pub struct Terminal {
     pending_pty_resize: Option<std::time::Instant>,
     pty_resized: bool,
     child_exited: bool,
+    child_exit_status: Option<std::process::ExitStatus>,
     bell_pending: bool,
     pending_notification: Option<AgentNotification>,
 }

--- a/crates/horizon-core/src/terminal/content.rs
+++ b/crates/horizon-core/src/terminal/content.rs
@@ -171,6 +171,14 @@ impl Terminal {
         self.child_exited
     }
 
+    /// Returns the exit status of the child process if it has exited *and* a
+    /// status was reported. `None` while the child is still running, or after
+    /// an `Event::Exit` that didn't carry a status (e.g. internal teardown).
+    #[must_use]
+    pub fn child_exit_status(&self) -> Option<std::process::ExitStatus> {
+        self.child_exit_status
+    }
+
     pub fn with_renderable_content<R>(&self, render: impl FnOnce(RenderableContent<'_>) -> R) -> R {
         let term = self.term.lock();
         render(term.renderable_content())

--- a/crates/horizon-core/src/terminal/events.rs
+++ b/crates/horizon-core/src/terminal/events.rs
@@ -117,8 +117,12 @@ impl Terminal {
             Event::TextAreaSizeRequest(formatter) => {
                 self.write_input(formatter(self.window_size()).as_bytes());
             }
-            Event::Exit | Event::ChildExit(_) => {
+            Event::Exit => {
                 self.child_exited = true;
+            }
+            Event::ChildExit(status) => {
+                self.child_exited = true;
+                self.child_exit_status = Some(status);
             }
             Event::Bell => {
                 self.bell_pending = true;

--- a/crates/horizon-core/src/terminal/lifecycle.rs
+++ b/crates/horizon-core/src/terminal/lifecycle.rs
@@ -81,6 +81,7 @@ impl Terminal {
             pending_pty_resize: None,
             pty_resized: false,
             child_exited: false,
+            child_exit_status: None,
             bell_pending: false,
             pending_notification: None,
         };


### PR DESCRIPTION
## Summary

Launching e.g. `Gemini CLI` from the new-panel menu when the underlying `gemini` binary is not installed currently produces a 127 from the shell, the panel auto-closes immediately, and the user has no idea what went wrong. Same shape for any agent panel where the binary is missing, the process crashes, or it's killed by a signal.

Capture the child's `ExitStatus` from `Event::ChildExit` (alacritty already provides it; we were ignoring the payload) and only auto-close the panel when the child reported a *successful* exit (status code 0). Anything else — failure, signal, or no recorded status — leaves the panel visible so the user can read the error. SSH panels still never auto-close, same as before.

The decision is now made by a small pure helper `should_close_for_exit_status(kind, exit_status)` so the four cases are covered by direct unit tests instead of having to spin up a real terminal in tests.

## Behavior matrix

| Panel kind | Child status | Auto-close? |
|---|---|---|
| SSH | any | **No** (unchanged) |
| Any other | clean exit (`code == 0`) | **Yes** (unchanged) |
| Any other | failure (`code != 0`, includes 127 \"command not found\") | **No** (new — was Yes) |
| Any other | signal kill | **No** (new — was Yes) |
| Any other | child still running / no `ChildExit` event yet | **No** (unchanged) |

## Test plan

- [x] `cargo test -p horizon-core` — 243 passed, 0 failed (4 new unit tests on `should_close_for_exit_status` covering each cell of the matrix)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p horizon-core --all-targets --all-features -- -D warnings` clean
- [x] `./scripts/check-maintainability.sh` clean
- [ ] Manual: rename `gemini` out of `$PATH` (or pick any uninstalled agent), launch from menu → panel stays open with the shell's error visible
- [ ] Manual: launch a working agent, type `/exit` → panel auto-closes as before

## Why this approach

Alternatives considered:

- **Always leave panels open** (matching SSH). Predictable but punishes the common case where you exit cleanly and don't want a stale panel hanging around.
- **Detect 127 specifically** (just \"command not found\"). Too narrow — segfaults, crashes, and signal kills would still vanish silently.

The selected `success vs anything else` rule treats every abnormal exit the same and matches the user's mental model: \"if the program ran fine, close; if anything went wrong, leave it so I can see why.\"