### PR TITLE
feat(ui): reveal panel when focusing it from menus, shortcuts, and overlays

### DIFF
--- a/crates/horizon-ui/src/app/actions/command_palette.rs
+++ b/crates/horizon-ui/src/app/actions/command_palette.rs
@@ -60,14 +60,7 @@ impl HorizonApp {
             CommandId::SwitchWorkspace(workspace_id) => {
                 let _ = self.focus_workspace_visible(ctx, workspace_id, true);
             }
-            CommandId::FocusPanel(panel_id) => {
-                self.board.focus(panel_id);
-                if let Some(workspace_id) = self.board.panel(panel_id).map(|panel| panel.workspace_id)
-                    && let Some((min, max)) = self.board.workspace_bounds(workspace_id)
-                {
-                    self.focus_workspace_bounds(ctx, min, max, true);
-                }
-            }
+            CommandId::FocusPanel(panel_id) => self.reveal_panel_visible(ctx, panel_id),
             CommandId::FocusActiveWorkspace => {
                 let _ = self.focus_active_workspace(ctx, false);
             }

--- a/crates/horizon-ui/src/app/actions/search.rs
+++ b/crates/horizon-ui/src/app/actions/search.rs
@@ -21,11 +21,7 @@ impl HorizonApp {
                 }
                 self.board.focus(panel_id);
                 scroll_to_search_match(&mut self.board, panel_id, line_index, total_lines);
-                if let Some(workspace_id) = self.board.panel(panel_id).map(|panel| panel.workspace_id)
-                    && let Some((min, max)) = self.board.workspace_bounds(workspace_id)
-                {
-                    self.focus_workspace_bounds(ui.ctx(), min, max, true);
-                }
+                self.reveal_panel_visible(ui.ctx(), panel_id);
             }
         }
     }

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -857,12 +857,7 @@ impl HorizonApp {
                 let _ = self.board.dismiss_attention(attention_id);
             }
             if let Some(panel_id) = feed_result.focus_panel {
-                self.board.focus(panel_id);
-                if let Some(ws_id) = self.board.panel(panel_id).map(|p| p.workspace_id)
-                    && let Some((min, max)) = self.board.workspace_bounds(ws_id)
-                {
-                    self.focus_workspace_bounds(ctx, min, max, true);
-                }
+                self.reveal_panel_visible(ctx, panel_id);
             }
         }
         self.render_canvas_hud(ctx);

