### PR TITLE
Agent Squad worktree, state, UI, fanout, review, and cleanup

### DIFF
--- a/crates/horizon-core/src/horizon_home.rs
+++ b/crates/horizon-core/src/horizon_home.rs
@@ -55,6 +55,11 @@ impl HorizonHome {
     }
 
     #[must_use]
+    pub fn session_squad_path(&self, session_id: &str) -> PathBuf {
+        self.session_dir(session_id).join("squad.json")
+    }
+
+    #[must_use]
     pub fn session_lease_path(&self, session_id: &str) -> PathBuf {
         self.session_dir(session_id).join("lease.json")
     }
@@ -103,6 +108,10 @@ mod tests {
         assert_eq!(
             home.session_runtime_path("session-1"),
             PathBuf::from("/tmp/horizon-home/sessions/session-1/runtime.yaml")
+        );
+        assert_eq!(
+            home.session_squad_path("session-1"),
+            PathBuf::from("/tmp/horizon-home/sessions/session-1/squad.json")
         );
         assert_eq!(
             home.session_transcripts_dir("session-1"),

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -21,6 +21,7 @@ mod runtime_state;
 pub mod search;
 mod session_store;
 mod shortcuts;
+mod squad;
 mod ssh;
 mod terminal;
 mod transcript;
@@ -61,6 +62,10 @@ pub use session_store::{
     StartupDecision, StartupPromptReason,
 };
 pub use shortcuts::{AppShortcuts, ShortcutBinding, ShortcutKey, ShortcutModifiers};
+pub use squad::{
+    AGENT_SQUAD_VERSION, AgentPanelLink, AgentSquad, IsolationMode, PerformerReport, PerformerSlot, RunStatus,
+    SquadRun, WorkItem, WorkStatus,
+};
 pub use ssh::{DiscoveredSshHost, SshConnection, SshConnectionStatus, discover_ssh_hosts};
 pub use terminal::{AgentNotification, Terminal, open_url};
 pub use transcript::PanelTranscript;

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -28,6 +28,7 @@ mod usage_dashboard;
 mod usage_stats;
 mod view;
 mod workspace;
+mod worktree;
 
 pub use agents::{AgentDefinition, AgentIntegrationKind, AgentResumeMode, agent_definition, all_agent_kinds};
 pub use alacritty_terminal::index::Side as TerminalSide;
@@ -67,3 +68,4 @@ pub use usage_dashboard::UsageDashboard;
 pub use usage_stats::{DailyUsage, ToolUsage, UsageSnapshot, format_cost, format_tokens};
 pub use view::{CanvasViewState, DEFAULT_CANVAS_ZOOM, MAX_CANVAS_ZOOM, MIN_CANVAS_ZOOM, clamp_canvas_zoom};
 pub use workspace::{WORKSPACE_COLORS, Workspace, WorkspaceId};
+pub use worktree::WorktreeManager;

--- a/crates/horizon-core/src/session_store.rs
+++ b/crates/horizon-core/src/session_store.rs
@@ -12,6 +12,7 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::horizon_home::HorizonHome;
 use crate::runtime_state::RuntimeState;
+use crate::squad::AgentSquad;
 use model::{ProfileSnapshot, SessionIndex, SessionMeta, StoredSession};
 
 pub use model::{
@@ -234,6 +235,43 @@ impl SessionStore {
         index.touch_profile_session(&self.profile_id, session_id);
         self.save_session_index(&index)?;
         Ok(())
+    }
+
+    /// Load the Agent Squad state for a session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the per-session `squad.json` exists but cannot be
+    /// read or decoded.
+    pub fn load_agent_squad(&self, session_id: &str) -> Result<AgentSquad> {
+        AgentSquad::load(&self.home.session_squad_path(session_id))
+    }
+
+    /// Persist the Agent Squad state for a session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the squad state cannot be serialized or atomically
+    /// written to the session directory.
+    pub fn save_agent_squad(&self, session_id: &str, squad: &AgentSquad) -> Result<()> {
+        let json = squad.to_json()?;
+        atomic_write(&self.home.session_squad_path(session_id), &json)
+    }
+
+    /// Load, mutate, and atomically persist Agent Squad state for one transition.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the current state cannot be loaded, the transition
+    /// fails, or the updated state cannot be written.
+    pub fn update_agent_squad<F>(&self, session_id: &str, update: F) -> Result<AgentSquad>
+    where
+        F: FnOnce(&mut AgentSquad) -> Result<()>,
+    {
+        let mut squad = self.load_agent_squad(session_id)?;
+        update(&mut squad)?;
+        self.save_agent_squad(session_id, &squad)?;
+        Ok(squad)
     }
 
     /// Create or replace the lease file for an active session.

--- a/crates/horizon-core/src/session_store/tests.rs
+++ b/crates/horizon-core/src/session_store/tests.rs
@@ -1,3 +1,7 @@
+use crate::panel::PanelKind;
+use crate::squad::{AgentPanelLink, PerformerSlot, RunStatus, WorkItem};
+use std::path::PathBuf;
+
 use super::{Config, HorizonHome, RuntimeState, SessionOpenDisposition, SessionStore, StartupDecision};
 
 #[test]
@@ -95,6 +99,55 @@ fn delete_session_rejects_live_sessions() {
 
     assert!(error.to_string().contains("cannot delete live session"));
     assert!(home.session_dir(&created.session_id).exists());
+}
+
+#[test]
+fn agent_squad_state_round_trips_per_session() {
+    let root = test_root("squad-round-trip");
+    let home = HorizonHome::from_root(root);
+    let store = SessionStore::new(home, PathBuf::from("/tmp/horizon-config.yaml"));
+    let created = store.create_new_session(&Config::default()).expect("create session");
+
+    let mut squad = store.load_agent_squad(&created.session_id).expect("load empty squad");
+    squad.create_run("Find bugs", 42);
+    store.save_agent_squad(&created.session_id, &squad).expect("save squad");
+
+    let loaded = store.load_agent_squad(&created.session_id).expect("load saved squad");
+
+    assert_eq!(loaded, squad);
+}
+
+#[test]
+fn update_agent_squad_persists_one_transition() {
+    let root = test_root("squad-transition");
+    let home = HorizonHome::from_root(root);
+    let store = SessionStore::new(home, PathBuf::from("/tmp/horizon-config.yaml"));
+    let created = store.create_new_session(&Config::default()).expect("create session");
+
+    let updated = store
+        .update_agent_squad(&created.session_id, |squad| {
+            let run = squad.create_run("Parallelize bug fixes", 100);
+            run.start_decomposing(AgentPanelLink::new(PanelKind::Claude, Some("panel-r".to_string())));
+            run.queue_plan("one item", vec![slot("s1")]);
+            Ok(())
+        })
+        .expect("update squad");
+
+    let loaded = store
+        .load_agent_squad(&created.session_id)
+        .expect("load persisted squad");
+
+    assert_eq!(loaded, updated);
+    assert_eq!(loaded.runs[0].status, RunStatus::FanningOut);
+}
+
+fn slot(id: &str) -> PerformerSlot {
+    PerformerSlot::new(
+        id,
+        WorkItem::new(id, format!("Task {id}"), "Do the thing"),
+        PanelKind::Codex,
+        PathBuf::from(format!("/tmp/squad/{id}")),
+    )
 }
 
 fn test_root(label: &str) -> std::path::PathBuf {

--- a/crates/horizon-core/src/squad.rs
+++ b/crates/horizon-core/src/squad.rs
@@ -1,0 +1,450 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{Error, Result};
+use crate::panel::PanelKind;
+
+pub const AGENT_SQUAD_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentSquad {
+    pub version: u32,
+    pub runs: Vec<SquadRun>,
+}
+
+impl AgentSquad {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load an Agent Squad file if one exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file exists but cannot be read or decoded.
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let content = std::fs::read_to_string(path)?;
+        let mut squad = serde_json::from_str::<Self>(&content).map_err(|error| Error::State(error.to_string()))?;
+        squad.version = AGENT_SQUAD_VERSION;
+        Ok(squad)
+    }
+
+    /// Serialize this Agent Squad state as stable pretty JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails.
+    pub fn to_json(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec_pretty(self).map_err(|error| Error::State(error.to_string()))
+    }
+
+    pub fn create_run(&mut self, goal: impl Into<String>, created_at_millis: i64) -> &mut SquadRun {
+        self.runs.push(SquadRun::new(new_id(), goal, created_at_millis));
+        let index = self.runs.len() - 1;
+        &mut self.runs[index]
+    }
+
+    /// Return a mutable run by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no run with `run_id` exists.
+    pub fn run_mut(&mut self, run_id: &str) -> Result<&mut SquadRun> {
+        self.runs
+            .iter_mut()
+            .find(|run| run.id == run_id)
+            .ok_or_else(|| Error::State(format!("squad run {run_id} was not found")))
+    }
+}
+
+impl Default for AgentSquad {
+    fn default() -> Self {
+        Self {
+            version: AGENT_SQUAD_VERSION,
+            runs: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct SquadRun {
+    pub id: String,
+    pub goal: String,
+    pub created_at_millis: i64,
+    pub status: RunStatus,
+    pub researcher: Option<AgentPanelLink>,
+    pub reviewer: Option<AgentPanelLink>,
+    pub performers: Vec<PerformerSlot>,
+    pub isolation: IsolationMode,
+    pub primary_worktree: Option<PathBuf>,
+    pub plan_text: String,
+    pub failure_reason: Option<String>,
+}
+
+impl SquadRun {
+    #[must_use]
+    pub fn new(id: impl Into<String>, goal: impl Into<String>, created_at_millis: i64) -> Self {
+        Self {
+            id: id.into(),
+            goal: goal.into(),
+            created_at_millis,
+            ..Self::default()
+        }
+    }
+
+    pub fn start_decomposing(&mut self, researcher: AgentPanelLink) {
+        self.researcher = Some(researcher);
+        self.status = RunStatus::Decomposing;
+    }
+
+    pub fn queue_plan(&mut self, plan_text: impl Into<String>, performers: Vec<PerformerSlot>) {
+        self.plan_text = plan_text.into();
+        self.performers = performers;
+        self.status = RunStatus::FanningOut;
+    }
+
+    pub fn set_primary_worktree(&mut self, path: PathBuf) {
+        self.primary_worktree = Some(path);
+    }
+
+    /// Mark a performer slot as dispatched to a panel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no slot with `slot_id` exists.
+    pub fn dispatch_slot(&mut self, slot_id: &str, panel_local_id: impl Into<String>) -> Result<()> {
+        let slot = self.slot_mut(slot_id)?;
+        slot.panel_local_id = Some(panel_local_id.into());
+        slot.work_item.status = WorkStatus::Dispatched;
+        self.status = RunStatus::Working;
+        Ok(())
+    }
+
+    /// Mark a performer slot as done and store its report.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no slot with `slot_id` exists.
+    pub fn mark_slot_done(&mut self, slot_id: &str, report: PerformerReport) -> Result<()> {
+        let slot = self.slot_mut(slot_id)?;
+        slot.report = Some(report);
+        slot.work_item.status = WorkStatus::Done;
+        self.refresh_working_status();
+        Ok(())
+    }
+
+    /// Mark a performer slot as blocked with reviewer follow-up context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no slot with `slot_id` exists.
+    pub fn mark_slot_blocked(&mut self, slot_id: &str, follow_up: impl Into<String>) -> Result<()> {
+        let slot = self.slot_mut(slot_id)?;
+        let follow_up = follow_up.into();
+        slot.report = Some(PerformerReport {
+            summary: "Blocked".to_string(),
+            follow_up,
+            ..PerformerReport::default()
+        });
+        slot.work_item.status = WorkStatus::Blocked;
+        self.refresh_working_status();
+        Ok(())
+    }
+
+    /// Move a run into review and bind its reviewer panel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any performer slot is not done.
+    pub fn start_reviewing(&mut self, reviewer: AgentPanelLink) -> Result<()> {
+        if self
+            .performers
+            .iter()
+            .any(|slot| slot.work_item.status != WorkStatus::Done)
+        {
+            return Err(Error::State(format!(
+                "squad run {} cannot start review until every slot is done",
+                self.id
+            )));
+        }
+
+        self.reviewer = Some(reviewer);
+        self.status = RunStatus::Reviewing;
+        Ok(())
+    }
+
+    pub fn finish(&mut self) {
+        self.status = RunStatus::Done;
+    }
+
+    pub fn fail(&mut self, reason: impl Into<String>) {
+        self.failure_reason = Some(reason.into());
+        self.status = RunStatus::Failed;
+    }
+
+    fn slot_mut(&mut self, slot_id: &str) -> Result<&mut PerformerSlot> {
+        self.performers
+            .iter_mut()
+            .find(|slot| slot.id == slot_id)
+            .ok_or_else(|| Error::State(format!("performer slot {slot_id} was not found")))
+    }
+
+    fn refresh_working_status(&mut self) {
+        if self.performers.is_empty() {
+            return;
+        }
+        if self.status == RunStatus::Reviewing || self.status == RunStatus::Done || self.status == RunStatus::Failed {
+            return;
+        }
+        if self
+            .performers
+            .iter()
+            .all(|slot| slot.work_item.status == WorkStatus::Done)
+        {
+            self.status = RunStatus::Working;
+        }
+    }
+}
+
+impl Default for SquadRun {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            goal: String::new(),
+            created_at_millis: 0,
+            status: RunStatus::Draft,
+            researcher: None,
+            reviewer: None,
+            performers: Vec::new(),
+            isolation: IsolationMode::Worktree,
+            primary_worktree: None,
+            plan_text: String::new(),
+            failure_reason: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct PerformerSlot {
+    pub id: String,
+    pub work_item: WorkItem,
+    pub assigned_kind: PanelKind,
+    pub panel_local_id: Option<String>,
+    pub scratch: PathBuf,
+    pub report: Option<PerformerReport>,
+}
+
+impl PerformerSlot {
+    #[must_use]
+    pub fn new(id: impl Into<String>, work_item: WorkItem, assigned_kind: PanelKind, scratch: PathBuf) -> Self {
+        Self {
+            id: id.into(),
+            work_item,
+            assigned_kind,
+            panel_local_id: None,
+            scratch,
+            report: None,
+        }
+    }
+}
+
+impl Default for PerformerSlot {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            work_item: WorkItem::default(),
+            assigned_kind: PanelKind::Codex,
+            panel_local_id: None,
+            scratch: PathBuf::new(),
+            report: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct WorkItem {
+    pub id: String,
+    pub title: String,
+    pub request: String,
+    pub acceptance_criteria: Vec<String>,
+    pub suggested_commands: Vec<String>,
+    pub status: WorkStatus,
+}
+
+impl WorkItem {
+    #[must_use]
+    pub fn new(id: impl Into<String>, title: impl Into<String>, request: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            request: request.into(),
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct PerformerReport {
+    pub summary: String,
+    pub validation_commands: Vec<String>,
+    pub validation_result: String,
+    pub follow_up: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentPanelLink {
+    pub kind: PanelKind,
+    pub panel_local_id: Option<String>,
+}
+
+impl AgentPanelLink {
+    #[must_use]
+    pub fn new(kind: PanelKind, panel_local_id: Option<String>) -> Self {
+        Self { kind, panel_local_id }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    #[default]
+    Draft,
+    Decomposing,
+    FanningOut,
+    Working,
+    Reviewing,
+    Done,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkStatus {
+    #[default]
+    Queued,
+    Dispatched,
+    Done,
+    Blocked,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IsolationMode {
+    #[default]
+    Worktree,
+    TmpDir,
+}
+
+fn new_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn missing_squad_file_loads_empty_model() {
+        let dir = TempDir::new().unwrap();
+
+        let squad = AgentSquad::load(&dir.path().join("squad.json")).unwrap();
+
+        assert_eq!(squad.version, AGENT_SQUAD_VERSION);
+        assert!(squad.runs.is_empty());
+    }
+
+    #[test]
+    fn squad_model_round_trips_as_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("squad.json");
+        let mut squad = AgentSquad::new();
+        let run = squad.create_run("Find perf wins", 42);
+        run.start_decomposing(AgentPanelLink::new(PanelKind::Claude, Some("panel-r".to_string())));
+        run.queue_plan("Two tasks", vec![slot("s1"), slot("s2")]);
+
+        fs::write(&path, squad.to_json().unwrap()).unwrap();
+        let loaded = AgentSquad::load(&path).unwrap();
+
+        assert_eq!(loaded, squad);
+    }
+
+    #[test]
+    fn run_transitions_from_research_to_review() {
+        let mut run = SquadRun::new("run-1", "Fix issues", 123);
+
+        run.start_decomposing(AgentPanelLink::new(PanelKind::Claude, Some("panel-r".to_string())));
+        assert_eq!(run.status, RunStatus::Decomposing);
+
+        run.queue_plan("Plan", vec![slot("s1"), slot("s2")]);
+        assert_eq!(run.status, RunStatus::FanningOut);
+
+        run.dispatch_slot("s1", "panel-1").unwrap();
+        run.dispatch_slot("s2", "panel-2").unwrap();
+        assert_eq!(run.status, RunStatus::Working);
+
+        run.mark_slot_done("s1", report("s1 done")).unwrap();
+        assert!(
+            run.start_reviewing(AgentPanelLink::new(PanelKind::Claude, None))
+                .is_err()
+        );
+
+        run.mark_slot_done("s2", report("s2 done")).unwrap();
+        run.start_reviewing(AgentPanelLink::new(PanelKind::Claude, Some("panel-review".to_string())))
+            .unwrap();
+        assert_eq!(run.status, RunStatus::Reviewing);
+
+        run.finish();
+        assert_eq!(run.status, RunStatus::Done);
+    }
+
+    #[test]
+    fn blocked_slot_prevents_review() {
+        let mut run = SquadRun::new("run-1", "Fix issues", 123);
+        run.queue_plan("Plan", vec![slot("s1")]);
+        run.dispatch_slot("s1", "panel-1").unwrap();
+
+        run.mark_slot_blocked("s1", "needs fixture").unwrap();
+        let error = run
+            .start_reviewing(AgentPanelLink::new(PanelKind::Claude, Some("panel-review".to_string())))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cannot start review"));
+        assert_eq!(run.performers[0].work_item.status, WorkStatus::Blocked);
+        assert_eq!(run.status, RunStatus::Working);
+    }
+
+    fn slot(id: &str) -> PerformerSlot {
+        PerformerSlot::new(
+            id,
+            WorkItem::new(id, format!("Task {id}"), "Do the thing"),
+            PanelKind::Codex,
+            PathBuf::from(format!("/tmp/squad/{id}")),
+        )
+    }
+
+    fn report(summary: &str) -> PerformerReport {
+        PerformerReport {
+            summary: summary.to_string(),
+            validation_commands: vec!["cargo test".to_string()],
+            validation_result: "pass".to_string(),
+            follow_up: String::new(),
+        }
+    }
+}

--- a/crates/horizon-core/src/squad.rs
+++ b/crates/horizon-core/src/squad.rs
@@ -63,6 +63,20 @@ impl AgentSquad {
             .find(|run| run.id == run_id)
             .ok_or_else(|| Error::State(format!("squad run {run_id} was not found")))
     }
+
+    /// Remove a run from the model and return it for cleanup/audit work.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no run with `run_id` exists.
+    pub fn remove_run(&mut self, run_id: &str) -> Result<SquadRun> {
+        let index = self
+            .runs
+            .iter()
+            .position(|run| run.id == run_id)
+            .ok_or_else(|| Error::State(format!("squad run {run_id} was not found")))?;
+        Ok(self.runs.remove(index))
+    }
 }
 
 impl Default for AgentSquad {
@@ -114,6 +128,16 @@ impl SquadRun {
 
     pub fn set_primary_worktree(&mut self, path: PathBuf) {
         self.primary_worktree = Some(path);
+    }
+
+    #[must_use]
+    pub fn worktree_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::with_capacity(self.performers.len() + usize::from(self.primary_worktree.is_some()));
+        if let Some(path) = &self.primary_worktree {
+            paths.push(path.clone());
+        }
+        paths.extend(self.performers.iter().map(|slot| slot.scratch.clone()));
+        paths
     }
 
     /// Mark a performer slot as dispatched to a panel.
@@ -428,6 +452,32 @@ mod tests {
         assert!(error.to_string().contains("cannot start review"));
         assert_eq!(run.performers[0].work_item.status, WorkStatus::Blocked);
         assert_eq!(run.status, RunStatus::Working);
+    }
+
+    #[test]
+    fn remove_run_returns_removed_run_only() {
+        let mut squad = AgentSquad::new();
+        squad.create_run("First", 1);
+        let second_id = squad.create_run("Second", 2).id.clone();
+
+        let removed = squad.remove_run(&second_id).unwrap();
+
+        assert_eq!(removed.goal, "Second");
+        assert_eq!(squad.runs.len(), 1);
+        assert_eq!(squad.runs[0].goal, "First");
+    }
+
+    #[test]
+    fn worktree_paths_include_review_before_slots() {
+        let mut run = SquadRun::new("run-1", "Fix issues", 123);
+        run.set_primary_worktree(PathBuf::from("/tmp/squad/run-1/_review"));
+        run.queue_plan("Plan", vec![slot("s1"), slot("s2")]);
+
+        let paths = run.worktree_paths();
+
+        assert_eq!(paths[0], PathBuf::from("/tmp/squad/run-1/_review"));
+        assert_eq!(paths[1], PathBuf::from("/tmp/squad/s1"));
+        assert_eq!(paths[2], PathBuf::from("/tmp/squad/s2"));
     }
 
     fn slot(id: &str) -> PerformerSlot {

--- a/crates/horizon-core/src/worktree.rs
+++ b/crates/horizon-core/src/worktree.rs
@@ -1,0 +1,317 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use git2::{
+    ApplyLocation, BranchType, Diff, DiffFormat, DiffOptions, Repository, WorktreeAddOptions, WorktreePruneOptions,
+};
+
+use crate::error::{Error, Result};
+
+const WORKTREE_NAME_PREFIX: &str = "horizon-squad";
+
+/// Git worktree helpers used by Agent Squad isolation.
+pub struct WorktreeManager;
+
+impl WorktreeManager {
+    /// Create a performer worktree under `scratch_root` for `slot_id`.
+    ///
+    /// The new worktree is checked out on a dedicated local branch created from
+    /// `base_ref`. Pass `HEAD` for the current checkout state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `repo` is not inside a Git repository, `base_ref`
+    /// cannot be resolved to a commit, the slot path already exists, or libgit2
+    /// cannot create the branch/worktree.
+    pub fn create(repo: &Path, base_ref: &str, scratch_root: &Path, slot_id: &str) -> Result<PathBuf> {
+        let repository = open_repo(repo)?;
+        fs::create_dir_all(scratch_root)?;
+
+        let worktree_path = scratch_root.join(path_component(slot_id));
+        if worktree_path.exists() {
+            return Err(Error::Git(format!(
+                "worktree path already exists: {}",
+                worktree_path.display()
+            )));
+        }
+
+        let branch_name = worktree_name(scratch_root, slot_id);
+        let base_commit = resolve_commit(&repository, base_ref)?;
+        let branch = repository
+            .branch(&branch_name, &base_commit, false)
+            .map_err(|error| git_error("create worktree branch", &error))?;
+        let branch_ref = branch.into_reference();
+
+        let mut options = WorktreeAddOptions::new();
+        options.reference(Some(&branch_ref));
+
+        match repository.worktree(&branch_name, &worktree_path, Some(&options)) {
+            Ok(_) => Ok(worktree_path),
+            Err(error) => {
+                remove_branch(&repository, &branch_name);
+                Err(git_error("create worktree", &error))
+            }
+        }
+    }
+
+    /// Remove a worktree directory and prune its Git metadata.
+    ///
+    /// Missing paths are treated as already removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `path` exists but is not an openable worktree, or if
+    /// libgit2 cannot prune the worktree metadata and working tree.
+    pub fn remove(path: &Path) -> Result<()> {
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let repository = Repository::open(path)
+            .or_else(|_| Repository::discover(path))
+            .map_err(|error| {
+                Error::Git(format!(
+                    "open worktree repository at {}: {}",
+                    path.display(),
+                    error.message()
+                ))
+            })?;
+        let worktree = git2::Worktree::open_from_repository(&repository)
+            .map_err(|error| git_error("open worktree metadata", &error))?;
+        let mut options = WorktreePruneOptions::new();
+        options.valid(true).working_tree(true);
+        worktree
+            .prune(Some(&mut options))
+            .map_err(|error| git_error("prune worktree", &error))
+    }
+
+    /// Return the unified diff for changes in a worktree.
+    ///
+    /// The diff includes staged, unstaged, and untracked files relative to
+    /// `HEAD`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `path` is not inside a Git repository or if libgit2
+    /// cannot compute or format the diff.
+    pub fn diff(path: &Path) -> Result<String> {
+        let repository = open_repo(path)?;
+        let head_tree = repository.head().ok().and_then(|head| head.peel_to_tree().ok());
+
+        let mut options = DiffOptions::new();
+        options
+            .include_untracked(true)
+            .recurse_untracked_dirs(true)
+            .show_untracked_content(true);
+
+        let diff = repository
+            .diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut options))
+            .map_err(|error| git_error("compute worktree diff", &error))?;
+        format_diff(&diff)
+    }
+
+    /// Apply a unified diff to `dest` without staging the result.
+    ///
+    /// Empty diffs are accepted and leave `dest` unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `dest` is not inside a Git repository, the diff
+    /// cannot be parsed, or libgit2 cannot apply it cleanly.
+    pub fn apply_to(diff: &str, dest: &Path) -> Result<()> {
+        if diff.trim().is_empty() {
+            return Ok(());
+        }
+
+        let repository = open_repo(dest)?;
+        let parsed = Diff::from_buffer(diff.as_bytes()).map_err(|error| git_error("parse diff", &error))?;
+        repository
+            .apply(&parsed, ApplyLocation::WorkDir, None)
+            .map_err(|error| git_error("apply diff", &error))
+    }
+}
+
+fn open_repo(path: &Path) -> Result<Repository> {
+    Repository::discover(path).map_err(|error| {
+        Error::Git(format!(
+            "discover repository at {}: {}",
+            path.display(),
+            error.message()
+        ))
+    })
+}
+
+fn resolve_commit<'repo>(repository: &'repo Repository, base_ref: &str) -> Result<git2::Commit<'repo>> {
+    let reference = if base_ref.trim().is_empty() { "HEAD" } else { base_ref };
+
+    repository
+        .revparse_single(reference)
+        .and_then(|object| object.peel_to_commit())
+        .map_err(|error| Error::Git(format!("resolve base ref {reference}: {}", error.message())))
+}
+
+fn format_diff(diff: &Diff<'_>) -> Result<String> {
+    let mut output = String::new();
+    diff.print(DiffFormat::Patch, |_delta, _hunk, line| {
+        if matches!(line.origin(), ' ' | '+' | '-') {
+            output.push(line.origin());
+        }
+        output.push_str(&String::from_utf8_lossy(line.content()));
+        true
+    })
+    .map_err(|error| git_error("format worktree diff", &error))?;
+    Ok(output)
+}
+
+fn remove_branch(repository: &Repository, branch_name: &str) {
+    if let Ok(mut branch) = repository.find_branch(branch_name, BranchType::Local) {
+        let _ = branch.delete();
+    }
+}
+
+fn worktree_name(scratch_root: &Path, slot_id: &str) -> String {
+    let run = scratch_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map_or_else(|| "run".to_string(), path_component);
+    let slot = path_component(slot_id);
+    let suffix = stable_path_suffix(scratch_root);
+    format!("{WORKTREE_NAME_PREFIX}-{run}-{slot}-{suffix:08x}")
+}
+
+fn path_component(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "slot".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn stable_path_suffix(path: &Path) -> u32 {
+    let mut hash = 0x811c_9dc5_u32;
+    for byte in path.as_os_str().to_string_lossy().as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
+}
+
+fn git_error(context: &str, error: &git2::Error) -> Error {
+    Error::Git(format!("{context}: {}", error.message()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use git2::{IndexAddOption, Repository, Signature};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn create_checks_out_base_ref_in_slot_worktree() {
+        let fixture = TestRepo::new();
+        let scratch_root = fixture.root.path().join("squad").join("run-a");
+
+        let worktree_path = WorktreeManager::create(fixture.repo_root(), "HEAD", &scratch_root, "s1").unwrap();
+
+        assert_eq!(worktree_path, scratch_root.join("s1"));
+        assert_eq!(fs::read_to_string(worktree_path.join("README.md")).unwrap(), "base\n");
+
+        let worktree_repo = Repository::open(&worktree_path).unwrap();
+        assert!(
+            worktree_repo
+                .head()
+                .unwrap()
+                .shorthand()
+                .unwrap()
+                .starts_with("horizon-squad-run-a-s1-")
+        );
+    }
+
+    #[test]
+    fn diff_and_apply_to_move_slot_changes_into_review_worktree() {
+        let fixture = TestRepo::new();
+        let scratch_root = fixture.root.path().join("squad").join("run-b");
+        let source = WorktreeManager::create(fixture.repo_root(), "HEAD", &scratch_root, "s1").unwrap();
+        let review = WorktreeManager::create(fixture.repo_root(), "HEAD", &scratch_root, "_review").unwrap();
+
+        fs::write(source.join("README.md"), "changed\n").unwrap();
+        fs::write(source.join("new-file.txt"), "new\n").unwrap();
+
+        let diff = WorktreeManager::diff(&source).unwrap();
+        assert!(diff.contains("+changed"));
+        assert!(diff.contains("new-file.txt"));
+
+        WorktreeManager::apply_to(&diff, &review).unwrap();
+
+        assert_eq!(fs::read_to_string(review.join("README.md")).unwrap(), "changed\n");
+        assert_eq!(fs::read_to_string(review.join("new-file.txt")).unwrap(), "new\n");
+    }
+
+    #[test]
+    fn remove_prunes_worktree_directory() {
+        let fixture = TestRepo::new();
+        let scratch_root = fixture.root.path().join("squad").join("run-c");
+        let worktree_path = WorktreeManager::create(fixture.repo_root(), "HEAD", &scratch_root, "s1").unwrap();
+
+        assert!(worktree_path.exists());
+
+        WorktreeManager::remove(&worktree_path).unwrap();
+
+        assert!(!worktree_path.exists());
+    }
+
+    #[test]
+    fn empty_diff_applies_as_noop() {
+        let fixture = TestRepo::new();
+        let scratch_root = fixture.root.path().join("squad").join("run-d");
+        let review = WorktreeManager::create(fixture.repo_root(), "HEAD", &scratch_root, "_review").unwrap();
+
+        WorktreeManager::apply_to("", &review).unwrap();
+
+        assert_eq!(fs::read_to_string(review.join("README.md")).unwrap(), "base\n");
+    }
+
+    struct TestRepo {
+        root: TempDir,
+        repo: Repository,
+    }
+
+    impl TestRepo {
+        fn new() -> Self {
+            let root = TempDir::new().unwrap();
+            let repo = Repository::init(root.path()).unwrap();
+            fs::write(root.path().join("README.md"), "base\n").unwrap();
+            commit_all(&repo, "initial");
+            Self { root, repo }
+        }
+
+        fn repo_root(&self) -> &Path {
+            self.repo.workdir().unwrap()
+        }
+    }
+
+    fn commit_all(repo: &Repository, message: &str) {
+        let mut index = repo.index().unwrap();
+        index.add_all(["*"], IndexAddOption::DEFAULT, None).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let signature = Signature::now("Horizon Test", "horizon@example.invalid").unwrap();
+        repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &[])
+            .unwrap();
+    }
+}

--- a/crates/horizon-ui/src/app/actions/command_palette.rs
+++ b/crates/horizon-ui/src/app/actions/command_palette.rs
@@ -114,6 +114,7 @@ impl HorizonApp {
                     self.create_panel(ctx);
                 }
             }
+            CommandId::OpenSquad => self.open_agent_squad_dashboard(),
             CommandId::OpenRemoteHosts => self.toggle_remote_hosts_overlay(ctx),
             CommandId::ToggleSessions => self.toggle_session_manager(),
             CommandId::CreatePanelFromPreset(index) => {

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -374,6 +374,7 @@ impl HorizonApp {
         self.render_command_palette(ctx);
         self.render_remote_hosts_overlay(ctx);
         self.render_session_manager(ctx);
+        self.render_agent_squad(ctx);
         self.render_ssh_upload_flow(ctx);
         self.sync_window_config(ctx);
         self.refresh_active_session_lease();

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -18,6 +18,7 @@ mod settings;
 mod shortcut_inventory;
 pub(crate) mod shortcuts;
 mod sidebar;
+mod squad;
 mod ssh_upload;
 mod startup_session;
 mod updates;
@@ -33,9 +34,9 @@ use std::time::Instant;
 
 use egui::{Color32, Context, Pos2, Rect, Vec2, ViewportId};
 use horizon_core::{
-    AgentSessionCatalog, AppShortcuts, AppearanceTheme, Board, CanvasViewState, Config, GitWatcher, ManagedInstall,
-    PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease, SessionStore,
-    ShutdownProgress, StartupChooser, StartupDecision, WindowConfig, WorkspaceId,
+    AgentSessionCatalog, AgentSquad, AppShortcuts, AppearanceTheme, Board, CanvasViewState, Config, GitWatcher,
+    ManagedInstall, PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease,
+    SessionStore, ShutdownProgress, StartupChooser, StartupDecision, WindowConfig, WorkspaceId,
 };
 
 use self::canvas::CanvasGridCache;
@@ -206,6 +207,8 @@ pub struct HorizonApp {
     last_terminal_output_at: Option<Instant>,
     settings: Option<SettingsEditor>,
     session_manager: Option<RuntimeSessionManagerState>,
+    agent_squad: AgentSquad,
+    squad_panel: Option<squad::SquadPanelState>,
     managed_install: Option<ManagedInstall>,
     surge_update_check_rx: Option<Receiver<UpdateCheckMessage>>,
     surge_available_update: Option<AvailableUpdate>,
@@ -352,6 +355,8 @@ impl HorizonApp {
             last_terminal_output_at: Some(Instant::now()),
             settings: None,
             session_manager: None,
+            agent_squad: squad::empty_squad(),
+            squad_panel: None,
             managed_install,
             surge_update_check_rx: None,
             surge_available_update: None,

--- a/crates/horizon-ui/src/app/root_chrome.rs
+++ b/crates/horizon-ui/src/app/root_chrome.rs
@@ -21,6 +21,7 @@ pub(super) const SIDEBAR_MIN_WIDTH: f32 = 168.0;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ToolbarAction {
     QuickNav,
+    Squad,
     RemoteHosts,
     Sessions,
     Update,
@@ -28,11 +29,12 @@ pub(super) enum ToolbarAction {
 }
 
 impl ToolbarAction {
-    const SECONDARY: [Self; 1] = [Self::RemoteHosts];
+    const SECONDARY: [Self; 2] = [Self::Squad, Self::RemoteHosts];
 
     pub(super) fn label(self) -> &'static str {
         match self {
             Self::QuickNav => "Quick Nav",
+            Self::Squad => "Squad",
             Self::RemoteHosts => "Remote Hosts",
             Self::Sessions => "Sessions",
             Self::Update => "Update",
@@ -93,10 +95,13 @@ pub(super) fn root_toolbar_layout(viewport: Rect, show_update: bool) -> RootTool
         ),
     );
 
+    let max_secondary = ToolbarAction::SECONDARY.len();
     let states = [
-        (true, 1_usize, true),
+        (true, max_secondary, true),
+        (false, max_secondary, true),
         (false, 1_usize, true),
         (false, 0_usize, true),
+        (false, max_secondary, false),
         (false, 1_usize, false),
         (false, 0_usize, false),
     ];
@@ -238,7 +243,10 @@ mod tests {
         let layout = root_toolbar_layout(viewport, false);
 
         assert!(!layout.show_tagline);
-        assert_eq!(layout.overflow_actions, vec![ToolbarAction::RemoteHosts]);
+        assert_eq!(
+            layout.overflow_actions,
+            vec![ToolbarAction::Squad, ToolbarAction::RemoteHosts]
+        );
         assert!(layout.visible_items.contains(&ToolbarItem::FpsMeter));
         assert!(layout.visible_items.contains(&ToolbarItem::OverflowMenu));
         assert!((layout.search_rect.center().y - TOOLBAR_HEIGHT * 0.5).abs() <= f32::EPSILON);
@@ -264,6 +272,10 @@ mod tests {
                 .visible_items
                 .contains(&ToolbarItem::Action(ToolbarAction::Settings))
         );
+        let squad_visible = layout
+            .visible_items
+            .contains(&ToolbarItem::Action(ToolbarAction::Squad));
+        assert!(squad_visible || layout.overflow_actions.contains(&ToolbarAction::Squad));
     }
 
     #[test]
@@ -276,6 +288,21 @@ mod tests {
                 .visible_items
                 .contains(&ToolbarItem::Action(ToolbarAction::Update))
         );
-        assert_eq!(layout.overflow_actions, vec![ToolbarAction::RemoteHosts]);
+        assert_eq!(
+            layout.overflow_actions,
+            vec![ToolbarAction::Squad, ToolbarAction::RemoteHosts]
+        );
+    }
+
+    #[test]
+    fn toolbar_keeps_squad_visible_on_wide_viewports() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1280.0, 768.0));
+        let layout = root_toolbar_layout(viewport, false);
+
+        assert!(
+            layout
+                .visible_items
+                .contains(&ToolbarItem::Action(ToolbarAction::Squad))
+        );
     }
 }

--- a/crates/horizon-ui/src/app/session.rs
+++ b/crates/horizon-ui/src/app/session.rs
@@ -144,6 +144,13 @@ impl HorizonApp {
             last_lease_refresh: Some(Instant::now()),
             persistent: true,
         });
+        self.agent_squad = self
+            .session_store
+            .load_agent_squad(&session.session_id)
+            .unwrap_or_else(|error| {
+                tracing::warn!("failed to load Agent Squad state: {error}");
+                super::squad::empty_squad()
+            });
         self.apply_runtime_state(&session.runtime_state);
     }
 
@@ -155,6 +162,7 @@ impl HorizonApp {
             last_lease_refresh: None,
             persistent: false,
         });
+        self.agent_squad = super::squad::empty_squad();
         self.transcript_root = None;
         self.startup_chooser = None;
         self.apply_runtime_state(runtime_state);

--- a/crates/horizon-ui/src/app/sidebar/toolbar.rs
+++ b/crates/horizon-ui/src/app/sidebar/toolbar.rs
@@ -182,7 +182,7 @@ impl HorizonApp {
                     response
                 }
             }
-            ToolbarAction::Sessions | ToolbarAction::Settings => ui.add(
+            ToolbarAction::Squad | ToolbarAction::Sessions | ToolbarAction::Settings => ui.add(
                 util::chrome_button(action.label())
                     .min_size(Vec2::new(action_button_width(action), ROOT_TOOLBAR_BUTTON_HEIGHT)),
             ),
@@ -217,6 +217,7 @@ impl HorizonApp {
     fn perform_toolbar_action(&mut self, ctx: &Context, action: ToolbarAction) {
         match action {
             ToolbarAction::QuickNav => self.open_command_palette(),
+            ToolbarAction::Squad => self.toggle_agent_squad(),
             ToolbarAction::RemoteHosts => self.toggle_remote_hosts_overlay(ctx),
             ToolbarAction::Sessions => self.toggle_session_manager(),
             ToolbarAction::Update => self.open_available_update(),
@@ -232,6 +233,7 @@ fn fps_meter_width() -> f32 {
 fn action_button_width(action: ToolbarAction) -> f32 {
     match action {
         ToolbarAction::QuickNav => 102.0,
+        ToolbarAction::Squad => 82.0,
         ToolbarAction::RemoteHosts => 120.0,
         ToolbarAction::Sessions => 94.0,
         ToolbarAction::Update => 84.0,

--- a/crates/horizon-ui/src/app/squad/composer.rs
+++ b/crates/horizon-ui/src/app/squad/composer.rs
@@ -1,0 +1,106 @@
+use egui::{Align, ComboBox, Layout, RichText};
+use horizon_core::PanelKind;
+
+use crate::app::util;
+use crate::theme;
+
+use super::SquadAction;
+use super::state::SquadComposerState;
+
+const AGENT_KINDS: [PanelKind; 5] = [
+    PanelKind::Codex,
+    PanelKind::Claude,
+    PanelKind::OpenCode,
+    PanelKind::Gemini,
+    PanelKind::KiloCode,
+];
+
+pub(super) fn render_composer(ui: &mut egui::Ui, composer: &mut SquadComposerState) -> SquadAction {
+    let mut action = SquadAction::None;
+
+    ui.horizontal(|ui| {
+        ui.heading(RichText::new("New Squad Run").size(16.0).color(theme::FG()));
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if ui.add(util::chrome_button("Dashboard")).clicked() {
+                action = SquadAction::Dashboard;
+            }
+        });
+    });
+    ui.add_space(10.0);
+
+    ui.label(RichText::new("Goal").size(10.5).strong().color(theme::FG_DIM()));
+    ui.add(
+        egui::TextEdit::multiline(&mut composer.goal)
+            .desired_rows(4)
+            .desired_width(f32::INFINITY),
+    );
+    ui.add_space(12.0);
+
+    ui.label(RichText::new("Roles").size(10.5).strong().color(theme::FG_DIM()));
+    egui::Grid::new("agent_squad_roles_grid")
+        .num_columns(2)
+        .spacing([14.0, 8.0])
+        .show(ui, |ui| {
+            role_label(ui, "Researcher");
+            kind_combo(ui, "agent_squad_researcher_kind", &mut composer.researcher_kind);
+            ui.end_row();
+
+            role_label(ui, "Reviewer");
+            kind_combo(ui, "agent_squad_reviewer_kind", &mut composer.reviewer_kind);
+            ui.end_row();
+
+            role_label(ui, "Performers");
+            ui.horizontal(|ui| {
+                kind_combo(ui, "agent_squad_performer_kind", &mut composer.performer_kind);
+                ComboBox::from_id_salt("agent_squad_performer_count")
+                    .selected_text(composer.performer_count.to_string())
+                    .show_ui(ui, |ui| {
+                        for count in SquadComposerState::MIN_PERFORMERS..=SquadComposerState::MAX_PERFORMERS {
+                            ui.selectable_value(&mut composer.performer_count, count, count.to_string());
+                        }
+                    });
+            });
+            ui.end_row();
+        });
+    ui.add_space(12.0);
+
+    ui.label(RichText::new("Isolation").size(10.5).strong().color(theme::FG_DIM()));
+    ui.label(RichText::new("Worktree").monospace().color(theme::FG_SOFT()));
+    ui.add_space(12.0);
+
+    ui.label(RichText::new("Advanced").size(10.5).strong().color(theme::FG_DIM()));
+    ui.checkbox(&mut composer.auto_start_reviewer, "Auto-start reviewer");
+    ui.checkbox(&mut composer.reviewer_commits, "Reviewer commits");
+    ui.checkbox(&mut composer.auto_close_performers, "Auto-close performers");
+    ui.add_space(16.0);
+
+    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+        let start_enabled = composer.draft().is_some();
+        if ui
+            .add_enabled(start_enabled, util::primary_button("Start Run"))
+            .clicked()
+            && let Some(draft) = composer.draft()
+        {
+            action = SquadAction::StartRun(draft);
+        }
+        if ui.add(util::chrome_button("Cancel")).clicked() {
+            action = SquadAction::Dashboard;
+        }
+    });
+
+    action
+}
+
+fn role_label(ui: &mut egui::Ui, label: &str) {
+    ui.label(RichText::new(label).color(theme::FG_DIM()));
+}
+
+fn kind_combo(ui: &mut egui::Ui, id: &'static str, value: &mut PanelKind) {
+    ComboBox::from_id_salt(id)
+        .selected_text(value.display_name())
+        .show_ui(ui, |ui| {
+            for kind in AGENT_KINDS {
+                ui.selectable_value(value, kind, kind.display_name());
+            }
+        });
+}

--- a/crates/horizon-ui/src/app/squad/dashboard.rs
+++ b/crates/horizon-ui/src/app/squad/dashboard.rs
@@ -34,7 +34,7 @@ pub(super) fn render_dashboard(ui: &mut egui::Ui, squad: &AgentSquad) -> SquadAc
             header(ui, "Roles");
             header(ui, "Status");
             header(ui, "Progress");
-            header(ui, "");
+            header(ui, "Actions");
             ui.end_row();
 
             for run in squad.runs.iter().rev() {
@@ -43,9 +43,14 @@ pub(super) fn render_dashboard(ui: &mut egui::Ui, squad: &AgentSquad) -> SquadAc
                 ui.label(RichText::new(role_summary(run)).color(theme::FG_DIM()));
                 ui.label(status_text(run.status));
                 ui.label(RichText::new(progress_text(run)).monospace().color(theme::FG_SOFT()));
-                if ui.add(util::chrome_button("Open")).clicked() {
-                    action = SquadAction::OpenRun(run.id.clone());
-                }
+                ui.horizontal(|ui| {
+                    if ui.add(util::chrome_button("Open")).clicked() {
+                        action = SquadAction::OpenRun(run.id.clone());
+                    }
+                    if ui.add(util::chrome_button("Delete")).clicked() {
+                        action = SquadAction::DeleteRun(run.id.clone());
+                    }
+                });
                 ui.end_row();
             }
         });

--- a/crates/horizon-ui/src/app/squad/dashboard.rs
+++ b/crates/horizon-ui/src/app/squad/dashboard.rs
@@ -25,7 +25,7 @@ pub(super) fn render_dashboard(ui: &mut egui::Ui, squad: &AgentSquad) -> SquadAc
     }
 
     egui::Grid::new("agent_squad_dashboard_grid")
-        .num_columns(5)
+        .num_columns(6)
         .spacing([18.0, 8.0])
         .striped(true)
         .show(ui, |ui| {
@@ -34,6 +34,7 @@ pub(super) fn render_dashboard(ui: &mut egui::Ui, squad: &AgentSquad) -> SquadAc
             header(ui, "Roles");
             header(ui, "Status");
             header(ui, "Progress");
+            header(ui, "");
             ui.end_row();
 
             for run in squad.runs.iter().rev() {
@@ -42,6 +43,9 @@ pub(super) fn render_dashboard(ui: &mut egui::Ui, squad: &AgentSquad) -> SquadAc
                 ui.label(RichText::new(role_summary(run)).color(theme::FG_DIM()));
                 ui.label(status_text(run.status));
                 ui.label(RichText::new(progress_text(run)).monospace().color(theme::FG_SOFT()));
+                if ui.add(util::chrome_button("Open")).clicked() {
+                    action = SquadAction::OpenRun(run.id.clone());
+                }
                 ui.end_row();
             }
         });

--- a/crates/horizon-ui/src/app/squad/dashboard.rs
+++ b/crates/horizon-ui/src/app/squad/dashboard.rs
@@ -1,0 +1,153 @@
+use egui::{Align, Layout, RichText};
+use horizon_core::{AgentSquad, RunStatus, SquadRun, WorkStatus};
+
+use crate::app::util;
+use crate::theme;
+
+use super::SquadAction;
+
+pub(super) fn render_dashboard(ui: &mut egui::Ui, squad: &AgentSquad) -> SquadAction {
+    let mut action = SquadAction::None;
+
+    ui.horizontal(|ui| {
+        ui.heading(RichText::new("Squad Dashboard").size(16.0).color(theme::FG()));
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if ui.add(util::primary_button("New run")).clicked() {
+                action = SquadAction::NewRun;
+            }
+        });
+    });
+    ui.add_space(10.0);
+
+    if squad.runs.is_empty() {
+        render_empty_dashboard(ui);
+        return action;
+    }
+
+    egui::Grid::new("agent_squad_dashboard_grid")
+        .num_columns(5)
+        .spacing([18.0, 8.0])
+        .striped(true)
+        .show(ui, |ui| {
+            header(ui, "Run");
+            header(ui, "Goal");
+            header(ui, "Roles");
+            header(ui, "Status");
+            header(ui, "Progress");
+            ui.end_row();
+
+            for run in squad.runs.iter().rev() {
+                ui.label(RichText::new(short_run_id(&run.id)).monospace().color(theme::ACCENT()));
+                ui.label(RichText::new(run_goal(run)).color(theme::FG()));
+                ui.label(RichText::new(role_summary(run)).color(theme::FG_DIM()));
+                ui.label(status_text(run.status));
+                ui.label(RichText::new(progress_text(run)).monospace().color(theme::FG_SOFT()));
+                ui.end_row();
+            }
+        });
+
+    action
+}
+
+fn render_empty_dashboard(ui: &mut egui::Ui) {
+    let available = ui.available_width();
+    let (rect, _) = ui.allocate_exact_size(egui::Vec2::new(available, 120.0), egui::Sense::hover());
+    let painter = ui.painter();
+    painter.rect_filled(rect, 6.0, theme::PANEL_BG());
+    painter.rect_stroke(
+        rect,
+        6.0,
+        egui::Stroke::new(1.0, theme::BORDER_SUBTLE()),
+        egui::StrokeKind::Outside,
+    );
+    painter.text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        "No squad runs",
+        egui::FontId::proportional(13.0),
+        theme::FG_DIM(),
+    );
+}
+
+fn header(ui: &mut egui::Ui, label: &str) {
+    ui.label(RichText::new(label).size(10.0).strong().color(theme::FG_DIM()));
+}
+
+fn short_run_id(run_id: &str) -> String {
+    format!("#{}", run_id.get(..4).unwrap_or(run_id))
+}
+
+fn run_goal(run: &SquadRun) -> String {
+    let count = run.performers.len();
+    if count == 0 {
+        return truncate(&run.goal, 44);
+    }
+    format!("{} (x{count})", truncate(&run.goal, 36))
+}
+
+fn role_summary(run: &SquadRun) -> String {
+    let researcher = run.researcher.as_ref().map_or("None", |link| link.kind.display_name());
+    let reviewer = run.reviewer.as_ref().map_or("None", |link| link.kind.display_name());
+    let performer = run
+        .performers
+        .first()
+        .map_or("None", |slot| slot.assigned_kind.display_name());
+    format!("{researcher} -> {performer} -> {reviewer}")
+}
+
+fn status_text(status: RunStatus) -> RichText {
+    let color = match status {
+        RunStatus::Done => theme::PALETTE_GREEN(),
+        RunStatus::Failed => theme::PALETTE_RED(),
+        RunStatus::Reviewing => theme::ACCENT(),
+        RunStatus::Working | RunStatus::FanningOut | RunStatus::Decomposing => theme::PALETTE_YELLOW(),
+        RunStatus::Draft => theme::FG_DIM(),
+    };
+    RichText::new(format!("{status:?}").to_lowercase())
+        .monospace()
+        .color(color)
+}
+
+fn progress_text(run: &SquadRun) -> String {
+    if run.performers.is_empty() {
+        return "-".to_string();
+    }
+
+    run.performers
+        .iter()
+        .map(|slot| match slot.work_item.status {
+            WorkStatus::Queued => "q",
+            WorkStatus::Dispatched => "w",
+            WorkStatus::Done => "d",
+            WorkStatus::Blocked => "b",
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated = value.chars().take(max_chars.saturating_sub(3)).collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use horizon_core::SquadRun;
+
+    use super::run_goal;
+
+    #[test]
+    fn run_goal_includes_performer_count() {
+        let mut run = SquadRun::new("run-1", "Fix flaky tests", 1);
+        run.performers = vec![
+            horizon_core::PerformerSlot::default(),
+            horizon_core::PerformerSlot::default(),
+        ];
+
+        assert_eq!(run_goal(&run), "Fix flaky tests (x2)");
+    }
+}

--- a/crates/horizon-ui/src/app/squad/lane.rs
+++ b/crates/horizon-ui/src/app/squad/lane.rs
@@ -28,6 +28,9 @@ pub(super) fn render_run_lane(ui: &mut egui::Ui, squad: &AgentSquad, run_id: &st
             if ui.add(util::chrome_button("Dashboard")).clicked() {
                 action = SquadAction::Dashboard;
             }
+            if ui.add(util::chrome_button("Delete")).clicked() {
+                action = SquadAction::DeleteRun(run.id.clone());
+            }
         });
     });
     ui.add_space(8.0);

--- a/crates/horizon-ui/src/app/squad/lane.rs
+++ b/crates/horizon-ui/src/app/squad/lane.rs
@@ -5,6 +5,7 @@ use crate::app::util;
 use crate::theme;
 
 use super::SquadAction;
+use super::review::ready_for_blocked_decision;
 
 pub(super) fn render_run_lane(ui: &mut egui::Ui, squad: &AgentSquad, run_id: &str) -> SquadAction {
     let Some(run) = squad.runs.iter().find(|run| run.id == run_id) else {
@@ -37,6 +38,8 @@ pub(super) fn render_run_lane(ui: &mut egui::Ui, squad: &AgentSquad, run_id: &st
         render_researcher(ui, run);
         ui.add_space(10.0);
         render_performer_slots(ui, run, &mut action);
+        ui.add_space(10.0);
+        render_blocked_decision(ui, run, &mut action);
         ui.add_space(10.0);
         render_reviewer(ui, run);
     });
@@ -92,6 +95,25 @@ fn render_performer_slots(ui: &mut egui::Ui, run: &SquadRun, action: &mut SquadA
     });
 }
 
+fn render_blocked_decision(ui: &mut egui::Ui, run: &SquadRun, action: &mut SquadAction) {
+    if !ready_for_blocked_decision(run) {
+        return;
+    }
+
+    card_frame().show(ui, |ui| {
+        ui.label(
+            RichText::new("Blocked slots need a review decision")
+                .strong()
+                .color(theme::PALETTE_YELLOW()),
+        );
+        ui.label(RichText::new(waiting_summary(run)).color(theme::FG_SOFT()));
+        ui.add_space(8.0);
+        if ui.add(util::primary_button("Review Done Slots")).clicked() {
+            *action = SquadAction::ReviewDoneSlots(run.id.clone());
+        }
+    });
+}
+
 fn render_slot_card(ui: &mut egui::Ui, run: &SquadRun, slot: &PerformerSlot) -> SquadAction {
     let mut action = SquadAction::None;
     card_frame().show(ui, |ui| {
@@ -113,6 +135,12 @@ fn render_slot_card(ui: &mut egui::Ui, run: &SquadRun, slot: &PerformerSlot) -> 
         );
         ui.add_space(8.0);
         ui.horizontal_wrapped(|ui| {
+            if ui.add(util::chrome_button("Details")).clicked() {
+                action = SquadAction::OpenSlot {
+                    run_id: run.id.clone(),
+                    slot_id: slot.id.clone(),
+                };
+            }
             if let Some(panel_local_id) = &slot.panel_local_id
                 && ui.add(util::chrome_button("Focus")).clicked()
             {
@@ -128,6 +156,7 @@ fn render_slot_card(ui: &mut egui::Ui, run: &SquadRun, slot: &PerformerSlot) -> 
                 action = SquadAction::MarkSlotBlocked {
                     run_id: run.id.clone(),
                     slot_id: slot.id.clone(),
+                    follow_up: "Marked blocked manually from the Squad lane.".to_string(),
                 };
             }
         });

--- a/crates/horizon-ui/src/app/squad/lane.rs
+++ b/crates/horizon-ui/src/app/squad/lane.rs
@@ -1,0 +1,245 @@
+use egui::{Align, Layout, Margin, RichText, Stroke, Vec2};
+use horizon_core::{AgentPanelLink, AgentSquad, PerformerSlot, RunStatus, SquadRun, WorkStatus};
+
+use crate::app::util;
+use crate::theme;
+
+use super::SquadAction;
+
+pub(super) fn render_run_lane(ui: &mut egui::Ui, squad: &AgentSquad, run_id: &str) -> SquadAction {
+    let Some(run) = squad.runs.iter().find(|run| run.id == run_id) else {
+        ui.label(RichText::new("Run not found").color(theme::FG_DIM()));
+        return if ui.add(util::chrome_button("Dashboard")).clicked() {
+            SquadAction::Dashboard
+        } else {
+            SquadAction::None
+        };
+    };
+
+    let mut action = SquadAction::None;
+    ui.horizontal(|ui| {
+        ui.heading(
+            RichText::new(format!("Run {} - {}", short_run_id(&run.id), status_label(run.status)))
+                .size(16.0)
+                .color(theme::FG()),
+        );
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if ui.add(util::chrome_button("Dashboard")).clicked() {
+                action = SquadAction::Dashboard;
+            }
+        });
+    });
+    ui.add_space(8.0);
+    ui.label(RichText::new(&run.goal).color(theme::FG_SOFT()));
+    ui.add_space(12.0);
+
+    egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
+        render_researcher(ui, run);
+        ui.add_space(10.0);
+        render_performer_slots(ui, run, &mut action);
+        ui.add_space(10.0);
+        render_reviewer(ui, run);
+    });
+
+    action
+}
+
+fn render_researcher(ui: &mut egui::Ui, run: &SquadRun) {
+    render_panel_link(
+        ui,
+        "Researcher",
+        run.researcher.as_ref(),
+        &format!("Plan: {}", plan_summary(run)),
+    );
+}
+
+fn render_reviewer(ui: &mut egui::Ui, run: &SquadRun) {
+    let detail = match run.status {
+        RunStatus::Reviewing => "Reviewing slot reports and diffs".to_string(),
+        RunStatus::Done => "Review complete".to_string(),
+        RunStatus::Failed => run
+            .failure_reason
+            .clone()
+            .unwrap_or_else(|| "Run failed before review completed".to_string()),
+        _ => format!("Waiting on {}", waiting_summary(run)),
+    };
+    render_panel_link(ui, "Reviewer", run.reviewer.as_ref(), &detail);
+}
+
+fn render_panel_link(ui: &mut egui::Ui, title: &str, link: Option<&AgentPanelLink>, detail: &str) {
+    card_frame().show(ui, |ui| {
+        ui.label(RichText::new(title).size(12.5).strong().color(theme::ACCENT()));
+        let agent = link.map_or("Not started", |link| link.kind.display_name());
+        let panel = link
+            .and_then(|link| link.panel_local_id.as_deref())
+            .map_or("no panel", |panel_id| panel_id);
+        ui.label(RichText::new(format!("{agent} - {panel}")).color(theme::FG_SOFT()));
+        ui.label(RichText::new(detail).color(theme::FG_DIM()));
+    });
+}
+
+fn render_performer_slots(ui: &mut egui::Ui, run: &SquadRun, action: &mut SquadAction) {
+    ui.label(RichText::new("Performers").size(10.5).strong().color(theme::FG_DIM()));
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing = Vec2::new(10.0, 10.0);
+        for slot in &run.performers {
+            let next = render_slot_card(ui, run, slot);
+            if !matches!(next, SquadAction::None) {
+                *action = next;
+            }
+        }
+    });
+}
+
+fn render_slot_card(ui: &mut egui::Ui, run: &SquadRun, slot: &PerformerSlot) -> SquadAction {
+    let mut action = SquadAction::None;
+    card_frame().show(ui, |ui| {
+        ui.set_min_width(220.0);
+        ui.set_max_width(260.0);
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(&slot.id).monospace().strong().color(theme::ACCENT()));
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                ui.label(status_text(slot.work_item.status));
+            });
+        });
+        ui.label(RichText::new(&slot.work_item.title).color(theme::FG()).strong());
+        ui.label(RichText::new(slot.assigned_kind.display_name()).color(theme::FG_SOFT()));
+        ui.label(RichText::new(panel_text(slot)).color(theme::FG_DIM()));
+        ui.label(
+            RichText::new(path_text(&slot.scratch))
+                .monospace()
+                .color(theme::FG_DIM()),
+        );
+        ui.add_space(8.0);
+        ui.horizontal_wrapped(|ui| {
+            if let Some(panel_local_id) = &slot.panel_local_id
+                && ui.add(util::chrome_button("Focus")).clicked()
+            {
+                action = SquadAction::FocusPanel(panel_local_id.clone());
+            }
+            if slot.work_item.status != WorkStatus::Done && ui.add(util::primary_button("Mark Done")).clicked() {
+                action = SquadAction::MarkSlotDone {
+                    run_id: run.id.clone(),
+                    slot_id: slot.id.clone(),
+                };
+            }
+            if slot.work_item.status != WorkStatus::Blocked && ui.add(util::chrome_button("Block")).clicked() {
+                action = SquadAction::MarkSlotBlocked {
+                    run_id: run.id.clone(),
+                    slot_id: slot.id.clone(),
+                };
+            }
+        });
+    });
+    action
+}
+
+fn card_frame() -> egui::Frame {
+    egui::Frame::new()
+        .fill(theme::alpha(theme::PANEL_BG(), 238))
+        .stroke(Stroke::new(1.0, theme::BORDER_SUBTLE()))
+        .corner_radius(6)
+        .inner_margin(Margin::same(10))
+}
+
+fn status_text(status: WorkStatus) -> RichText {
+    let color = match status {
+        WorkStatus::Queued => theme::FG_DIM(),
+        WorkStatus::Dispatched => theme::PALETTE_YELLOW(),
+        WorkStatus::Done => theme::PALETTE_GREEN(),
+        WorkStatus::Blocked => theme::PALETTE_RED(),
+    };
+    RichText::new(work_status_label(status)).monospace().color(color)
+}
+
+fn work_status_label(status: WorkStatus) -> &'static str {
+    match status {
+        WorkStatus::Queued => "queued",
+        WorkStatus::Dispatched => "working",
+        WorkStatus::Done => "done",
+        WorkStatus::Blocked => "blocked",
+    }
+}
+
+fn status_label(status: RunStatus) -> &'static str {
+    match status {
+        RunStatus::Draft => "draft",
+        RunStatus::Decomposing => "decomposing",
+        RunStatus::FanningOut => "fanning out",
+        RunStatus::Working => "working",
+        RunStatus::Reviewing => "reviewing",
+        RunStatus::Done => "done",
+        RunStatus::Failed => "failed",
+    }
+}
+
+fn plan_summary(run: &SquadRun) -> String {
+    if run.plan_text.trim().is_empty() {
+        format!("{} slots queued", run.performers.len())
+    } else {
+        let plan_items = run.plan_text.lines().filter(|line| !line.trim().is_empty()).count();
+        format!("{plan_items} plan items, {} slots queued", run.performers.len())
+    }
+}
+
+fn waiting_summary(run: &SquadRun) -> String {
+    let waiting = run
+        .performers
+        .iter()
+        .filter(|slot| slot.work_item.status != WorkStatus::Done)
+        .map(|slot| slot.id.as_str())
+        .collect::<Vec<_>>();
+    if waiting.is_empty() {
+        "reviewer start".to_string()
+    } else {
+        waiting.join(", ")
+    }
+}
+
+fn panel_text(slot: &PerformerSlot) -> String {
+    slot.panel_local_id
+        .as_ref()
+        .map_or_else(|| "no panel".to_string(), |panel_id| format!("panel {panel_id}"))
+}
+
+fn path_text(path: &std::path::Path) -> String {
+    let value = path.display().to_string();
+    let char_count = value.chars().count();
+    if char_count <= 38 {
+        return value;
+    }
+    let tail = value
+        .chars()
+        .rev()
+        .take(35)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+    format!("...{tail}")
+}
+
+fn short_run_id(run_id: &str) -> String {
+    format!("#{}", run_id.get(..4).unwrap_or(run_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::path_text;
+
+    #[test]
+    fn path_text_keeps_short_paths_verbatim() {
+        assert_eq!(path_text(&PathBuf::from("/tmp/s1")), "/tmp/s1");
+    }
+
+    #[test]
+    fn path_text_truncates_from_front() {
+        let text = path_text(&PathBuf::from("/very/long/path/that/keeps/the/slot/worktree/s1"));
+
+        assert!(text.starts_with("..."));
+        assert!(text.ends_with("/s1"));
+    }
+}

--- a/crates/horizon-ui/src/app/squad/mod.rs
+++ b/crates/horizon-ui/src/app/squad/mod.rs
@@ -1,12 +1,16 @@
 mod composer;
 mod dashboard;
+mod lane;
 mod render;
 mod state;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use horizon_core::{AgentPanelLink, AgentSquad, PerformerSlot, WorkItem, WorkStatus};
+use horizon_core::{
+    AgentPanelLink, AgentSquad, PanelKind, PanelOptions, PanelResume, PerformerReport, PerformerSlot, WorkItem,
+    WorkStatus, WorkspaceId, WorktreeManager,
+};
 
 use self::render::render_agent_squad;
 pub(super) use self::state::SquadPanelState;
@@ -19,7 +23,28 @@ enum SquadAction {
     Close,
     Dashboard,
     NewRun,
+    OpenRun(String),
+    FocusPanel(String),
     StartRun(SquadRunDraft),
+    MarkSlotDone { run_id: String, slot_id: String },
+    MarkSlotBlocked { run_id: String, slot_id: String },
+}
+
+struct CreatedSquadRun {
+    run_id: String,
+    slots: Vec<CreatedPerformerSlot>,
+}
+
+struct CreatedPerformerSlot {
+    slot_id: String,
+    kind: PanelKind,
+    scratch: PathBuf,
+    prompt: String,
+}
+
+struct SpawnedSlot {
+    slot_id: String,
+    panel_local_id: String,
 }
 
 impl HorizonApp {
@@ -45,48 +70,214 @@ impl HorizonApp {
         };
 
         let action = render_agent_squad(ctx, state, &self.agent_squad);
-        self.apply_squad_action(action);
+        self.apply_squad_action(ctx, action);
     }
 
-    fn apply_squad_action(&mut self, action: SquadAction) {
+    fn apply_squad_action(&mut self, ctx: &egui::Context, action: SquadAction) {
         match action {
             SquadAction::None => {}
             SquadAction::Close => self.squad_panel = None,
             SquadAction::Dashboard => {
                 if let Some(state) = &mut self.squad_panel {
                     state.view = SquadView::Dashboard;
+                    state.error_message = None;
                 }
             }
             SquadAction::NewRun => {
                 self.squad_panel = Some(SquadPanelState::composer());
             }
-            SquadAction::StartRun(draft) => {
-                self.create_stub_squad_run(&draft);
+            SquadAction::OpenRun(run_id) => {
                 if let Some(state) = &mut self.squad_panel {
-                    state.view = SquadView::Dashboard;
-                    state.composer.goal.clear();
+                    state.view = SquadView::RunLane { run_id };
+                    state.error_message = None;
                 }
             }
+            SquadAction::FocusPanel(panel_local_id) => {
+                self.focus_squad_panel(ctx, &panel_local_id);
+            }
+            SquadAction::StartRun(draft) => match self.start_squad_run(ctx, &draft) {
+                Ok(run_id) => {
+                    if let Some(state) = &mut self.squad_panel {
+                        state.view = SquadView::RunLane { run_id };
+                        state.composer.goal.clear();
+                        state.error_message = None;
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!("failed to start Agent Squad run: {error}");
+                    if let Some(state) = &mut self.squad_panel {
+                        state.error_message = Some(error.to_string());
+                    }
+                }
+            },
+            SquadAction::MarkSlotDone { run_id, slot_id } => self.mark_squad_slot_done(&run_id, &slot_id),
+            SquadAction::MarkSlotBlocked { run_id, slot_id } => self.mark_squad_slot_blocked(&run_id, &slot_id),
         }
     }
 
-    fn create_stub_squad_run(&mut self, draft: &SquadRunDraft) {
+    fn start_squad_run(&mut self, ctx: &egui::Context, draft: &SquadRunDraft) -> horizon_core::Result<String> {
+        let workspace_id = self.ensure_workspace_visible(ctx);
+        let source_repo = self.squad_source_repo(workspace_id)?;
         let scratch_root = self.session_store.home().root().join("squad-tmp");
         let now = current_unix_millis();
-        let result = self.update_agent_squad(|squad| {
+        let mut created_paths = Vec::new();
+        let mut created_run = None;
+
+        let create_result = self.update_agent_squad(|squad| {
             let run = squad.create_run(draft.goal.clone(), now);
             run.start_decomposing(AgentPanelLink::new(draft.researcher_kind, None));
             run.reviewer = Some(AgentPanelLink::new(draft.reviewer_kind, None));
+            let run_id = run.id.clone();
             let run_scratch_root = scratch_root.join(&run.id);
-            run.set_primary_worktree(run_scratch_root.join("_review"));
-            let performers = stub_performer_slots(draft, &run_scratch_root);
-            run.queue_plan(String::new(), performers);
+            let primary_worktree = WorktreeManager::create(&source_repo, "HEAD", &run_scratch_root, "_review")?;
+            created_paths.push(primary_worktree.clone());
+            let performers = create_performer_slots(draft, &source_repo, &run_scratch_root, &mut created_paths)?;
+            let slots = performers
+                .iter()
+                .map(|slot| CreatedPerformerSlot {
+                    slot_id: slot.id.clone(),
+                    kind: slot.assigned_kind,
+                    scratch: slot.scratch.clone(),
+                    prompt: performer_prompt(&run_id, draft, slot),
+                })
+                .collect();
+            run.set_primary_worktree(primary_worktree);
+            run.queue_plan(plan_text(draft), performers);
+            created_run = Some(CreatedSquadRun { run_id, slots });
             Ok(())
         });
 
-        if let Err(error) = result {
-            tracing::warn!("failed to persist Agent Squad run: {error}");
+        if let Err(error) = create_result {
+            cleanup_created_worktrees(&created_paths);
+            return Err(error);
         }
+
+        let created_run =
+            created_run.ok_or_else(|| horizon_core::Error::State("squad run was not created".to_string()))?;
+        let spawned = match self.spawn_squad_performers(workspace_id, &created_run) {
+            Ok(spawned) => spawned,
+            Err(error) => {
+                self.fail_squad_run(&created_run.run_id, error.to_string());
+                return Err(error);
+            }
+        };
+        if let Err(error) = self.dispatch_squad_slots(&created_run.run_id, &spawned) {
+            self.fail_squad_run(&created_run.run_id, error.to_string());
+            return Err(error);
+        }
+        self.mark_runtime_dirty();
+        Ok(created_run.run_id)
+    }
+
+    fn spawn_squad_performers(
+        &mut self,
+        workspace_id: WorkspaceId,
+        run: &CreatedSquadRun,
+    ) -> horizon_core::Result<Vec<SpawnedSlot>> {
+        let mut spawned = Vec::with_capacity(run.slots.len());
+        for slot in &run.slots {
+            let options = PanelOptions {
+                name: Some(format!("Squad {} {}", short_run_id(&run.run_id), slot.slot_id)),
+                cwd: Some(slot.scratch.clone()),
+                kind: slot.kind,
+                resume: PanelResume::Fresh,
+                ..PanelOptions::default()
+            };
+            let panel_id = self.create_panel_with_options(options, workspace_id)?;
+            let panel = self
+                .board
+                .panel_mut(panel_id)
+                .ok_or_else(|| horizon_core::Error::State(format!("panel {} was not created", panel_id.0)))?;
+            panel.write_input(slot.prompt.as_bytes());
+            spawned.push(SpawnedSlot {
+                slot_id: slot.slot_id.clone(),
+                panel_local_id: panel.local_id.clone(),
+            });
+        }
+        Ok(spawned)
+    }
+
+    fn dispatch_squad_slots(&mut self, run_id: &str, spawned: &[SpawnedSlot]) -> horizon_core::Result<()> {
+        self.update_agent_squad(|squad| {
+            let run = squad.run_mut(run_id)?;
+            for slot in spawned {
+                run.dispatch_slot(&slot.slot_id, slot.panel_local_id.clone())?;
+            }
+            Ok(())
+        })
+    }
+
+    fn focus_squad_panel(&mut self, ctx: &egui::Context, panel_local_id: &str) {
+        let Some(panel_id) = self.board.panel_id_by_local_id(panel_local_id) else {
+            return;
+        };
+        self.board.focus(panel_id);
+        if let Some(workspace_id) = self.board.panel_workspace_id(panel_id)
+            && let Some((min, max)) = self.board.workspace_bounds(workspace_id)
+        {
+            self.focus_workspace_bounds(ctx, min, max, true);
+        }
+    }
+
+    fn mark_squad_slot_done(&mut self, run_id: &str, slot_id: &str) {
+        if let Err(error) = self.update_agent_squad(|squad| {
+            squad.run_mut(run_id)?.mark_slot_done(
+                slot_id,
+                PerformerReport {
+                    summary: "Marked done manually from the Squad lane.".to_string(),
+                    validation_result: "Manual status update.".to_string(),
+                    ..PerformerReport::default()
+                },
+            )
+        }) {
+            tracing::warn!("failed to mark Squad slot done: {error}");
+        }
+    }
+
+    fn mark_squad_slot_blocked(&mut self, run_id: &str, slot_id: &str) {
+        if let Err(error) = self.update_agent_squad(|squad| {
+            squad
+                .run_mut(run_id)?
+                .mark_slot_blocked(slot_id, "Marked blocked manually from the Squad lane.")
+        }) {
+            tracing::warn!("failed to mark Squad slot blocked: {error}");
+        }
+    }
+
+    fn fail_squad_run(&mut self, run_id: &str, reason: String) {
+        if let Err(error) = self.update_agent_squad(|squad| {
+            squad.run_mut(run_id)?.fail(reason);
+            Ok(())
+        }) {
+            tracing::warn!("failed to persist failed Squad run: {error}");
+        }
+    }
+
+    fn squad_source_repo(&self, workspace_id: WorkspaceId) -> horizon_core::Result<PathBuf> {
+        if let Some(panel_id) = self.board.focused
+            && self.board.panel_workspace_id(panel_id) == Some(workspace_id)
+            && let Some(cwd) = self.board.panel(panel_id).and_then(|panel| panel.launch_cwd.clone())
+        {
+            return Ok(cwd);
+        }
+        if let Some(cwd) = self
+            .board
+            .workspace(workspace_id)
+            .and_then(|workspace| workspace.cwd.clone())
+        {
+            return Ok(cwd);
+        }
+        if let Some(cwd) = self
+            .board
+            .workspace(workspace_id)
+            .and_then(|workspace| workspace.panels.iter().find_map(|panel_id| self.board.panel(*panel_id)))
+            .and_then(|panel| panel.launch_cwd.clone())
+        {
+            return Ok(cwd);
+        }
+        Err(horizon_core::Error::State(
+            "Agent Squad needs an active workspace or panel directory inside a Git repository".to_string(),
+        ))
     }
 
     fn update_agent_squad<F>(&mut self, update: F) -> horizon_core::Result<()>
@@ -105,25 +296,87 @@ impl HorizonApp {
     }
 }
 
-fn stub_performer_slots(draft: &SquadRunDraft, scratch_root: &Path) -> Vec<PerformerSlot> {
+fn create_performer_slots(
+    draft: &SquadRunDraft,
+    source_repo: &Path,
+    scratch_root: &Path,
+    created_paths: &mut Vec<PathBuf>,
+) -> horizon_core::Result<Vec<PerformerSlot>> {
     (1..=draft.performer_count)
         .map(|index| {
             let slot_id = format!("s{index}");
+            let scratch = WorktreeManager::create(source_repo, "HEAD", scratch_root, &slot_id)?;
+            created_paths.push(scratch.clone());
             let work_item = WorkItem {
                 id: slot_id.clone(),
-                title: format!("Slot {index}"),
-                request: draft.goal.clone(),
+                title: format!("Slot {index}: {}", truncated_goal(&draft.goal)),
+                request: slot_request(draft, index),
+                acceptance_criteria: vec![
+                    "Keep the change isolated to this slot's worktree.".to_string(),
+                    "Run the most relevant validation available for the touched files.".to_string(),
+                    "Report summary, validation, and any follow-up before marking done.".to_string(),
+                ],
                 status: WorkStatus::Queued,
                 ..WorkItem::default()
             };
-            PerformerSlot::new(
-                slot_id.clone(),
-                work_item,
-                draft.performer_kind,
-                scratch_root.join(&slot_id),
-            )
+            Ok(PerformerSlot::new(slot_id, work_item, draft.performer_kind, scratch))
         })
         .collect()
+}
+
+fn cleanup_created_worktrees(paths: &[PathBuf]) {
+    for path in paths.iter().rev() {
+        if let Err(error) = WorktreeManager::remove(path) {
+            tracing::warn!(path = %path.display(), "failed to clean up Squad worktree after start failure: {error}");
+        }
+    }
+}
+
+fn slot_request(draft: &SquadRunDraft, index: usize) -> String {
+    format!(
+        "Work independently on performer slot {index} for this goal:\n\n{}",
+        draft.goal
+    )
+}
+
+fn plan_text(draft: &SquadRunDraft) -> String {
+    (1..=draft.performer_count)
+        .map(|index| format!("{index}. {}", slot_request(draft, index).replace('\n', " ")))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn performer_prompt(run_id: &str, draft: &SquadRunDraft, slot: &PerformerSlot) -> String {
+    let criteria = slot
+        .work_item
+        .acceptance_criteria
+        .iter()
+        .map(|criterion| format!("- {criterion}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "You are Agent Squad performer {slot_id} for run {run_short}.\n\nGoal:\n{goal}\n\nWork item:\n{title}\n\nRequest:\n{request}\n\nAcceptance criteria:\n{criteria}\n\nWhen finished, leave a concise report with summary, validation, and follow-up.\n",
+        slot_id = slot.id,
+        run_short = short_run_id(run_id),
+        goal = draft.goal,
+        title = slot.work_item.title,
+        request = slot.work_item.request,
+        criteria = criteria,
+    )
+}
+
+fn truncated_goal(goal: &str) -> String {
+    let trimmed = goal.trim();
+    if trimmed.chars().count() <= 42 {
+        return trimmed.to_string();
+    }
+    let mut value = trimmed.chars().take(39).collect::<String>();
+    value.push_str("...");
+    value
+}
+
+fn short_run_id(run_id: &str) -> String {
+    run_id.get(..4).unwrap_or(run_id).to_string()
 }
 
 fn current_unix_millis() -> i64 {

--- a/crates/horizon-ui/src/app/squad/mod.rs
+++ b/crates/horizon-ui/src/app/squad/mod.rs
@@ -1,0 +1,139 @@
+mod composer;
+mod dashboard;
+mod render;
+mod state;
+
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use horizon_core::{AgentPanelLink, AgentSquad, PerformerSlot, WorkItem, WorkStatus};
+
+use self::render::render_agent_squad;
+pub(super) use self::state::SquadPanelState;
+use self::state::{SquadRunDraft, SquadView};
+use super::HorizonApp;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SquadAction {
+    None,
+    Close,
+    Dashboard,
+    NewRun,
+    StartRun(SquadRunDraft),
+}
+
+impl HorizonApp {
+    pub(super) fn open_agent_squad_dashboard(&mut self) {
+        if let Some(state) = &mut self.squad_panel {
+            state.view = SquadView::Dashboard;
+        } else {
+            self.squad_panel = Some(SquadPanelState::dashboard());
+        }
+    }
+
+    pub(super) fn toggle_agent_squad(&mut self) {
+        self.squad_panel = if self.squad_panel.is_some() {
+            None
+        } else {
+            Some(SquadPanelState::dashboard())
+        };
+    }
+
+    pub(super) fn render_agent_squad(&mut self, ctx: &egui::Context) {
+        let Some(state) = &mut self.squad_panel else {
+            return;
+        };
+
+        let action = render_agent_squad(ctx, state, &self.agent_squad);
+        self.apply_squad_action(action);
+    }
+
+    fn apply_squad_action(&mut self, action: SquadAction) {
+        match action {
+            SquadAction::None => {}
+            SquadAction::Close => self.squad_panel = None,
+            SquadAction::Dashboard => {
+                if let Some(state) = &mut self.squad_panel {
+                    state.view = SquadView::Dashboard;
+                }
+            }
+            SquadAction::NewRun => {
+                self.squad_panel = Some(SquadPanelState::composer());
+            }
+            SquadAction::StartRun(draft) => {
+                self.create_stub_squad_run(&draft);
+                if let Some(state) = &mut self.squad_panel {
+                    state.view = SquadView::Dashboard;
+                    state.composer.goal.clear();
+                }
+            }
+        }
+    }
+
+    fn create_stub_squad_run(&mut self, draft: &SquadRunDraft) {
+        let scratch_root = self.session_store.home().root().join("squad-tmp");
+        let now = current_unix_millis();
+        let result = self.update_agent_squad(|squad| {
+            let run = squad.create_run(draft.goal.clone(), now);
+            run.start_decomposing(AgentPanelLink::new(draft.researcher_kind, None));
+            run.reviewer = Some(AgentPanelLink::new(draft.reviewer_kind, None));
+            let run_scratch_root = scratch_root.join(&run.id);
+            run.set_primary_worktree(run_scratch_root.join("_review"));
+            let performers = stub_performer_slots(draft, &run_scratch_root);
+            run.queue_plan(String::new(), performers);
+            Ok(())
+        });
+
+        if let Err(error) = result {
+            tracing::warn!("failed to persist Agent Squad run: {error}");
+        }
+    }
+
+    fn update_agent_squad<F>(&mut self, update: F) -> horizon_core::Result<()>
+    where
+        F: FnOnce(&mut AgentSquad) -> horizon_core::Result<()>,
+    {
+        if let Some(active_session) = &self.active_session
+            && active_session.persistent
+        {
+            let session_id = active_session.session_id.clone();
+            self.agent_squad = self.session_store.update_agent_squad(&session_id, update)?;
+            return Ok(());
+        }
+
+        update(&mut self.agent_squad)
+    }
+}
+
+fn stub_performer_slots(draft: &SquadRunDraft, scratch_root: &Path) -> Vec<PerformerSlot> {
+    (1..=draft.performer_count)
+        .map(|index| {
+            let slot_id = format!("s{index}");
+            let work_item = WorkItem {
+                id: slot_id.clone(),
+                title: format!("Slot {index}"),
+                request: draft.goal.clone(),
+                status: WorkStatus::Queued,
+                ..WorkItem::default()
+            };
+            PerformerSlot::new(
+                slot_id.clone(),
+                work_item,
+                draft.performer_kind,
+                scratch_root.join(&slot_id),
+            )
+        })
+        .collect()
+}
+
+fn current_unix_millis() -> i64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    i64::try_from(millis).unwrap_or(i64::MAX)
+}
+
+pub(super) fn empty_squad() -> AgentSquad {
+    AgentSquad::new()
+}

--- a/crates/horizon-ui/src/app/squad/mod.rs
+++ b/crates/horizon-ui/src/app/squad/mod.rs
@@ -2,6 +2,8 @@ mod composer;
 mod dashboard;
 mod lane;
 mod render;
+mod review;
+mod slot_detail;
 mod state;
 
 use std::path::{Path, PathBuf};
@@ -13,8 +15,12 @@ use horizon_core::{
 };
 
 use self::render::render_agent_squad;
+use self::review::{
+    apply_slot_diffs, blocked_slots, collect_review_contexts, ready_for_blocked_decision, ready_for_review,
+    reviewer_prompt,
+};
 pub(super) use self::state::SquadPanelState;
-use self::state::{SquadRunDraft, SquadView};
+use self::state::{SquadRunDraft, SquadSlotDetailState, SquadView};
 use super::HorizonApp;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -24,10 +30,28 @@ enum SquadAction {
     Dashboard,
     NewRun,
     OpenRun(String),
+    OpenSlot {
+        run_id: String,
+        slot_id: String,
+    },
+    RefreshSlotDetail,
     FocusPanel(String),
     StartRun(SquadRunDraft),
-    MarkSlotDone { run_id: String, slot_id: String },
-    MarkSlotBlocked { run_id: String, slot_id: String },
+    MarkSlotDone {
+        run_id: String,
+        slot_id: String,
+    },
+    MarkSlotDoneWithReport {
+        run_id: String,
+        slot_id: String,
+        report: PerformerReport,
+    },
+    MarkSlotBlocked {
+        run_id: String,
+        slot_id: String,
+        follow_up: String,
+    },
+    ReviewDoneSlots(String),
 }
 
 struct CreatedSquadRun {
@@ -51,6 +75,8 @@ impl HorizonApp {
     pub(super) fn open_agent_squad_dashboard(&mut self) {
         if let Some(state) = &mut self.squad_panel {
             state.view = SquadView::Dashboard;
+            state.slot_detail = None;
+            state.error_message = None;
         } else {
             self.squad_panel = Some(SquadPanelState::dashboard());
         }
@@ -80,6 +106,7 @@ impl HorizonApp {
             SquadAction::Dashboard => {
                 if let Some(state) = &mut self.squad_panel {
                     state.view = SquadView::Dashboard;
+                    state.slot_detail = None;
                     state.error_message = None;
                 }
             }
@@ -89,9 +116,12 @@ impl HorizonApp {
             SquadAction::OpenRun(run_id) => {
                 if let Some(state) = &mut self.squad_panel {
                     state.view = SquadView::RunLane { run_id };
+                    state.slot_detail = None;
                     state.error_message = None;
                 }
             }
+            SquadAction::OpenSlot { run_id, slot_id } => self.open_squad_slot_detail(&run_id, &slot_id),
+            SquadAction::RefreshSlotDetail => self.refresh_squad_slot_detail(),
             SquadAction::FocusPanel(panel_local_id) => {
                 self.focus_squad_panel(ctx, &panel_local_id);
             }
@@ -100,6 +130,7 @@ impl HorizonApp {
                     if let Some(state) = &mut self.squad_panel {
                         state.view = SquadView::RunLane { run_id };
                         state.composer.goal.clear();
+                        state.slot_detail = None;
                         state.error_message = None;
                     }
                 }
@@ -110,8 +141,27 @@ impl HorizonApp {
                     }
                 }
             },
-            SquadAction::MarkSlotDone { run_id, slot_id } => self.mark_squad_slot_done(&run_id, &slot_id),
-            SquadAction::MarkSlotBlocked { run_id, slot_id } => self.mark_squad_slot_blocked(&run_id, &slot_id),
+            SquadAction::MarkSlotDone { run_id, slot_id } => self.mark_squad_slot_done(
+                ctx,
+                &run_id,
+                &slot_id,
+                PerformerReport {
+                    summary: "Marked done manually from the Squad lane.".to_string(),
+                    validation_result: "Manual status update.".to_string(),
+                    ..PerformerReport::default()
+                },
+            ),
+            SquadAction::MarkSlotDoneWithReport {
+                run_id,
+                slot_id,
+                report,
+            } => self.mark_squad_slot_done(ctx, &run_id, &slot_id, report),
+            SquadAction::MarkSlotBlocked {
+                run_id,
+                slot_id,
+                follow_up,
+            } => self.mark_squad_slot_blocked(&run_id, &slot_id, follow_up),
+            SquadAction::ReviewDoneSlots(run_id) => self.review_done_squad_slots(ctx, &run_id),
         }
     }
 
@@ -219,28 +269,215 @@ impl HorizonApp {
         }
     }
 
-    fn mark_squad_slot_done(&mut self, run_id: &str, slot_id: &str) {
-        if let Err(error) = self.update_agent_squad(|squad| {
-            squad.run_mut(run_id)?.mark_slot_done(
-                slot_id,
-                PerformerReport {
-                    summary: "Marked done manually from the Squad lane.".to_string(),
-                    validation_result: "Manual status update.".to_string(),
-                    ..PerformerReport::default()
-                },
-            )
-        }) {
-            tracing::warn!("failed to mark Squad slot done: {error}");
+    fn open_squad_slot_detail(&mut self, run_id: &str, slot_id: &str) {
+        match self.build_slot_detail_state(run_id, slot_id) {
+            Ok(detail) => {
+                if let Some(state) = &mut self.squad_panel {
+                    state.view = SquadView::SlotDetail;
+                    state.slot_detail = Some(detail);
+                    state.error_message = None;
+                }
+            }
+            Err(error) => self.set_squad_error(error.to_string()),
         }
     }
 
-    fn mark_squad_slot_blocked(&mut self, run_id: &str, slot_id: &str) {
-        if let Err(error) = self.update_agent_squad(|squad| {
-            squad
-                .run_mut(run_id)?
-                .mark_slot_blocked(slot_id, "Marked blocked manually from the Squad lane.")
-        }) {
+    fn refresh_squad_slot_detail(&mut self) {
+        let Some((run_id, slot_id)) = self.squad_panel.as_ref().and_then(|state| {
+            state
+                .slot_detail
+                .as_ref()
+                .map(|detail| (detail.run_id.clone(), detail.slot_id.clone()))
+        }) else {
+            return;
+        };
+        self.open_squad_slot_detail(&run_id, &slot_id);
+    }
+
+    fn build_slot_detail_state(&self, run_id: &str, slot_id: &str) -> horizon_core::Result<SquadSlotDetailState> {
+        let run = self
+            .agent_squad
+            .runs
+            .iter()
+            .find(|run| run.id == run_id)
+            .ok_or_else(|| horizon_core::Error::State(format!("squad run {run_id} was not found")))?;
+        let slot = run
+            .performers
+            .iter()
+            .find(|slot| slot.id == slot_id)
+            .ok_or_else(|| horizon_core::Error::State(format!("performer slot {slot_id} was not found")))?;
+        let (diff, diff_error) = match WorktreeManager::diff(&slot.scratch) {
+            Ok(diff) => (diff, None),
+            Err(error) => (String::new(), Some(error.to_string())),
+        };
+        Ok(SquadSlotDetailState::from_slot(
+            run_id.to_string(),
+            slot,
+            diff,
+            diff_error,
+        ))
+    }
+
+    fn mark_squad_slot_done(&mut self, ctx: &egui::Context, run_id: &str, slot_id: &str, report: PerformerReport) {
+        if let Err(error) = self.update_agent_squad(|squad| squad.run_mut(run_id)?.mark_slot_done(slot_id, report)) {
+            tracing::warn!("failed to mark Squad slot done: {error}");
+            self.set_squad_error(error.to_string());
+            return;
+        }
+
+        if let Err(error) = self.maybe_start_squad_review(ctx, run_id) {
+            tracing::warn!("failed to start Squad review: {error}");
+            self.set_squad_error(error.to_string());
+        }
+    }
+
+    fn mark_squad_slot_blocked(&mut self, run_id: &str, slot_id: &str, follow_up: String) {
+        if let Err(error) =
+            self.update_agent_squad(|squad| squad.run_mut(run_id)?.mark_slot_blocked(slot_id, follow_up))
+        {
             tracing::warn!("failed to mark Squad slot blocked: {error}");
+            self.set_squad_error(error.to_string());
+            return;
+        }
+
+        if let Some(run) = self.agent_squad.runs.iter().find(|run| run.id == run_id)
+            && ready_for_blocked_decision(run)
+        {
+            self.set_squad_error(blocked_review_message(run));
+        }
+    }
+
+    fn review_done_squad_slots(&mut self, ctx: &egui::Context, run_id: &str) {
+        let blocked_slot_ids = self
+            .agent_squad
+            .runs
+            .iter()
+            .find(|run| run.id == run_id)
+            .map(|run| {
+                blocked_slots(run)
+                    .into_iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        if blocked_slot_ids.is_empty() {
+            return;
+        }
+
+        let result = self.update_agent_squad(|squad| {
+            let run = squad.run_mut(run_id)?;
+            for slot_id in &blocked_slot_ids {
+                run.mark_slot_done(
+                    slot_id,
+                    PerformerReport {
+                        summary: "Skipped blocked slot for reviewer pass.".to_string(),
+                        validation_result: "Skipped by manual review decision.".to_string(),
+                        follow_up: "Original slot was blocked; reviewer should inspect remaining context.".to_string(),
+                        ..PerformerReport::default()
+                    },
+                )?;
+            }
+            Ok(())
+        });
+
+        if let Err(error) = result {
+            tracing::warn!("failed to skip blocked Squad slots: {error}");
+            self.set_squad_error(error.to_string());
+            return;
+        }
+
+        if let Err(error) = self.maybe_start_squad_review(ctx, run_id) {
+            tracing::warn!("failed to start Squad review after skip: {error}");
+            self.set_squad_error(error.to_string());
+        }
+    }
+
+    fn maybe_start_squad_review(&mut self, ctx: &egui::Context, run_id: &str) -> horizon_core::Result<()> {
+        let Some(run) = self.agent_squad.runs.iter().find(|run| run.id == run_id).cloned() else {
+            return Err(horizon_core::Error::State(format!("squad run {run_id} was not found")));
+        };
+
+        if matches!(
+            run.status,
+            horizon_core::RunStatus::Reviewing | horizon_core::RunStatus::Done | horizon_core::RunStatus::Failed
+        ) {
+            self.clear_squad_error();
+            return Ok(());
+        }
+        if ready_for_blocked_decision(&run) {
+            self.set_squad_error(blocked_review_message(&run));
+            return Ok(());
+        }
+        if !ready_for_review(&run) {
+            self.clear_squad_error();
+            return Ok(());
+        }
+
+        self.start_squad_review(ctx, &run)
+    }
+
+    fn start_squad_review(&mut self, ctx: &egui::Context, run: &horizon_core::SquadRun) -> horizon_core::Result<()> {
+        let primary_worktree = run
+            .primary_worktree
+            .clone()
+            .ok_or_else(|| horizon_core::Error::State(format!("squad run {} has no review worktree", run.id)))?;
+        let contexts = collect_review_contexts(run)?;
+        apply_slot_diffs(&contexts, &primary_worktree)?;
+        let prompt = reviewer_prompt(run, &contexts);
+        let reviewer_kind = run.reviewer.as_ref().map_or(PanelKind::Claude, |link| link.kind);
+        let workspace_id = self
+            .squad_run_workspace_id(run)
+            .unwrap_or_else(|| self.ensure_workspace_visible(ctx));
+        let options = PanelOptions {
+            name: Some(format!("Squad {} review", short_run_id(&run.id))),
+            cwd: Some(primary_worktree),
+            kind: reviewer_kind,
+            resume: PanelResume::Fresh,
+            ..PanelOptions::default()
+        };
+        let panel_id = self.create_panel_with_options(options, workspace_id)?;
+        let panel = self
+            .board
+            .panel_mut(panel_id)
+            .ok_or_else(|| horizon_core::Error::State(format!("panel {} was not created", panel_id.0)))?;
+        panel.write_input(prompt.as_bytes());
+        let panel_local_id = panel.local_id.clone();
+        let reviewer = AgentPanelLink::new(reviewer_kind, Some(panel_local_id));
+        self.update_agent_squad(|squad| squad.run_mut(&run.id)?.start_reviewing(reviewer))?;
+        self.mark_runtime_dirty();
+        self.clear_squad_error();
+        Ok(())
+    }
+
+    fn squad_run_workspace_id(&self, run: &horizon_core::SquadRun) -> Option<WorkspaceId> {
+        for slot in &run.performers {
+            if let Some(panel_local_id) = &slot.panel_local_id
+                && let Some(workspace_id) = self.workspace_id_for_panel_local_id(panel_local_id)
+            {
+                return Some(workspace_id);
+            }
+        }
+        if let Some(panel_local_id) = run.reviewer.as_ref().and_then(|link| link.panel_local_id.as_ref()) {
+            return self.workspace_id_for_panel_local_id(panel_local_id);
+        }
+        None
+    }
+
+    fn workspace_id_for_panel_local_id(&self, panel_local_id: &str) -> Option<WorkspaceId> {
+        let panel_id = self.board.panel_id_by_local_id(panel_local_id)?;
+        self.board.panel_workspace_id(panel_id)
+    }
+
+    fn set_squad_error(&mut self, message: String) {
+        if let Some(state) = &mut self.squad_panel {
+            state.error_message = Some(message);
+        }
+    }
+
+    fn clear_squad_error(&mut self) {
+        if let Some(state) = &mut self.squad_panel {
+            state.error_message = None;
         }
     }
 
@@ -363,6 +600,11 @@ fn performer_prompt(run_id: &str, draft: &SquadRunDraft, slot: &PerformerSlot) -
         request = slot.work_item.request,
         criteria = criteria,
     )
+}
+
+fn blocked_review_message(run: &horizon_core::SquadRun) -> String {
+    let slots = blocked_slots(run).join(", ");
+    format!("Review paused for blocked slots: {slots}. Use Review Done Slots to skip blocked work.")
 }
 
 fn truncated_goal(goal: &str) -> String {

--- a/crates/horizon-ui/src/app/squad/mod.rs
+++ b/crates/horizon-ui/src/app/squad/mod.rs
@@ -6,6 +6,7 @@ mod review;
 mod slot_detail;
 mod state;
 
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -30,6 +31,7 @@ enum SquadAction {
     Dashboard,
     NewRun,
     OpenRun(String),
+    DeleteRun(String),
     OpenSlot {
         run_id: String,
         slot_id: String,
@@ -120,6 +122,7 @@ impl HorizonApp {
                     state.error_message = None;
                 }
             }
+            SquadAction::DeleteRun(run_id) => self.delete_squad_run(&run_id),
             SquadAction::OpenSlot { run_id, slot_id } => self.open_squad_slot_detail(&run_id, &slot_id),
             SquadAction::RefreshSlotDetail => self.refresh_squad_slot_detail(),
             SquadAction::FocusPanel(panel_local_id) => {
@@ -481,6 +484,45 @@ impl HorizonApp {
         }
     }
 
+    fn delete_squad_run(&mut self, run_id: &str) {
+        let Some(run) = self.agent_squad.runs.iter().find(|run| run.id == run_id).cloned() else {
+            self.set_squad_error(format!("squad run {run_id} was not found"));
+            return;
+        };
+
+        if let Err(error) = self.cleanup_squad_run_worktrees(&run) {
+            tracing::warn!("failed to delete Squad run worktrees: {error}");
+            self.set_squad_error(error.to_string());
+            return;
+        }
+
+        if let Err(error) = self.update_agent_squad(|squad| {
+            squad.remove_run(run_id)?;
+            Ok(())
+        }) {
+            tracing::warn!("failed to remove Squad run: {error}");
+            self.set_squad_error(error.to_string());
+            return;
+        }
+
+        if let Some(state) = &mut self.squad_panel {
+            state.view = SquadView::Dashboard;
+            state.slot_detail = None;
+            state.error_message = None;
+        }
+        self.mark_runtime_dirty();
+    }
+
+    fn cleanup_squad_run_worktrees(&self, run: &horizon_core::SquadRun) -> horizon_core::Result<()> {
+        let run_root = self.session_store.home().root().join("squad-tmp").join(&run.id);
+        for path in run.worktree_paths().iter().rev() {
+            validate_squad_cleanup_path(&run_root, path)?;
+            WorktreeManager::remove(path)?;
+        }
+        remove_empty_run_root(&run_root)?;
+        Ok(())
+    }
+
     fn fail_squad_run(&mut self, run_id: &str, reason: String) {
         if let Err(error) = self.update_agent_squad(|squad| {
             squad.run_mut(run_id)?.fail(reason);
@@ -569,6 +611,26 @@ fn cleanup_created_worktrees(paths: &[PathBuf]) {
     }
 }
 
+fn validate_squad_cleanup_path(run_root: &Path, path: &Path) -> horizon_core::Result<()> {
+    if path.starts_with(run_root) {
+        Ok(())
+    } else {
+        Err(horizon_core::Error::State(format!(
+            "refusing to delete Squad path outside run root: {}",
+            path.display()
+        )))
+    }
+}
+
+fn remove_empty_run_root(run_root: &Path) -> horizon_core::Result<()> {
+    match std::fs::remove_dir(run_root) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) if error.kind() == ErrorKind::DirectoryNotEmpty => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
 fn slot_request(draft: &SquadRunDraft, index: usize) -> String {
     format!(
         "Work independently on performer slot {index} for this goal:\n\n{}",
@@ -631,4 +693,27 @@ fn current_unix_millis() -> i64 {
 
 pub(super) fn empty_squad() -> AgentSquad {
     AgentSquad::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::validate_squad_cleanup_path;
+
+    #[test]
+    fn cleanup_path_validation_accepts_run_root_children() {
+        let run_root = PathBuf::from("/tmp/horizon/squad-tmp/run-1");
+        let slot = run_root.join("s1");
+
+        assert!(validate_squad_cleanup_path(&run_root, &slot).is_ok());
+    }
+
+    #[test]
+    fn cleanup_path_validation_rejects_paths_outside_run_root() {
+        let run_root = PathBuf::from("/tmp/horizon/squad-tmp/run-1");
+        let other_run = PathBuf::from("/tmp/horizon/squad-tmp/run-2/s1");
+
+        assert!(validate_squad_cleanup_path(&run_root, &other_run).is_err());
+    }
 }

--- a/crates/horizon-ui/src/app/squad/render.rs
+++ b/crates/horizon-ui/src/app/squad/render.rs
@@ -7,6 +7,7 @@ use super::SquadAction;
 use super::composer::render_composer;
 use super::dashboard::render_dashboard;
 use super::lane::render_run_lane;
+use super::slot_detail::render_slot_detail;
 use super::state::{SquadPanelState, SquadView};
 
 pub(super) fn render_agent_squad(ctx: &egui::Context, state: &mut SquadPanelState, squad: &AgentSquad) -> SquadAction {
@@ -32,6 +33,13 @@ pub(super) fn render_agent_squad(ctx: &egui::Context, state: &mut SquadPanelStat
                 SquadView::Dashboard => render_dashboard(ui, squad),
                 SquadView::Composer => render_composer(ui, &mut state.composer),
                 SquadView::RunLane { run_id } => render_run_lane(ui, squad, run_id),
+                SquadView::SlotDetail => {
+                    if let Some(detail) = &mut state.slot_detail {
+                        render_slot_detail(ui, squad, detail)
+                    } else {
+                        SquadAction::Dashboard
+                    }
+                }
             };
             if !matches!(next, SquadAction::None) {
                 action = next;

--- a/crates/horizon-ui/src/app/squad/render.rs
+++ b/crates/horizon-ui/src/app/squad/render.rs
@@ -6,6 +6,7 @@ use crate::theme;
 use super::SquadAction;
 use super::composer::render_composer;
 use super::dashboard::render_dashboard;
+use super::lane::render_run_lane;
 use super::state::{SquadPanelState, SquadView};
 
 pub(super) fn render_agent_squad(ctx: &egui::Context, state: &mut SquadPanelState, squad: &AgentSquad) -> SquadAction {
@@ -23,9 +24,14 @@ pub(super) fn render_agent_squad(ctx: &egui::Context, state: &mut SquadPanelStat
         .collapsible(false)
         .show(ctx, |ui| {
             ui.set_min_size(Vec2::new(580.0, 320.0));
-            let next = match state.view {
+            if let Some(message) = &state.error_message {
+                ui.label(RichText::new(message).color(theme::PALETTE_RED()).strong());
+                ui.add_space(8.0);
+            }
+            let next = match &state.view {
                 SquadView::Dashboard => render_dashboard(ui, squad),
                 SquadView::Composer => render_composer(ui, &mut state.composer),
+                SquadView::RunLane { run_id } => render_run_lane(ui, squad, run_id),
             };
             if !matches!(next, SquadAction::None) {
                 action = next;

--- a/crates/horizon-ui/src/app/squad/render.rs
+++ b/crates/horizon-ui/src/app/squad/render.rs
@@ -1,0 +1,36 @@
+use egui::{Id, Order, RichText, Vec2};
+use horizon_core::AgentSquad;
+
+use crate::theme;
+
+use super::SquadAction;
+use super::composer::render_composer;
+use super::dashboard::render_dashboard;
+use super::state::{SquadPanelState, SquadView};
+
+pub(super) fn render_agent_squad(ctx: &egui::Context, state: &mut SquadPanelState, squad: &AgentSquad) -> SquadAction {
+    let mut open = true;
+    let mut action = SquadAction::None;
+
+    egui::Window::new(RichText::new("Agent Squad").color(theme::FG()).strong())
+        .id(Id::new("agent_squad_window"))
+        .open(&mut open)
+        .default_width(820.0)
+        .min_width(620.0)
+        .min_height(360.0)
+        .order(Order::Debug)
+        .resizable(true)
+        .collapsible(false)
+        .show(ctx, |ui| {
+            ui.set_min_size(Vec2::new(580.0, 320.0));
+            let next = match state.view {
+                SquadView::Dashboard => render_dashboard(ui, squad),
+                SquadView::Composer => render_composer(ui, &mut state.composer),
+            };
+            if !matches!(next, SquadAction::None) {
+                action = next;
+            }
+        });
+
+    if open { action } else { SquadAction::Close }
+}

--- a/crates/horizon-ui/src/app/squad/review.rs
+++ b/crates/horizon-ui/src/app/squad/review.rs
@@ -1,0 +1,171 @@
+use std::fmt::Write as _;
+use std::path::Path;
+
+use horizon_core::{PerformerReport, SquadRun, WorkStatus, WorktreeManager};
+
+pub(super) struct SlotReviewContext {
+    pub slot_id: String,
+    pub title: String,
+    pub report: PerformerReport,
+    pub diff: String,
+}
+
+pub(super) fn collect_review_contexts(run: &SquadRun) -> horizon_core::Result<Vec<SlotReviewContext>> {
+    run.performers
+        .iter()
+        .map(|slot| {
+            let diff = WorktreeManager::diff(&slot.scratch)?;
+            Ok(SlotReviewContext {
+                slot_id: slot.id.clone(),
+                title: slot.work_item.title.clone(),
+                report: slot.report.clone().unwrap_or_default(),
+                diff,
+            })
+        })
+        .collect()
+}
+
+pub(super) fn apply_slot_diffs(contexts: &[SlotReviewContext], primary_worktree: &Path) -> horizon_core::Result<()> {
+    for context in contexts {
+        WorktreeManager::apply_to(&context.diff, primary_worktree)?;
+    }
+    Ok(())
+}
+
+pub(super) fn reviewer_prompt(run: &SquadRun, contexts: &[SlotReviewContext]) -> String {
+    let mut prompt = format!(
+        "You are the Agent Squad reviewer for run {run_id}.\n\nGoal:\n{goal}\n\nResearcher plan:\n{plan}\n\nReview the consolidated changes in this checkout and produce final review notes.\n",
+        run_id = short_run_id(&run.id),
+        goal = run.goal,
+        plan = if run.plan_text.trim().is_empty() {
+            "(no plan text recorded)"
+        } else {
+            run.plan_text.as_str()
+        },
+    );
+
+    for context in contexts {
+        prompt.push_str("\n---\n");
+        let _ = writeln!(prompt, "Slot {}: {}", context.slot_id, context.title);
+        let _ = writeln!(prompt, "Summary: {}", empty_label(&context.report.summary));
+        let validation_commands = if context.report.validation_commands.is_empty() {
+            "(none)".to_string()
+        } else {
+            context.report.validation_commands.join(", ")
+        };
+        let _ = writeln!(prompt, "Validation commands: {validation_commands}");
+        let _ = writeln!(
+            prompt,
+            "Validation result: {}",
+            empty_label(&context.report.validation_result)
+        );
+        if !context.report.follow_up.trim().is_empty() {
+            let _ = writeln!(prompt, "Follow-up: {}", context.report.follow_up.trim());
+        }
+        prompt.push_str("Diff:\n");
+        if context.diff.trim().is_empty() {
+            prompt.push_str("(empty diff)\n");
+        } else {
+            prompt.push_str(&context.diff);
+            if !context.diff.ends_with('\n') {
+                prompt.push('\n');
+            }
+        }
+    }
+
+    prompt.push_str("\nWhen finished, report issues found, validation performed, and final merge recommendation.\n");
+    prompt
+}
+
+pub(super) fn blocked_slots(run: &SquadRun) -> Vec<&str> {
+    run.performers
+        .iter()
+        .filter(|slot| slot.work_item.status == WorkStatus::Blocked)
+        .map(|slot| slot.id.as_str())
+        .collect()
+}
+
+pub(super) fn ready_for_blocked_decision(run: &SquadRun) -> bool {
+    let has_blocked = run
+        .performers
+        .iter()
+        .any(|slot| slot.work_item.status == WorkStatus::Blocked);
+    has_blocked
+        && run
+            .performers
+            .iter()
+            .all(|slot| matches!(slot.work_item.status, WorkStatus::Done | WorkStatus::Blocked))
+}
+
+pub(super) fn ready_for_review(run: &SquadRun) -> bool {
+    !run.performers.is_empty()
+        && run
+            .performers
+            .iter()
+            .all(|slot| slot.work_item.status == WorkStatus::Done)
+}
+
+fn empty_label(value: &str) -> &str {
+    if value.trim().is_empty() {
+        "(none)"
+    } else {
+        value.trim()
+    }
+}
+
+fn short_run_id(run_id: &str) -> String {
+    format!("#{}", run_id.get(..4).unwrap_or(run_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use horizon_core::{PanelKind, PerformerReport, PerformerSlot, SquadRun, WorkItem};
+
+    use super::{ready_for_blocked_decision, ready_for_review, reviewer_prompt};
+
+    #[test]
+    fn readiness_requires_all_done_and_no_blocked_slots() {
+        let mut run = SquadRun::new("run-1234", "Fix issues", 1);
+        run.queue_plan("Plan", vec![slot("s1"), slot("s2")]);
+
+        run.mark_slot_done("s1", PerformerReport::default()).unwrap();
+        run.mark_slot_blocked("s2", "needs fixture").unwrap();
+
+        assert!(!ready_for_review(&run));
+        assert!(ready_for_blocked_decision(&run));
+    }
+
+    #[test]
+    fn reviewer_prompt_includes_each_slot_report_and_diff() {
+        let mut run = SquadRun::new("run-1234", "Fix issues", 1);
+        run.plan_text = "1. Do s1".to_string();
+        let contexts = vec![super::SlotReviewContext {
+            slot_id: "s1".to_string(),
+            title: "Task s1".to_string(),
+            report: horizon_core::PerformerReport {
+                summary: "Changed parser".to_string(),
+                validation_commands: vec!["cargo test".to_string()],
+                validation_result: "passed".to_string(),
+                follow_up: String::new(),
+            },
+            diff: "diff --git a/file b/file\n+changed\n".to_string(),
+        }];
+
+        let prompt = reviewer_prompt(&run, &contexts);
+
+        assert!(prompt.contains("Changed parser"));
+        assert!(prompt.contains("cargo test"));
+        assert!(prompt.contains("+changed"));
+    }
+
+    fn slot(id: &str) -> PerformerSlot {
+        PerformerSlot::new(
+            id,
+            WorkItem::new(id, format!("Task {id}"), "Do the thing"),
+            PanelKind::Codex,
+            PathBuf::from(format!("/tmp/squad/{id}")),
+        )
+    }
+}

--- a/crates/horizon-ui/src/app/squad/slot_detail.rs
+++ b/crates/horizon-ui/src/app/squad/slot_detail.rs
@@ -1,0 +1,229 @@
+use egui::{Align, Layout, Margin, RichText, Stroke, TextEdit};
+use horizon_core::{AgentSquad, PerformerSlot, SquadRun, WorkStatus};
+
+use crate::app::util;
+use crate::theme;
+
+use super::SquadAction;
+use super::state::SquadSlotDetailState;
+
+pub(super) fn render_slot_detail(
+    ui: &mut egui::Ui,
+    squad: &AgentSquad,
+    detail: &mut SquadSlotDetailState,
+) -> SquadAction {
+    let Some((run, slot)) = find_slot(squad, &detail.run_id, &detail.slot_id) else {
+        ui.label(RichText::new("Slot not found").color(theme::FG_DIM()));
+        return if ui.add(util::chrome_button("Dashboard")).clicked() {
+            SquadAction::Dashboard
+        } else {
+            SquadAction::None
+        };
+    };
+
+    let mut action = SquadAction::None;
+    ui.horizontal(|ui| {
+        ui.heading(
+            RichText::new(format!(
+                "Slot {} - {}",
+                slot.id,
+                work_status_label(slot.work_item.status)
+            ))
+            .size(16.0)
+            .color(theme::FG()),
+        );
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if ui.add(util::chrome_button("Run Lane")).clicked() {
+                action = SquadAction::OpenRun(run.id.clone());
+            }
+            if ui.add(util::chrome_button("Refresh Diff")).clicked() {
+                action = SquadAction::RefreshSlotDetail;
+            }
+        });
+    });
+    ui.add_space(8.0);
+
+    egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
+        render_slot_summary(ui, slot, &mut action);
+        ui.add_space(10.0);
+        render_work_item(ui, slot);
+        ui.add_space(10.0);
+        render_report_editor(ui, detail, slot, &mut action);
+        ui.add_space(10.0);
+        render_diff(ui, detail);
+        ui.add_space(10.0);
+        render_reviewer_notes(ui, run);
+    });
+
+    action
+}
+
+fn render_slot_summary(ui: &mut egui::Ui, slot: &PerformerSlot, action: &mut SquadAction) {
+    card_frame().show(ui, |ui| {
+        ui.label(RichText::new("Panel").size(12.5).strong().color(theme::ACCENT()));
+        ui.label(RichText::new(slot.assigned_kind.display_name()).color(theme::FG_SOFT()));
+        ui.label(
+            RichText::new(slot.scratch.display().to_string())
+                .monospace()
+                .color(theme::FG_DIM()),
+        );
+        if let Some(panel_local_id) = &slot.panel_local_id
+            && ui.add(util::chrome_button("Focus")).clicked()
+        {
+            *action = SquadAction::FocusPanel(panel_local_id.clone());
+        }
+    });
+}
+
+fn render_work_item(ui: &mut egui::Ui, slot: &PerformerSlot) {
+    card_frame().show(ui, |ui| {
+        ui.label(RichText::new("Brief").size(12.5).strong().color(theme::ACCENT()));
+        ui.label(RichText::new(&slot.work_item.title).strong().color(theme::FG()));
+        ui.label(RichText::new(&slot.work_item.request).color(theme::FG_SOFT()));
+        if !slot.work_item.acceptance_criteria.is_empty() {
+            ui.add_space(6.0);
+            for criterion in &slot.work_item.acceptance_criteria {
+                ui.label(RichText::new(format!("- {criterion}")).color(theme::FG_DIM()));
+            }
+        }
+    });
+}
+
+fn render_report_editor(
+    ui: &mut egui::Ui,
+    detail: &mut SquadSlotDetailState,
+    slot: &PerformerSlot,
+    action: &mut SquadAction,
+) {
+    card_frame().show(ui, |ui| {
+        ui.label(RichText::new("Report").size(12.5).strong().color(theme::ACCENT()));
+        labeled_multiline(ui, "Summary", &mut detail.report_summary, 2);
+        labeled_multiline(ui, "Validation commands", &mut detail.validation_commands, 2);
+        labeled_multiline(ui, "Validation result", &mut detail.validation_result, 2);
+        labeled_multiline(ui, "Follow-up", &mut detail.follow_up, 2);
+        ui.add_space(8.0);
+        ui.horizontal_wrapped(|ui| {
+            if slot.work_item.status != WorkStatus::Done && ui.add(util::primary_button("Mark Done")).clicked() {
+                *action = SquadAction::MarkSlotDoneWithReport {
+                    run_id: detail.run_id.clone(),
+                    slot_id: detail.slot_id.clone(),
+                    report: detail.report(),
+                };
+            }
+            if slot.work_item.status != WorkStatus::Blocked && ui.add(util::chrome_button("Block")).clicked() {
+                *action = SquadAction::MarkSlotBlocked {
+                    run_id: detail.run_id.clone(),
+                    slot_id: detail.slot_id.clone(),
+                    follow_up: block_reason(detail),
+                };
+            }
+        });
+    });
+}
+
+fn render_diff(ui: &mut egui::Ui, detail: &mut SquadSlotDetailState) {
+    card_frame().show(ui, |ui| {
+        ui.label(RichText::new("Diff").size(12.5).strong().color(theme::ACCENT()));
+        if let Some(error) = &detail.diff_error {
+            ui.label(RichText::new(error).color(theme::PALETTE_RED()));
+        }
+        if detail.diff.trim().is_empty() {
+            ui.label(RichText::new("Empty diff").color(theme::FG_DIM()));
+        } else {
+            ui.add(
+                TextEdit::multiline(&mut detail.diff)
+                    .font(egui::TextStyle::Monospace)
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(12)
+                    .interactive(false),
+            );
+        }
+    });
+}
+
+fn render_reviewer_notes(ui: &mut egui::Ui, run: &SquadRun) {
+    card_frame().show(ui, |ui| {
+        ui.label(
+            RichText::new("Reviewer Notes")
+                .size(12.5)
+                .strong()
+                .color(theme::ACCENT()),
+        );
+        let text = if let Some(reason) = &run.failure_reason {
+            reason.as_str()
+        } else if run
+            .reviewer
+            .as_ref()
+            .and_then(|link| link.panel_local_id.as_ref())
+            .is_some()
+        {
+            "Reviewer panel is active; final notes are captured in that panel."
+        } else {
+            "Reviewer has not started."
+        };
+        ui.label(RichText::new(text).color(theme::FG_SOFT()));
+    });
+}
+
+fn labeled_multiline(ui: &mut egui::Ui, label: &str, value: &mut String, rows: usize) {
+    ui.label(RichText::new(label).size(10.5).strong().color(theme::FG_DIM()));
+    ui.add(
+        TextEdit::multiline(value)
+            .desired_width(f32::INFINITY)
+            .desired_rows(rows),
+    );
+}
+
+fn card_frame() -> egui::Frame {
+    egui::Frame::new()
+        .fill(theme::alpha(theme::PANEL_BG(), 238))
+        .stroke(Stroke::new(1.0, theme::BORDER_SUBTLE()))
+        .corner_radius(6)
+        .inner_margin(Margin::same(10))
+}
+
+fn find_slot<'a>(squad: &'a AgentSquad, run_id: &str, slot_id: &str) -> Option<(&'a SquadRun, &'a PerformerSlot)> {
+    let run = squad.runs.iter().find(|run| run.id == run_id)?;
+    let slot = run.performers.iter().find(|slot| slot.id == slot_id)?;
+    Some((run, slot))
+}
+
+fn block_reason(detail: &SquadSlotDetailState) -> String {
+    let follow_up = detail.follow_up.trim();
+    if follow_up.is_empty() {
+        "Marked blocked manually from the slot detail.".to_string()
+    } else {
+        follow_up.to_string()
+    }
+}
+
+fn work_status_label(status: WorkStatus) -> &'static str {
+    match status {
+        WorkStatus::Queued => "queued",
+        WorkStatus::Dispatched => "working",
+        WorkStatus::Done => "done",
+        WorkStatus::Blocked => "blocked",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::block_reason;
+    use crate::app::squad::state::SquadSlotDetailState;
+
+    #[test]
+    fn block_reason_falls_back_when_follow_up_is_empty() {
+        let detail = SquadSlotDetailState {
+            run_id: "run-1".to_string(),
+            slot_id: "s1".to_string(),
+            diff: String::new(),
+            diff_error: None,
+            report_summary: String::new(),
+            validation_commands: String::new(),
+            validation_result: String::new(),
+            follow_up: String::new(),
+        };
+
+        assert!(block_reason(&detail).contains("slot detail"));
+    }
+}

--- a/crates/horizon-ui/src/app/squad/state.rs
+++ b/crates/horizon-ui/src/app/squad/state.rs
@@ -4,12 +4,14 @@ use horizon_core::PanelKind;
 pub(super) enum SquadView {
     Dashboard,
     Composer,
+    RunLane { run_id: String },
 }
 
 #[derive(Clone, Debug)]
 pub(in crate::app) struct SquadPanelState {
     pub(super) view: SquadView,
     pub(super) composer: SquadComposerState,
+    pub(super) error_message: Option<String>,
 }
 
 impl SquadPanelState {
@@ -17,6 +19,7 @@ impl SquadPanelState {
         Self {
             view: SquadView::Dashboard,
             composer: SquadComposerState::default(),
+            error_message: None,
         }
     }
 
@@ -24,6 +27,7 @@ impl SquadPanelState {
         Self {
             view: SquadView::Composer,
             composer: SquadComposerState::default(),
+            error_message: None,
         }
     }
 }

--- a/crates/horizon-ui/src/app/squad/state.rs
+++ b/crates/horizon-ui/src/app/squad/state.rs
@@ -1,16 +1,18 @@
-use horizon_core::PanelKind;
+use horizon_core::{PanelKind, PerformerReport, PerformerSlot};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum SquadView {
     Dashboard,
     Composer,
     RunLane { run_id: String },
+    SlotDetail,
 }
 
 #[derive(Clone, Debug)]
 pub(in crate::app) struct SquadPanelState {
     pub(super) view: SquadView,
     pub(super) composer: SquadComposerState,
+    pub(super) slot_detail: Option<SquadSlotDetailState>,
     pub(super) error_message: Option<String>,
 }
 
@@ -19,6 +21,7 @@ impl SquadPanelState {
         Self {
             view: SquadView::Dashboard,
             composer: SquadComposerState::default(),
+            slot_detail: None,
             error_message: None,
         }
     }
@@ -27,6 +30,7 @@ impl SquadPanelState {
         Self {
             view: SquadView::Composer,
             composer: SquadComposerState::default(),
+            slot_detail: None,
             error_message: None,
         }
     }
@@ -86,6 +90,54 @@ pub(super) struct SquadRunDraft {
     pub reviewer_kind: PanelKind,
     pub performer_kind: PanelKind,
     pub performer_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SquadSlotDetailState {
+    pub run_id: String,
+    pub slot_id: String,
+    pub diff: String,
+    pub diff_error: Option<String>,
+    pub report_summary: String,
+    pub validation_commands: String,
+    pub validation_result: String,
+    pub follow_up: String,
+}
+
+impl SquadSlotDetailState {
+    pub fn from_slot(
+        run_id: impl Into<String>,
+        slot: &PerformerSlot,
+        diff: String,
+        diff_error: Option<String>,
+    ) -> Self {
+        let report = slot.report.clone().unwrap_or_default();
+        Self {
+            run_id: run_id.into(),
+            slot_id: slot.id.clone(),
+            diff,
+            diff_error,
+            report_summary: report.summary,
+            validation_commands: report.validation_commands.join("\n"),
+            validation_result: report.validation_result,
+            follow_up: report.follow_up,
+        }
+    }
+
+    pub fn report(&self) -> PerformerReport {
+        PerformerReport {
+            summary: self.report_summary.trim().to_string(),
+            validation_commands: self
+                .validation_commands
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(ToString::to_string)
+                .collect(),
+            validation_result: self.validation_result.trim().to_string(),
+            follow_up: self.follow_up.trim().to_string(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/horizon-ui/src/app/squad/state.rs
+++ b/crates/horizon-ui/src/app/squad/state.rs
@@ -1,0 +1,108 @@
+use horizon_core::PanelKind;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SquadView {
+    Dashboard,
+    Composer,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::app) struct SquadPanelState {
+    pub(super) view: SquadView,
+    pub(super) composer: SquadComposerState,
+}
+
+impl SquadPanelState {
+    pub fn dashboard() -> Self {
+        Self {
+            view: SquadView::Dashboard,
+            composer: SquadComposerState::default(),
+        }
+    }
+
+    pub fn composer() -> Self {
+        Self {
+            view: SquadView::Composer,
+            composer: SquadComposerState::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SquadComposerState {
+    pub goal: String,
+    pub researcher_kind: PanelKind,
+    pub reviewer_kind: PanelKind,
+    pub performer_kind: PanelKind,
+    pub performer_count: usize,
+    pub auto_start_reviewer: bool,
+    pub reviewer_commits: bool,
+    pub auto_close_performers: bool,
+}
+
+impl SquadComposerState {
+    pub const MIN_PERFORMERS: usize = 1;
+    pub const MAX_PERFORMERS: usize = 8;
+
+    pub fn draft(&self) -> Option<SquadRunDraft> {
+        let goal = self.goal.trim();
+        if goal.is_empty() {
+            return None;
+        }
+
+        Some(SquadRunDraft {
+            goal: goal.to_string(),
+            researcher_kind: self.researcher_kind,
+            reviewer_kind: self.reviewer_kind,
+            performer_kind: self.performer_kind,
+            performer_count: self.performer_count.clamp(Self::MIN_PERFORMERS, Self::MAX_PERFORMERS),
+        })
+    }
+}
+
+impl Default for SquadComposerState {
+    fn default() -> Self {
+        Self {
+            goal: String::new(),
+            researcher_kind: PanelKind::Claude,
+            reviewer_kind: PanelKind::Claude,
+            performer_kind: PanelKind::Codex,
+            performer_count: 3,
+            auto_start_reviewer: true,
+            reviewer_commits: true,
+            auto_close_performers: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SquadRunDraft {
+    pub goal: String,
+    pub researcher_kind: PanelKind,
+    pub reviewer_kind: PanelKind,
+    pub performer_kind: PanelKind,
+    pub performer_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SquadComposerState;
+
+    #[test]
+    fn composer_draft_requires_goal() {
+        assert!(SquadComposerState::default().draft().is_none());
+    }
+
+    #[test]
+    fn composer_draft_clamps_performer_count() {
+        let state = SquadComposerState {
+            goal: "Fix bugs".to_string(),
+            performer_count: 99,
+            ..SquadComposerState::default()
+        };
+
+        let draft = state.draft().expect("draft");
+
+        assert_eq!(draft.performer_count, SquadComposerState::MAX_PERFORMERS);
+    }
+}

--- a/crates/horizon-ui/src/command_registry.rs
+++ b/crates/horizon-ui/src/command_registry.rs
@@ -22,6 +22,7 @@ pub enum CommandId {
 
     // Workspace / panel
     NewPanel,
+    OpenSquad,
     OpenRemoteHosts,
     ToggleSessions,
     CreatePanelFromPreset(usize),
@@ -61,11 +62,11 @@ pub struct CommandEntry {
     pub keywords: Vec<String>,
 }
 
-fn command_entry(id: CommandId, label: &str, shortcut: String, keywords: &[&str]) -> CommandEntry {
+fn command_entry(id: CommandId, label: &str, shortcut: Option<String>, keywords: &[&str]) -> CommandEntry {
     CommandEntry {
         id,
         label: label.into(),
-        shortcut: Some(shortcut),
+        shortcut,
         keywords: keywords.iter().map(|keyword| (*keyword).into()).collect(),
     }
 }
@@ -84,37 +85,43 @@ fn workspace_commands(shortcuts: &AppShortcuts, primary_label: &str) -> Vec<Comm
         command_entry(
             CommandId::NewPanel,
             "New Panel",
-            shortcuts.new_terminal.display_label(primary_label),
+            Some(shortcuts.new_terminal.display_label(primary_label)),
             &["create", "terminal", "add"],
+        ),
+        command_entry(
+            CommandId::OpenSquad,
+            "Agent Squad",
+            None,
+            &["squad", "agent", "run", "fanout", "parallel"],
         ),
         command_entry(
             CommandId::FocusActiveWorkspace,
             "Focus Active Workspace",
-            shortcuts.focus_active_workspace.display_label(primary_label),
+            Some(shortcuts.focus_active_workspace.display_label(primary_label)),
             &["workspace", "focus", "pan", "center"],
         ),
         command_entry(
             CommandId::FitActiveWorkspace,
             "Fit Active Workspace",
-            shortcuts.fit_active_workspace.display_label(primary_label),
+            Some(shortcuts.fit_active_workspace.display_label(primary_label)),
             &["workspace", "fit", "zoom", "frame"],
         ),
         command_entry(
             CommandId::OpenRemoteHosts,
             "Remote Hosts",
-            shortcuts.open_remote_hosts.display_label(primary_label),
+            Some(shortcuts.open_remote_hosts.display_label(primary_label)),
             &["ssh", "tailscale", "remote", "hosts", "nodes"],
         ),
         command_entry(
             CommandId::ToggleSessions,
             "Sessions",
-            shortcuts.toggle_sessions.display_label(primary_label),
+            Some(shortcuts.toggle_sessions.display_label(primary_label)),
             &["session", "switch", "resume", "restore"],
         ),
         command_entry(
             CommandId::AlignWorkspacesHorizontally,
             "Align Workspaces",
-            shortcuts.align_workspaces_horizontally.display_label(primary_label),
+            Some(shortcuts.align_workspaces_horizontally.display_label(primary_label)),
             &["arrange", "horizontal", "layout", "row"],
         ),
     ]
@@ -125,49 +132,49 @@ fn view_commands(shortcuts: &AppShortcuts, primary_label: &str) -> Vec<CommandEn
         command_entry(
             CommandId::ToggleSidebar,
             "Toggle Sidebar",
-            shortcuts.toggle_sidebar.display_label(primary_label),
+            Some(shortcuts.toggle_sidebar.display_label(primary_label)),
             &["sidebar", "hide", "show"],
         ),
         command_entry(
             CommandId::ToggleHud,
             "Toggle HUD",
-            shortcuts.toggle_hud.display_label(primary_label),
+            Some(shortcuts.toggle_hud.display_label(primary_label)),
             &["heads", "up", "display", "info"],
         ),
         command_entry(
             CommandId::ToggleMinimap,
             "Toggle Minimap",
-            shortcuts.toggle_minimap.display_label(primary_label),
+            Some(shortcuts.toggle_minimap.display_label(primary_label)),
             &["overview", "map"],
         ),
         command_entry(
             CommandId::ToggleFullscreenWindow,
             "Toggle Fullscreen (Window)",
-            shortcuts.fullscreen_window.display_label(primary_label),
+            Some(shortcuts.fullscreen_window.display_label(primary_label)),
             &["maximize", "window", "fullscreen"],
         ),
         command_entry(
             CommandId::ToggleFullscreenPanel,
             "Toggle Fullscreen (Panel)",
-            shortcuts.fullscreen_panel.display_label(primary_label),
+            Some(shortcuts.fullscreen_panel.display_label(primary_label)),
             &["maximize", "panel", "fullscreen", "focus"],
         ),
         command_entry(
             CommandId::ZoomReset,
             "Reset Zoom",
-            shortcuts.zoom_reset.display_label(primary_label),
+            Some(shortcuts.zoom_reset.display_label(primary_label)),
             &["zoom", "reset", "100", "percent"],
         ),
         command_entry(
             CommandId::ZoomIn,
             "Zoom In",
-            shortcuts.zoom_in.display_label(primary_label),
+            Some(shortcuts.zoom_in.display_label(primary_label)),
             &["zoom", "bigger", "enlarge"],
         ),
         command_entry(
             CommandId::ZoomOut,
             "Zoom Out",
-            shortcuts.zoom_out.display_label(primary_label),
+            Some(shortcuts.zoom_out.display_label(primary_label)),
             &["zoom", "smaller", "shrink"],
         ),
     ]
@@ -178,13 +185,13 @@ fn global_commands(shortcuts: &AppShortcuts, primary_label: &str) -> Vec<Command
         command_entry(
             CommandId::ToggleSettings,
             "Settings",
-            shortcuts.toggle_settings.display_label(primary_label),
+            Some(shortcuts.toggle_settings.display_label(primary_label)),
             &["settings", "config", "preferences"],
         ),
         command_entry(
             CommandId::ToggleSearch,
             "Search Terminals",
-            shortcuts.search.display_label(primary_label),
+            Some(shortcuts.search.display_label(primary_label)),
             &["find", "search", "grep", "text"],
         ),
     ]
@@ -209,8 +216,23 @@ mod tests {
     #[test]
     fn action_commands_all_have_shortcuts() {
         for entry in action_commands(&AppShortcuts::default(), "Ctrl") {
-            assert!(entry.shortcut.is_some(), "entry '{}' has no shortcut", entry.label);
+            if entry.id != CommandId::OpenSquad {
+                assert!(entry.shortcut.is_some(), "entry '{}' has no shortcut", entry.label);
+            }
         }
+    }
+
+    #[test]
+    fn action_commands_include_agent_squad() {
+        let entries = action_commands(&AppShortcuts::default(), "Ctrl");
+        let entry = entries
+            .iter()
+            .find(|entry| entry.id == CommandId::OpenSquad)
+            .expect("agent squad command");
+
+        assert_eq!(entry.label, "Agent Squad");
+        assert_eq!(entry.shortcut, None);
+        assert!(entry.keywords.iter().any(|keyword| keyword == "parallel"));
     }
 
     #[test]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -23,6 +23,8 @@ back into large multi-purpose modules.
 - `worktree.rs` owns Agent Squad git isolation primitives only: creating slot
   worktrees, collecting diffs, applying diffs into a review checkout, and
   pruning worktree directories.
+- `squad.rs` owns the Agent Squad data model and state transitions; session
+  persistence stays in `session_store.rs`.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -20,6 +20,9 @@ back into large multi-purpose modules.
 - `runtime_state.rs` should stay focused on persisted board/window state; agent
   session discovery and external-store parsing belong in `runtime_state/`
   helper modules.
+- `worktree.rs` owns Agent Squad git isolation primitives only: creating slot
+  worktrees, collecting diffs, applying diffs into a review checkout, and
+  pruning worktree directories.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -42,6 +42,9 @@ back into large multi-purpose modules.
   - `lifecycle`: frame orchestration, shutdown flow, and repaint pacing
   - `panel_chrome`: panel titlebar chrome, badges, context menus, and rename UI
   - `panels`: panel-area orchestration and body rendering
+  - `squad`: Agent Squad overlay state/action dispatch, composer/dashboard/run
+    lane rendering, and UI-only fanout controls; worktree, persistence, and
+    domain transitions stay in `horizon-core` and `session_store`
   - `remote_hosts_overlay`: overlay state/input shell with query/filter,
     layout, and row/header paint helpers split into `remote_hosts_overlay/`
   - `sidebar`: sidebar rendering and deferred sidebar actions

--- a/docs/testing/2026-05-25-agent-squad-smoke.md
+++ b/docs/testing/2026-05-25-agent-squad-smoke.md
@@ -41,6 +41,27 @@ cargo test -p horizon-core worktree
 3. Confirm the source repository still has its original worktree intact and
    that no performer worktree was mutated by applying into `_review`.
 
+## Current Slice: Data Model And Persistence
+
+1. Validate the model, transition helpers, and per-session persistence:
+
+```bash
+cargo test -p horizon-core squad
+cargo test -p horizon-core session_store::tests::agent_squad
+```
+
+2. Inspect a saved `squad.json` fixture from an isolated smoke session and
+   confirm it contains:
+   - `version: 1`
+   - one or more `runs`
+   - researcher and reviewer `AgentPanelLink` fields
+   - performer slot `work_item`, `scratch`, `panel_local_id`, and `report`
+     fields
+   - `primary_worktree` when review worktree creation has run
+
+3. Exercise one transition through `SessionStore::update_agent_squad` and
+   confirm the changed run status survives a fresh `load_agent_squad` call.
+
 ## UI Shell Slices
 
 Run these once the composer and dashboard are wired.

--- a/docs/testing/2026-05-25-agent-squad-smoke.md
+++ b/docs/testing/2026-05-25-agent-squad-smoke.md
@@ -262,7 +262,8 @@ Manual smoke, all-done path:
 
 1. Start a three-performer run from the disposable repository.
 2. Make a distinct edit in each performer worktree.
-3. Mark each performer slot Done with a short report and validation command.
+3. Open each slot detail, use Refresh Diff, then mark each performer slot Done
+   with a short report and validation command.
 4. Confirm the reviewer panel auto-spawns only after the last Done transition.
 5. In the reviewer panel, run `pwd` and confirm it is `_review`.
 6. Confirm reviewer context includes:
@@ -276,15 +277,20 @@ Manual smoke, blocked path:
 
 1. Start another run with at least two performers.
 2. Mark one slot Blocked and all remaining slots Done.
-3. Confirm Horizon surfaces a skip-blocked or retry-blocked decision.
-4. Confirm the reviewer is not auto-spawned until the user chooses a path.
+3. Confirm Horizon surfaces the blocked decision banner in the run lane.
+4. Confirm the reviewer is not auto-spawned before the user chooses a path.
+5. Choose `Review Done Slots`.
+6. Confirm the reviewer starts from `_review` and the skipped blocked slot is
+   represented in reviewer context.
 
 Slot detail smoke:
 
 1. Open a slot from the run lane.
 2. Verify the detail surface shows status, panel link, scratch path, work item,
    performer report, diff, and reviewer notes.
-3. Use the slot detail `Focus` or equivalent action and verify it selects the
+3. Edit the report fields and verify `Mark Done` persists the report to
+   `squad.json`.
+4. Use the slot detail `Focus` or equivalent action and verify it selects the
    correct performer panel.
 
 Evidence:

--- a/docs/testing/2026-05-25-agent-squad-smoke.md
+++ b/docs/testing/2026-05-25-agent-squad-smoke.md
@@ -1,134 +1,373 @@
-# macOS Agent Squad Smoke Plan
+# macOS/OSX Agent Squad Smoke Plan
 
-This retained smoke plan covers the Agent Squad epic from the first worktree
-primitive slice through the later UI fanout slices. Run it on macOS before
-marking an Agent Squad PR ready when the PR touches core worktree logic,
-composer/dashboard UI, panel spawning, slot status, reviewer automation, or
-`squad.json` persistence.
+This temporary smoke-test plan covers every implementation slice for issue
+203, from worktree primitives through cleanup. Run the section for each slice
+as that slice lands. Before marking the PR ready after slice 5 or slice 6, rerun
+the full plan on macOS with the final branch or commit.
+
+Keep this file in the PR while the epic is under active validation. Remove it
+after the final UI validation pass unless the reviewer asks to keep it.
 
 ## Environment
 
 - macOS with Xcode Command Line Tools installed.
 - Rust stable 1.88 or newer.
+- The branch or commit under test checked out locally.
 - A disposable Git repository with at least one committed file.
-- A clean Horizon checkout on the branch under test.
-- An isolated runtime home:
+- An isolated Horizon runtime home:
 
 ```bash
 export HORIZON_SMOKE_HOME="$(mktemp -d)"
-export HOME="$HORIZON_SMOKE_HOME"
+export HORIZON_HOME="$HORIZON_SMOKE_HOME/.horizon"
+mkdir -p "$HORIZON_HOME"
 ```
 
-## Current Slice: Worktree Primitives
+Prepare the disposable repository:
 
-1. Validate formatting and focused tests:
+```bash
+export SQUAD_REPO="$HORIZON_SMOKE_HOME/repo"
+mkdir -p "$SQUAD_REPO"
+cd "$SQUAD_REPO"
+git init
+git config user.name "Horizon Smoke"
+git config user.email "horizon-smoke@example.invalid"
+printf 'one\n' > smoke.txt
+git add smoke.txt
+git commit -m "seed smoke repository"
+cd -
+```
+
+Use debug builds for UI smoke work:
+
+```bash
+cargo build
+HORIZON_HOME="$HORIZON_HOME" target/debug/horizon
+```
+
+Capture screenshots with:
+
+```bash
+screencapture -x "$HORIZON_SMOKE_HOME/<name>.png"
+```
+
+## Shared Validation Gate
+
+Run this gate after each slice before committing or pushing that slice:
 
 ```bash
 cargo fmt --all -- --check
-cargo test -p horizon-core worktree
 ./scripts/check-maintainability.sh
+cargo test --workspace
+cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
+cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
 ```
 
-2. In a disposable Git repository, exercise the core worktree path through a
-   small Rust caller or unit-test harness:
-   - create slot worktrees under
-     `~/.horizon/squad-tmp/<run-id>/s{1,2,3}/`
-   - edit one slot worktree
-   - collect its diff
-   - apply that diff into `~/.horizon/squad-tmp/<run-id>/_review/`
-   - remove a slot worktree and confirm the directory is gone
+For UI slices, also launch the debug app and capture screenshots after launch,
+after opening the Squad surface, after resizing narrower, and after resizing
+back wider.
 
-3. Confirm the source repository still has its original worktree intact and
-   that no performer worktree was mutated by applying into `_review`.
+## Slice 1: Worktree Primitives
 
-## Current Slice: Data Model And Persistence
+Scope:
 
-1. Validate the model, transition helpers, and per-session persistence:
+- `crates/horizon-core/src/worktree.rs`
+- `WorktreeManager::create`, `remove`, `diff`, and `apply_to`
+- `tempfile` Git repository tests
+
+Validation:
+
+```bash
+cargo test -p horizon-core worktree
+```
+
+Manual smoke:
+
+1. In the disposable repository, create three slot worktrees under
+   `$HORIZON_HOME/squad-tmp/<run-id>/s1`, `s2`, and `s3`.
+2. Edit `smoke.txt` in `s1` and collect the slot diff.
+3. Create a primary review worktree under
+   `$HORIZON_HOME/squad-tmp/<run-id>/_review`.
+4. Apply the `s1` diff into `_review`.
+5. Remove `s1` and confirm the worktree registration and directory are gone.
+
+Expected:
+
+- The source repository remains clean.
+- Applying a slot diff changes `_review`, not the performer worktree.
+- Empty diffs are accepted as no-ops.
+- Invalid diffs fail without modifying `_review`.
+
+Evidence:
+
+- Focused test output.
+- `git worktree list` before and after removal.
+- `git -C "$SQUAD_REPO" status --short`.
+
+## Slice 2: Data Model And Persistence
+
+Scope:
+
+- `crates/horizon-core/src/squad.rs`
+- `AgentSquad`, `SquadRun`, `PerformerSlot`, `WorkItem`,
+  `PerformerReport`
+- Per-session `~/.horizon/sessions/<sid>/squad.json`
+- Atomic save on state transitions
+
+Validation:
 
 ```bash
 cargo test -p horizon-core squad
 cargo test -p horizon-core session_store::tests::agent_squad
 ```
 
-2. Inspect a saved `squad.json` fixture from an isolated smoke session and
-   confirm it contains:
-   - `version: 1`
-   - one or more `runs`
-   - researcher and reviewer `AgentPanelLink` fields
-   - performer slot `work_item`, `scratch`, `panel_local_id`, and `report`
-     fields
-   - `primary_worktree` when review worktree creation has run
+Manual smoke:
 
-3. Exercise one transition through `SessionStore::update_agent_squad` and
-   confirm the changed run status survives a fresh `load_agent_squad` call.
+1. Create or update one `AgentSquad` run through `SessionStore`.
+2. Confirm `squad.json` exists under the active session directory.
+3. Exercise at least one transition through `SessionStore::update_agent_squad`.
+4. Reload the same session and confirm the transition persists.
 
-## UI Shell Slices
+Expected `squad.json` fields:
 
-Run these once the composer and dashboard are wired.
+- `version`
+- `runs`
+- `goal`, `status`, `created_at_millis`
+- researcher and reviewer `AgentPanelLink` objects
+- performer `work_item`, `assigned_kind`, `panel_local_id`, `scratch`, and
+  `report`
+- `primary_worktree`
+- `plan_text`
 
-1. Build and launch the debug app from the branch under test:
+Evidence:
+
+- Focused test output.
+- Redacted `cat "$HORIZON_HOME/sessions/<sid>/squad.json"`.
+- Before/after status values from the transition.
+
+## Slice 3: UI Shell, Composer, And Dashboard
+
+Scope:
+
+- `crates/horizon-ui/src/app/squad/{mod,render,state,composer,dashboard}.rs`
+- Toolbar `Squad` entry
+- Command palette `CommandId::OpenSquad`
+- Dashboard and composer backed by the persisted model
+- Start Run stub that creates persisted run state without spawning panels
+
+Validation:
 
 ```bash
-cargo build
-HORIZON_HOME="$HORIZON_SMOKE_HOME/.horizon" target/debug/horizon
+cargo test -p horizon-ui command_registry
+cargo test -p horizon-ui squad
+cargo test -p horizon-ui root_chrome
 ```
 
-2. Open the Squad surface from the toolbar. Verify:
-   - the dashboard opens without resizing or obscuring the terminal canvas
-   - `New run` opens the composer
-   - the composer keeps goal text, role selectors, performer count, isolation
-     mode, and auto-start toggles visible at 1280x800 and 1728x1117
+Manual smoke:
 
-3. Open the command palette and run the Squad command. Verify it focuses the
-   same Squad surface rather than creating duplicate overlays.
+1. Launch the debug app with `HORIZON_HOME` set to the isolated runtime.
+2. Open Squad from the toolbar.
+3. Verify the dashboard opens above the canvas and does not get hidden by the
+   empty-canvas card, HUD, minimap, or toolbar.
+4. Click `New run` and verify the composer shows:
+   - goal editor
+   - researcher selector
+   - reviewer selector
+   - performer kind selector
+   - performer count selector
+   - worktree isolation label
+   - advanced toggles
+5. Enter a goal, keep three performers, and click `Start Run`.
+6. Verify the dashboard shows a new run row and no performer panels are spawned
+   yet.
+7. Reopen Squad from the command palette by searching for `squad` and verify it
+   focuses the same Squad surface rather than creating duplicates.
+8. Restart Horizon with the same `HORIZON_HOME` and confirm the run row is
+   restored from `squad.json`.
 
-4. Resize the window smaller and larger. Capture screenshots at launch, after
-   opening the composer, and after returning to the dashboard.
+Resize checks:
 
-## Fanout And Review Slices
+- 1280x800: composer content remains readable and controls do not overlap.
+- 1728x1117: dashboard remains compact and does not stretch into unreadable
+  spacing.
+- Narrow window: Squad remains usable or scrollable; no text overlaps.
 
-Run these once Start Run, performer panels, and reviewer automation are wired.
+Evidence:
 
-1. Use a disposable Git repository as Horizon's active panel cwd.
-2. Open Squad composer, enter a goal, set 3 performers, keep worktree isolation,
-   and start the run.
-3. Verify on disk:
-   - `~/.horizon/squad-tmp/<run-id>/s1/`
-   - `~/.horizon/squad-tmp/<run-id>/s2/`
-   - `~/.horizon/squad-tmp/<run-id>/s3/`
-   - `~/.horizon/squad-tmp/<run-id>/_review/`
-4. In each performer panel, run `pwd` and confirm it matches that slot's
-   worktree path.
-5. Verify each performer panel receives the generated brief through stdin and
-   that focusing each slot returns to the correct panel.
-6. Mark each slot Done manually. Confirm the reviewer panel auto-spawns only
-   after all slots are Done.
-7. In the reviewer panel, run `pwd` and confirm it is `_review`.
-8. Confirm reviewer context includes the original goal, plan text, every slot
-   report, and every slot diff.
-9. Restart Horizon with the same isolated home. Verify the dashboard restores
-   the run, slot statuses, worktree paths, and reviewer link from
-   `~/.horizon/sessions/<sid>/squad.json`.
-10. Create a blocked slot and mark the remaining slots Done. Confirm Horizon
-    prompts for skip blocked or retry blocked instead of auto-spawning the
-    reviewer blindly.
+- Screenshot after launch.
+- Screenshot of empty dashboard.
+- Screenshot of composer at the narrowest tested size.
+- Screenshot of dashboard after the Start Run stub.
+- Redacted `squad.json` showing the stubbed run.
 
-## Regression Checks
+## Slice 4: Spawn And Fanout
 
-- Slot worktree creation must never write into the primary checkout.
-- Applying a slot diff to `_review` must not modify the slot worktree.
-- Restarting Horizon must not duplicate existing performer or reviewer panels.
-- Deleting a run must remove only that run's scratch worktrees.
-- Empty diffs must be accepted without changing `_review`.
-- Invalid diffs must produce a visible failure and leave `_review` unchanged.
+Scope:
 
-## Evidence To Attach To PR
+- Start Run creates N performer worktrees and one primary review worktree.
+- Performer panels spawn with `cwd` set to each slot worktree.
+- Per-slot brief prompts are written to each performer panel.
+- Scenario A run lane renders live slot chips.
+- Manual `Mark Done` and `Block` transitions are available.
 
-- The exact commit SHA tested.
-- Terminal output for the validation commands.
-- Screenshot of the dashboard.
-- Screenshot of the composer at the smallest tested window size.
-- Screenshot of the run lane with three performers.
-- `find ~/.horizon/squad-tmp/<run-id> -maxdepth 2 -type d | sort` output.
-- `cat ~/.horizon/sessions/<sid>/squad.json` with secrets redacted if any are
-  ever added.
+Manual smoke:
+
+1. Launch Horizon with the disposable repository as the active panel cwd.
+2. Open Squad composer from the toolbar.
+3. Enter a goal that can be split into three independent file edits.
+4. Set performers to three and keep worktree isolation.
+5. Start the run.
+6. Verify directories:
+   - `$HORIZON_HOME/squad-tmp/<run-id>/s1`
+   - `$HORIZON_HOME/squad-tmp/<run-id>/s2`
+   - `$HORIZON_HOME/squad-tmp/<run-id>/s3`
+   - `$HORIZON_HOME/squad-tmp/<run-id>/_review`
+7. In each performer panel, run `pwd`.
+8. Confirm each `pwd` matches the slot worktree path.
+9. Confirm each performer panel received the generated brief.
+10. Use `Focus` on each slot and verify focus returns to the correct panel.
+11. Mark one slot Done and one slot Blocked.
+12. Confirm the run lane and `squad.json` reflect both transitions.
+
+Expected:
+
+- Performer worktrees never share the same directory.
+- The primary checkout remains clean unless the user edits it directly.
+- Slot chips show queued, working, done, and blocked states correctly.
+- Manual status changes persist immediately.
+
+Evidence:
+
+- Screenshot of run lane with three performers.
+- `find "$HORIZON_HOME/squad-tmp/<run-id>" -maxdepth 2 -type d | sort`.
+- `pwd` output from each performer panel.
+- Redacted `squad.json` after status changes.
+
+## Slice 5: Reviewer Auto-Spawn And Slot Detail
+
+Scope:
+
+- Reviewer auto-spawns after all slots are Done.
+- Reviewer panel cwd is the primary review worktree.
+- Reviewer receives consolidated context: original goal, plan text, every slot
+  report, and every slot diff.
+- Blocked-slot prompt appears instead of blindly spawning reviewer.
+- Scenario C slot drill-down renders slot worktree, brief, report, diff, and
+  reviewer notes.
+
+Manual smoke, all-done path:
+
+1. Start a three-performer run from the disposable repository.
+2. Make a distinct edit in each performer worktree.
+3. Mark each performer slot Done with a short report and validation command.
+4. Confirm the reviewer panel auto-spawns only after the last Done transition.
+5. In the reviewer panel, run `pwd` and confirm it is `_review`.
+6. Confirm reviewer context includes:
+   - the original goal
+   - the researcher plan
+   - all performer reports
+   - all slot diffs
+7. Apply or inspect the slot diffs in `_review`.
+
+Manual smoke, blocked path:
+
+1. Start another run with at least two performers.
+2. Mark one slot Blocked and all remaining slots Done.
+3. Confirm Horizon surfaces a skip-blocked or retry-blocked decision.
+4. Confirm the reviewer is not auto-spawned until the user chooses a path.
+
+Slot detail smoke:
+
+1. Open a slot from the run lane.
+2. Verify the detail surface shows status, panel link, scratch path, work item,
+   performer report, diff, and reviewer notes.
+3. Use the slot detail `Focus` or equivalent action and verify it selects the
+   correct performer panel.
+
+Evidence:
+
+- Screenshot of reviewer waiting state.
+- Screenshot after reviewer auto-spawn.
+- Screenshot of blocked-slot decision prompt.
+- Screenshot of slot detail.
+- Redacted reviewer prompt/context.
+- `git -C "$HORIZON_HOME/squad-tmp/<run-id>/_review" diff --stat`.
+
+## Slice 6: Polish, Cleanup, And Regression Pass
+
+Scope:
+
+- Run deletion removes only that run's scratch worktrees.
+- Existing runs restore without duplicate performer or reviewer panels.
+- Optional done-hint detection remains advisory, not an automatic status change.
+- Final maintainability and pedantic clippy gates are green.
+
+Manual smoke:
+
+1. Create two Squad runs in the same Horizon session.
+2. Delete one run.
+3. Confirm only that run's scratch directory is removed.
+4. Confirm the other run's worktrees and `squad.json` entry remain.
+5. Restart Horizon with the same `HORIZON_HOME`.
+6. Confirm existing runs restore once and do not duplicate panels.
+7. If done-hint detection is present, print the sentinel text in a performer
+   panel and confirm Horizon shows a hint without changing the slot to Done
+   until the user confirms.
+8. Resize the app, detach and reattach a workspace if relevant, and reopen
+   Squad. Confirm overlays stay layered above the canvas and below modal
+   dialogs.
+
+Expected:
+
+- Deleting a run cannot remove the source checkout or another run's worktree.
+- Restart restore is idempotent.
+- Cleanup errors are visible and leave state recoverable.
+- The dashboard remains accurate after restart, delete, and restore.
+
+Evidence:
+
+- Before/after `find "$HORIZON_HOME/squad-tmp" -maxdepth 3 -type d | sort`.
+- Redacted `squad.json` before and after deletion.
+- Screenshot after restart restore.
+- Final validation gate output.
+
+## Full End-To-End Pass
+
+Run this after slice 5 and again after slice 6:
+
+1. Open Squad composer from toolbar and command palette.
+2. Set a goal and three performers.
+3. Start the run.
+4. Verify three performer worktrees and one primary worktree exist.
+5. Verify each performer panel starts in the correct cwd and receives a brief.
+6. Complete all performers with reports and validation results.
+7. Verify reviewer auto-spawns in `_review` with consolidated context.
+8. Restart Horizon and confirm the run, slot statuses, worktree paths, reports,
+   and reviewer link persist.
+9. Create a second run with one blocked slot and confirm the blocked decision
+   prompt appears.
+10. Delete one run and confirm only that run's scratch data is removed.
+
+## Regression Checklist
+
+- Slot worktree creation never writes into the source checkout.
+- Applying a slot diff to `_review` never mutates performer worktrees.
+- Empty diffs are accepted without changing `_review`.
+- Invalid diffs produce a visible failure and leave `_review` unchanged.
+- Restarting Horizon does not duplicate existing performer or reviewer panels.
+- Deleting a run removes only that run's scratch worktrees.
+- Dashboard state always matches `squad.json`.
+- Toolbar and command palette open the same Squad surface.
+- Squad overlays do not sit behind foreground canvas helpers.
+- Text and controls do not overlap at 1280x800 or 1728x1117.
+
+## PR Evidence Checklist
+
+- Exact commit SHA tested.
+- Terminal output for the shared validation gate.
+- Focused test output for touched slice modules.
+- Screenshots for dashboard, composer, run lane, slot detail, and reviewer
+  states as the corresponding slices land.
+- Directory listing for `$HORIZON_HOME/squad-tmp`.
+- Redacted `squad.json`.
+- Any known smoke limitations, including skipped macOS checks and why.

--- a/docs/testing/2026-05-25-agent-squad-smoke.md
+++ b/docs/testing/2026-05-25-agent-squad-smoke.md
@@ -212,7 +212,8 @@ Scope:
 
 Manual smoke:
 
-1. Launch Horizon with the disposable repository as the active panel cwd.
+1. Launch Horizon with the disposable repository as the active workspace or
+   panel cwd.
 2. Open Squad composer from the toolbar.
 3. Enter a goal that can be split into three independent file edits.
 4. Set performers to three and keep worktree isolation.
@@ -232,6 +233,8 @@ Manual smoke:
 Expected:
 
 - Performer worktrees never share the same directory.
+- Start Run fails visibly if there is no active source checkout for the current
+  workspace.
 - The primary checkout remains clean unless the user edits it directly.
 - Slot chips show queued, working, done, and blocked states correctly.
 - Manual status changes persist immediately.

--- a/docs/testing/2026-05-25-agent-squad-smoke.md
+++ b/docs/testing/2026-05-25-agent-squad-smoke.md
@@ -1,0 +1,113 @@
+# macOS Agent Squad Smoke Plan
+
+This retained smoke plan covers the Agent Squad epic from the first worktree
+primitive slice through the later UI fanout slices. Run it on macOS before
+marking an Agent Squad PR ready when the PR touches core worktree logic,
+composer/dashboard UI, panel spawning, slot status, reviewer automation, or
+`squad.json` persistence.
+
+## Environment
+
+- macOS with Xcode Command Line Tools installed.
+- Rust stable 1.88 or newer.
+- A disposable Git repository with at least one committed file.
+- A clean Horizon checkout on the branch under test.
+- An isolated runtime home:
+
+```bash
+export HORIZON_SMOKE_HOME="$(mktemp -d)"
+export HOME="$HORIZON_SMOKE_HOME"
+```
+
+## Current Slice: Worktree Primitives
+
+1. Validate formatting and focused tests:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p horizon-core worktree
+./scripts/check-maintainability.sh
+```
+
+2. In a disposable Git repository, exercise the core worktree path through a
+   small Rust caller or unit-test harness:
+   - create slot worktrees under
+     `~/.horizon/squad-tmp/<run-id>/s{1,2,3}/`
+   - edit one slot worktree
+   - collect its diff
+   - apply that diff into `~/.horizon/squad-tmp/<run-id>/_review/`
+   - remove a slot worktree and confirm the directory is gone
+
+3. Confirm the source repository still has its original worktree intact and
+   that no performer worktree was mutated by applying into `_review`.
+
+## UI Shell Slices
+
+Run these once the composer and dashboard are wired.
+
+1. Build and launch the debug app from the branch under test:
+
+```bash
+cargo build
+HORIZON_HOME="$HORIZON_SMOKE_HOME/.horizon" target/debug/horizon
+```
+
+2. Open the Squad surface from the toolbar. Verify:
+   - the dashboard opens without resizing or obscuring the terminal canvas
+   - `New run` opens the composer
+   - the composer keeps goal text, role selectors, performer count, isolation
+     mode, and auto-start toggles visible at 1280x800 and 1728x1117
+
+3. Open the command palette and run the Squad command. Verify it focuses the
+   same Squad surface rather than creating duplicate overlays.
+
+4. Resize the window smaller and larger. Capture screenshots at launch, after
+   opening the composer, and after returning to the dashboard.
+
+## Fanout And Review Slices
+
+Run these once Start Run, performer panels, and reviewer automation are wired.
+
+1. Use a disposable Git repository as Horizon's active panel cwd.
+2. Open Squad composer, enter a goal, set 3 performers, keep worktree isolation,
+   and start the run.
+3. Verify on disk:
+   - `~/.horizon/squad-tmp/<run-id>/s1/`
+   - `~/.horizon/squad-tmp/<run-id>/s2/`
+   - `~/.horizon/squad-tmp/<run-id>/s3/`
+   - `~/.horizon/squad-tmp/<run-id>/_review/`
+4. In each performer panel, run `pwd` and confirm it matches that slot's
+   worktree path.
+5. Verify each performer panel receives the generated brief through stdin and
+   that focusing each slot returns to the correct panel.
+6. Mark each slot Done manually. Confirm the reviewer panel auto-spawns only
+   after all slots are Done.
+7. In the reviewer panel, run `pwd` and confirm it is `_review`.
+8. Confirm reviewer context includes the original goal, plan text, every slot
+   report, and every slot diff.
+9. Restart Horizon with the same isolated home. Verify the dashboard restores
+   the run, slot statuses, worktree paths, and reviewer link from
+   `~/.horizon/sessions/<sid>/squad.json`.
+10. Create a blocked slot and mark the remaining slots Done. Confirm Horizon
+    prompts for skip blocked or retry blocked instead of auto-spawning the
+    reviewer blindly.
+
+## Regression Checks
+
+- Slot worktree creation must never write into the primary checkout.
+- Applying a slot diff to `_review` must not modify the slot worktree.
+- Restarting Horizon must not duplicate existing performer or reviewer panels.
+- Deleting a run must remove only that run's scratch worktrees.
+- Empty diffs must be accepted without changing `_review`.
+- Invalid diffs must produce a visible failure and leave `_review` unchanged.
+
+## Evidence To Attach To PR
+
+- The exact commit SHA tested.
+- Terminal output for the validation commands.
+- Screenshot of the dashboard.
+- Screenshot of the composer at the smallest tested window size.
+- Screenshot of the run lane with three performers.
+- `find ~/.horizon/squad-tmp/<run-id> -maxdepth 2 -type d | sort` output.
+- `cat ~/.horizon/sessions/<sid>/squad.json` with secrets redacted if any are
+  ever added.

--- a/docs/testing/2026-05-25-agent-squad-smoke.md
+++ b/docs/testing/2026-05-25-agent-squad-smoke.md
@@ -314,7 +314,7 @@ Scope:
 Manual smoke:
 
 1. Create two Squad runs in the same Horizon session.
-2. Delete one run.
+2. Delete one run from either the dashboard row action or the run lane.
 3. Confirm only that run's scratch directory is removed.
 4. Confirm the other run's worktrees and `squad.json` entry remain.
 5. Restart Horizon with the same `HORIZON_HOME`.
@@ -330,7 +330,7 @@ Expected:
 
 - Deleting a run cannot remove the source checkout or another run's worktree.
 - Restart restore is idempotent.
-- Cleanup errors are visible and leave state recoverable.
+- Cleanup errors are visible and leave the run entry recoverable.
 - The dashboard remains accurate after restart, delete, and restore.
 
 Evidence:


### PR DESCRIPTION
## Purpose

Implements the Agent Squad foundations from issue #203 in separate slices:

- git worktree isolation primitives for slot and review checkouts
- persisted per-session Squad run model
- Squad dashboard/composer UI shell
- performer fanout into isolated panels with a run lane for live status controls
- reviewer handoff with slot detail, report entry, diff context, and blocked-slot decision flow
- guarded run deletion and scratch worktree cleanup

## Behavior Impact

- Adds Agent Squad entry points from the toolbar and command palette.
- Persists Squad run state in the active session store.
- Start Run creates one primary review worktree and one worktree per performer slot from the active workspace or panel checkout.
- Performer panels open in their slot worktrees and receive the generated slot brief.
- Dashboard rows can open or delete runs.
- Run lanes can focus performer panels, open slot detail, mark slots done/blocked, choose `Review Done Slots`, or delete the run.
- Slot detail captures report fields, refreshes a worktree diff preview, and can persist Done/Blocked transitions.
- When every slot is done, Horizon applies slot diffs into the review worktree, opens a reviewer panel there, and writes the consolidated review prompt.
- Run deletion removes only paths under that run's `squad-tmp/<run-id>` root and keeps the run entry if cleanup fails.
- Start and cleanup failures are shown inline in the Squad overlay.

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `cargo test -p horizon-core squad`
- `cargo test -p horizon-ui squad`
- `cargo test -p horizon-ui`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `git diff --check`

## Smoke Plan

- macOS/OSX smoke coverage for every issue slice is documented in `docs/testing/2026-05-25-agent-squad-smoke.md`.
- Live macOS smoke has not been run from this Linux workspace.
