### PR TITLE
feat(startup): prompt to resume all agent sessions on restore

### DIFF
--- a/crates/horizon-core/src/agents.rs
+++ b/crates/horizon-core/src/agents.rs
@@ -109,6 +109,11 @@ impl AgentDefinition {
     }
 
     #[must_use]
+    pub const fn supports_resume(self) -> bool {
+        !matches!(self.resume_mode, AgentResumeMode::None)
+    }
+
+    #[must_use]
     pub const fn requires_exact_session_validation(self) -> bool {
         matches!(self.session_validation, AgentSessionValidationMode::ParentThreadRoots)
     }

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -65,7 +65,7 @@ pub use runtime_state::{
 };
 pub use search::{PanelSearchResult, SearchMatch, SearchOptions, SearchResults, search_board};
 pub use session_store::{
-    ResolvedSession, SessionLease, SessionOpenDisposition, SessionStore, SessionSummary, StartupChooser,
+    ResolvedSession, SessionLease, SessionMeta, SessionOpenDisposition, SessionStore, SessionSummary, StartupChooser,
     StartupDecision, StartupPromptReason,
 };
 pub use shortcuts::{AppShortcuts, ShortcutBinding, ShortcutKey, ShortcutModifiers};

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -66,6 +66,11 @@ impl PanelKind {
     }
 
     #[must_use]
+    pub fn supports_agent_resume(self) -> bool {
+        agent_definition(self).is_some_and(crate::AgentDefinition::supports_resume)
+    }
+
+    #[must_use]
     pub fn requires_exact_session_validation(self) -> bool {
         agent_definition(self).is_some_and(crate::AgentDefinition::requires_exact_session_validation)
     }

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -1050,6 +1050,33 @@ mod tests {
     }
 
     #[test]
