### PR TITLE
fix(panel): make Restart start a fresh agent session

### DIFF
--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -417,9 +417,11 @@ impl Panel {
         self.layout.size = size;
     }
 
-    /// Restart the terminal process while keeping the same panel identity,
-    /// layout, and session binding. For agent panels this
-    /// resumes the existing session so no work is lost.
+    /// Restart the terminal process while keeping the same panel identity
+    /// and layout. Agent panels start a fresh session unless the panel was
+    /// explicitly rebound to a specific session (`PanelResume::Session`),
+    /// in which case that session is resumed. To resume the previous
+    /// session, use the "Rebind Session" submenu.
     ///
     /// # Errors
     ///
@@ -451,7 +453,14 @@ impl Panel {
         // Graceful shutdown of the old terminal.
         let _ = terminal.shutdown_with_timeout(Duration::from_secs(2));
 
-        let should_resume = self.kind.supports_session_binding() && self.session_binding.is_some();
+        // Restart always starts a fresh agent session: `should_resume` is
+        // hard-coded to `false` so the binding is ignored. An explicit
+        // `PanelResume::Session { .. }` (set by "Rebind Session") still wins
+        // because `resolve_launch_command` honors it directly.
+        let should_resume = false;
+        if !matches!(self.resume, PanelResume::Session { .. }) {
+            self.session_binding = None;
+        }
         let (program, launch_args) = resolve_launch_command(
             self.launch_command.clone(),
             self.launch_args.clone(),


### PR DESCRIPTION
## Summary

- Clicking **Restart** on a Claude / Codex / OpenCode panel relaunched the agent with `--resume <bound-session-id>`. After `/clear`, the cleared conversation reappeared, so the button labelled "Restart" effectively behaved like "Resume".
- Restart now always launches with a fresh session id and clears the stale binding, so the dynamic rebinder picks up the new session as soon as it shows activity.
- One exception preserved: if the panel was explicitly rebound via **Rebind Session** (`PanelResume::Session { .. }`), Restart still resumes that specific session, since the user encoded that intent.

The "Rebind Session" submenu remains the explicit way to bring back a prior session, so the resume path is not lost, just no longer the default.

## Test plan

- [ ] Open a Claude panel, type something, run `/clear`, click Restart from the panel context menu, confirm a fresh session (no prior conversation) is shown.
- [ ] Open a Claude panel, pick a different session via "Rebind Session", click Restart, confirm the chosen session is resumed.
- [ ] Restart a Codex panel and verify it launches without `resume` args.
- [ ] Restart an SSH panel ("Reconnect") and verify nothing about that path changed.