### PR TITLE
feat(minimap): spotlight active and attention workspaces

### DIFF
--- a/crates/horizon-core/src/board/attention.rs
+++ b/crates/horizon-core/src/board/attention.rs
@@ -145,6 +145,12 @@ impl Board {
         id
     }
 
+    pub(super) fn reassign_panel_attention(&mut self, panel_id: PanelId, workspace_id: WorkspaceId) {
+        for item in self.attention.iter_mut().filter(|item| item.panel_id == Some(panel_id)) {
+            item.workspace_id = workspace_id;
+        }
+    }
+
     #[must_use]
     pub fn resolve_attention(&mut self, id: AttentionId) -> bool {
         if let Some(item) = self.attention.iter_mut().find(|item| item.id == id) {

--- a/crates/horizon-core/src/board/tests/mod.rs
+++ b/crates/horizon-core/src/board/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::panel::{PanelKind, PanelOptions};
 mod core;
 mod layout;
 mod workspace;
+mod workspace_attention;
 
 fn editor_panel_options() -> PanelOptions {
     PanelOptions {

--- a/crates/horizon-core/src/board/tests/workspace_attention.rs
+++ b/crates/horizon-core/src/board/tests/workspace_attention.rs
@@ -1,0 +1,85 @@
+use super::super::*;
+use super::editor_panel_options;
+
+#[test]
+fn assign_panel_moves_open_and_resolved_attention_to_target_workspace() {
+    let mut board = Board::new();
+    let source_workspace = board.create_workspace("source");
+    let target_workspace = board.create_workspace("target");
+    let panel_id = board
+        .create_panel(editor_panel_options(), source_workspace)
+        .expect("panel should spawn");
+    let open_attention = board.create_attention(
+        source_workspace,
+        Some(panel_id),
+        "agent",
+        "Needs input",
+        AttentionSeverity::High,
+    );
+    let resolved_attention = board.create_attention(
+        source_workspace,
+        Some(panel_id),
+        "agent-notify",
+        "Task completed",
+        AttentionSeverity::Medium,
+    );
+    assert!(board.resolve_attention(resolved_attention));
+
+    board.assign_panel_to_workspace(panel_id, target_workspace);
+
+    for attention_id in [open_attention, resolved_attention] {
+        let attention = board
+            .attention
+            .iter()
+            .find(|item| item.id == attention_id)
+            .expect("panel attention should remain available");
+        assert_eq!(attention.workspace_id, target_workspace);
+    }
+    assert!(
+        board
+            .attention
+            .iter()
+            .find(|item| item.id == resolved_attention)
+            .is_some_and(AttentionItem::is_resolved)
+    );
+}
+
+#[test]
+fn remove_workspace_preserves_attention_for_reassigned_panel() {
+    let mut board = Board::new();
+    let source_workspace = board.create_workspace("source");
+    let target_workspace = board.create_workspace("target");
+    let panel_id = board
+        .create_panel(editor_panel_options(), source_workspace)
+        .expect("panel should spawn");
+    let panel_attention = board.create_attention(
+        source_workspace,
+        Some(panel_id),
+        "agent",
+        "Needs input",
+        AttentionSeverity::High,
+    );
+    let workspace_attention = board.create_attention(
+        source_workspace,
+        None,
+        "system",
+        "Workspace notice",
+        AttentionSeverity::Low,
+    );
+
+    board.remove_workspace(source_workspace);
+
+    assert!(board.workspace(source_workspace).is_none());
+    assert_eq!(
+        board.panel(panel_id).expect("reassigned panel").workspace_id,
+        target_workspace
+    );
+    let attention = board
+        .attention
+        .iter()
+        .find(|item| item.id == panel_attention)
+        .expect("reassigned panel attention should survive workspace removal");
+    assert_eq!(attention.workspace_id, target_workspace);
+    assert!(attention.is_open());
+    assert!(board.attention.iter().all(|item| item.id != workspace_attention));
+}

--- a/crates/horizon-core/src/board/workspaces.rs
+++ b/crates/horizon-core/src/board/workspaces.rs
@@ -233,6 +233,7 @@ impl Board {
         if let Some(panel) = self.panel_mut(panel_id) {
             panel.workspace_id = workspace_id;
         }
+        self.reassign_panel_attention(panel_id, workspace_id);
 
         if let Some(layout) = target_layout {
             self.apply_workspace_layout(workspace_id, layout);

--- a/crates/horizon-ui/src/app/attention_feed.rs
+++ b/crates/horizon-ui/src/app/attention_feed.rs
@@ -337,7 +337,7 @@ fn visible_attention_items(attention: &[AttentionItem], now: SystemTime) -> Vec<
     items
 }
 
-fn is_visible_attention_item(item: &AttentionItem, now: SystemTime) -> bool {
+pub(super) fn is_visible_attention_item(item: &AttentionItem, now: SystemTime) -> bool {
     if item.is_open() {
         return true;
     }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -170,7 +170,6 @@ impl HorizonApp {
             self.workspace_screen_rects = saved_workspace_screen_rects;
             return;
         }
-
         self.handle_detached_shortcuts(ctx, workspace_id);
         self.render_detached_toolbar(ctx, workspace_id, workspace_local_id, &workspace_name);
 

--- a/crates/horizon-ui/src/app/minimap.rs
+++ b/crates/horizon-ui/src/app/minimap.rs
@@ -1,14 +1,14 @@
-use std::{cmp::Ordering, collections::HashMap};
+use std::{collections::HashMap, time::SystemTime};
 
-use egui::{
-    Align2, Color32, Context, CornerRadius, FontId, Id, Order, Painter, Pos2, Rect, Sense, Stroke, StrokeKind, Vec2,
-    text::{LayoutJob, TextFormat, TextWrapping},
-};
+use egui::{Context, CornerRadius, Id, Order, Painter, Pos2, Rect, Sense, Stroke, StrokeKind, Ui, Vec2};
 use horizon_core::WorkspaceId;
 
 use crate::theme;
 
 use super::{HorizonApp, MINIMAP_MARGIN, MINIMAP_PAD, WS_BG_PAD, WS_EMPTY_SIZE, WS_TITLE_HEIGHT};
+
+mod labels;
+mod spotlight;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MinimapScope {
@@ -25,12 +25,11 @@ struct MinimapModel {
     view_max: Pos2,
 }
 
-struct MinimapWorkspaceLabel<'a> {
-    name: &'a str,
-    color: Color32,
-    is_active: bool,
-    workspace_rect: Rect,
-    title_strip_rect: Option<Rect>,
+struct MinimapPaintGeometry<'a> {
+    rect: Rect,
+    model: &'a MinimapModel,
+    workspace_bounds: &'a HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
+    scope: MinimapScope,
 }
 
 impl HorizonApp {
@@ -84,18 +83,27 @@ fn render_scoped_minimap(
         return 0.0;
     };
     let minimap_height = model.outer_size.y;
+    let spotlight = spotlight::MinimapSpotlight::collect(app, scope, SystemTime::now());
 
     let response = egui::Area::new(overlay_id)
         .anchor(egui::Align2::RIGHT_BOTTOM, Vec2::new(-MINIMAP_MARGIN, -MINIMAP_MARGIN))
         .order(Order::Foreground)
         .show(ctx, |ui| {
             let (response, painter) = ui.allocate_painter(model.outer_size, Sense::click_and_drag());
-            paint_minimap_contents(app, &painter, response.rect, &model, workspace_bounds, scope);
-            response
+            let geometry = MinimapPaintGeometry {
+                rect: response.rect,
+                model: &model,
+                workspace_bounds,
+                scope,
+            };
+            let paint_result = paint_minimap_contents(app, ui, &painter, &geometry, &spotlight);
+            (response, paint_result)
         });
 
-    let inner = response.inner;
-    if (inner.clicked() || inner.dragged())
+    let (inner, paint_result) = response.inner;
+    if let Some(navigation) = paint_result.navigation {
+        apply_minimap_navigation(app, navigation, canvas_rect);
+    } else if (inner.clicked() || inner.dragged())
         && let Some(pointer) = ctx.input(|input| input.pointer.interact_pos())
     {
         let local = pointer - inner.rect.min;
@@ -112,6 +120,25 @@ fn render_scoped_minimap(
     }
 
     minimap_height
+}
+
+fn apply_minimap_navigation(app: &mut HorizonApp, navigation: spotlight::MinimapNavigationTarget, canvas_rect: Rect) {
+    match navigation {
+        spotlight::MinimapNavigationTarget::Panel { workspace_id, panel_id } => {
+            if app
+                .board
+                .panel(panel_id)
+                .is_some_and(|panel| panel.workspace_id == workspace_id)
+            {
+                app.focus_panel_in_rect(panel_id, canvas_rect);
+            } else {
+                let _ = app.focus_workspace_in_rect(workspace_id, canvas_rect);
+            }
+        }
+        spotlight::MinimapNavigationTarget::Workspace(workspace_id) => {
+            let _ = app.focus_workspace_in_rect(workspace_id, canvas_rect);
+        }
+    }
 }
 
 fn minimap_model(
@@ -146,401 +173,37 @@ fn minimap_model(
 
 fn paint_minimap_contents(
     app: &HorizonApp,
+    ui: &mut Ui,
     painter: &Painter,
-    rect: Rect,
-    model: &MinimapModel,
-    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
-    scope: MinimapScope,
-) {
-    painter.rect_filled(rect, CornerRadius::same(8), theme::alpha(theme::BG_ELEVATED(), 220));
+    geometry: &MinimapPaintGeometry<'_>,
+    spotlight: &spotlight::MinimapSpotlight,
+) -> spotlight::MinimapPaintResult {
+    painter.rect_filled(
+        geometry.rect,
+        CornerRadius::same(8),
+        theme::alpha(theme::BG_ELEVATED(), 220),
+    );
     painter.rect_stroke(
-        rect,
+        geometry.rect,
         CornerRadius::same(8),
         Stroke::new(1.0_f32, theme::alpha(theme::BORDER_SUBTLE(), 180)),
         StrokeKind::Outside,
     );
 
-    let origin = rect.min;
-    paint_minimap_workspaces(app, painter, origin, model, workspace_bounds, scope);
-    paint_minimap_panels(app, painter, origin, model, scope);
-    paint_minimap_workspace_labels(app, painter, origin, model, workspace_bounds, scope);
-    paint_minimap_viewport(painter, origin, model);
-}
-
-fn paint_minimap_workspaces(
-    app: &HorizonApp,
-    painter: &Painter,
-    origin: Pos2,
-    model: &MinimapModel,
-    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
-    scope: MinimapScope,
-) {
-    for workspace in &app.board.workspaces {
-        if !scope_includes_workspace(app, scope, workspace.id) {
-            continue;
-        }
-        let (r, g, b) = workspace.accent();
-        let workspace_color = Color32::from_rgb(r, g, b);
-        let is_active =
-            app.board.active_workspace == Some(workspace.id) || scope == MinimapScope::Workspace(workspace.id);
-        let (workspace_min, workspace_max) =
-            workspace_minimap_bounds(workspace.id, workspace_bounds).unwrap_or_else(|| {
-                let pos = workspace.position;
-                (pos, [pos[0] + WS_EMPTY_SIZE[0], pos[1] + WS_EMPTY_SIZE[1]])
-            });
-        let workspace_rect = Rect::from_min_max(
-            origin + minimap_point(model, workspace_min[0], workspace_min[1]).to_vec2(),
-            origin + minimap_point(model, workspace_max[0], workspace_max[1]).to_vec2(),
-        );
-
-        painter.rect_filled(
-            workspace_rect,
-            CornerRadius::same(2),
-            theme::alpha(workspace_color, if is_active { 40 } else { 22 }),
-        );
-        painter.rect_stroke(
-            workspace_rect,
-            CornerRadius::same(2),
-            Stroke::new(0.8_f32, theme::alpha(workspace_color, if is_active { 140 } else { 80 })),
-            StrokeKind::Outside,
-        );
-    }
-}
-
-fn paint_minimap_workspace_labels(
-    app: &HorizonApp,
-    painter: &Painter,
-    origin: Pos2,
-    model: &MinimapModel,
-    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
-    scope: MinimapScope,
-) {
-    let mut labels = collect_minimap_workspace_labels(app, origin, model, workspace_bounds, scope);
-    labels.sort_by(minimap_workspace_label_order);
-
-    let mut occupied = Vec::with_capacity(labels.len());
-    for label in labels {
-        paint_minimap_workspace_label(painter, &label, &mut occupied);
-    }
-}
-
-fn collect_minimap_workspace_labels<'a>(
-    app: &'a HorizonApp,
-    origin: Pos2,
-    model: &MinimapModel,
-    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
-    scope: MinimapScope,
-) -> Vec<MinimapWorkspaceLabel<'a>> {
-    let mut labels = Vec::new();
-
-    for workspace in &app.board.workspaces {
-        if !scope_includes_workspace(app, scope, workspace.id) {
-            continue;
-        }
-
-        let is_active =
-            app.board.active_workspace == Some(workspace.id) || scope == MinimapScope::Workspace(workspace.id);
-        let (workspace_min, workspace_max) =
-            workspace_minimap_bounds(workspace.id, workspace_bounds).unwrap_or_else(|| {
-                let pos = workspace.position;
-                (pos, [pos[0] + WS_EMPTY_SIZE[0], pos[1] + WS_EMPTY_SIZE[1]])
-            });
-        let workspace_rect = Rect::from_min_max(
-            origin + minimap_point(model, workspace_min[0], workspace_min[1]).to_vec2(),
-            origin + minimap_point(model, workspace_max[0], workspace_max[1]).to_vec2(),
-        );
-        let title_strip_rect = minimap_workspace_title_strip_rect(workspace_rect, model.scale_y);
-
-        let (r, g, b) = workspace.accent();
-        labels.push(MinimapWorkspaceLabel {
-            name: &workspace.name,
-            color: Color32::from_rgb(r, g, b),
-            is_active,
-            workspace_rect,
-            title_strip_rect,
-        });
-    }
-
-    labels
-}
-
-fn minimap_workspace_label_order(left: &MinimapWorkspaceLabel<'_>, right: &MinimapWorkspaceLabel<'_>) -> Ordering {
-    right
-        .is_active
-        .cmp(&left.is_active)
-        .then_with(|| {
-            let left_area = left.workspace_rect.width() * left.workspace_rect.height();
-            let right_area = right.workspace_rect.width() * right.workspace_rect.height();
-            right_area.total_cmp(&left_area)
-        })
-        .then_with(|| left.workspace_rect.min.y.total_cmp(&right.workspace_rect.min.y))
-        .then_with(|| left.workspace_rect.min.x.total_cmp(&right.workspace_rect.min.x))
-}
-
-fn minimap_workspace_title_strip_rect(workspace_rect: Rect, scale_y: f32) -> Option<Rect> {
-    const MIN_LABEL_WIDTH: f32 = 34.0;
-    const MIN_STRIP_HEIGHT: f32 = 10.0;
-
-    if workspace_rect.width() < MIN_LABEL_WIDTH || workspace_rect.height() < MIN_STRIP_HEIGHT {
-        return None;
-    }
-
-    let desired_height = (WS_TITLE_HEIGHT * scale_y).clamp(10.0, 18.0);
-    let strip_height = desired_height.min(workspace_rect.height() - 2.0);
-    if strip_height < MIN_STRIP_HEIGHT {
-        return None;
-    }
-
-    Some(Rect::from_min_max(
-        workspace_rect.min,
-        Pos2::new(workspace_rect.max.x, workspace_rect.min.y + strip_height),
-    ))
-}
-
-fn paint_minimap_workspace_label(painter: &Painter, label: &MinimapWorkspaceLabel<'_>, occupied: &mut Vec<Rect>) {
-    let horiz_cap = label.title_strip_rect.map_or(0, estimated_horizontal_chars);
-    let vert_cap = estimated_vertical_chars(label.workspace_rect);
-
-    if horiz_cap >= vert_cap {
-        if let Some(strip) = label.title_strip_rect
-            && try_paint_horizontal_label(painter, label, strip, occupied)
-        {
-            return;
-        }
-        try_paint_vertical_label(painter, label, occupied);
-    } else {
-        if try_paint_vertical_label(painter, label, occupied) {
-            return;
-        }
-        if let Some(strip) = label.title_strip_rect {
-            try_paint_horizontal_label(painter, label, strip, occupied);
-        }
-    }
-}
-
-const HORIZ_LABEL_PAD_X: f32 = 5.0;
-const HORIZ_MIN_TEXT_WIDTH: f32 = 12.0;
-const VERT_PAD: f32 = 3.0;
-const VERT_MIN_HEIGHT: f32 = 16.0;
-
-fn horiz_label_metrics(strip: Rect) -> (f32, f32, f32) {
-    let badge_height = (strip.height() - 2.0).clamp(10.0, 16.0);
-    let font_size = (badge_height - 2.0).clamp(7.5, 10.5);
-    let max_text_width = strip.width() - HORIZ_LABEL_PAD_X * 2.0 - 4.0;
-    (badge_height, font_size, max_text_width)
-}
-
-fn vert_label_metrics(workspace_rect: Rect) -> (f32, f32, f32) {
-    let font_size = (workspace_rect.width() * 0.35).clamp(6.0, 9.0);
-    let line_height = font_size + 2.0;
-    let available_height = workspace_rect.height() - 2.0;
-    (font_size, line_height, available_height)
-}
-
-fn estimated_horizontal_chars(strip: Rect) -> usize {
-    let (_, font_size, max_text_width) = horiz_label_metrics(strip);
-    if max_text_width < HORIZ_MIN_TEXT_WIDTH {
-        return 0;
-    }
-    let avg_char_width = font_size * 0.65;
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    {
-        (max_text_width / avg_char_width).floor() as usize
-    }
-}
-
-fn estimated_vertical_chars(workspace_rect: Rect) -> usize {
-    if workspace_rect.height() < VERT_MIN_HEIGHT {
-        return 0;
-    }
-    let (_, line_height, available_height) = vert_label_metrics(workspace_rect);
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    {
-        ((available_height - VERT_PAD * 2.0) / line_height).floor().max(0.0) as usize
-    }
-}
-
-fn try_paint_horizontal_label(
-    painter: &Painter,
-    label: &MinimapWorkspaceLabel<'_>,
-    strip: Rect,
-    occupied: &mut Vec<Rect>,
-) -> bool {
-    let (badge_height, font_size, max_text_width) = horiz_label_metrics(strip);
-    let font = FontId::proportional(font_size);
-    if max_text_width < HORIZ_MIN_TEXT_WIDTH {
-        return false;
-    }
-
-    let text_color = label_text_color(label.is_active);
-    let galley = painter.layout_job(single_line_label_job(label.name, &font, text_color, max_text_width));
-    let badge_width = (galley.size().x + HORIZ_LABEL_PAD_X * 2.0).min(strip.width() - 2.0);
-    let base_rect = Rect::from_min_size(
-        Pos2::new(strip.min.x + 1.0, strip.center().y - badge_height * 0.5),
-        Vec2::new(badge_width, badge_height),
+    spotlight::paint_minimap_scene(app, painter, geometry);
+    let mut cue_layout = spotlight::MinimapCueLayout::collect_active_tabs(app, geometry);
+    let label_rects = labels::paint_minimap_workspace_labels(
+        app,
+        painter,
+        geometry.rect.min,
+        geometry.model,
+        geometry.workspace_bounds,
+        geometry.scope,
+        cue_layout.exclusions(),
     );
-
-    let Some(badge_rect) = place_minimap_label_rect(base_rect, label.workspace_rect, occupied, label.is_active) else {
-        return false;
-    };
-
-    paint_label_badge(painter, badge_rect, label.color, label.is_active);
-
-    let text_pos = Pos2::new(
-        badge_rect.min.x + HORIZ_LABEL_PAD_X,
-        badge_rect.center().y - galley.size().y * 0.5,
-    );
-    painter
-        .with_clip_rect(badge_rect.shrink2(Vec2::new(HORIZ_LABEL_PAD_X - 1.0, 1.0)))
-        .galley(text_pos, galley, Color32::TRANSPARENT);
-
-    occupied.push(badge_rect.expand(1.0));
-    true
-}
-
-fn try_paint_vertical_label(painter: &Painter, label: &MinimapWorkspaceLabel<'_>, occupied: &mut Vec<Rect>) -> bool {
-    if label.workspace_rect.height() < VERT_MIN_HEIGHT {
-        return false;
-    }
-
-    let (font_size, line_height, available_height) = vert_label_metrics(label.workspace_rect);
-
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let max_chars = ((available_height - VERT_PAD * 2.0) / line_height).floor().max(0.0) as usize;
-
-    // Single-pass: take up to max_chars+1 to detect truncation without a separate .count()
-    let mut visible: Vec<char> = label.name.chars().take(max_chars.saturating_add(1)).collect();
-    let truncated = visible.len() > max_chars;
-    visible.truncate(max_chars);
-    if visible.is_empty() {
-        return false;
-    }
-
-    #[allow(clippy::cast_precision_loss)]
-    let badge_height = (visible.len() as f32 * line_height + VERT_PAD * 2.0).min(available_height);
-    let Some(badge_rect) = vertical_label_badge_rect(label.workspace_rect, font_size, badge_height) else {
-        return false;
-    };
-
-    if occupied.iter().any(|r| r.intersects(badge_rect)) && !label.is_active {
-        return false;
-    }
-
-    paint_label_badge(painter, badge_rect, label.color, label.is_active);
-
-    let font = FontId::proportional(font_size);
-    let text_color = label_text_color(label.is_active);
-    let clipped = painter.with_clip_rect(badge_rect.shrink(1.0));
-    let mut buf = [0u8; 4];
-    for (i, &ch) in visible.iter().enumerate() {
-        let is_last = i + 1 == visible.len() && truncated;
-        let display = if is_last { "\u{2026}" } else { ch.encode_utf8(&mut buf) };
-        #[allow(clippy::cast_precision_loss)]
-        let char_y = badge_rect.min.y + VERT_PAD + (i as f32) * line_height + line_height * 0.5;
-        clipped.text(
-            Pos2::new(badge_rect.center().x, char_y),
-            Align2::CENTER_CENTER,
-            display,
-            font.clone(),
-            text_color,
-        );
-    }
-
-    occupied.push(badge_rect.expand(1.0));
-    true
-}
-
-fn vertical_label_badge_rect(workspace_rect: Rect, font_size: f32, badge_height: f32) -> Option<Rect> {
-    let badge_width = (font_size + VERT_PAD * 2.0).min(workspace_rect.width() - 2.0);
-    if badge_width <= 0.0 || badge_height <= 0.0 {
-        return None;
-    }
-
-    Some(Rect::from_min_size(
-        Pos2::new(workspace_rect.min.x + 1.0, workspace_rect.min.y + 1.0),
-        Vec2::new(badge_width, badge_height),
-    ))
-}
-
-fn paint_label_badge(painter: &Painter, rect: Rect, color: Color32, is_active: bool) {
-    let fill = theme::alpha(
-        theme::blend(theme::BG_ELEVATED(), color, if is_active { 0.24 } else { 0.14 }),
-        236,
-    );
-    let stroke = Stroke::new(1.0_f32, theme::alpha(color, if is_active { 210 } else { 140 }));
-    painter.rect_filled(rect, CornerRadius::same(4), fill);
-    painter.rect_stroke(rect, CornerRadius::same(4), stroke, StrokeKind::Outside);
-}
-
-fn label_text_color(is_active: bool) -> Color32 {
-    if is_active {
-        theme::FG()
-    } else {
-        theme::alpha(theme::FG_SOFT(), 240)
-    }
-}
-
-fn single_line_label_job(text: &str, font: &FontId, color: Color32, max_width: f32) -> LayoutJob {
-    let mut job = LayoutJob::single_section(
-        text.to_string(),
-        TextFormat {
-            font_id: font.clone(),
-            color,
-            ..Default::default()
-        },
-    );
-    job.wrap = TextWrapping {
-        max_width: max_width.max(0.0),
-        max_rows: 1,
-        break_anywhere: true,
-        overflow_character: Some('\u{2026}'),
-    };
-    job
-}
-
-fn place_minimap_label_rect(base_rect: Rect, workspace_rect: Rect, occupied: &[Rect], is_active: bool) -> Option<Rect> {
-    const Y_OFFSETS: [f32; 4] = [0.0, 6.0, 12.0, 18.0];
-
-    for y_offset in Y_OFFSETS {
-        let max_top = (workspace_rect.max.y - base_rect.height() - 1.0).max(base_rect.min.y);
-        let top = (base_rect.min.y + y_offset).min(max_top);
-        let candidate = Rect::from_min_size(Pos2::new(base_rect.min.x, top), base_rect.size());
-        if !occupied.iter().any(|rect| rect.intersects(candidate)) {
-            return Some(candidate);
-        }
-    }
-
-    is_active.then_some(base_rect)
-}
-
-fn paint_minimap_panels(app: &HorizonApp, painter: &Painter, origin: Pos2, model: &MinimapModel, scope: MinimapScope) {
-    for panel in &app.board.panels {
-        if !scope_includes_workspace(app, scope, panel.workspace_id) {
-            continue;
-        }
-        let pos = panel.layout.position;
-        let size = panel.layout.size;
-        let panel_rect = Rect::from_min_max(
-            origin + minimap_point(model, pos[0], pos[1]).to_vec2(),
-            origin + minimap_point(model, pos[0] + size[0], pos[1] + size[1]).to_vec2(),
-        );
-        let workspace_color = app
-            .board
-            .workspace(panel.workspace_id)
-            .map_or(theme::ACCENT(), |workspace| {
-                let (r, g, b) = workspace.accent();
-                Color32::from_rgb(r, g, b)
-            });
-
-        painter.rect_filled(
-            panel_rect,
-            CornerRadius::same(1),
-            theme::alpha(
-                workspace_color,
-                if app.board.focused == Some(panel.id) { 120 } else { 70 },
-            ),
-        );
-    }
+    cue_layout.place_attention(app, geometry, spotlight, &label_rects);
+    paint_minimap_viewport(painter, geometry.rect.min, geometry.model);
+    spotlight::paint_minimap_cues(app, ui, painter, spotlight, &cue_layout)
 }
 
 fn workspace_content_bounds(
@@ -589,6 +252,26 @@ fn workspace_minimap_bounds(
         })
 }
 
+fn workspace_minimap_rect(
+    workspace_id: WorkspaceId,
+    workspace_position: [f32; 2],
+    origin: Pos2,
+    model: &MinimapModel,
+    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
+) -> Rect {
+    let (workspace_min, workspace_max) = workspace_minimap_bounds(workspace_id, workspace_bounds).unwrap_or((
+        workspace_position,
+        [
+            workspace_position[0] + WS_EMPTY_SIZE[0],
+            workspace_position[1] + WS_EMPTY_SIZE[1],
+        ],
+    ));
+    Rect::from_min_max(
+        origin + minimap_point(model, workspace_min[0], workspace_min[1]).to_vec2(),
+        origin + minimap_point(model, workspace_max[0], workspace_max[1]).to_vec2(),
+    )
+}
+
 fn minimap_point(model: &MinimapModel, canvas_x: f32, canvas_y: f32) -> Pos2 {
     Pos2::new(
         MINIMAP_PAD + (canvas_x - model.content_min[0]) * model.scale_x,
@@ -630,24 +313,12 @@ fn scope_has_content(app: &HorizonApp, scope: MinimapScope) -> bool {
 }
 
 fn scope_includes_workspace(app: &HorizonApp, scope: MinimapScope, workspace_id: WorkspaceId) -> bool {
-    match scope {
-        MinimapScope::Attached => !app.workspace_is_detached(workspace_id),
-        MinimapScope::Workspace(target_workspace_id) => target_workspace_id == workspace_id,
-    }
+    scope_includes_workspace_state(scope, workspace_id, app.workspace_is_detached(workspace_id))
 }
 
-#[cfg(test)]
-mod tests {
-    use egui::{Pos2, Rect, Vec2};
-
-    use super::vertical_label_badge_rect;
-
-    #[test]
-    fn vertical_label_badge_rect_skips_sub_two_pixel_workspaces() {
-        let workspace_rect = Rect::from_min_size(Pos2::new(10.0, 20.0), Vec2::new(1.5, 40.0));
-
-        let badge_rect = vertical_label_badge_rect(workspace_rect, 6.0, 24.0);
-
-        assert_eq!(badge_rect, None);
+fn scope_includes_workspace_state(scope: MinimapScope, workspace_id: WorkspaceId, is_detached: bool) -> bool {
+    match scope {
+        MinimapScope::Attached => !is_detached,
+        MinimapScope::Workspace(target_workspace_id) => target_workspace_id == workspace_id,
     }
 }

--- a/crates/horizon-ui/src/app/minimap/labels.rs
+++ b/crates/horizon-ui/src/app/minimap/labels.rs
@@ -1,0 +1,398 @@
+use std::{cmp::Ordering, collections::HashMap};
+
+use egui::{
+    Align2, Color32, CornerRadius, FontId, Painter, Pos2, Rect, Stroke, StrokeKind, Vec2,
+    text::{LayoutJob, TextFormat, TextWrapping},
+};
+use horizon_core::WorkspaceId;
+
+use crate::theme;
+
+use super::{
+    HorizonApp, MinimapModel, MinimapScope, WS_TITLE_HEIGHT, scope_includes_workspace, workspace_minimap_rect,
+};
+
+struct MinimapWorkspaceLabel<'a> {
+    name: &'a str,
+    color: Color32,
+    is_active: bool,
+    workspace_rect: Rect,
+    title_strip_rect: Option<Rect>,
+}
+
+pub(super) fn paint_minimap_workspace_labels(
+    app: &HorizonApp,
+    painter: &Painter,
+    origin: Pos2,
+    model: &MinimapModel,
+    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
+    scope: MinimapScope,
+    exclusions: &[Rect],
+) -> Vec<Rect> {
+    let mut labels = collect_minimap_workspace_labels(app, origin, model, workspace_bounds, scope);
+    labels.sort_by(minimap_workspace_label_order);
+
+    let exclusion_count = exclusions.len();
+    let mut occupied = Vec::with_capacity(exclusion_count + labels.len());
+    occupied.extend_from_slice(exclusions);
+    for label in labels {
+        paint_minimap_workspace_label(painter, &label, &mut occupied, exclusion_count);
+    }
+    occupied.into_iter().skip(exclusion_count).collect()
+}
+
+fn collect_minimap_workspace_labels<'a>(
+    app: &'a HorizonApp,
+    origin: Pos2,
+    model: &MinimapModel,
+    workspace_bounds: &HashMap<WorkspaceId, ([f32; 2], [f32; 2])>,
+    scope: MinimapScope,
+) -> Vec<MinimapWorkspaceLabel<'a>> {
+    let mut labels = Vec::new();
+
+    for workspace in &app.board.workspaces {
+        if !scope_includes_workspace(app, scope, workspace.id) {
+            continue;
+        }
+
+        let is_active =
+            app.board.active_workspace == Some(workspace.id) || scope == MinimapScope::Workspace(workspace.id);
+        let workspace_rect = workspace_minimap_rect(workspace.id, workspace.position, origin, model, workspace_bounds);
+        let title_strip_rect = minimap_workspace_title_strip_rect(workspace_rect, model.scale_y);
+
+        let (r, g, b) = workspace.accent();
+        labels.push(MinimapWorkspaceLabel {
+            name: &workspace.name,
+            color: Color32::from_rgb(r, g, b),
+            is_active,
+            workspace_rect,
+            title_strip_rect,
+        });
+    }
+
+    labels
+}
+
+fn minimap_workspace_label_order(left: &MinimapWorkspaceLabel<'_>, right: &MinimapWorkspaceLabel<'_>) -> Ordering {
+    right
+        .is_active
+        .cmp(&left.is_active)
+        .then_with(|| {
+            let left_area = left.workspace_rect.width() * left.workspace_rect.height();
+            let right_area = right.workspace_rect.width() * right.workspace_rect.height();
+            right_area.total_cmp(&left_area)
+        })
+        .then_with(|| left.workspace_rect.min.y.total_cmp(&right.workspace_rect.min.y))
+        .then_with(|| left.workspace_rect.min.x.total_cmp(&right.workspace_rect.min.x))
+}
+
+fn minimap_workspace_title_strip_rect(workspace_rect: Rect, scale_y: f32) -> Option<Rect> {
+    const MIN_LABEL_WIDTH: f32 = 34.0;
+    const MIN_STRIP_HEIGHT: f32 = 10.0;
+
+    if workspace_rect.width() < MIN_LABEL_WIDTH || workspace_rect.height() < MIN_STRIP_HEIGHT {
+        return None;
+    }
+
+    let desired_height = (WS_TITLE_HEIGHT * scale_y).clamp(10.0, 18.0);
+    let strip_height = desired_height.min(workspace_rect.height() - 2.0);
+    if strip_height < MIN_STRIP_HEIGHT {
+        return None;
+    }
+
+    Some(Rect::from_min_max(
+        workspace_rect.min,
+        Pos2::new(workspace_rect.max.x, workspace_rect.min.y + strip_height),
+    ))
+}
+
+fn paint_minimap_workspace_label(
+    painter: &Painter,
+    label: &MinimapWorkspaceLabel<'_>,
+    occupied: &mut Vec<Rect>,
+    protected_count: usize,
+) {
+    let horiz_cap = label.title_strip_rect.map_or(0, estimated_horizontal_chars);
+    let vert_cap = estimated_vertical_chars(label.workspace_rect);
+
+    if horiz_cap >= vert_cap {
+        if let Some(strip) = label.title_strip_rect
+            && try_paint_horizontal_label(painter, label, strip, occupied, protected_count)
+        {
+            return;
+        }
+        try_paint_vertical_label(painter, label, occupied, protected_count);
+    } else {
+        if try_paint_vertical_label(painter, label, occupied, protected_count) {
+            return;
+        }
+        if let Some(strip) = label.title_strip_rect {
+            try_paint_horizontal_label(painter, label, strip, occupied, protected_count);
+        }
+    }
+}
+
+const HORIZ_LABEL_PAD_X: f32 = 5.0;
+const HORIZ_MIN_TEXT_WIDTH: f32 = 12.0;
+const VERT_PAD: f32 = 3.0;
+const VERT_MIN_HEIGHT: f32 = 16.0;
+
+fn horiz_label_metrics(strip: Rect) -> (f32, f32, f32) {
+    let badge_height = (strip.height() - 2.0).clamp(10.0, 16.0);
+    let font_size = (badge_height - 2.0).clamp(7.5, 10.5);
+    let max_text_width = strip.width() - HORIZ_LABEL_PAD_X * 2.0 - 4.0;
+    (badge_height, font_size, max_text_width)
+}
+
+fn vert_label_metrics(workspace_rect: Rect) -> (f32, f32, f32) {
+    let font_size = (workspace_rect.width() * 0.35).clamp(6.0, 9.0);
+    let line_height = font_size + 2.0;
+    let available_height = workspace_rect.height() - 2.0;
+    (font_size, line_height, available_height)
+}
+
+fn estimated_horizontal_chars(strip: Rect) -> usize {
+    let (_, font_size, max_text_width) = horiz_label_metrics(strip);
+    if max_text_width < HORIZ_MIN_TEXT_WIDTH {
+        return 0;
+    }
+    let avg_char_width = font_size * 0.65;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    {
+        (max_text_width / avg_char_width).floor() as usize
+    }
+}
+
+fn estimated_vertical_chars(workspace_rect: Rect) -> usize {
+    if workspace_rect.height() < VERT_MIN_HEIGHT {
+        return 0;
+    }
+    let (_, line_height, available_height) = vert_label_metrics(workspace_rect);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    {
+        ((available_height - VERT_PAD * 2.0) / line_height).floor().max(0.0) as usize
+    }
+}
+
+fn try_paint_horizontal_label(
+    painter: &Painter,
+    label: &MinimapWorkspaceLabel<'_>,
+    strip: Rect,
+    occupied: &mut Vec<Rect>,
+    protected_count: usize,
+) -> bool {
+    let (badge_height, font_size, max_text_width) = horiz_label_metrics(strip);
+    let font = FontId::proportional(font_size);
+    if max_text_width < HORIZ_MIN_TEXT_WIDTH {
+        return false;
+    }
+
+    let text_color = label_text_color(label.is_active);
+    let galley = painter.layout_job(single_line_label_job(label.name, &font, text_color, max_text_width));
+    let badge_width = (galley.size().x + HORIZ_LABEL_PAD_X * 2.0).min(strip.width() - 2.0);
+    let base_rect = Rect::from_min_size(
+        Pos2::new(strip.min.x + 1.0, strip.center().y - badge_height * 0.5),
+        Vec2::new(badge_width, badge_height),
+    );
+
+    let Some(badge_rect) = place_minimap_label_rect(
+        base_rect,
+        label.workspace_rect,
+        occupied,
+        protected_count,
+        label.is_active,
+    ) else {
+        return false;
+    };
+
+    paint_label_badge(painter, badge_rect, label.color, label.is_active);
+
+    let text_pos = Pos2::new(
+        badge_rect.min.x + HORIZ_LABEL_PAD_X,
+        badge_rect.center().y - galley.size().y * 0.5,
+    );
+    painter
+        .with_clip_rect(badge_rect.shrink2(Vec2::new(HORIZ_LABEL_PAD_X - 1.0, 1.0)))
+        .galley(text_pos, galley, Color32::TRANSPARENT);
+
+    occupied.push(badge_rect.expand(1.0));
+    true
+}
+
+fn try_paint_vertical_label(
+    painter: &Painter,
+    label: &MinimapWorkspaceLabel<'_>,
+    occupied: &mut Vec<Rect>,
+    protected_count: usize,
+) -> bool {
+    if label.workspace_rect.height() < VERT_MIN_HEIGHT {
+        return false;
+    }
+
+    let (font_size, line_height, available_height) = vert_label_metrics(label.workspace_rect);
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let max_chars = ((available_height - VERT_PAD * 2.0) / line_height).floor().max(0.0) as usize;
+
+    // Single-pass: take up to max_chars+1 to detect truncation without a separate .count()
+    let mut visible: Vec<char> = label.name.chars().take(max_chars.saturating_add(1)).collect();
+    let truncated = visible.len() > max_chars;
+    visible.truncate(max_chars);
+    if visible.is_empty() {
+        return false;
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let badge_height = (visible.len() as f32 * line_height + VERT_PAD * 2.0).min(available_height);
+    let Some(badge_rect) = vertical_label_badge_rect(label.workspace_rect, font_size, badge_height) else {
+        return false;
+    };
+
+    let overlaps_protected = occupied[..protected_count]
+        .iter()
+        .any(|rect| rect.intersects(badge_rect));
+    let overlaps_label = occupied[protected_count..]
+        .iter()
+        .any(|rect| rect.intersects(badge_rect));
+    if overlaps_protected || (overlaps_label && !label.is_active) {
+        return false;
+    }
+
+    paint_label_badge(painter, badge_rect, label.color, label.is_active);
+
+    let font = FontId::proportional(font_size);
+    let text_color = label_text_color(label.is_active);
+    let clipped = painter.with_clip_rect(badge_rect.shrink(1.0));
+    let mut buf = [0u8; 4];
+    for (i, &ch) in visible.iter().enumerate() {
+        let is_last = i + 1 == visible.len() && truncated;
+        let display = if is_last { "\u{2026}" } else { ch.encode_utf8(&mut buf) };
+        #[allow(clippy::cast_precision_loss)]
+        let char_y = badge_rect.min.y + VERT_PAD + (i as f32) * line_height + line_height * 0.5;
+        clipped.text(
+            Pos2::new(badge_rect.center().x, char_y),
+            Align2::CENTER_CENTER,
+            display,
+            font.clone(),
+            text_color,
+        );
+    }
+
+    occupied.push(badge_rect.expand(1.0));
+    true
+}
+
+fn vertical_label_badge_rect(workspace_rect: Rect, font_size: f32, badge_height: f32) -> Option<Rect> {
+    let badge_width = (font_size + VERT_PAD * 2.0).min(workspace_rect.width() - 2.0);
+    if badge_width <= 0.0 || badge_height <= 0.0 {
+        return None;
+    }
+
+    Some(Rect::from_min_size(
+        Pos2::new(workspace_rect.min.x + 1.0, workspace_rect.min.y + 1.0),
+        Vec2::new(badge_width, badge_height),
+    ))
+}
+
+fn paint_label_badge(painter: &Painter, rect: Rect, color: Color32, is_active: bool) {
+    let fill = theme::alpha(
+        theme::blend(theme::BG_ELEVATED(), color, if is_active { 0.24 } else { 0.14 }),
+        236,
+    );
+    let stroke = Stroke::new(1.0_f32, theme::alpha(color, if is_active { 210 } else { 140 }));
+    painter.rect_filled(rect, CornerRadius::same(4), fill);
+    painter.rect_stroke(rect, CornerRadius::same(4), stroke, StrokeKind::Outside);
+}
+
+fn label_text_color(is_active: bool) -> Color32 {
+    if is_active {
+        theme::FG()
+    } else {
+        theme::alpha(theme::FG_SOFT(), 240)
+    }
+}
+
+fn single_line_label_job(text: &str, font: &FontId, color: Color32, max_width: f32) -> LayoutJob {
+    let mut job = LayoutJob::single_section(
+        text.to_string(),
+        TextFormat {
+            font_id: font.clone(),
+            color,
+            ..Default::default()
+        },
+    );
+    job.wrap = TextWrapping {
+        max_width: max_width.max(0.0),
+        max_rows: 1,
+        break_anywhere: true,
+        overflow_character: Some('\u{2026}'),
+    };
+    job
+}
+
+fn place_minimap_label_rect(
+    base_rect: Rect,
+    workspace_rect: Rect,
+    occupied: &[Rect],
+    protected_count: usize,
+    is_active: bool,
+) -> Option<Rect> {
+    let candidates = minimap_label_candidates(base_rect, workspace_rect);
+    if let Some(candidate) = candidates
+        .iter()
+        .find(|candidate| occupied.iter().all(|rect| !rect.intersects(**candidate)))
+    {
+        return Some(*candidate);
+    }
+    is_active.then(|| {
+        candidates.into_iter().find(|candidate| {
+            occupied[..protected_count]
+                .iter()
+                .all(|rect| !rect.intersects(*candidate))
+        })
+    })?
+}
+
+fn minimap_label_candidates(base_rect: Rect, workspace_rect: Rect) -> [Rect; 4] {
+    const Y_OFFSETS: [f32; 4] = [0.0, 6.0, 12.0, 18.0];
+
+    Y_OFFSETS.map(|y_offset| {
+        let max_top = (workspace_rect.max.y - base_rect.height() - 1.0).max(base_rect.min.y);
+        let top = (base_rect.min.y + y_offset).min(max_top);
+        Rect::from_min_size(Pos2::new(base_rect.min.x, top), base_rect.size())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::{Pos2, Rect, Vec2};
+
+    use super::{place_minimap_label_rect, vertical_label_badge_rect};
+
+    #[test]
+    fn vertical_label_badge_rect_skips_sub_two_pixel_workspaces() {
+        let workspace_rect = Rect::from_min_size(Pos2::new(10.0, 20.0), Vec2::new(1.5, 40.0));
+
+        let badge_rect = vertical_label_badge_rect(workspace_rect, 6.0, 24.0);
+
+        assert_eq!(badge_rect, None);
+    }
+
+    #[test]
+    fn active_label_fallback_avoids_protected_cue_geometry() {
+        let workspace_rect = Rect::from_min_size(Pos2::new(10.0, 10.0), Vec2::new(60.0, 50.0));
+        let base_rect = Rect::from_min_size(Pos2::new(12.0, 12.0), Vec2::new(36.0, 10.0));
+        let protected = Rect::from_min_size(Pos2::new(10.0, 10.0), Vec2::new(60.0, 11.0));
+        let ordinary_label = workspace_rect;
+
+        let placed = place_minimap_label_rect(base_rect, workspace_rect, &[protected, ordinary_label], 1, true)
+            .expect("active label should find a protected-safe fallback");
+
+        assert!(!placed.intersects(protected));
+        assert!(placed.intersects(ordinary_label));
+        assert_eq!(
+            place_minimap_label_rect(base_rect, workspace_rect, &[protected, ordinary_label], 1, false,),
+            None
+        );
+    }
+}

--- a/crates/horizon-ui/src/app/minimap/spotlight.rs
+++ b/crates/horizon-ui/src/app/minimap/spotlight.rs
@@ -1,0 +1,332 @@
+use egui::{
+    Align2, Color32, CornerRadius, FontId, Id, Painter, Rect, Response, Sense, Stroke, StrokeKind, Ui, WidgetInfo,
+    WidgetType,
+};
+use horizon_core::{AttentionId, AttentionSeverity, PanelId, WorkspaceId};
+
+use crate::theme;
+
+use super::{
+    HorizonApp, MinimapPaintGeometry, MinimapScope, minimap_point, scope_includes_workspace, workspace_minimap_rect,
+};
+
+const MAX_PANEL_MARKERS: usize = 2;
+const PANEL_MARKER_MIN_WIDTH: f32 = 18.0;
+const PANEL_MARKER_MIN_HEIGHT: f32 = 16.0;
+const PANEL_MARKER_RADIUS: f32 = 6.0;
+const ACCESSIBLE_TARGET_SIZE: f32 = 24.0;
+
+mod aggregation;
+mod layout;
+
+pub(super) use aggregation::MinimapSpotlight;
+use aggregation::WorkspaceAttentionCue;
+pub(super) use layout::MinimapCueLayout;
+use layout::{ActiveTab, accessible_hit_rect};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MinimapNavigationTarget {
+    Panel {
+        workspace_id: WorkspaceId,
+        panel_id: PanelId,
+    },
+    Workspace(WorkspaceId),
+}
+
+#[derive(Default)]
+pub(super) struct MinimapPaintResult {
+    pub(super) navigation: Option<MinimapNavigationTarget>,
+}
+
+pub(super) fn paint_minimap_scene(app: &HorizonApp, painter: &Painter, geometry: &MinimapPaintGeometry<'_>) {
+    let origin = geometry.rect.min;
+    let model = geometry.model;
+    let workspace_bounds = geometry.workspace_bounds;
+    let scope = geometry.scope;
+
+    for workspace in &app.board.workspaces {
+        if !scope_includes_workspace(app, scope, workspace.id) {
+            continue;
+        }
+
+        let workspace_rect = workspace_minimap_rect(workspace.id, workspace.position, origin, model, workspace_bounds);
+        let (red, green, blue) = workspace.accent();
+        let workspace_color = Color32::from_rgb(red, green, blue);
+        let is_active =
+            app.board.active_workspace == Some(workspace.id) || scope == MinimapScope::Workspace(workspace.id);
+
+        paint_workspace(painter, workspace_rect, workspace_color, is_active);
+    }
+
+    for panel in &app.board.panels {
+        if !scope_includes_workspace(app, scope, panel.workspace_id) {
+            continue;
+        }
+
+        let panel_rect = Rect::from_min_max(
+            origin + minimap_point(model, panel.layout.position[0], panel.layout.position[1]).to_vec2(),
+            origin
+                + minimap_point(
+                    model,
+                    panel.layout.position[0] + panel.layout.size[0],
+                    panel.layout.position[1] + panel.layout.size[1],
+                )
+                .to_vec2(),
+        );
+        let workspace_color = app
+            .board
+            .workspace(panel.workspace_id)
+            .map_or(theme::ACCENT(), |workspace| {
+                let (red, green, blue) = workspace.accent();
+                Color32::from_rgb(red, green, blue)
+            });
+        painter.rect_filled(
+            panel_rect,
+            CornerRadius::same(1),
+            theme::alpha(
+                workspace_color,
+                if app.board.focused == Some(panel.id) { 120 } else { 70 },
+            ),
+        );
+    }
+}
+
+pub(super) fn paint_minimap_cues(
+    app: &HorizonApp,
+    ui: &mut Ui,
+    painter: &Painter,
+    spotlight: &MinimapSpotlight,
+    layout: &MinimapCueLayout,
+) -> MinimapPaintResult {
+    paint_active_tabs(app, painter, layout);
+    let panel_navigation = paint_panel_attention_cues(app, ui, painter, layout);
+    let workspace_navigation = paint_workspace_attention_cues(app, ui, painter, spotlight, layout);
+
+    MinimapPaintResult {
+        navigation: panel_navigation.or(workspace_navigation),
+    }
+}
+
+fn paint_active_tabs(app: &HorizonApp, painter: &Painter, layout: &MinimapCueLayout) {
+    for workspace in &app.board.workspaces {
+        if let Some(tab) = layout.active_tabs.get(&workspace.id) {
+            paint_active_tab(painter, tab);
+        }
+    }
+}
+
+fn paint_panel_attention_cues(
+    app: &HorizonApp,
+    ui: &mut Ui,
+    painter: &Painter,
+    layout: &MinimapCueLayout,
+) -> Option<MinimapNavigationTarget> {
+    let mut navigation = None;
+    for marker in &layout.panel_markers {
+        paint_panel_marker(painter, marker.visual_rect, marker.severity);
+        let response = minimap_button_response(
+            ui,
+            marker.hit_rect,
+            Id::new(("minimap_panel_attention", marker.workspace_id.0, marker.panel_id.0)),
+            "Focus and center attention panel",
+        );
+        let clicked = response.clicked();
+        if response.hovered() {
+            let summary = attention_summary(app, marker.attention_id).unwrap_or("Attention item");
+            let _ = response.on_hover_text(format!(
+                "{}: {summary}. Focus and center this panel.",
+                severity_label(marker.severity),
+            ));
+        }
+        if clicked && navigation.is_none() {
+            navigation = Some(MinimapNavigationTarget::Panel {
+                workspace_id: marker.workspace_id,
+                panel_id: marker.panel_id,
+            });
+        }
+    }
+    navigation
+}
+
+fn paint_workspace_attention_cues(
+    app: &HorizonApp,
+    ui: &mut Ui,
+    painter: &Painter,
+    spotlight: &MinimapSpotlight,
+    layout: &MinimapCueLayout,
+) -> Option<MinimapNavigationTarget> {
+    let mut navigation = None;
+    for workspace in &app.board.workspaces {
+        let Some(cue) = spotlight.workspaces.get(&workspace.id) else {
+            continue;
+        };
+        let Some(&badge_rect) = layout.workspace_badges.get(&workspace.id) else {
+            continue;
+        };
+        let badge_text = workspace_badge_text(cue);
+        paint_workspace_badge(painter, badge_rect, &badge_text, cue.display_severity);
+
+        let hit_rect = accessible_hit_rect(badge_rect, layout.map_rect);
+        let response = minimap_button_response(
+            ui,
+            hit_rect,
+            Id::new(("minimap_workspace_attention", workspace.id.0)),
+            "Focus highest-priority workspace attention",
+        );
+        let clicked = response.clicked();
+        if response.hovered() {
+            let summary = attention_summary(app, cue.attention_id).unwrap_or("Attention item");
+            let tooltip = if cue.open_count == 0 {
+                format!(
+                    "Recently completed attention in {}: {summary}. Focus its target.",
+                    workspace.name
+                )
+            } else {
+                format!(
+                    "{} open attention item{} in {}: {summary}. Focus the highest-priority target.",
+                    cue.open_count,
+                    if cue.open_count == 1 { "" } else { "s" },
+                    workspace.name,
+                )
+            };
+            let _ = response.on_hover_text(tooltip);
+        }
+        if clicked && navigation.is_none() {
+            navigation = Some(cue.target);
+        }
+    }
+
+    navigation
+}
+
+fn paint_workspace(painter: &Painter, rect: Rect, workspace_color: Color32, is_active: bool) {
+    painter.rect_filled(
+        rect,
+        CornerRadius::same(2),
+        theme::alpha(workspace_color, if is_active { 60 } else { 22 }),
+    );
+    painter.rect_stroke(
+        rect,
+        CornerRadius::same(2),
+        Stroke::new(0.8_f32, theme::alpha(workspace_color, if is_active { 210 } else { 80 })),
+        StrokeKind::Outside,
+    );
+
+    if is_active {
+        painter.rect_stroke(
+            rect.expand(3.5),
+            CornerRadius::same(4),
+            Stroke::new(2.0_f32, theme::alpha(theme::ACCENT(), 180)),
+            StrokeKind::Outside,
+        );
+        painter.rect_stroke(
+            rect.expand(1.3),
+            CornerRadius::same(3),
+            Stroke::new(1.2_f32, theme::alpha(theme::FG(), 220)),
+            StrokeKind::Outside,
+        );
+    }
+}
+
+fn paint_active_tab(painter: &Painter, tab: &ActiveTab) {
+    painter.rect_filled(tab.rect, CornerRadius::same(5), theme::ACCENT());
+    painter.text(
+        tab.rect.center(),
+        Align2::CENTER_CENTER,
+        tab.label,
+        FontId::proportional(7.5),
+        theme::BG(),
+    );
+}
+
+fn paint_panel_marker(painter: &Painter, rect: Rect, severity: AttentionSeverity) {
+    let color = severity_color(severity);
+    painter.circle_filled(
+        rect.center(),
+        PANEL_MARKER_RADIUS,
+        theme::alpha(theme::BG_ELEVATED(), 245),
+    );
+    painter.circle_stroke(rect.center(), PANEL_MARKER_RADIUS, Stroke::new(1.5_f32, color));
+    painter.text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        severity_icon(severity),
+        FontId::proportional(8.5),
+        color,
+    );
+}
+
+fn workspace_badge_text(cue: &WorkspaceAttentionCue) -> String {
+    if cue.open_count == 0 {
+        return "✓".to_string();
+    }
+
+    let count = if cue.open_count > 9 {
+        "9+".to_string()
+    } else {
+        cue.open_count.to_string()
+    };
+    format!("{}{count}", severity_icon(cue.display_severity))
+}
+
+fn paint_workspace_badge(painter: &Painter, rect: Rect, text: &str, severity: AttentionSeverity) {
+    let color = severity_color(severity);
+    painter.rect_filled(rect, CornerRadius::same(7), theme::alpha(theme::BG_ELEVATED(), 245));
+    painter.rect_stroke(
+        rect,
+        CornerRadius::same(7),
+        Stroke::new(1.4_f32, color),
+        StrokeKind::Outside,
+    );
+    painter.text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        text,
+        FontId::monospace(8.0),
+        color,
+    );
+}
+
+fn minimap_button_response(ui: &mut Ui, rect: Rect, id: Id, accessibility_label: &'static str) -> Response {
+    let response = ui.interact(rect, id, Sense::click());
+    response.widget_info(|| WidgetInfo::labeled(WidgetType::Button, true, accessibility_label));
+    if response.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    response
+}
+
+fn attention_summary(app: &HorizonApp, attention_id: AttentionId) -> Option<&str> {
+    app.board
+        .attention
+        .iter()
+        .find(|item| item.id == attention_id)
+        .map(|item| item.summary.as_str())
+}
+
+fn severity_color(severity: AttentionSeverity) -> Color32 {
+    match severity {
+        AttentionSeverity::High => theme::PALETTE_RED(),
+        AttentionSeverity::Medium => theme::PALETTE_GREEN(),
+        AttentionSeverity::Low => theme::ACCENT(),
+    }
+}
+
+fn severity_icon(severity: AttentionSeverity) -> &'static str {
+    match severity {
+        AttentionSeverity::High => "!",
+        AttentionSeverity::Medium => "✓",
+        AttentionSeverity::Low => "i",
+    }
+}
+
+fn severity_label(severity: AttentionSeverity) -> &'static str {
+    match severity {
+        AttentionSeverity::High => "Needs attention",
+        AttentionSeverity::Medium => "Completed",
+        AttentionSeverity::Low => "Information",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-ui/src/app/minimap/spotlight/aggregation.rs
+++ b/crates/horizon-ui/src/app/minimap/spotlight/aggregation.rs
@@ -1,0 +1,145 @@
+use std::{cmp::Ordering, collections::HashMap, time::SystemTime};
+
+use horizon_core::{AttentionId, AttentionItem, AttentionSeverity, PanelId, WorkspaceId};
+
+use crate::app::attention_feed::is_visible_attention_item;
+
+use super::{HorizonApp, MinimapNavigationTarget, MinimapScope, scope_includes_workspace};
+
+#[derive(Default)]
+pub(in crate::app::minimap) struct MinimapSpotlight {
+    pub(super) workspaces: HashMap<WorkspaceId, WorkspaceAttentionCue>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct WorkspaceAttentionCue {
+    pub(super) display_severity: AttentionSeverity,
+    pub(super) open_count: usize,
+    pub(super) attention_id: AttentionId,
+    pub(super) target: MinimapNavigationTarget,
+    pub(super) panel_cues: Vec<PanelAttentionCue>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PanelAttentionCue {
+    pub(super) panel_id: PanelId,
+    pub(super) display_severity: AttentionSeverity,
+    priority_severity: AttentionSeverity,
+    pub(super) attention_id: AttentionId,
+    created_at: SystemTime,
+}
+
+impl MinimapSpotlight {
+    pub(in crate::app::minimap) fn collect(app: &HorizonApp, scope: MinimapScope, now: SystemTime) -> Self {
+        project_attention(
+            &app.board.attention,
+            now,
+            app.template_config.features.attention_feed,
+            |workspace_id| scope_includes_workspace(app, scope, workspace_id),
+        )
+    }
+}
+
+pub(super) fn aggregate_attention(
+    attention: &[AttentionItem],
+    now: SystemTime,
+    includes_workspace: impl Fn(WorkspaceId) -> bool,
+) -> MinimapSpotlight {
+    let mut grouped = HashMap::<WorkspaceId, Vec<&AttentionItem>>::new();
+    for item in attention {
+        if includes_workspace(item.workspace_id) && is_visible_attention_item(item, now) {
+            grouped.entry(item.workspace_id).or_default().push(item);
+        }
+    }
+
+    let workspaces = grouped
+        .into_iter()
+        .filter_map(|(workspace_id, items)| {
+            aggregate_workspace_attention(workspace_id, &items).map(|cue| (workspace_id, cue))
+        })
+        .collect();
+
+    MinimapSpotlight { workspaces }
+}
+
+pub(super) fn project_attention(
+    attention: &[AttentionItem],
+    now: SystemTime,
+    attention_enabled: bool,
+    includes_workspace: impl Fn(WorkspaceId) -> bool,
+) -> MinimapSpotlight {
+    if attention_enabled {
+        aggregate_attention(attention, now, includes_workspace)
+    } else {
+        MinimapSpotlight::default()
+    }
+}
+
+fn aggregate_workspace_attention(workspace_id: WorkspaceId, items: &[&AttentionItem]) -> Option<WorkspaceAttentionCue> {
+    let open_items: Vec<_> = items.iter().copied().filter(|item| item.is_open()).collect();
+    let completed = open_items.is_empty();
+    let selected = if completed { items } else { &open_items };
+    let target_item = selected
+        .iter()
+        .copied()
+        .max_by(|left, right| attention_priority(left, right))?;
+    let display_severity = if completed {
+        AttentionSeverity::Medium
+    } else {
+        target_item.severity
+    };
+    let target = target_item
+        .panel_id
+        .map_or(MinimapNavigationTarget::Workspace(workspace_id), |panel_id| {
+            MinimapNavigationTarget::Panel { workspace_id, panel_id }
+        });
+
+    let mut panel_items = HashMap::<PanelId, &AttentionItem>::new();
+    for item in selected.iter().copied() {
+        let Some(panel_id) = item.panel_id else {
+            continue;
+        };
+        let replace = panel_items
+            .get(&panel_id)
+            .is_none_or(|current| attention_priority(current, item) == Ordering::Less);
+        if replace {
+            panel_items.insert(panel_id, item);
+        }
+    }
+
+    let mut panel_cues: Vec<_> = panel_items
+        .into_iter()
+        .map(|(panel_id, item)| PanelAttentionCue {
+            panel_id,
+            display_severity: if completed {
+                AttentionSeverity::Medium
+            } else {
+                item.severity
+            },
+            priority_severity: item.severity,
+            attention_id: item.id,
+            created_at: item.created_at,
+        })
+        .collect();
+    panel_cues.sort_by(|left, right| {
+        right
+            .priority_severity
+            .cmp(&left.priority_severity)
+            .then_with(|| right.created_at.cmp(&left.created_at))
+            .then_with(|| right.panel_id.0.cmp(&left.panel_id.0))
+    });
+    Some(WorkspaceAttentionCue {
+        display_severity,
+        open_count: open_items.len(),
+        attention_id: target_item.id,
+        target,
+        panel_cues,
+    })
+}
+
+fn attention_priority(left: &AttentionItem, right: &AttentionItem) -> Ordering {
+    left.severity
+        .cmp(&right.severity)
+        .then_with(|| left.created_at.cmp(&right.created_at))
+        .then_with(|| left.id.0.cmp(&right.id.0))
+}

--- a/crates/horizon-ui/src/app/minimap/spotlight/layout.rs
+++ b/crates/horizon-ui/src/app/minimap/spotlight/layout.rs
@@ -1,0 +1,306 @@
+use std::collections::HashMap;
+
+use egui::{Pos2, Rect, Vec2};
+use horizon_core::{AttentionId, AttentionSeverity, PanelId, WorkspaceId};
+
+use super::{
+    ACCESSIBLE_TARGET_SIZE, MAX_PANEL_MARKERS, PANEL_MARKER_MIN_HEIGHT, PANEL_MARKER_MIN_WIDTH, PANEL_MARKER_RADIUS,
+    aggregation::{MinimapSpotlight, PanelAttentionCue},
+};
+use crate::app::minimap::{
+    HorizonApp, MinimapPaintGeometry, MinimapScope, minimap_point, scope_includes_workspace, workspace_minimap_rect,
+};
+
+pub(in crate::app::minimap) struct MinimapCueLayout {
+    pub(super) map_rect: Rect,
+    pub(super) active_tabs: HashMap<WorkspaceId, ActiveTab>,
+    pub(super) workspace_badges: HashMap<WorkspaceId, Rect>,
+    pub(super) panel_markers: Vec<PanelMarkerLayout>,
+    exclusions: Vec<Rect>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct PanelMarkerLayout {
+    pub(super) workspace_id: WorkspaceId,
+    pub(super) panel_id: PanelId,
+    pub(super) attention_id: AttentionId,
+    pub(super) severity: AttentionSeverity,
+    pub(super) visual_rect: Rect,
+    pub(super) hit_rect: Rect,
+}
+
+impl MinimapCueLayout {
+    pub(in crate::app::minimap) fn collect_active_tabs(app: &HorizonApp, geometry: &MinimapPaintGeometry<'_>) -> Self {
+        let map_rect = Rect::from_min_size(geometry.rect.min, geometry.model.outer_size);
+        let mut active_tabs = HashMap::new();
+        let mut exclusions = Vec::new();
+        for workspace in &app.board.workspaces {
+            if !scope_includes_workspace(app, geometry.scope, workspace.id) {
+                continue;
+            }
+            let is_active = app.board.active_workspace == Some(workspace.id)
+                || geometry.scope == MinimapScope::Workspace(workspace.id);
+            let workspace_rect = workspace_minimap_rect(
+                workspace.id,
+                workspace.position,
+                geometry.rect.min,
+                geometry.model,
+                geometry.workspace_bounds,
+            );
+            if is_active && let Some(tab) = active_tab_layout(workspace_rect, map_rect) {
+                exclusions.push(tab.rect.expand(1.0).intersect(map_rect));
+                active_tabs.insert(workspace.id, tab);
+            }
+        }
+        Self {
+            map_rect,
+            active_tabs,
+            workspace_badges: HashMap::new(),
+            panel_markers: Vec::new(),
+            exclusions,
+        }
+    }
+
+    pub(in crate::app::minimap) fn exclusions(&self) -> &[Rect] {
+        &self.exclusions
+    }
+
+    pub(in crate::app::minimap) fn place_attention(
+        &mut self,
+        app: &HorizonApp,
+        geometry: &MinimapPaintGeometry<'_>,
+        spotlight: &MinimapSpotlight,
+        label_rects: &[Rect],
+    ) {
+        self.exclusions.extend_from_slice(label_rects);
+
+        let mut workspace_ids: Vec<_> = app
+            .board
+            .workspaces
+            .iter()
+            .filter(|workspace| {
+                scope_includes_workspace(app, geometry.scope, workspace.id)
+                    && spotlight.workspaces.contains_key(&workspace.id)
+            })
+            .map(|workspace| workspace.id)
+            .collect();
+        workspace_ids.sort_by_key(|workspace_id| app.board.active_workspace != Some(*workspace_id));
+
+        for workspace_id in workspace_ids {
+            let Some(workspace) = app.board.workspace(workspace_id) else {
+                continue;
+            };
+            let Some(cue) = spotlight.workspaces.get(&workspace_id) else {
+                continue;
+            };
+            let workspace_rect = workspace_minimap_rect(
+                workspace.id,
+                workspace.position,
+                geometry.rect.min,
+                geometry.model,
+                geometry.workspace_bounds,
+            );
+            let badge = workspace_badge_rect(workspace_rect, self.map_rect, cue.open_count, &self.exclusions);
+            self.exclusions.push(accessible_hit_rect(badge, self.map_rect));
+            self.workspace_badges.insert(workspace_id, badge);
+        }
+
+        for workspace in &app.board.workspaces {
+            if !scope_includes_workspace(app, geometry.scope, workspace.id) {
+                continue;
+            }
+            let Some(cue) = spotlight.workspaces.get(&workspace.id) else {
+                continue;
+            };
+            let markers = panel_marker_layouts(
+                &cue.panel_cues,
+                |panel_id| panel_minimap_rect(app, geometry, workspace.id, panel_id),
+                self.map_rect,
+                &self.exclusions,
+            );
+            for (panel_cue, visual_rect) in markers {
+                let hit_rect = accessible_hit_rect(visual_rect, self.map_rect);
+                self.exclusions.push(hit_rect);
+                self.panel_markers.push(PanelMarkerLayout {
+                    workspace_id: workspace.id,
+                    panel_id: panel_cue.panel_id,
+                    attention_id: panel_cue.attention_id,
+                    severity: panel_cue.display_severity,
+                    visual_rect,
+                    hit_rect,
+                });
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct ActiveTab {
+    pub(super) rect: Rect,
+    pub(super) label: &'static str,
+}
+
+pub(super) fn active_tab_layout(workspace_rect: Rect, map_rect: Rect) -> Option<ActiveTab> {
+    let (label, width): (&str, f32) = if workspace_rect.width() >= 44.0 {
+        ("ACTIVE", 42.0)
+    } else if workspace_rect.width() >= 28.0 {
+        ("ACT", 26.0)
+    } else if workspace_rect.width() >= 17.0 {
+        ("A", 16.0)
+    } else {
+        return None;
+    };
+    let desired = Rect::from_min_size(
+        Pos2::new(workspace_rect.max.x - width - 2.0, workspace_rect.max.y - 6.0),
+        Vec2::new(width.min(workspace_rect.width()), 12.0),
+    );
+
+    Some(ActiveTab {
+        rect: clamp_rect(desired, map_rect),
+        label,
+    })
+}
+
+fn panel_minimap_rect(
+    app: &HorizonApp,
+    geometry: &MinimapPaintGeometry<'_>,
+    workspace_id: WorkspaceId,
+    panel_id: PanelId,
+) -> Option<Rect> {
+    app.board
+        .panel(panel_id)
+        .filter(|panel| panel.workspace_id == workspace_id)
+        .map(|panel| {
+            Rect::from_min_max(
+                geometry.rect.min
+                    + minimap_point(geometry.model, panel.layout.position[0], panel.layout.position[1]).to_vec2(),
+                geometry.rect.min
+                    + minimap_point(
+                        geometry.model,
+                        panel.layout.position[0] + panel.layout.size[0],
+                        panel.layout.position[1] + panel.layout.size[1],
+                    )
+                    .to_vec2(),
+            )
+        })
+}
+
+pub(super) fn panel_marker_rect(panel_rect: Rect, map_rect: Rect, reserved: &[Rect]) -> Option<Rect> {
+    if panel_rect.width() < PANEL_MARKER_MIN_WIDTH || panel_rect.height() < PANEL_MARKER_MIN_HEIGHT {
+        return None;
+    }
+
+    let centers = [
+        Pos2::new(panel_rect.max.x - 3.0, panel_rect.min.y + 3.0),
+        Pos2::new(panel_rect.max.x - 3.0, panel_rect.max.y - 3.0),
+        Pos2::new(panel_rect.min.x + 3.0, panel_rect.max.y - 3.0),
+        Pos2::new(panel_rect.min.x + 3.0, panel_rect.min.y + 3.0),
+    ];
+    centers.into_iter().find_map(|center| {
+        let marker = clamp_rect(
+            Rect::from_center_size(center, Vec2::splat(PANEL_MARKER_RADIUS * 2.0)),
+            map_rect,
+        );
+        let hit_rect = accessible_hit_rect(marker, map_rect);
+        reserved
+            .iter()
+            .all(|reserved_rect| !reserved_rect.intersects(hit_rect))
+            .then_some(marker)
+    })
+}
+
+pub(super) fn panel_marker_layouts<'a>(
+    cues: &'a [PanelAttentionCue],
+    mut panel_rect: impl FnMut(PanelId) -> Option<Rect>,
+    map_rect: Rect,
+    reserved: &[Rect],
+) -> Vec<(&'a PanelAttentionCue, Rect)> {
+    let mut occupied = reserved.to_vec();
+    let mut markers = Vec::with_capacity(MAX_PANEL_MARKERS);
+    for cue in cues {
+        if markers.len() == MAX_PANEL_MARKERS {
+            break;
+        }
+        let Some(marker_rect) = panel_rect(cue.panel_id).and_then(|rect| panel_marker_rect(rect, map_rect, &occupied))
+        else {
+            continue;
+        };
+        occupied.push(accessible_hit_rect(marker_rect, map_rect));
+        markers.push((cue, marker_rect));
+    }
+    markers
+}
+
+pub(super) fn workspace_badge_rect(workspace_rect: Rect, map_rect: Rect, open_count: usize, reserved: &[Rect]) -> Rect {
+    let width = if open_count == 0 {
+        18.0
+    } else if open_count > 9 {
+        30.0
+    } else {
+        24.0
+    };
+    let size = Vec2::new(width, 15.0);
+    let positions = [
+        Pos2::new(workspace_rect.max.x - width + 4.0, workspace_rect.min.y - 7.0),
+        Pos2::new(workspace_rect.min.x - 4.0, workspace_rect.min.y - 7.0),
+        Pos2::new(workspace_rect.max.x + 3.0, workspace_rect.center().y - size.y * 0.5),
+        Pos2::new(
+            workspace_rect.min.x - width - 3.0,
+            workspace_rect.center().y - size.y * 0.5,
+        ),
+        Pos2::new(workspace_rect.max.x - width + 4.0, workspace_rect.max.y - 8.0),
+        Pos2::new(workspace_rect.min.x - 4.0, workspace_rect.max.y - 8.0),
+        Pos2::new(workspace_rect.center().x - width * 0.5, workspace_rect.min.y - 18.0),
+        Pos2::new(workspace_rect.center().x - width * 0.5, workspace_rect.max.y + 3.0),
+    ];
+    let candidates = positions.map(|position| clamp_rect(Rect::from_min_size(position, size), map_rect));
+    candidates
+        .iter()
+        .copied()
+        .find(|candidate| {
+            let hit_rect = accessible_hit_rect(*candidate, map_rect);
+            reserved.iter().all(|occupied| !occupied.intersects(hit_rect))
+        })
+        .unwrap_or_else(|| {
+            candidates
+                .into_iter()
+                .min_by(|left, right| {
+                    overlap_area(accessible_hit_rect(*left, map_rect), reserved)
+                        .total_cmp(&overlap_area(accessible_hit_rect(*right, map_rect), reserved))
+                })
+                .unwrap_or_else(|| Rect::from_min_size(map_rect.min, size))
+        })
+}
+
+pub(super) fn accessible_hit_rect(visual_rect: Rect, map_rect: Rect) -> Rect {
+    clamp_rect(
+        Rect::from_center_size(
+            visual_rect.center(),
+            Vec2::new(
+                visual_rect.width().max(ACCESSIBLE_TARGET_SIZE),
+                visual_rect.height().max(ACCESSIBLE_TARGET_SIZE),
+            ),
+        ),
+        map_rect,
+    )
+}
+
+fn overlap_area(rect: Rect, occupied: &[Rect]) -> f32 {
+    occupied
+        .iter()
+        .map(|occupied_rect| {
+            let overlap = rect.intersect(*occupied_rect);
+            overlap.width().max(0.0) * overlap.height().max(0.0)
+        })
+        .sum()
+}
+
+fn clamp_rect(rect: Rect, bounds: Rect) -> Rect {
+    let max_x = (bounds.max.x - rect.width()).max(bounds.min.x);
+    let max_y = (bounds.max.y - rect.height()).max(bounds.min.y);
+    let min = Pos2::new(
+        rect.min.x.clamp(bounds.min.x, max_x),
+        rect.min.y.clamp(bounds.min.y, max_y),
+    );
+    Rect::from_min_size(min, rect.size())
+}

--- a/crates/horizon-ui/src/app/minimap/spotlight/tests.rs
+++ b/crates/horizon-ui/src/app/minimap/spotlight/tests.rs
@@ -1,0 +1,488 @@
+use std::time::{Duration, SystemTime};
+
+use egui::{Pos2, Rect, Vec2};
+use horizon_core::{AttentionId, AttentionItem, AttentionSeverity, AttentionState, PanelId, WorkspaceId};
+
+use super::super::{MinimapScope, scope_includes_workspace_state};
+use super::{
+    ACCESSIBLE_TARGET_SIZE, MinimapNavigationTarget,
+    aggregation::{aggregate_attention, project_attention},
+    layout::{accessible_hit_rect, active_tab_layout, panel_marker_layouts, panel_marker_rect, workspace_badge_rect},
+    workspace_badge_text,
+};
+
+fn attention_item(
+    id: u64,
+    workspace_id: WorkspaceId,
+    panel_id: Option<PanelId>,
+    severity: AttentionSeverity,
+    state: AttentionState,
+    created_at: SystemTime,
+    resolved_at: Option<SystemTime>,
+) -> AttentionItem {
+    let mut item = AttentionItem::new(
+        AttentionId(id),
+        workspace_id,
+        panel_id,
+        "test",
+        format!("item-{id}"),
+        severity,
+    );
+    item.state = state;
+    item.created_at = created_at;
+    item.resolved_at = resolved_at;
+    item
+}
+
+#[test]
+fn aggregation_matches_attention_feed_visibility() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+    let workspace_id = WorkspaceId(1);
+    let attention = [
+        attention_item(
+            1,
+            workspace_id,
+            None,
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now - Duration::from_secs(90),
+            None,
+        ),
+        attention_item(
+            2,
+            workspace_id,
+            None,
+            AttentionSeverity::High,
+            AttentionState::Resolved,
+            now - Duration::from_secs(10),
+            Some(now - Duration::from_secs(29)),
+        ),
+        attention_item(
+            3,
+            WorkspaceId(2),
+            None,
+            AttentionSeverity::High,
+            AttentionState::Resolved,
+            now - Duration::from_secs(10),
+            Some(now - Duration::from_secs(30)),
+        ),
+        attention_item(
+            4,
+            WorkspaceId(3),
+            None,
+            AttentionSeverity::High,
+            AttentionState::Dismissed,
+            now,
+            Some(now),
+        ),
+    ];
+
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+
+    assert_eq!(spotlight.workspaces.len(), 1);
+    assert!(spotlight.workspaces.contains_key(&workspace_id));
+}
+
+#[test]
+fn open_attention_takes_precedence_over_recently_resolved_attention() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(200);
+    let workspace_id = WorkspaceId(1);
+    let attention = [
+        attention_item(
+            1,
+            workspace_id,
+            Some(PanelId(1)),
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now - Duration::from_secs(20),
+            None,
+        ),
+        attention_item(
+            2,
+            workspace_id,
+            Some(PanelId(2)),
+            AttentionSeverity::High,
+            AttentionState::Resolved,
+            now - Duration::from_secs(5),
+            Some(now - Duration::from_secs(2)),
+        ),
+    ];
+
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+
+    assert_eq!(cue.display_severity, AttentionSeverity::Low);
+    assert_eq!(cue.open_count, 1);
+    assert_eq!(cue.panel_cues.len(), 1);
+    assert_eq!(cue.panel_cues[0].panel_id, PanelId(1));
+}
+
+#[test]
+fn aggregation_uses_highest_severity_and_counts_all_open_items() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
+    let workspace_id = WorkspaceId(1);
+    let mut attention = Vec::new();
+    for id in 1_u64..=10 {
+        attention.push(attention_item(
+            id,
+            workspace_id,
+            Some(PanelId(id)),
+            if id == 10 {
+                AttentionSeverity::High
+            } else {
+                AttentionSeverity::Low
+            },
+            AttentionState::Open,
+            now - Duration::from_secs(10 - id),
+            None,
+        ));
+    }
+
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+
+    assert_eq!(cue.display_severity, AttentionSeverity::High);
+    assert_eq!(cue.open_count, 10);
+    assert_eq!(workspace_badge_text(cue), "!9+");
+    assert_eq!(cue.panel_cues.len(), 10);
+}
+
+#[test]
+fn workspace_only_attention_targets_workspace_without_panel_marker() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(400);
+    let workspace_id = WorkspaceId(7);
+    let attention = [attention_item(
+        1,
+        workspace_id,
+        None,
+        AttentionSeverity::High,
+        AttentionState::Open,
+        now,
+        None,
+    )];
+
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+
+    assert_eq!(cue.target, MinimapNavigationTarget::Workspace(workspace_id));
+    assert!(cue.panel_cues.is_empty());
+}
+
+#[test]
+fn click_target_prefers_severity_before_recency_and_recency_breaks_ties() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(500);
+    let workspace_id = WorkspaceId(1);
+    let attention = [
+        attention_item(
+            1,
+            workspace_id,
+            Some(PanelId(1)),
+            AttentionSeverity::High,
+            AttentionState::Open,
+            now - Duration::from_secs(20),
+            None,
+        ),
+        attention_item(
+            2,
+            workspace_id,
+            Some(PanelId(2)),
+            AttentionSeverity::Medium,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            3,
+            workspace_id,
+            Some(PanelId(3)),
+            AttentionSeverity::High,
+            AttentionState::Open,
+            now - Duration::from_secs(10),
+            None,
+        ),
+    ];
+
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+
+    assert_eq!(
+        cue.target,
+        MinimapNavigationTarget::Panel {
+            workspace_id,
+            panel_id: PanelId(3),
+        }
+    );
+}
+
+#[test]
+fn recent_resolved_attention_becomes_completed_cue() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(600);
+    let workspace_id = WorkspaceId(1);
+    let attention = [attention_item(
+        1,
+        workspace_id,
+        Some(PanelId(4)),
+        AttentionSeverity::High,
+        AttentionState::Resolved,
+        now - Duration::from_secs(5),
+        Some(now - Duration::from_secs(1)),
+    )];
+
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+
+    assert_eq!(cue.display_severity, AttentionSeverity::Medium);
+    assert_eq!(cue.open_count, 0);
+    assert_eq!(workspace_badge_text(cue), "✓");
+}
+
+#[test]
+fn detached_scope_projects_attention_through_real_minimap_scope_rules() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(700);
+    let detached_workspace = WorkspaceId(2);
+    let attention = [
+        attention_item(
+            1,
+            WorkspaceId(1),
+            None,
+            AttentionSeverity::High,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            2,
+            detached_workspace,
+            None,
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+    ];
+
+    let attached_spotlight = aggregate_attention(&attention, now, |workspace_id| {
+        scope_includes_workspace_state(MinimapScope::Attached, workspace_id, workspace_id == detached_workspace)
+    });
+    let detached_spotlight = aggregate_attention(&attention, now, |workspace_id| {
+        scope_includes_workspace_state(
+            MinimapScope::Workspace(detached_workspace),
+            workspace_id,
+            workspace_id == detached_workspace,
+        )
+    });
+
+    assert_eq!(attached_spotlight.workspaces.len(), 1);
+    assert!(attached_spotlight.workspaces.contains_key(&WorkspaceId(1)));
+    assert!(!attached_spotlight.workspaces.contains_key(&detached_workspace));
+    assert_eq!(detached_spotlight.workspaces.len(), 1);
+    assert!(detached_spotlight.workspaces.contains_key(&detached_workspace));
+}
+
+#[test]
+fn disabled_attention_feature_produces_no_minimap_cues() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(725);
+    let attention = [attention_item(
+        1,
+        WorkspaceId(1),
+        None,
+        AttentionSeverity::High,
+        AttentionState::Open,
+        now,
+        None,
+    )];
+
+    let spotlight = project_attention(&attention, now, false, |_| true);
+
+    assert!(spotlight.workspaces.is_empty());
+}
+
+#[test]
+fn marker_requires_large_geometry_and_hit_target_remains_accessible() {
+    let map_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(120.0, 120.0));
+    let tiny_panel = Rect::from_min_size(Pos2::new(10.0, 10.0), Vec2::new(17.0, 15.0));
+    let large_panel = Rect::from_min_size(Pos2::new(20.0, 20.0), Vec2::new(40.0, 30.0));
+
+    assert!(panel_marker_rect(tiny_panel, map_rect, &[]).is_none());
+    let marker = panel_marker_rect(large_panel, map_rect, &[]).expect("marker");
+    let hit = accessible_hit_rect(marker, map_rect);
+    assert!(hit.width() >= ACCESSIBLE_TARGET_SIZE);
+    assert!(hit.height() >= ACCESSIBLE_TARGET_SIZE);
+}
+
+#[test]
+fn marker_layout_skips_tiny_panels_before_limiting_to_two() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(750);
+    let workspace_id = WorkspaceId(1);
+    let attention = [
+        attention_item(
+            1,
+            workspace_id,
+            Some(PanelId(1)),
+            AttentionSeverity::High,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            2,
+            workspace_id,
+            Some(PanelId(2)),
+            AttentionSeverity::Medium,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            3,
+            workspace_id,
+            Some(PanelId(3)),
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            4,
+            workspace_id,
+            Some(PanelId(4)),
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now - Duration::from_secs(1),
+            None,
+        ),
+    ];
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+    let map_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(120.0, 120.0));
+
+    let markers = panel_marker_layouts(
+        &cue.panel_cues,
+        |panel_id| {
+            Some(if panel_id == PanelId(1) {
+                Rect::from_min_size(Pos2::new(5.0, 5.0), Vec2::new(10.0, 10.0))
+            } else {
+                let x = match panel_id.0 {
+                    2 => 20.0,
+                    3 => 60.0,
+                    _ => 90.0,
+                };
+                Rect::from_min_size(Pos2::new(x, 20.0), Vec2::new(20.0, 20.0))
+            })
+        },
+        map_rect,
+        &[],
+    );
+
+    let panel_ids: Vec<_> = markers.iter().map(|(cue, _)| cue.panel_id).collect();
+    assert_eq!(panel_ids, vec![PanelId(2), PanelId(3)]);
+}
+
+#[test]
+fn marker_layout_avoids_badge_and_other_accessible_hit_targets() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(760);
+    let workspace_id = WorkspaceId(1);
+    let attention = [
+        attention_item(
+            1,
+            workspace_id,
+            Some(PanelId(1)),
+            AttentionSeverity::High,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            2,
+            workspace_id,
+            Some(PanelId(2)),
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+        attention_item(
+            3,
+            workspace_id,
+            Some(PanelId(3)),
+            AttentionSeverity::Low,
+            AttentionState::Open,
+            now,
+            None,
+        ),
+    ];
+    let spotlight = aggregate_attention(&attention, now, |_| true);
+    let cue = spotlight.workspaces.get(&workspace_id).expect("workspace cue");
+    let map_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(160.0, 120.0));
+    let panel_rect = Rect::from_min_size(Pos2::new(50.0, 20.0), Vec2::new(70.0, 70.0));
+    let top_right_marker = panel_marker_rect(panel_rect, map_rect, &[]).expect("top-right marker");
+    let badge_hit = accessible_hit_rect(top_right_marker, map_rect);
+
+    let markers = panel_marker_layouts(&cue.panel_cues, |_| Some(panel_rect), map_rect, &[badge_hit]);
+
+    assert_eq!(markers.len(), 2);
+    let marker_hits: Vec<_> = markers
+        .iter()
+        .map(|(_, marker)| accessible_hit_rect(*marker, map_rect))
+        .collect();
+    assert!(marker_hits.iter().all(|hit| !hit.intersects(badge_hit)));
+    assert!(!marker_hits[0].intersects(marker_hits[1]));
+}
+
+#[test]
+fn active_tab_adapts_and_clamps_to_map_bounds() {
+    let map_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(120.0, 120.0));
+    let full = active_tab_layout(
+        Rect::from_min_size(Pos2::new(92.0, 104.0), Vec2::new(48.0, 20.0)),
+        map_rect,
+    )
+    .expect("full tab");
+    let compact = active_tab_layout(
+        Rect::from_min_size(Pos2::new(100.0, 100.0), Vec2::new(20.0, 20.0)),
+        map_rect,
+    )
+    .expect("compact tab");
+
+    assert_eq!(full.label, "ACTIVE");
+    assert_eq!(compact.label, "A");
+    assert!(full.rect.min.x >= map_rect.min.x && full.rect.max.x <= map_rect.max.x);
+    assert!(full.rect.min.y >= map_rect.min.y && full.rect.max.y <= map_rect.max.y);
+    assert!(active_tab_layout(Rect::from_min_size(Pos2::ZERO, Vec2::new(12.0, 20.0)), map_rect).is_none());
+}
+
+#[test]
+fn workspace_badge_clamps_at_top_right_edge() {
+    let map_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(120.0, 120.0));
+    let workspace_rect = Rect::from_min_size(Pos2::new(110.0, -4.0), Vec2::new(20.0, 20.0));
+
+    let badge = workspace_badge_rect(workspace_rect, map_rect, 12, &[]);
+
+    assert!(badge.min.x >= map_rect.min.x && badge.max.x <= map_rect.max.x);
+    assert!(badge.min.y >= map_rect.min.y && badge.max.y <= map_rect.max.y);
+}
+
+#[test]
+fn compressed_workspace_badges_reserve_global_hit_targets_and_active_tab() {
+    let map_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(120.0, 120.0));
+    let workspace_rects = [
+        Rect::from_min_size(Pos2::new(8.0, 8.0), Vec2::new(30.0, 18.0)),
+        Rect::from_min_size(Pos2::new(45.0, 8.0), Vec2::new(30.0, 18.0)),
+        Rect::from_min_size(Pos2::new(8.0, 45.0), Vec2::new(30.0, 18.0)),
+        Rect::from_min_size(Pos2::new(45.0, 45.0), Vec2::new(30.0, 18.0)),
+    ];
+    let active_tab = active_tab_layout(workspace_rects[0], map_rect).expect("active tab");
+    let tab_exclusion = active_tab.rect.expand(1.0).intersect(map_rect);
+    let mut occupied = vec![tab_exclusion];
+    let mut badge_hits = Vec::new();
+
+    for workspace_rect in workspace_rects {
+        let badge = workspace_badge_rect(workspace_rect, map_rect, 1, &occupied);
+        let hit_rect = accessible_hit_rect(badge, map_rect);
+        assert!(occupied.iter().all(|reserved| !reserved.intersects(hit_rect)));
+        occupied.push(hit_rect);
+        badge_hits.push(hit_rect);
+    }
+
+    assert_eq!(badge_hits.len(), 4);
+    assert!(badge_hits.iter().all(|hit| !hit.intersects(tab_exclusion)));
+}

--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -141,7 +141,23 @@ impl HorizonApp {
     pub(super) fn focus_panel_visible(&mut self, ctx: &Context, panel_id: PanelId, left_align: bool) {
         self.board.focus(panel_id);
         if let Some((pos, size)) = self.panel_focus_frame(panel_id) {
-            self.pan_to_canvas_pos_aligned(ctx, pos, size, left_align);
+            self.pan_target = Some(aligned_pan_offset(
+                self.canvas_rect(ctx),
+                pos,
+                size,
+                self.canvas_view.zoom,
+                left_align,
+            ));
+        }
+    }
+
+    pub(super) fn focus_panel_in_rect(&mut self, panel_id: PanelId, canvas_rect: Rect) {
+        self.board.focus(panel_id);
+        if let Some((pos, size)) = self.panel_focus_frame(panel_id) {
+            let pan_offset = aligned_pan_offset(canvas_rect, pos, size, self.canvas_view.zoom, false);
+            self.pan_target = None;
+            self.canvas_view.set_pan_offset([pan_offset.x, pan_offset.y]);
+            self.mark_runtime_dirty();
         }
     }
 
@@ -169,7 +185,13 @@ impl HorizonApp {
         };
 
         self.board.focus_workspace(workspace_id);
-        self.pan_to_canvas_pos_aligned(ctx, pos, size, left_align);
+        self.pan_target = Some(aligned_pan_offset(
+            self.canvas_rect(ctx),
+            pos,
+            size,
+            self.canvas_view.zoom,
+            left_align,
+        ));
         true
     }
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -35,6 +35,9 @@ back into large multi-purpose modules.
     dispatch, picker flows, and canvas interaction helpers
   - `canvas`: canvas rendering and HUD
   - `lifecycle`: frame orchestration, shutdown flow, and repaint pacing
+  - `minimap`: minimap scope/model orchestration, viewport painting, and
+    panning dispatch, with label layout and workspace spotlight
+    aggregation/painting/hit-testing split into `minimap/` leaf modules
   - `panel_chrome`: panel titlebar chrome, badges, context menus, and rename UI
   - `panels`: panel-area orchestration and body rendering
   - `remote_hosts_overlay`: overlay state/input shell with query/filter,

--- a/docs/design/2026-07-19-minimap-workspace-attention-concepts.html
+++ b/docs/design/2026-07-19-minimap-workspace-attention-concepts.html
@@ -1,0 +1,1095 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>Horizon minimap workspace and attention concepts</title>
+  <style>
+    :root {
+      --bg: #070a10;
+      --bg-elevated: #0c1018;
+      --panel: #0f131c;
+      --panel-alt: #151a25;
+      --fg: #e0e6f1;
+      --fg-soft: #aab5c7;
+      --fg-dim: #6c788e;
+      --accent: #74a2f7;
+      --border: #252e3d;
+      --border-strong: #3f4e65;
+      --green: #a6e3a1;
+      --red: #f38ba8;
+      --yellow: #e9be6d;
+      --cyan: #66d4d6;
+      --shadow: rgba(0, 0, 0, 0.38);
+      --radius: 18px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      min-width: 320px;
+      margin: 0;
+      background:
+        radial-gradient(circle at 12% -8%, rgba(116, 162, 247, 0.13), transparent 32rem),
+        radial-gradient(circle at 92% 12%, rgba(255, 146, 80, 0.08), transparent 28rem),
+        var(--bg);
+    }
+
+    button,
+    input {
+      font: inherit;
+    }
+
+    .page-shell {
+      width: min(1480px, calc(100% - 40px));
+      margin: 0 auto;
+      padding: 54px 0 72px;
+    }
+
+    .eyebrow {
+      margin: 0 0 12px;
+      color: var(--cyan);
+      font-size: 11px;
+      font-weight: 760;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 920px;
+      margin: 0;
+      font-size: clamp(34px, 5vw, 66px);
+      font-weight: 660;
+      letter-spacing: -0.045em;
+      line-height: 0.98;
+    }
+
+    .intro {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+      gap: 34px;
+      align-items: end;
+      margin-top: 24px;
+    }
+
+    .intro-copy {
+      max-width: 810px;
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 16px;
+      line-height: 1.7;
+    }
+
+    .signal-note {
+      border: 1px solid rgba(102, 212, 214, 0.19);
+      border-radius: 14px;
+      padding: 16px 18px;
+      background: rgba(102, 212, 214, 0.055);
+      color: var(--fg-soft);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.6;
+    }
+
+    .signal-note strong {
+      color: var(--fg);
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      font-weight: 650;
+    }
+
+    .recommendation {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      margin: 34px 0 24px;
+      border: 1px solid rgba(116, 162, 247, 0.24);
+      border-radius: 16px;
+      padding: 15px 18px;
+      background: linear-gradient(100deg, rgba(116, 162, 247, 0.12), rgba(116, 162, 247, 0.035));
+      color: var(--fg-soft);
+      font-size: 13px;
+      line-height: 1.55;
+    }
+
+    .recommendation .pick {
+      flex: 0 0 auto;
+      border-radius: 999px;
+      padding: 7px 10px;
+      background: var(--accent);
+      color: #07101f;
+      font-size: 10px;
+      font-weight: 820;
+      letter-spacing: 0.09em;
+      text-transform: uppercase;
+    }
+
+    .demo-toolbar {
+      position: sticky;
+      top: 14px;
+      z-index: 20;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 26px;
+      border: 1px solid rgba(63, 78, 101, 0.8);
+      border-radius: 16px;
+      padding: 10px;
+      background: rgba(12, 16, 24, 0.88);
+      box-shadow: 0 14px 44px var(--shadow);
+      backdrop-filter: blur(18px);
+    }
+
+    .scenario-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .scenario-button {
+      min-height: 38px;
+      border: 1px solid transparent;
+      border-radius: 10px;
+      padding: 0 14px;
+      background: transparent;
+      color: var(--fg-soft);
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 650;
+    }
+
+    .scenario-button:hover {
+      background: rgba(116, 162, 247, 0.08);
+      color: var(--fg);
+    }
+
+    .scenario-button[aria-pressed="true"] {
+      border-color: rgba(116, 162, 247, 0.32);
+      background: rgba(116, 162, 247, 0.14);
+      color: #dbe8ff;
+      box-shadow: inset 0 0 0 1px rgba(116, 162, 247, 0.05);
+    }
+
+    .toolbar-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      padding-right: 4px;
+      color: var(--fg-dim);
+      font-size: 11px;
+    }
+
+    .concept-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+      align-items: start;
+    }
+
+    .concept-card {
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: linear-gradient(160deg, rgba(21, 26, 37, 0.82), rgba(12, 16, 24, 0.96));
+      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.24);
+    }
+
+    .concept-card.recommended {
+      border-color: rgba(116, 162, 247, 0.42);
+      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.24), 0 0 50px rgba(116, 162, 247, 0.055);
+    }
+
+    .card-header {
+      min-height: 194px;
+      padding: 23px 24px 18px;
+    }
+
+    .card-index-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 17px;
+      color: var(--fg-dim);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .card-tag {
+      border: 1px solid var(--border-strong);
+      border-radius: 999px;
+      padding: 5px 8px;
+      color: var(--fg-soft);
+      letter-spacing: 0.06em;
+    }
+
+    .recommended .card-tag {
+      border-color: rgba(116, 162, 247, 0.32);
+      background: rgba(116, 162, 247, 0.09);
+      color: #cfe0ff;
+    }
+
+    h2 {
+      margin: 0 0 9px;
+      font-size: 24px;
+      font-weight: 650;
+      letter-spacing: -0.025em;
+    }
+
+    .card-description {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 13px;
+      line-height: 1.62;
+    }
+
+    .preview-shell {
+      position: relative;
+      border-block: 1px solid var(--border);
+      padding: 14px;
+      background:
+        linear-gradient(rgba(255, 255, 255, 0.012), rgba(255, 255, 255, 0)),
+        #080b12;
+    }
+
+    .preview-label {
+      position: absolute;
+      top: 22px;
+      left: 24px;
+      z-index: 2;
+      color: rgba(170, 181, 199, 0.68);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 8px;
+      letter-spacing: 0.14em;
+      pointer-events: none;
+      text-transform: uppercase;
+    }
+
+    .minimap-preview {
+      display: block;
+      width: 100%;
+      height: auto;
+      aspect-ratio: 16 / 9;
+    }
+
+    .minimap-preview text {
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      user-select: none;
+    }
+
+    .minimap-preview .mono {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    .minimap-preview .workspace-shape,
+    .minimap-preview .panel-shape,
+    .minimap-preview .state-stroke,
+    .minimap-preview .viewport {
+      vector-effect: non-scaling-stroke;
+    }
+
+    .card-notes {
+      display: grid;
+      gap: 13px;
+      padding: 19px 24px 24px;
+    }
+
+    .note-row {
+      display: grid;
+      grid-template-columns: 78px minmax(0, 1fr);
+      gap: 12px;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .note-label {
+      color: var(--fg-dim);
+      font-size: 9px;
+      font-weight: 760;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .note-value {
+      color: var(--fg-soft);
+    }
+
+    .comparison {
+      margin-top: 32px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 28px;
+      background: rgba(12, 16, 24, 0.76);
+    }
+
+    .comparison h2 {
+      margin-bottom: 8px;
+    }
+
+    .comparison-intro {
+      max-width: 760px;
+      margin: 0 0 22px;
+      color: var(--fg-soft);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+
+    .decision-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }
+
+    .decision-cell {
+      min-height: 76px;
+      border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      padding: 14px;
+      color: var(--fg-soft);
+      font-size: 11px;
+      line-height: 1.45;
+    }
+
+    .decision-cell:nth-child(4n) {
+      border-right: 0;
+    }
+
+    .decision-cell:nth-last-child(-n + 4) {
+      border-bottom: 0;
+    }
+
+    .decision-cell.heading {
+      min-height: auto;
+      background: rgba(21, 26, 37, 0.78);
+      color: var(--fg);
+      font-size: 10px;
+      font-weight: 750;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .decision-cell.row-label {
+      color: var(--fg);
+      font-weight: 620;
+    }
+
+    .good {
+      color: var(--green);
+    }
+
+    .caution {
+      color: var(--yellow);
+    }
+
+    .implementation-note {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+      margin-top: 18px;
+    }
+
+    .principle {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 15px;
+      background: rgba(15, 19, 28, 0.6);
+    }
+
+    .principle strong {
+      display: block;
+      margin-bottom: 6px;
+      color: var(--fg);
+      font-size: 11px;
+    }
+
+    .principle span {
+      color: var(--fg-dim);
+      font-size: 11px;
+      line-height: 1.55;
+    }
+
+    .page-footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 20px;
+      margin-top: 24px;
+      padding: 0 4px;
+      color: var(--fg-dim);
+      font-size: 10px;
+      line-height: 1.5;
+    }
+
+    @media (max-width: 1120px) {
+      .concept-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .card-header {
+        min-height: auto;
+      }
+
+      .preview-shell {
+        padding: 18px;
+      }
+
+      .minimap-preview {
+        max-height: 540px;
+      }
+    }
+
+    @media (max-width: 760px) {
+      .page-shell {
+        width: min(100% - 22px, 1480px);
+        padding-top: 30px;
+      }
+
+      .intro,
+      .implementation-note {
+        grid-template-columns: 1fr;
+      }
+
+      .recommendation {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .demo-toolbar {
+        position: static;
+      }
+
+      .decision-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .decision-cell,
+      .decision-cell:nth-child(4n),
+      .decision-cell:nth-last-child(-n + 4) {
+        border-right: 0;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .decision-cell:last-child {
+        border-bottom: 0;
+      }
+
+      .decision-cell.heading:not(:first-child) {
+        display: none;
+      }
+
+      .page-footer {
+        flex-direction: column;
+      }
+    }
+
+  </style>
+</head>
+<body>
+  <main class="page-shell">
+    <p class="eyebrow">Horizon UI exploration · 19 July 2026</p>
+    <h1>Make the minimap answer “where should I look?”</h1>
+
+    <div class="recommendation">
+      <span class="pick">Temporary exploration</span>
+      <span>
+        This pre-implementation artifact is retained only for draft-PR context. Motion was evaluated and rejected:
+        the accepted workspace spotlight and attention cues are fully static, with no pulse or continuous repaint.
+      </span>
+    </div>
+
+    <section class="intro" aria-label="Design brief">
+      <p class="intro-copy">
+        The current minimap is good at preserving board geometry, but workspace identity colors, focus,
+        labels, panels, and the viewport all compete at the same tiny scale. These concepts separate the
+        two important questions: <strong>which workspace is active</strong>, and <strong>which workspace or
+        panel needs attention</strong>. Each preview uses the same simulated board and the same Horizon dark
+        theme tokens.
+      </p>
+      <div class="signal-note">
+        <strong>Already available in the model</strong><br>
+        board.active_workspace<br>
+        board.attention { workspace_id, panel_id,<br>
+        severity, state, summary, created_at }
+      </div>
+    </section>
+
+    <div class="recommendation">
+      <span class="pick">Start here</span>
+      <span>
+        Prototype <strong>Workspace spotlight</strong> first. It is the smallest change to the current map,
+        keeps spatial meaning intact, and uses outline + icon + count so state is not communicated by color alone.
+      </span>
+    </div>
+
+    <section class="demo-toolbar" aria-label="Preview controls">
+      <div class="scenario-group" role="group" aria-label="Attention scenario">
+        <button class="scenario-button" type="button" data-scenario="calm" aria-pressed="false">Focus only</button>
+        <button class="scenario-button" type="button" data-scenario="mixed" aria-pressed="true">Mixed signals</button>
+        <button class="scenario-button" type="button" data-scenario="busy" aria-pressed="false">Busy board</button>
+      </div>
+      <div class="toolbar-meta">
+        <span id="scenario-summary" aria-live="polite">1 active · 3 attention workspaces · 4 items</span>
+      </div>
+    </section>
+
+    <section class="concept-grid" aria-label="Three minimap concepts">
+      <article class="concept-card recommended">
+        <header class="card-header">
+          <div class="card-index-row">
+            <span>Concept 01</span>
+            <span class="card-tag">Recommended</span>
+          </div>
+          <h2>Workspace spotlight</h2>
+          <p class="card-description">
+            A neutral blue double ring marks the active workspace. Exact panels get shaped attention
+            beacons, while a count pill keeps the signal legible when the panel becomes too small.
+          </p>
+        </header>
+        <div class="preview-shell">
+          <span class="preview-label">2× design preview · target 320 × 180</span>
+          <div id="spotlight-preview" aria-live="polite"></div>
+        </div>
+        <div class="card-notes">
+          <div class="note-row"><span class="note-label">Active</span><span class="note-value">Double outline, brighter fill, and an <strong>ACTIVE</strong> tab.</span></div>
+          <div class="note-row"><span class="note-label">Attention</span><span class="note-value">Panel beacon plus workspace count. High = !, done = ✓, info = i.</span></div>
+          <div class="note-row"><span class="note-label">Best for</span><span class="note-value">A familiar default that adds strong state without changing minimap layout.</span></div>
+        </div>
+      </article>
+
+      <article class="concept-card">
+        <header class="card-header">
+          <div class="card-index-row">
+            <span>Concept 02</span>
+            <span class="card-tag">Dense scale</span>
+          </div>
+          <h2>Orthogonal edge rails</h2>
+          <p class="card-description">
+            Active and attention use different edges: a left-side focus rail and a top-side severity rail.
+            Their width stays constant even when a workspace collapses into a narrow sliver.
+          </p>
+        </header>
+        <div class="preview-shell">
+          <span class="preview-label">2× design preview · constant-pixel cues</span>
+          <div id="rails-preview" aria-live="polite"></div>
+        </div>
+        <div class="card-notes">
+          <div class="note-row"><span class="note-label">Active</span><span class="note-value">Blue left rail and corner brackets; independent of workspace accent.</span></div>
+          <div class="note-row"><span class="note-label">Attention</span><span class="note-value">Red, green, or cyan top rail with icon and count at its endpoint.</span></div>
+          <div class="note-row"><span class="note-label">Best for</span><span class="note-value">Very dense boards where fills, glows, and text disappear at minimap scale.</span></div>
+        </div>
+      </article>
+
+      <article class="concept-card">
+        <header class="card-header">
+          <div class="card-index-row">
+            <span>Concept 03</span>
+            <span class="card-tag">Attention-first</span>
+          </div>
+          <h2>Attention radar</h2>
+          <p class="card-description">
+            The spatial map stays quiet while numbered urgent beacons connect to a compact workspace rail.
+            It trades some canvas area for fast scanning and larger, more reliable click targets.
+          </p>
+        </header>
+        <div class="preview-shell">
+          <span class="preview-label">2× design preview · map + status rail</span>
+          <div id="radar-preview" aria-live="polite"></div>
+        </div>
+        <div class="card-notes">
+          <div class="note-row"><span class="note-label">Active</span><span class="note-value">Persistent target glyph and underline on the workspace chip.</span></div>
+          <div class="note-row"><span class="note-label">Attention</span><span class="note-value">Numbered urgent pins map to rail chips; completed work uses a check.</span></div>
+          <div class="note-row"><span class="note-label">Best for</span><span class="note-value">Agent-heavy boards where triage order matters more than maximum map area.</span></div>
+        </div>
+      </article>
+    </section>
+
+    <section class="comparison" aria-labelledby="comparison-title">
+      <h2 id="comparison-title">Decision guide</h2>
+      <p class="comparison-intro">
+        All three can be built from current board state. The main decision is how much of the minimap should
+        remain a pure spatial overview versus becoming an operational status surface.
+      </p>
+
+      <div class="decision-grid" role="table" aria-label="Concept comparison">
+        <div class="decision-cell heading" role="columnheader">Concept</div>
+        <div class="decision-cell heading" role="columnheader">Read at 320 × 180</div>
+        <div class="decision-cell heading" role="columnheader">Implementation</div>
+        <div class="decision-cell heading" role="columnheader">Main tradeoff</div>
+
+        <div class="decision-cell row-label" role="rowheader">Workspace spotlight</div>
+        <div class="decision-cell"><span class="good">Strong</span> unless many badges overlap</div>
+        <div class="decision-cell"><span class="good">Smallest change</span>; aggregate existing attention by workspace</div>
+        <div class="decision-cell">Tiny panel beacons still need adaptive collapse</div>
+
+        <div class="decision-cell row-label" role="rowheader">Edge rails</div>
+        <div class="decision-cell"><span class="good">Strongest at narrow widths</span></div>
+        <div class="decision-cell">Moderate; paint constant-pixel rails above fills</div>
+        <div class="decision-cell">Less expressive when many severities share one workspace</div>
+
+        <div class="decision-cell row-label" role="rowheader">Attention radar</div>
+        <div class="decision-cell"><span class="good">Strongest for triage</span></div>
+        <div class="decision-cell"><span class="caution">Largest change</span>; adds chip hit-testing and ordering</div>
+        <div class="decision-cell">Consumes map area and changes the interaction model</div>
+      </div>
+
+      <div class="implementation-note">
+        <div class="principle">
+          <strong>Use more than color</strong>
+          <span>Ring or rail for active; !, ✓, and i plus a count for severity. This remains readable with color-vision differences.</span>
+        </div>
+        <div class="principle">
+          <strong>Collapse adaptively</strong>
+          <span>Paint panel-level markers only above a size threshold. Otherwise show one workspace count outside the geometry.</span>
+        </div>
+        <div class="principle">
+          <strong>Stay static</strong>
+          <span>Attention cues do not pulse or animate. A normal UI event refreshes time-windowed state without adding a repaint loop.</span>
+        </div>
+      </div>
+    </section>
+
+    <footer class="page-footer">
+      <span>Self-contained design artifact — no external fonts, scripts, or assets.</span>
+      <span>Simulated state uses Horizon’s dark theme palette and current attention semantics.</span>
+    </footer>
+  </main>
+
+  <script>
+    const workspaces = [
+      {
+        id: "youpark",
+        name: "youpark.no",
+        short: "YP",
+        accent: "#a6e3a1",
+        x: 28, y: 91, w: 76, h: 190,
+        panels: [
+          { x: 0.12, y: 0.14, w: 0.30, h: 0.70 },
+          { x: 0.50, y: 0.10, w: 0.34, h: 0.82 }
+        ]
+      },
+      {
+        id: "billing",
+        name: "Billing",
+        short: "BL",
+        accent: "#e9be6d",
+        x: 117, y: 75, w: 82, h: 151,
+        panels: [
+          { x: 0.10, y: 0.18, w: 0.33, h: 0.66 },
+          { x: 0.51, y: 0.10, w: 0.38, h: 0.74 }
+        ]
+      },
+      {
+        id: "api",
+        name: "API v2",
+        short: "API",
+        accent: "#f38ba8",
+        x: 212, y: 94, w: 75, h: 172,
+        panels: [
+          { x: 0.10, y: 0.08, w: 0.35, h: 0.78 },
+          { x: 0.54, y: 0.18, w: 0.34, h: 0.69 }
+        ]
+      },
+      {
+        id: "ci",
+        name: "CI runners",
+        short: "CI",
+        accent: "#74a2f7",
+        x: 300, y: 72, w: 104, h: 181,
+        panels: [
+          { x: 0.08, y: 0.12, w: 0.24, h: 0.73 },
+          { x: 0.38, y: 0.08, w: 0.24, h: 0.82 },
+          { x: 0.68, y: 0.16, w: 0.24, h: 0.68 }
+        ]
+      },
+      {
+        id: "docs",
+        name: "Docs",
+        short: "DOC",
+        accent: "#ca97ea",
+        x: 417, y: 89, w: 85, h: 153,
+        panels: [
+          { x: 0.10, y: 0.13, w: 0.35, h: 0.74 },
+          { x: 0.54, y: 0.08, w: 0.35, h: 0.65 }
+        ]
+      },
+      {
+        id: "horizon",
+        name: "Horizon",
+        short: "HZ",
+        accent: "#66d4d6",
+        x: 515, y: 79, w: 98, h: 194,
+        panels: [
+          { x: 0.08, y: 0.09, w: 0.25, h: 0.75 },
+          { x: 0.38, y: 0.16, w: 0.25, h: 0.74 },
+          { x: 0.68, y: 0.07, w: 0.24, h: 0.82 }
+        ]
+      }
+    ];
+
+    const scenarios = {
+      calm: {
+        label: "Focus only",
+        summary: "1 active · no open attention",
+        recent: ["api"],
+        statuses: {}
+      },
+      mixed: {
+        label: "Mixed signals",
+        summary: "1 active · 3 attention workspaces · 4 items",
+        recent: ["horizon"],
+        statuses: {
+          billing: { severity: "high", count: 1, panels: [1], summary: "Needs input" },
+          api: { severity: "medium", count: 1, panels: [0], summary: "Done" },
+          docs: { severity: "high", count: 2, panels: [0, 1], summary: "Needs input" }
+        }
+      },
+      busy: {
+        label: "Busy board",
+        summary: "1 active · 6 attention workspaces · 11 items",
+        recent: [],
+        statuses: {
+          youpark: { severity: "low", count: 2, panels: [0], summary: "Info" },
+          billing: { severity: "high", count: 1, panels: [1], summary: "Needs input" },
+          api: { severity: "medium", count: 2, panels: [0, 1], summary: "Done" },
+          ci: { severity: "high", count: 1, panels: [1], summary: "Needs input" },
+          docs: { severity: "high", count: 3, panels: [0, 1], summary: "Needs input" },
+          horizon: { severity: "medium", count: 2, panels: [2], summary: "Done" }
+        }
+      }
+    };
+
+    const activeWorkspaceId = "ci";
+    const severity = {
+      high: { color: "#f38ba8", icon: "!", label: "needs input" },
+      medium: { color: "#a6e3a1", icon: "✓", label: "done" },
+      low: { color: "#74a2f7", icon: "i", label: "info" }
+    };
+
+    let selectedScenario = "mixed";
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+    }
+
+    function panelRect(workspace, panel) {
+      return {
+        x: workspace.x + workspace.w * panel.x,
+        y: workspace.y + workspace.h * panel.y,
+        w: workspace.w * panel.w,
+        h: workspace.h * panel.h
+      };
+    }
+
+    function svgDefinitions(id) {
+      return `
+        <defs>
+          <pattern id="grid-${id}" width="24" height="24" patternUnits="userSpaceOnUse">
+            <circle cx="2" cy="2" r="1.15" fill="#252e3d" fill-opacity="0.72" />
+          </pattern>
+          <filter id="blue-glow-${id}" x="-40%" y="-40%" width="180%" height="180%">
+            <feGaussianBlur stdDeviation="5" result="blur" />
+            <feFlood flood-color="#74a2f7" flood-opacity="0.36" />
+            <feComposite in2="blur" operator="in" />
+            <feMerge><feMergeNode /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+          <filter id="red-glow-${id}" x="-80%" y="-80%" width="260%" height="260%">
+            <feGaussianBlur stdDeviation="4" result="blur" />
+            <feFlood flood-color="#f38ba8" flood-opacity="0.32" />
+            <feComposite in2="blur" operator="in" />
+            <feMerge><feMergeNode /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+        </defs>`;
+    }
+
+    function svgFrame(id, title, description, content) {
+      return `
+        <svg class="minimap-preview" viewBox="0 0 640 360" role="img" aria-labelledby="${id}-title ${id}-description">
+          <title id="${id}-title">${escapeHtml(title)}</title>
+          <desc id="${id}-description">${escapeHtml(description)}</desc>
+          ${svgDefinitions(id)}
+          <rect x="10" y="34" width="620" height="310" rx="14" fill="#0c1018" fill-opacity="0.96" stroke="#252e3d" />
+          <rect x="18" y="42" width="604" height="294" rx="10" fill="url(#grid-${id})" />
+          <text x="616" y="24" text-anchor="end" fill="#6c788e" font-size="9" letter-spacing="1.3" class="mono">${escapeHtml(scenarios[selectedScenario].label.toUpperCase())}</text>
+          ${content}
+        </svg>`;
+    }
+
+    function basePanels(workspace, opacity, status, mode) {
+      return workspace.panels.map((panel, index) => {
+        const rect = panelRect(workspace, panel);
+        const affected = status && status.panels.includes(index);
+        const fillOpacity = affected ? Math.min(opacity + 0.22, 0.82) : opacity;
+        return `
+          <rect class="panel-shape" x="${rect.x.toFixed(1)}" y="${rect.y.toFixed(1)}"
+            width="${rect.w.toFixed(1)}" height="${rect.h.toFixed(1)}" rx="3"
+            fill="${workspace.accent}" fill-opacity="${fillOpacity}"
+            stroke="${workspace.accent}" stroke-opacity="${mode === "radar" ? 0.22 : 0.42}" stroke-width="0.8">
+            <title>${escapeHtml(workspace.name)} panel ${index + 1}${affected ? ` — ${escapeHtml(status.summary)}` : ""}</title>
+          </rect>`;
+      }).join("");
+    }
+
+    function marker(workspace, status, panelIndex, markerIndex, id, compact = false) {
+      const panel = panelRect(workspace, workspace.panels[panelIndex] ?? workspace.panels[0]);
+      const meta = severity[status.severity];
+      const cx = panel.x + panel.w - 1;
+      const cy = panel.y + 3;
+      const radius = compact ? 9 : 10;
+      const label = markerIndex ?? meta.icon;
+      return `
+        <g aria-label="${escapeHtml(workspace.name)}: ${escapeHtml(status.summary)}, ${status.count}">
+          <circle cx="${cx}" cy="${cy}" r="${radius}" fill="#0c1018" stroke="${meta.color}" stroke-width="2" ${status.severity === "high" ? `filter="url(#red-glow-${id})"` : ""} />
+          <text x="${cx}" y="${cy + 3.4}" text-anchor="middle" fill="${meta.color}" font-size="${compact ? 9 : 10}" font-weight="800">${escapeHtml(label)}</text>
+        </g>`;
+    }
+
+    function workspaceCountBadge(workspace, status, id) {
+      const meta = severity[status.severity];
+      const text = `${meta.icon}${status.count}`;
+      const width = status.count > 9 ? 31 : 26;
+      const x = workspace.x + workspace.w - width + 5;
+      const y = workspace.y - 14;
+      return `
+        <g aria-label="${escapeHtml(status.count)} ${escapeHtml(meta.label)} items in ${escapeHtml(workspace.name)}">
+          <rect x="${x}" y="${y}" width="${width}" height="16" rx="8" fill="#0c1018" stroke="${meta.color}" stroke-width="1.4" />
+          <text x="${x + width / 2}" y="${y + 11.3}" text-anchor="middle" fill="${meta.color}" font-size="8.5" font-weight="800" class="mono">${escapeHtml(text)}</text>
+        </g>`;
+    }
+
+    function renderSpotlight() {
+      const state = scenarios[selectedScenario];
+      const id = "spotlight";
+      const workspaceMarkup = workspaces.map((workspace) => {
+        const isActive = workspace.id === activeWorkspaceId;
+        const status = state.statuses[workspace.id];
+        const opacity = isActive ? 1 : (status ? 0.78 : 0.42);
+        const labelWidth = Math.min(workspace.w - 8, Math.max(26, workspace.short.length * 8 + 12));
+        const activeRing = isActive ? `
+          <rect x="${workspace.x - 5}" y="${workspace.y - 5}" width="${workspace.w + 10}" height="${workspace.h + 10}" rx="7"
+            fill="none" stroke="#74a2f7" stroke-opacity="0.25" stroke-width="7" filter="url(#blue-glow-${id})" />
+          <rect class="state-stroke" x="${workspace.x - 2}" y="${workspace.y - 2}" width="${workspace.w + 4}" height="${workspace.h + 4}" rx="5"
+            fill="none" stroke="#dbe8ff" stroke-width="2.2" />
+          <rect x="${workspace.x + 4}" y="${workspace.y - 19}" width="48" height="16" rx="8" fill="#74a2f7" />
+          <text x="${workspace.x + 28}" y="${workspace.y - 8}" text-anchor="middle" fill="#07101f" font-size="8" font-weight="850" letter-spacing="0.8">ACTIVE</text>` : "";
+
+        const statusMarkers = status
+          ? status.panels.slice(0, 2).map((panelIndex) => marker(workspace, status, panelIndex, null, id)).join("") + workspaceCountBadge(workspace, status, id)
+          : "";
+
+        return `
+          <g opacity="${opacity}">
+            ${activeRing}
+            <rect class="workspace-shape" x="${workspace.x}" y="${workspace.y}" width="${workspace.w}" height="${workspace.h}" rx="4"
+              fill="${workspace.accent}" fill-opacity="${isActive ? 0.18 : 0.10}" stroke="${workspace.accent}" stroke-opacity="${isActive ? 0.88 : 0.54}" stroke-width="1.1">
+              <title>${escapeHtml(workspace.name)}${isActive ? " — active workspace" : ""}</title>
+            </rect>
+            ${basePanels(workspace, isActive ? 0.38 : 0.22, status, "spotlight")}
+            <rect x="${workspace.x + 4}" y="${workspace.y + 5}" width="${labelWidth}" height="16" rx="5" fill="#0c1018" fill-opacity="0.88" stroke="${workspace.accent}" stroke-opacity="0.65" />
+            <text x="${workspace.x + 4 + labelWidth / 2}" y="${workspace.y + 16}" text-anchor="middle" fill="${isActive ? "#e0e6f1" : "#aab5c7"}" font-size="8.5" font-weight="720">${escapeHtml(workspace.short)}</text>
+            ${statusMarkers}
+          </g>`;
+      }).join("");
+
+      const viewport = `
+        <rect class="viewport" x="280" y="57" width="152" height="218" rx="5" fill="#e0e6f1" fill-opacity="0.025"
+          stroke="#e0e6f1" stroke-opacity="0.28" stroke-width="1" stroke-dasharray="4 4" />
+        <text x="428" y="287" text-anchor="end" fill="#6c788e" font-size="7" letter-spacing="0.8" class="mono">VIEWPORT</text>`;
+
+      document.getElementById("spotlight-preview").innerHTML = svgFrame(
+        id,
+        "Workspace spotlight minimap concept",
+        "The active CI runners workspace has a double outline. Attention markers identify exact panels and counts by workspace.",
+        `${workspaceMarkup}${viewport}`
+      );
+    }
+
+    function railStatusMarkup(workspace, status, id) {
+      if (!status) return "";
+      const meta = severity[status.severity];
+      const railStart = workspace.x + 5;
+      const railEnd = workspace.x + workspace.w - 5;
+      const badgeX = Math.max(workspace.x + 9, railEnd - 13);
+      return `
+        <line class="state-stroke" x1="${railStart}" y1="${workspace.y + 1}" x2="${railEnd}" y2="${workspace.y + 1}"
+          stroke="${meta.color}" stroke-width="5" stroke-linecap="round" />
+        <circle cx="${badgeX}" cy="${workspace.y + 1}" r="8" fill="#0c1018" stroke="${meta.color}" stroke-width="1.7" />
+        <text x="${badgeX}" y="${workspace.y + 4}" text-anchor="middle" fill="${meta.color}" font-size="8" font-weight="850">${escapeHtml(status.count > 1 ? status.count : meta.icon)}</text>`;
+    }
+
+    function activeBrackets(workspace) {
+      const x = workspace.x - 4;
+      const y = workspace.y - 4;
+      const right = workspace.x + workspace.w + 4;
+      const bottom = workspace.y + workspace.h + 4;
+      return `
+        <line class="state-stroke" x1="${x}" y1="${y + 18}" x2="${x}" y2="${bottom - 18}" stroke="#74a2f7" stroke-width="4" stroke-linecap="round" />
+        <path class="state-stroke" d="M ${x} ${y + 11} V ${y} H ${x + 11} M ${right - 11} ${y} H ${right} V ${y + 11}
+          M ${x} ${bottom - 11} V ${bottom} H ${x + 11} M ${right - 11} ${bottom} H ${right} V ${bottom - 11}"
+          fill="none" stroke="#dbe8ff" stroke-width="1.6" stroke-linecap="round" />`;
+    }
+
+    function renderRails() {
+      const state = scenarios[selectedScenario];
+      const id = "rails";
+      const workspaceMarkup = workspaces.map((workspace) => {
+        const isActive = workspace.id === activeWorkspaceId;
+        const status = state.statuses[workspace.id];
+        const recent = state.recent.includes(workspace.id);
+        return `
+          <g opacity="${isActive || status ? 1 : 0.62}">
+            <rect class="workspace-shape" x="${workspace.x}" y="${workspace.y}" width="${workspace.w}" height="${workspace.h}" rx="3"
+              fill="#151a25" fill-opacity="0.92" stroke="${workspace.accent}" stroke-opacity="0.42" stroke-width="1">
+              <title>${escapeHtml(workspace.name)}${isActive ? " — active workspace" : ""}${status ? ` — ${escapeHtml(status.summary)}` : ""}</title>
+            </rect>
+            ${basePanels(workspace, 0.20, status, "rails")}
+            <rect x="${workspace.x + 7}" y="${workspace.y + 10}" width="${Math.max(24, workspace.short.length * 8 + 10)}" height="17" rx="4"
+              fill="${workspace.accent}" fill-opacity="0.13" stroke="${workspace.accent}" stroke-opacity="0.42" />
+            <text x="${workspace.x + 7 + Math.max(24, workspace.short.length * 8 + 10) / 2}" y="${workspace.y + 21.5}"
+              text-anchor="middle" fill="#c5cede" font-size="8.5" font-weight="720">${escapeHtml(workspace.short)}</text>
+            ${recent ? `<circle cx="${workspace.x + workspace.w - 10}" cy="${workspace.y + workspace.h - 10}" r="3" fill="#e9be6d"><title>Recently active</title></circle>` : ""}
+            ${railStatusMarkup(workspace, status, id)}
+            ${isActive ? activeBrackets(workspace) : ""}
+          </g>`;
+      }).join("");
+
+      const legend = `
+        <g transform="translate(30 312)">
+          <line x1="0" y1="0" x2="18" y2="0" stroke="#74a2f7" stroke-width="4" stroke-linecap="round" />
+          <text x="25" y="3" fill="#aab5c7" font-size="8" class="mono">LEFT = ACTIVE</text>
+          <line x1="124" y1="0" x2="142" y2="0" stroke="#f38ba8" stroke-width="4" stroke-linecap="round" />
+          <text x="149" y="3" fill="#aab5c7" font-size="8" class="mono">TOP = NEEDS INPUT</text>
+          <line x1="292" y1="0" x2="310" y2="0" stroke="#a6e3a1" stroke-width="4" stroke-linecap="round" />
+          <text x="317" y="3" fill="#aab5c7" font-size="8" class="mono">TOP = DONE</text>
+          <circle cx="424" cy="0" r="3" fill="#e9be6d" />
+          <text x="434" y="3" fill="#aab5c7" font-size="8" class="mono">RECENT</text>
+        </g>`;
+
+      document.getElementById("rails-preview").innerHTML = svgFrame(
+        id,
+        "Orthogonal edge rails minimap concept",
+        "A blue left rail marks the active workspace while red, green, and blue top rails represent attention independently.",
+        `${workspaceMarkup}${legend}`
+      );
+    }
+
+    function radarQueue(state) {
+      const urgent = workspaces
+        .filter((workspace) => {
+          const status = state.statuses[workspace.id];
+          return status && status.severity !== "medium";
+        })
+        .sort((left, right) => {
+          const leftSeverity = state.statuses[left.id].severity === "high" ? 0 : 1;
+          const rightSeverity = state.statuses[right.id].severity === "high" ? 0 : 1;
+          return leftSeverity - rightSeverity || left.x - right.x;
+        });
+      return new Map(urgent.map((workspace, index) => [workspace.id, index + 1]));
+    }
+
+    function renderRadar() {
+      const state = scenarios[selectedScenario];
+      const id = "radar";
+      const queue = radarQueue(state);
+      const shifted = workspaces.map((workspace) => ({
+        ...workspace,
+        y: 66 + (workspace.y - 72) * 0.77,
+        h: workspace.h * 0.72
+      }));
+
+      const workspaceMarkup = shifted.map((workspace) => {
+        const isActive = workspace.id === activeWorkspaceId;
+        const status = state.statuses[workspace.id];
+        const queueNumber = queue.get(workspace.id);
+        const activeOpacity = isActive ? 0.95 : (status ? 0.68 : 0.30);
+        const statusMarker = status
+          ? marker(workspace, status, status.panels[0] ?? 0, queueNumber ?? severity[status.severity].icon, id, true)
+          : "";
+        return `
+          <g opacity="${activeOpacity}">
+            ${isActive ? `<rect x="${workspace.x - 4}" y="${workspace.y - 4}" width="${workspace.w + 8}" height="${workspace.h + 8}" rx="7"
+              fill="#74a2f7" fill-opacity="0.05" stroke="#dbe8ff" stroke-width="1.8" filter="url(#blue-glow-${id})" />` : ""}
+            <rect class="workspace-shape" x="${workspace.x}" y="${workspace.y}" width="${workspace.w}" height="${workspace.h}" rx="4"
+              fill="${workspace.accent}" fill-opacity="0.08" stroke="${workspace.accent}" stroke-opacity="0.42" stroke-width="1">
+              <title>${escapeHtml(workspace.name)}${isActive ? " — active workspace" : ""}</title>
+            </rect>
+            ${basePanels(workspace, 0.17, status, "radar")}
+            ${statusMarker}
+          </g>`;
+      }).join("");
+
+      const chipWidth = 91;
+      const chipGap = 8;
+      const chipStart = 25;
+      const chips = workspaces.map((workspace, index) => {
+        const status = state.statuses[workspace.id];
+        const meta = status ? severity[status.severity] : null;
+        const isActive = workspace.id === activeWorkspaceId;
+        const queueNumber = queue.get(workspace.id);
+        const x = chipStart + index * (chipWidth + chipGap);
+        const markerText = status ? (queueNumber ?? meta.icon) : "";
+        const markerColor = meta?.color ?? "#6c788e";
+        return `
+          <g>
+            <rect x="${x}" y="294" width="${chipWidth}" height="34" rx="8" fill="${isActive ? "#151f31" : "#0f131c"}"
+              stroke="${isActive ? "#74a2f7" : "#252e3d"}" stroke-width="${isActive ? 1.4 : 1}" />
+            ${isActive ? `<line x1="${x + 10}" y1="328" x2="${x + chipWidth - 10}" y2="328" stroke="#74a2f7" stroke-width="3" stroke-linecap="round" />` : ""}
+            <circle cx="${x + 14}" cy="311" r="3.2" fill="${workspace.accent}" />
+            <text x="${x + 23}" y="314" fill="${isActive ? "#e0e6f1" : "#aab5c7"}" font-size="8.5" font-weight="720">${escapeHtml(workspace.short)}</text>
+            ${isActive ? `<text x="${x + chipWidth - 28}" y="314" fill="#74a2f7" font-size="12" font-weight="800">◎</text>` : ""}
+            ${status ? `
+              <circle cx="${x + chipWidth - 12}" cy="311" r="8" fill="#0c1018" stroke="${markerColor}" stroke-width="1.5" />
+              <text x="${x + chipWidth - 12}" y="314" text-anchor="middle" fill="${markerColor}" font-size="8" font-weight="850">${escapeHtml(markerText)}</text>` : ""}
+          </g>`;
+      }).join("");
+
+      const queueLabel = queue.size > 0
+        ? `<text x="616" y="282" text-anchor="end" fill="#f38ba8" font-size="8" font-weight="750" letter-spacing="1" class="mono">${queue.size} IN QUEUE</text>`
+        : `<text x="616" y="282" text-anchor="end" fill="#a6e3a1" font-size="8" font-weight="750" letter-spacing="1" class="mono">QUEUE CLEAR</text>`;
+
+      document.getElementById("radar-preview").innerHTML = svgFrame(
+        id,
+        "Attention radar minimap concept",
+        "Numbered attention beacons in the spatial map correspond to larger workspace chips in a bottom status rail.",
+        `${workspaceMarkup}<line x1="24" y1="282" x2="616" y2="282" stroke="#252e3d" />${queueLabel}${chips}`
+      );
+    }
+
+    function renderAll() {
+      renderSpotlight();
+      renderRails();
+      renderRadar();
+      document.getElementById("scenario-summary").textContent = scenarios[selectedScenario].summary;
+    }
+
+    document.querySelectorAll("[data-scenario]").forEach((button) => {
+      button.addEventListener("click", () => {
+        selectedScenario = button.dataset.scenario;
+        document.querySelectorAll("[data-scenario]").forEach((candidate) => {
+          candidate.setAttribute("aria-pressed", String(candidate === button));
+        });
+        renderAll();
+      });
+    });
+
+    renderAll();
+  </script>
+</body>
+</html>

--- a/docs/testing/2026-07-19-macos-minimap-workspace-attention-smoke.md
+++ b/docs/testing/2026-07-19-macos-minimap-workspace-attention-smoke.md
@@ -1,0 +1,954 @@
+# macOS Smoke Plan: Minimap Workspace Spotlight + Attention
+
+> Temporary validation artifact. Keep this file and
+> `docs/design/2026-07-19-minimap-workspace-attention-concepts.html` in the draft
+> pull request while validation is in progress. Remove both only after the full
+> macOS pass succeeds, then rebuild and repeat the decisive checks listed under
+> **Final-head cleanup pass**.
+
+## Purpose and pass criteria
+
+Validate the minimap workspace spotlight and attention interactions on macOS at
+the exact pull-request head handed off by the implementation agent. The pass is
+complete only when all of the following are true:
+
+- the active workspace remains visually distinct with a brighter fill, static
+  blue/foreground double outline, and a clamped `ACTIVE` tab;
+- High, recently completed, and Info attention cues are correct, static, and
+  gated by the Attention Feed feature;
+- counts, `9+` clamping, marker limits, tiny-map collapse, severity precedence,
+  and the 30-second completed window behave as specified;
+- panel markers and workspace pills navigate to the intended target without
+  resolving or dismissing the attention;
+- ordinary minimap panning, viewport outline, fit/resize, themes, persistence,
+  and detached-window scope have no regression;
+- idle traces do not show a continuous repaint loop, and matched pointer-redraw
+  measurements are recorded against the branch base;
+- evidence is tied to the exact tested SHA and every failure is either fixed and
+  fully retested or explicitly blocks readiness/merge.
+
+This plan does not require agent credentials or network activity. It uses local
+fake agent panels controlled through named pipes. Workspace-only attention has
+no public UI injection path; its behavior is covered by the branch unit tests.
+
+## Handoff values
+
+The implementation agent must replace or provide every placeholder below in the
+PR handoff. Do not infer a SHA from a branch name after testing starts.
+
+The handoff comment must begin with this exact request line:
+
+```text
+SMOKE-TEST REQUEST macOS — plan: docs/testing/2026-07-19-macos-minimap-workspace-attention-smoke.md — scope: full macOS/Metal lane, final-head cleanup, readiness, and squash merge
+```
+
+```bash
+export PR_NUMBER="<draft PR number>"
+export PR_HEAD_SHA="<40-character handoff SHA>"
+export EXPECTED_BRANCH="feature/minimap-workspace-spotlight"
+export SOURCE_REPO="/path/to/local/horizon"
+```
+
+Record the values in the evidence comment. If the PR head changes at any point,
+stop: the previous UI, screenshot, video, and performance evidence is stale.
+
+## Machine and permissions
+
+- macOS 14 or newer, Intel or Apple Silicon.
+- Xcode Command Line Tools and the repository's Rust stable toolchain installed.
+- A real logged-in Aqua desktop session, not a headless SSH-only session.
+- Terminal (or the test runner) granted Accessibility permission for exact-PID
+  window inspection and Quartz pointer automation.
+- Terminal granted Screen Recording permission for screenshots/video.
+- Mouse or trackpad available. Test a trackpad path when the machine has one.
+- Prefer a built-in Retina display. If an external display is available, include
+  one scale-transition check; otherwise record that as not available.
+
+Capture machine facts before building:
+
+```bash
+sw_vers
+uname -m
+rustc --version
+cargo --version
+system_profiler SPDisplaysDataType
+```
+
+## Exact-SHA checkout and build
+
+Create a disposable detached worktree so another Horizon checkout and any local
+edits remain untouched:
+
+```bash
+cd "$SOURCE_REPO"
+git fetch origin "$EXPECTED_BRANCH"
+test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"
+
+export SMOKE_ROOT="$(mktemp -d /tmp/horizon-minimap-macos.XXXXXX)"
+export SMOKE_CHECKOUT="$SMOKE_ROOT/checkout"
+git worktree add --detach "$SMOKE_CHECKOUT" "$PR_HEAD_SHA"
+cd "$SMOKE_CHECKOUT"
+
+test "$(git rev-parse HEAD)" = "$PR_HEAD_SHA"
+test -z "$(git status --porcelain)"
+cargo build
+```
+
+Record the complete `cargo build` result. All UI validation below must launch
+`$SMOKE_CHECKOUT/target/debug/horizon`, not a binary from another checkout.
+
+## Isolated deterministic runtime
+
+Use an isolated home so the smoke does not read or mutate the tester's normal
+Horizon sessions, config, plugins, or agent state:
+
+```bash
+export SMOKE_HOME="$(mktemp -d /tmp/horizon-minimap-home.XXXXXX)"
+export SMOKE_EVIDENCE="$SMOKE_ROOT/evidence"
+mkdir -p "$SMOKE_HOME/.horizon" "$SMOKE_HOME/bin" \
+  "$SMOKE_HOME/control" "$SMOKE_EVIDENCE"
+touch "$SMOKE_HOME/.zshrc"
+```
+
+Create the fake agent. A High or Info event writes its notification and terminal
+bell in one PTY write so Horizon observes both in the same update and keeps the
+item open. A Done event intentionally writes only its notification; Horizon
+resolves it in that output pass, making it a deterministic recently resolved
+item in the feed's existing 30-second visibility window.
+
+```bash
+cat > "$SMOKE_HOME/bin/fake-agent" <<'ZSH'
+#!/bin/zsh
+set -eu
+
+key="${1:?panel key is required}"
+control_dir="$HOME/control"
+fifo="$control_dir/$key.fifo"
+mkdir -p "$control_dir"
+rm -f "$fifo"
+mkfifo "$fifo"
+printf 'Fake agent %s ready\n' "$key"
+
+while true; do
+  payload=''
+  if ! IFS= read -r payload < "$fifo"; then
+    continue
+  fi
+  level="${payload%%|*}"
+  message="${payload#*|}"
+  case "$level" in
+    high)
+      wire_level='attention'
+      keep_open='yes'
+      ;;
+    done)
+      wire_level='done'
+      keep_open='no'
+      ;;
+    info)
+      wire_level='info'
+      keep_open='yes'
+      ;;
+    *)
+      printf 'Unknown smoke level: %s\n' "$level" >&2
+      continue
+      ;;
+  esac
+
+  if [[ "$keep_open" = 'yes' ]]; then
+    printf '\033]0;HORIZON_NOTIFY:%s:%s\007\a' "$wire_level" "$message"
+  else
+    printf '\033]0;HORIZON_NOTIFY:%s:%s\007' "$wire_level" "$message"
+  fi
+done
+ZSH
+chmod +x "$SMOKE_HOME/bin/fake-agent"
+```
+
+Create a deterministic 2-by-2 board. Three separate Alpha panels allow marker
+limit and newest-target checks. Beta can hold eleven open items on one exact
+panel. Gamma separates completed and open precedence. Delta supplies a movable
+Info target.
+
+```bash
+cat > "$SMOKE_HOME/.horizon/config.yaml" <<YAML
+version: 8
+window:
+  width: 1500
+  height: 950
+appearance:
+  theme: dark
+features:
+  attention_feed: true
+overlays:
+  attention_feed_width: 320
+  attention_feed_height: 600
+  minimap_width: 320
+  minimap_height: 180
+workspaces:
+  - name: Alpha Build
+    color: "#89b4fa"
+    cwd: "$SMOKE_HOME"
+    position: [0, 0]
+    terminals:
+      - name: Alpha High Old
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["alpha-high-old"]
+        position: [25, 70]
+        size: [300, 220]
+      - name: Alpha Info
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["alpha-info"]
+        position: [355, 70]
+        size: [300, 220]
+      - name: Alpha High New
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["alpha-high-new"]
+        position: [190, 325]
+        size: [300, 220]
+  - name: Beta Review
+    color: "#cba6f7"
+    cwd: "$SMOKE_HOME"
+    position: [1050, 0]
+    terminals:
+      - name: Beta Count
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["beta-count"]
+        position: [30, 75]
+        size: [620, 455]
+  - name: Gamma Delivery
+    color: "#a6e3a1"
+    cwd: "$SMOKE_HOME"
+    position: [0, 760]
+    terminals:
+      - name: Gamma Done
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["gamma-done"]
+        position: [25, 75]
+        size: [300, 390]
+      - name: Gamma High
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["gamma-high"]
+        position: [355, 75]
+        size: [300, 390]
+  - name: Delta Triage
+    color: "#fab387"
+    cwd: "$SMOKE_HOME"
+    position: [1050, 760]
+    terminals:
+      - name: Delta Info
+        kind: gemini
+        command: "$SMOKE_HOME/bin/fake-agent"
+        args: ["delta-info"]
+        position: [25, 75]
+        size: [300, 390]
+      - name: Delta Quiet
+        kind: shell
+        position: [355, 75]
+        size: [300, 390]
+YAML
+```
+
+## Launch and exact-PID guard
+
+The first launch creates one persistent session from the config. Keep the launch
+Terminal open so `$HORIZON_PID` remains the authoritative process under test.
+
+```bash
+cd "$SMOKE_CHECKOUT"
+export SMOKE_LOG="$SMOKE_EVIDENCE/horizon-debug.log"
+HOME="$SMOKE_HOME" ZDOTDIR="$SMOKE_HOME" SHELL=/bin/zsh \
+  RUST_LOG=horizon=info,horizon_core=info \
+  target/debug/horizon --config "$SMOKE_HOME/.horizon/config.yaml" \
+  --new-session >"$SMOKE_LOG" 2>&1 &
+export HORIZON_PID=$!
+
+kill -0 "$HORIZON_PID"
+ps -p "$HORIZON_PID" -o pid=,ppid=,etime=,command=
+```
+
+Never replace this PID with `pgrep`, and never drive windows by the application
+name alone. Before every detached-window or motion-sensitive check, enumerate
+only windows owned by this PID:
+
+```bash
+osascript - "$HORIZON_PID" <<'APPLESCRIPT'
+on run argv
+  set targetPid to (item 1 of argv) as integer
+  tell application "System Events"
+    set matches to every application process whose unix id is targetPid
+    if (count of matches) is not 1 then error "expected exactly one process for PID " & targetPid
+    set targetProcess to item 1 of matches
+    set report to "pid=" & targetPid & " process=" & (name of targetProcess) & " windows=" & (count of windows of targetProcess)
+    repeat with currentWindow in windows of targetProcess
+      set report to report & linefeed & "position=" & (position of currentWindow) & " size=" & (size of currentWindow)
+    end repeat
+    return report
+  end tell
+end run
+APPLESCRIPT
+```
+
+Expected before detaching: one root window owned by `$HORIZON_PID`. If another
+Horizon process exists, leave it alone and continue to scope every assertion to
+the recorded PID.
+
+## Attention controls
+
+In a second Terminal, source these functions. Each write blocks until the exact
+fake panel has opened its FIFO and sleeps long enough for a separate UI frame to
+consume the event.
+
+```bash
+wait_for_panel() {
+  local key="$1"
+  local fifo="$SMOKE_HOME/control/$key.fifo"
+  local tries=0
+  while [[ ! -p "$fifo" ]]; do
+    sleep 0.1
+    tries=$((tries + 1))
+    if (( tries > 200 )); then
+      echo "timed out waiting for $fifo" >&2
+      return 1
+    fi
+  done
+}
+
+send_attention() {
+  local key="$1"
+  local level="$2"
+  local message="$3"
+  wait_for_panel "$key"
+  printf '%s|%s\n' "$level" "$message" > "$SMOKE_HOME/control/$key.fifo"
+  sleep 0.55
+}
+
+seed_spotlight() {
+  send_attention alpha-info info 'Alpha informational result'
+  send_attention alpha-high-old high 'Alpha approval needed'
+  send_attention alpha-high-new high 'Alpha newest urgent target'
+
+  local n=1
+  while (( n <= 11 )); do
+    send_attention beta-count high "Beta open item $n"
+    n=$((n + 1))
+  done
+
+  send_attention delta-info info 'Delta informational result'
+}
+
+seed_gamma_precedence() {
+  send_attention gamma-done done 'Gamma completed successfully'
+  send_attention gamma-high high 'Gamma urgent follow-up'
+}
+```
+
+Run `seed_spotlight` once after all seven FIFOs exist. Run
+`seed_gamma_precedence` immediately before the precedence test because the Done
+cue intentionally expires 30 seconds after resolution. To reseed from a clean
+state, quit the smoke process, relaunch the same persistent session without
+`--new-session`, update `$HORIZON_PID`, and run the desired seed function again.
+
+## Test 1: default minimap baseline
+
+At the configured 320 by 180 map size:
+
+1. Click Alpha Build in the sidebar to establish the initial active workspace,
+   then confirm all four workspace frames preserve their distinct accent identity,
+   labels remain readable, focused-panel fill remains visible, and the viewport
+   outline remains distinct from workspace and attention outlines.
+2. Confirm the active Alpha workspace has a brighter fill, two static outline
+   strokes (blue plus foreground), and an `ACTIVE` tab that does not cover its
+   label or escape the map bounds.
+3. Switch active workspace through the sidebar in the order Alpha, Beta, Gamma,
+   Delta, Alpha. The spotlight must move exactly once to the selected workspace;
+   the previous workspace returns to its normal accent presentation.
+4. Leave the pointer idle for at least 15 seconds. No active outline, pill,
+   beacon, or tab may pulse, shimmer, or animate.
+5. Capture `01-default-dark.png` with the exact SHA and PID recorded alongside it.
+
+## Test 2: High, Info, counts, and marker limit
+
+Run `seed_spotlight`, then verify:
+
+1. Alpha has three open items, a red High `!` workspace pill with count `3`, and
+   no more than two exact-panel beacons even though three distinct panels own
+   attention. The beacons must not obscure labels or the `ACTIVE` tab.
+2. Alpha's red High aggregate wins over its older blue Info item.
+3. Beta has eleven open items, a red High cue whose visible count is exactly
+   `9+`, and one exact-panel marker because all eleven items target the same
+   panel.
+4. Delta has one open Info item and a blue `i` cue, not a red or green cue.
+5. Quiet Gamma has no attention cue before its dedicated seed.
+6. Workspace and panel geometry, active fill, labels, focused-panel fill, and
+   viewport outline remain legible under every cue.
+7. Capture `02-high-info-counts.png`.
+
+## Test 3: recently completed cue and open precedence
+
+Run `seed_gamma_precedence` and complete steps 1 through 3 within 20 seconds:
+
+1. Gamma has a recently resolved Done item and an open High item. Its workspace
+   aggregate must be red High because open items take precedence.
+   Capture `03-open-precedence.png` now, before dismissal.
+2. In the Attention Feed, dismiss only `Gamma urgent follow-up` with its `x`.
+   Dismissal is used here solely to expose the already resolved item.
+3. With no open Gamma item left, Gamma immediately becomes a green completed
+   `✓` cue. It must not inherit the original Done item's severity color if that
+   differs from the completed-state rule. Immediately capture
+   `04-recently-completed.png` while the cue is still inside its visibility
+   window.
+4. Wait until 30 seconds have elapsed since the Done event, then move the
+   pointer once to request a normal UI frame. The green Gamma cue must disappear
+   without leaving a stale pill or marker. Do not expect a timer-driven repaint;
+   the cues are intentionally static.
+5. If the 30-second window is missed, call
+   `send_attention gamma-done done 'Gamma completed successfully'` and repeat;
+   do not accept a guessed result.
+
+## Test 4: click targets, tooltips, and navigation
+
+Attention navigation must not change attention state.
+
+1. Pan so Alpha High Old is clearly away from the canvas center, then hover its
+   visible panel beacon. Confirm a useful tooltip names or identifies the target
+   and state, the cursor communicates clickability, and the padded hit target is
+   easier to acquire than the painted symbol alone.
+2. Click the beacon once. Alpha becomes active, Alpha High Old becomes focused,
+   and the canvas centers that panel. Alpha's open count remains `3`; nothing is
+   resolved or dismissed.
+3. Move the view away again, hover Alpha's workspace pill, and click it. The
+   highest-severity newest target must win: `Alpha High New`, not Alpha High Old
+   or Alpha Info. The panel becomes focused and centered, while Alpha's count
+   remains unchanged.
+4. Click the Beta workspace pill. It must focus and center Beta Count, and its
+   visible count remains `9+`.
+5. Probe the outer part of each padded cue hit target with mouse and trackpad.
+   Hover must remain stable and must not accidentally initiate minimap panning.
+6. Capture `05-click-target-focused.png`. If hover or focus jumps under motion,
+   record a short video rather than relying on the still image.
+
+## Test 5: attention ownership after moving a panel
+
+1. Note Alpha's count (`3`) and Delta's count (`1`).
+2. Use the Alpha Info panel context menu, choose **Move to Workspace**, and move
+   it to Delta Triage.
+3. Confirm Alpha immediately drops to `2`, its Info panel beacon does not remain
+   at the old geometry, and Delta rises to `2` with the moved panel represented
+   in Delta's geometry.
+4. Click the moved panel beacon. It must activate Delta, focus Alpha Info in its
+   new workspace, and keep both Info items open.
+5. Pan away and back and fit the active workspace. No old-workspace ghost cue may
+   reappear.
+6. This move will be reused by the persistence test; do not move the panel back.
+
+## Test 6: minimum size, badge collapse, and clamping
+
+Open Settings, General, Overlays and set Map Width to `80` and Map Height to `60`.
+The renderer clamps the effective map content to its supported 120 by 120
+minimum.
+
+1. Confirm the minimap remains fully inside the root viewport and usable at the
+   effective minimum.
+2. Panel beacons must collapse when their geometry is too small; no partial,
+   clipped, or overlapping beacon may remain. Workspace pills continue to carry
+   the aggregate state.
+3. Beta remains `9+`, never `10`, `11`, `9++`, or clipped text.
+4. The `ACTIVE` tab adapts or clamps within the available edge. It must not
+   overlap a pill, leak outside the map, or become unreadable.
+5. Workspace labels either use the existing adaptive placement or collapse
+   cleanly. Do not accept text painted outside its workspace/map bounds.
+6. Click one remaining workspace pill and verify navigation still works at the
+   minimum size.
+7. Drag empty minimap space and verify panning still works at the minimum size.
+8. Capture `06-minimum-map.png`.
+9. Restore Map Width `320` and Map Height `180`, then save Settings.
+
+## Test 7: minimap panning and viewport regression
+
+Use `screencapture -V` for this motion-sensitive test:
+
+```bash
+screencapture -V 12 "$SMOKE_EVIDENCE/07-minimap-pan.mov"
+```
+
+During the recording:
+
+1. Drag from empty minimap background horizontally, vertically, and diagonally.
+2. Confirm the canvas moves continuously with the drag, in the expected
+   direction, with no snap-back or oscillation.
+3. Confirm the minimap viewport outline tracks the resulting view and attention
+   counts do not change.
+4. Repeat after clicking a panel marker, then drag from empty map space. A prior
+   cue click must not leave a stuck click/drag state.
+5. Resize one panel, fit the active workspace, and resize the root window. The
+   minimap and viewport outline must update without stale geometry.
+
+## Test 8: Attention Feed feature gate
+
+1. Make Alpha active so its non-attention spotlight is obvious.
+2. Open Settings, General and disable **Attention Feed**. Save.
+3. Confirm the Attention Feed and every minimap attention pill/beacon disappear
+   immediately, including the existing Alpha/Beta/Delta items.
+4. Confirm the active Alpha brighter fill, static double outline, and `ACTIVE`
+   tab remain visible. Active highlighting is not feature-gated.
+5. Confirm minimap panning and workspace switching still work while disabled.
+6. Capture `08-attention-disabled.png`.
+7. Re-enable **Attention Feed**, save, and confirm the existing in-memory cues
+   return without duplicated counts. Do not emit a new fake event while disabled;
+   disabled detection intentionally does not consume its terminal notification.
+
+## Test 9: detached workspace scope and exact-window behavior
+
+1. Reseed Gamma Done if needed, then detach Gamma Delivery from its workspace
+   toolbar or sidebar context menu.
+2. Re-run the exact-PID AppleScript. It must report two windows owned by the same
+   `$HORIZON_PID`: the root plus one non-root detached member. Do not identify the
+   detached window by title alone.
+3. The root minimap must exclude Gamma workspace geometry and Gamma attention.
+   The detached minimap must scope itself to Gamma only; Alpha, Beta, and Delta
+   counts must not leak into it.
+4. Activate Gamma in the detached window and confirm its active spotlight is
+   drawn there. Activate Alpha from the root and confirm active state changes do
+   not corrupt either scoped minimap.
+5. Hover and click a Gamma cue in the detached minimap. It must focus/center the
+   Gamma target inside the detached window and must not pan the root canvas or
+   resolve attention. After the target reaches center, leave the pointer idle
+   for 15 seconds and confirm navigation settles with no continued repaint loop.
+6. Drag empty space in each minimap. Each drag affects only its own canvas view.
+7. Resize and move the detached native window while sampling only the recorded
+   PID. A motion trace is mandatory; in a second Terminal, run this exact-PID
+   sampler and move/resize the detached window throughout its 12-second run:
+
+   ```bash
+   osascript - "$HORIZON_PID" \
+     > "$SMOKE_EVIDENCE/10-detached-position-trace.txt" <<'APPLESCRIPT' &
+   on run argv
+     set targetPid to (item 1 of argv) as integer
+     tell application "System Events"
+       set matches to every application process whose unix id is targetPid
+       if (count of matches) is not 1 then error "expected exact PID " & targetPid
+       set targetProcess to item 1 of matches
+       set report to "pid=" & targetPid
+       repeat with sampleIndex from 1 to 600
+         set report to report & linefeed & "sample=" & sampleIndex
+         repeat with currentWindow in windows of targetProcess
+           set report to report & " position=" & (position of currentWindow) & " size=" & (size of currentWindow)
+         end repeat
+         delay 0.02
+       end repeat
+       return report
+     end tell
+   end run
+   APPLESCRIPT
+   export DETACHED_TRACE_PID=$!
+   # Move and resize only the detached member for the next 12 seconds.
+   wait "$DETACHED_TRACE_PID"
+   ```
+
+   Confirm the trace is monotonic during each gesture and shows no snap-back,
+   alternating coordinates, or repeated saved restore position. A 12-second
+   `screencapture -V` video may be added as supporting evidence, but does not
+   replace the exact-PID trace.
+8. Capture `09-root-detached-scope.png` and
+   `10-detached-minimap-scope.png`.
+9. Reattach Gamma and confirm it returns to the root minimap exactly once with
+   no duplicate or stale detached cue. Detach it again before the persistence
+   test so detached restore is exercised.
+
+## Test 10: root resize, fullscreen, Retina, and themes
+
+1. Resize the root window from approximately 1500 by 950 down to its minimum,
+   then back up. At both extremes, verify map containment, label placement,
+   `ACTIVE` tab clamping, pill clamping, and clickable hit targets.
+2. Enter and exit native macOS fullscreen. Verify the minimap relocates cleanly,
+   remains clickable, and keeps the correct viewport outline.
+3. Switch away with Cmd-Tab and back. Repeat one pill click and one minimap pan.
+4. On a Retina display, inspect the double outline, one-pixel-style strokes,
+   marker shapes, icons, and text for blur, unequal edges, or half-pixel clipping.
+5. If an external display is available, move the exact-PID root and detached
+   windows across displays with different scale factors and repeat one click and
+   resize. Otherwise record `external scale transition: not available`.
+6. Immediately before the theme comparison, run
+   `send_attention gamma-done done 'Gamma theme completed'` so the green cue is
+   inside its 30-second window. In Settings, force Light. Verify High red, Done green, Info blue, accent
+   identity, foreground outline, focused-panel fill, labels, and viewport outline
+   remain distinguishable without relying on color alone. Capture
+   `11-light-retina.png`.
+7. Force Dark again and capture `12-dark-retina.png`. Save Settings.
+
+## Test 11: persistence and relaunch
+
+This smoke intentionally uses a persistent isolated session.
+
+1. Leave Alpha Info moved to Delta, leave Gamma detached, select a known active
+   workspace/panel, and leave the minimap at 320 by 180, Dark, Attention Feed on.
+2. Quit Horizon cleanly with Cmd-Q. Confirm the exact `$HORIZON_PID` exits.
+3. Relaunch the same config and isolated home without `--new-session`:
+
+   ```bash
+   cd "$SMOKE_CHECKOUT"
+   HOME="$SMOKE_HOME" ZDOTDIR="$SMOKE_HOME" SHELL=/bin/zsh \
+     RUST_LOG=horizon=info,horizon_core=info \
+     target/debug/horizon --config "$SMOKE_HOME/.horizon/config.yaml" \
+     >>"$SMOKE_LOG" 2>&1 &
+   export HORIZON_PID=$!
+   kill -0 "$HORIZON_PID"
+   ```
+
+4. Re-run the exact-PID window inventory. Confirm the expected detached member,
+   root window, active selection, panel move, board positions, and canvas views
+   restore without a stale native-window position replay.
+5. Attention items themselves are not a persisted schema. Before reseeding,
+   confirm no stale minimap cue was serialized from the previous process.
+6. Wait for the recreated FIFOs, then send:
+
+   ```bash
+   send_attention alpha-info info 'Moved panel after relaunch'
+   send_attention gamma-done done 'Detached done after relaunch'
+   ```
+
+7. Alpha Info must appear under persisted Delta ownership, not Alpha. Gamma's
+   recent completed cue must appear only in its detached scope.
+8. Confirm config version remains `8`; this feature must not add a migration,
+   persisted field, public config key, dependency, or version change.
+9. Capture `13-persistence-relaunch.png` and retain the relevant runtime/config
+   excerpts with secrets reviewed and removed.
+
+## Matched pointer-redraw profiling
+
+Profile the exact PR head and its branch base with the same window size, board,
+signals, point sets, binary profile, trace mode, durations, and isolated runtime.
+Keep generated harnesses and traces under `$SMOKE_ROOT`, not in the repository.
+
+### Build both exact revisions
+
+```bash
+cd "$SOURCE_REPO"
+git fetch origin main
+export BASE_SHA="$(git merge-base "$PR_HEAD_SHA" origin/main)"
+export BASE_CHECKOUT="$SMOKE_ROOT/base-checkout"
+git worktree add --detach "$BASE_CHECKOUT" "$BASE_SHA"
+
+cd "$BASE_CHECKOUT"
+cargo build --profile profiling --features trace-profiling
+cd "$SMOKE_CHECKOUT"
+cargo build --profile profiling --features trace-profiling
+```
+
+Record `BASE_SHA`. Do not compare a moving `origin/main` binary or a release
+binary against the PR profiling binary.
+
+### Create the exact-PID pointer driver
+
+The helper rejects point sets outside the largest on-screen window owned by the
+supplied PID and posts native Quartz mouse-move events at a fixed 16 ms cadence.
+
+```bash
+cat > "$SMOKE_ROOT/pointer-sweep.swift" <<'SWIFT'
+import ApplicationServices
+import Foundation
+
+func mousePoint() -> CGPoint {
+    CGEvent(source: nil)?.location ?? .zero
+}
+
+func largestWindow(pid: Int) -> CGRect? {
+    let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let raw = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+        return nil
+    }
+    return raw.compactMap { info -> CGRect? in
+        guard let owner = info[kCGWindowOwnerPID as String] as? Int, owner == pid,
+              let bounds = info[kCGWindowBounds as String] as? CFDictionary else {
+            return nil
+        }
+        return CGRect(dictionaryRepresentation: bounds)
+    }.max { left, right in
+        left.width * left.height < right.width * right.height
+    }
+}
+
+if CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "point" {
+    let point = mousePoint()
+    print("\(Int(point.x)),\(Int(point.y))")
+    exit(0)
+}
+
+guard CommandLine.arguments.count >= 5,
+      CommandLine.arguments[1] == "sweep",
+      let pid = Int(CommandLine.arguments[2]),
+      let cycles = Int(CommandLine.arguments[3]),
+      let window = largestWindow(pid: pid) else {
+    fputs("usage: pointer-sweep.swift point | sweep PID CYCLES X,Y [X,Y ...]\n", stderr)
+    exit(2)
+}
+
+let points = CommandLine.arguments.dropFirst(4).compactMap { value -> CGPoint? in
+    let parts = value.split(separator: ",")
+    guard parts.count == 2, let x = Double(parts[0]), let y = Double(parts[1]) else { return nil }
+    return CGPoint(x: x, y: y)
+}
+guard !points.isEmpty && points.allSatisfy(window.contains) else {
+    fputs("every point must be inside the exact PID's largest on-screen window\n", stderr)
+    exit(3)
+}
+
+for _ in 0..<cycles {
+    for point in points {
+        guard let event = CGEvent(
+            mouseEventSource: nil,
+            mouseType: .mouseMoved,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else { continue }
+        event.post(tap: .cghidEventTap)
+        usleep(16_000)
+    }
+}
+SWIFT
+xcrun swiftc "$SMOKE_ROOT/pointer-sweep.swift" \
+  -o "$SMOKE_ROOT/pointer-sweep"
+```
+
+With the PR profiling binary open at 1500 by 950, collect and save three point
+sets. Move the pointer to each intended location, then run
+`"$SMOKE_ROOT/pointer-sweep" point` and copy the reported
+coordinate. Use exactly six points per set so 125 cycles at the fixed 16 ms
+cadence produces a 12-second sweep:
+
+- `EMPTY_POINTS`: empty canvas outside all workspace frames;
+- `CHROME_POINTS`: visible panel titlebars/workspace chrome;
+- `MINIMAP_POINTS`: empty minimap background, workspace edge, panel geometry,
+  active tab, a panel beacon, and a workspace pill.
+
+Reuse the exact coordinate strings for every comparison run. Do not recapture
+them between base and PR runs unless the window geometry changed; if it did,
+restart the entire matched series.
+
+### Run the matched matrix
+
+Quit the debug smoke process first. Never run two Horizon processes against the
+same smoke home or FIFO directory. Before each matrix row, remove stale FIFO
+nodes with this zsh command and let the new fake agents recreate them:
+
+```bash
+for fifo in "$SMOKE_HOME"/control/*.fifo(N); do rm -f "$fifo"; done
+
+export ATTENTION_ON_CONFIG="$SMOKE_HOME/.horizon/config.yaml"
+export ATTENTION_OFF_CONFIG="$SMOKE_ROOT/config-attention-off.yaml"
+cp "$ATTENTION_ON_CONFIG" "$ATTENTION_OFF_CONFIG"
+/usr/bin/sed -i '' 's/attention_feed: true/attention_feed: false/' \
+  "$ATTENTION_OFF_CONFIG"
+```
+
+For each row below, use a fresh `--ephemeral` process, record `$!` as the exact
+PID, wait for every FIFO, run `seed_spotlight`, wait 3 seconds, perform the
+workload for 12 seconds, wait 2 seconds, then terminate that exact PID and save
+its complete trace log.
+
+| Revision | Attention Feed | Workload |
+|---|---:|---|
+| `BASE_SHA` | on | idle, no pointer movement |
+| `BASE_SHA` | on | `EMPTY_POINTS` sweep |
+| `BASE_SHA` | on | `CHROME_POINTS` sweep |
+| `BASE_SHA` | on | `MINIMAP_POINTS` sweep |
+| `PR_HEAD_SHA` | on | idle, no pointer movement |
+| `PR_HEAD_SHA` | on | `EMPTY_POINTS` sweep |
+| `PR_HEAD_SHA` | on | `CHROME_POINTS` sweep |
+| `PR_HEAD_SHA` | on | `MINIMAP_POINTS` sweep |
+| `PR_HEAD_SHA` | off | idle, no pointer movement |
+| `PR_HEAD_SHA` | off | `MINIMAP_POINTS` sweep |
+
+For the off rows, copy the config outside the repo and change only
+`features.attention_feed` to `false`. Keep all workspaces and fake-panel output
+identical. Select `$ATTENTION_ON_CONFIG` or `$ATTENTION_OFF_CONFIG` to match the
+row. A representative Attention Feed on traced launch is:
+
+```bash
+HOME="$SMOKE_HOME" ZDOTDIR="$SMOKE_HOME" SHELL=/bin/zsh \
+  HORIZON_TRACE_SPANS=1 RUST_LOG=info \
+  "$SMOKE_CHECKOUT/target/profiling/horizon" \
+  --config "$ATTENTION_ON_CONFIG" --ephemeral \
+  > "$SMOKE_EVIDENCE/pr-minimap-pointer.log" 2>&1 &
+PROFILE_PID=$!
+
+# After FIFO readiness, seeding, and the fixed 3-second settle:
+"$SMOKE_ROOT/pointer-sweep" sweep "$PROFILE_PID" 125 \
+  "${MINIMAP_POINTS[@]}"
+sleep 2
+kill -TERM "$PROFILE_PID"
+wait "$PROFILE_PID" || true
+```
+
+Use the trace summarization logic in `scripts/profile.sh` (its embedded
+`summarize_trace_spans` routine) or an equivalent parser. For every row report
+call count and normalized `avg_us`, not only total wall time, for at least:
+
+- `horizon::app::update`;
+- `horizon::app::lifecycle::render_active_view`;
+- `horizon::app::panels::render_panels`;
+- `egui::context::pass`.
+
+Interpretation and rerun rules:
+
+- The PR idle trace must settle; static attention cues must not introduce a
+  continuous repaint/animation loop. Compare call counts as well as average cost.
+- Compare base and PR only within the same workload. Do not compare an idle row
+  with a pointer row or totals from different frame counts.
+- The Attention Feed off rows must still render the active spotlight and must
+  not retain attention-cue hover work.
+- If a pointer cost looks materially worse, rerun the same row twice with a
+  denser/longer sweep before deciding. Save all runs and report variance rather
+  than selecting the best result.
+- Capture a live screenshot after the minimap pointer workload; a faster trace
+  is invalid if culling or layering made content disappear.
+
+## Evidence to post on the draft PR
+
+Post one full-run comment tied to `PR_HEAD_SHA` using this template. This first
+report is evidence for the pre-cleanup head; do not post the exact
+`SMOKE-TEST: DONE` completion marker until the temporary artifacts are removed
+and the final-head decisive pass succeeds.
+
+```text
+SMOKE-TEST REPORT (macOS)
+
+PR head SHA:
+Base SHA used for perf:
+macOS version / build:
+Architecture:
+Rust / Cargo:
+GPU and display(s), scale/Retina:
+Input devices:
+Exact Horizon PID(s) used:
+
+Build: PASS/FAIL
+Default active spotlight: PASS/FAIL
+High / Info / Done / precedence: PASS/FAIL
+Counts, 9+, marker limit, tiny collapse: PASS/FAIL
+Panel beacon navigation: PASS/FAIL
+Workspace pill newest-target navigation: PASS/FAIL
+Move-to-workspace attention ownership: PASS/FAIL
+Minimap pan / viewport / fit: PASS/FAIL
+Attention disabled, active still visible: PASS/FAIL
+Detached scope and exact-PID windows: PASS/FAIL
+Resize / fullscreen / Retina / themes: PASS/FAIL
+Persistence / relaunch: PASS/FAIL
+Static idle / no continuous repaint: PASS/FAIL
+
+Perf table: workload, revision, feature state, calls and avg_us for key spans
+Performance interpretation and rerun variance:
+
+Screenshots:
+Videos:
+Trace logs / summaries:
+Failures or deviations:
+External display transition: PASS/FAIL/NOT AVAILABLE
+Overall result: PASS/FAIL
+```
+
+Attach or link the numbered screenshots, required motion video and exact-PID
+position trace, exact-PID inventory, debug log, trace summaries, and raw logs.
+Screenshots are supporting evidence only; the pan and detached movement verdicts
+must use their required motion evidence even when the UI looks stable.
+
+## Failure, correction, and rerun policy
+
+- A crash, stale cue, wrong target, clipped badge/tab, lost accent, scope leak,
+  continuous repaint, pan regression, or exact-PID window anomaly is a failure.
+- Preserve the log, precise interaction sequence, screenshot/video, window
+  inventory, machine facts, and SHA before changing code.
+- Any code correction creates a new head. Rerun formatting and every repository
+  gate affected by the correction, then rerun this entire macOS smoke plan—not
+  only the step that originally failed—against the new exact SHA.
+- This checkout is intentionally detached. Before publishing a correction,
+  guard against overwriting a newer remote head and push the new commit
+  explicitly to the feature branch:
+
+  ```bash
+  git fetch origin "$EXPECTED_BRANCH"
+  test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"
+  # Apply the correction and commit it in this detached worktree.
+  export PR_HEAD_SHA="$(git rev-parse HEAD)"
+  git push origin HEAD:"refs/heads/$EXPECTED_BRANCH"
+  ```
+
+  A rejected push means the remote head changed; stop, fetch the new head, and
+  restart the validation rather than forcing the branch.
+- Documentation-only evidence corrections do not require rerunning UI behavior,
+  but the posted SHA and artifact names must remain exact.
+- Do not mark the PR ready and do not merge while any result is missing,
+  ambiguous, tied to an old SHA, or failed.
+
+## Final-head cleanup pass
+
+Only after the full pass and evidence comment are complete:
+
+1. Remove both temporary artifacts from the PR branch:
+
+   ```bash
+   git fetch origin "$EXPECTED_BRANCH"
+   test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"
+   git rm docs/design/2026-07-19-minimap-workspace-attention-concepts.html \
+     docs/testing/2026-07-19-macos-minimap-workspace-attention-smoke.md
+   git commit -m "docs: remove minimap validation artifacts"
+   export PR_HEAD_SHA="$(git rev-parse HEAD)"
+   git push origin HEAD:"refs/heads/$EXPECTED_BRANCH"
+   ```
+
+2. Treat the pushed cleanup commit as the final head. If the push is rejected,
+   do not force it; restart from the current remote head.
+3. Verify, rebuild, and launch a clean final-head process. Do not reuse a PID,
+   FIFO, process, or screenshot from the pre-cleanup or profiling runs:
+
+   ```bash
+   test "$(git rev-parse HEAD)" = "$PR_HEAD_SHA"
+   cargo build
+   for fifo in "$SMOKE_HOME"/control/*.fifo(N); do rm -f "$fifo"; done
+
+   export FINAL_SMOKE_LOG="$SMOKE_EVIDENCE/horizon-final-head.log"
+   HOME="$SMOKE_HOME" ZDOTDIR="$SMOKE_HOME" SHELL=/bin/zsh \
+     RUST_LOG=horizon=info,horizon_core=info \
+     target/debug/horizon --config "$SMOKE_HOME/.horizon/config.yaml" \
+     --ephemeral >"$FINAL_SMOKE_LOG" 2>&1 &
+   export HORIZON_PID=$!
+   kill -0 "$HORIZON_PID"
+   ps -p "$HORIZON_PID" -o pid=,ppid=,etime=,command=
+
+   for key in alpha-high-old alpha-info alpha-high-new beta-count \
+     gamma-done gamma-high delta-info; do
+     wait_for_panel "$key"
+   done
+   seed_spotlight
+   seed_gamma_precedence
+   ```
+
+   Re-run the exact-PID window inventory and record this new PID with the final
+   SHA before interacting.
+4. Against the final head, repeat at minimum:
+   - active switching and the static double outline/`ACTIVE` tab;
+   - one High, one Info, and one recent Done cue plus open precedence;
+   - Alpha marker click and workspace-pill newest-target click with counts intact;
+   - default and minimum map resize/clamping;
+   - one minimap pan and viewport-outline update;
+   - Attention Feed off with active spotlight still present;
+   - detached-scope cue navigation and exact-PID window count;
+   - root resize and one Dark/Light check.
+5. Post the final cleanup SHA and decisive-pass result to the PR using a new
+   comment headed `SMOKE-TEST REPORT (macOS)`. Only when every final-head item
+   passes, refresh current-head CI, mergeability, and unresolved review threads,
+   then end that comment with the exact standalone line
+   `SMOKE-TEST: DONE`. Any code change after cleanup requires the complete plan
+   again; do not reuse pre-cleanup proof or its completion marker.
+
+The macOS agent may mark the PR ready and squash-merge only when the final head
+is mergeable, current-head CI is green, all review threads are resolved, the
+macOS result is PASS, and the two temporary artifacts are absent. Use a squash
+merge only; the implementation/Linux agent does not merge this PR.


### PR DESCRIPTION
## Purpose

Spotlight the active workspace and surface Attention Feed state directly in the minimap without adding animation or continuous repaint work.

## Behavior

- gives the active workspace a brighter accent fill, static double outline, and adaptive `ACTIVE` tab
- aggregates visible attention once per minimap render, with open-item precedence and the existing 30-second resolved window
- shows severity-aware workspace counts plus up to two geometry-safe panel markers
- makes attention cues accessible and clickable while preserving ordinary minimap panning
- focuses and centers the selected panel or workspace without resolving attention
- scopes attention to the current attached or detached minimap and keeps active highlighting independent of the Attention Feed feature flag
- reassigns panel-owned attention when panels move between workspaces
- splits minimap labels, aggregation, layout, and painting into focused modules and updates the maintainability note

No dependency, persisted-schema, public-configuration, or version change is included.

## Validation

Passed on implementation SHA `3639bcf7f2158e796d84e172504c186dab53aaa9`:

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --offline --workspace`
- `cargo clippy --offline --all-targets --all-features -- -D warnings`
- `cargo clippy --offline --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --offline --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `./scripts/check-version-sync.sh`

Linux GUI smoke testing was stopped at the requester’s direction. The full live UI, interaction, detached-window, theme, Retina, resize, persistence, exact-PID motion, and matched performance pass is delegated to macOS through [the temporary smoke plan](docs/testing/2026-07-19-macos-minimap-workspace-attention-smoke.md).

[The temporary concept page](docs/design/2026-07-19-minimap-workspace-attention-concepts.html) and smoke plan remain in this draft for that validation. After the complete pass, the macOS validation owner removes both files, rebuilds the final head, repeats the decisive checks, confirms current-head CI and review state, marks the PR ready, and squash-merges.
