### PR TITLE
fix(terminal): restore shell panel working directory after cd + restart (Linux)

### DIFF
--- a/crates/horizon-core/src/terminal/support.rs
+++ b/crates/horizon-core/src/terminal/support.rs
@@ -93,7 +93,10 @@ fn replay_mode_reset_bytes(mode: TermMode) -> Vec<u8> {
 pub(super) fn current_cwd_for_pid(pid: u32) -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
-        std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
+        let target_pid = shell_pid_behind_wrapper(pid);
+        std::fs::read_link(format!("/proc/{target_pid}/cwd"))
+            .or_else(|_| std::fs::read_link(format!("/proc/{pid}/cwd")))
+            .ok()
     }
 
     #[cfg(target_os = "macos")]
@@ -106,6 +109,39 @@ pub(super) fn current_cwd_for_pid(pid: u32) -> Option<PathBuf> {
         let _ = pid;
         None
     }
+}
+
+/// The transcript wrapper (`script`) is the PTY's direct child but never changes
+/// its own working directory, so reading its cwd would always report the panel's
+/// original spawn directory. When `pid` is that wrapper, return the shell it
+/// launched so callers read the shell's live cwd (which tracks `cd`). Returns
+/// `pid` unchanged when it is not a `script` wrapper (transcript capture
+/// disabled), in which case the PTY child already is the shell.
+#[cfg(target_os = "linux")]
+fn shell_pid_behind_wrapper(pid: u32) -> u32 {
+    if proc_comm(pid).as_deref() != Some("script") {
+        return pid;
+    }
+    first_child_pid(pid).unwrap_or(pid)
+}
+
+#[cfg(target_os = "linux")]
+fn proc_comm(pid: u32) -> Option<String> {
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    Some(comm.trim_end().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn first_child_pid(pid: u32) -> Option<u32> {
+    let children = std::fs::read_to_string(format!("/proc/{pid}/task/{pid}/children")).ok()?;
+    parse_first_child_pid(&children)
+}
+
+/// Parse the space-separated PID list from `/proc/<pid>/task/<pid>/children`,
+/// returning the first child (the shell launched by the wrapper).
+#[cfg(any(target_os = "linux", test))]
+fn parse_first_child_pid(children: &str) -> Option<u32> {
+    children.split_whitespace().find_map(|token| token.parse().ok())
 }
 
 #[cfg(target_os = "macos")]
@@ -352,5 +388,16 @@ mod tests {
         let output = "12027\n12099\n";
 
         assert_eq!(super::parse_pgrep_pid(output), Some(12027));
+    }
+
+    #[test]
+    fn parse_first_child_pid_extracts_first_child() {
+        assert_eq!(super::parse_first_child_pid("31219 31300\n"), Some(31219));
+    }
+
+    #[test]
+    fn parse_first_child_pid_returns_none_when_empty() {
+        assert_eq!(super::parse_first_child_pid(""), None);
+        assert_eq!(super::parse_first_child_pid("\n"), None);
     }
 }

--- a/docs/testing/2026-05-29-macos-shell-panel-cwd-restore-smoke.md
+++ b/docs/testing/2026-05-29-macos-shell-panel-cwd-restore-smoke.md
@@ -105,15 +105,24 @@ the workspace directory.
 
 ## Test 3 - Transcript-disabled fallback (optional)
 
-Confirm the wrapper-skip logic does not misbehave when `script` is unavailable:
+Confirm the wrapper-skip logic does not misbehave when `script` is unavailable.
+Horizon discovers `script` by scanning `PATH`, so the directory that contains it
+(`/usr/bin` on macOS) must be excluded. Point `PATH` at an empty directory; the
+shell itself is launched by absolute path, and `cd`/`pwd -P` are shell builtins,
+so the panel still works.
 
 ```bash
-PATH="/usr/bin:/bin:/usr/sbin:/sbin" HOME="$SMOKE_HOME" target/debug/horizon \
-  --config "$SMOKE_HOME/.horizon/config.yaml"
+command -v script                                  # confirms the real path, e.g. /usr/bin/script
+export NOSCRIPT_BIN="$(mktemp -d /tmp/horizon-noscript.XXXXXX)"
+PATH="$NOSCRIPT_BIN" command -v script || echo "script not resolvable (good)"
+PATH="$NOSCRIPT_BIN" HOME="$SMOKE_HOME" RUST_LOG=horizon_core=info \
+  target/debug/horizon --config "$SMOKE_HOME/.horizon/config.yaml"
 ```
 
-`cd` in `Roamer`, quit, relaunch, and confirm the panel still restores the cd'd
-directory (cwd is read directly from the shell when there is no `script` wrapper).
+Confirm the log shows `transcript capture disabled: \`script\` was not found in PATH`
+(so there is genuinely no wrapper). Then `cd` in `Roamer`, quit, relaunch, and
+confirm the panel still restores the cd'd directory (with no wrapper, cwd is read
+directly from the shell pid).
 
 ## Evidence To Attach To PR
 

