### PR TITLE
Fix session rebind menu click handling

### DIFF
--- a/crates/horizon-ui/src/app/attention_feed.rs
+++ b/crates/horizon-ui/src/app/attention_feed.rs
@@ -332,7 +332,7 @@ fn visible_attention_items(attention: &[AttentionItem], now: SystemTime) -> Vec<
         .iter()
         .filter(|item| is_visible_attention_item(item, now))
         .collect();
-    items.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+    items.sort_by_key(|item| std::cmp::Reverse(item.created_at));
     items.truncate(10);
     items
 }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -430,10 +430,8 @@ impl HorizonApp {
         if let Some(pos) = outer_rect {
             let new_x = pos.min.x;
             let new_y = pos.min.y;
-            let moved = window_config.x.is_none()
-                || window_config.x.is_some_and(|x| (x - new_x).abs() > 1.0)
-                || window_config.y.is_none()
-                || window_config.y.is_some_and(|y| (y - new_y).abs() > 1.0);
+            let moved = window_config.x.is_none_or(|x| (x - new_x).abs() > 1.0)
+                || window_config.y.is_none_or(|y| (y - new_y).abs() > 1.0);
             if moved {
                 window_config.x = Some(new_x);
                 window_config.y = Some(new_y);

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -315,7 +315,6 @@ impl HorizonApp {
         for (panel_id, workspace_id) in self.workspace_assignments.drain(..) {
             self.board.assign_panel_to_workspace(panel_id, workspace_id);
         }
-        self.apply_pending_session_rebinds();
     }
 
     #[profiling::function]

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -33,9 +33,9 @@ use std::time::Instant;
 
 use egui::{Color32, Context, Pos2, Rect, Vec2, ViewportId};
 use horizon_core::{
-    AgentSessionBinding, AgentSessionCatalog, AppShortcuts, AppearanceTheme, Board, CanvasViewState, Config,
-    GitWatcher, ManagedInstall, PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease,
-    SessionStore, ShutdownProgress, StartupChooser, StartupDecision, WindowConfig, WorkspaceId,
+    AgentSessionCatalog, AppShortcuts, AppearanceTheme, Board, CanvasViewState, Config, GitWatcher, ManagedInstall,
+    PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease, SessionStore,
+    ShutdownProgress, StartupChooser, StartupDecision, WindowConfig, WorkspaceId,
 };
 
 use self::canvas::CanvasGridCache;
@@ -204,7 +204,6 @@ pub struct HorizonApp {
     remote_hosts_last_refresh: Option<Instant>,
     last_session_catalog_refresh: Option<Instant>,
     last_terminal_output_at: Option<Instant>,
-    pending_session_rebinds: Vec<(PanelId, AgentSessionBinding)>,
     settings: Option<SettingsEditor>,
     session_manager: Option<RuntimeSessionManagerState>,
     managed_install: Option<ManagedInstall>,
@@ -351,7 +350,6 @@ impl HorizonApp {
             remote_hosts_last_refresh: None,
             last_session_catalog_refresh: None,
             last_terminal_output_at: Some(Instant::now()),
-            pending_session_rebinds: Vec::new(),
             settings: None,
             session_manager: None,
             managed_install,

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -1,5 +1,8 @@
 use egui::{Align, Color32, Context, Id, Layout, Order, Pos2, Rect, Sense, UiBuilder, Vec2};
-use horizon_core::{AttentionSeverity, Panel, PanelId, PanelKind, ShortcutBinding, SshConnectionStatus, WorkspaceId};
+use horizon_core::{
+    AgentSessionBinding, AttentionSeverity, Panel, PanelId, PanelKind, ShortcutBinding, SshConnectionStatus,
+    WorkspaceId,
+};
 
 use super::super::editor_widget::{MarkdownEditorView, MarkdownPreviewCache};
 use super::super::git_changes_widget::GitChangesView;
@@ -46,6 +49,7 @@ struct PanelUiOutcome {
     resize_delta: Vec2,
     commit_terminal_resize: bool,
     workspace_assignment: Option<WorkspaceId>,
+    session_rebind: Option<AgentSessionBinding>,
     command: Option<PanelCommand>,
     rename_action: RenameEditAction,
 }
@@ -583,17 +587,16 @@ impl HorizonApp {
             // actually open instead of every frame for every panel.
             let rebind_options = self.session_rebind_options(panel_id);
             if !rebind_options.is_empty() {
-                ui.menu_button("Rebind Session", |ui| {
-                    ui.set_min_width(220.0);
-                    for (label, binding) in &rebind_options {
-                        let button = egui::Button::new(egui::RichText::new(label).size(12.0).color(theme::FG_SOFT()))
-                            .frame(false);
-                        if ui.add(button).clicked() {
-                            self.pending_session_rebinds.push((panel_id, binding.clone()));
-                            ui.close();
-                        }
+                ui.set_min_width(260.0);
+                for (label, binding) in &rebind_options {
+                    let text = format!("Rebind Session · {label}");
+                    let button =
+                        egui::Button::new(egui::RichText::new(text).size(12.0).color(theme::FG_SOFT())).frame(false);
+                    if ui.add(button).clicked() {
+                        outcome.session_rebind = Some(binding.clone());
+                        ui.close();
                     }
-                });
+                }
                 ui.separator();
             }
             if ui.button("New Workspace").clicked() {
@@ -687,6 +690,12 @@ impl HorizonApp {
         }
         if let Some(workspace_id) = outcome.workspace_assignment {
             self.workspace_assignments.push((panel_id, workspace_id));
+        }
+        if let Some(binding) = outcome.session_rebind.clone()
+            && self.rebind_panel_session(panel_id, binding)
+        {
+            self.mark_runtime_dirty();
+            ctx.request_repaint();
         }
 
         matches!(outcome.command, Some(PanelCommand::Close))

--- a/crates/horizon-ui/src/app/persistence.rs
+++ b/crates/horizon-ui/src/app/persistence.rs
@@ -62,10 +62,8 @@ impl HorizonApp {
             if let Some(pos) = input.viewport().outer_rect {
                 let new_x = pos.min.x;
                 let new_y = pos.min.y;
-                let changed = self.window_config.x.is_none()
-                    || self.window_config.x.is_some_and(|x| (x - new_x).abs() > 1.0)
-                    || self.window_config.y.is_none()
-                    || self.window_config.y.is_some_and(|y| (y - new_y).abs() > 1.0);
+                let changed = self.window_config.x.is_none_or(|x| (x - new_x).abs() > 1.0)
+                    || self.window_config.y.is_none_or(|y| (y - new_y).abs() > 1.0);
                 if changed {
                     self.window_config.x = Some(new_x);
                     self.window_config.y = Some(new_y);

--- a/crates/horizon-ui/src/app/session.rs
+++ b/crates/horizon-ui/src/app/session.rs
@@ -45,7 +45,7 @@ fn collect_dynamic_binding_updates(
     let mut assignments = Vec::new();
     for ((kind, cwd), panels) in grouped_panels {
         let mut candidates = recent_for(kind, empty_string_as_none(&cwd));
-        candidates.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.updated_at));
 
         let active_bound_panels: Vec<_> = panels
             .iter()
@@ -75,7 +75,7 @@ fn collect_dynamic_binding_updates(
             continue;
         }
 
-        unbound_panels.sort_by(|left, right| right.launched_at_millis.cmp(&left.launched_at_millis));
+        unbound_panels.sort_by_key(|panel| std::cmp::Reverse(panel.launched_at_millis));
         let oldest_launch = unbound_panels
             .iter()
             .map(|panel| panel.launched_at_millis)
@@ -459,25 +459,16 @@ impl HorizonApp {
             .collect()
     }
 
-    pub(super) fn apply_pending_session_rebinds(&mut self) {
-        if self.pending_session_rebinds.is_empty() {
-            return;
-        }
+    pub(super) fn rebind_panel_session(&mut self, panel_id: PanelId, binding: AgentSessionBinding) -> bool {
+        let Some(panel) = self.board.panel_mut(panel_id) else {
+            return false;
+        };
 
-        let mut changed = false;
-        for (panel_id, binding) in self.pending_session_rebinds.drain(..) {
-            if let Some(panel) = self.board.panel_mut(panel_id) {
-                panel.resume = PanelResume::Session {
-                    session_id: binding.session_id.clone(),
-                };
-                panel.set_session_binding(Some(binding));
-                changed = true;
-            }
-        }
-
-        if changed {
-            self.mark_runtime_dirty();
-        }
+        panel.resume = PanelResume::Session {
+            session_id: binding.session_id.clone(),
+        };
+        panel.set_session_binding(Some(binding));
+        true
     }
 }
 

--- a/crates/horizon-ui/src/app/session_manager.rs
+++ b/crates/horizon-ui/src/app/session_manager.rs
@@ -226,7 +226,6 @@ impl HorizonApp {
         self.panels_to_restart.clear();
         self.workspace_assignments.clear();
         self.workspace_creates.clear();
-        self.pending_session_rebinds.clear();
         self.panel_screen_rects.clear();
         self.terminal_body_screen_rects.clear();
         self.panel_screen_order.clear();

--- a/crates/horizon-ui/src/main.rs
+++ b/crates/horizon-ui/src/main.rs
@@ -144,7 +144,7 @@ fn select_adapter(adapters: &[wgpu::Adapter], surface: Option<&wgpu::Surface<'_>
         })
         .collect();
 
-    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    candidates.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
 
     if let Some((best, _)) = candidates.into_iter().next() {
         let info = best.get_info();

--- a/docs/testing/rebind-session-context-menu-smoke.md
+++ b/docs/testing/rebind-session-context-menu-smoke.md
@@ -1,0 +1,47 @@
+# macOS Rebind Session Context Menu Smoke
+
+## Setup
+
+- Build the debug binary on macOS: `cargo build -p horizon-ui`.
+- Use an isolated home directory so local settings and real session state are not touched.
+- Create an isolated Horizon config with one workspace and one binding-capable agent panel whose working directory matches the seeded session catalog.
+- Seed at least two recent local agent session records for that same agent kind and working directory.
+- Launch `target/debug/horizon` with the isolated `HOME`.
+
+## Baseline
+
+- Confirm the root Horizon window opens and shows the seeded workspace and panel.
+- Confirm the panel titlebar responds to left-click focus.
+- Right-click or Control-click the panel titlebar and confirm the context menu opens.
+- Capture a baseline screenshot with `screencapture -x <path>`.
+
+## Primary Flow
+
+- Open the panel titlebar context menu.
+- Confirm each available rebind candidate appears as a visible top-level row prefixed with `Rebind Session`.
+- Click a rebind row directly and confirm the menu closes immediately.
+- Quit Horizon cleanly.
+- Inspect the isolated runtime state and confirm the panel `resume` value is `Session` with the clicked session id.
+- Confirm the panel `session_binding.session_id` matches the same clicked session id.
+
+## Edge Cases
+
+- Repeat with only one available rebind option and confirm the single visible row is clickable.
+- Repeat when the current binding is already the newest matching session and confirm the current session is omitted from the menu.
+- Repeat with a non-agent panel and confirm no rebind rows appear.
+- Repeat with an agent kind that does not support exact session binding and confirm no rebind rows appear.
+- Reopen the context menu after a successful rebind and confirm the newly selected session is no longer listed as a candidate.
+
+## Persistence
+
+- Relaunch Horizon with the same isolated `HOME`.
+- Confirm the panel restores with the rebound `Session` resume target.
+- Restart the rebound panel.
+- Confirm the launched agent command receives the selected session id.
+
+## Visual Checks
+
+- Capture a screenshot immediately after opening the panel context menu.
+- Confirm the menu width expands enough for the rebind rows without clipping or overlapping the workspace and restart actions.
+- Resize the Horizon window and reopen the same context menu near the left, right, top, and bottom edges of the viewport.
+- Confirm the menu remains usable and does not overlap panel chrome in a way that blocks clicking a visible rebind row.


### PR DESCRIPTION
## Summary

- Replaces the nested session rebind submenu with direct top-level context-menu rows so the visible row is the actual click target.
- Applies the selected binding immediately through the panel outcome path and removes the deferred rebind queue.
- Adds a macOS smoke-test plan at `docs/testing/rebind-session-context-menu-smoke.md` covering setup, primary flow, persistence, edge cases, and screenshots.
- Updates touched UI code for current clippy lints so the validation tier stays green.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p horizon-ui`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Isolated desktop smoke verified that clicking a visible rebind row closes the menu and persists the selected session id to both `resume` and `session_binding` in runtime state.

## macOS Smoke Plan

The PR includes a macOS-specific smoke-test plan under `docs/testing/`. It uses an isolated `HOME`, seeded local session records, direct titlebar context-menu interaction, runtime-state inspection, relaunch persistence, restart validation, and `screencapture` screenshots.
