### PR TITLE
feat(ui): show working indicator in agent panel titlebars

### DIFF
--- a/crates/horizon-core/src/agents.rs
+++ b/crates/horizon-core/src/agents.rs
@@ -1,5 +1,64 @@
 use crate::panel::PanelKind;
 
+/// Coarse activity state of an agent panel, derived from what the agent TUI
+/// renders in the terminal.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AgentStatus {
+    /// No working indicator visible; the agent is at its prompt (or the panel
+    /// is not an agent panel).
+    #[default]
+    Idle,
+    /// The agent TUI is rendering its working indicator (streaming a response,
+    /// running a command, compacting, retrying, ...).
+    Working,
+}
+
+/// Number of visible bottom screen rows scanned for agent working indicators.
+/// Agent TUIs pin their status line a few rows above the bottom input/footer
+/// area, so a small bottom window catches the line without scanning the whole
+/// screen.
+pub const AGENT_WORKING_SCAN_ROWS: usize = 6;
+
+/// Status words agent TUIs print next to their working spinner. Covers the
+/// working/thinking labels of the built-in agents (Pi, Codex, Claude Code,
+/// Gemini, `OpenCode`, Grok) plus the retry/reuse/compaction variants.
+const WORKING_KEYWORDS: [&str; 7] = [
+    "Working",
+    "Thinking",
+    "Compacting",
+    "Retrying",
+    "Reusing",
+    "Summarizing",
+    "Context overflow",
+];
+
+/// Interrupt/stop hints the working status line always carries, so custom
+/// working messages without a status word still count.
+const WORKING_HINTS: [&str; 3] = ["to interrupt", "to stop", "to cancel"];
+
+fn is_spinner_glyph(ch: char) -> bool {
+    // Braille spinner frames (pi-tui, ink, codex) and star spinners (Claude
+    // Code uses \u{273B}).
+    ('\u{2800}'..='\u{28FF}').contains(&ch) || ('\u{2737}'..='\u{273B}').contains(&ch)
+}
+
+/// A terminal line counts as a working indicator when it starts with an
+/// animated spinner glyph and carries a working keyword or the usual
+/// interrupt/stop/cancel hint. Requiring the spinner prefix keeps ordinary
+/// output text that merely mentions "Working" from flipping the status.
+#[must_use]
+pub fn is_agent_working_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some(first) = trimmed.chars().next() else {
+        return false;
+    };
+    if !is_spinner_glyph(first) {
+        return false;
+    }
+    WORKING_KEYWORDS.iter().any(|keyword| trimmed.contains(keyword))
+        || WORKING_HINTS.iter().any(|hint| trimmed.contains(hint))
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AgentResumeMode {
     ExactSubcommand {
@@ -191,7 +250,7 @@ pub const fn agent_definition(kind: PanelKind) -> Option<AgentDefinition> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentResumeMode, PanelKind, agent_definition};
+    use super::{AgentResumeMode, PanelKind, agent_definition, is_agent_working_line};
 
     #[test]
     fn exact_session_binding_support_is_reserved_for_catalog_backed_agents() {
@@ -254,6 +313,35 @@ mod tests {
                     .requires_exact_session_validation()
             );
         }
+    }
+
+    #[test]
+    fn working_line_requires_spinner_glyph_and_working_marker() {
+        // Pi: braille spinner + default working message.
+        assert!(is_agent_working_line("\u{280b} Working... (esc to interrupt)"));
+        // Codex-style: braille spinner + elapsed time.
+        assert!(is_agent_working_line("\u{2809} Working (5s) · esc to stop"));
+        // Claude Code star spinner + unicode ellipsis.
+        assert!(is_agent_working_line("\u{273B} Working…"));
+        // Thinking / compaction / retry variants.
+        assert!(is_agent_working_line("\u{2801} Thinking..."));
+        assert!(is_agent_working_line("\u{280F} Compacting context..."));
+        // Retrying / reusing variants.
+        assert!(is_agent_working_line(
+            "\u{2808} Retrying (1/5) in 3s... (esc to cancel)"
+        ));
+        assert!(is_agent_working_line("\u{280b} Reusing context..."));
+        // Custom working message: no keyword, but the interrupt hint remains.
+        assert!(is_agent_working_line("\u{2808} Deploying to prod (esc to interrupt)"));
+        // Leading whitespace is fine.
+        assert!(is_agent_working_line("  \u{280b} Working..."));
+
+        // Plain output text mentioning "Working" has no spinner prefix.
+        assert!(!is_agent_working_line("Working on the fix"));
+        // Spinner glyph without a working marker (prompt line, done line).
+        assert!(!is_agent_working_line("\u{280b} > ready"));
+        assert!(!is_agent_working_line("\u{2713} Done"));
+        assert!(!is_agent_working_line(""));
     }
 
     #[test]