--- a/docs/testing/2026-05-29-macos-shell-panel-cwd-restore-smoke.md
+++ b/docs/testing/2026-05-29-macos-shell-panel-cwd-restore-smoke.md
@@ -1,0 +1,124 @@
+# macOS Shell Panel CWD Restore Smoke Plan
+
+## Scope
+
+Validate that a shell panel restores its **last working directory** after the user
+`cd`s and restarts Horizon, on macOS. This exercises the cross-platform cwd
+persistence feature whose Linux path is fixed in this PR. The macOS read path
+(`lsof` + deepest-child walk in `crates/horizon-core/src/terminal/support.rs`) is
+unchanged by this PR, so this smoke is a regression check that macOS still tracks
+and restores the live shell cwd, and that the build is healthy on macOS.
+
+Background: shell/command panels are launched wrapped in `script` for transcript
+capture, so the PTY child is the wrapper, not the shell. The cwd reader must look
+past the wrapper to the real shell. On macOS this already works via the lsof
+path; this plan proves it.
+
+## Prerequisites
+
+- macOS 14 or newer on Apple Silicon or Intel.
+- Xcode Command Line Tools:
+  ```bash
+  xcode-select --install
+  ```
+- Build Horizon from the PR branch:
+  ```bash
+  git switch fix/shell-panel-cwd-restore
+  cargo build
+  ```
+
+## Isolated Runtime Setup
+
+Use an isolated home directory so the test does not mutate the tester's real
+Horizon state.
+
+```bash
+export SMOKE_HOME="$(mktemp -d /tmp/horizon-cwd-smoke.XXXXXX)"
+mkdir -p "$SMOKE_HOME/.horizon"
+export CWD_TARGET="$SMOKE_HOME/cd-target"
+mkdir -p "$CWD_TARGET"
+cat > "$SMOKE_HOME/.horizon/config.yaml" <<YAML
+version: 8
+window:
+  width: 1280
+  height: 860
+workspaces:
+  - name: CWD Smoke
+    cwd: $SMOKE_HOME
+    terminals:
+      - name: Roamer
+        kind: shell
+      - name: Stayer
+        kind: shell
+YAML
+```
+
+`Roamer` is the panel we will `cd` in. `Stayer` is the no-`cd` control that must
+still restore at the workspace directory.
+
+## Launch
+
+```bash
+HOME="$SMOKE_HOME" RUST_LOG=horizon=info,horizon_core=info target/debug/horizon \
+  --config "$SMOKE_HOME/.horizon/config.yaml"
+```
+
+Verify Horizon opens without crashing and both `Roamer` and `Stayer` shell panels
+are visible in the `CWD Smoke` workspace.
+
+## Test 1 - Live cwd tracking follows `cd`
+
+1. Click into the `Roamer` panel and run:
+   ```bash
+   cd "$CWD_TARGET"
+   pwd -P          # note this resolved path, call it TARGET_RESOLVED
+   ```
+   (On macOS `/tmp` and `$TMPDIR` are symlinks, so `pwd -P` gives the real path
+   that will be persisted. Use that value for comparisons below.)
+2. Leave the `Stayer` panel untouched.
+3. Wait about 2 seconds (runtime state auto-saves on a 500 ms debounce), then in a
+   separate terminal inspect the persisted state:
+   ```bash
+   cat "$SMOKE_HOME"/.horizon/sessions/*/runtime.yaml
+   ```
+   Confirm:
+   - the `Roamer` panel entry has `cwd:` equal to `TARGET_RESOLVED` (the cd'd dir),
+     **not** the workspace dir.
+   - the `Stayer` panel entry still has `cwd:` equal to the workspace dir
+     (the resolved form of `$SMOKE_HOME`).
+
+## Test 2 - Restart restores the cd'd directory
+
+1. Quit Horizon (Cmd-Q or close the window). This triggers a final save.
+2. Relaunch with the same command as in **Launch**.
+3. In the restored `Roamer` panel run:
+   ```bash
+   pwd -P
+   ```
+   Confirm it prints `TARGET_RESOLVED` (the directory you cd'd into before quit).
+4. In the restored `Stayer` panel run `pwd -P` and confirm it prints the workspace
+   directory. This is the no-regression control.
+
+Expected result: `Roamer` reopens in the directory it was left in; `Stayer`
+reopens at the workspace directory. Before this feature worked, both reopened at
+the workspace directory.
+
+## Test 3 - Transcript-disabled fallback (optional)
+
+Confirm the wrapper-skip logic does not misbehave when `script` is unavailable:
+
+```bash
+PATH="/usr/bin:/bin:/usr/sbin:/sbin" HOME="$SMOKE_HOME" target/debug/horizon \
+  --config "$SMOKE_HOME/.horizon/config.yaml"
+```
+
+`cd` in `Roamer`, quit, relaunch, and confirm the panel still restores the cd'd
+directory (cwd is read directly from the shell when there is no `script` wrapper).
+
+## Evidence To Attach To PR
+
+- `cargo build` result on macOS (arch: arm64 or x64).
+- The `runtime.yaml` `Roamer` and `Stayer` `cwd:` lines from Test 1.
+- `pwd -P` output from the restored panels in Test 2.
+- A one-line note confirming `Roamer` restored to the cd'd dir and `Stayer` stayed
+  at the workspace dir.


### PR DESCRIPTION
## Problem

Add a shell panel, `cd` into a different directory, restart Horizon: the panel
reopens at the original workspace directory instead of the directory you cd'd
into. Reported on Linux.

## Root cause

Shell/command panels are launched wrapped in `script` for transcript capture
(`crates/horizon-core/src/transcript.rs`), e.g. `script -qef --log-out <file>
--command "/bin/bash"`. So the PTY's direct child (`child_pid`, set at
`terminal/lifecycle.rs`) is the **`script` wrapper**, not the interactive shell.

`Terminal::current_cwd()` reads `/proc/<child_pid>/cwd`. The `script` wrapper
never changes directory, so on Linux this always returned the original spawn
directory and never observed the user's `cd`. That stale value fed both:

- live cwd tracking (`Panel::process_output` -> `update_tracked_cwd`), so
  `launch_cwd` never advanced, and
- persistence (`RuntimeState::from_board_with_detached_workspaces`), so
  `runtime.yaml` recorded the workspace dir.

On restart the panel correctly respawns at the saved cwd, but the saved value
was already wrong. The restore path was never the problem.

This was Linux-specific: macOS already walks past the wrapper via the `lsof`
deepest-child path; Windows never tracked cwd.

Confirmed against the live app:

```
script wrapper pid 31202   /proc/31202/cwd = /home/peters/github/youpark.no   (frozen spawn dir)
  └─ bash       pid 31219  /proc/31219/cwd = /home/peters/mongodb-youpark      (where the user cd'd)
```

and `runtime.yaml` for that panel recorded `cwd: /home/peters/github/youpark.no`.

## Fix

When `child_pid` is a `script` wrapper, resolve its first child (the shell) via
`/proc/<pid>/task/<pid>/children` and read that pid's cwd instead. A `comm`
check keeps the no-wrapper case (transcript capture disabled) correct, since it
returns the pid unchanged. All `/proc` reads, no subprocess spawn, so it is
cheap on the per-frame hot path. One file changed plus unit tests.

## Verification

Local (mirrors CI), in a worktree sharing the build cache:

- `cargo fmt --all -- --check`
- `scripts/check-maintainability.sh`, `scripts/check-version-sync.sh`
- `cargo clippy --all-targets --all-features -- -D warnings` (blocking)
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` (strict)
- `cargo test --workspace` (257 + 2 new parser tests, all pass)

End-to-end proof on Linux, applying the new algorithm to the live wrapped
shells (OLD = wrapper cwd that the bug read, NEW = shell cwd this PR reads):

```
script=31202 child=31219
  OLD(wrapper)=/home/peters/github/youpark.no
  NEW(shell)  =/home/peters/mongodb-youpark   <-- fix returns the cd'd dir
script=30903 child=30905
  OLD(wrapper)=/home/peters/github/youpark.no
  NEW(shell)  =/home/peters/github/youpark.no  (no cd: unchanged, no regression)
```

## macOS smoke test

Added `docs/testing/2026-05-29-macos-shell-panel-cwd-restore-smoke.md` covering
cd + restart restore plus a no-cd control and a transcript-disabled fallback, to
run on a Mac. PR CI also builds and unit-tests on macOS arm64 and macOS x64 via
the `rust-test` matrix.

## Scope / risk

Linux read path only. macOS and Windows code paths are untouched. Graceful
degradation: if `/proc/.../children` is unavailable, it falls back to the prior
behavior rather than failing.
