### PR TITLE
fix(panel): never auto-close panels on child exit

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -304,16 +304,6 @@ impl Board {
         output
     }
 
-    /// Returns IDs of panels whose child process has exited.
-    #[must_use]
-    pub fn exited_panels(&self) -> Vec<PanelId> {
-        self.panels
-            .iter()
-            .filter(|panel| panel.child_exited() && panel.should_close_after_exit())
-            .map(|panel| panel.id)
-            .collect()
-    }
-
     pub fn focus(&mut self, id: PanelId) {
         self.focused = Some(id);
         self.active_workspace = self.panel_workspace_id(id);

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -336,20 +336,6 @@ impl Panel {
         self.content.terminal().is_some_and(Terminal::child_exited)
     }
 
-    /// Returns `true` only when the panel should be auto-removed after its
-    /// child process exits.
-    ///
-    /// SSH panels never auto-close (the user often wants to see the
-    /// disconnection message). For every other kind we keep the panel open
-    /// unless the child reported a *successful* exit (status code `0`):
-    /// a missing binary, crash, or signal kill leaves the panel around so
-    /// the user can read the error instead of having it vanish silently.
-    #[must_use]
-    pub fn should_close_after_exit(&self) -> bool {
-        let exit_status = self.content.terminal().and_then(Terminal::child_exit_status);
-        should_close_for_exit_status(self.kind, exit_status)
-    }
-
     /// Returns `true` if the terminal bell has fired since the last call.
     pub fn take_bell(&mut self) -> bool {
         self.content.terminal_mut().is_some_and(Terminal::take_bell)
@@ -597,13 +583,6 @@ impl Panel {
     }
 }
 
-fn should_close_for_exit_status(kind: PanelKind, exit_status: Option<std::process::ExitStatus>) -> bool {
-    if matches!(kind, PanelKind::Ssh) {
-        return false;
-    }
-    exit_status.is_some_and(|status| status.success())
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -611,7 +590,7 @@ mod tests {
     use super::{
         AGENT_PANEL_SCROLLBACK_LIMIT, AgentSessionBinding, DEFAULT_PANEL_SCROLLBACK_LIMIT, Panel, PanelContent,
         PanelId, PanelKind, PanelLayout, PanelResume, UsageDashboard, WorkspaceId, kitty_keyboard_for_kind,
-        platform_default_shell, resolve_launch_command, scrollback_limit_for_kind, should_close_for_exit_status,
+        platform_default_shell, resolve_launch_command, scrollback_limit_for_kind,
     };
     use crate::ssh::SshConnection;
 
@@ -672,64 +651,6 @@ mod tests {
         });
 
         assert_eq!(panel.display_title(), "Prod API (deploy@prod-api) — Connected");
-    }
-
-    #[test]
-    fn ssh_panels_do_not_auto_close_after_exit() {
-        let mut panel = test_panel("SSH: prod", "", false);
-        panel.kind = PanelKind::Ssh;
-
-        assert!(!panel.should_close_after_exit());
-    }
-
-    #[cfg(unix)]
-    fn exit_status_with_code(code: i32) -> std::process::ExitStatus {
-        use std::os::unix::process::ExitStatusExt;
-        // Wait status format on Unix: low 8 bits hold the signal (0 here),
-        // next 8 bits hold the exit code.
-        std::process::ExitStatus::from_raw(code << 8)
-    }
-
-    #[cfg(windows)]
-    fn exit_status_with_code(code: i32) -> std::process::ExitStatus {
-        use std::os::windows::process::ExitStatusExt;
-        std::process::ExitStatus::from_raw(code as u32)
-    }
-
-    #[test]
-    fn agent_panel_with_no_reported_exit_status_stays_open() {
-        // Mirrors the "binary not found" / "child still running" case where
-        // `Terminal::child_exit_status` returns `None`.
-        assert!(!should_close_for_exit_status(PanelKind::Codex, None));
-        assert!(!should_close_for_exit_status(PanelKind::Shell, None));
-    }
-
-    #[test]
-    fn agent_panel_with_failure_exit_stays_open() {
-        // 127 is the canonical "command not found" status from a shell — the
-        // exact case where we don't want the panel to vanish before the user
-        // can read the error.
-        let failure = exit_status_with_code(127);
-        assert!(!should_close_for_exit_status(PanelKind::Codex, Some(failure)));
-        assert!(!should_close_for_exit_status(PanelKind::Gemini, Some(failure)));
-        assert!(!should_close_for_exit_status(PanelKind::Shell, Some(failure)));
-    }
-
-    #[test]
-    fn agent_panel_with_clean_exit_auto_closes() {
-        let success = exit_status_with_code(0);
-        assert!(should_close_for_exit_status(PanelKind::Codex, Some(success)));
-        assert!(should_close_for_exit_status(PanelKind::Claude, Some(success)));
-        assert!(should_close_for_exit_status(PanelKind::Shell, Some(success)));
-    }
-
-    #[test]
-    fn ssh_panels_never_auto_close_regardless_of_exit_status() {
-        let success = exit_status_with_code(0);
-        let failure = exit_status_with_code(1);
-        assert!(!should_close_for_exit_status(PanelKind::Ssh, None));
-        assert!(!should_close_for_exit_status(PanelKind::Ssh, Some(success)));
-        assert!(!should_close_for_exit_status(PanelKind::Ssh, Some(failure)));
     }
 
     #[test]

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -139,10 +139,6 @@ impl HorizonApp {
         }
         let had_terminal_output = panel_output.had_terminal_output;
 
-        for panel_id in self.board.exited_panels() {
-            self.panels_to_close.push(panel_id);
-        }
-
         self.animate_pan(ctx);
         self.poll_primary_selection_paste();
         self.maybe_refresh_session_catalog();


### PR DESCRIPTION
## Summary

- A clean child exit (exit code `0`) still auto-removed the panel: `exit` in a shell, `Ctrl-D` / `/exit` in an agent, or any successful one-shot command would make the panel vanish.
- PR #180 already kept failure exits open; this finishes the job for the success case so the panel is never closed automatically. The user always closes panels manually via the X or the "Close" context menu item.
- Drops the now-unused machinery: `Panel::should_close_after_exit`, the `should_close_for_exit_status` helper, `Board::exited_panels`, and the lifecycle loop that fed exited ids into `panels_to_close`.
- SSH "Reconnect" still works: SSH panels were already exempted from auto-close, and `child_exited()` (used to flip `SshConnectionStatus::Disconnected`) is untouched.

## Test plan

- [ ] Open a Shell panel, type `exit`, confirm the panel stays open and can be closed via the X.
- [ ] Open a Claude panel, run `/exit` (or Ctrl-C then `exit`), confirm the panel stays open.
- [ ] Open a Command panel that runs a short-lived script (e.g. `echo hi`), confirm the panel stays open after the command finishes.
- [ ] Open an SSH panel, terminate the connection (`exit`), confirm the panel stays open and Reconnect still works.
- [ ] Click the X / Close menu item on each, confirm manual close works as before.