### PR TITLE
Speech input: capture via PulseAudio/PipeWire so the mic is shareable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +618,7 @@ dependencies = [
  "block2 0.6.2",
  "coreaudio-rs",
  "dasp_sample",
+ "futures",
  "jni",
  "js-sys",
  "libc",
@@ -627,6 +634,8 @@ dependencies = [
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "portable-atomic",
+ "pulseaudio",
  "web-sys",
  "windows",
  "windows-core",
@@ -949,6 +958,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-primitive-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "epaint"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,12 +1163,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1156,6 +1192,17 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1192,6 +1239,7 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2084,6 +2132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2890,6 +2939,22 @@ dependencies = [
  "bitflags 2.13.1",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pulseaudio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70623bd7967a9ca4c2ae0e807fc380b291f98480fc037042305ec643a4d3373"
+dependencies = [
+ "bitflags 2.13.1",
+ "byteorder",
+ "enum-primitive-derive",
+ "futures",
+ "log",
+ "mio",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,12 @@ surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.
 # -sys crate vendors the whole C++ tree, so cargo builds it from source —
 # needs only CMake + a C++ compiler, no git submodules.
 transcribe-cpp = "0.2.0"
-cpal = "0.18.2"
+# The `pulseaudio` feature (Linux-only effect) adds cpal's PulseAudio host, which
+# `default_host()` prefers over raw ALSA when a PulseAudio/PipeWire (pipewire-pulse)
+# server socket exists. Capture then shares the microphone with every other app
+# (Discord, calls, ...) instead of failing with a busy raw-ALSA device; without a
+# sound server it falls back to raw ALSA exactly as before.
+cpal = { version = "0.18.2", features = ["pulseaudio"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ features:
     language: "no"       # ISO hint; "auto" detects. Supported set = the model's GGUF metadata
     task: transcribe     # translate = speak any language, insert English text
     backend: auto        # auto | cpu | cuda | vulkan | metal
-    input_device: ""     # microphone name (exact or substring, e.g. "NT-USB"); "" = system default
+    input_device: ""     # microphone name (exact, substring, or cross-backend-normalized, e.g. "NT-USB"); "" = system default
     hotkey: "F9"         # push-to-talk; same syntax as the shortcuts table, "" disables
     hotkey_mode: hold    # hold (Ventrilo-style) | toggle
     preload: false       # true = load the model at startup; first dictation becomes instant

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ cargo speech-cuda     # NVIDIA GPU inference (needs the CUDA toolkit)
 cargo speech-vulkan   # any GPU via Vulkan (needs the Vulkan SDK to build)
 ```
 
+On Linux, capture routes through PulseAudio/PipeWire (pipewire-pulse) whenever that sound server is running, so the microphone is shared with whatever else is using it (Discord, a video call, ...). Without a sound server it falls back to raw ALSA, which claims the device exclusively.
+
 When a GPU backend is compiled in (Metal ships automatically in plain `speech` on macOS), the `auto` backend probes discrete GPUs first and always falls back to CPU; a CPU-only build simply runs on CPU.
 
 ```yaml

--- a/crates/horizon-core/src/speech_config.rs
+++ b/crates/horizon-core/src/speech_config.rs
@@ -27,10 +27,12 @@ pub struct SpeechConfig {
     pub target_language: String,
     pub backend: SpeechBackend,
     /// Microphone to record from, matched case-insensitively against the
-    /// names the audio host reports (exact match first, then substring, so
-    /// `NT-USB` finds `RØDE NT-USB+ Mono`). Empty uses the system default
-    /// input device; a configured name that matches nothing falls back to
-    /// the system default with a warning.
+    /// names the audio host reports: exact match first, then substring (so
+    /// `NT-USB` finds `RØDE NT-USB+ Mono`), then a normalized identity key
+    /// that maps the same physical microphone's ALSA- and pulse-host names
+    /// onto each other. Empty uses the system default input device; a
+    /// configured name that matches nothing falls back to the system
+    /// default with a warning.
     pub input_device: String,
     /// Push-to-talk shortcut in the shared shortcut syntax; empty disables.
     pub hotkey: String,

--- a/crates/horizon-ui/src/app/speech/capture.rs
+++ b/crates/horizon-ui/src/app/speech/capture.rs
@@ -510,7 +510,8 @@ fn start_recording(
     // One arm per interleaved sample type, each normalizing to f32 in
     // [-1, 1] before the shared downmix/resample. Covers the formats real
     // capture endpoints report: F32/I16/U16 plus 8-bit, 32-bit (incl. the
-    // I32 that 24-bit WASAPI/ALSA endpoints deliver), and F64.
+    // I32 that 24-bit WASAPI/ALSA endpoints deliver), the I24 that 24-bit
+    // PulseAudio/PipeWire endpoints deliver, and F64.
     macro_rules! input_stream {
         ($sample:ty, $to_f32:expr) => {{
             let sink = Arc::clone(&samples);
@@ -531,6 +532,7 @@ fn start_recording(
         SampleFormat::F64 => input_stream!(f64, |&sample| f64_to_sample(sample)),
         SampleFormat::I8 => input_stream!(i8, |&sample| f32::from(sample) / 128.0),
         SampleFormat::I16 => input_stream!(i16, |&sample| f32::from(sample) / 32_768.0),
+        SampleFormat::I24 => input_stream!(i32, |&sample| i24_to_sample(sample)),
         SampleFormat::I32 => input_stream!(i32, |&sample| i32_to_sample(sample)),
         SampleFormat::U8 => input_stream!(u8, |&sample| (f32::from(sample) - 128.0) / 128.0),
         SampleFormat::U16 => input_stream!(u16, |&sample| (f32::from(sample) - 32_768.0) / 32_768.0),
@@ -602,6 +604,14 @@ fn i32_to_sample(sample: i32) -> f32 {
     sample as f32 / 2_147_483_648.0
 }
 
+/// Normalize a 24-bit device sample (stored in a 4-byte i32 by cpal's I24
+/// format, as delivered by 24-bit PulseAudio/PipeWire sources) to f32 in
+/// [-1, 1).
+#[expect(clippy::cast_precision_loss, reason = "audio downconvert to the f32 pipeline")]
+fn i24_to_sample(sample: i32) -> f32 {
+    sample as f32 / 8_388_608.0
+}
+
 #[expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
@@ -656,8 +666,18 @@ mod tests {
 
     use super::{
         CaptureCmd, CaptureHandle, CapturePoll, CapturedAudio, MonoResampler, TARGET_SAMPLE_RATE,
-        deduplicate_device_names, to_mono_16k,
+        deduplicate_device_names, i24_to_sample, to_mono_16k,
     };
+
+    #[test]
+    fn i24_samples_normalize_to_the_f32_pipeline_range() {
+        let full = 1.0 / 8_388_608.0;
+        let close = |a: f32, b: f32| (a - b).abs() <= f32::EPSILON;
+        assert!(close(i24_to_sample(0), 0.0));
+        assert!(close(i24_to_sample(-8_388_608), -1.0));
+        assert!(close(i24_to_sample(8_388_607), 1.0 - full));
+        assert!(close(i24_to_sample(1), full));
+    }
 
     #[test]
     fn device_names_are_deduplicated_case_insensitively_in_host_order() {

--- a/crates/horizon-ui/src/app/speech/capture.rs
+++ b/crates/horizon-ui/src/app/speech/capture.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use cpal::Sample;
 use cpal::SampleFormat;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -547,8 +548,9 @@ fn start_recording(
     // One arm per interleaved sample type, each normalizing to f32 in
     // [-1, 1] before the shared downmix/resample. Covers the formats real
     // capture endpoints report: F32/I16/U16 plus 8-bit, 32-bit (incl. the
-    // I32 that 24-bit WASAPI/ALSA endpoints deliver), the I24 that 24-bit
-    // PulseAudio/PipeWire endpoints deliver, and F64.
+    // I32 that 24-bit WASAPI/ALSA endpoints deliver), and F64. The I24
+    // arm covers 24-bit PulseAudio/PipeWire endpoints: the s24-32le word
+    // spans the full i32 range, so it normalizes as i32.
     macro_rules! input_stream {
         ($sample:ty, $to_f32:expr) => {{
             let sink = Arc::clone(&samples);
@@ -569,7 +571,7 @@ fn start_recording(
         SampleFormat::F64 => input_stream!(f64, |&sample| f64_to_sample(sample)),
         SampleFormat::I8 => input_stream!(i8, |&sample| f32::from(sample) / 128.0),
         SampleFormat::I16 => input_stream!(i16, |&sample| f32::from(sample) / 32_768.0),
-        SampleFormat::I24 => input_stream!(i32, |&sample| i24_to_sample(sample)),
+        SampleFormat::I24 => input_stream!(cpal::I24, |&sample| i32_to_sample(sample.to_sample())),
         SampleFormat::I32 => input_stream!(i32, |&sample| i32_to_sample(sample)),
         SampleFormat::U8 => input_stream!(u8, |&sample| (f32::from(sample) - 128.0) / 128.0),
         SampleFormat::U16 => input_stream!(u16, |&sample| (f32::from(sample) - 32_768.0) / 32_768.0),
@@ -635,18 +637,12 @@ fn f64_to_sample(sample: f64) -> f32 {
     sample as f32
 }
 
-/// Normalize a 32-bit integer device sample to f32 in [-1, 1).
+/// Normalize a 32-bit integer device sample to f32 in [-1, 1). Also the
+/// right scale for cpal's I24: the s24-32le container holds the 24-bit
+/// value across the full i32 range (left-shifted, sign-extended).
 #[expect(clippy::cast_precision_loss, reason = "audio downconvert to the f32 pipeline")]
 fn i32_to_sample(sample: i32) -> f32 {
     sample as f32 / 2_147_483_648.0
-}
-
-/// Normalize a 24-bit device sample (stored in a 4-byte i32 by cpal's I24
-/// format, as delivered by 24-bit PulseAudio/PipeWire sources) to f32 in
-/// [-1, 1).
-#[expect(clippy::cast_precision_loss, reason = "audio downconvert to the f32 pipeline")]
-fn i24_to_sample(sample: i32) -> f32 {
-    sample as f32 / 8_388_608.0
 }
 
 #[expect(
@@ -703,18 +699,8 @@ mod tests {
 
     use super::{
         CaptureCmd, CaptureHandle, CapturePoll, CapturedAudio, MonoResampler, TARGET_SAMPLE_RATE,
-        deduplicate_device_names, device_identity_key, i24_to_sample, to_mono_16k,
+        deduplicate_device_names, device_identity_key, to_mono_16k,
     };
-
-    #[test]
-    fn i24_samples_normalize_to_the_f32_pipeline_range() {
-        let full = 1.0 / 8_388_608.0;
-        let close = |a: f32, b: f32| (a - b).abs() <= f32::EPSILON;
-        assert!(close(i24_to_sample(0), 0.0));
-        assert!(close(i24_to_sample(-8_388_608), -1.0));
-        assert!(close(i24_to_sample(8_388_607), 1.0 - full));
-        assert!(close(i24_to_sample(1), full));
-    }
 
     #[test]
     fn device_identity_key_converges_across_backend_namings() {

--- a/crates/horizon-ui/src/app/speech/capture.rs
+++ b/crates/horizon-ui/src/app/speech/capture.rs
@@ -419,8 +419,40 @@ pub fn list_input_devices() -> Vec<String> {
     )
 }
 
+/// Collapse a device name to a cross-backend identity key. The ALSA and
+/// Pulse hosts name the same physical microphone differently ("R\u{d8}DE NT-USB+,
+/// USB Audio" vs "R\u{d8}DE NT-USB+ Mono"): the ALSA name is the card long name
+/// plus a device descriptor, the Pulse name is the source description with a
+/// channel token. Keep the first comma field and drop trailing channel/format
+/// tokens so both converge on the same key.
+fn device_identity_key(name: &str) -> String {
+    const GENERIC_TOKENS: [&str; 5] = ["analog stereo", "digital stereo", "usb audio", "stereo", "mono"];
+    let first = name.split(',').next().unwrap_or("").to_lowercase();
+    let mut key = first.clone();
+    loop {
+        let stripped = GENERIC_TOKENS
+            .iter()
+            .find(|token| key.ends_with(&format!(" {token}")))
+            .map(|token| &key[..key.len() - token.len() - 1]);
+        match stripped {
+            Some(prefix) => key = prefix.to_string(),
+            None => break,
+        }
+    }
+    // An empty or whitespace-only name would produce an empty key, which
+    // would match every device; fall back to the raw (lowercased) name so
+    // it can only ever match itself.
+    if key.trim().is_empty() {
+        first
+    } else {
+        key.trim().to_string()
+    }
+}
+
 /// Resolve the configured device name against the host: exact
-/// case-insensitive match first, then substring, then the system default
+/// case-insensitive match first, then substring, then the normalized
+/// cross-backend identity key (a microphone configured under one host's
+/// naming still resolves under the other), then the system default
 /// (with a warning, so a renamed or unplugged microphone is diagnosable).
 fn resolve_input_device(host: &cpal::Host, preferred: Option<&str>) -> Result<cpal::Device, String> {
     let preferred = preferred.map(str::trim).filter(|wanted| !wanted.is_empty());
@@ -440,19 +472,24 @@ fn resolve_input_device(host: &cpal::Host, preferred: Option<&str>) -> Result<cp
             },
         );
         let wanted_lower = wanted.to_lowercase();
+        let wanted_key = device_identity_key(&wanted_lower);
         let mut exact = None;
         let mut substring = None;
-        for (name, device) in devices {
+        let mut normalized = None;
+        for (name, device) in &devices {
             let name_lower = name.to_lowercase();
             if name_lower == wanted_lower {
-                exact = Some((name, device));
+                exact = Some((name.clone(), device.clone()));
                 break;
             }
             if substring.is_none() && name_lower.contains(&wanted_lower) {
-                substring = Some((name, device));
+                substring = Some((name.clone(), device.clone()));
+            }
+            if normalized.is_none() && device_identity_key(&name_lower) == wanted_key {
+                normalized = Some((name.clone(), device.clone()));
             }
         }
-        if let Some((name, device)) = exact.or(substring) {
+        if let Some((name, device)) = exact.or(substring).or(normalized) {
             tracing::info!(configured = wanted, device = %name, "using configured speech input device");
             return Ok(device);
         }
@@ -666,7 +703,7 @@ mod tests {
 
     use super::{
         CaptureCmd, CaptureHandle, CapturePoll, CapturedAudio, MonoResampler, TARGET_SAMPLE_RATE,
-        deduplicate_device_names, i24_to_sample, to_mono_16k,
+        deduplicate_device_names, device_identity_key, i24_to_sample, to_mono_16k,
     };
 
     #[test]
@@ -677,6 +714,32 @@ mod tests {
         assert!(close(i24_to_sample(-8_388_608), -1.0));
         assert!(close(i24_to_sample(8_388_607), 1.0 - full));
         assert!(close(i24_to_sample(1), full));
+    }
+
+    #[test]
+    fn device_identity_key_converges_across_backend_namings() {
+        // The same physical microphone under the ALSA and Pulse hosts.
+        assert_eq!(
+            device_identity_key("R\u{d8}DE NT-USB+, USB Audio"),
+            device_identity_key("R\u{d8}DE NT-USB+ Mono")
+        );
+        assert_eq!(device_identity_key("R\u{d8}DE NT-USB+ Mono"), "r\u{f8}de nt-usb+");
+        assert_eq!(
+            device_identity_key("BRIO Ultra HD Webcam Analog Stereo"),
+            "brio ultra hd webcam"
+        );
+        // Matching is case-insensitive.
+        assert_eq!(
+            device_identity_key("R\u{d8}DE NT-USB+ mono"),
+            device_identity_key("r\u{f8}de nt-usb+ MONO")
+        );
+        // A name made only of generic tokens must not collapse to an empty key.
+        assert_eq!(device_identity_key("Mono"), "mono");
+        // Unrelated devices keep distinct keys.
+        assert_ne!(
+            device_identity_key("R\u{d8}DE NT-USB+ Mono"),
+            device_identity_key("USB Audio Front Microphone")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Speech capture on Linux uses cpal's default host, which is **raw ALSA** — it claims the microphone hardware device exclusively. While any other app (Discord, a video call) uses the same microphone through PipeWire, dictation fails with `DeviceBusy`, and the workaround was to point Discord at the webcam mic.

This PR routes capture through the sound server instead, so **multiple apps can read the same microphone at the same time**.

## Changes

- **`Cargo.toml`** — enable cpal's `pulseaudio` feature. cpal 0.18 ships a pure-Rust PulseAudio host (it speaks the Pulse protocol directly over the unix socket — no libpulse, no new system packages). With it enabled, `cpal::default_host()` on Linux prefers PipeWire (if the `pipewire` feature were on) then **PulseAudio** whenever a server socket exists, and falls back to raw ALSA otherwise — so behavior on headless/no-server machines is unchanged.
- **`crates/horizon-ui/src/app/speech/capture.rs`**
  - **24-bit support for the pulse path** (`SampleFormat::I24` arm). 24-bit microphones (the RØDE NT-USB+) report `S24In32Le` through the Pulse protocol. The arm uses a `cpal::I24` callback so the stream requests the source's native format, and normalizes with the existing 2^31 i32 scale — the s24-32le word carries the 24-bit value left-shifted into the upper 24 bits, spanning the full i32 range (measured: ambient peak ≈4% of 2^31, symmetric mean). (An earlier draft of this arm mis-scaled by 2^23 after Copilot review; see the thread on the arm.)
  - **Cross-backend device-name resolution.** The two Linux hosts name the same physical microphone differently (ALSA: `RØDE NT-USB+, USB Audio` — card long name + device descriptor; pulse: `RØDE NT-USB+ Mono` — source description), so a name stored while one host was active matched nothing under the other. `resolve_input_device` gains a third match tier: a normalized identity key (first comma field, trailing channel/format tokens like `Mono`/`Analog Stereo` dropped) that maps both namings onto each other. Match order stays exact → substring → normalized → system default (with the existing warning). No config change, no re-selection needed.
- **`README.md` / `speech_config.rs`** — document the Linux routing and the new match tier.

## Behavior impact

- Linux + PipeWire/Pulse (normal desktops): capture goes through the sound server → the mic is shared with every other app. The Pulse source fan-out means Horizon hears the same audio Discord hears. Existing `input_device` values keep working across host switches.
- Linux without a sound server: identical to before (raw ALSA).
- macOS/Windows: no change (the feature is a no-op off-Linux).

## Test evidence

- Full local validation matrix on this head: fmt, maintainability guard, `cargo test --workspace` (436), `cargo test --workspace --features speech` (475, incl. the new identity-key test), blocking + strict + pedantic Clippy — all green.
- Live on a PipeWire box with the RØDE NT-USB+ held open by a concurrent Pulse client (simulating Discord):
  - **Before (raw ALSA):** opening the RØDE fails with `cpal ErrorKind::DeviceBusy`.
  - **After (pulse host):** two simultaneous readers both capture the mic at full level (48 kHz mono); the shared-capture path is the exact API sequence `start_recording` uses.
  - Native I24 stream requested via the new arm: captured values span ±~4% of 2^31 with mean ≈ 0 (correct 2^31 normalization, no clipping).
- Full dictation smoke (hotkey → capture → whisper/parakeet transcription → PTY insertion) with a real Discord call in progress is offered by the machine owner and pending; the capture layer above is the only changed layer.