--- a/crates/horizon-ui/src/app/minimap/interaction.rs
+++ b/crates/horizon-ui/src/app/minimap/interaction.rs
@@ -59,8 +59,8 @@ pub(super) fn render_scoped_minimap(
     } else if inner.clicked() {
         match hovered {
             Some(MinimapHitTarget::Panel { panel_id, .. }) => match scope {
-                MinimapScope::Attached => app.focus_panel_visible(ctx, panel_id, false),
-                MinimapScope::Workspace(_) => app.focus_panel_in_rect(panel_id, canvas_rect),
+                MinimapScope::Attached => app.reveal_panel_visible(ctx, panel_id),
+                MinimapScope::Workspace(_) => app.reveal_panel_in_rect(panel_id, canvas_rect),
             },
             Some(MinimapHitTarget::Workspace(workspace_id)) if scope == MinimapScope::Attached => {
                 let _ = app.focus_workspace_visible(ctx, workspace_id, false);

--- a/crates/horizon-ui/src/app/remote_hosts.rs
+++ b/crates/horizon-ui/src/app/remote_hosts.rs
@@ -150,7 +150,7 @@ impl HorizonApp {
 
         match self.create_panel_with_options(options, workspace_id) {
             Ok(panel_id) => {
-                self.focus_panel_visible(ctx, panel_id, false);
+                self.reveal_panel_visible(ctx, panel_id);
                 self.mark_runtime_dirty();
             }
             Err(error) => {

--- a/crates/horizon-ui/src/app/sidebar.rs
+++ b/crates/horizon-ui/src/app/sidebar.rs
@@ -652,10 +652,13 @@ impl HorizonApp {
             self.board.focus(panel_id);
         }
 
+        let pan_to_panel_workspace = actions
+            .pan_to_panel
+            .and_then(|panel_id| self.board.panel(panel_id).map(|panel| panel.workspace_id));
         let pan_workspace_id = if workspace_drop_target.is_some() {
             workspace_drop_target
-        } else if let Some(panel_id) = actions.pan_to_panel {
-            self.board.panel(panel_id).map(|panel| panel.workspace_id)
+        } else if pan_to_panel_workspace.is_some() {
+            pan_to_panel_workspace
         } else {
             actions.pan_to_workspace
         };
@@ -667,6 +670,10 @@ impl HorizonApp {
                 if let Some(panel_id) = actions.focus_panel {
                     self.board.focus(panel_id);
                 }
+            } else if let Some(panel_id) = actions.pan_to_panel {
+                // Attached canvas: reveal the clicked panel (zooming out when
+                // needed) instead of panning to the whole workspace bounds.
+                self.reveal_panel_visible(ctx, panel_id);
             } else if let Some((min, max)) = self.board.workspace_bounds(workspace_id) {
                 let pos = Pos2::new(min[0] - WS_BG_PAD, min[1] - WS_BG_PAD - WS_TITLE_HEIGHT);
                 let size = Vec2::new(

--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -209,21 +209,22 @@ impl HorizonApp {
         true
     }
 
-    pub(super) fn focus_panel_visible(&mut self, ctx: &Context, panel_id: PanelId, left_align: bool) {
-        self.board.focus(panel_id);
-        if let Some((pos, size)) = self.panel_focus_frame(panel_id) {
-            self.pan_to_canvas_pos_aligned(ctx, pos, size, left_align);
-        }
+    /// Focus a panel and move the view so the panel is visible: zoom out just
+    /// enough for it to fit (never zoom in), or bottom-align it when it stays
+    /// larger than the viewport even at the minimum zoom.
+    pub(super) fn reveal_panel_visible(&mut self, ctx: &Context, panel_id: PanelId) {
+        self.reveal_panel_in_rect(panel_id, self.canvas_rect(ctx));
     }
 
-    pub(super) fn focus_panel_in_rect(&mut self, panel_id: PanelId, canvas_rect: Rect) {
+    pub(super) fn reveal_panel_in_rect(&mut self, panel_id: PanelId, canvas_rect: Rect) {
         let Some((pos, size)) = self.panel_focus_frame(panel_id) else {
             return;
         };
 
-        let pan_offset = aligned_pan_offset(canvas_rect, pos, size, self.canvas_view.zoom, false);
+        let (zoom, pan_offset) = reveal_view_state(canvas_rect, pos, size, self.canvas_view.zoom);
         self.board.focus(panel_id);
         self.pan_target = None;
+        self.canvas_view.set_zoom(zoom);
         self.canvas_view.set_pan_offset([pan_offset.x, pan_offset.y]);
         self.mark_runtime_dirty();
     }
@@ -344,6 +345,36 @@ fn panel_focus_frame(position: [f32; 2], size: [f32; 2]) -> (Pos2, Vec2) {
     )
 }
 
+/// Inset (px) kept between the revealed panel and the viewport edge.
+const REVEAL_MARGIN: f32 = 40.0;
+
+/// View state that keeps a canvas frame visible: the current zoom is kept while
+/// the frame already fits, otherwise the view zooms out just enough for the
+/// frame to fit (never zooming in).
+fn reveal_view_state(canvas_rect: Rect, canvas_pos: Pos2, canvas_size: Vec2, current_zoom: f32) -> (f32, Vec2) {
+    let zoom = current_zoom.min(fit_zoom_for_frame(
+        canvas_rect.size(),
+        canvas_size,
+        Vec2::splat(REVEAL_MARGIN),
+    ));
+    (zoom, reveal_pan_offset(canvas_rect, canvas_pos, canvas_size, zoom))
+}
+
+fn reveal_pan_offset(canvas_rect: Rect, canvas_pos: Pos2, canvas_size: Vec2, zoom: f32) -> Vec2 {
+    let frame_screen_size = canvas_size * zoom;
+    // When the frame is taller than the viewport (oversized panel at the
+    // minimum zoom) it is bottom-aligned so the panel's bottom edge — where a
+    // terminal's active prompt lives — stays visible. It is always centered
+    // horizontally, which keeps the middle visible for overly wide panels.
+    let x = canvas_rect.width() * 0.5 - (canvas_pos.x + canvas_size.x * 0.5) * zoom;
+    let y = if frame_screen_size.y + REVEAL_MARGIN * 2.0 <= canvas_rect.height() {
+        canvas_rect.height() * 0.5 - (canvas_pos.y + canvas_size.y * 0.5) * zoom
+    } else {
+        canvas_rect.height() - REVEAL_MARGIN - (canvas_pos.y + canvas_size.y) * zoom
+    };
+    Vec2::new(x, y)
+}
+
 fn fit_zoom_for_frame(canvas_size: Vec2, frame_size: Vec2, margin: Vec2) -> f32 {
     if frame_size.x <= f32::EPSILON || frame_size.y <= f32::EPSILON {
         return horizon_core::DEFAULT_CANVAS_ZOOM;
@@ -385,7 +416,7 @@ mod tests {
     use egui::{Pos2, Rect, Vec2};
     use horizon_core::{CanvasViewState, MAX_CANVAS_ZOOM, MIN_CANVAS_ZOOM};
 
-    use super::{aligned_pan_offset, canvas_scene_transform, fit_zoom_for_frame, panel_focus_frame};
+    use super::{aligned_pan_offset, canvas_scene_transform, fit_zoom_for_frame, panel_focus_frame, reveal_view_state};
 
     #[test]
     fn canvas_scene_transform_matches_canvas_view_mapping() {
@@ -445,5 +476,46 @@ mod tests {
 
         assert!((zoomed_out - MIN_CANVAS_ZOOM).abs() <= f32::EPSILON);
         assert!((zoomed_in - MAX_CANVAS_ZOOM).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn reveal_view_state_keeps_zoom_and_centers_fitting_frame() {
+        let canvas = Rect::from_min_size(Pos2::ZERO, Vec2::new(1200.0, 800.0));
+        let (zoom, pan) = reveal_view_state(canvas, Pos2::new(500.0, 300.0), Vec2::new(400.0, 300.0), 1.0);
+
+        assert!((zoom - 1.0).abs() <= f32::EPSILON);
+        assert!((pan.x + 100.0).abs() < 0.001);
+        assert!((pan.y + 50.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn reveal_view_state_zooms_out_just_enough_for_oversized_frame() {
+        let canvas = Rect::from_min_size(Pos2::ZERO, Vec2::new(1200.0, 800.0));
+        // Available (1200-80) x (800-80) vs frame 1600x1200 -> min(0.7, 0.6).
+        let (zoom, pan) = reveal_view_state(canvas, Pos2::new(0.0, 0.0), Vec2::new(1600.0, 1200.0), 1.0);
+
+        assert!((zoom - 0.6).abs() < 0.001);
+        assert!((pan.x - 120.0).abs() < 0.001);
+        assert!((pan.y - 40.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn reveal_view_state_never_zooms_in() {
+        let canvas = Rect::from_min_size(Pos2::ZERO, Vec2::new(1200.0, 800.0));
+        let (zoom, _) = reveal_view_state(canvas, Pos2::new(0.0, 0.0), Vec2::new(100.0, 80.0), 1.5);
+
+        assert!((zoom - 1.5).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn reveal_view_state_bottom_aligns_frame_taller_than_viewport() {
+        let canvas = Rect::from_min_size(Pos2::ZERO, Vec2::new(1200.0, 800.0));
+        // 4000x4000 frame cannot fit even at the minimum zoom (0.25 -> 1000x1000).
+        let (zoom, pan) = reveal_view_state(canvas, Pos2::new(100.0, 0.0), Vec2::new(4000.0, 4000.0), 1.0);
+
+        assert!((zoom - MIN_CANVAS_ZOOM).abs() <= f32::EPSILON);
+        // x centered: 600 - (100 + 2000) * 0.25 ; y bottom-aligned: 800 - 40 - (0 + 4000) * 0.25
+        assert!((pan.x - 75.0).abs() < 0.001);
+        assert!((pan.y - (-240.0)).abs() < 0.001);
     }
 }


### PR DESCRIPTION
## Purpose

Focusing a panel from the sidebar, command palette, terminal search, attention feed, minimap, or SSH-host picker now moves the canvas so the panel is actually **visible**:

- zooms out just enough for the panel to fit (with a 40px margin) — **never zooms in**;
- if the panel is still larger than the viewport at the minimum zoom (0.25), it is **bottom-aligned** so the panel's bottom edge — where a terminal's active prompt lives — stays 40px above the viewport bottom, and centered horizontally (overly wide panels show their middle).

Previously these paths panned to the *workspace* bounds (or not at all), or centered the panel at the current zoom — so a panel bigger than the screen (or one sitting in a large workspace) stayed off-screen until manually panned.

## Behavior impact

- **Changed:** sidebar panel-row click, command-palette "Focus panel", terminal-search result selection, attention-feed focus, minimap panel click (attached + detached workspace scope), and SSH-host panel creation now reveal the panel instead of panning to the workspace frame. A *single-panel* workspace-row click behaves exactly like its panel-row click (it has always set the same `focus_panel` + `pan_to_panel` actions), so it now reveals the panel too.
- **Unchanged:** multi-panel workspace-row clicks (still pan to workspace bounds, no zoom change), "Fit workspace" / "Focus workspace" commands, zoom reset, detached-window focus, minimap double-click fit.

## Implementation

- `app/view.rs`: new `reveal_panel_visible` / `reveal_panel_in_rect` replacing `focus_panel_visible` / `focus_panel_in_rect`; pure helpers `reveal_view_state` (current zoom kept while the frame fits, else zoom out to fit — clamped to canvas zoom limits) and `reveal_pan_offset` (center while the frame fits; bottom-align when taller than the viewport). 4 new unit tests.
- Call sites in `sidebar.rs`, `actions/command_palette.rs`, `actions/search.rs`, `lifecycle.rs` (attention feed), `minimap/interaction.rs`, `remote_hosts.rs`.
- Sidebar: a panel click on an attached workspace now reveals the panel; detached workspaces still focus the child window (no main-canvas pan).

## Test evidence

- Full validation matrix in this branch/worktree: `cargo fmt --check`, maintainability guard, `cargo test --workspace` (± `--features speech`, 858 passed), blocking + strict + pedantic Clippy all green.
- Live smoke (X11 :1, debug build, isolated HOME with a seeded 3-panel session: Small 420×320, Wide 2600×420, Tall 420×4000 on a 1400×860 window), verified via screenshots + persisted `canvas_view` state:
  - sidebar → Tall: zoom 1.0 → 0.25 (min), Tall bottom-aligned ~40px above viewport bottom, centered (top cut off) ✓
  - sidebar → Wide from zoom 1.0: zoom → 0.4243 (exact fit), whole panel visible with margins, centered ✓
  - sidebar → Small while zoomed out: zoom unchanged (no zoom-in), panel centered ✓
  - command palette → "Tall": same reveal ✓ · minimap click → Tall: same reveal ✓
  - terminal search → result: focus + reveal, no view error ✓
  - regressions: workspace-row click pans to bounds without zoom change; "Fit workspace" and "Reset Zoom" behave as before ✓
- Temporary smoke plan was created under `docs/testing/` and deleted after the pass, per the repo convention.