--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -1,3 +1,4 @@
+mod agent_status;
 mod arrangement;
 mod attention;
 mod geometry;
@@ -302,6 +303,11 @@ impl Board {
         if self.attention_enabled && output.had_terminal_output {
             self.update_attention();
         }
+        // Working-status refresh runs every frame: the per-panel check is a
+        // cheap timestamp compare for quiet panels, and the screen scan only
+        // happens for panels with new output this frame. It is independent of
+        // the attention-feed feature flag.
+        self.update_agent_status();
         output
     }
 

--- a/crates/horizon-core/src/board/agent_status.rs
+++ b/crates/horizon-core/src/board/agent_status.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+
+use crate::agents::AgentStatus;
+use crate::panel::Panel;
+
+use super::Board;
+
+/// A working indicator that receives no terminal output for this long is
+/// treated as stale: the agent finished without a final repaint, hung, or the
+/// TUI stopped redrawing.
+const WORKING_STALE_AFTER: Duration = Duration::from_secs(2);
+
+impl Board {
+    /// Refresh each agent panel's working status.
+    ///
+    /// Runs every frame, but only panels that received new terminal output
+    /// this frame pay for the screen scan; quiet panels keep their status
+    /// until a working flag goes stale.
+    pub(super) fn update_agent_status(&mut self) {
+        for panel in self.panels.iter_mut().filter(|panel| panel.kind.is_agent()) {
+            update_panel_agent_status(panel, WORKING_STALE_AFTER);
+        }
+    }
+}
+
+fn update_panel_agent_status(panel: &mut Panel, stale_after: Duration) {
+    if panel.had_recent_output {
+        panel.agent_status = panel.detect_agent_status();
+    } else if panel.agent_status == AgentStatus::Working && !panel.had_recent_output_within(stale_after) {
+        panel.agent_status = AgentStatus::Idle;
+    }
+}

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -34,8 +34,8 @@ mod view;
 mod workspace;
 
 pub use agents::{
-    AgentDefinition, AgentIntegrationKind, AgentResumeMode, AgentSessionValidationMode, agent_definition,
-    all_agent_kinds,
+    AgentDefinition, AgentIntegrationKind, AgentResumeMode, AgentSessionValidationMode, AgentStatus, agent_definition,
+    all_agent_kinds, is_agent_working_line,
 };
 pub use alacritty_terminal::index::Side as TerminalSide;
 pub use alacritty_terminal::selection::SelectionType;

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use serde::Deserialize;
 
 use crate::agent_definition;
+use crate::agents::{AGENT_WORKING_SCAN_ROWS, AgentStatus, is_agent_working_line};
 use crate::editor::{MarkdownEditor, PanelContent};
 use crate::error::Result;
 use crate::git_changes::DiffViewer;
