### PR TITLE
fix(release): update Surge toolchain to beta.52

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
-  SURGE_VERSION: v1.0.0-beta.6
+  SURGE_VERSION: v1.0.0-beta.52
   SURGE_STORAGE_REPOSITORY: peters/horizon-updates
 
 permissions:


### PR DESCRIPTION
## Purpose

Recover the stable v0.2.7 release without moving or replacing its published tag. Update the release packaging toolchain from Surge v1.0.0-beta.6 to v1.0.0-beta.52.

## Root cause

The publication-triggered Release run built all four Horizon binaries, then every platform failed while compiling the pinned beta.6 Surge installer UI. Rust 1.97 introduced `float_literal_f32_fallback` diagnostics, and the release workflow's strict `RUSTFLAGS=-D warnings` promoted the 12 diagnostics to errors.

Beta.52 builds cleanly under the existing strict policy, matches Horizon's embedded `surge-core` version, and includes the Unix executable-mode packaging repair missing from beta.6.

## Impact

There is no Horizon runtime, API, configuration, or schema change. Stable release installers and update packages will be assembled with Surge beta.52. Snap remains paused and skipped.

## Validation

- `git diff --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- `RUSTFLAGS="-D warnings" cargo build --release`
- Built the exact Surge beta.52 tag (`e211e88f4481ac1d8587c14aa364ef1efe19fb22`) with strict warnings; all five Linux toolchain outputs were staged.
- Packed the exact v0.2.7 Linux release binary against the current stable update index; full and delta packages plus the offline GUI installer were created, and the packaged `horizon` entry retained executable mode.

The failed publication run is https://github.com/peters/horizon/actions/runs/30748253205. Manual recovery will reuse the existing `v0.2.7` tag after this PR is squash-merged and exact-head CI succeeds.