+    fn pi_bound_restore_launches_with_exact_session_flag() {
+        let binding = AgentSessionBinding::new(
+            PanelKind::Pi,
+            "pi-123".to_string(),
+            Some("/repo".to_string()),
+            None,
+            None,
+        );
+
+        let (_, args) = resolve_launch_command(
+            None,
+            Vec::new(),
+            None,
+            PanelKind::Pi,
+            AgentLaunchContext {
+                resume: &PanelResume::Last,
+                session_binding: Some(&binding),
+                should_resume_binding: true,
+                is_restore: true,
+            },
+        );
+
+        let joined = args.join(" ");
+        assert!(joined.contains("--session pi-123"), "{joined}");
+    }
+
+    #[test]
     fn claude_binding_resumes_only_when_transcript_exists() {
         let binding = AgentSessionBinding::new(PanelKind::Claude, "session-1".to_string(), None, None, None);
 

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
@@ -15,6 +15,7 @@ use crate::error::Error;
 
 mod grok;
 mod provider_scoping;
+mod resume_all;
 
 #[test]
 fn strict_catalog_load_propagates_provider_errors() {

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests/resume_all.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests/resume_all.rs
@@ -14,13 +14,14 @@ fn binding(kind: PanelKind, session_id: &str) -> AgentSessionBinding {
 }
 
 #[test]
-fn resumable_agent_panel_count_ignores_non_agent_and_unresumable_kinds() {
+fn resume_all_candidate_count_only_counts_fresh_unbound_panels() {
     let runtime_state = RuntimeState {
         workspaces: vec![WorkspaceState {
             panels: vec![
                 panel_state(PanelKind::Pi, PanelResume::Fresh, None),
                 panel_state(PanelKind::Pi, PanelResume::Fresh, Some(binding(PanelKind::Pi, "pi-1"))),
                 panel_state(PanelKind::KiloCode, PanelResume::Fresh, None),
+                panel_state(PanelKind::Codex, PanelResume::Last, None),
                 panel_state(PanelKind::Gemini, PanelResume::Fresh, None),
                 panel_state(PanelKind::Shell, PanelResume::Fresh, None),
             ],
@@ -29,7 +30,7 @@ fn resumable_agent_panel_count_ignores_non_agent_and_unresumable_kinds() {
         ..RuntimeState::default()
     };
 
-    assert_eq!(runtime_state.resumable_agent_panel_count(), 3);
+    assert_eq!(runtime_state.resume_all_candidate_count(), 2);
 }
 
 #[test]

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests/resume_all.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests/resume_all.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+fn panel_state(kind: PanelKind, resume: PanelResume, session_binding: Option<AgentSessionBinding>) -> PanelState {
+    PanelState {
+        kind,
+        resume,
+        session_binding,
+        ..PanelState::default()
+    }
+}
+
+fn binding(kind: PanelKind, session_id: &str) -> AgentSessionBinding {
+    AgentSessionBinding::new(kind, session_id.to_string(), None, None, None)
+}
+
+#[test]
+fn resumable_agent_panel_count_ignores_non_agent_and_unresumable_kinds() {
+    let runtime_state = RuntimeState {
+        workspaces: vec![WorkspaceState {
+            panels: vec![
+                panel_state(PanelKind::Pi, PanelResume::Fresh, None),
+                panel_state(PanelKind::Pi, PanelResume::Fresh, Some(binding(PanelKind::Pi, "pi-1"))),
+                panel_state(PanelKind::KiloCode, PanelResume::Fresh, None),
+                panel_state(PanelKind::Gemini, PanelResume::Fresh, None),
+                panel_state(PanelKind::Shell, PanelResume::Fresh, None),
+            ],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    };
+
+    assert_eq!(runtime_state.resumable_agent_panel_count(), 3);
+}
+
+#[test]
+fn apply_resume_all_flips_only_fresh_unbound_agent_panels_to_last() {
+    let mut runtime_state = RuntimeState {
+        workspaces: vec![WorkspaceState {
+            panels: vec![
+                panel_state(PanelKind::Pi, PanelResume::Fresh, None),
+                panel_state(
+                    PanelKind::Claude,
+                    PanelResume::Fresh,
+                    Some(binding(PanelKind::Claude, "cc-1")),
+                ),
+                panel_state(PanelKind::Codex, PanelResume::Last, None),
+                panel_state(
+                    PanelKind::OpenCode,
+                    PanelResume::Session {
+                        session_id: "oc-1".to_string(),
+                    },
+                    None,
+                ),
+                panel_state(PanelKind::Gemini, PanelResume::Fresh, None),
+            ],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    };
+
+    let changed = runtime_state.apply_resume_all_agent_panels();
+
+    assert_eq!(changed, 1);
+    let panels = &runtime_state.workspaces[0].panels;
+    assert!(matches!(panels[0].resume, PanelResume::Last));
+    assert!(matches!(panels[1].resume, PanelResume::Fresh));
+    assert!(panels[1].session_binding.is_some());
+    assert!(matches!(panels[2].resume, PanelResume::Last));
+    assert!(matches!(
+        panels[3].resume,
+        PanelResume::Session {
+            ref session_id
+        } if session_id == "oc-1"
+    ));
+    assert!(matches!(panels[4].resume, PanelResume::Fresh));
+
+    // The flipped Pi panel must now be picked up by the startup binding
+    // bootstrap, which assigns it a catalog session before launch.
+    assert!(panels[0].session_binding.is_none());
+    assert!(runtime_state.needs_agent_binding_bootstrap_for(PanelKind::Pi));
+}
+
+#[test]
+fn start_agent_panels_fresh_clears_bindings_and_resumes() {
+    let mut runtime_state = RuntimeState {
+        workspaces: vec![WorkspaceState {
+            panels: vec![
+                panel_state(PanelKind::Pi, PanelResume::Fresh, Some(binding(PanelKind::Pi, "pi-1"))),
+                panel_state(PanelKind::Codex, PanelResume::Last, None),
+                panel_state(
+                    PanelKind::OpenCode,
+                    PanelResume::Session {
+                        session_id: "oc-1".to_string(),
+                    },
+                    Some(binding(PanelKind::OpenCode, "oc-1")),
+                ),
+                panel_state(PanelKind::Gemini, PanelResume::Fresh, None),
+            ],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    };
+
+    let changed = runtime_state.start_agent_panels_fresh();
+
+    assert_eq!(changed, 3);
+    let panels = &runtime_state.workspaces[0].panels;
+    for panel in panels.iter().take(3) {
+        assert!(panel.session_binding.is_none());
+        assert!(matches!(panel.resume, PanelResume::Fresh));
+    }
+    assert!(matches!(panels[3].resume, PanelResume::Fresh));
+}

--- a/crates/horizon-core/src/runtime_state/binding_bootstrap.rs
+++ b/crates/horizon-core/src/runtime_state/binding_bootstrap.rs
@@ -24,6 +24,54 @@ impl RuntimeState {
             .any(|panel| panel.kind == kind && panel_needs_agent_binding_bootstrap(panel))
     }
 
+    /// Agent panels that can reattach to a previous provider session at
+    /// startup (bound directly or via a catalog lookup).
+    #[must_use]
+    pub fn resumable_agent_panel_count(&self) -> usize {
+        self.workspaces
+            .iter()
+            .flat_map(|workspace| &workspace.panels)
+            .filter(|panel| panel.kind.is_agent() && panel.kind.supports_agent_resume())
+            .count()
+    }
+
+    /// Switch every fresh, unbound agent panel to `resume: last` so the
+    /// startup binding bootstrap reattaches it to the most recent session
+    /// for its provider. Returns how many panels changed.
+    pub fn apply_resume_all_agent_panels(&mut self) -> usize {
+        let mut changed = 0;
+        for panel in self.workspaces.iter_mut().flat_map(|workspace| &mut workspace.panels) {
+            if panel_is_resume_all_candidate(panel) {
+                panel.resume = PanelResume::Last;
+                changed += 1;
+            }
+        }
+        changed
+    }
+
+    /// Drop every agent panel's binding and resume setting so the board
+    /// relaunches all agent panels fresh; provider conversations are
+    /// untouched.
+    pub fn start_agent_panels_fresh(&mut self) -> usize {
+        let mut changed = 0;
+        for panel in self.workspaces.iter_mut().flat_map(|workspace| &mut workspace.panels) {
+            if !panel.kind.is_agent() {
+                continue;
+            }
+            let binding_cleared = neutralize_session_binding(panel);
+            let resume_cleared = if matches!(panel.resume, PanelResume::Last) {
+                panel.resume = PanelResume::Fresh;
+                true
+            } else {
+                false
+            };
+            if binding_cleared || resume_cleared {
+                changed += 1;
+            }
+        }
+        changed
+    }
+
     /// Repairs exact bindings that reference parent-controlled threads,
     /// enforces provider-scoped binding uniqueness, then assigns catalog
     /// sessions to legacy `resume: last` panels that were persisted without a
@@ -281,6 +329,13 @@ fn panel_needs_agent_binding_bootstrap(panel: &PanelState) -> bool {
     panel.kind.supports_session_binding()
         && (panel.stored_session_id().is_some()
             || (panel.session_binding.is_none() && matches!(panel.resume, PanelResume::Last)))
+}
+
+fn panel_is_resume_all_candidate(panel: &PanelState) -> bool {
+    panel.kind.is_agent()
+        && panel.kind.supports_agent_resume()
+        && panel.session_binding.is_none()
+        && matches!(panel.resume, PanelResume::Fresh)
 }
 
 fn empty_to_none(value: &str) -> Option<&str> {

--- a/crates/horizon-core/src/runtime_state/binding_bootstrap.rs
+++ b/crates/horizon-core/src/runtime_state/binding_bootstrap.rs
@@ -24,14 +24,15 @@ impl RuntimeState {
             .any(|panel| panel.kind == kind && panel_needs_agent_binding_bootstrap(panel))
     }
 
-    /// Agent panels that can reattach to a previous provider session at
-    /// startup (bound directly or via a catalog lookup).
+    /// Agent panels that "Resume all" would still change: fresh, unbound
+    /// panels that can be flipped to `resume: last` and reattached to the
+    /// latest catalog session.
     #[must_use]
-    pub fn resumable_agent_panel_count(&self) -> usize {
+    pub fn resume_all_candidate_count(&self) -> usize {
         self.workspaces
             .iter()
             .flat_map(|workspace| &workspace.panels)
-            .filter(|panel| panel.kind.is_agent() && panel.kind.supports_agent_resume())
+            .filter(|panel| panel_is_resume_all_candidate(panel))
             .count()
     }
 

--- a/crates/horizon-core/src/session_store.rs
+++ b/crates/horizon-core/src/session_store.rs
@@ -12,11 +12,11 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::horizon_home::HorizonHome;
 use crate::runtime_state::RuntimeState;
-use model::{ProfileSnapshot, SessionIndex, SessionMeta, StoredSession};
+use model::{ProfileSnapshot, SessionIndex, StoredSession};
 
 pub use model::{
-    ResolvedSession, SessionLease, SessionOpenDisposition, SessionSummary, StartupChooser, StartupDecision,
-    StartupPromptReason,
+    ResolvedSession, SessionLease, SessionMeta, SessionOpenDisposition, SessionSummary, StartupChooser,
+    StartupDecision, StartupPromptReason,
 };
 
 const SESSION_INDEX_VERSION: u32 = 1;

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -252,6 +252,10 @@ impl HorizonApp {
             self.editor_preview_cache.clear();
         }
 
+        if !self.prepare_resume_all_prompt(ui) {
+            return false;
+        }
+
         if !self.prepare_startup_bootstrap(ui) {
             return false;
         }
@@ -714,21 +718,22 @@ impl HorizonApp {
         // Check at most every 2 seconds.
         let now = Instant::now();
         if self
-            .config_last_check
+            .config_reload
+            .last_check
             .is_some_and(|t| now.duration_since(t) < Duration::from_secs(2))
         {
             return;
         }
-        self.config_last_check = Some(now);
+        self.config_reload.last_check = Some(now);
 
         let current_mtime = std::fs::metadata(&self.config_path)
             .ok()
             .and_then(|m| m.modified().ok());
 
-        if current_mtime == self.config_last_mtime {
+        if current_mtime == self.config_reload.last_mtime {
             return;
         }
-        self.config_last_mtime = current_mtime;
+        self.config_reload.last_mtime = current_mtime;
 
         if let Ok(config) = Config::load(Some(&self.config_path)) {
             tracing::info!("config file changed, reloading presets");

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/mod.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/mod.rs
@@ -124,5 +124,6 @@ fn assert_workspace_center_is_on_canvas(ctx: &Context, app: &HorizonApp, local_i
 }
 
 mod layout;
+mod resume_all_prompt;
 mod session_load;
 mod viewport;

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/resume_all_prompt.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/resume_all_prompt.rs
@@ -6,25 +6,35 @@ use horizon_core::{
 
 use super::*;
 
-fn pi_panel_state() -> PanelState {
-    PanelState {
-        local_id: "pi-panel".to_string(),
-        kind: PanelKind::Pi,
-        ..PanelState::default()
-    }
-}
-
 fn agent_runtime_state() -> RuntimeState {
     RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "agents".to_string(),
             name: "Agents".to_string(),
             position: Some([100.0, 80.0]),
-            panels: vec![pi_panel_state()],
+            panels: vec![PanelState {
+                local_id: "pi-panel".to_string(),
+                kind: PanelKind::Pi,
+                ..PanelState::default()
+            }],
             ..WorkspaceState::default()
         }],
         ..RuntimeState::default()
     }
+}
+
+fn bound_agent_runtime_state() -> RuntimeState {
+    let mut runtime_state = agent_runtime_state();
+    let panel = &mut runtime_state.workspaces[0].panels[0];
+    panel.resume = PanelResume::Last;
+    panel.session_binding = Some(AgentSessionBinding::new(
+        PanelKind::Pi,
+        "pi-1".to_string(),
+        None,
+        None,
+        None,
+    ));
+    runtime_state
 }
 
 fn resolved_session(runtime_state: RuntimeState) -> ResolvedSession {
@@ -71,6 +81,28 @@ fn restore_with_agent_panels_queues_resume_all_prompt() {
 }
 
 #[test]
+fn new_session_disposition_skips_resume_all_prompt() {
+    let decision = StartupDecision::Open {
+        disposition: SessionOpenDisposition::New,
+        session: Box::new(resolved_session(agent_runtime_state())),
+    };
+    let (_temp, _ctx, app) = test_app_with_config_and_startup(&Config::default(), decision);
+
+    assert!(app.pending_resume_all.is_none());
+    assert_eq!(app.board.workspaces.len(), 1);
+    assert!(app.active_session.is_some());
+}
+
+#[test]
+fn bound_agent_panels_skip_resume_all_prompt() {
+    let (_temp, _ctx, app) =
+        test_app_with_config_and_startup(&Config::default(), open_startup(bound_agent_runtime_state()));
+
+    assert!(app.pending_resume_all.is_none());
+    assert!(app.active_session.is_some());
+}
+
+#[test]
 fn restore_without_agent_panels_skips_resume_all_prompt() {
     let runtime_state = RuntimeState {
         workspaces: vec![editor_workspace_state("notes", [100.0, 80.0])],
@@ -93,12 +125,10 @@ fn resume_all_choice_activates_session_and_rearms_bootstrap() {
 
     assert!(app.pending_resume_all.is_none());
     assert!(app.active_session.is_some());
-    assert!(
-        app.board.workspaces.is_empty(),
-        "bootstrap must hold the board until it resolves"
-    );
-    assert!(app.startup_receiver.is_some());
 
+    // The real bootstrap worker may have delivered its own outcome before we
+    // get here; a Ready outcome always rebuilds the board, so driving the
+    // final frame from a known catalog outcome stays deterministic either way.
     let mut ready_state = agent_runtime_state();
     ready_state.apply_resume_all_agent_panels();
     ready_state.workspaces[0].panels[0].session_binding = Some(AgentSessionBinding::new(

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/resume_all_prompt.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/resume_all_prompt.rs
@@ -73,11 +73,13 @@ fn run_key_frame(ctx: &Context, app: &mut HorizonApp, key: Key) {
 
 #[test]
 fn restore_with_agent_panels_queues_resume_all_prompt() {
-    let (_temp, _ctx, app) = test_app_with_config_and_startup(&Config::default(), open_startup(agent_runtime_state()));
+    let (temp, _ctx, app) = test_app_with_config_and_startup(&Config::default(), open_startup(agent_runtime_state()));
 
     assert!(app.pending_resume_all.is_some());
     assert!(app.board.workspaces.is_empty());
     assert!(app.active_session.is_none());
+    let lease = temp.path().join(".horizon/sessions/test-resume-all-session/lease.json");
+    assert!(lease.exists(), "prompt must reserve the session lease while pending");
 }
 
 #[test]

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/resume_all_prompt.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/resume_all_prompt.rs
@@ -1,0 +1,147 @@
+use egui::{Event, Key, Modifiers};
+use horizon_core::{
+    AgentSessionBinding, Config, PanelKind, PanelResume, PanelState, ResolvedSession, RuntimeState, SessionMeta,
+    SessionOpenDisposition, StartupDecision,
+};
+
+use super::*;
+
+fn pi_panel_state() -> PanelState {
+    PanelState {
+        local_id: "pi-panel".to_string(),
+        kind: PanelKind::Pi,
+        ..PanelState::default()
+    }
+}
+
+fn agent_runtime_state() -> RuntimeState {
+    RuntimeState {
+        workspaces: vec![WorkspaceState {
+            local_id: "agents".to_string(),
+            name: "Agents".to_string(),
+            position: Some([100.0, 80.0]),
+            panels: vec![pi_panel_state()],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    }
+}
+
+fn resolved_session(runtime_state: RuntimeState) -> ResolvedSession {
+    let session_id = "test-resume-all-session".to_string();
+    ResolvedSession {
+        meta: SessionMeta {
+            session_id: session_id.clone(),
+            ..SessionMeta::default()
+        },
+        session_id,
+        runtime_state,
+        runtime_state_path: std::path::PathBuf::from("/tmp/resume-all-test/runtime.yaml"),
+        transcript_root: std::path::PathBuf::from("/tmp/resume-all-test/transcripts"),
+    }
+}
+
+fn open_startup(runtime_state: RuntimeState) -> StartupDecision {
+    StartupDecision::Open {
+        disposition: SessionOpenDisposition::Resume,
+        session: Box::new(resolved_session(runtime_state)),
+    }
+}
+
+fn run_key_frame(ctx: &Context, app: &mut HorizonApp, key: Key) {
+    let size = [app.window_config.width, app.window_config.height];
+    let mut input = raw_input(size, None);
+    input.events.push(Event::Key {
+        key,
+        physical_key: Some(key),
+        pressed: true,
+        repeat: false,
+        modifiers: Modifiers::NONE,
+    });
+    run_app_frame_with_input(ctx, app, input);
+}
+
+#[test]
+fn restore_with_agent_panels_queues_resume_all_prompt() {
+    let (_temp, _ctx, app) = test_app_with_config_and_startup(&Config::default(), open_startup(agent_runtime_state()));
+
+    assert!(app.pending_resume_all.is_some());
+    assert!(app.board.workspaces.is_empty());
+    assert!(app.active_session.is_none());
+}
+
+#[test]
+fn restore_without_agent_panels_skips_resume_all_prompt() {
+    let runtime_state = RuntimeState {
+        workspaces: vec![editor_workspace_state("notes", [100.0, 80.0])],
+        ..RuntimeState::default()
+    };
+    let (_temp, _ctx, app) = test_app_with_config_and_startup(&Config::default(), open_startup(runtime_state));
+
+    assert!(app.pending_resume_all.is_none());
+    assert_eq!(app.board.workspaces.len(), 1);
+    assert!(app.active_session.is_some());
+}
+
+#[test]
+fn resume_all_choice_activates_session_and_rearms_bootstrap() {
+    let (_temp, ctx, mut app) =
+        test_app_with_config_and_startup(&Config::default(), open_startup(agent_runtime_state()));
+    app.theme_applied = true;
+
+    run_key_frame(&ctx, &mut app, Key::Enter);
+
+    assert!(app.pending_resume_all.is_none());
+    assert!(app.active_session.is_some());
+    assert!(
+        app.board.workspaces.is_empty(),
+        "bootstrap must hold the board until it resolves"
+    );
+    assert!(app.startup_receiver.is_some());
+
+    let mut ready_state = agent_runtime_state();
+    ready_state.apply_resume_all_agent_panels();
+    ready_state.workspaces[0].panels[0].session_binding = Some(AgentSessionBinding::new(
+        PanelKind::Pi,
+        "pi-session-1".to_string(),
+        None,
+        None,
+        None,
+    ));
+    let (bootstrap_tx, bootstrap_rx) = std::sync::mpsc::channel();
+    app.startup_receiver = Some(bootstrap_rx);
+    bootstrap_tx
+        .send(StartupBootstrapOutcome::Ready(Box::new(StartupBootstrap {
+            runtime_state: ready_state,
+            session_catalog: AgentSessionCatalog::default(),
+            runtime_state_changed: false,
+        })))
+        .expect("bootstrap outcome");
+    run_frame_at_configured_size(&ctx, &mut app);
+
+    let panel = app.board.panels.first().expect("restored panel");
+    assert!(matches!(panel.resume, PanelResume::Last));
+    assert_eq!(
+        panel
+            .session_binding
+            .as_ref()
+            .map(|binding| binding.session_id.as_str()),
+        Some("pi-session-1")
+    );
+}
+
+#[test]
+fn start_fresh_choice_launches_agents_without_sessions() {
+    let (_temp, ctx, mut app) =
+        test_app_with_config_and_startup(&Config::default(), open_startup(agent_runtime_state()));
+    app.theme_applied = true;
+
+    run_key_frame(&ctx, &mut app, Key::Escape);
+
+    assert!(app.pending_resume_all.is_none());
+    assert!(app.active_session.is_some());
+    assert!(app.startup_receiver.is_none());
+    let panel = app.board.panels.first().expect("restored panel");
+    assert!(matches!(panel.resume, PanelResume::Fresh));
+    assert!(panel.session_binding.is_none());
+}

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod shortcuts;
 mod sidebar;
 pub(crate) mod speech;
 mod ssh_upload;
+mod startup_resume_all;
 mod startup_session;
 #[cfg(test)]
 mod test_support;
@@ -114,6 +115,21 @@ struct DetachedCanvasInteractionState {
     middle_pan_active: bool,
     canvas_pan_input_claimed: bool,
     pending_space_pan_key: CanvasPanSpaceKeyState,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ConfigReloadState {
+    last_mtime: Option<std::time::SystemTime>,
+    last_check: Option<Instant>,
+}
+
+impl ConfigReloadState {
+    const fn new(last_mtime: Option<std::time::SystemTime>) -> Self {
+        Self {
+            last_mtime,
+            last_check: None,
+        }
+    }
 }
 
 #[derive(Clone, Default)]
@@ -229,6 +245,7 @@ pub struct HorizonApp {
     session_store: SessionStore,
     active_session: Option<ActiveSession>,
     startup_chooser: Option<StartupChooserState>,
+    pending_resume_all: Option<ResolvedSession>,
     config_path: PathBuf,
     transcript_root: Option<PathBuf>,
     template_config: Config,
@@ -273,8 +290,7 @@ pub struct HorizonApp {
     ssh_upload_flow: Option<ssh_upload::SshUploadFlow>,
     ssh_upload_destinations: HashMap<String, String>,
     git_watchers: HashMap<WorkspaceId, GitWatcher>,
-    config_last_mtime: Option<std::time::SystemTime>,
-    config_last_check: Option<Instant>,
+    config_reload: ConfigReloadState,
     shutdown_progress: Option<ShutdownProgress>,
     exit_cleanup_complete: bool,
 }
@@ -346,7 +362,11 @@ impl HorizonApp {
         let mut app = Self::initial_state(config, bootstrap);
 
         match startup {
-            StartupDecision::Open { session, .. } => app.activate_persistent_session(&session),
+            StartupDecision::Open { session, .. } => {
+                if !app.maybe_queue_resume_all_prompt(&session) {
+                    app.activate_persistent_session(&session);
+                }
+            }
             StartupDecision::Ephemeral { runtime_state } => app.activate_ephemeral_session(&runtime_state),
             StartupDecision::Choose(chooser) => app.startup_chooser = Some(StartupChooserState::new(chooser)),
         }
@@ -401,6 +421,7 @@ impl HorizonApp {
             session_store,
             active_session: None,
             startup_chooser: None,
+            pending_resume_all: None,
             config_path,
             transcript_root: None,
             template_config: config.clone(),
@@ -466,8 +487,7 @@ impl HorizonApp {
             terminal_body_screen_rects: HashMap::new(),
             primary_selection: PrimarySelection::new(),
             terminal_selection_drag: TerminalSelectionDragState::default(),
-            config_last_mtime,
-            config_last_check: None,
+            config_reload: ConfigReloadState::new(config_last_mtime),
             shutdown_progress: None,
             exit_cleanup_complete: false,
         }

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -39,8 +39,8 @@ use std::time::Instant;
 use egui::{Color32, Context, Pos2, Rect, Vec2, ViewportId};
 use horizon_core::{
     AgentSessionCatalog, AppShortcuts, AppearanceTheme, Board, CanvasViewState, Config, GitWatcher, ManagedInstall,
-    PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease, SessionStore,
-    ShortcutBinding, ShutdownProgress, StartupChooser, StartupDecision, WindowConfig, WorkspaceId,
+    PanelId, PresetConfig, RemoteHostCatalog, ResolvedSession, RuntimeState, SessionLease, SessionOpenDisposition,
+    SessionStore, ShortcutBinding, ShutdownProgress, StartupChooser, StartupDecision, WindowConfig, WorkspaceId,
 };
 
 use self::canvas::CanvasGridCache;
@@ -362,8 +362,12 @@ impl HorizonApp {
         let mut app = Self::initial_state(config, bootstrap);
 
         match startup {
-            StartupDecision::Open { session, .. } => {
-                if !app.maybe_queue_resume_all_prompt(&session) {
+            StartupDecision::Open { disposition, session } => {
+                let restoring = matches!(
+                    disposition,
+                    SessionOpenDisposition::Resume | SessionOpenDisposition::Recover
+                );
+                if !restoring || !app.maybe_queue_resume_all_prompt(&session) {
                     app.activate_persistent_session(&session);
                 }
             }

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -245,7 +245,7 @@ pub struct HorizonApp {
     session_store: SessionStore,
     active_session: Option<ActiveSession>,
     startup_chooser: Option<StartupChooserState>,
-    pending_resume_all: Option<ResolvedSession>,
+    pending_resume_all: Option<startup_resume_all::PendingResumeAll>,
     config_path: PathBuf,
     transcript_root: Option<PathBuf>,
     template_config: Config,

--- a/crates/horizon-ui/src/app/startup_resume_all.rs
+++ b/crates/horizon-ui/src/app/startup_resume_all.rs
@@ -1,0 +1,128 @@
+use egui::{Align2, Color32, Margin, RichText, Stroke, Vec2};
+
+use crate::theme;
+
+use super::util::{chrome_button, primary_button};
+use super::{HorizonApp, ResolvedSession};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResumeAllAction {
+    None,
+    ResumeAll,
+    StartFresh,
+}
+
+impl HorizonApp {
+    /// Queue the resume-all prompt for a restored session that carries agent
+    /// panels; returns true when activation was deferred to the prompt.
+    pub(super) fn maybe_queue_resume_all_prompt(&mut self, session: &ResolvedSession) -> bool {
+        if session.runtime_state.resumable_agent_panel_count() == 0 {
+            return false;
+        }
+        self.pending_resume_all = Some(session.clone());
+        true
+    }
+
+    /// Gate the frame while the resume-all prompt is on screen; returns true
+    /// once the user has chosen (and the session is activating) or no prompt
+    /// is pending.
+    pub(super) fn prepare_resume_all_prompt(&mut self, ui: &mut egui::Ui) -> bool {
+        let Some(session) = self.pending_resume_all.take() else {
+            return true;
+        };
+
+        let action = render_resume_all_prompt(ui, session.runtime_state.resumable_agent_panel_count());
+        if matches!(action, ResumeAllAction::None) {
+            self.pending_resume_all = Some(session);
+            return false;
+        }
+
+        let mut session = session;
+        if action == ResumeAllAction::StartFresh {
+            session.runtime_state.start_agent_panels_fresh();
+        } else {
+            session.runtime_state.apply_resume_all_agent_panels();
+        }
+        let ctx = ui.ctx().clone();
+        self.activate_persistent_session(&session);
+        self.restore_window_viewport(&ctx);
+        true
+    }
+}
+
+fn render_resume_all_prompt(ui: &mut egui::Ui, panel_count: usize) -> ResumeAllAction {
+    let mut action = ResumeAllAction::None;
+    render_prompt_card(ui, panel_count, &mut action);
+    if matches!(action, ResumeAllAction::None) {
+        action = ui.input(|input| {
+            if input.key_pressed(egui::Key::Enter) {
+                ResumeAllAction::ResumeAll
+            } else if input.key_pressed(egui::Key::Escape) {
+                ResumeAllAction::StartFresh
+            } else {
+                ResumeAllAction::None
+            }
+        });
+    }
+    action
+}
+
+fn render_prompt_card(ui: &mut egui::Ui, panel_count: usize, action: &mut ResumeAllAction) {
+    let prompt_text = match panel_count {
+        1 => "This session has 1 agent panel that can reattach to its previous session.".to_string(),
+        _ => format!("This session has {panel_count} agent panels that can reattach to their previous sessions."),
+    };
+
+    egui::Window::new("resume_all_prompt")
+        .title_bar(false)
+        .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+        .collapsible(false)
+        .resizable(false)
+        .fixed_size(Vec2::new(640.0, 0.0))
+        .order(egui::Order::Debug)
+        .frame(
+            egui::Frame::NONE
+                .fill(theme::PANEL_BG())
+                .stroke(Stroke::new(1.5_f32, theme::alpha(theme::ACCENT(), 80)))
+                .corner_radius(egui::CornerRadius::same(20))
+                .shadow(egui::Shadow {
+                    offset: [0, 12],
+                    blur: 32,
+                    spread: 2,
+                    color: Color32::from_black_alpha(132),
+                }),
+        )
+        .show(ui.ctx(), |ui| {
+            egui::Frame::NONE.inner_margin(Margin::same(22)).show(ui, |ui| {
+                ui.label(
+                    RichText::new("Resume agent sessions?")
+                        .size(18.0)
+                        .strong()
+                        .color(theme::FG()),
+                );
+                ui.add_space(10.0);
+                ui.label(RichText::new(prompt_text).size(12.5).color(theme::FG_SOFT()));
+                ui.add_space(4.0);
+                ui.label(
+                    RichText::new("Resume all of them, or start every agent panel fresh?")
+                        .size(12.5)
+                        .color(theme::FG_SOFT()),
+                );
+                ui.add_space(20.0);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.add(chrome_button("Start fresh")).clicked() {
+                        *action = ResumeAllAction::StartFresh;
+                    }
+                    if ui.add(primary_button("Resume all")).clicked() {
+                        *action = ResumeAllAction::ResumeAll;
+                    }
+                });
+                ui.add_space(12.0);
+                ui.label(
+                    RichText::new("Enter — resume all · Esc — start fresh")
+                        .size(11.0)
+                        .color(theme::FG_DIM()),
+                );
+            });
+        });
+}

--- a/crates/horizon-ui/src/app/startup_resume_all.rs
+++ b/crates/horizon-ui/src/app/startup_resume_all.rs
@@ -16,7 +16,7 @@ impl HorizonApp {
     /// Queue the resume-all prompt for a restored session that carries agent
     /// panels; returns true when activation was deferred to the prompt.
     pub(super) fn maybe_queue_resume_all_prompt(&mut self, session: &ResolvedSession) -> bool {
-        if session.runtime_state.resumable_agent_panel_count() == 0 {
+        if session.runtime_state.resume_all_candidate_count() == 0 {
             return false;
         }
         self.pending_resume_all = Some(session.clone());
@@ -31,7 +31,7 @@ impl HorizonApp {
             return true;
         };
 
-        let action = render_resume_all_prompt(ui, session.runtime_state.resumable_agent_panel_count());
+        let action = render_resume_all_prompt(ui, session.runtime_state.resume_all_candidate_count());
         if matches!(action, ResumeAllAction::None) {
             self.pending_resume_all = Some(session);
             return false;

--- a/crates/horizon-ui/src/app/startup_resume_all.rs
+++ b/crates/horizon-ui/src/app/startup_resume_all.rs
@@ -1,9 +1,11 @@
+use std::time::{Duration, Instant};
+
 use egui::{Align2, Color32, Margin, RichText, Stroke, Vec2};
 
 use crate::theme;
 
 use super::util::{chrome_button, primary_button};
-use super::{HorizonApp, ResolvedSession};
+use super::{HorizonApp, ResolvedSession, SessionLease};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ResumeAllAction {
@@ -12,14 +14,37 @@ enum ResumeAllAction {
     StartFresh,
 }
 
+/// A restored session waiting on the resume-all prompt. Its session lease
+/// is held here so a second Horizon process sees the session as live while
+/// the prompt is on screen; activation takes the lease over via
+/// `activate_persistent_session`.
+#[derive(Debug)]
+pub(super) struct PendingResumeAll {
+    session: ResolvedSession,
+    lease: Option<SessionLease>,
+    last_lease_refresh: Option<Instant>,
+}
+
 impl HorizonApp {
-    /// Queue the resume-all prompt for a restored session that carries agent
-    /// panels; returns true when activation was deferred to the prompt.
+    /// Queue the resume-all prompt for a restored session that carries
+    /// resumable agent panels; returns true when activation was deferred to
+    /// the prompt (while reserving the session lease).
     pub(super) fn maybe_queue_resume_all_prompt(&mut self, session: &ResolvedSession) -> bool {
         if session.runtime_state.resume_all_candidate_count() == 0 {
             return false;
         }
-        self.pending_resume_all = Some(session.clone());
+        let lease = match self.session_store.acquire_lease(&session.session_id) {
+            Ok(lease) => Some(lease),
+            Err(error) => {
+                tracing::warn!("failed to reserve session lease for resume prompt: {error}");
+                None
+            }
+        };
+        self.pending_resume_all = Some(PendingResumeAll {
+            session: session.clone(),
+            lease,
+            last_lease_refresh: None,
+        });
         true
     }
 
@@ -27,17 +52,18 @@ impl HorizonApp {
     /// once the user has chosen (and the session is activating) or no prompt
     /// is pending.
     pub(super) fn prepare_resume_all_prompt(&mut self, ui: &mut egui::Ui) -> bool {
-        let Some(session) = self.pending_resume_all.take() else {
+        let Some(mut pending) = self.pending_resume_all.take() else {
             return true;
         };
 
-        let action = render_resume_all_prompt(ui, session.runtime_state.resume_all_candidate_count());
+        let action = render_resume_all_prompt(ui, pending.session.runtime_state.resume_all_candidate_count());
         if matches!(action, ResumeAllAction::None) {
-            self.pending_resume_all = Some(session);
+            self.refresh_pending_resume_all_lease(&mut pending);
+            self.pending_resume_all = Some(pending);
             return false;
         }
 
-        let mut session = session;
+        let mut session = pending.session;
         if action == ResumeAllAction::StartFresh {
             session.runtime_state.start_agent_panels_fresh();
         } else {
@@ -47,6 +73,25 @@ impl HorizonApp {
         self.activate_persistent_session(&session);
         self.restore_window_viewport(&ctx);
         true
+    }
+
+    /// Keep the reserved lease live while the prompt waits for a choice.
+    fn refresh_pending_resume_all_lease(&mut self, pending: &mut PendingResumeAll) {
+        const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+        let Some(lease) = pending.lease.as_mut() else {
+            return;
+        };
+        if pending
+            .last_lease_refresh
+            .is_some_and(|last_refresh| last_refresh.elapsed() < REFRESH_INTERVAL)
+        {
+            return;
+        }
+        match self.session_store.refresh_lease(lease) {
+            Ok(()) => pending.last_lease_refresh = Some(Instant::now()),
+            Err(error) => tracing::warn!("failed to refresh resume-prompt session lease: {error}"),
+        }
     }
 }
 

--- a/crates/horizon-ui/src/app/startup_session.rs
+++ b/crates/horizon-ui/src/app/startup_session.rs
@@ -28,7 +28,10 @@ impl HorizonApp {
             StartupChooserAction::None => {}
             StartupChooserAction::OpenNewSession => {
                 match self.session_store.create_new_session(&self.template_config) {
-                    Ok(session) => self.activate_startup_session(ctx, &session),
+                    Ok(session) => {
+                        self.activate_persistent_session(&session);
+                        self.restore_window_viewport(ctx);
+                    }
                     Err(error) => self.set_startup_error(format!("Failed to create session: {error}")),
                 }
             }

--- a/crates/horizon-ui/src/app/startup_session.rs
+++ b/crates/horizon-ui/src/app/startup_session.rs
@@ -54,6 +54,9 @@ impl HorizonApp {
     }
 
     fn activate_startup_session(&mut self, ctx: &Context, session: &horizon_core::ResolvedSession) {
+        if self.maybe_queue_resume_all_prompt(session) {
+            return;
+        }
         self.activate_persistent_session(session);
         self.restore_window_viewport(ctx);
     }


### PR DESCRIPTION
## Purpose

After a restart, a saved session with 5–10 agent panels across ~30 panels means re-attaching each agent session individually from per-panel menus. This adds a one-time startup prompt so all resumable agent sessions can be reattached in one action:

**Restore a session that contains agent panels (Pi, Claude Code, Codex, OpenCode, KiloCode, Grok) that can reattach to a previous provider session →**

```
Resume agent sessions?

This session has 6 agent panels that can reattach to their previous sessions.
Resume all of them, or start every agent panel fresh?

                [ Resume all ]  [ Start fresh ]
        Enter — resume all · Esc — start fresh
```

- **Resume all** (Enter / primary button): flips every fresh, unbound agent panel to `resume: last`; the existing startup binding bootstrap then reattaches each to its latest catalog session before launch (bound panels keep their explicit binding; panels that already use `Session`/`Last` are untouched).
- **Start fresh** (Esc / secondary button): clears agent panel bindings and resume settings so every agent panel launches fresh. Provider conversations are never modified — a panel can always be reattached later from its session menu.
- Sessions with **no** resumable agent panels skip the prompt entirely (no behavior change). The prompt only fires on real restores (`Resume`/`Recover` dispositions) — first-run boards built from config (`New`) and the chooser's explicit "Open New Session" action activate directly.
- Counted panels = fresh, unbound agent panels (what "Resume all" would actually change). Once the choice is persisted (panels become resume-bound), subsequent restarts skip the prompt and relaunch the same sessions; "Start fresh" keeps the prompt available on the next restore.

## Behavior impact

- New modal on restore only (not on runtime session switching or first-run/empty boards).
- The choice is persisted via the existing runtime-state autosave, so a restart after "Resume all" relaunches the same sessions without re-asking (panels already resume-bound).
- `panel.launch_args` semantics unchanged (resume flags are applied at launch resolution only).

## Implementation notes

- `AgentDefinition::supports_resume()` / `PanelKind::supports_agent_resume()` — kinds whose `resume_mode != None` (Gemini excluded).
- `RuntimeState::{resumable_agent_panel_count, apply_resume_all_agent_panels, start_agent_panels_fresh}` in `runtime_state/binding_bootstrap.rs` — pure state ops, no UI knowledge.
- UI: `app/startup_resume_all.rs` queues the prompt (`pending_resume_all`) and gates the frame in `prepare_frame` ahead of the bootstrap gate; the card reuses the session-manager window styling and `primary_button`/`chrome_button`.
- `ConfigReloadState` sub-struct groups the two config-reload timestamps (keeps `initial_state` within the clippy line budget; the pre-existing field pair is behavior-identical).

## Test evidence

- 10 new unit tests, all green: 3 core (`resume_all_candidate_count` candidate filtering, `apply_resume_all` candidate rules + bootstrap re-arm, `start_agent_panels_fresh` clearing) and 1 launch-resolution regression (bound Pi restore → `pi --session <id>`), 6 UI startup-flow tests (prompt queued on restore / skipped for `New` disposition and fully-bound sessions, both choices end-to-end through board construction and a deterministic bootstrap re-arm).
- Full validation matrix green on head `658167d`: fmt, maintainability guardrail, `cargo test --workspace` (840 passed), `--features speech` (879 passed), blocking + strict + pedantic clippy (0 warnings).
- Live UI smoke (isolated HOME under Xvfb + openbox): prompt renders correctly with count text and both actions; **Resume all** (click and Enter) relaunches the Pi panel with `resume=Last` and, once a catalog session exists, `should_resume=true cmd=/bin/bash -ic pi --session smoke-pi-session-001`; **Start fresh** (Esc) relaunches with `resume=Fresh` and no binding; a terminal-only session restores straight to the board with no prompt.
- Lease reservation: while the prompt is pending the chosen session's lease is acquired and refreshed on the 2s active-session cadence, so a second Horizon process sees the session as live and gets the existing LiveConflict chooser instead of both processes restoring/autosaving the same session (review finding, fixed on `35b8d5e`).
- Review: all 4 Copilot findings triaged in-scope and fixed on the current head (prompt scope: `New` disposition, chooser "Open New Session", candidate-only count, lease reservation); one test race on macOS CI fixed deterministically (the `session_manager` viewport-timing failure on the first head did not reproduce on later heads — that test is untouched by this diff).

## Scope note

14 source/test files, 536 changed lines — slightly over the 500-line soft guideline. The overflow is the test tail (393 lines of the new files are 288 lines of tests) and the 2 one-line module registrations; it is a single subsystem (startup restore flow), so no split is proposed unless requested.