@@ -178,6 +179,9 @@ pub struct Panel {
     /// Set by `process_output` each frame; read by attention detection to skip
     /// the expensive `last_lines_text` scan for panels without new content.
     pub(crate) had_recent_output: bool,
+    /// Working/idle state of the agent TUI, refreshed by
+    /// `Board::update_agent_status` from the terminal's working indicator.
+    pub(crate) agent_status: AgentStatus,
     last_output_at_millis: Option<i64>,
     /// Original launch command (for persistence).
     pub launch_command: Option<String>,
@@ -224,6 +228,11 @@ impl Panel {
         let window_millis = i64::try_from(window.as_millis()).unwrap_or(i64::MAX);
         self.last_output_at_millis
             .is_some_and(|last_output| current_unix_millis().saturating_sub(last_output) <= window_millis)
+    }
+
+    #[must_use]
+    pub const fn agent_status(&self) -> AgentStatus {
+        self.agent_status
     }
 
     /// Convenience accessor for the editor content (if this panel holds one).
@@ -587,6 +596,28 @@ impl Panel {
         None
     }
 
+    /// Check whether this panel's agent TUI is rendering its working
+    /// indicator (animated spinner plus a working status line pinned near the
+    /// bottom of the screen, as Pi, Codex, Claude Code & co. do while busy).
+    #[must_use]
+    pub fn detect_agent_status(&self) -> AgentStatus {
+        if !self.kind.is_agent() {
+            return AgentStatus::Idle;
+        }
+        let Some(terminal) = self.content.terminal() else {
+            return AgentStatus::Idle;
+        };
+        if terminal
+            .bottom_lines_text(AGENT_WORKING_SCAN_ROWS)
+            .iter()
+            .any(|line| is_agent_working_line(line))
+        {
+            AgentStatus::Working
+        } else {
+            AgentStatus::Idle
+        }
+    }
+
     fn should_track_live_cwd(&self) -> bool {
         matches!(self.kind, PanelKind::Shell | PanelKind::Command)
     }
@@ -613,9 +644,10 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{
-        AGENT_PANEL_SCROLLBACK_LIMIT, AgentLaunchContext, AgentSessionBinding, DEFAULT_PANEL_SCROLLBACK_LIMIT, Panel,
-        PanelContent, PanelId, PanelKind, PanelLayout, PanelResume, UsageDashboard, WorkspaceId,
-        kitty_keyboard_for_kind, platform_default_shell, resolve_launch_command, scrollback_limit_for_kind,
+        AGENT_PANEL_SCROLLBACK_LIMIT, AgentLaunchContext, AgentSessionBinding, AgentStatus,
+        DEFAULT_PANEL_SCROLLBACK_LIMIT, Panel, PanelContent, PanelId, PanelKind, PanelLayout, PanelResume,
+        UsageDashboard, WorkspaceId, kitty_keyboard_for_kind, platform_default_shell, resolve_launch_command,
+        scrollback_limit_for_kind,
     };
     use crate::ssh::SshConnection;
 
@@ -635,6 +667,7 @@ mod tests {
             launched_at_millis: 0,
             has_custom_name,
             had_recent_output: false,
+            agent_status: AgentStatus::default(),
             last_output_at_millis: None,
             launch_command: None,
             launch_args: Vec::new(),

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use uuid::Uuid;
 
+use crate::agents::AgentStatus;
 use crate::editor::{MarkdownEditor, PanelContent};
 use crate::error::Result;
 use crate::git_changes::DiffViewer;
@@ -129,6 +130,7 @@ impl StaticPanelSeed {
             launched_at_millis: current_unix_millis(),
             has_custom_name,
             had_recent_output: false,
+            agent_status: AgentStatus::default(),
             last_output_at_millis: None,
             launch_command,
             launch_args: Vec::new(),
@@ -514,6 +516,7 @@ fn build_terminal_panel(
         launched_at_millis: current_unix_millis(),
         has_custom_name,
         had_recent_output: false,
+        agent_status: AgentStatus::default(),
         last_output_at_millis: None,
         terminal_title: String::new(),
         launch_command,

--- a/crates/horizon-core/src/terminal/content.rs
+++ b/crates/horizon-core/src/terminal/content.rs
@@ -1,8 +1,8 @@
 use alacritty_terminal::term::cell::{Cell, Flags};
 
 use super::{
-    Column, Dimensions, PathBuf, Point, RenderableContent, Scroll, Term, TermDamage, Terminal, current_cwd_for_pid,
-    find_file_path_at_column, find_url_at_column, viewport_to_point,
+    Column, Dimensions, PathBuf, Point, RenderableContent, Scroll, Term, TermDamage, Terminal, TerminalEventProxy,
+    current_cwd_for_pid, find_file_path_at_column, find_url_at_column, viewport_to_point,
 };
 
 impl Terminal {
@@ -81,6 +81,15 @@ impl Terminal {
         }
         let start = lines.len().saturating_sub(max_lines);
         lines[start..].join("\n")
+    }
+
+    /// Extract the text of the bottom `max_rows` visible rows of the screen
+    /// (empty rows omitted), for detecting status lines that agent TUIs pin
+    /// near the bottom of the screen.
+    #[must_use]
+    pub fn bottom_lines_text(&self, max_rows: usize) -> Vec<String> {
+        let term = self.term.lock();
+        bottom_row_texts(&term, usize::from(self.rows), max_rows)
     }
 
     /// Extract all text from the terminal grid including scrollback history.
@@ -246,6 +255,46 @@ fn wrapped_line_chars_at_viewport_point<T>(
     Some((line_chars, logical_col))
 }
 
+/// Text of the non-empty rows within the bottom `max_rows` rows of a visible
+/// screen, in top-to-bottom order.
+#[must_use]
+fn bottom_row_texts(term: &Term<TerminalEventProxy>, rows: usize, max_rows: usize) -> Vec<String> {
+    let content = term.renderable_content();
+    let start_row = rows.saturating_sub(max_rows);
+    let mut lines: Vec<String> = Vec::new();
+    let mut current_line = String::new();
+    let mut current_line_columns = 0;
+    let mut current_row: Option<usize> = None;
+
+    for indexed in content.display_iter {
+        let Ok(row) = usize::try_from(indexed.point.line.0) else {
+            continue;
+        };
+        if row < start_row || row >= rows {
+            continue;
+        }
+        if current_row != Some(row) {
+            if current_row.is_some() && !current_line.is_empty() {
+                lines.push(std::mem::take(&mut current_line));
+            }
+            current_row = Some(row);
+            current_line.clear();
+            current_line_columns = 0;
+        }
+        append_cell_text(
+            &mut current_line,
+            &mut current_line_columns,
+            indexed.point.column.0,
+            indexed.cell,
+        );
+    }
+    if current_row.is_some() && !current_line.is_empty() {
+        lines.push(current_line);
+    }
+
+    lines
+}
+
 fn append_cell_text(line: &mut String, occupied_columns: &mut usize, target_column: usize, cell: &Cell) {
     if cell
         .flags
@@ -280,7 +329,7 @@ mod tests {
     use alacritty_terminal::term::{self, Term};
     use alacritty_terminal::vte::ansi;
 
-    use super::{append_cell_text, wrapped_line_chars_at_viewport_point};
+    use super::{append_cell_text, bottom_row_texts, wrapped_line_chars_at_viewport_point};
     use crate::terminal::{TerminalDimensions, TerminalEventProxy, find_url_at_column};
 
     fn reconstruct_line(cells: &[(usize, Cell)]) -> String {
@@ -371,6 +420,35 @@ mod tests {
         };
 
         Term::new(config, &dimensions, TerminalEventProxy { event_tx })
+    }
+
+    #[test]
+    fn bottom_row_texts_only_includes_the_bottom_window() {
+        let mut term = test_term(6, 20);
+        let mut parser = ansi::Processor::<ansi::StdSyncHandler>::default();
+        parser.advance(
+            &mut term,
+            b"top-one\r\ntop-two\r\nmid-one\r\nmid-two\r\nmid-three\r\nworking-line",
+        );
+
+        let lines = bottom_row_texts(&term, 6, 3);
+
+        assert_eq!(lines, vec!["mid-two", "mid-three", "working-line"]);
+    }
+
+    #[test]
+    fn bottom_row_texts_omits_empty_rows_and_accepts_wide_window() {
+        let mut term = test_term(8, 20);
+        let mut parser = ansi::Processor::<ansi::StdSyncHandler>::default();
+        // Row 0 carries text, rows 1-5 are empty, row 6 has the status line.
+        parser.advance(&mut term, b"alpha\r\n\r\n\r\n\r\n\r\n\r\n\xe2\xa0\x8b Working...\n");
+
+        let lines = bottom_row_texts(&term, 8, 4);
+
+        assert_eq!(lines, vec!["\u{280b} Working..."]);
+
+        let all = bottom_row_texts(&term, 8, 16);
+        assert_eq!(all, vec!["alpha", "\u{280b} Working..."]);
     }
 
     #[test]

--- a/crates/horizon-core/tests/agent_working_status.rs
+++ b/crates/horizon-core/tests/agent_working_status.rs
@@ -1,0 +1,148 @@
+#![cfg(not(windows))]
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+use horizon_core::{AgentStatus, Board, Panel, PanelId, PanelKind, PanelOptions};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+const WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Comfortably past the 2s stale-working window.
+const STALE_GRACE: Duration = Duration::from_millis(2500);
+
+/// Fake agent TUI built from plain newlines only (cursor moves like `\r` get
+/// mangled by the PTY line discipline). Each state is written to a fresh
+/// bottom line and previous states are pushed out of the 6-row bottom scan
+/// window with filler lines — a real TUI repaints in place, but scrolling
+/// exercises the same detection path without depending on terminal erase
+/// sequences. Octal escapes keep the braille spinner byte portable (POSIX
+/// printf has no `\u`), and the filler loops use POSIX shell arithmetic so
+/// the script needs no utilities (`seq`) beyond a stock `/bin/sh`.
+fn fake_agent_script() -> &'static str {
+    concat!(
+        "fill() { n=$1; i=0; while [ $i -lt $n ]; do i=$((i+1)); echo filler-$i; done; }\n",
+        "fill 18\n",
+        "printf '\\342\\240\\213 Working... (esc to interrupt)'\n",
+        "sleep 1.2\n",
+        "fill 12\n",
+        "printf 'ready: at prompt'\n",
+        "sleep 1.2\n",
+        "fill 12\n",
+        "printf '\\342\\240\\213 Compacting context...'\n",
+        "sleep 300\n",
+    )
+}
+
+fn agent_status(board: &Board, panel_id: PanelId) -> AgentStatus {
+    board.panel(panel_id).map_or(AgentStatus::Idle, Panel::agent_status)
+}
+
+fn screen_text(board: &Board, panel_id: PanelId) -> String {
+    board
+        .panel(panel_id)
+        .and_then(|panel| panel.terminal())
+        .map_or(String::new(), |terminal| terminal.last_lines_text(24))
+}
+
+fn wait_for_status(board: &mut Board, panel_id: PanelId, expected: AgentStatus) {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    while Instant::now() < deadline {
+        board.process_output();
+        if agent_status(board, panel_id) == expected {
+            return;
+        }
+        let panel = board
+            .panel(panel_id)
+            .unwrap_or_else(|| panic!("panel {panel_id:?} should exist"));
+        assert!(
+            !panel.child_exited(),
+            "agent panel exited before status reached {expected:?}"
+        );
+        thread::sleep(POLL_INTERVAL);
+    }
+    panic!(
+        "expected agent status {expected:?}, got {:?}\n--- terminal ---\n{}",
+        agent_status(board, panel_id),
+        screen_text(board, panel_id)
+    );
+}
+
+#[test]
+fn agent_working_status_tracks_working_indicator() {
+    let mut board = Board::new();
+    let workspace_id = board.create_workspace("working");
+    let panel_id = board
+        .create_panel(
+            PanelOptions {
+                kind: PanelKind::Pi,
+                command: Some("/bin/sh".to_string()),
+                args: vec!["-c".to_string(), fake_agent_script().to_string()],
+                ..PanelOptions::default()
+            },
+            workspace_id,
+        )
+        .expect("panel should spawn");
+
+    // Working line appears at the bottom of the screen -> Working.
+    wait_for_status(&mut board, panel_id, AgentStatus::Working);
+
+    // The TUI scrolls the working line out of the bottom window and shows its
+    // prompt (well before the 2s stale window elapses) -> detection must flip
+    // the status back to Idle.
+    wait_for_status(&mut board, panel_id, AgentStatus::Idle);
+
+    // A new turn starts -> Working again.
+    wait_for_status(&mut board, panel_id, AgentStatus::Working);
+
+    // The script now stays silent: the working flag must clear on its own
+    // once the terminal output goes stale.
+    thread::sleep(STALE_GRACE);
+    board.process_output();
+    assert_eq!(
+        agent_status(&board, panel_id),
+        AgentStatus::Idle,
+        "stale working status should reset to idle"
+    );
+
+    board.shutdown_terminal_panels();
+}
+
+#[test]
+fn shell_panels_never_report_working() {
+    let mut board = Board::new();
+    let workspace_id = board.create_workspace("shells");
+    let panel_id = board
+        .create_panel(
+            PanelOptions {
+                kind: PanelKind::Shell,
+                command: Some("/bin/sh".to_string()),
+                args: vec![
+                    "-c".to_string(),
+                    concat!(
+                        "printf '\\342\\240\\213 Working... (esc to interrupt)'\n",
+                        "sleep 300\n",
+                    )
+                    .to_string(),
+                ],
+                ..PanelOptions::default()
+            },
+            workspace_id,
+        )
+        .expect("shell panel should spawn");
+
+    // Let the line reach the terminal, then confirm a non-agent panel stays
+    // Idle even though the working pattern is visible.
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        board.process_output();
+        if screen_text(&board, panel_id).contains("Working...") {
+            break;
+        }
+        assert!(Instant::now() < deadline, "shell line never appeared");
+        thread::sleep(POLL_INTERVAL);
+    }
+    board.process_output();
+    assert_eq!(agent_status(&board, panel_id), AgentStatus::Idle);
+
+    board.shutdown_terminal_panels();
+}

--- a/crates/horizon-ui/src/app/panel_chrome.rs
+++ b/crates/horizon-ui/src/app/panel_chrome.rs
@@ -1,5 +1,5 @@
 use egui::{Align, Color32, CornerRadius, Id, Layout, Margin, Pos2, Rect, Stroke, StrokeKind, UiBuilder, Vec2};
-use horizon_core::{AttentionSeverity, PanelId, PanelKind, SshConnectionStatus, agent_definition};
+use horizon_core::{AgentStatus, AttentionSeverity, PanelId, PanelKind, SshConnectionStatus, agent_definition};
 
 use crate::theme;
 
@@ -11,6 +11,7 @@ use super::util::{format_compact_count, usize_to_f32};
 pub(super) struct PanelChrome<'a> {
     pub panel_id: PanelId,
     pub kind: PanelKind,
+    pub agent_status: AgentStatus,
     pub panel_rect: Rect,
     pub titlebar_rect: Rect,
     pub close_rect: Rect,
@@ -241,6 +242,16 @@ pub(super) fn paint_panel_chrome(ui: &mut egui::Ui, chrome: PanelChrome<'_>) {
     if let Some(mic) = chrome.mic {
         paint_mic_control(ui, &painter, mic);
     }
+    if chrome.agent_status == AgentStatus::Working {
+        paint_working_indicator(
+            ui,
+            &painter,
+            chrome.titlebar_rect,
+            badges_left_boundary(&chrome),
+            chrome.kind,
+            chrome.focused,
+        );
+    }
     paint_close_and_resize_controls(&painter, chrome.close_rect, chrome.resize_rect, chrome.close_hovered);
 }
 
@@ -337,8 +348,20 @@ fn paint_close_and_resize_controls(painter: &egui::Painter, close_rect: Rect, re
 }
 
 /// Compute the right x boundary where the title text must stop, accounting
-/// for all badges (history meter, SSH status, attention) that sit to its right.
+/// for all badges (history meter, SSH status, attention) that sit to its
+/// right, plus the working indicator when the agent is busy.
 fn title_right_boundary(chrome: &PanelChrome<'_>) -> f32 {
+    let badges_left = badges_left_boundary(chrome);
+    if chrome.agent_status == AgentStatus::Working {
+        badges_left - working_indicator_reserve()
+    } else {
+        badges_left
+    }
+}
+
+/// Left edge of the titlebar's right-side badge cluster (history meter,
+/// SSH status, attention).
+fn badges_left_boundary(chrome: &PanelChrome<'_>) -> f32 {
     let anchor = chrome.controls_anchor();
     let mut right = anchor.min.x - 12.0;
     if chrome.scrollback_limit > 0 {
@@ -353,6 +376,68 @@ fn title_right_boundary(chrome: &PanelChrome<'_>) -> f32 {
         right -= 110.0;
     }
     right
+}
+
+/// Three-dot "working" indicator mirroring the agent TUI's own busy
+/// spinner, pulsing left-to-right while the agent executes.
+const WORKING_DOT_RADIUS: f32 = 2.0;
+const WORKING_DOT_SPACING: f32 = 6.0;
+const WORKING_BADGE_GAP: f32 = 6.0;
+const WORKING_TITLE_GAP: f32 = 8.0;
+const WORKING_PULSE_HZ: f32 = 1.0;
+
+const fn working_indicator_width() -> f32 {
+    WORKING_DOT_RADIUS * 6.0 + WORKING_DOT_SPACING * 2.0
+}
+
+const fn working_indicator_reserve() -> f32 {
+    working_indicator_width() + WORKING_BADGE_GAP + WORKING_TITLE_GAP
+}
+
+fn working_indicator_base_color(kind: PanelKind, focused: bool) -> Color32 {
+    let base = match agent_definition(kind) {
+        Some(definition) => {
+            let [r, g, b] = definition.accent_rgb;
+            Color32::from_rgb(r, g, b)
+        }
+        None => theme::ACCENT(),
+    };
+    let base = match theme::current_theme() {
+        theme::ResolvedTheme::Dark => base,
+        theme::ResolvedTheme::Light => theme::ensure_terminal_text_contrast(base, theme::PANEL_BG_ALT()),
+    };
+    theme::alpha(base, if focused { 235 } else { 175 })
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "time-to-f32 and wave-scaled alpha both stay within representable range"
+)]
+#[profiling::function]
+fn paint_working_indicator(
+    ui: &egui::Ui,
+    painter: &egui::Painter,
+    titlebar_rect: Rect,
+    badges_left: f32,
+    kind: PanelKind,
+    focused: bool,
+) {
+    let time = ui.input(|input| input.time as f32);
+    let base = working_indicator_base_color(kind, focused);
+    let base_alpha = f32::from(base.a());
+    let left = badges_left - WORKING_BADGE_GAP - working_indicator_width();
+    let step = WORKING_DOT_RADIUS * 2.0 + WORKING_DOT_SPACING;
+    let center_y = titlebar_rect.center().y;
+
+    for dot in [0.0_f32, 1.0, 2.0] {
+        // A wave travelling left to right, like the agent's typing dots.
+        let phase = time * WORKING_PULSE_HZ - dot / 3.0;
+        let wave = (0.5 + 0.5 * (phase * std::f32::consts::TAU).sin()).clamp(0.0, 1.0);
+        let alpha = (base_alpha * (0.30 + 0.70 * wave)) as u8;
+        let x = left + WORKING_DOT_RADIUS + dot * step;
+        painter.circle_filled(Pos2::new(x, center_y), WORKING_DOT_RADIUS, theme::alpha(base, alpha));
+    }
 }
 
 #[profiling::function]
@@ -636,9 +721,64 @@ mod tests {
     use egui::{Color32, Pos2, Rect};
 
     use super::{
-        focus_ring_stroke, panel_border_stroke, panel_fill, panel_title_color, panel_titlebar_fill,
-        title_focus_indicator_rect,
+        AgentStatus, PanelChrome, badges_left_boundary, focus_ring_stroke, panel_border_stroke, panel_fill,
+        panel_title_color, panel_titlebar_fill, title_focus_indicator_rect, title_right_boundary,
+        working_indicator_reserve,
     };
+
+    /// The boundary math is exact constant arithmetic, so an epsilon of one
+    /// ULP keeps `assert_eq!`-level strictness without tripping `float_cmp`.
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() <= f32::EPSILON
+    }
+
+    fn test_chrome(agent_status: AgentStatus) -> PanelChrome<'static> {
+        let panel_rect = Rect::from_min_max(Pos2::new(10.0, 20.0), Pos2::new(600.0, 400.0));
+        let titlebar_rect = Rect::from_min_max(Pos2::new(10.0, 20.0), Pos2::new(600.0, 54.0));
+        let close_rect = Rect::from_center_size(Pos2::new(582.0, 37.0), egui::Vec2::splat(16.0));
+        PanelChrome {
+            panel_id: horizon_core::PanelId(1),
+            kind: horizon_core::PanelKind::Pi,
+            agent_status,
+            panel_rect,
+            titlebar_rect,
+            close_rect,
+            resize_rect: panel_rect,
+            title: Some("Smoke"),
+            history_size: 100,
+            scrollback_limit: 24_000,
+            focused: true,
+            close_hovered: false,
+            workspace_accent: Some(Color32::from_rgb(137, 180, 250)),
+            attention_badge: None,
+            ssh_status: None,
+            mic: None,
+        }
+    }
+
+    #[test]
+    fn working_indicator_reserves_titlebar_space() {
+        let idle = test_chrome(AgentStatus::Idle);
+        let working = test_chrome(AgentStatus::Working);
+
+        assert!(approx_eq(title_right_boundary(&idle), badges_left_boundary(&idle)));
+        assert!(approx_eq(
+            title_right_boundary(&working),
+            badges_left_boundary(&working) - working_indicator_reserve()
+        ));
+        assert!(title_right_boundary(&working) < title_right_boundary(&idle));
+    }
+
+    #[test]
+    fn working_indicator_reserve_covers_three_dots_and_gaps() {
+        // Three dots of radius 2 (width 4) plus two 6px gaps, plus the
+        // badge gap (6) and the title gap (8).
+        assert!(approx_eq(
+            working_indicator_reserve(),
+            4.0 * 3.0 + 6.0 * 2.0 + 6.0 + 8.0
+        ));
+        assert!(working_indicator_reserve() > 0.0);
+    }
 
     #[test]
     fn focused_panel_style_is_more_prominent() {

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -1,7 +1,7 @@
 use egui::{Align, Color32, Context, Id, Layout, Order, Pos2, Rect, Sense, UiBuilder, Vec2};
 use horizon_core::{
-    AgentSessionBinding, AttentionSeverity, Panel, PanelId, PanelKind, ShortcutBinding, SshConnectionStatus,
-    WorkspaceId,
+    AgentSessionBinding, AgentStatus, AttentionSeverity, Panel, PanelId, PanelKind, ShortcutBinding,
+    SshConnectionStatus, WorkspaceId,
 };
 
 use super::super::editor_widget::{MarkdownEditorView, MarkdownPreviewCache};
@@ -34,6 +34,7 @@ struct PanelSnapshot {
     canvas_size: Vec2,
     current_workspace_id: WorkspaceId,
     kind: PanelKind,
+    agent_status: AgentStatus,
     history_size: usize,
     scrollback_limit: usize,
     workspace_accent: Option<Color32>,
@@ -423,6 +424,7 @@ impl HorizonApp {
                 canvas_size,
                 current_workspace_id: panel.workspace_id,
                 kind: panel.kind,
+                agent_status: panel.agent_status(),
                 history_size: terminal.map_or(0, horizon_core::Terminal::history_size),
                 scrollback_limit: terminal.map_or(0, horizon_core::Terminal::scrollback_limit),
                 workspace_accent,
@@ -573,6 +575,7 @@ impl HorizonApp {
                     PanelChrome {
                         panel_id,
                         kind: snapshot.kind,
+                        agent_status: snapshot.agent_status,
                         panel_rect: rects.panel,
                         titlebar_rect: rects.titlebar,
                         close_rect: rects.close,

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -10,8 +10,9 @@ back into large multi-purpose modules.
 - Owns board state, workspace metadata, panel lifecycle, persistence
   projections, and shared layout math.
 - `board.rs` should stay orchestration-focused, with board-local submodules for
-  attention flows, workspace and panel membership changes, arrangement/collision
-  logic, geometry queries, and shutdown state.
+  attention flows, agent working-status detection, workspace and panel
+  membership changes, arrangement/collision logic, geometry queries, and
+  shutdown state.
 - Large board test surfaces should live in `board/tests/` topic files so
   `board.rs` can stay focused on production orchestration.
 - `terminal.rs` should keep the terminal types and shared imports; lifecycle,


### PR DESCRIPTION
## Purpose

Horizon has no "agent is working" affordance in the titlebar, unlike the
agent TUIs themselves (Pi/Codex/Claude Code all show a busy spinner). This
PR detects the working indicator an agent TUI renders in its terminal and
mirrors it as a three-dot pulsing indicator in the panel titlebar.

## Behavior

- **Detection (core):** an agent-kind panel is *Working* when any of the
  bottom 6 visible screen rows starts with a spinner glyph (braille
  `U+2800–U+28FF`, stars `U+2737–U+273B`) followed by a working keyword
  (`Working`, `Thinking`, `Compacting`, `Retrying`, `Reusing`, `Summarizing`,
  `Context overflow`) or the usual `to interrupt`/`to stop`/`to cancel`
  hint. The spinner prefix keeps ordinary output that merely mentions
  "Working" from flipping the status.
- **Refresh (core):** `Board::update_agent_status` runs every frame but
  only panels with new terminal output pay for a scan; a Working status
  with no output for 2s goes stale to Idle (hung TUI / stopped redraw).
  Independent of the attention-feed feature flag.
- **UI:** three dots in the panel's agent accent color pulse left-to-right
  at 1Hz while working, positioned left of the existing badge cluster
  (history meter / SSH / attention); title truncation reserves their space
  while working. Shell, editor, and other non-agent panels never light up.
  Detached viewports get the indicator through the same chrome path;
  fullscreen panels have no titlebar (no change).

## Tests

- Unit: line matching (`agents.rs`), bottom-window row extraction
  (`terminal/content.rs`), titlebar boundary math + reserve
  (`panel_chrome.rs`).
- Integration: `crates/horizon-core/tests/agent_working_status.rs` runs a
  fake agent through a real PTY and asserts the
  Working → Idle → Working cycle and the stale reset; a shell panel stays
  Idle throughout.
- Full matrix green in this worktree: fmt, maintainability,
  `cargo test --workspace` (+ `--features speech`), clippy blocking/strict,
  pedantic clean.
- Live smoke (Linux/X11): isolated instance with a fake Pi panel cycling a
  braille working line — 30-frame pixel capture cross-checked against
  per-frame status dumps: 0 mismatches, dots present iff Working; shell
  panel Idle on all 3278 samples.

## Notes

- Detection is intentionally conservative: it reads what the agent TUI
  itself paints, so it works for any agent that shows a spinner line
  (including unknown/custom agent presets).
