### PR TITLE
docs: add pointer to the horizon-server POC repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,15 @@ Two NB-Whisper quirks worth knowing: it *normalizes* dialect speech into standar
 | [**alacritty_terminal**](https://github.com/alacritty/alacritty) | Battle-tested terminal emulation |
 | [**Catppuccin**](https://catppuccin.com) | Terminal palettes (Mocha dark / Latte light) on a warm editorial UI chrome |
 
+## Server (experimental)
+
+[**horizon-server**](https://github.com/peters/horizon-server) is a
+standalone POC that reuses the same terminal stack to stream PTY-backed
+panels to a browser (xterm.js) over WebSocket: workspaces, per-panel
+terminate/restart, per-panel stream on/off, and token-gated access over a
+tunnel. It is a separate crate and repository — not part of the Horizon
+build.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Purpose

One-line README pointer to the companion **horizon-server** POC
(`peters/horizon-server`): a standalone crate that reuses
`alacritty_terminal`'s public PTY/tty API to stream panels to a browser
(xterm.js) over WebSocket.

## Behavior impact

None — README only, new "Server (experimental)" section between
"Built With" and "Contributing". No code, config, or dependency changes.

## Evidence

- `git diff` shows README.md only (+11 lines)
- No build impact; CI matrix runs for completeness