### PR TITLE
Fix X11 crash after root window destruction

### DIFF
--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -925,6 +925,12 @@ impl HorizonApp {
     }
 }
 
+impl Drop for HorizonApp {
+    fn drop(&mut self) {
+        self.run_exit_cleanup();
+    }
+}
+
 #[cfg(test)]
 #[path = "lifecycle/startup_organization_tests.rs"]
 mod startup_organization_tests;

--- a/crates/horizon-ui/src/native_app.rs
+++ b/crates/horizon-ui/src/native_app.rs
@@ -24,6 +24,7 @@ struct KeyboardAwareApp<'app> {
     inner: EframeWinitApplication<'app>,
     observed_keyboard_inputs: ObservedKeyboardInputs,
     modifiers: egui::Modifiers,
+    native_window_liveness: NativeWindowLiveness,
 }
 
 impl<'app> KeyboardAwareApp<'app> {
@@ -32,16 +33,70 @@ impl<'app> KeyboardAwareApp<'app> {
             inner,
             observed_keyboard_inputs,
             modifiers: egui::Modifiers::default(),
+            native_window_liveness: NativeWindowLiveness::default(),
         }
+    }
+}
+
+#[derive(Default)]
+struct NativeWindowLiveness {
+    root_window_id: Option<winit::window::WindowId>,
+    root_destroyed: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NativeWindowEventAction {
+    Forward,
+    RootDestroyed,
+    Ignore,
+}
+
+impl NativeWindowLiveness {
+    /// A destroyed native handle must never reach eframe again. Its queued
+    /// redraw path queries window geometry, which panics on X11 `BadWindow`.
+    fn classify(&mut self, window_id: winit::window::WindowId, event: &WindowEvent) -> NativeWindowEventAction {
+        if self.root_destroyed {
+            return NativeWindowEventAction::Ignore;
+        }
+
+        // `resumed` creates the root window before any viewport callback can
+        // create children, so the first dispatched window event identifies it.
+        let root_window_id = *self.root_window_id.get_or_insert(window_id);
+        if window_id == root_window_id && matches!(event, WindowEvent::Destroyed) {
+            self.root_destroyed = true;
+            NativeWindowEventAction::RootDestroyed
+        } else {
+            NativeWindowEventAction::Forward
+        }
+    }
+
+    fn is_root_destroyed(&self) -> bool {
+        self.root_destroyed
     }
 }
 
 impl ApplicationHandler<UserEvent> for KeyboardAwareApp<'_> {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.resumed(event_loop);
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, window_id: winit::window::WindowId, event: WindowEvent) {
+        match self.native_window_liveness.classify(window_id, &event) {
+            NativeWindowEventAction::RootDestroyed => {
+                tracing::warn!(
+                    ?window_id,
+                    "root native window was destroyed outside the normal close flow; exiting cleanly"
+                );
+                event_loop.exit();
+                return;
+            }
+            NativeWindowEventAction::Ignore => return,
+            NativeWindowEventAction::Forward => {}
+        }
+
         match &event {
             WindowEvent::ModifiersChanged(state) => {
                 let state = state.state();
@@ -70,10 +125,16 @@ impl ApplicationHandler<UserEvent> for KeyboardAwareApp<'_> {
     }
 
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: winit::event::StartCause) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.new_events(event_loop, cause);
     }
 
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: UserEvent) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.user_event(event_loop, event);
     }
 
@@ -83,22 +144,68 @@ impl ApplicationHandler<UserEvent> for KeyboardAwareApp<'_> {
         device_id: winit::event::DeviceId,
         event: winit::event::DeviceEvent,
     ) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.device_event(event_loop, device_id, event);
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.about_to_wait(event_loop);
     }
 
     fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.suspended(event_loop);
     }
 
     fn exiting(&mut self, event_loop: &ActiveEventLoop) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.exiting(event_loop);
     }
 
     fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
+        if self.native_window_liveness.is_root_destroyed() {
+            return;
+        }
         self.inner.memory_warning(event_loop);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use winit::event::WindowEvent;
+
+    use super::{NativeWindowEventAction, NativeWindowLiveness};
+
+    #[test]
+    fn native_window_destruction_stops_later_event_dispatch() {
+        let mut liveness = NativeWindowLiveness::default();
+        let root_window_id = winit::window::WindowId::from(1);
+        let child_window_id = winit::window::WindowId::from(2);
+
+        assert_eq!(
+            liveness.classify(root_window_id, &WindowEvent::CloseRequested),
+            NativeWindowEventAction::Forward
+        );
+        assert_eq!(
+            liveness.classify(child_window_id, &WindowEvent::Destroyed),
+            NativeWindowEventAction::Forward
+        );
+        assert_eq!(
+            liveness.classify(root_window_id, &WindowEvent::Destroyed),
+            NativeWindowEventAction::RootDestroyed
+        );
+        assert_eq!(
+            liveness.classify(root_window_id, &WindowEvent::RedrawRequested),
+            NativeWindowEventAction::Ignore
+        );
     }
 }


### PR DESCRIPTION
## Purpose

Prevent Horizon from panicking when X11 destroys the root native window while an asynchronous repaint is queued.

Closes #294.

## Behavior impact

- Detect root-window `Destroyed` events before forwarding them to eframe.
- Stop dispatching subsequent callbacks that could query the invalid native handle and exit the event loop cleanly.
- Run Horizon's idempotent exit cleanup from `Drop` so runtime state, terminal sessions, watchers, and the active session lease are handled on this exit path.
- Continue forwarding detached child-window destruction so normal detach, close, and reattach behavior is unchanged.

The speech completion seen immediately before the reported panic was a timing trigger for the queued repaint, not a decoder failure.

## Reproduction and smoke evidence

- Reproduced the original failure from the unchanged base under an isolated X11/Xvfb session: destroying the root window exited with code 101 and panicked in winit's `TranslateCoordinates` path with `BadWindow`.
- Repeated the same reproduction with this head: Horizon emitted one clean-exit warning, returned code 0, and produced no panic or backtrace.
- Verified normal `Alt+F4` shutdown.
- Verified resize and repaint behavior visually.
- Verified detaching a workspace, normally closing the detached child window, and observing the workspace reattach while the root window remained alive.

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
