### PR TITLE
fix(editor): accept non-ASCII input under X11 ibus XIM

### DIFF
--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -160,6 +160,7 @@ pub struct HorizonApp {
     canvas_pan_input_claimed: bool,
     pending_space_pan_key: CanvasPanSpaceKeyState,
     observed_keyboard_inputs: input::ObservedKeyboardInputs,
+    ime_commit_normalizer: input::ImeCommitNormalizer,
     frame_keyboard_events: HashMap<ViewportId, Vec<input::FrameKeyEvent>>,
     terminal_keyboard_events: Vec<input::TerminalInputEvent>,
     panel_screen_rects: HashMap<PanelId, Rect>,
@@ -374,6 +375,7 @@ impl HorizonApp {
             canvas_pan_input_claimed: false,
             pending_space_pan_key: CanvasPanSpaceKeyState::Idle,
             observed_keyboard_inputs,
+            ime_commit_normalizer: input::ImeCommitNormalizer::default(),
             frame_keyboard_events: HashMap::new(),
             terminal_keyboard_events: Vec::new(),
             git_watchers: HashMap::new(),
@@ -493,6 +495,7 @@ impl eframe::App for HorizonApp {
 
     fn raw_input_hook(&mut self, _ctx: &egui::Context, raw_input: &mut egui::RawInput) {
         let viewport_id = raw_input.viewport_id;
+        self.ime_commit_normalizer.normalize(viewport_id, &mut raw_input.events);
         let frame_keyboard_events = self.observed_keyboard_inputs.take_frame_key_events(raw_input);
         if frame_keyboard_events.is_empty() {
             self.frame_keyboard_events.remove(&viewport_id);

--- a/crates/horizon-ui/src/input/ime_commit.rs
+++ b/crates/horizon-ui/src/input/ime_commit.rs
@@ -1,0 +1,114 @@
+use std::collections::HashSet;
+
+use egui::{Event, ImeEvent, ViewportId};
+
+/// Rewrites orphan IME commits into plain text events.
+///
+/// On X11 with an ibus XIM bridge (`XMODIFIERS=@im=ibus`), winit delivers
+/// plain non-ASCII keystrokes (e.g. Norwegian æøå) as a bare `Ime::Commit`
+/// with no preceding `Ime::Enabled`/`Preedit`. egui's `TextEdit` discards
+/// such orphan commits because its stored IME cursor range is stale, so the
+/// characters never appear. Rewriting orphan commits into `Event::Text`
+/// routes them through the normal typing path while leaving genuine
+/// composition sessions (CJK preedit flows) untouched.
+#[derive(Default)]
+pub(crate) struct ImeCommitNormalizer {
+    composing: HashSet<ViewportId>,
+}
+
+impl ImeCommitNormalizer {
+    pub(crate) fn normalize(&mut self, viewport_id: ViewportId, events: &mut [Event]) {
+        for event in events {
+            match event {
+                Event::Ime(ImeEvent::Enabled | ImeEvent::Preedit(_)) => {
+                    self.composing.insert(viewport_id);
+                }
+                Event::Ime(ImeEvent::Disabled) => {
+                    self.composing.remove(&viewport_id);
+                }
+                Event::Ime(ImeEvent::Commit(text)) => {
+                    let orphan_commit = !self.composing.remove(&viewport_id);
+                    if orphan_commit {
+                        *event = Event::Text(std::mem::take(text));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::{Event, ImeEvent, ViewportId};
+
+    use super::ImeCommitNormalizer;
+
+    fn commit(text: &str) -> Event {
+        Event::Ime(ImeEvent::Commit(text.to_owned()))
+    }
+
+    #[test]
+    fn orphan_commit_becomes_text_event() {
+        let mut normalizer = ImeCommitNormalizer::default();
+        let mut events = vec![
+            Event::Ime(ImeEvent::Disabled),
+            commit("æ"),
+            Event::Ime(ImeEvent::Disabled),
+        ];
+
+        normalizer.normalize(ViewportId::ROOT, &mut events);
+
+        assert_eq!(events[1], Event::Text("æ".to_owned()));
+    }
+
+    #[test]
+    fn commit_after_enabled_stays_a_commit() {
+        let mut normalizer = ImeCommitNormalizer::default();
+        let mut events = vec![
+            Event::Ime(ImeEvent::Enabled),
+            Event::Ime(ImeEvent::Preedit("中".to_owned())),
+            commit("中"),
+        ];
+
+        normalizer.normalize(ViewportId::ROOT, &mut events);
+
+        assert_eq!(events[2], commit("中"));
+    }
+
+    #[test]
+    fn composition_state_spans_frames() {
+        let mut normalizer = ImeCommitNormalizer::default();
+        let mut first_frame = vec![Event::Ime(ImeEvent::Enabled)];
+        normalizer.normalize(ViewportId::ROOT, &mut first_frame);
+
+        let mut second_frame = vec![commit("中")];
+        normalizer.normalize(ViewportId::ROOT, &mut second_frame);
+
+        assert_eq!(second_frame[0], commit("中"));
+    }
+
+    #[test]
+    fn commit_ends_the_composition_session() {
+        let mut normalizer = ImeCommitNormalizer::default();
+        let mut events = vec![Event::Ime(ImeEvent::Enabled), commit("中"), commit("ø")];
+
+        normalizer.normalize(ViewportId::ROOT, &mut events);
+
+        assert_eq!(events[1], commit("中"));
+        assert_eq!(events[2], Event::Text("ø".to_owned()));
+    }
+
+    #[test]
+    fn composition_state_is_tracked_per_viewport() {
+        let mut normalizer = ImeCommitNormalizer::default();
+        let mut root_frame = vec![Event::Ime(ImeEvent::Enabled)];
+        normalizer.normalize(ViewportId::ROOT, &mut root_frame);
+
+        let other = ViewportId::from_hash_of("detached");
+        let mut other_frame = vec![commit("å")];
+        normalizer.normalize(other, &mut other_frame);
+
+        assert_eq!(other_frame[0], Event::Text("å".to_owned()));
+    }
+}

--- a/crates/horizon-ui/src/input/mod.rs
+++ b/crates/horizon-ui/src/input/mod.rs
@@ -1,8 +1,10 @@
+mod ime_commit;
 mod keyboard;
 mod mouse;
 mod sequence;
 mod winit_keyboard;
 
+pub(crate) use ime_commit::ImeCommitNormalizer;
 pub use keyboard::{
     KeyEventContext, KeyIdentity, KeyTranslation, paste_bytes, should_defer_textual_key,
     translate_key_event_with_physical, translate_text_event,


### PR DESCRIPTION
## Purpose

On Linux X11 with an ibus XIM bridge active (`XMODIFIERS=@im=ibus`, the default on e.g. Ubuntu GNOME Xorg sessions), plain non-ASCII keystrokes — Norwegian `æøå`, and any other character ibus routes through XIM — cannot be typed into the markdown editor. The characters are silently dropped.

## Root cause

For these keys, winit delivers a bare `Ime::Commit("æ")` with no preceding `Ime::Enabled`/`Preedit`. egui's `TextEdit` only applies a commit when the cursor still matches its stored IME cursor range, which is only ever set by `Enabled`/`Preedit` (egui 0.33.3 `widgets/text_edit/builder.rs`), so these orphan commits are discarded. The terminal widget was unaffected because it handles `Ime::Commit` itself, unconditionally.

Diagnosed by instrumenting `raw_input_hook` in a minimal `TextEdit` app and injecting keys via XTEST under live ibus: `a`/`b` arrive as `Event::Text` and insert, while `æøå` arrive as `Ime(Disabled)`, `Ime(Commit("æ"))`, `Ime(Disabled)` and never reach the buffer.

## Change

Adds `ImeCommitNormalizer` (`crates/horizon-ui/src/input/ime_commit.rs`), wired into `raw_input_hook`: it tracks per-viewport whether a real composition session is active (`Enabled`/`Preedit` seen) and rewrites orphan `Ime::Commit` events into plain `Event::Text`.

## Behavior impact

- Markdown editor (and any other egui text widget) accepts æøå and other XIM-committed characters on X11 with ibus.
- Genuine IME composition (CJK preedit flows) is untouched: commits inside an active session pass through unchanged.
- Terminal input is unaffected: its input path treats `Event::Text` and `Ime::Commit` identically.

## Test evidence

- 5 new unit tests cover orphan commits, commits after `Enabled`/`Preedit`, composition state spanning frames, session termination by commit, and per-viewport tracking.
- End-to-end verified on X11 + ibus (Norwegian layout) with XTEST key injection: buffer fills `aæøåb` with the fix, drops to `ab` without it.
- Pre-push validation run on this exact branch with current stable (1.96.0): `cargo fmt --check`, `./scripts/check-maintainability.sh`, `RUSTFLAGS="-D warnings" cargo test --workspace` (all green), blocking and strict clippy tiers clean, pedantic tier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)