### PR TITLE
Add Pi agent panel integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ git2 = { version = "0.21", default-features = false }
 regex = "1.12.3"
 arboard = "3.6.1"
 tokio = { version = "1.52.3", features = ["rt", "macros"] }
-surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.0.0-beta.16", package = "surge-core" }
+surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.0.0-beta.41", package = "surge-core" }
 
 [profile.release]
 lto = true

--- a/crates/horizon-core/src/agents.rs
+++ b/crates/horizon-core/src/agents.rs
@@ -104,12 +104,27 @@ const KILO_CODE: AgentDefinition = AgentDefinition {
     kitty_keyboard: true,
 };
 
-pub const BUILTIN_AGENT_KINDS: [PanelKind; 5] = [
+const PI: AgentDefinition = AgentDefinition {
+    id: "pi",
+    display_name: "Pi",
+    icon_label: "PI",
+    accent_rgb: [250, 179, 135],
+    default_command: "pi",
+    resume_mode: AgentResumeMode::ExactFlag {
+        flag: "--session",
+        fresh_session_flag: None,
+    },
+    integration: AgentIntegrationKind::None,
+    kitty_keyboard: true,
+};
+
+pub const BUILTIN_AGENT_KINDS: [PanelKind; 6] = [
     PanelKind::Codex,
     PanelKind::Claude,
     PanelKind::OpenCode,
     PanelKind::Gemini,
     PanelKind::KiloCode,
+    PanelKind::Pi,
 ];
 
 #[must_use]
@@ -125,6 +140,7 @@ pub const fn agent_definition(kind: PanelKind) -> Option<AgentDefinition> {
         PanelKind::OpenCode => Some(OPENCODE),
         PanelKind::Gemini => Some(GEMINI),
         PanelKind::KiloCode => Some(KILO_CODE),
+        PanelKind::Pi => Some(PI),
         PanelKind::Shell
         | PanelKind::Ssh
         | PanelKind::Command
@@ -156,6 +172,11 @@ mod tests {
                 .supports_session_binding()
         );
         assert!(
+            agent_definition(PanelKind::Pi)
+                .expect("pi agent")
+                .supports_session_binding()
+        );
+        assert!(
             !agent_definition(PanelKind::Gemini)
                 .expect("gemini agent")
                 .supports_session_binding()
@@ -173,5 +194,23 @@ mod tests {
             agent_definition(PanelKind::KiloCode).expect("kilo agent").resume_mode,
             AgentResumeMode::ContinueFlag { flag: "--continue" }
         );
+    }
+
+    #[test]
+    fn pi_definition_uses_exact_session_flag() {
+        let definition = agent_definition(PanelKind::Pi).expect("pi agent");
+
+        assert_eq!(definition.id, "pi");
+        assert_eq!(definition.display_name, "Pi");
+        assert_eq!(definition.icon_label, "PI");
+        assert_eq!(definition.default_command, "pi");
+        assert_eq!(
+            definition.resume_mode,
+            AgentResumeMode::ExactFlag {
+                flag: "--session",
+                fresh_session_flag: None,
+            }
+        );
+        assert!(definition.kitty_keyboard);
     }
 }

--- a/crates/horizon-core/src/config.rs
+++ b/crates/horizon-core/src/config.rs
@@ -176,6 +176,18 @@ pub(crate) fn default_kilo_preset() -> PresetConfig {
     }
 }
 
