### PR TITLE
fix: align Horizon branding with its canvas workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/hero-banner.svg" />
     <source media="(prefers-color-scheme: light)" srcset="assets/hero-banner.svg" />
-    <img src="assets/hero-banner.svg" alt="Horizon — Your Terminals, One Canvas" width="100%" />
+    <img src="assets/hero-banner.svg" alt="Horizon — Your Work, One Canvas" width="100%" />
   </picture>
 </p>
 

--- a/assets/hero-banner.svg
+++ b/assets/hero-banner.svg
@@ -158,5 +158,5 @@
   <text x="600" y="232" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="52" font-weight="700" fill="#E0E6F1" letter-spacing="6">HORIZON</text>
 
   <!-- Subtitle -->
-  <text x="600" y="264" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="16" fill="#6C788E" letter-spacing="3">YOUR TERMINALS, ONE CANVAS</text>
+  <text x="600" y="264" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="16" fill="#6C788E" letter-spacing="3">YOUR WORK, ONE CANVAS</text>
 </svg>

--- a/crates/horizon-ui/src/app/root_chrome.rs
+++ b/crates/horizon-ui/src/app/root_chrome.rs
@@ -233,6 +233,20 @@ mod tests {
     }
 
     #[test]
+    fn toolbar_prioritizes_available_update_over_tagline() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1024.0, 768.0));
+        let layout = root_toolbar_layout(viewport, true);
+
+        assert!(!layout.show_tagline);
+        assert!(
+            layout
+                .visible_items
+                .contains(&ToolbarItem::Action(ToolbarAction::Update))
+        );
+        assert!(layout.search_rect.width() >= 180.0);
+    }
+
+    #[test]
     fn toolbar_hides_tagline_before_collapsing_actions() {
         let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(960.0, 768.0));
         let layout = root_toolbar_layout(viewport, false);

--- a/crates/horizon-ui/src/app/root_chrome.rs
+++ b/crates/horizon-ui/src/app/root_chrome.rs
@@ -13,7 +13,7 @@ const ROOT_TOOLBAR_SEARCH_MAX_WIDTH: f32 = 420.0;
 pub(super) const ROOT_TOOLBAR_FPS_WIDTH: f32 = 72.0;
 const ROOT_TOOLBAR_MORE_WIDTH: f32 = 72.0;
 const ROOT_TOOLBAR_NAME_WIDTH: f32 = 72.0;
-const ROOT_TOOLBAR_TAGLINE_WIDTH: f32 = 324.0;
+const ROOT_TOOLBAR_TAGLINE_WIDTH: f32 = 152.0;
 const SIDEBAR_WIDTH_RATIO: f32 = 0.18;
 
 pub(super) const SIDEBAR_MIN_WIDTH: f32 = 168.0;
@@ -218,17 +218,27 @@ mod tests {
     }
 
     #[test]
-    fn toolbar_hides_tagline_before_collapsing_actions() {
+    fn toolbar_keeps_short_tagline_when_search_still_fits() {
         let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1024.0, 768.0));
         let layout = root_toolbar_layout(viewport, false);
 
-        assert!(!layout.show_tagline);
+        assert!(layout.show_tagline);
         assert!(layout.visible_items.contains(&ToolbarItem::FpsMeter));
         assert!(
             layout
                 .visible_items
                 .contains(&ToolbarItem::Action(ToolbarAction::Sessions))
         );
+        assert!(layout.search_rect.width() >= 180.0);
+    }
+
+    #[test]
+    fn toolbar_hides_tagline_before_collapsing_actions() {
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(960.0, 768.0));
+        let layout = root_toolbar_layout(viewport, false);
+
+        assert!(!layout.show_tagline);
+        assert!(layout.visible_items.contains(&ToolbarItem::FpsMeter));
         assert!(layout.search_rect.width() >= 180.0);
     }
 

--- a/crates/horizon-ui/src/branding.rs
+++ b/crates/horizon-ui/src/branding.rs
@@ -2,7 +2,7 @@ use egui::IconData;
 
 pub const APP_NAME: &str = "Horizon";
 pub const APP_ID: &str = "horizon";
-pub const APP_TAGLINE: &str = "spatial terminal observatory for multi-agent development";
+pub const APP_TAGLINE: &str = "your terminals, one canvas";
 
 const ICON_SIZE: u32 = 256;
 const BG: [u8; 4] = [10, 22, 34, 255];

--- a/crates/horizon-ui/src/branding.rs
+++ b/crates/horizon-ui/src/branding.rs
@@ -2,7 +2,7 @@ use egui::IconData;
 
 pub const APP_NAME: &str = "Horizon";
 pub const APP_ID: &str = "horizon";
-pub const APP_TAGLINE: &str = "your terminals, one canvas";
+pub const APP_TAGLINE: &str = "your work, one canvas";
 
 const ICON_SIZE: u32 = 256;
 const BG: [u8; 4] = [10, 22, 34, 255];

--- a/packaging/linux/horizon.desktop
+++ b/packaging/linux/horizon.desktop
@@ -2,8 +2,8 @@
 Type=Application
 Version=1.0
 Name=Horizon
-GenericName=Spatial Terminal Workspace
-Comment=Your terminals, one canvas
+GenericName=Spatial Workspace
+Comment=Your work, one canvas
 Exec=horizon
 Icon=horizon
 Terminal=false

--- a/packaging/linux/horizon.desktop
+++ b/packaging/linux/horizon.desktop
@@ -2,8 +2,8 @@
 Type=Application
 Version=1.0
 Name=Horizon
-GenericName=Agent Workspace Observatory
-Comment=Spatial terminal observatory for multi-agent development
+GenericName=Spatial Terminal Workspace
+Comment=Your terminals, one canvas
 Exec=horizon
 Icon=horizon
 Terminal=false

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: horizon-ui
 title: Horizon
-summary: GPU-accelerated terminal board on an infinite canvas
+summary: GPU-accelerated workspace on an infinite canvas
 description: |
   Horizon is a GPU-accelerated terminal board that puts your terminals on
   an infinite canvas. Organize shell, command, and SSH sessions as freely

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: horizon-ui
 title: Horizon
-summary: GPU-accelerated terminal board for multi-agent development
+summary: GPU-accelerated terminal board on an infinite canvas
 description: |
   Horizon is a GPU-accelerated terminal board that puts your terminals on
   an infinite canvas. Organize shell, command, and SSH sessions as freely


### PR DESCRIPTION
## Purpose

Replace the observatory and multi-agent wording with the panel-agnostic brand line **Your work, one canvas**. The canvas is Horizon's durable product idea, while panels can grow beyond terminals into browsers, editors, dashboards, and future tools.

## Behavior impact

- Updates the native toolbar tagline while preserving its existing responsive visibility rules.
- Updates the README hero artwork and accessible alternative text.
- Makes the Linux desktop generic name and comment panel-agnostic.
- Makes the Snap summary panel-agnostic while keeping its detailed description accurate for today's terminal capabilities.

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- `desktop-file-validate packaging/linux/horizon.desktop`
- Rendered and visually inspected the 1200 x 400 README hero.
- Native exact-head smoke at 1280, 1024, and 960 px; verified compact hiding, workspace creation, Fit, and a blank ephemeral relaunch.

Validated on `7f71abe04839a6387c7de2eaf29ff6a8d06646ba`.
