### PR TITLE
fix(usage): parse Claude tokens from live jsonl files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,16 +1005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,15 +2725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,18 +3421,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "surge-core"
 version = "1.0.0"
-source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.39#a05297915ad3590426e011920fbae014029fd387"
+source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.16#396ff1ca3eccc641f97c545150143398bb37691e"
 dependencies = [
  "async-trait",
  "base64",
  "cc",
  "chrono",
- "fs2",
  "futures-util",
  "hex",
  "nix",
  "percent-encoding",
- "quick-xml 0.40.1",
+ "quick-xml",
  "reqwest",
  "serde",
  "serde_json",
@@ -4236,7 +4216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -4449,22 +4429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4472,12 +4436,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/crates/horizon-core/src/usage_stats.rs
+++ b/crates/horizon-core/src/usage_stats.rs
@@ -6,6 +6,9 @@ use serde::Deserialize;
 
 use crate::opencode_paths::opencode_db_path;
 
+mod claude;
+use claude::{ClaudeLiveLoader, ClaudeLiveStats};
+
 const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Snapshot of usage statistics for Claude Code, Codex CLI, and `OpenCode`.
@@ -48,8 +51,9 @@ pub fn spawn_usage_poll() -> mpsc::Receiver<UsageSnapshot> {
     let (tx, rx) = mpsc::channel();
 
     std::thread::spawn(move || {
+        let mut claude_loader = ClaudeLiveLoader::new();
         loop {
-            let snapshot = collect_snapshot();
+            let snapshot = collect_snapshot(&mut claude_loader);
             if tx.send(snapshot).is_err() {
                 break;
             }
@@ -98,7 +102,7 @@ fn format_scaled_tokens(n: u64, divisor: u64, suffix: char) -> String {
     }
 }
 
-fn collect_snapshot() -> UsageSnapshot {
+fn collect_snapshot(loader: &mut ClaudeLiveLoader) -> UsageSnapshot {
     let today = today_date_string();
     let week_dates = last_n_days_dates(7);
     let fortnight_dates = last_n_days_dates(14);
@@ -106,13 +110,26 @@ fn collect_snapshot() -> UsageSnapshot {
     let claude_data = load_claude_stats();
     let codex_data = load_codex_stats();
     let opencode_data = load_opencode_stats();
+    let claude_live = loader.collect(&fortnight_dates);
 
     let claude_today_extra_sessions = count_claude_today_sessions();
 
-    let claude = build_tool_usage(&claude_data, &today, &week_dates, claude_today_extra_sessions);
+    let claude = build_tool_usage(
+        &claude_data,
+        &claude_live,
+        &today,
+        &week_dates,
+        claude_today_extra_sessions,
+    );
     let codex = build_tool_usage_codex(&codex_data, &today, &week_dates);
     let opencode = build_tool_usage_opencode(&opencode_data, &today, &week_dates);
-    let daily = build_daily(&claude_data, &codex_data, &opencode_data, &fortnight_dates);
+    let daily = build_daily(
+        &claude_data,
+        &claude_live,
+        &codex_data,
+        &opencode_data,
+        &fortnight_dates,
+    );
 
     UsageSnapshot {
         claude,
@@ -123,9 +140,11 @@ fn collect_snapshot() -> UsageSnapshot {
     }
 }
 
-/// Build `ToolUsage` for Claude Code from the stats cache.
+/// Build `ToolUsage` for Claude Code from the stats cache and the live
+/// jsonl parser (the latter is the source of truth for token totals).
 fn build_tool_usage(
     data: &ClaudeStatsCache,
+    live: &ClaudeLiveStats,
     today: &str,
     week_dates: &[String],
     extra_today_sessions: u32,
@@ -153,13 +172,12 @@ fn build_tool_usage(
         usage.week_messages = usage.today_messages;
     }
 
-    for day in &data.daily_model_tokens {
-        let day_total: u64 = day.tokens_by_model.values().sum();
-        if day.date == today {
-            usage.today_tokens = day_total;
-        }
-        if week_dates.iter().any(|d| d == &day.date) {
-            usage.week_tokens = usage.week_tokens.saturating_add(day_total);
+    if let Some(totals) = live.by_day.get(today) {
+        usage.today_tokens = totals.tokens;
+    }
+    for date in week_dates {
+        if let Some(totals) = live.by_day.get(date) {
+            usage.week_tokens = usage.week_tokens.saturating_add(totals.tokens);
         }
     }
 
@@ -206,6 +224,7 @@ fn build_tool_usage_opencode(data: &[OpenCodeDayRow], today: &str, week_dates: &
 
 fn build_daily(
     claude_data: &ClaudeStatsCache,
+    claude_live: &ClaudeLiveStats,
     codex_data: &[CodexDayRow],
     opencode_data: &[OpenCodeDayRow],
     dates: &[String],
@@ -218,11 +237,7 @@ fn build_daily(
                 .iter()
                 .find(|d| d.date == *date)
                 .map_or(0, |d| d.session_count);
-            let claude_tokens: u64 = claude_data
-                .daily_model_tokens
-                .iter()
-                .find(|d| d.date == *date)
-                .map_or(0, |d| d.tokens_by_model.values().sum());
+            let claude_tokens = claude_live.by_day.get(date).map_or(0, |t| t.tokens);
             let codex_row = codex_data.iter().find(|r| r.day == *date);
             let codex_sessions = codex_row.map_or(0, |r| r.sessions);
             let codex_tokens = codex_row.map_or(0, |r| r.total_tokens);
@@ -251,7 +266,6 @@ fn build_daily(
 #[serde(default, rename_all = "camelCase")]
 struct ClaudeStatsCache {
     daily_activity: Vec<ClaudeDailyActivity>,
-    daily_model_tokens: Vec<ClaudeDailyModelTokens>,
 }
 
 #[derive(Deserialize)]
@@ -262,14 +276,6 @@ struct ClaudeDailyActivity {
     message_count: u32,
     #[serde(default)]
     session_count: u32,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ClaudeDailyModelTokens {
-    date: String,
-    #[serde(default)]
-    tokens_by_model: std::collections::HashMap<String, u64>,
 }
 
 fn load_claude_stats() -> ClaudeStatsCache {

--- a/crates/horizon-core/src/usage_stats/claude.rs
+++ b/crates/horizon-core/src/usage_stats/claude.rs
@@ -1,0 +1,343 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+
+/// Lookback window for which jsonl files are considered "active enough" to
+/// scan. Files older than this are skipped to keep steady-state polling cheap.
+const LOOKBACK_SECS: u64 = 14 * 86_400;
+
+/// Live loader that scans `~/.claude/projects/*.jsonl` and aggregates
+/// per-day token totals from assistant messages.
+///
+/// Parse results are cached per-file by `(mtime, size)` so unchanged files
+/// are not re-read between polls.
+pub(super) struct ClaudeLiveLoader {
+    cache: HashMap<PathBuf, CachedFile>,
+}
+
+#[derive(Default)]
+pub(super) struct ClaudeLiveStats {
+    pub by_day: HashMap<String, ClaudeDayTotals>,
+}
+
+#[derive(Default, Clone, Copy)]
+pub(super) struct ClaudeDayTotals {
+    pub tokens: u64,
+    pub messages: u32,
+}
+
+struct CachedFile {
+    mtime_secs: u64,
+    size: u64,
+    per_day: HashMap<String, ClaudeDayTotals>,
+}
+
+#[derive(Deserialize)]
+struct AssistantLine {
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    kind: String,
+    timestamp: String,
+    #[serde(default)]
+    message: AssistantMessage,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct AssistantMessage {
+    usage: AssistantUsage,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+#[allow(clippy::struct_field_names)] // field names mirror the JSON schema exactly
+struct AssistantUsage {
+    input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    cache_read_input_tokens: u64,
+    output_tokens: u64,
+}
+
+impl ClaudeLiveLoader {
+    pub(super) fn new() -> Self {
+        Self { cache: HashMap::new() }
+    }
+
+    /// Walk `~/.claude/projects/`, aggregate per-day token totals from jsonl
+    /// files modified in the last 14 days. Files unchanged since the last
+    /// call are served from the `(mtime, size)`-keyed cache.
+    pub(super) fn collect(&mut self, _recent_dates: &[String]) -> ClaudeLiveStats {
+        let Some(dir) = super::home_dir().map(|h| h.join(".claude/projects")) else {
+            return ClaudeLiveStats::default();
+        };
+        if !dir.exists() {
+            return ClaudeLiveStats::default();
+        }
+        self.collect_from_dir(&dir)
+    }
+
+    pub(super) fn collect_from_dir(&mut self, dir: &Path) -> ClaudeLiveStats {
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let cutoff_secs = now_secs.saturating_sub(LOOKBACK_SECS);
+
+        let files = walk_claude_projects(dir, cutoff_secs);
+        let mut seen: HashSet<PathBuf> = HashSet::with_capacity(files.len());
+
+        for (path, mtime_secs, size) in files {
+            seen.insert(path.clone());
+            let needs_reparse = self
+                .cache
+                .get(&path)
+                .is_none_or(|cached| cached.mtime_secs != mtime_secs || cached.size != size);
+            if needs_reparse {
+                let per_day = parse_file(&path);
+                self.cache.insert(
+                    path,
+                    CachedFile {
+                        mtime_secs,
+                        size,
+                        per_day,
+                    },
+                );
+            }
+        }
+
+        self.cache.retain(|p, _| seen.contains(p));
+
+        let mut by_day: HashMap<String, ClaudeDayTotals> = HashMap::new();
+        for cached in self.cache.values() {
+            for (date, totals) in &cached.per_day {
+                let entry = by_day.entry(date.clone()).or_default();
+                entry.tokens = entry.tokens.saturating_add(totals.tokens);
+                entry.messages = entry.messages.saturating_add(totals.messages);
+            }
+        }
+
+        ClaudeLiveStats { by_day }
+    }
+
+    #[cfg(test)]
+    pub(super) fn cached_files(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+/// Recursive walk over `dir` returning `(path, mtime_secs, size)` for every
+/// `.jsonl` file modified at or after `cutoff_secs`. Recurses into all
+/// subdirectories, including `subagents/` (those turns still consumed tokens).
+fn walk_claude_projects(dir: &Path, cutoff_secs: u64) -> Vec<(PathBuf, u64, u64)> {
+    let mut out = Vec::new();
+    walk_into(dir, cutoff_secs, &mut out);
+    out
+}
+
+fn walk_into(dir: &Path, cutoff_secs: u64, out: &mut Vec<(PathBuf, u64, u64)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            walk_into(&path, cutoff_secs, out);
+            continue;
+        }
+        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        let mtime_secs = modified.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        if mtime_secs < cutoff_secs {
+            continue;
+        }
+        out.push((path, mtime_secs, meta.len()));
+    }
+}
+
+/// Parse a single jsonl file and aggregate assistant-message token usage
+/// per UTC day (taken from the first 10 chars of `timestamp`).
+///
+/// Lines that are not assistant messages are skipped via a cheap substring
+/// pre-check. Malformed JSON lines and assistant lines without `usage` still
+/// have well-defined behavior: the former are skipped, the latter contribute
+/// 0 tokens but increment the day's message counter (they are real assistant
+/// turns; the usage object just happens to be absent or unparseable).
+fn parse_file(path: &Path) -> HashMap<String, ClaudeDayTotals> {
+    let mut per_day: HashMap<String, ClaudeDayTotals> = HashMap::new();
+    let Ok(file) = File::open(path) else {
+        return per_day;
+    };
+    let reader = BufReader::new(file);
+    for line in reader.lines().map_while(Result::ok) {
+        if !line.contains("\"type\":\"assistant\"") {
+            continue;
+        }
+        let Ok(parsed) = serde_json::from_str::<AssistantLine>(&line) else {
+            continue;
+        };
+        if parsed.kind != "assistant" {
+            continue;
+        }
+        if parsed.timestamp.len() < 10 {
+            continue;
+        }
+        let day = parsed.timestamp[..10].to_string();
+        let usage = &parsed.message.usage;
+        let tokens = usage
+            .input_tokens
+            .saturating_add(usage.cache_creation_input_tokens)
+            .saturating_add(usage.cache_read_input_tokens)
+            .saturating_add(usage.output_tokens);
+        let entry = per_day.entry(day).or_default();
+        entry.tokens = entry.tokens.saturating_add(tokens);
+        entry.messages = entry.messages.saturating_add(1);
+    }
+    per_day
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    fn write_lines(path: &Path, lines: &[&str]) {
+        let mut file = fs::File::create(path).expect("create jsonl");
+        for line in lines {
+            writeln!(file, "{line}").expect("write line");
+        }
+    }
+
+    #[test]
+    fn parse_file_aggregates_assistant_usage_by_timestamp_date() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"user","timestamp":"2026-05-24T10:00:00.000Z","message":{}}"#,
+                r#"{"type":"assistant","timestamp":"2026-05-24T10:05:00.000Z","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":200,"output_tokens":30}}}"#,
+                r#"{"type":"assistant","timestamp":"2026-05-24T11:00:00.000Z","message":{"usage":{"input_tokens":5,"cache_creation_input_tokens":50,"cache_read_input_tokens":150,"output_tokens":20}}}"#,
+                r#"{"type":"assistant","timestamp":"2026-05-25T08:00:00.000Z","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}"#,
+                r#"{"type":"assistant","timestamp":"2026-05-24T12:00:00.000Z","message":{}}"#,
+                r"this line is not json",
+            ],
+        );
+
+        let per_day = parse_file(&path);
+
+        // 2026-05-24: two assistant lines with usage (10+100+200+30=340 and 5+50+150+20=225 = 565)
+        // plus one assistant line without usage (0 tokens but +1 message).
+        let day_24 = per_day.get("2026-05-24").copied().expect("2026-05-24 bucket");
+        assert_eq!(day_24.tokens, 565);
+        assert_eq!(day_24.messages, 3);
+
+        // 2026-05-25: one assistant line (1+2+3+4=10 tokens, 1 message).
+        let day_25 = per_day.get("2026-05-25").copied().expect("2026-05-25 bucket");
+        assert_eq!(day_25.tokens, 10);
+        assert_eq!(day_25.messages, 1);
+
+        // Malformed line and user line are ignored.
+        assert_eq!(per_day.len(), 2);
+    }
+
+    #[test]
+    fn claude_live_loader_walks_subagents_and_recurses() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::create_dir_all(dir.path().join("proj-a/subagents")).expect("mkdir subagents");
+        fs::create_dir_all(dir.path().join("proj-b")).expect("mkdir proj-b");
+
+        let line = r#"{"type":"assistant","timestamp":"2026-05-24T10:00:00.000Z","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}"#;
+
+        write_lines(&dir.path().join("proj-a/foo.jsonl"), &[line]);
+        write_lines(&dir.path().join("proj-a/subagents/bar.jsonl"), &[line]);
+        write_lines(&dir.path().join("proj-b/baz.jsonl"), &[line]);
+
+        let mut loader = ClaudeLiveLoader::new();
+        let stats = loader.collect_from_dir(dir.path());
+
+        // Three files of 10 tokens each = 30 tokens, 3 messages on 2026-05-24.
+        let day = stats.by_day.get("2026-05-24").copied().expect("2026-05-24 totals");
+        assert_eq!(day.tokens, 30);
+        assert_eq!(day.messages, 3);
+    }
+
+    #[test]
+    fn claude_live_loader_reuses_cache_for_unchanged_files() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{"type":"assistant","timestamp":"2026-05-24T10:00:00.000Z","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}"#,
+            ],
+        );
+
+        let mut loader = ClaudeLiveLoader::new();
+        let _ = loader.collect_from_dir(dir.path());
+        assert_eq!(loader.cached_files(), 1);
+
+        let _ = loader.collect_from_dir(dir.path());
+        assert_eq!(loader.cached_files(), 1);
+
+        fs::remove_file(&path).expect("rm jsonl");
+        let _ = loader.collect_from_dir(dir.path());
+        assert_eq!(loader.cached_files(), 0);
+    }
+
+    #[test]
+    fn assistant_line_deserialization_tolerates_unknown_fields() {
+        let line = r#"{
+            "parentUuid": "e6139ceb-5fd7-4d04-b377-0759b4357e0a",
+            "isSidechain": false,
+            "message": {
+                "model": "claude-opus-4-7",
+                "id": "msg_01KnicQUNSXzireRha82Xqe7",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "x"}],
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 6,
+                    "cache_creation_input_tokens": 7617,
+                    "cache_read_input_tokens": 17317,
+                    "output_tokens": 326,
+                    "service_tier": "standard",
+                    "iterations": [{"input_tokens": 6, "output_tokens": 326}]
+                },
+                "diagnostics": null
+            },
+            "requestId": "req_011CbNnbnkqHUbbF3G2hZK9q",
+            "type": "assistant",
+            "uuid": "b20a798c-487a-4efc-8ad1-c0af13c5556b",
+            "timestamp": "2026-05-25T06:08:05.576Z",
+            "userType": "external",
+            "entrypoint": "cli",
+            "cwd": "/home/peters/github/nativesdk",
+            "sessionId": "ad040111-fc9b-4497-9787-c6af1f41eeb2",
+            "version": "2.1.150",
+            "gitBranch": "main"
+        }"#;
+
+        let parsed: AssistantLine = serde_json::from_str(line).expect("decode realistic line");
+        assert_eq!(parsed.kind, "assistant");
+        assert_eq!(&parsed.timestamp[..10], "2026-05-25");
+        let usage = &parsed.message.usage;
+        assert_eq!(usage.input_tokens, 6);
+        assert_eq!(usage.cache_creation_input_tokens, 7617);
+        assert_eq!(usage.cache_read_input_tokens, 17317);
+        assert_eq!(usage.output_tokens, 326);
+    }
+}

--- a/crates/horizon-core/src/usage_stats/claude.rs
+++ b/crates/horizon-core/src/usage_stats/claude.rs
@@ -181,7 +181,7 @@ fn parse_file(path: &Path) -> HashMap<String, ClaudeDayTotals> {
     };
     let reader = BufReader::new(file);
     for line in reader.lines().map_while(Result::ok) {
-        if !line.contains("\"type\":\"assistant\"") {
+        if !line_has_assistant_type(&line) {
             continue;
         }
         let Ok(parsed) = serde_json::from_str::<AssistantLine>(&line) else {
@@ -205,6 +205,17 @@ fn parse_file(path: &Path) -> HashMap<String, ClaudeDayTotals> {
         entry.messages = entry.messages.saturating_add(1);
     }
     per_day
+}
+
+fn line_has_assistant_type(line: &str) -> bool {
+    line.match_indices("\"type\"").any(|(start, _)| {
+        let rest = &line[start + "\"type\"".len()..];
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix(':') else {
+            return false;
+        };
+        rest.trim_start().starts_with("\"assistant\"")
+    })
 }
 
 #[cfg(test)]
@@ -272,6 +283,24 @@ mod tests {
         let day = stats.by_day.get("2026-05-24").copied().expect("2026-05-24 totals");
         assert_eq!(day.tokens, 30);
         assert_eq!(day.messages, 3);
+    }
+
+    #[test]
+    fn parse_file_accepts_whitespace_around_type_separator() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("session.jsonl");
+        write_lines(
+            &path,
+            &[
+                r#"{ "type" : "assistant", "timestamp":"2026-05-24T10:00:00.000Z","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}"#,
+            ],
+        );
+
+        let per_day = parse_file(&path);
+
+        let day = per_day.get("2026-05-24").copied().expect("2026-05-24 bucket");
+        assert_eq!(day.tokens, 10);
+        assert_eq!(day.messages, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Claude session tokens show 0 in the Usage panel because they're sourced from `~/.claude/stats-cache.json`, which Claude Code stops updating in some environments (19 days stale on the dev machine that surfaced the bug).
- Replaces the cache token lookup with a live parser over `~/.claude/projects/*.jsonl`, summing per-message `usage` fields and bucketing by message timestamp date.
- Caches per-file parse results by `(mtime, size)` so steady-state polls only re-parse the actively-mutating session file.
- Sessions and messages still flow through the existing paths (they already had a live fallback that worked).

## Why
The bug appeared as "Claude Code: 8 sessions · 0 tokens" while Codex CLI showed accurate token totals from its live SQLite source. Sessions worked thanks to `count_claude_today_sessions()`; tokens had no equivalent fallback. Rather than depending on Claude Code resuming cache writes, this PR removes the dependency for token counting.

## Implementation notes
- New submodule `crates/horizon-core/src/usage_stats/claude.rs` holds `ClaudeLiveLoader` with the mtime+size cache, `walk_claude_projects` (recurses into `subagents/` because those turns consumed real tokens), and `parse_file` with a `"\"type\":\"assistant\""` substring pre-check before any JSON parse.
- Per-line `timestamp[..10]` bucketing handles sessions that cross midnight.
- Malformed lines, assistant lines without `usage`, and lines with extra Claude Code fields all decode cleanly (`#[serde(default)]` everywhere; serde skips unknown fields).
- Drops the unused `daily_model_tokens` field from `ClaudeStatsCache` and the `ClaudeDailyModelTokens` struct.

## Smoke test plan (macOS)
Run on a macOS machine actively using Claude Code:

- [ ] `cargo build --release` succeeds.
- [ ] Launch the app, open the Usage panel.
- [ ] "Today" Claude Code card shows a non-zero token count matching actual usage (not 0).
- [ ] "This Week" Claude line shows a non-zero token count.
- [ ] "Last 14 Days" chart Claude column still shows correct session counts.
- [ ] Start an interactive Claude Code session, send a few messages, wait ~30s, confirm today's token count increased.
- [ ] Confirm session counts are unchanged from before this PR (regression check).
- [ ] Path check: macOS uses `~/.claude/projects/` like Linux; `home_dir()` resolves via `HOME`. Confirm no platform-specific path issues.

## Test plan
- [x] `cargo test -p horizon-core` - new tests in `claude.rs` pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean.
- [x] `./scripts/check-maintainability.sh` - touched files stay under limits.