### PR TITLE
fix(speech): deduplicate microphone choices

### DIFF
--- a/crates/horizon-ui/src/app/settings/speech.rs
+++ b/crates/horizon-ui/src/app/settings/speech.rs
@@ -235,6 +235,10 @@ fn input_device_list(ui: &Ui) -> Option<std::sync::Arc<Vec<String>>> {
 /// Global microphone picker. Dictating into one microphone while capture
 /// reads another (e.g. a webcam mic as system default) yields empty
 /// transcripts that present as broken hotkeys, so the device is explicit.
+fn input_device_names_equal(left: &str, right: &str) -> bool {
+    left.to_lowercase() == right.to_lowercase()
+}
+
 fn speech_microphone_row(ui: &mut Ui, config: &mut Config) -> bool {
     let mut changed = false;
     ui.label(egui::RichText::new("Microphone").color(theme::FG_SOFT()).size(12.0));
@@ -260,7 +264,7 @@ fn speech_microphone_row(ui: &mut Ui, config: &mut Config) -> bool {
                     Some(device_names) => {
                         let mut current_listed = current.is_empty();
                         for device in device_names {
-                            let is_current = *device == current;
+                            let is_current = input_device_names_equal(device, &current);
                             current_listed |= is_current;
                             if ui.selectable_label(is_current, device).clicked() && !is_current {
                                 config.features.speech.input_device.clone_from(device);
@@ -781,8 +785,20 @@ mod tests {
 
     use super::{
         CLIPBOARD_HOTKEY_ERROR, ClipboardCapture, HotkeyCaptureAttempt, captured_binding_string,
-        hotkey_capture_attempt, render_hotkey_binder, speech_output_row,
+        hotkey_capture_attempt, input_device_names_equal, render_hotkey_binder, speech_output_row,
     };
+
+    #[test]
+    fn input_device_selection_uses_case_insensitive_name_matching() {
+        assert!(input_device_names_equal(
+            "RØDE NT-USB+, USB Audio",
+            "røde nt-usb+, usb audio"
+        ));
+        assert!(!input_device_names_equal(
+            "RØDE NT-USB+, USB Audio",
+            "RØDE NT-USB+ Mono"
+        ));
+    }
 
     #[test]
     fn pending_model_metadata_does_not_rewrite_translation_target() {

--- a/crates/horizon-ui/src/app/speech/capture.rs
+++ b/crates/horizon-ui/src/app/speech/capture.rs
@@ -4,6 +4,7 @@
 //! recording generation so a stale error or buffer from an earlier,
 //! cancelled recording can never affect a newer one.
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
@@ -394,9 +395,17 @@ fn capture_loop(
     }
 }
 
-/// Every input device the audio host reports, in host order. Used by the
-/// settings microphone picker; enumeration can block, so callers must keep
-/// it off the UI thread.
+fn deduplicate_device_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    names
+        .into_iter()
+        .filter(|name| seen.insert(name.to_lowercase()))
+        .collect()
+}
+
+/// Every distinct input device name the audio host reports, in host order.
+/// Used by the settings microphone picker; enumeration can block, so callers
+/// must keep it off the UI thread.
 pub fn list_input_devices() -> Vec<String> {
     let host = cpal::default_host();
     host.input_devices().map_or_else(
@@ -405,9 +414,7 @@ pub fn list_input_devices() -> Vec<String> {
             Vec::new()
         },
         |devices| {
-            devices
-                .filter_map(|device| Some(device.description().ok()?.name().to_string()))
-                .collect()
+            deduplicate_device_names(devices.filter_map(|device| Some(device.description().ok()?.name().to_string())))
         },
     )
 }
@@ -648,8 +655,32 @@ mod tests {
     use std::sync::mpsc::channel;
 
     use super::{
-        CaptureCmd, CaptureHandle, CapturePoll, CapturedAudio, MonoResampler, TARGET_SAMPLE_RATE, to_mono_16k,
+        CaptureCmd, CaptureHandle, CapturePoll, CapturedAudio, MonoResampler, TARGET_SAMPLE_RATE,
+        deduplicate_device_names, to_mono_16k,
     };
+
+    #[test]
+    fn device_names_are_deduplicated_case_insensitively_in_host_order() {
+        let names = [
+            "Logitech BRIO, USB Audio",
+            "RØDE NT-USB+, USB Audio",
+            "RØDE NT-USB+, USB Audio",
+            "USB Audio Front Microphone",
+            "røde nt-usb+, usb audio",
+            "RØDE NT-USB+ Mono",
+            "Logitech BRIO, USB Audio",
+        ];
+
+        assert_eq!(
+            deduplicate_device_names(names.into_iter().map(str::to_owned)),
+            [
+                "Logitech BRIO, USB Audio",
+                "RØDE NT-USB+, USB Audio",
+                "USB Audio Front Microphone",
+                "RØDE NT-USB+ Mono",
+            ]
+        );
+    }
 
     fn stream_in_chunks(samples: &[f32], sample_rate: u32, chunk_sizes: &[usize]) -> (usize, Vec<f32>) {
         let mut resampler = MonoResampler::new(sample_rate, 1);


### PR DESCRIPTION
## What changed

- collapse case-insensitive duplicate CPAL microphone descriptions while preserving the first host-reported order
- keep the selected row aligned with capture's case-insensitive device-name resolution
- add focused regressions for duplicate filtering, first-seen ordering, distinct labels, and Unicode case handling

## Why

On Linux, CPAL can expose several ALSA backend endpoints with the same human-readable microphone name. Horizon discarded the endpoint identity, rendered every repeated name, and saved only that name. Every repeated row therefore performed the same action and capture subsequently selected the first matching endpoint.

## User impact

The microphone picker now shows one choice per selectable name. Existing configured names continue to be recognized even if their casing differs from the host-reported label.

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- live Linux/X11 smoke with an isolated home: one RØDE row after enumeration and refresh, saved selection persisted after reopening Settings, and the picker remained usable at 800x600, 1280x900, and 1600x900
