### PR TITLE
feat(agents): add Grok Build panel integration

### DIFF
--- a/crates/horizon-core/src/agents.rs
+++ b/crates/horizon-core/src/agents.rs
@@ -136,13 +136,33 @@ const PI: AgentDefinition = AgentDefinition {
     kitty_keyboard: true,
 };
 
-pub const BUILTIN_AGENT_KINDS: [PanelKind; 6] = [
+/// xAI's Grok Build CLI (`grok`). Resumes by exact session id via
+/// `--resume <session-id>`; it has no flag to pre-assign ids for fresh
+/// sessions, and its ratatui TUI is driven without the kitty keyboard
+/// protocol (same posture as Codex).
+const GROK: AgentDefinition = AgentDefinition {
+    id: "grok",
+    display_name: "Grok",
+    icon_label: "GB",
+    accent_rgb: [249, 249, 249],
+    default_command: "grok",
+    resume_mode: AgentResumeMode::ExactFlag {
+        flag: "--resume",
+        fresh_session_flag: None,
+    },
+    session_validation: AgentSessionValidationMode::None,
+    integration: AgentIntegrationKind::None,
+    kitty_keyboard: false,
+};
+
+pub const BUILTIN_AGENT_KINDS: [PanelKind; 7] = [
     PanelKind::Codex,
     PanelKind::Claude,
     PanelKind::OpenCode,
     PanelKind::Gemini,
     PanelKind::KiloCode,
     PanelKind::Pi,
+    PanelKind::Grok,
 ];
 
 #[must_use]
@@ -159,6 +179,7 @@ pub const fn agent_definition(kind: PanelKind) -> Option<AgentDefinition> {
         PanelKind::Gemini => Some(GEMINI),
         PanelKind::KiloCode => Some(KILO_CODE),
         PanelKind::Pi => Some(PI),
+        PanelKind::Grok => Some(GROK),
         PanelKind::Shell
         | PanelKind::Ssh
         | PanelKind::Command
@@ -195,6 +216,11 @@ mod tests {
                 .supports_session_binding()
         );
         assert!(
+            agent_definition(PanelKind::Grok)
+                .expect("grok agent")
+                .supports_session_binding()
+        );
+        assert!(
             !agent_definition(PanelKind::Gemini)
                 .expect("gemini agent")
                 .supports_session_binding()
@@ -221,7 +247,7 @@ mod tests {
                 .expect("codex agent")
                 .requires_exact_session_validation()
         );
-        for kind in [PanelKind::Claude, PanelKind::OpenCode, PanelKind::Pi] {
+        for kind in [PanelKind::Claude, PanelKind::OpenCode, PanelKind::Pi, PanelKind::Grok] {
             assert!(
                 !agent_definition(kind)
                     .expect("catalog-backed agent")
@@ -246,5 +272,23 @@ mod tests {
             }
         );
         assert!(definition.kitty_keyboard);
+    }
+
+    #[test]
+    fn grok_definition_uses_exact_resume_flag() {
+        let definition = agent_definition(PanelKind::Grok).expect("grok agent");
+
+        assert_eq!(definition.id, "grok");
+        assert_eq!(definition.display_name, "Grok");
+        assert_eq!(definition.icon_label, "GB");
+        assert_eq!(definition.default_command, "grok");
+        assert_eq!(
+            definition.resume_mode,
+            AgentResumeMode::ExactFlag {
+                flag: "--resume",
+                fresh_session_flag: None,
+            }
+        );
+        assert!(!definition.kitty_keyboard);
     }
 }

--- a/crates/horizon-core/src/config.rs
+++ b/crates/horizon-core/src/config.rs
@@ -189,6 +189,25 @@ pub(crate) fn default_pi_preset() -> PresetConfig {
     }
 }
 
+/// Single Grok Build preset. The CLI starts a fresh session on every launch
+/// unless `--resume` is passed, so menu launches always start fresh like the
+/// other coding-agent defaults.
+pub(crate) fn default_grok_preset() -> PresetConfig {
+    PresetConfig {
+        name: "Grok".to_string(),
+        alias: Some("gb".to_string()),
+        kind: PanelKind::Grok,
+        command: None,
+        args: Vec::new(),
+        resume: PanelResume::Fresh,
+        ssh_connection: None,
+    }
+}
+
+pub(crate) fn default_grok_presets() -> [PresetConfig; 1] {
+    [default_grok_preset()]
+}
+
 fn insert_missing_agent_presets(presets: &mut Vec<PresetConfig>, defaults: impl IntoIterator<Item = PresetConfig>) {
     for default_preset in defaults {
         let expected_name = default_preset.name.to_ascii_lowercase();
@@ -231,6 +250,22 @@ pub(crate) fn insert_missing_pi_presets(presets: &mut Vec<PresetConfig>) {
                 .as_deref()
                 .is_some_and(|alias| alias.eq_ignore_ascii_case("pi"))
             || preset.kind == PanelKind::Pi
+    });
+
+    if !exists {
+        presets.push(default_preset);
+    }
+}
+
+pub(crate) fn insert_missing_grok_presets(presets: &mut Vec<PresetConfig>) {
+    let default_preset = default_grok_preset();
+    let exists = presets.iter().any(|preset| {
+        preset.name.eq_ignore_ascii_case(&default_preset.name)
+            || preset
+                .alias
+                .as_deref()
+                .is_some_and(|alias| alias.eq_ignore_ascii_case("gb"))
+            || preset.kind == PanelKind::Grok
     });
 
     if !exists {
@@ -288,6 +323,7 @@ fn default_presets() -> Vec<PresetConfig> {
     presets.extend(default_gemini_presets());
     presets.extend(default_kilo_presets());
     insert_missing_pi_presets(&mut presets);
+    presets.extend(default_grok_presets());
     presets.extend([
         PresetConfig {
             name: "Git Changes".to_string(),

--- a/crates/horizon-core/src/config_migration.rs
+++ b/crates/horizon-core/src/config_migration.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 
 use crate::config::{
     Config, PresetConfig, default_claude_preset, default_codex_preset, default_kilo_preset, default_opencode_preset,
-    insert_missing_gemini_presets, insert_missing_kilo_presets, insert_missing_opencode_presets,
-    insert_missing_pi_presets,
+    insert_missing_gemini_presets, insert_missing_grok_presets, insert_missing_kilo_presets,
+    insert_missing_opencode_presets, insert_missing_pi_presets,
 };
 use crate::error::{Error, Result};
 use crate::panel::{PanelKind, PanelResume};
 use crate::shortcuts::ShortcutBinding;
 
-pub const CURRENT_CONFIG_VERSION: u32 = 8;
+pub const CURRENT_CONFIG_VERSION: u32 = 9;
 
 /// Run any pending migrations on `config` and write back to disk.
 ///
@@ -33,6 +33,7 @@ pub fn migrate_if_needed(config: &mut Config, config_path: &Path) -> Result<bool
             5 => migrate_v5_to_v6(config),
             6 => migrate_v6_to_v7(config),
             7 => migrate_v7_to_v8(config),
+            8 => migrate_v8_to_v9(config),
             _ => {
                 return Err(Error::Config(format!(
                     "unknown config version {version}, expected 1..={CURRENT_CONFIG_VERSION}"
@@ -130,6 +131,11 @@ fn migrate_v6_to_v7(config: &mut Config) {
 /// already exists by name, alias, or kind.
 fn migrate_v7_to_v8(config: &mut Config) {
     insert_missing_pi_presets(&mut config.presets);
+}
+
+/// v8 -> v9: add the default `Grok` coding-agent preset when it is missing.
+fn migrate_v8_to_v9(config: &mut Config) {
+    insert_missing_grok_presets(&mut config.presets);
 }
 
 /// Remove every preset matching `should_remove`, then insert `replacement()`
@@ -369,7 +375,7 @@ presets:
         assert_eq!(config.version, CURRENT_CONFIG_VERSION);
 
         let reloaded = std::fs::read_to_string(&path).expect("read back");
-        assert!(reloaded.contains("version: 8"));
+        assert!(reloaded.contains("version: 9"));
         assert!(reloaded.contains("Ctrl+Shift+K"));
         assert!(reloaded.contains("zoom_reset: Ctrl+0"));
         assert!(reloaded.contains("appearance:"));
@@ -378,7 +384,7 @@ presets:
     #[test]
     fn serialized_config_includes_version() {
         let yaml = Config::default().to_yaml().expect("should serialize");
-        assert!(yaml.contains("version: 8"));
+        assert!(yaml.contains("version: 9"));
     }
 
     #[test]
@@ -850,6 +856,67 @@ presets:
             let mut config: Config = serde_yaml::from_str(existing).expect("should deserialize");
 
             migrate_v7_to_v8(&mut config);
+
+            assert_eq!(config.presets.len(), 1);
+        }
+    }
+
+    #[test]
+    fn migration_v8_to_v9_adds_missing_grok_preset() {
+        let mut config: Config = serde_yaml::from_str(
+            "\
+version: 8
+presets:
+  - name: Shell
+    alias: sh
+    kind: shell
+",
+        )
+        .expect("should deserialize");
+
+        migrate_v8_to_v9(&mut config);
+
+        let grok = config
+            .presets
+            .iter()
+            .find(|preset| preset.kind == PanelKind::Grok)
+            .expect("Grok preset");
+        assert_eq!(grok.name, "Grok");
+        assert_eq!(grok.alias.as_deref(), Some("gb"));
+        assert_eq!(grok.command, None);
+        assert!(grok.args.is_empty());
+        assert_eq!(grok.resume, PanelResume::Fresh);
+    }
+
+    #[test]
+    fn migration_v8_to_v9_does_not_duplicate_existing_grok_preset() {
+        for existing in [
+            "\
+version: 8
+presets:
+  - name: Grok
+    alias: custom-gb
+    kind: shell
+",
+            "\
+version: 8
+presets:
+  - name: My Grok
+    alias: gb
+    kind: shell
+",
+            "\
+version: 8
+presets:
+  - name: Custom Agent
+    alias: custom
+    kind: grok
+    resume: last
+",
+        ] {
+            let mut config: Config = serde_yaml::from_str(existing).expect("should deserialize");
+
+            migrate_v8_to_v9(&mut config);
 
             assert_eq!(config.presets.len(), 1);
         }

--- a/crates/horizon-core/src/local_store.rs
+++ b/crates/horizon-core/src/local_store.rs
@@ -18,6 +18,10 @@ pub(crate) fn codex_home_dir() -> Option<PathBuf> {
     codex_home_dir_from_env(env_path("CODEX_HOME"), user_home_dir())
 }
 
+pub(crate) fn grok_home_dir() -> Option<PathBuf> {
+    grok_home_dir_from_env(env_path("GROK_HOME"), user_home_dir())
+}
+
 fn user_home_dir_from_env(home: Option<PathBuf>, user_profile: Option<PathBuf>) -> Option<PathBuf> {
     home.or(user_profile)
 }
@@ -26,8 +30,19 @@ fn codex_home_dir_from_env(codex_home: Option<PathBuf>, user_home: Option<PathBu
     codex_home.or_else(|| user_home.map(|home| home.join(".codex")))
 }
 
+fn grok_home_dir_from_env(grok_home: Option<PathBuf>, user_home: Option<PathBuf>) -> Option<PathBuf> {
+    grok_home.or_else(|| user_home.map(|home| home.join(".grok")))
+}
+
 pub(crate) fn codex_db_path() -> Option<PathBuf> {
     codex_db_path_in(&codex_home_dir()?)
+}
+
+/// Local session index maintained by the Grok CLI (`session_search.sqlite`
+/// lives next to the on-disk session tree, unlike every other provider's
+/// store). Missing file is not an error: the CLI creates it on first run.
+pub(crate) fn grok_sessions_db_path() -> Option<PathBuf> {
+    grok_home_dir().map(|home| home.join("sessions").join("session_search.sqlite"))
 }
 
 fn codex_db_path_in(codex_home: &Path) -> Option<PathBuf> {
@@ -44,7 +59,7 @@ pub(crate) fn open_read_only_sqlite(path: &Path) -> Result<Connection> {
 mod tests {
     use tempfile::TempDir;
 
-    use super::{codex_db_path_in, codex_home_dir_from_env, user_home_dir_from_env};
+    use super::{codex_db_path_in, codex_home_dir_from_env, grok_home_dir_from_env, user_home_dir_from_env};
 
     #[test]
     fn codex_store_uses_the_supported_state_database() {
@@ -87,6 +102,27 @@ mod tests {
         assert_eq!(
             codex_home_dir_from_env(Some(codex_home.clone()), Some(user_home)),
             Some(codex_home)
+        );
+    }
+
+    #[test]
+    fn grok_home_honors_the_explicit_override() {
+        let grok_home = std::path::PathBuf::from("/stores/grok");
+        let user_home = std::path::PathBuf::from("/Users/tester");
+
+        assert_eq!(
+            grok_home_dir_from_env(Some(grok_home.clone()), Some(user_home)),
+            Some(grok_home)
+        );
+    }
+
+    #[test]
+    fn grok_home_falls_back_to_the_dot_directory() {
+        let user_home = std::path::PathBuf::from("/Users/tester");
+
+        assert_eq!(
+            grok_home_dir_from_env(None, Some(user_home)),
+            Some(std::path::PathBuf::from("/Users/tester/.grok"))
         );
     }
 }

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -46,6 +46,7 @@ pub enum PanelKind {
     Gemini,
     KiloCode,
     Pi,
+    Grok,
     Command,
     Editor,
     GitChanges,
@@ -81,7 +82,7 @@ impl PanelKind {
             Self::Editor => "Editor",
             Self::GitChanges => "Git Changes",
             Self::Usage => "Usage",
-            Self::Codex | Self::Claude | Self::OpenCode | Self::Gemini | Self::KiloCode | Self::Pi => {
+            Self::Codex | Self::Claude | Self::OpenCode | Self::Gemini | Self::KiloCode | Self::Pi | Self::Grok => {
                 unreachable!()
             }
         }
@@ -916,6 +917,47 @@ mod tests {
     }
 
     #[test]
+    fn grok_fresh_without_binding_starts_without_resume_flag() {
+        let (_program, args) = resolve_launch_command(
+            None,
+            Vec::new(),
+            None,
+            PanelKind::Grok,
+            AgentLaunchContext {
+                resume: &PanelResume::Fresh,
+                session_binding: None,
+                should_resume_binding: false,
+                is_restore: false,
+            },
+        );
+
+        assert_eq!(args, vec!["-ic".to_string(), "grok".to_string()]);
+    }
+
+    #[test]
+    fn grok_session_resume_uses_resume_flag_before_custom_args() {
+        let binding = AgentSessionBinding::new(PanelKind::Grok, "session-42".to_string(), None, None, None);
+        let (_program, args) = resolve_launch_command(
+            None,
+            vec!["-m".to_string(), "grok-build".to_string()],
+            None,
+            PanelKind::Grok,
+            AgentLaunchContext {
+                resume: &PanelResume::Session {
+                    session_id: "session-42".to_string(),
+                },
+                session_binding: Some(&binding),
+                should_resume_binding: true,
+                is_restore: false,
+            },
+        );
+
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "-ic");
+        assert_eq!(args[1], "grok --resume session-42 -m grok-build");
+    }
+
+    #[test]
     fn gemini_panels_start_without_implicit_resume_flags() {
         let (_program, args) = resolve_launch_command(
             None,
@@ -1032,6 +1074,7 @@ mod tests {
             AGENT_PANEL_SCROLLBACK_LIMIT
         );
         assert_eq!(scrollback_limit_for_kind(PanelKind::Pi), AGENT_PANEL_SCROLLBACK_LIMIT);
+        assert_eq!(scrollback_limit_for_kind(PanelKind::Grok), AGENT_PANEL_SCROLLBACK_LIMIT);
     }
 
     #[test]
@@ -1042,6 +1085,7 @@ mod tests {
         assert!(!kitty_keyboard_for_kind(PanelKind::Gemini));
         assert!(kitty_keyboard_for_kind(PanelKind::KiloCode));
         assert!(kitty_keyboard_for_kind(PanelKind::Pi));
+        assert!(!kitty_keyboard_for_kind(PanelKind::Grok));
         assert!(kitty_keyboard_for_kind(PanelKind::Shell));
         assert!(kitty_keyboard_for_kind(PanelKind::Ssh));
     }

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -643,7 +643,8 @@ pub(super) fn resolve_launch_command(
         | PanelKind::OpenCode
         | PanelKind::Gemini
         | PanelKind::KiloCode
-        | PanelKind::Pi => resolve_agent_launch_command(command, args, kind, launch),
+        | PanelKind::Pi
+        | PanelKind::Grok => resolve_agent_launch_command(command, args, kind, launch),
     }
 }
 
@@ -879,7 +880,8 @@ pub(super) fn scrollback_limit_for_kind(kind: PanelKind) -> usize {
             | PanelKind::OpenCode
             | PanelKind::Gemini
             | PanelKind::KiloCode
-            | PanelKind::Pi => unreachable!(),
+            | PanelKind::Pi
+            | PanelKind::Grok => unreachable!(),
         }
     }
 }

--- a/crates/horizon-core/src/runtime_state/agent_sessions.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions.rs
@@ -13,6 +13,7 @@ use crate::opencode_paths::opencode_db_path;
 use super::{AgentSessionBinding, PanelKind, RuntimeState, normalize_cwd};
 
 mod codex;
+mod grok;
 
 #[derive(Clone, Debug, Default)]
 pub struct AgentSessionCatalog {
@@ -34,7 +35,7 @@ pub struct AgentSessionBootstrapCatalog {
 }
 
 impl AgentSessionCatalog {
-    /// Load recent Claude, Codex, `OpenCode`, and Pi sessions from their local stores.
+    /// Load recent Claude, Codex, `OpenCode`, Pi, and Grok sessions from their local stores.
     ///
     /// # Errors
     ///
@@ -45,6 +46,7 @@ impl AgentSessionCatalog {
             || codex::load_sessions(&HashSet::new(), true),
             load_opencode_sessions,
             load_pi_sessions,
+            grok::load_grok_sessions,
         )
     }
 
@@ -73,6 +75,7 @@ impl AgentSessionCatalog {
         let has_codex_panels = Self::has_provider_panel(runtime_state, PanelKind::Codex);
         let has_opencode_panels = Self::has_provider_panel(runtime_state, PanelKind::OpenCode);
         let has_pi_panels = Self::has_provider_panel(runtime_state, PanelKind::Pi);
+        let has_grok_panels = Self::has_provider_panel(runtime_state, PanelKind::Grok);
 
         let mut sessions = Vec::new();
         if has_claude_panels {
@@ -83,6 +86,9 @@ impl AgentSessionCatalog {
         }
         if has_pi_panels {
             extend_best_effort(&mut sessions, "Pi", load_pi_sessions());
+        }
+        if has_grok_panels {
+            extend_best_effort(&mut sessions, "Grok", grok::load_grok_sessions());
         }
         let mut codex_binding_ids = HashSet::new();
         for (kind, binding_ids) in exact_binding_ids {
@@ -123,11 +129,13 @@ impl AgentSessionCatalog {
         codex: impl FnOnce() -> Result<codex::CodexSessions>,
         opencode: impl FnOnce() -> Result<Vec<AgentSessionRecord>>,
         pi: impl FnOnce() -> Result<Vec<AgentSessionRecord>>,
+        grok: impl FnOnce() -> Result<Vec<AgentSessionRecord>>,
     ) -> Result<Self> {
         let mut sessions = claude()?;
         let codex = codex()?;
         sessions.extend(opencode()?);
         sessions.extend(pi()?);
+        sessions.extend(grok()?);
         Ok(Self::from_provider_sessions(sessions, &codex))
     }
 

--- a/crates/horizon-core/src/runtime_state/agent_sessions/grok.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/grok.rs
@@ -1,0 +1,89 @@
+use std::path::Path;
+
+use crate::error::{Error, Result};
+use crate::local_store::{grok_sessions_db_path, open_read_only_sqlite};
+
+use super::{AgentSessionRecord, PanelKind, normalize_cwd};
+
+/// Cap on catalog rows: the picker and binding bootstrap only consume
+/// recent sessions, and unbounded tables would slow every startup.
+const MAX_SESSION_ROWS: i64 = 1000;
+
+/// Load Grok sessions from the CLI-maintained local search index.
+///
+/// Unlike Claude/Codex/Pi, Grok organizes its on-disk session tree under
+/// URL-encoded working directories, so the raw `cwd` is not recoverable by
+/// walking the tree. The `session_docs` index in `session_search.sqlite`
+/// carries the decoded cwd and is the local source of truth Horizon reads.
+pub(super) fn load_grok_sessions() -> Result<Vec<AgentSessionRecord>> {
+    let Some(db_path) = grok_sessions_db_path() else {
+        return Ok(Vec::new());
+    };
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+    load_grok_sessions_from_path(&db_path)
+}
+
+pub(super) fn load_grok_sessions_from_path(db_path: &Path) -> Result<Vec<AgentSessionRecord>> {
+    let connection = open_read_only_sqlite(db_path)?;
+    let table_rows: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'session_docs'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| Error::State(error.to_string()))?;
+    // Older or differently configured CLI builds may not maintain the
+    // search index; treat a missing table as "no sessions", not a failure.
+    if table_rows == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut statement = connection
+        .prepare(&format!(
+            "SELECT session_id, cwd, updated_at, title
+             FROM session_docs
+             ORDER BY updated_at DESC
+             LIMIT {MAX_SESSION_ROWS}"
+        ))
+        .map_err(|error| Error::State(error.to_string()))?;
+
+    let rows = statement
+        .query_map([], |row| {
+            Ok(AgentSessionRecord {
+                kind: PanelKind::Grok,
+                session_id: row.get(0)?,
+                label: row
+                    .get::<_, String>(3)
+                    .ok()
+                    .filter(|title| !title.trim().is_empty())
+                    .or_else(|| Some("Grok session".to_string())),
+                cwd: normalize_cwd(row.get::<_, String>(1).ok().as_deref()),
+                updated_at: normalize_updated_at(row.get::<_, i64>(2)?),
+                interactive: true,
+            })
+        })
+        .map_err(|error| Error::State(error.to_string()))?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        sessions.push(row.map_err(|error| Error::State(error.to_string()))?);
+    }
+    Ok(sessions)
+}
+
+/// The CLI does not document the unit of `session_docs.updated_at`. Horizon
+/// compares catalog timestamps against panel launch times in milliseconds,
+/// so normalize epoch-second values to milliseconds before they leave this
+/// module. Any real-world second timestamp is far below the threshold, and
+/// any real-world millisecond timestamp is far above it.
+fn normalize_updated_at(value: i64) -> i64 {
+    const SECOND_TIMESTAMP_THRESHOLD: u64 = 1_000_000_000_000;
+
+    if value.unsigned_abs() < SECOND_TIMESTAMP_THRESHOLD {
+        value.saturating_mul(1000)
+    } else {
+        value
+    }
+}

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use crate::error::Error;
 
+mod grok;
 mod provider_scoping;
 
 #[test]
@@ -21,6 +22,7 @@ fn strict_catalog_load_propagates_provider_errors() {
         || Ok(Vec::new()),
         || Ok(CodexSessions::default()),
         || Err(Error::State("OpenCode store unavailable".to_string())),
+        || Ok(Vec::new()),
         || Ok(Vec::new()),
     );
 

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests/grok.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests/grok.rs
@@ -1,0 +1,80 @@
+use super::super::grok as loader;
+use super::*;
+
+#[test]
+fn provider_catalog_presence_includes_grok_panels() {
+    let runtime_state = RuntimeState {
+        workspaces: vec![WorkspaceState {
+            panels: vec![PanelState {
+                kind: PanelKind::Grok,
+                resume: PanelResume::Session {
+                    session_id: "grok-pinned".into(),
+                },
+                ..PanelState::default()
+            }],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    };
+
+    assert!(AgentSessionCatalog::has_provider_panel(&runtime_state, PanelKind::Grok));
+    assert!(!AgentSessionCatalog::has_provider_panel(
+        &runtime_state,
+        PanelKind::Claude
+    ));
+}
+
+#[test]
+fn load_grok_sessions_reads_sessions_from_search_index() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let sqlite_path = temp_dir.path().join("session_search.sqlite");
+    let conn = Connection::open(&sqlite_path).expect("sqlite");
+    conn.execute_batch(
+        "\
+CREATE TABLE session_docs (
+session_id TEXT PRIMARY KEY,
+cwd TEXT NOT NULL,
+updated_at INTEGER NOT NULL,
+title TEXT NOT NULL,
+content TEXT NOT NULL,
+content_hash TEXT NOT NULL
+,
+last_indexed_offset INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO session_docs (session_id, cwd, updated_at, title, content, content_hash) VALUES
+('grok-older', '/repo', 1750000000, 'Older fix', 'payload', 'hash-1'),
+('grok-newer', '/repo', 1750000000123, 'Newer fix', 'payload', 'hash-2'),
+('grok-untitled', '/other', 1749999999, '', 'payload', 'hash-3');
+",
+    )
+    .expect("seed");
+
+    let sessions = loader::load_grok_sessions_from_path(&sqlite_path).expect("grok sessions");
+
+    assert_eq!(sessions.len(), 3);
+    assert_eq!(sessions[0].kind, PanelKind::Grok);
+    assert_eq!(sessions[0].session_id, "grok-newer");
+    assert_eq!(sessions[0].cwd.as_deref(), Some("/repo"));
+    assert_eq!(sessions[0].label.as_deref(), Some("Newer fix"));
+    assert_eq!(sessions[0].updated_at, 1_750_000_000_123);
+    assert!(sessions[0].interactive);
+    // Epoch-second timestamps are normalized to milliseconds so catalog
+    // ordering and launch-window comparisons match the other providers.
+    assert_eq!(sessions[1].session_id, "grok-older");
+    assert_eq!(sessions[1].updated_at, 1_750_000_000_000);
+    assert_eq!(sessions[2].session_id, "grok-untitled");
+    assert_eq!(sessions[2].label.as_deref(), Some("Grok session"));
+}
+
+#[test]
+fn load_grok_sessions_treats_missing_table_as_empty() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let sqlite_path = temp_dir.path().join("session_search.sqlite");
+    let conn = Connection::open(&sqlite_path).expect("sqlite");
+    conn.execute_batch("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);")
+        .expect("seed");
+
+    let sessions = loader::load_grok_sessions_from_path(&sqlite_path).expect("grok sessions");
+
+    assert!(sessions.is_empty());
+}

--- a/crates/horizon-ui/src/app/actions/panels.rs
+++ b/crates/horizon-ui/src/app/actions/panels.rs
@@ -152,7 +152,13 @@ mod tests {
 
     #[test]
     fn new_agent_panels_always_start_fresh_sessions() {
-        for kind in [PanelKind::Claude, PanelKind::Codex, PanelKind::OpenCode, PanelKind::Pi] {
+        for kind in [
+            PanelKind::Claude,
+            PanelKind::Codex,
+            PanelKind::OpenCode,
+            PanelKind::Pi,
+            PanelKind::Grok,
+        ] {
             let mut options = PanelOptions {
                 kind,
                 resume: PanelResume::Last,

--- a/crates/horizon-ui/src/app/panel_chrome.rs
+++ b/crates/horizon-ui/src/app/panel_chrome.rs
@@ -110,7 +110,8 @@ pub(super) fn panel_kind_icon(kind: PanelKind, workspace_color: Color32, focused
         | PanelKind::OpenCode
         | PanelKind::Gemini
         | PanelKind::KiloCode
-        | PanelKind::Pi => {
+        | PanelKind::Pi
+        | PanelKind::Grok => {
             unreachable!()
         }
     }

--- a/crates/horizon-ui/src/app/settings/presets.rs
+++ b/crates/horizon-ui/src/app/settings/presets.rs
@@ -3,7 +3,7 @@ use horizon_core::{Config, PanelKind, PanelResume, PresetConfig};
 
 use crate::theme;
 
-const ALL_KINDS: [PanelKind; 12] = [
+const ALL_KINDS: [PanelKind; 13] = [
     PanelKind::Shell,
     PanelKind::Ssh,
     PanelKind::Codex,
@@ -12,6 +12,7 @@ const ALL_KINDS: [PanelKind; 12] = [
     PanelKind::Gemini,
     PanelKind::KiloCode,
     PanelKind::Pi,
+    PanelKind::Grok,
     PanelKind::Command,
     PanelKind::Editor,
     PanelKind::GitChanges,

--- a/docs/testing/2026-08-16-grok-agent-panel-smoke.md
+++ b/docs/testing/2026-08-16-grok-agent-panel-smoke.md
@@ -1,0 +1,144 @@
+# Grok Build agent panel — smoke test plan (temporary)
+
+Validates the new `Grok` panel kind (xAI Grok Build CLI, binary `grok`).
+Each lane is self-contained: no Horizon-specific context is needed beyond
+this file. The `grok` CLI must be installed on PATH for the TUI lanes
+(`npm install -g @xai-official/grok` is the supported install; it is not
+required for the catalog/migration lanes).
+
+## Shared preconditions
+
+- Build: `cargo build` (debug binary `target/debug/horizon` is sufficient).
+- Isolated runtime state: use a temp `HOME` so the tester's real
+  `~/.horizon` and `~/.grok` state is untouched:
+  ```bash
+  SMOKE_HOME=$(mktemp -d)/home && mkdir -p "$SMOKE_HOME/.horizon"
+  ```
+- When multiple Horizon instances may be running, scope every window
+  inspection and kill to the exact PID under test (match via
+  `tr '\0' '\n' < /proc/<pid>/environ | grep '^HOME='`), never by app name.
+
+## Lane A — Linux / macOS (local, any machine with a GPU or llvmpipe)
+
+### A1. Config migration v8 -> v9
+
+Seed a v8 config (no Grok preset) into the smoke home:
+
+```bash
+cp <real ~/.horizon/config.yaml> "$SMOKE_HOME/.horizon/config.yaml"
+# then: set `version: 9` -> `version: 8` and delete any `Grok` preset block
+```
+
+Launch:
+
+```bash
+HOME="$SMOKE_HOME" RUST_LOG=info target/debug/horizon
+```
+
+Expected:
+- Window maps (`xwininfo -root -tree` on X11; `screencapture`/window list on
+  macOS).
+- `$SMOKE_HOME/.horizon/config.yaml` is rewritten to `version: 9` with a
+  `Grok` preset appended after the last existing preset
+  (`alias: gb`, `kind: grok`, `resume: fresh`).
+- Log contains `migrated config to version 9`.
+
+### A2. Panel launch (fresh and resume)
+
+Seed a runtime session with two Grok panels so restore drives the launches
+(copy the shape below into
+`$SMOKE_HOME/.horizon/sessions/<sid>/runtime.yaml`; also create
+`meta.yaml` — `profile_id` must equal the FNV-1a hash of the canonical
+config path, which Horizon itself writes into other session dirs, so reuse
+the profile_id from an existing session of the same smoke home — and list
+the session in `sessions/index.yaml` with `last_session_id: <sid>`):
+
+```yaml
+workspaces:
+- local_id: ws-smoke
+  name: Grok Smoke
+  cwd: <any existing dir>
+  position: [0.0, 0.0]
+  template: null
+  layout: Grid
+  panels:
+  - local_id: grok-fresh
+    name: Grok Fresh
+    kind: grok
+    command: null
+    args: []
+    cwd: <any existing dir>
+    rows: 30
+    cols: 100
+    resume: fresh
+    position: [0.0, 0.0]
+    size: [780.0, 500.0]
+    session_binding: null
+    template: null
+  - local_id: grok-resume
+    name: Grok Resume
+    kind: grok
+    command: null
+    args: []
+    cwd: <any existing dir>
+    rows: 30
+    cols: 100
+    resume: !session
+      session_id: smoke-session-123
+    position: [800.0, 0.0]
+    size: [780.0, 500.0]
+    session_binding: null
+    template: null
+```
+
+Launch with the smoke home. Expected (from the `launching agent panel`
+trace lines):
+
+- Panel 1: `cmd=... -ic grok` (fresh, no resume flags).
+- Panel 2: `cmd=... -ic grok --resume smoke-session-123`.
+- Both child processes stay alive (grok TUI shows its auth/welcome screen;
+  auth is not required for this smoke).
+- Panel title-bar badge reads `GB`.
+- Resize the panels and run fit-workspace: no crash, TUI reflows.
+
+### A3. Session catalog (only when `grok` has real sessions)
+
+If the machine has an authenticated Grok account with at least one session:
+
+- Create/finish one session in `<dir>` with the real `grok` CLI.
+- Restart Horizon (same or real home) with a Grok panel in `<dir>`.
+- The panel's session picker lists the session with a sensible title and
+  cwd; picking a session rebinds the panel and relaunches with
+  `--resume <session-id>`.
+- Without `grok` installed or without a store: picker is empty, no crash,
+  no error spam (catalog load is best-effort).
+
+## Lane B — macOS (Apple Silicon)
+
+Same as Lane A, plus:
+
+- Binary install: `npm install -g @xai-official/grok` (pulls the
+  darwin-arm64 platform binary).
+- Window inspection via window-server tooling instead of xwininfo;
+  screenshots via `screencapture -o <id>` or `-V` video for the resize pass.
+
+## Lane C — Windows
+
+Same as Lane A, plus:
+
+- Binary install: `npm install -g @xai-official/grok` (win32-x64 binary).
+- `grok` must be resolvable from the PTY login shell (`bash -ic grok`);
+  npm global bin must be on PATH.
+- No `~/.grok` store: panel launch still works (fresh + resume cmds as in
+  A2); session catalog stays empty.
+
+## Pass criteria
+
+- A1/A2/B/C all pass; migration output is byte-identical in shape to the
+  documented preset.
+- Kill the horizon PID; no orphaned `grok` children survive.
+
+## Cleanup
+
+- Remove the smoke home and any screenshots.
+- Delete this plan file once every requested lane reports pass.


### PR DESCRIPTION
## Purpose

First-class support for xAI's **Grok Build** CLI (`grok`, https://x.ai/build — verified against the official `@xai-official/grok` npm package and its binary), matching the existing agent integrations (Pi/OpenCode pattern):

- New `Grok` panel kind with `GB` title-bar badge and a default `Grok` preset (alias `gb`, always-fresh resume)
- Session binding via `--resume <session-id>` (exact-flag resume mode; the CLI has no fresh-session-id flag)
- Session catalog reads the CLI-maintained `~/.grok/sessions/session_search.sqlite` index (`GROK_HOME` override honored). The on-disk session tree uses URL-encoded cwd directory names that are not reliably reversible, so the index — which carries the raw cwd — is the catalog source. Epoch-second timestamps are normalized to milliseconds so the dynamic launch-window binding logic works for Grok like the other providers
- Config migration **v8 → v9** inserts the default preset for existing installs (name/alias/kind dedup, Pi-style)
- Kitty keyboard protocol stays off (ratatui TUI, same posture as Codex)

## Behavior impact

- Panel kind `grok` is accepted in runtime state, presets, and panel chrome; old configs migrate on launch
- Fresh Grok panels launch `grok` with no resume flags; bound/explicit-session panels launch `grok --resume <id>`
- Grok sessions appear in the session picker for Grok panels; missing index/table/DB degrades to an empty catalog (best-effort, like OpenCode/Pi)
- No changes to other agents' behavior

## Test evidence

- Full local validation matrix in the push worktree: `cargo fmt --check`, `scripts/check-maintainability.sh`, `cargo test --workspace` (804 passed), `cargo test --workspace --features speech` (842 passed), blocking + strict + pedantic clippy tiers all clean
- New unit tests: Grok agent definition, fresh/resume launch commands, scrollback/kitty, v8→v9 migration (incl. no-duplication), `session_docs` loader (normalization, sorting, empty-title fallback, missing-table → empty), provider-scoping
- **Live Linux/X11 smoke** (isolated temp HOME, debug binary, real `grok` 0.1.220 binary): v8→v9 migration wrote the Grok preset; seeded two-panel session restored with exact launch commands from the trace log:
  - `launching agent panel kind=Grok resume=Fresh cmd=/bin/bash -ic grok`
  - `launching agent panel kind=Grok resume=Session { session_id: "smoke-session-123" } should_resume=true cmd=/bin/bash -ic grok --resume smoke-session-123`
  - Both TUI processes ran in-board (auth welcome screen; auth not required for the smoke)
- Cross-machine smoke plan for the remaining lanes: `docs/testing/2026-08-16-grok-agent-panel-smoke.md` (delete after all lanes pass)

## Runtime / platform assumptions

- `grok` must be on PATH for the panel to start (install: `npm install -g @xai-official/grok`); without it the panel shows the shell's command-not-found, same as any agent
- Session catalog requires the CLI to have created its store (created on first CLI run); unit tests cover the missing-store paths
