### PR TITLE
feat(mission): core types and plan.json schema (stack 1/6)

### DIFF
--- a/crates/horizon-core/src/error.rs
+++ b/crates/horizon-core/src/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
     #[error("Git error: {0}")]
     Git(String),
 
+    #[error("Mission error: {0}")]
+    Mission(String),
+
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -15,6 +15,7 @@ mod horizon_home;
 mod layout;
 mod local_store;
 mod managed_install;
+mod mission;
 mod opencode_paths;
 mod panel;
 mod remote_hosts;
@@ -53,6 +54,11 @@ pub use git_status::{DiffHunk, DiffLine, DiffLineKind, FileChange, FileDiff, Fil
 pub use git_watcher::GitWatcher;
 pub use horizon_home::HorizonHome;
 pub use managed_install::ManagedInstall;
+pub use mission::{
+    FIRST_PLAN_VERSION, MAX_MISSION_TASKS, MISSION_PLAN_SCHEMA, MissionMeta, MissionPlan, MissionStatus, PlanTask,
+    PlannerKind, TaskId, TaskModel, TaskSize, TaskStatus, ThinkingLevel, load_mission_file, load_plan_file,
+    save_mission_file, save_plan_file,
+};
 pub use panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind, PanelLayout, PanelOptions, PanelResume};
 pub use remote_hosts::{
     RemoteHost, RemoteHostCatalog, RemoteHostConnectionHistoryEntry, RemoteHostConnectionSummary, RemoteHostSources,

--- a/crates/horizon-core/src/mission.rs
+++ b/crates/horizon-core/src/mission.rs
@@ -1,0 +1,465 @@
+//! Mission orchestration domain types and the `plan.json` schema.
+//!
+//! A mission is a frontier-model-produced plan of self-contained tasks that
+//! Horizon executes with local worker agents. The plan file is the only
+//! machine interface between the planner (an agent panel) and Horizon: the
+//! planner writes `plan.json`, Horizon watches and validates it, and never
+//! parses model chatter.
+
+use std::fmt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+
+/// Bumped when the `plan.json` shape changes incompatibly.
+pub const MISSION_PLAN_SCHEMA: u32 = 1;
+
+/// Upper bound on tasks a single mission plan may carry.
+pub const MAX_MISSION_TASKS: usize = 32;
+
+/// Minimum plan revision. Refines bump it monotonically.
+pub const FIRST_PLAN_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TaskId(String);
+
+impl TaskId {
+    /// Create a task id, rejecting malformed ids up front.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the id is not 2-8 alphanumeric characters starting with a letter.
+    pub fn new(raw: impl Into<String>) -> Result<Self> {
+        let id = Self(raw.into());
+        validate_task_id(&id)?;
+        Ok(id)
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Coarse size class of a task; drives token estimates and scheduling weight.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskSize {
+    Small,
+    #[default]
+    Medium,
+    Large,
+}
+
+impl TaskSize {
+    /// Baseline worker token estimate in millions, before the thinking
+    /// multiplier. Matches the mission cost model used by the UI.
+    #[must_use]
+    pub const fn base_megatokens(self) -> f32 {
+        match self {
+            Self::Small => 0.3,
+            Self::Medium => 0.6,
+            Self::Large => 0.9,
+        }
+    }
+}
+
+/// Worker thinking level, passed through to `pi --thinking <level>`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThinkingLevel {
+    Off,
+    Minimal,
+    Low,
+    Medium,
+    #[default]
+    High,
+    Xhigh,
+    Max,
+}
+
+impl ThinkingLevel {
+    /// Token multiplier applied to the size baseline (thinking tokens are
+    /// free on self-hosted workers but still count toward the estimate).
+    #[must_use]
+    pub const fn effort_factor(self) -> f32 {
+        match self {
+            Self::Off => 1.0,
+            Self::Minimal => 1.1,
+            Self::Low => 1.25,
+            Self::Medium => 1.5,
+            Self::High => 2.0,
+            Self::Xhigh => 2.8,
+            Self::Max => 3.5,
+        }
+    }
+
+    /// Value of the `--thinking` flag; `None` when the flag is omitted.
+    #[must_use]
+    pub fn flag_value(self) -> Option<&'static str> {
+        (self != Self::Off).then_some(match self {
+            Self::Off => "off",
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Xhigh => "xhigh",
+            Self::Max => "max",
+        })
+    }
+}
+
+impl fmt::Display for ThinkingLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.flag_value().unwrap_or("off"))
+    }
+}
+
+/// Which model family runs a task: the mission's self-hosted worker profile
+/// (default) or the frontier model.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskModel {
+    #[default]
+    Worker,
+    Frontier,
+}
+
+/// Planner backend for a mission. The planner spends frontier tokens once,
+/// up front, and only ever writes plan files.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlannerKind {
+    /// `codex` CLI in planner mode.
+    CodexCli,
+    /// `pi` pointed at a frontier model.
+    Pi,
+}
+
+/// Lifecycle of the mission as a whole.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionStatus {
+    /// Planner panel is running; no (valid) plan yet.
+    Planning,
+    /// A validated plan exists; mutable until execution starts.
+    Planned,
+    /// Workers are running; the plan is locked except for live refinements.
+    Running,
+    /// All selected tasks finished.
+    Complete,
+    /// Abandoned by the user; worktrees may be pruned.
+    Discarded,
+}
+
+/// Lifecycle of a single task.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Queued,
+    Running,
+    Done,
+    Failed,
+    /// The task was re-planned away; `by` names the replacement task.
+    /// Treated as terminal for dependency and progress purposes.
+    Replaced {
+        by: TaskId,
+    },
+    /// Deselected before execution; never spawned.
+    Skipped,
+}
+
+impl TaskStatus {
+    /// Terminal statuses that satisfy dependency edges.
+    #[must_use]
+    pub fn satisfies_deps(self) -> bool {
+        matches!(self, Self::Done | Self::Replaced { .. })
+    }
+
+    /// Terminal statuses that count toward mission completion.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Done | Self::Failed | Self::Replaced { .. } | Self::Skipped)
+    }
+}
+
+/// One self-contained unit of work in a mission plan.
+///
+/// `brief` must be complete on its own: workers start without the planning
+/// conversation, so every assumption the planner made has to live here.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanTask {
+    pub id: TaskId,
+    pub title: String,
+    pub brief: String,
+    pub size: TaskSize,
+    /// Task ids that must finish (or be replaced) first.
+    pub deps: Vec<TaskId>,
+    /// Git worktree name isolating this worker's edits.
+    pub worktree: String,
+    pub model: TaskModel,
+    pub effort: ThinkingLevel,
+    #[serde(default = "default_selected")]
+    pub selected: bool,
+    /// Plan version in which this task was introduced.
+    pub version: u32,
+    pub status: TaskStatus,
+}
+
+fn default_selected() -> bool {
+    true
+}
+
+/// The parsed and validated shape of a `plan.json` file.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MissionPlan {
+    pub schema: u32,
+    pub version: u32,
+    pub tasks: Vec<PlanTask>,
+}
+
+/// Mission metadata persisted next to the plan (`mission.json`): identity,
+/// goal, planner choice, and the mission-level status.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MissionMeta {
+    pub id: String,
+    pub goal: String,
+    pub planner: PlannerKind,
+    pub status: MissionStatus,
+}
+
+impl MissionPlan {
+    /// Validate a plan: ids, deps, cycles, briefs, worktree names, and
+    /// replacement consistency. Call this on every load so a hand-edited or
+    /// hallucinated plan can never wedge the scheduler.
+    ///
+    /// # Errors
+    ///
+    /// Fails on unknown or duplicate ids, cycles, empty titles/briefs, bad
+    /// worktree names, or inconsistent replacement links.
+    pub fn validate(&self) -> Result<()> {
+        if self.version < FIRST_PLAN_VERSION {
+            return Err(crate::Error::Mission(format!(
+                "plan version {} is below the first version {FIRST_PLAN_VERSION}",
+                self.version
+            )));
+        }
+        if self.tasks.len() > MAX_MISSION_TASKS {
+            return Err(crate::Error::Mission(format!(
+                "plan has {} tasks, limit is {MAX_MISSION_TASKS}",
+                self.tasks.len()
+            )));
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        for task in &self.tasks {
+            validate_task_id(&task.id)?;
+            if !seen.insert(task.id.clone()) {
+                return Err(crate::Error::Mission(format!("duplicate task id `{}`", task.id)));
+            }
+        }
+
+        for task in &self.tasks {
+            let id = task.id.to_string();
+            if task.title.trim().is_empty() {
+                return Err(crate::Error::Mission(format!("task {id} has an empty title")));
+            }
+            if task.brief.trim().is_empty() {
+                return Err(crate::Error::Mission(format!(
+                    "task {id} has an empty brief; workers need a self-contained prompt"
+                )));
+            }
+            validate_worktree_name(&task.worktree, &id)?;
+            for dep in &task.deps {
+                if dep == &task.id {
+                    return Err(crate::Error::Mission(format!("task {id} depends on itself")));
+                }
+                if !seen.contains(dep) {
+                    return Err(crate::Error::Mission(format!(
+                        "task {id} depends on unknown task `{dep}`"
+                    )));
+                }
+            }
+            if let TaskStatus::Replaced { by } = &task.status {
+                if by == &task.id {
+                    return Err(crate::Error::Mission(format!("task {id} is replaced by itself")));
+                }
+                if !seen.contains(by) {
+                    return Err(crate::Error::Mission(format!(
+                        "task {id} was replaced by unknown task `{by}`"
+                    )));
+                }
+            }
+        }
+
+        ensure_acyclic(&self.tasks)
+    }
+}
+
+impl MissionMeta {
+    /// Mission ids become directory names under `.horizon/missions/`.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the id is not a safe slug or the goal is empty.
+    pub fn validate_id(&self) -> Result<()> {
+        let id = self.id.as_str();
+        if !is_valid_slug(id) {
+            return Err(crate::Error::Mission(format!(
+                "mission id `{id}` must match [a-z0-9][a-z0-9-]* (1..=32 chars)"
+            )));
+        }
+        if self.goal.trim().is_empty() {
+            return Err(crate::Error::Mission("mission goal is empty".into()));
+        }
+        Ok(())
+    }
+}
+
+fn is_valid_slug(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_lowercase() || first.is_ascii_digit() => {}
+        _ => return false,
+    }
+    (1..=32).contains(&value.len()) && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+fn validate_task_id(id: &TaskId) -> Result<()> {
+    let raw = id.as_str();
+    let valid = (2..=8).contains(&raw.len()) && raw.chars().all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit());
+    if !valid || !raw.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        return Err(crate::Error::Mission(format!(
+            "task id `{raw}` must be 2-8 alphanumeric chars starting with a letter"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_worktree_name(name: &str, task_id: &str) -> Result<()> {
+    let valid = (1..=60).contains(&name.len())
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_');
+    if !valid {
+        return Err(crate::Error::Mission(format!(
+            "task {task_id} has invalid worktree name `{name}`; use [a-z0-9_-], 1-60 chars, not starting with -"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_acyclic(tasks: &[PlanTask]) -> Result<()> {
+    let index: std::collections::HashMap<&TaskId, usize> = tasks.iter().enumerate().map(|(i, t)| (&t.id, i)).collect();
+    let mut color = vec![0u8; tasks.len()]; // 0 unvisited, 1 in progress, 2 done
+    for start in 0..tasks.len() {
+        if color[start] == 0 {
+            dfs_acyclic(start, tasks, &index, &mut color)?;
+        }
+    }
+    Ok(())
+}
+
+fn dfs_acyclic(
+    node: usize,
+    tasks: &[PlanTask],
+    index: &std::collections::HashMap<&TaskId, usize>,
+    color: &mut [u8],
+) -> Result<()> {
+    color[node] = 1;
+    for dep in &tasks[node].deps {
+        let Some(&next) = index.get(dep) else {
+            continue; // unknown deps are reported by the id pass
+        };
+        match color[next] {
+            1 => {
+                return Err(crate::Error::Mission(format!(
+                    "dependency cycle involving `{}` and `{}`",
+                    tasks[node].id, tasks[next].id
+                )));
+            }
+            0 => dfs_acyclic(next, tasks, index, color)?,
+            _ => {}
+        }
+    }
+    color[node] = 2;
+    Ok(())
+}
+
+/// Read and validate `plan.json`. A stale or hand-corrupted file is an error,
+/// never a silent partial plan.
+///
+/// # Errors
+///
+/// Fails on I/O problems, unparseable JSON, a schema mismatch, or any
+/// validation failure in [`MissionPlan::validate`].
+pub fn load_plan_file(path: &Path) -> Result<MissionPlan> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| crate::Error::Mission(format!("reading plan file {}: {e}", path.display())))?;
+    let plan: MissionPlan = serde_json::from_str(&raw)
+        .map_err(|e| crate::Error::Mission(format!("parsing plan file {}: {e}", path.display())))?;
+    if plan.schema != MISSION_PLAN_SCHEMA {
+        return Err(crate::Error::Mission(format!(
+            "plan file {} uses schema {}, expected {MISSION_PLAN_SCHEMA}",
+            path.display(),
+            plan.schema
+        )));
+    }
+    plan.validate()?;
+    Ok(plan)
+}
+
+/// Write `plan.json` atomically-enough for the watcher (write, then sync).
+///
+/// # Errors
+///
+/// Fails on serialization problems or I/O errors writing the file.
+pub fn save_plan_file(path: &Path, plan: &MissionPlan) -> Result<()> {
+    let mut raw =
+        serde_json::to_string_pretty(plan).map_err(|e| crate::Error::Mission(format!("serializing plan: {e}")))?;
+    raw.push('\n');
+    std::fs::write(path, raw).map_err(|e| crate::Error::Mission(format!("writing plan file {}: {e}", path.display())))
+}
+
+/// Read the mission metadata file (`mission.json`).
+///
+/// # Errors
+///
+/// Fails on I/O problems, unparseable JSON, or an invalid mission id/goal.
+pub fn load_mission_file(path: &Path) -> Result<MissionMeta> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| crate::Error::Mission(format!("reading mission file {}: {e}", path.display())))?;
+    let meta: MissionMeta = serde_json::from_str(&raw)
+        .map_err(|e| crate::Error::Mission(format!("parsing mission file {}: {e}", path.display())))?;
+    meta.validate_id()?;
+    Ok(meta)
+}
+
+/// Write the mission metadata file (`mission.json`).
+///
+/// # Errors
+///
+/// Fails on serialization problems or I/O errors writing the file.
+pub fn save_mission_file(path: &Path, meta: &MissionMeta) -> Result<()> {
+    let mut raw =
+        serde_json::to_string_pretty(meta).map_err(|e| crate::Error::Mission(format!("serializing mission: {e}")))?;
+    raw.push('\n');
+    std::fs::write(path, raw)
+        .map_err(|e| crate::Error::Mission(format!("writing mission file {}: {e}", path.display())))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/mission.rs
+++ b/crates/horizon-core/src/mission.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::Result;
 
@@ -22,7 +22,7 @@ pub const MAX_MISSION_TASKS: usize = 32;
 /// Minimum plan revision. Refines bump it monotonically.
 pub const FIRST_PLAN_VERSION: u32 = 1;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct TaskId(String);
 
@@ -41,6 +41,16 @@ impl TaskId {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskId {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::new(raw).map_err(serde::de::Error::custom)
     }
 }
 
@@ -179,10 +189,14 @@ pub enum TaskStatus {
 }
 
 impl TaskStatus {
-    /// Terminal statuses that satisfy dependency edges.
+    /// Statuses that satisfy dependency edges without replacement indirection.
+    ///
+    /// Replaced tasks require plan-level resolution via
+    /// [`MissionPlan::dependency_satisfied`], because the replacement task may
+    /// still be queued or running.
     #[must_use]
-    pub fn satisfies_deps(self) -> bool {
-        matches!(self, Self::Done | Self::Replaced { .. })
+    pub fn satisfies_deps(&self) -> bool {
+        matches!(self, Self::Done)
     }
 
     /// Terminal statuses that count toward mission completion.
@@ -301,7 +315,38 @@ impl MissionPlan {
             }
         }
 
+        ensure_replacement_acyclic(&self.tasks)?;
         ensure_acyclic(&self.tasks)
+    }
+
+    /// Resolve a dependency through replacement chains and report whether the
+    /// effective task has completed.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the dependency references an unknown task id or the plan has
+    /// a replacement cycle.
+    pub fn dependency_satisfied(&self, dep: &TaskId) -> Result<bool> {
+        let index: std::collections::HashMap<&TaskId, usize> =
+            self.tasks.iter().enumerate().map(|(i, task)| (&task.id, i)).collect();
+        let mut current = dep;
+        let mut seen = std::collections::HashSet::new();
+        loop {
+            if !seen.insert(current.clone()) {
+                return Err(crate::Error::Mission(format!(
+                    "replacement cycle involving `{current}`"
+                )));
+            }
+            let Some(&task_idx) = index.get(current) else {
+                return Err(crate::Error::Mission(format!(
+                    "dependency references unknown task `{current}`"
+                )));
+            };
+            match &self.tasks[task_idx].status {
+                TaskStatus::Replaced { by } => current = by,
+                status => return Ok(status.satisfies_deps()),
+            }
+        }
     }
 }
 
@@ -368,6 +413,28 @@ fn ensure_acyclic(tasks: &[PlanTask]) -> Result<()> {
     for start in 0..tasks.len() {
         if color[start] == 0 {
             dfs_acyclic(start, tasks, &index, &mut color)?;
+        }
+    }
+    Ok(())
+}
+
+fn ensure_replacement_acyclic(tasks: &[PlanTask]) -> Result<()> {
+    let index: std::collections::HashMap<&TaskId, usize> =
+        tasks.iter().enumerate().map(|(i, task)| (&task.id, i)).collect();
+    for start in 0..tasks.len() {
+        let mut current = start;
+        let mut seen = std::collections::HashSet::new();
+        while let TaskStatus::Replaced { by } = &tasks[current].status {
+            if !seen.insert(current) {
+                return Err(crate::Error::Mission(format!(
+                    "replacement cycle involving `{}`",
+                    tasks[current].id
+                )));
+            }
+            let Some(&next) = index.get(by) else {
+                break;
+            };
+            current = next;
         }
     }
     Ok(())

--- a/crates/horizon-core/src/mission/tests/mod.rs
+++ b/crates/horizon-core/src/mission/tests/mod.rs
@@ -1,0 +1,164 @@
+use crate::mission::{
+    FIRST_PLAN_VERSION, MAX_MISSION_TASKS, MISSION_PLAN_SCHEMA, MissionMeta, MissionPlan, MissionStatus, PlanTask,
+    PlannerKind, TaskId, TaskModel, TaskSize, TaskStatus, ThinkingLevel, load_mission_file, load_plan_file,
+    save_mission_file, save_plan_file,
+};
+
+fn task(id: &str, deps: &[&str]) -> PlanTask {
+    PlanTask {
+        id: TaskId::new(id).expect("valid id in test"),
+        title: format!("task {id}"),
+        brief: format!("do {id}"),
+        size: TaskSize::Medium,
+        deps: deps
+            .iter()
+            .map(|d| TaskId::new(*d).expect("valid dep in test"))
+            .collect(),
+        worktree: format!("m01-{}", id.to_lowercase()),
+        model: TaskModel::Worker,
+        effort: ThinkingLevel::High,
+        selected: true,
+        version: 1,
+        status: TaskStatus::Queued,
+    }
+}
+
+fn plan(tasks: Vec<PlanTask>) -> MissionPlan {
+    MissionPlan {
+        schema: MISSION_PLAN_SCHEMA,
+        version: FIRST_PLAN_VERSION,
+        tasks,
+    }
+}
+
+mod schema;
+mod validate;
+
+#[cfg(test)]
+mod file_io {
+    use super::*;
+
+    #[test]
+    fn plan_round_trips_through_json() {
+        let dir = tempfile_dir();
+        let path = dir.join("plan.json");
+        let mut original = plan(vec![task("T1", &[]), task("T2", &["T1"])]);
+        original.tasks[1].status = TaskStatus::Replaced {
+            by: TaskId::new("T2b").expect("valid"),
+        };
+        original.tasks.push(task("T2b", &["T1"]));
+
+        save_plan_file(&path, &original).expect("save");
+        let loaded = load_plan_file(&path).expect("load");
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn mission_round_trips_through_json() {
+        let dir = tempfile_dir();
+        let path = dir.join("mission.json");
+        let meta = MissionMeta {
+            id: "mission-01".into(),
+            goal: "add mission orchestration".into(),
+            planner: PlannerKind::CodexCli,
+            status: MissionStatus::Planned,
+        };
+        save_mission_file(&path, &meta).expect("save");
+        assert_eq!(load_mission_file(&path).expect("load"), meta);
+    }
+
+    #[test]
+    fn wrong_schema_is_rejected() {
+        let dir = tempfile_dir();
+        let path = dir.join("plan.json");
+        std::fs::write(&path, r#"{"schema": 99, "version": 1, "tasks": []}"#).expect("write");
+        let err = load_plan_file(&path).expect_err("bad schema");
+        assert!(err.to_string().contains("schema 99"), "{err}");
+    }
+
+    #[test]
+    fn invalid_json_is_an_error_not_a_partial_plan() {
+        let dir = tempfile_dir();
+        let path = dir.join("plan.json");
+        std::fs::write(&path, "{not json").expect("write");
+        assert!(load_plan_file(&path).is_err());
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        let dir = tempfile_dir();
+        assert!(load_plan_file(&dir.join("nope.json")).is_err());
+    }
+
+    fn tempfile_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "horizon-mission-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("create");
+        dir
+    }
+}
+
+#[cfg(test)]
+mod status_semantics {
+    use super::*;
+
+    #[test]
+    fn replaced_and_done_satisfy_dependency_edges() {
+        assert!(TaskStatus::Done.satisfies_deps());
+        assert!(
+            TaskStatus::Replaced {
+                by: TaskId::new("T2").expect("valid")
+            }
+            .satisfies_deps()
+        );
+        assert!(!TaskStatus::Failed.satisfies_deps());
+        assert!(!TaskStatus::Queued.satisfies_deps());
+        assert!(!TaskStatus::Running.satisfies_deps());
+    }
+
+    #[test]
+    fn terminal_statuses_count_toward_completion() {
+        assert!(TaskStatus::Done.is_terminal());
+        assert!(TaskStatus::Failed.is_terminal());
+        assert!(TaskStatus::Skipped.is_terminal());
+        assert!(!TaskStatus::Queued.is_terminal());
+        assert!(!TaskStatus::Running.is_terminal());
+    }
+
+    #[test]
+    fn effort_factors_scale_token_estimates() {
+        let off = TaskSize::Small.base_megatokens() * ThinkingLevel::Off.effort_factor();
+        assert!((off - 0.3).abs() < 1e-6, "off effort must not scale: {off}");
+        assert!((TaskSize::Large.base_megatokens() * ThinkingLevel::Max.effort_factor() - 3.15).abs() < 1e-6);
+        assert!(ThinkingLevel::High.effort_factor() > ThinkingLevel::Medium.effort_factor());
+    }
+
+    #[test]
+    fn thinking_flag_omits_off() {
+        assert_eq!(ThinkingLevel::Off.flag_value(), None);
+        assert_eq!(ThinkingLevel::Xhigh.flag_value(), Some("xhigh"));
+        assert_eq!(ThinkingLevel::High.to_string(), "high");
+        assert_eq!(ThinkingLevel::Off.to_string(), "off");
+    }
+
+    #[track_caller]
+    fn expect_task_count_error(plan: &MissionPlan, expected: usize) {
+        let err = plan.validate().expect_err("should reject");
+        let msg = err.to_string();
+        assert!(msg.contains(&expected.to_string()), "{msg}");
+    }
+
+    #[test]
+    fn task_count_limit_is_enforced() {
+        let tasks = (0..=MAX_MISSION_TASKS)
+            .map(|i| task(&format!("T{i:02}"), &[]))
+            .collect();
+        expect_task_count_error(&plan(tasks), MAX_MISSION_TASKS + 1);
+    }
+}

--- a/crates/horizon-core/src/mission/tests/mod.rs
+++ b/crates/horizon-core/src/mission/tests/mod.rs
@@ -109,10 +109,10 @@ mod status_semantics {
     use super::*;
 
     #[test]
-    fn replaced_and_done_satisfy_dependency_edges() {
+    fn only_done_satisfies_dependency_edges_without_plan_context() {
         assert!(TaskStatus::Done.satisfies_deps());
         assert!(
-            TaskStatus::Replaced {
+            !TaskStatus::Replaced {
                 by: TaskId::new("T2").expect("valid")
             }
             .satisfies_deps()
@@ -120,6 +120,27 @@ mod status_semantics {
         assert!(!TaskStatus::Failed.satisfies_deps());
         assert!(!TaskStatus::Queued.satisfies_deps());
         assert!(!TaskStatus::Running.satisfies_deps());
+    }
+
+    #[test]
+    fn dependency_satisfaction_follows_replacement_chain() {
+        let mut t1 = task("T1", &[]);
+        t1.status = TaskStatus::Replaced {
+            by: TaskId::new("T1b").expect("valid"),
+        };
+        let mut t1b = task("T1b", &[]);
+        t1b.status = TaskStatus::Queued;
+        let mut p = plan(vec![t1, t1b]);
+        assert!(
+            !p.dependency_satisfied(&TaskId::new("T1").expect("valid"))
+                .expect("resolves")
+        );
+
+        p.tasks[1].status = TaskStatus::Done;
+        assert!(
+            p.dependency_satisfied(&TaskId::new("T1").expect("valid"))
+                .expect("resolves")
+        );
     }
 
     #[test]

--- a/crates/horizon-core/src/mission/tests/schema.rs
+++ b/crates/horizon-core/src/mission/tests/schema.rs
@@ -1,0 +1,74 @@
+use crate::mission::{TaskSize, ThinkingLevel};
+
+#[test]
+fn thinking_level_serde_is_lowercase() {
+    assert_eq!(
+        serde_json::to_string(&ThinkingLevel::Xhigh).expect("serde"),
+        "\"xhigh\""
+    );
+    let parsed: ThinkingLevel = serde_json::from_str("\"medium\"").expect("serde");
+    assert_eq!(parsed, ThinkingLevel::Medium);
+    let err = serde_json::from_str::<ThinkingLevel>("\"turbo\"").expect_err("unknown level");
+    assert!(err.to_string().contains("turbo"));
+}
+
+#[test]
+fn task_size_serde_is_snake_case() {
+    assert_eq!(serde_json::to_string(&TaskSize::Small).expect("serde"), "\"small\"");
+    let parsed: TaskSize = serde_json::from_str("\"large\"").expect("serde");
+    assert_eq!(parsed, TaskSize::Large);
+}
+
+#[test]
+fn plan_task_selected_defaults_to_true_when_omitted() {
+    let raw = r#"{
+        "id": "T1",
+        "title": "core",
+        "brief": "build it",
+        "size": "small",
+        "deps": [],
+        "worktree": "m01-t1",
+        "model": "worker",
+        "effort": "high",
+        "version": 1,
+        "status": "queued"
+    }"#;
+    let task: crate::mission::PlanTask = serde_json::from_str(raw).expect("serde");
+    assert!(task.selected);
+}
+
+#[test]
+fn replaced_status_carries_the_replacement_id() {
+    let raw = r#"{
+        "id": "T4",
+        "title": "ui",
+        "brief": "build it",
+        "size": "medium",
+        "deps": ["T2"],
+        "worktree": "m01-t4",
+        "model": "worker",
+        "effort": "high",
+        "selected": true,
+        "version": 1,
+        "status": { "replaced": { "by": "T4b" } }
+    }"#;
+    let task: crate::mission::PlanTask = serde_json::from_str(raw).expect("serde");
+    assert!(matches!(task.status, crate::mission::TaskStatus::Replaced { .. }));
+    let round = serde_json::to_string(&task).expect("serde");
+    let reparsed: crate::mission::PlanTask = serde_json::from_str(&round).expect("serde");
+    assert_eq!(reparsed, task);
+}
+
+#[test]
+fn plan_file_shape_round_trips_verbatim_fields() {
+    let task = super::task("T1", &[]);
+    let raw = serde_json::to_string(&crate::mission::MissionPlan {
+        schema: crate::mission::MISSION_PLAN_SCHEMA,
+        version: 2,
+        tasks: vec![task],
+    })
+    .expect("serde");
+    let back: crate::mission::MissionPlan = serde_json::from_str(&raw).expect("serde");
+    assert_eq!(back.version, 2);
+    assert_eq!(back.tasks.len(), 1);
+}

--- a/crates/horizon-core/src/mission/tests/schema.rs
+++ b/crates/horizon-core/src/mission/tests/schema.rs
@@ -1,4 +1,4 @@
-use crate::mission::{TaskSize, ThinkingLevel};
+use crate::mission::{TaskId, TaskSize, ThinkingLevel};
 
 #[test]
 fn thinking_level_serde_is_lowercase() {
@@ -71,4 +71,11 @@ fn plan_file_shape_round_trips_verbatim_fields() {
     let back: crate::mission::MissionPlan = serde_json::from_str(&raw).expect("serde");
     assert_eq!(back.version, 2);
     assert_eq!(back.tasks.len(), 1);
+}
+
+#[test]
+fn task_id_deserialize_enforces_format() {
+    let parsed: TaskId = serde_json::from_str("\"T1\"").expect("valid id");
+    assert_eq!(parsed.as_str(), "T1");
+    assert!(serde_json::from_str::<TaskId>("\"1bad\"").is_err());
 }

--- a/crates/horizon-core/src/mission/tests/validate.rs
+++ b/crates/horizon-core/src/mission/tests/validate.rs
@@ -118,6 +118,20 @@ fn replaced_by_existing_task_passes() {
 }
 
 #[test]
+fn replacement_cycles_are_rejected() {
+    let mut t1 = task("T1", &[]);
+    t1.status = TaskStatus::Replaced {
+        by: TaskId::new("T2").expect("valid"),
+    };
+    let mut t2 = task("T2", &[]);
+    t2.status = TaskStatus::Replaced {
+        by: TaskId::new("T1").expect("valid"),
+    };
+    let err = plan(vec![t1, t2]).validate().expect_err("replacement cycle");
+    assert!(err.to_string().contains("replacement cycle"), "{err}");
+}
+
+#[test]
 fn version_below_first_is_rejected() {
     let mut p = plan(vec![task("T1", &[])]);
     p.version = 0;

--- a/crates/horizon-core/src/mission/tests/validate.rs
+++ b/crates/horizon-core/src/mission/tests/validate.rs
@@ -1,0 +1,163 @@
+use crate::mission::{MissionMeta, PlannerKind, TaskId, TaskStatus};
+
+use super::{plan, task};
+
+#[test]
+fn valid_plan_passes() {
+    let p = plan(vec![
+        task("T1", &[]),
+        task("T2", &["T1"]),
+        task("T3", &["T1"]),
+        task("T4", &["T2"]),
+    ]);
+    assert!(p.validate().is_ok());
+}
+
+#[test]
+fn duplicate_ids_are_rejected() {
+    let mut p = plan(vec![task("T1", &[]), task("T1", &[])]);
+    p.version = 1;
+    let err = p.validate().expect_err("dup ids");
+    assert!(err.to_string().contains("duplicate"), "{err}");
+}
+
+#[test]
+fn unknown_deps_are_rejected() {
+    let p = plan(vec![task("T1", &["T9"])]);
+    let err = p.validate().expect_err("unknown dep");
+    assert!(err.to_string().contains("T9"), "{err}");
+}
+
+#[test]
+fn self_dependency_is_rejected() {
+    let p = plan(vec![task("T1", &["T1"])]);
+    let err = p.validate().expect_err("self dep");
+    assert!(err.to_string().contains("itself"), "{err}");
+}
+
+#[test]
+fn direct_cycle_is_rejected() {
+    let p = plan(vec![task("T1", &["T2"]), task("T2", &["T1"])]);
+    let err = p.validate().expect_err("cycle");
+    assert!(err.to_string().contains("cycle"), "{err}");
+}
+
+#[test]
+fn transitive_cycle_is_rejected() {
+    let p = plan(vec![task("T1", &["T3"]), task("T2", &["T1"]), task("T3", &["T2"])]);
+    let err = p.validate().expect_err("cycle");
+    assert!(err.to_string().contains("cycle"), "{err}");
+}
+
+#[test]
+fn diamond_dependencies_are_not_a_cycle() {
+    let p = plan(vec![
+        task("T1", &[]),
+        task("T2", &["T1"]),
+        task("T3", &["T1"]),
+        task("T4", &["T2", "T3"]),
+    ]);
+    assert!(p.validate().is_ok());
+}
+
+#[test]
+fn empty_brief_is_rejected() {
+    let mut t = task("T1", &[]);
+    t.brief = "   ".into();
+    let err = plan(vec![t]).validate().expect_err("empty brief");
+    assert!(err.to_string().contains("brief"), "{err}");
+}
+
+#[test]
+fn empty_title_is_rejected() {
+    let mut t = task("T1", &[]);
+    t.title = String::new();
+    let err = plan(vec![t]).validate().expect_err("empty title");
+    assert!(err.to_string().contains("title"), "{err}");
+}
+
+#[test]
+fn bad_worktree_names_are_rejected() {
+    for name in ["-leading", "Upper", "has space", "dot.dot"] {
+        let mut t = task("T1", &[]);
+        t.worktree = name.into();
+        let err = plan(vec![t]).validate().expect_err("bad worktree");
+        assert!(err.to_string().contains(name), "{err} for `{name}`");
+    }
+}
+
+#[test]
+fn replaced_by_unknown_task_is_rejected() {
+    let mut t = task("T4", &[]);
+    t.status = TaskStatus::Replaced {
+        by: TaskId::new("T4b").expect("valid"),
+    };
+    let err = plan(vec![t]).validate().expect_err("replaced by missing");
+    assert!(err.to_string().contains("T4b"), "{err}");
+}
+
+#[test]
+fn replaced_by_self_is_rejected() {
+    let mut t = task("T4", &[]);
+    t.status = TaskStatus::Replaced {
+        by: TaskId::new("T4").expect("valid"),
+    };
+    let err = plan(vec![t]).validate().expect_err("self replace");
+    assert!(err.to_string().contains("itself"), "{err}");
+}
+
+#[test]
+fn replaced_by_existing_task_passes() {
+    let mut old = task("T4", &[]);
+    old.status = TaskStatus::Replaced {
+        by: TaskId::new("T4b").expect("valid"),
+    };
+    let new = task("T4b", &[]);
+    let p = plan(vec![old, new]);
+    assert!(p.validate().is_ok());
+}
+
+#[test]
+fn version_below_first_is_rejected() {
+    let mut p = plan(vec![task("T1", &[])]);
+    p.version = 0;
+    let err = p.validate().expect_err("version 0");
+    assert!(err.to_string().contains("version"), "{err}");
+}
+
+#[test]
+fn task_id_format_is_enforced() {
+    let bad: Vec<String> = vec!["1".into(), "1abc".into(), "a".repeat(9), "ab-c".into(), String::new()];
+    for bad in &bad {
+        assert!(TaskId::new(bad).is_err(), "should reject `{bad}`");
+    }
+    for good in ["T1", "T3a", "T4b", "ab12cd34"] {
+        assert!(TaskId::new(good).is_ok(), "should accept `{good}`");
+    }
+}
+
+#[test]
+fn mission_id_must_be_a_safe_slug() {
+    let cases: Vec<(String, bool)> = vec![
+        ("mission-01".into(), true),
+        ("m1".into(), true),
+        ("Mission-01".into(), false),
+        ("-lead".into(), false),
+        ("has_underscore".into(), false),
+        ("x".repeat(40), false),
+        (String::new(), false),
+    ];
+    for (id, ok) in cases {
+        let meta = MissionMeta {
+            id: id.clone(),
+            goal: "goal".into(),
+            planner: PlannerKind::Pi,
+            status: crate::mission::MissionStatus::Planning,
+        };
+        if ok {
+            assert!(meta.validate_id().is_ok(), "`{id}` should pass");
+        } else {
+            assert!(meta.validate_id().is_err(), "`{id}` should fail");
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Stack layer 1 of 6 for the native mission orchestrator (design mockup: `docs/mockups/mission-orchestrator.html`, in the main checkout, not yet committed).

Introduces the mission domain core in `horizon-core`: the types, the versioned `plan.json` schema, and validation. No app-visible behavior in this layer.

## Design

- `MissionPlan` (plan.json) / `MissionMeta` (mission.json): the plan file is the only machine interface between the planner agent and Horizon — Horizon never parses model chatter
- `TaskStatus::Replaced { by }` + `satisfies_deps()`/`is_terminal()` semantics support mid-run re-planning (live refine) without breaking dependency edges
- `ThinkingLevel` mirrors the real `pi --thinking` flag values; `effort_factor()` drives token estimates (free on self-hosted workers, still counted)
- `TaskId` is a validated newtype (2-8 alphanumerics, letter-first); worktree names and mission ids are safe slugs (they become branch/dir names)
- `Error::Mission` typed variant; `load_*` validate on every read so a hand-edited or hallucinated plan can never wedge the scheduler

## Behavior impact

None. New module, no UI, no new dependencies, no runtime paths touched.

## Test evidence

- 31 new unit tests in `mission/tests/` (schema serde shapes, file round-trips, wrong-schema rejection, id/deps/cycle/brief/worktree validation, replacement consistency, status semantics, effort factors, task-count limit)
- Full pre-push matrix green on `2e92f7d`: `cargo fmt --check`, `check-maintainability.sh`, `cargo test --workspace` (+ `--features speech`), clippy blocking + strict + pedantic tiers

## Scope note

875 lines added (~430 production / ~445 tests) — over the 500-line soft guideline because schema and validation form one inseparable unit. Split into two stack layers if you prefer.