+pub(crate) fn default_pi_preset() -> PresetConfig {
+    PresetConfig {
+        name: "Pi".to_string(),
+        alias: Some("pi".to_string()),
+        kind: PanelKind::Pi,
+        command: None,
+        args: Vec::new(),
+        resume: PanelResume::Fresh,
+        ssh_connection: None,
+    }
+}
+
 fn insert_missing_agent_presets(presets: &mut Vec<PresetConfig>, defaults: impl IntoIterator<Item = PresetConfig>) {
     for default_preset in defaults {
         let expected_name = default_preset.name.to_ascii_lowercase();
@@ -207,6 +219,22 @@ pub(crate) fn insert_missing_gemini_presets(presets: &mut Vec<PresetConfig>) {
 
 pub(crate) fn insert_missing_kilo_presets(presets: &mut Vec<PresetConfig>) {
     insert_missing_agent_presets(presets, default_kilo_presets());
+}
+
+pub(crate) fn insert_missing_pi_presets(presets: &mut Vec<PresetConfig>) {
+    let default_preset = default_pi_preset();
+    let exists = presets.iter().any(|preset| {
+        preset.name.eq_ignore_ascii_case(&default_preset.name)
+            || preset
+                .alias
+                .as_deref()
+                .is_some_and(|alias| alias.eq_ignore_ascii_case("pi"))
+            || preset.kind == PanelKind::Pi
+    });
+
+    if !exists {
+        presets.push(default_preset);
+    }
 }
 
 /// Single Codex preset. Codex 0.128's default invocation is auto mode
@@ -258,6 +286,7 @@ fn default_presets() -> Vec<PresetConfig> {
     presets.extend(default_opencode_presets());
     presets.extend(default_gemini_presets());
     presets.extend(default_kilo_presets());
+    insert_missing_pi_presets(&mut presets);
     presets.extend([
         PresetConfig {
             name: "Git Changes".to_string(),
@@ -754,6 +783,23 @@ mod tests {
     fn features_default_enables_attention_feed() {
         assert!(FeaturesConfig::default().attention_feed);
         assert!(Config::default().features.attention_feed);
+    }
+
+    #[test]
+    fn default_config_includes_one_pi_preset() {
+        let config = Config::default();
+        let pi_presets: Vec<_> = config
+            .presets
+            .iter()
+            .filter(|preset| preset.kind == PanelKind::Pi)
+            .collect();
+
+        assert_eq!(pi_presets.len(), 1);
+        assert_eq!(pi_presets[0].name, "Pi");
+        assert_eq!(pi_presets[0].alias.as_deref(), Some("pi"));
+        assert_eq!(pi_presets[0].command, None);
+        assert!(pi_presets[0].args.is_empty());
+        assert_eq!(pi_presets[0].resume, super::PanelResume::Fresh);
     }
 
     #[test]

--- a/crates/horizon-core/src/config_migration.rs
+++ b/crates/horizon-core/src/config_migration.rs
@@ -3,12 +3,13 @@ use std::path::Path;
 use crate::config::{
     Config, PresetConfig, default_claude_preset, default_codex_preset, default_kilo_preset, default_opencode_preset,
     insert_missing_gemini_presets, insert_missing_kilo_presets, insert_missing_opencode_presets,
+    insert_missing_pi_presets,
 };
 use crate::error::{Error, Result};
 use crate::panel::{PanelKind, PanelResume};
 use crate::shortcuts::ShortcutBinding;
 
-pub const CURRENT_CONFIG_VERSION: u32 = 7;
+pub const CURRENT_CONFIG_VERSION: u32 = 8;
 
 /// Run any pending migrations on `config` and write back to disk.
 ///
@@ -31,6 +32,7 @@ pub fn migrate_if_needed(config: &mut Config, config_path: &Path) -> Result<bool
             4 => migrate_v4_to_v5(config),
             5 => migrate_v5_to_v6(config),
             6 => migrate_v6_to_v7(config),
+            7 => migrate_v7_to_v8(config),
             _ => {
                 return Err(Error::Config(format!(
                     "unknown config version {version}, expected 1..={CURRENT_CONFIG_VERSION}"
@@ -122,6 +124,12 @@ fn migrate_v6_to_v7(config: &mut Config) {
         matches_default_opencode_pair,
     );
     collapse_agent_presets(config, "KiloCode", default_kilo_preset, matches_default_kilo_pair);
+}
+
+/// v7 -> v8: add the default `Pi` coding-agent preset when no Pi preset
+/// already exists by name, alias, or kind.
+fn migrate_v7_to_v8(config: &mut Config) {
+    insert_missing_pi_presets(&mut config.presets);
 }
 
 /// Remove every preset matching `should_remove`, then insert `replacement()`
@@ -361,7 +369,7 @@ presets:
         assert_eq!(config.version, CURRENT_CONFIG_VERSION);
 
         let reloaded = std::fs::read_to_string(&path).expect("read back");
-        assert!(reloaded.contains("version: 7"));
+        assert!(reloaded.contains("version: 8"));
         assert!(reloaded.contains("Ctrl+Shift+K"));
         assert!(reloaded.contains("zoom_reset: Ctrl+0"));
         assert!(reloaded.contains("appearance:"));
@@ -370,7 +378,7 @@ presets:
     #[test]
     fn serialized_config_includes_version() {
         let yaml = Config::default().to_yaml().expect("should serialize");
-        assert!(yaml.contains("version: 7"));
+        assert!(yaml.contains("version: 8"));
     }
 
     #[test]
@@ -784,6 +792,67 @@ presets:
             .find(|preset| preset.name == "Codex")
             .expect("codex preset");
         assert_eq!(codex.args.last().map(String::as_str), Some("gpt-5"));
+    }
+
+    #[test]
+    fn migration_v7_to_v8_adds_missing_pi_preset() {
+        let mut config: Config = serde_yaml::from_str(
+            "\
+version: 7
+presets:
+  - name: Shell
+    alias: sh
+    kind: shell
+",
+        )
+        .expect("should deserialize");
+
+        migrate_v7_to_v8(&mut config);
+
+        let pi = config
+            .presets
+            .iter()
+            .find(|preset| preset.kind == PanelKind::Pi)
+            .expect("Pi preset");
+        assert_eq!(pi.name, "Pi");
+        assert_eq!(pi.alias.as_deref(), Some("pi"));
+        assert_eq!(pi.command, None);
+        assert!(pi.args.is_empty());
+        assert_eq!(pi.resume, PanelResume::Fresh);
+    }
+
+    #[test]
+    fn migration_v7_to_v8_does_not_duplicate_existing_pi_preset() {
+        for existing in [
+            "\
+version: 7
+presets:
+  - name: Pi
+    alias: custom-pi
+    kind: shell
+",
+            "\
+version: 7
+presets:
+  - name: Custom Pi
+    alias: pi
+    kind: shell
+",
+            "\
+version: 7
+presets:
+  - name: Custom Agent
+    alias: custom
+    kind: pi
+    resume: last
+",
+        ] {
+            let mut config: Config = serde_yaml::from_str(existing).expect("should deserialize");
+
+            migrate_v7_to_v8(&mut config);
+
+            assert_eq!(config.presets.len(), 1);
+        }
     }
 
     #[test]

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -42,6 +42,7 @@ pub enum PanelKind {
     OpenCode,
     Gemini,
     KiloCode,
+    Pi,
     Command,
     Editor,
     GitChanges,
@@ -72,7 +73,9 @@ impl PanelKind {
             Self::Editor => "Editor",
             Self::GitChanges => "Git Changes",
             Self::Usage => "Usage",
-            Self::Codex | Self::Claude | Self::OpenCode | Self::Gemini | Self::KiloCode => unreachable!(),
+            Self::Codex | Self::Claude | Self::OpenCode | Self::Gemini | Self::KiloCode | Self::Pi => {
+                unreachable!()
+            }
         }
     }
 }
@@ -665,12 +668,19 @@ mod tests {
 
     #[test]
     fn agent_panels_keep_original_launch_cwd() {
-        let mut panel = test_panel("Codex", "", false);
-        panel.kind = PanelKind::Codex;
+        let mut panel = test_panel("Pi", "", false);
+        panel.kind = PanelKind::Pi;
         panel.launch_cwd = Some(PathBuf::from("/workspace"));
 
         assert!(!panel.update_tracked_cwd(Some(PathBuf::from("/workspace/subdir"))));
         assert_eq!(panel.launch_cwd, Some(PathBuf::from("/workspace")));
+    }
+
+    #[test]
+    fn pi_kind_is_agent_with_display_name() {
+        assert!(PanelKind::Pi.is_agent());
+        assert!(PanelKind::Pi.supports_session_binding());
+        assert_eq!(PanelKind::Pi.display_name(), "Pi");
     }
 
     #[test]
@@ -823,6 +833,34 @@ mod tests {
     }
 
     #[test]
+    fn pi_fresh_without_binding_starts_without_session_flag() {
+        let (_program, args) =
+            resolve_launch_command(None, Vec::new(), None, PanelKind::Pi, &PanelResume::Fresh, None, false);
+
+        assert_eq!(args, vec!["-ic".to_string(), "pi".to_string()]);
+    }
+
+    #[test]
+    fn pi_session_resume_uses_session_flag_before_custom_args() {
+        let binding = AgentSessionBinding::new(PanelKind::Pi, "session-42".to_string(), None, None, None);
+        let (_program, args) = resolve_launch_command(
+            None,
+            vec!["--model".to_string(), "fast".to_string()],
+            None,
+            PanelKind::Pi,
+            &PanelResume::Session {
+                session_id: "session-42".to_string(),
+            },
+            Some(&binding),
+            true,
+        );
+
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "-ic");
+        assert_eq!(args[1], "pi --session session-42 --model fast");
+    }
+
+    #[test]
     fn gemini_panels_start_without_implicit_resume_flags() {
         let (_program, args) = resolve_launch_command(
             None,
@@ -910,6 +948,7 @@ mod tests {
             scrollback_limit_for_kind(PanelKind::KiloCode),
             AGENT_PANEL_SCROLLBACK_LIMIT
         );
+        assert_eq!(scrollback_limit_for_kind(PanelKind::Pi), AGENT_PANEL_SCROLLBACK_LIMIT);
     }
 
     #[test]
@@ -919,6 +958,7 @@ mod tests {
         assert!(kitty_keyboard_for_kind(PanelKind::OpenCode));
         assert!(!kitty_keyboard_for_kind(PanelKind::Gemini));
         assert!(kitty_keyboard_for_kind(PanelKind::KiloCode));
+        assert!(kitty_keyboard_for_kind(PanelKind::Pi));
         assert!(kitty_keyboard_for_kind(PanelKind::Shell));
         assert!(kitty_keyboard_for_kind(PanelKind::Ssh));
     }

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -616,7 +616,12 @@ pub(super) fn resolve_launch_command(
                 (default_shell(), args)
             }
         }
-        PanelKind::Codex | PanelKind::Claude | PanelKind::OpenCode | PanelKind::Gemini | PanelKind::KiloCode => {
+        PanelKind::Codex
+        | PanelKind::Claude
+        | PanelKind::OpenCode
+        | PanelKind::Gemini
+        | PanelKind::KiloCode
+        | PanelKind::Pi => {
             resolve_agent_launch_command(command, args, kind, resume, session_binding, should_resume_binding)
         }
     }
@@ -826,9 +831,12 @@ pub(super) fn scrollback_limit_for_kind(kind: PanelKind) -> usize {
         match kind {
             PanelKind::Shell | PanelKind::Ssh | PanelKind::Command => DEFAULT_PANEL_SCROLLBACK_LIMIT,
             PanelKind::Editor | PanelKind::GitChanges | PanelKind::Usage => 0,
-            PanelKind::Codex | PanelKind::Claude | PanelKind::OpenCode | PanelKind::Gemini | PanelKind::KiloCode => {
-                unreachable!()
-            }
+            PanelKind::Codex
+            | PanelKind::Claude
+            | PanelKind::OpenCode
+            | PanelKind::Gemini
+            | PanelKind::KiloCode
+            | PanelKind::Pi => unreachable!(),
         }
     }
 }

--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -21,9 +21,13 @@ const RUNTIME_STATE_VERSION: u32 = 2;
 const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_COLS: u16 = 80;
 const MAX_CLAUDE_SESSION_FILES: usize = 64;
+const MAX_PI_SESSION_FILES: usize = 128;
 const CLAUDE_SESSION_HEAD_LINE_LIMIT: usize = 48;
 const CLAUDE_SESSION_TAIL_LINE_LIMIT: usize = 24;
 const CLAUDE_SESSION_TAIL_BYTES: u64 = 32 * 1024;
+const PI_SESSION_HEAD_LINE_LIMIT: usize = 64;
+const PI_SESSION_TAIL_LINE_LIMIT: usize = 64;
+const PI_SESSION_TAIL_BYTES: u64 = 64 * 1024;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
@@ -722,6 +726,48 @@ workspaces:
 
         assert_eq!(state.workspaces.len(), 2);
         assert!(state.workspaces.iter().all(|workspace| workspace.layout.is_none()));
+    }
+
+    #[test]
+    fn pi_panel_state_round_trips_through_runtime_yaml() {
+        let state = RuntimeState {
+            workspaces: vec![WorkspaceState {
+                local_id: "workspace".to_string(),
+                name: "alpha".to_string(),
+                panels: vec![PanelState {
+                    local_id: "panel".to_string(),
+                    name: "Pi".to_string(),
+                    kind: PanelKind::Pi,
+                    resume: PanelResume::Session {
+                        session_id: "pi-session-123".to_string(),
+                    },
+                    session_binding: Some(AgentSessionBinding::new(
+                        PanelKind::Pi,
+                        "pi-session-123".to_string(),
+                        Some("/repo".to_string()),
+                        Some("Fix the build".to_string()),
+                        Some(42),
+                    )),
+                    ..PanelState::default()
+                }],
+                ..WorkspaceState::default()
+            }],
+            ..RuntimeState::default()
+        };
+
+        let yaml = state.to_yaml().expect("serialize runtime state");
+        assert!(yaml.contains("kind: pi"));
+
+        let reloaded: RuntimeState = serde_yaml::from_str(&yaml).expect("deserialize runtime state");
+        let panel = &reloaded.workspaces[0].panels[0];
+        assert_eq!(panel.kind, PanelKind::Pi);
+        assert_eq!(
+            panel
+                .session_binding
+                .as_ref()
+                .map(|binding| binding.session_id.as_str()),
+            Some("pi-session-123")
+        );
     }
 
     #[test]

--- a/crates/horizon-core/src/runtime_state/agent_sessions.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions.rs
@@ -476,7 +476,7 @@ impl PiSessionSummary {
             kind: PanelKind::Pi,
             session_id,
             cwd: self.cwd,
-            label: self.last_user_message.or(Some("Pi session".to_string())),
+            label: self.last_user_message.or_else(|| Some("Pi session".to_string())),
             updated_at: fallback_updated_at,
         })
     }

--- a/crates/horizon-core/src/runtime_state/agent_sessions.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions.rs
@@ -18,7 +18,7 @@ pub struct AgentSessionCatalog {
 }
 
 impl AgentSessionCatalog {
-    /// Load recent Claude, Codex, and `OpenCode` sessions from their local stores.
+    /// Load recent Claude, Codex, `OpenCode`, and Pi sessions from their local stores.
     ///
     /// # Errors
     ///
@@ -27,6 +27,7 @@ impl AgentSessionCatalog {
         let mut sessions = load_claude_sessions()?;
         sessions.extend(load_codex_sessions()?);
         sessions.extend(load_opencode_sessions()?);
+        sessions.extend(load_pi_sessions()?);
         sessions.sort_by_key(|session| Reverse(session.updated_at));
         Ok(Self { sessions })
     }
@@ -355,6 +356,246 @@ fn load_opencode_sessions_from_path(sqlite_path: &Path) -> Result<Vec<AgentSessi
     Ok(sessions)
 }
 
+fn load_pi_sessions() -> Result<Vec<AgentSessionRecord>> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Ok(Vec::new());
+    };
+    let sessions_dir = home.join(".pi/agent/sessions");
+    if !sessions_dir.exists() {
+        return Ok(Vec::new());
+    }
+    load_pi_sessions_from_dir(&sessions_dir)
+}
+
+fn load_pi_sessions_from_dir(sessions_dir: &Path) -> Result<Vec<AgentSessionRecord>> {
+    let mut session_paths = Vec::new();
+    collect_pi_session_files(sessions_dir, &mut session_paths)?;
+    session_paths.sort_by_key(|(_, updated_at)| Reverse(*updated_at));
+    session_paths.truncate(super::MAX_PI_SESSION_FILES);
+
+    let mut sessions = Vec::new();
+    for (path, updated_at) in session_paths {
+        match load_pi_session_summary(&path, updated_at) {
+            Ok(Some(session)) => sessions.push(session),
+            Ok(None) => {}
+            Err(error) => tracing::warn!("failed loading Pi session {}: {error}", path.display()),
+        }
+    }
+    sessions.sort_by_key(|session| Reverse(session.updated_at));
+    Ok(sessions)
+}
+
+fn collect_pi_session_files(dir: &Path, files: &mut Vec<(PathBuf, i64)>) -> Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::debug!("skipping unreadable Pi session dir {}: {error}", dir.display());
+            return Ok(());
+        }
+    };
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_pi_session_files(&path, files)?;
+        } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("jsonl")
+            && let Ok(updated_at) = file_updated_at_millis(&path)
+        {
+            files.push((path, updated_at));
+        }
+    }
+    Ok(())
+}
+
+fn load_pi_session_summary(path: &Path, updated_at: i64) -> Result<Option<AgentSessionRecord>> {
+    let fallback_session_id = path
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .map(str::to_owned)
+        .ok_or_else(|| Error::State(format!("invalid Pi session path {}", path.display())))?;
+    let mut file = std::fs::File::open(path)?;
+    let mut summary = PiSessionSummary::default();
+    scan_pi_session_reader(
+        BufReader::new(file.try_clone()?),
+        Some(super::PI_SESSION_HEAD_LINE_LIMIT),
+        &mut summary,
+    );
+    scan_pi_session_tail(&mut file, &mut summary)?;
+    Ok(summary.into_record(&fallback_session_id, updated_at))
+}
+
+#[derive(Default)]
+struct PiSessionSummary {
+    session_id: Option<String>,
+    cwd: Option<String>,
+    last_user_message: Option<String>,
+}
+
+impl PiSessionSummary {
+    fn apply_line(&mut self, line: &str) {
+        if line.trim().is_empty() {
+            return;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            return;
+        };
+
+        if self.session_id.is_none()
+            && let Some(found_session_id) = extract_pi_session_id(&value)
+            && !found_session_id.is_empty()
+        {
+            self.session_id = Some(found_session_id.to_string());
+        }
+
+        if self.cwd.is_none()
+            && let Some(found_cwd) = extract_pi_cwd(&value)
+        {
+            self.cwd = normalize_cwd(Some(found_cwd));
+        }
+
+        if let Some(user_message) = extract_pi_user_message(&value) {
+            self.last_user_message = Some(truncate_session_label(&user_message));
+        }
+    }
+
+    fn into_record(self, fallback_session_id: &str, fallback_updated_at: i64) -> Option<AgentSessionRecord> {
+        let session_id = self
+            .session_id
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| fallback_session_id.to_string());
+
+        if session_id.is_empty() {
+            return None;
+        }
+
+        Some(AgentSessionRecord {
+            kind: PanelKind::Pi,
+            session_id,
+            cwd: self.cwd,
+            label: self.last_user_message.or(Some("Pi session".to_string())),
+            updated_at: fallback_updated_at,
+        })
+    }
+}
+
+fn scan_pi_session_reader<R: BufRead>(mut reader: R, limit: Option<usize>, summary: &mut PiSessionSummary) {
+    let mut buffer = Vec::new();
+    let mut index = 0usize;
+    loop {
+        if limit.is_some_and(|line_limit| index >= line_limit) {
+            break;
+        }
+        buffer.clear();
+        match reader.read_until(b'\n', &mut buffer) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {
+                let line = String::from_utf8_lossy(&buffer);
+                summary.apply_line(line.trim_end_matches(['\r', '\n']));
+                index += 1;
+            }
+        }
+    }
+}
+
+fn scan_pi_session_tail(file: &mut std::fs::File, summary: &mut PiSessionSummary) -> Result<()> {
+    let file_len = file.metadata()?.len();
+    let start = file_len.saturating_sub(super::PI_SESSION_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start))?;
+
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+    let text = String::from_utf8_lossy(&buffer);
+    let mut lines: Vec<&str> = text.lines().collect();
+    if start > 0 && !lines.is_empty() {
+        lines.remove(0);
+    }
+    let tail_start = lines.len().saturating_sub(super::PI_SESSION_TAIL_LINE_LIMIT);
+    for line in &lines[tail_start..] {
+        summary.apply_line(line);
+    }
+    Ok(())
+}
+
+fn extract_pi_session_id(value: &Value) -> Option<&str> {
+    string_field(value, &["session_id", "sessionId", "sessionID"])
+        .or_else(|| nested_string_field(value, "session", &["id", "session_id", "sessionId"]))
+        .or_else(|| {
+            let record_kind = string_field(value, &["type", "event", "kind"])?;
+            let normalized_kind = record_kind.to_ascii_lowercase();
+            let is_session_record = normalized_kind.contains("session")
+                || matches!(normalized_kind.as_str(), "agent_start" | "conversation_start");
+            is_session_record.then(|| string_field(value, &["id"])).flatten()
+        })
+}
+
+fn extract_pi_cwd(value: &Value) -> Option<&str> {
+    string_field(value, &["cwd", "working_directory", "workingDirectory"])
+        .or_else(|| nested_string_field(value, "session", &["cwd", "working_directory", "workingDirectory"]))
+        .or_else(|| nested_string_field(value, "metadata", &["cwd", "working_directory", "workingDirectory"]))
+        .or_else(|| nested_string_field(value, "context", &["cwd", "working_directory", "workingDirectory"]))
+}
+
+fn extract_pi_user_message(value: &Value) -> Option<String> {
+    let root_role = string_field(value, &["role"]);
+    let message_role = nested_string_field(value, "message", &["role"]);
+    let record_kind = string_field(value, &["type", "event", "kind"]);
+    let is_user = root_role
+        .or(message_role)
+        .is_some_and(|role| role.eq_ignore_ascii_case("user"))
+        || record_kind.is_some_and(|kind| matches!(kind.to_ascii_lowercase().as_str(), "user" | "user_message"));
+
+    if !is_user {
+        return None;
+    }
+
+    for key in ["text", "content", "prompt", "message"] {
+        if let Some(text) = value.get(key).and_then(text_from_json_value) {
+            return Some(text);
+        }
+    }
+    None
+}
+
+fn string_field<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_str))
+}
+
+fn nested_string_field<'a>(value: &'a Value, object_key: &str, keys: &[&str]) -> Option<&'a str> {
+    value.get(object_key).and_then(|nested| string_field(nested, keys))
+}
+
+fn text_from_json_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => non_empty_text(text),
+        Value::Array(values) => {
+            let parts: Vec<_> = values.iter().filter_map(text_from_json_value).collect();
+            (!parts.is_empty()).then(|| parts.join(" "))
+        }
+        Value::Object(_) => {
+            for key in ["text", "content", "message", "value", "input"] {
+                if let Some(text) = value.get(key).and_then(text_from_json_value) {
+                    return Some(text);
+                }
+            }
+            value.get("parts").and_then(text_from_json_value)
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => None,
+    }
+}
+
+fn non_empty_text(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
@@ -364,8 +605,9 @@ mod tests {
 
     use super::super::{PanelResume, PanelState, RuntimeState, WorkspaceState};
     use super::{
-        AgentSessionCatalog, AgentSessionRecord, ClaudeSessionSummary, PanelKind, load_claude_project_session_summary,
-        load_opencode_sessions_from_path, scan_claude_session_reader,
+        AgentSessionCatalog, AgentSessionRecord, ClaudeSessionSummary, PanelKind, PiSessionSummary,
+        load_claude_project_session_summary, load_opencode_sessions_from_path, load_pi_sessions_from_dir,
+        scan_claude_session_reader, scan_pi_session_reader,
     };
 
     fn parse_claude_project_session<R: std::io::BufRead>(
@@ -375,6 +617,16 @@ mod tests {
     ) -> Option<AgentSessionRecord> {
         let mut summary = ClaudeSessionSummary::default();
         scan_claude_session_reader(reader, None, &mut summary);
+        summary.into_record(fallback_session_id, fallback_updated_at)
+    }
+
+    fn parse_pi_session<R: std::io::BufRead>(
+        reader: R,
+        fallback_session_id: &str,
+        fallback_updated_at: i64,
+    ) -> Option<AgentSessionRecord> {
+        let mut summary = PiSessionSummary::default();
+        scan_pi_session_reader(reader, None, &mut summary);
         summary.into_record(fallback_session_id, fallback_updated_at)
     }
 
@@ -525,5 +777,69 @@ INSERT INTO session (id, title, directory, parent_id, time_updated, time_archive
         assert_eq!(sessions[0].cwd.as_deref(), Some("/other"));
         assert_eq!(sessions[1].session_id, "session-root");
         assert_eq!(sessions[1].cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn parse_pi_session_uses_header_metadata_and_latest_user_message() {
+        let jsonl = concat!(
+            "{\"type\":\"session\",\"id\":\"pi-session-123\",\"cwd\":\"/repo\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"first prompt\"}]}}\n",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"working\"}}\n",
+            "{\"type\":\"user_message\",\"text\":\"latest prompt\"}\n",
+        );
+
+        let session = parse_pi_session(Cursor::new(jsonl), "fallback-id", 42).expect("session");
+
+        assert_eq!(session.kind, PanelKind::Pi);
+        assert_eq!(session.session_id, "pi-session-123");
+        assert_eq!(session.cwd.as_deref(), Some("/repo"));
+        assert_eq!(session.label.as_deref(), Some("latest prompt"));
+        assert_eq!(session.updated_at, 42);
+    }
+
+    #[test]
+    fn parse_pi_session_falls_back_to_filename_id_and_default_label() {
+        let jsonl = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}\n";
+
+        let session = parse_pi_session(Cursor::new(jsonl), "fallback-id", 7).expect("session");
+
+        assert_eq!(session.kind, PanelKind::Pi);
+        assert_eq!(session.session_id, "fallback-id");
+        assert_eq!(session.cwd, None);
+        assert_eq!(session.label.as_deref(), Some("Pi session"));
+        assert_eq!(session.updated_at, 7);
+    }
+
+    #[test]
+    fn load_pi_sessions_recurses_and_filters_by_cwd() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let nested = temp_dir.path().join("project/subdir");
+        std::fs::create_dir_all(&nested).expect("create nested session dir");
+        std::fs::write(
+            nested.join("pi-session-123.jsonl"),
+            concat!(
+                "{\"session_id\":\"pi-session-123\",\"metadata\":{\"cwd\":\"/repo\"}}\n",
+                "{\"role\":\"user\",\"content\":\"Fix the build\"}\n",
+            ),
+        )
+        .expect("write pi session");
+        std::fs::write(
+            temp_dir.path().join("pi-session-other.jsonl"),
+            concat!(
+                "{\"session_id\":\"pi-session-other\",\"cwd\":\"/other\"}\n",
+                "{\"role\":\"user\",\"content\":\"Other repo\"}\n",
+            ),
+        )
+        .expect("write other pi session");
+
+        let sessions = load_pi_sessions_from_dir(temp_dir.path()).expect("pi sessions");
+        let catalog = AgentSessionCatalog { sessions };
+        let repo_sessions = catalog.recent_for(PanelKind::Pi, Some("/repo"));
+
+        assert_eq!(repo_sessions.len(), 1);
+        assert_eq!(repo_sessions[0].session_id, "pi-session-123");
+        assert_eq!(repo_sessions[0].label.as_deref(), Some("Fix the build"));
+        assert!(catalog.recent_for(PanelKind::Pi, Some("/missing")).is_empty());
+        assert!(catalog.recent_for(PanelKind::Claude, Some("/repo")).is_empty());
     }
 }

--- a/crates/horizon-ui/src/app/panel_chrome.rs
+++ b/crates/horizon-ui/src/app/panel_chrome.rs
@@ -85,7 +85,12 @@ pub(super) fn panel_kind_icon(kind: PanelKind, workspace_color: Color32, focused
         PanelKind::Editor => ("MD", panel_kind_label_color(theme::PALETTE_GREEN(), focused)),
         PanelKind::GitChanges => ("GC", panel_kind_label_color(theme::PALETTE_YELLOW(), focused)),
         PanelKind::Usage => ("US", panel_kind_label_color(theme::PALETTE_YELLOW(), focused)),
-        PanelKind::Codex | PanelKind::Claude | PanelKind::OpenCode | PanelKind::Gemini | PanelKind::KiloCode => {
+        PanelKind::Codex
+        | PanelKind::Claude
+        | PanelKind::OpenCode
+        | PanelKind::Gemini
+        | PanelKind::KiloCode
+        | PanelKind::Pi => {
             unreachable!()
         }
     }

--- a/crates/horizon-ui/src/app/session.rs
+++ b/crates/horizon-ui/src/app/session.rs
@@ -545,6 +545,30 @@ mod tests {
     }
 
     #[test]
+    fn runtime_state_needs_bootstrap_for_unbound_last_pi_panel() {
+        let state = RuntimeState {
+            workspaces: vec![WorkspaceState {
+                local_id: "workspace".to_string(),
+                name: "alpha".to_string(),
+                cwd: None,
+                position: None,
+                template: None,
+                layout: None,
+                panels: vec![PanelState {
+                    local_id: "panel".to_string(),
+                    name: "Pi".to_string(),
+                    kind: PanelKind::Pi,
+                    resume: PanelResume::Last,
+                    ..PanelState::default()
+                }],
+            }],
+            ..RuntimeState::default()
+        };
+
+        assert!(HorizonApp::runtime_state_needs_session_bootstrap(&state));
+    }
+
+    #[test]
     fn runtime_state_skips_bootstrap_for_fresh_or_bound_panels() {
         let state = RuntimeState {
             workspaces: vec![WorkspaceState {

--- a/crates/horizon-ui/src/app/settings/presets.rs
+++ b/crates/horizon-ui/src/app/settings/presets.rs
@@ -3,7 +3,7 @@ use horizon_core::{Config, PanelKind, PanelResume, PresetConfig};
 
 use crate::theme;
 
-const ALL_KINDS: [PanelKind; 11] = [
+const ALL_KINDS: [PanelKind; 12] = [
     PanelKind::Shell,
     PanelKind::Ssh,
     PanelKind::Codex,
@@ -11,6 +11,7 @@ const ALL_KINDS: [PanelKind; 11] = [
     PanelKind::OpenCode,
     PanelKind::Gemini,
     PanelKind::KiloCode,
+    PanelKind::Pi,
     PanelKind::Command,
     PanelKind::Editor,
     PanelKind::GitChanges,

--- a/docs/architecture/pi-rpc-follow-up.md
+++ b/docs/architecture/pi-rpc-follow-up.md
@@ -1,0 +1,7 @@
+# Pi RPC Follow-Up
+
+Horizon's first Pi integration launches the standard `pi` CLI/TUI in a PTY, matching the existing agent panel model and preserving Pi's native interactive behavior.
+
+An optional v2 integration can add a Horizon-native Pi status feed by launching `pi --mode rpc`, writing JSONL commands to stdin, and parsing event records from stdout. Candidate events to map into Horizon UI state include `agent_start`, `message_update`, `tool_execution_*`, and `queue_update`.
+
+Keep the PTY launch path as the default. RPC mode should be additive, opt-in, and limited to structured status or inspection surfaces until it can faithfully preserve Pi's interactive session behavior.

--- a/docs/testing/2026-05-28-macos-pi-agent-panel-smoke.md
+++ b/docs/testing/2026-05-28-macos-pi-agent-panel-smoke.md
@@ -1,0 +1,129 @@
+# macOS Pi Agent Panel Smoke Plan
+
+## Scope
+
+Validate the Pi agent panel integration on macOS from a clean user runtime. Horizon should shell out to a user-installed `pi` CLI, create fresh Pi panels with `pi`, resume exact sessions with `pi --session <id>`, and keep existing agent presets unchanged.
+
+## Prerequisites
+
+- macOS 14 or newer on Apple Silicon or Intel.
+- Xcode Command Line Tools installed:
+  ```bash
+  xcode-select --install
+  ```
+- Build Horizon from the PR branch:
+  ```bash
+  cargo build
+  ```
+
+## Install Pi Runtime
+
+The smoke-test agent must install the Pi runtime themselves. Horizon does not install or vendor Pi.
+
+1. Install Node.js `22.19.0` or newer. Using `nvm`:
+   ```bash
+   brew install nvm
+   mkdir -p ~/.nvm
+   export NVM_DIR="$HOME/.nvm"
+   . "$(brew --prefix nvm)/nvm.sh"
+   nvm install 22.19.0
+   nvm use 22.19.0
+   ```
+
+2. Install the Pi coding-agent package:
+   ```bash
+   npm install -g @earendil-works/pi-coding-agent
+   ```
+
+3. Verify the CLI resolves:
+   ```bash
+   node --version
+   pi --version
+   command -v pi
+   ```
+
+4. For repeatable smoke runs, disable Pi network side effects unless the test explicitly covers them:
+   ```bash
+   export PI_SKIP_VERSION_CHECK=1
+   export PI_TELEMETRY=0
+   ```
+
+## Isolated Runtime Setup
+
+Use an isolated home directory so the test does not mutate the tester's real Horizon or Pi state.
+
+```bash
+export SMOKE_HOME="$(mktemp -d /tmp/horizon-pi-smoke.XXXXXX)"
+mkdir -p "$SMOKE_HOME/.horizon" "$SMOKE_HOME/.pi/agent/sessions/project"
+cat > "$SMOKE_HOME/.horizon/config.yaml" <<'YAML'
+version: 7
+window:
+  width: 1280
+  height: 860
+presets:
+  - name: Shell
+    alias: sh
+    kind: shell
+workspaces:
+  - name: Pi Smoke
+    cwd: /tmp
+    terminals:
+      - name: Pi Smoke
+        kind: pi
+        resume: last
+YAML
+cat > "$SMOKE_HOME/.pi/agent/sessions/project/session-123.jsonl" <<'JSONL'
+{"type":"session","id":"session-123","cwd":"/tmp"}
+{"type":"user_message","text":"Smoke Pi panel"}
+JSONL
+```
+
+## Launch And Visual Checks
+
+```bash
+HOME="$SMOKE_HOME" RUST_LOG=horizon=info,horizon_core=info target/debug/horizon --config "$SMOKE_HOME/.horizon/config.yaml" --ephemeral
+```
+
+Verify:
+
+- Horizon opens without crashing.
+- The config migrates to `version: 8`.
+- The panel badge reads `PI`.
+- The Pi panel is visible in the `Pi Smoke` workspace.
+- The terminal launches the installed Pi TUI. If Pi requires auth, it may show its normal auth/setup prompt; Horizon must remain responsive.
+- The Pi preset appears exactly once in settings or the panel picker.
+
+## Resume Checks
+
+With the seeded session file still present, relaunch Horizon and confirm the log contains:
+
+```text
+kind=Pi resume=Last session_id="session-123"
+cmd=... pi --session session-123
+```
+
+Then create a fresh Pi panel from the picker and confirm the launch command is plain `pi` with no implicit `--offline` or session flag.
+
+## Interaction Checks
+
+- Type into the Pi panel and confirm keyboard input reaches the TUI.
+- Resize the panel and confirm the terminal grid redraws cleanly.
+- Restart the Pi panel and confirm it keeps the selected working directory.
+- Save runtime state, quit, relaunch, and confirm the Pi panel restores as kind `pi` with the same session binding.
+
+## Missing Runtime Check
+
+Temporarily remove Pi from `PATH`:
+
+```bash
+PATH="/usr/bin:/bin:/usr/sbin:/sbin" HOME="$SMOKE_HOME" target/debug/horizon --config "$SMOKE_HOME/.horizon/config.yaml" --ephemeral
+```
+
+Verify Horizon shows the normal terminal command failure for `pi` and does not crash.
+
+## Evidence To Attach To PR
+
+- `cargo build` result.
+- A screenshot after launch showing the `PI` badge and Pi terminal.
+- Log lines proving `pi --session session-123` for the seeded session.
+- A short note saying whether Pi reached the TUI or stopped at its expected auth/setup prompt.


### PR DESCRIPTION
## Purpose

Add Pi as a first-class Horizon agent panel using the existing PTY-backed agent launch path.

## Behavior

- Adds PanelKind::Pi with the PI badge, Pi accent, pi default command, kitty keyboard enabled, and exact session resume via pi --session <id>.
- Adds the default Pi preset and migrates config v7 to v8 without duplicating existing Pi presets by name, alias, or kind.
- Adds Pi session catalog support for ~/.pi/agent/sessions/**/*.jsonl with cwd filtering and labels from the latest user message.
- Keeps RPC mode deferred and documented in docs/architecture/pi-rpc-follow-up.md.

## macOS Smoke Plan

Added docs/testing/2026-05-28-macos-pi-agent-panel-smoke.md as the retained macOS smoke-test artifact. The tester must install the Pi runtime themselves. Horizon does not bundle it. The plan tells them to install Node.js 22.19.0 or newer, then run:

```bash
npm install -g @earendil-works/pi-coding-agent
node --version
pi --version
command -v pi
```

It also covers isolated HOME setup, seeded Pi session resume, fresh panel launch, interaction, persistence, and missing-runtime behavior.

## Validation

- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- Xvfb smoke: Horizon opened, migrated a v7 config to v8, inserted the Pi preset, loaded a seeded Pi session, and launched pi --session session-123.