### PR TITLE
feat(browser-core): add browser driver session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1535,7 @@ name = "horizon-core"
 version = "0.2.7"
 dependencies = [
  "alacritty_terminal",
+ "atomicwrites",
  "base64 0.23.1",
  "comrak",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tungstenite = "0.30.0"
 # JPEG decoder for CDP screencast frames (change-driven video stream).
 zune-jpeg = "0.5.15"
 base64 = "0.23.1"
+atomicwrites = "0.4.4"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 profiling = "1.0.18"
 serde = { version = "1.0.229", features = ["derive"] }

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -21,6 +21,7 @@ profiling.workspace = true
 tungstenite.workspace = true
 zune-jpeg.workspace = true
 base64.workspace = true
+atomicwrites.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true

--- a/crates/horizon-core/src/browser/frames.rs
+++ b/crates/horizon-core/src/browser/frames.rs
@@ -137,14 +137,14 @@ impl FrameSlot {
     /// Claim the single outstanding UI wake-up for this slot. Further
     /// frames remain coalesced in `latest` until the UI releases the claim.
     #[must_use]
-    pub fn claim_notification(&self) -> bool {
+    pub(crate) fn claim_notification(&self) -> bool {
         self.notification_pending
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
     }
 
     /// Let a later frame enqueue the next UI wake-up.
-    pub fn release_notification(&self) {
+    pub(crate) fn release_notification(&self) {
         self.notification_pending.store(false, Ordering::Release);
     }
 }

--- a/crates/horizon-core/src/browser/input.rs
+++ b/crates/horizon-core/src/browser/input.rs
@@ -1,0 +1,979 @@
+//! Core input model for browser panels.
+//!
+//! The UI layer translates egui events into these platform-neutral values;
+//! the driver thread translates them into CDP `Input.*` calls. CDP uses
+//! Windows virtual-key codes and modifier bitmasks on every platform, so
+//! the mapping table lives here in core.
+
+use serde_json::{Value, json};
+
+/// CDP modifier bitmask (matches `protocol::Input.Modifier`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)] // the four CDP modifier bits
+pub struct BrowserModifiers {
+    pub alt: bool,
+    pub ctrl: bool,
+    /// Command (macOS) / Windows key.
+    pub meta: bool,
+    pub shift: bool,
+}
+
+impl BrowserModifiers {
+    #[must_use]
+    pub const fn cdp_bits(self) -> u32 {
+        let mut bits = 0u32;
+        if self.alt {
+            bits |= 1;
+        }
+        if self.ctrl {
+            bits |= 2;
+        }
+        if self.meta {
+            bits |= 4;
+        }
+        if self.shift {
+            bits |= 8;
+        }
+        bits
+    }
+
+    #[must_use]
+    pub const fn none() -> Self {
+        Self {
+            alt: false,
+            ctrl: false,
+            meta: false,
+            shift: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrowserButton {
+    Left,
+    Middle,
+    Right,
+}
+
+impl BrowserButton {
+    #[must_use]
+    pub fn cdp_name(self) -> &'static str {
+        match self {
+            Self::Left => "left",
+            Self::Middle => "middle",
+            Self::Right => "right",
+        }
+    }
+}
+
+/// Keyboard keys with a distinct CDP representation. Printable characters
+/// and unmodified Enter ride on a `keyDown` event carrying `text` (Chrome then
+/// synthesizes the full keydown/keypress/input DOM sequence); other
+/// non-printable keys use `rawKeyDown` with a virtual-key code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BrowserKey {
+    ArrowUp,
+    ArrowDown,
+    ArrowLeft,
+    ArrowRight,
+    Enter,
+    Tab,
+    Escape,
+    Space,
+    Backspace,
+    Delete,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Insert,
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+    F13,
+    F14,
+    F15,
+    /// Printable character (e.g. `a`, `7`, `=`).
+    Char(char),
+}
+
+/// Chromium editing command attached to a synthetic key-down.
+///
+/// Clipboard pseudo-events need the explicit command because modifier bits
+/// alone do not invoke the platform editing action in every headless Chrome
+/// build (notably on macOS).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrowserEditCommand {
+    Copy,
+    Cut,
+    SelectAll,
+}
+
+impl BrowserEditCommand {
+    const fn cdp_name(self) -> &'static str {
+        match self {
+            Self::Copy => "Copy",
+            Self::Cut => "Cut",
+            Self::SelectAll => "SelectAll",
+        }
+    }
+}
+
+impl BrowserKey {
+    /// Windows virtual-key code, as CDP expects on all platforms.
+    #[must_use]
+    pub fn vk_code(self) -> u32 {
+        match self {
+            Self::ArrowUp => 0x26,
+            Self::ArrowDown => 0x28,
+            Self::ArrowRight => 0x27,
+            Self::ArrowLeft => 0x25,
+            Self::Enter => 0x0D,
+            Self::Tab => 0x09,
+            Self::Escape => 0x1B,
+            Self::Space => 0x20,
+            Self::Backspace => 0x08,
+            Self::Delete => 0x2E,
+            Self::Home => 0x24,
+            Self::End => 0x23,
+            Self::PageUp => 0x21,
+            Self::PageDown => 0x22,
+            Self::Insert => 0x2D,
+            Self::F1 => 0x70,
+            Self::F2 => 0x71,
+            Self::F3 => 0x72,
+            Self::F4 => 0x73,
+            Self::F5 => 0x74,
+            Self::F6 => 0x75,
+            Self::F7 => 0x76,
+            Self::F8 => 0x77,
+            Self::F9 => 0x78,
+            Self::F10 => 0x79,
+            Self::F11 => 0x7A,
+            Self::F12 => 0x7B,
+            Self::F13 => 0x7C,
+            Self::F14 => 0x7D,
+            Self::F15 => 0x7E,
+            Self::Char(c) => vk_for_char(c),
+        }
+    }
+
+    #[must_use]
+    pub fn printable_char(self) -> Option<char> {
+        match self {
+            Self::Char(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn printable_char_with_shift(self, shift: bool) -> Option<char> {
+        self.printable_char().map(|c| if shift { shifted_char(c) } else { c })
+    }
+}
+
+fn vk_for_char(c: char) -> u32 {
+    match c {
+        'a'..='z' | 'A'..='Z' => (c.to_ascii_uppercase() as u32) - ('A' as u32) + 0x41,
+        '0'..='9' => (c as u32) - ('0' as u32) + 0x30,
+        ';' => 0xBA,
+        '=' => 0xBB,
+        ',' => 0xBC,
+        '-' => 0xBD,
+        '.' => 0xBE,
+        '/' => 0xBF,
+        '`' => 0xC0,
+        '[' => 0xDB,
+        '\\' => 0xDC,
+        ']' => 0xDD,
+        '\'' => 0xDE,
+        c => c as u32,
+    }
+}
+
+/// One input event to deliver to the page. Coordinates are in CSS pixels
+/// of the emulated viewport.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BrowserInput {
+    MouseMove {
+        x: f64,
+        y: f64,
+        buttons: u32,
+        modifiers: BrowserModifiers,
+    },
+    MousePress {
+        x: f64,
+        y: f64,
+        button: BrowserButton,
+        click_count: u32,
+        buttons: u32,
+        modifiers: BrowserModifiers,
+    },
+    MouseRelease {
+        x: f64,
+        y: f64,
+        button: BrowserButton,
+        click_count: u32,
+        buttons: u32,
+        modifiers: BrowserModifiers,
+    },
+    Wheel {
+        x: f64,
+        y: f64,
+        delta_x: f64,
+        delta_y: f64,
+        modifiers: BrowserModifiers,
+    },
+    /// Key press. `text` (for printable keys) makes Chrome run the normal
+    /// keydown→keypress→input pipeline instead of a bare text insertion.
+    /// `repeat` marks auto-repeat of a held key.
+    KeyDown {
+        /// Physical key position used for DOM `code` and Windows VK. The
+        /// logical `key` and committed `text` still drive DOM `key`/input.
+        physical_key: Option<BrowserKey>,
+        key: BrowserKey,
+        text: Option<String>,
+        modifiers: BrowserModifiers,
+        repeat: bool,
+        edit_command: Option<BrowserEditCommand>,
+    },
+    KeyUp {
+        /// Physical key position retained from the matching key-down.
+        physical_key: Option<BrowserKey>,
+        key: BrowserKey,
+        /// Effective DOM key captured on key-down for layout-correct key-up.
+        text: Option<String>,
+        modifiers: BrowserModifiers,
+    },
+    /// Paste-style raw text insertion (IME path; also used for pasting).
+    InsertText { text: String },
+}
+
+impl BrowserInput {
+    /// Map to a CDP `(method, params)` pair.
+    #[must_use]
+    pub fn cdp(self) -> (&'static str, Value) {
+        match self {
+            Self::MouseMove {
+                x,
+                y,
+                buttons,
+                modifiers,
+            } => (
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseMoved",
+                    "x": x,
+                    "y": y,
+                    "buttons": buttons,
+                    "modifiers": modifiers.cdp_bits(),
+                }),
+            ),
+            Self::MousePress {
+                x,
+                y,
+                button,
+                click_count,
+                buttons,
+                modifiers,
+            } => (
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mousePressed",
+                    "x": x,
+                    "y": y,
+                    "button": button.cdp_name(),
+                    "clickCount": click_count,
+                    "buttons": buttons,
+                    "modifiers": modifiers.cdp_bits(),
+                }),
+            ),
+            Self::MouseRelease {
+                x,
+                y,
+                button,
+                click_count,
+                buttons,
+                modifiers,
+            } => (
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseReleased",
+                    "x": x,
+                    "y": y,
+                    "button": button.cdp_name(),
+                    "clickCount": click_count,
+                    "buttons": buttons,
+                    "modifiers": modifiers.cdp_bits(),
+                }),
+            ),
+            Self::Wheel {
+                x,
+                y,
+                delta_x,
+                delta_y,
+                modifiers,
+            } => (
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseWheel",
+                    "x": x,
+                    "y": y,
+                    "deltaX": delta_x,
+                    "deltaY": delta_y,
+                    "modifiers": modifiers.cdp_bits(),
+                }),
+            ),
+            Self::KeyDown {
+                physical_key,
+                key,
+                text,
+                modifiers,
+                repeat,
+                edit_command,
+            } => key_down_cdp(physical_key, key, text, modifiers, repeat, edit_command),
+            Self::KeyUp {
+                physical_key,
+                key,
+                text,
+                modifiers,
+            } => key_up_cdp(physical_key, key, text.as_deref(), modifiers),
+            Self::InsertText { text } => ("Input.insertText", json!({ "text": text })),
+        }
+    }
+
+    /// Whether this event changes page state (used for activity tracking).
+    #[must_use]
+    pub fn is_activity(&self) -> bool {
+        matches!(
+            self,
+            Self::MousePress { .. } | Self::Wheel { .. } | Self::KeyDown { .. } | Self::InsertText { .. }
+        )
+    }
+
+    /// Whether this key-down asks Chrome to copy the current page selection.
+    /// The driver snapshots that selection before dispatch so the UI can
+    /// bridge headless Chrome's private clipboard to the host clipboard.
+    #[must_use]
+    pub const fn copies_selection(&self) -> bool {
+        matches!(
+            self,
+            Self::KeyDown {
+                edit_command: Some(BrowserEditCommand::Copy | BrowserEditCommand::Cut),
+                ..
+            }
+        )
+    }
+}
+
+fn key_down_cdp(
+    physical_key: Option<BrowserKey>,
+    key: BrowserKey,
+    text: Option<String>,
+    modifiers: BrowserModifiers,
+    repeat: bool,
+    edit_command: Option<BrowserEditCommand>,
+) -> (&'static str, Value) {
+    let text = text.or_else(|| {
+        (key == BrowserKey::Enter && !modifiers.ctrl && !modifiers.alt && !modifiers.meta).then(|| "\r".to_string())
+    });
+    // Printable keys (`text` present) use `keyDown` so Chrome runs the normal
+    // keydown→keypress→input pipeline; other keys use `rawKeyDown`.
+    let ty = if text.is_some() { "keyDown" } else { "rawKeyDown" };
+    let dom_key = dispatch_dom_key(key, text.as_deref(), modifiers.shift);
+    let hardware_key = physical_key.unwrap_or(key);
+    let mut params = json!({
+        "type": ty,
+        "key": dom_key,
+        "code": hardware_key.code_name(),
+        "windowsVirtualKeyCode": hardware_key.vk_code(),
+        "autoRepeat": repeat,
+        "modifiers": modifiers.cdp_bits(),
+    });
+    if let Some(text) = text {
+        params["text"] = json!(text);
+    }
+    if let Some(command) = edit_command {
+        params["commands"] = json!([command.cdp_name()]);
+    }
+    ("Input.dispatchKeyEvent", params)
+}
+
+fn key_up_cdp(
+    physical_key: Option<BrowserKey>,
+    key: BrowserKey,
+    text: Option<&str>,
+    modifiers: BrowserModifiers,
+) -> (&'static str, Value) {
+    let dom_key = dispatch_dom_key(key, text, modifiers.shift);
+    let hardware_key = physical_key.unwrap_or(key);
+    (
+        "Input.dispatchKeyEvent",
+        json!({
+            "type": "keyUp",
+            "key": dom_key,
+            "windowsVirtualKeyCode": hardware_key.vk_code(),
+            "code": hardware_key.code_name(),
+            "modifiers": modifiers.cdp_bits(),
+        }),
+    )
+}
+
+impl BrowserKey {
+    /// DOM `KeyboardEvent.key` value for CDP `keyDown` events (Chrome
+    /// accepts a missing `key`, but the name is what page handlers see).
+    #[must_use]
+    pub fn dom_key_name(self) -> &'static str {
+        match self {
+            Self::ArrowUp => "ArrowUp",
+            Self::ArrowDown => "ArrowDown",
+            Self::ArrowLeft => "ArrowLeft",
+            Self::ArrowRight => "ArrowRight",
+            Self::Enter => "Enter",
+            Self::Tab => "Tab",
+            Self::Escape => "Escape",
+            Self::Space => " ",
+            Self::Backspace => "Backspace",
+            Self::Delete => "Delete",
+            Self::Home => "Home",
+            Self::End => "End",
+            Self::PageUp => "PageUp",
+            Self::PageDown => "PageDown",
+            Self::Insert => "Insert",
+            Self::F1 => "F1",
+            Self::F2 => "F2",
+            Self::F3 => "F3",
+            Self::F4 => "F4",
+            Self::F5 => "F5",
+            Self::F6 => "F6",
+            Self::F7 => "F7",
+            Self::F8 => "F8",
+            Self::F9 => "F9",
+            Self::F10 => "F10",
+            Self::F11 => "F11",
+            Self::F12 => "F12",
+            Self::F13 => "F13",
+            Self::F14 => "F14",
+            Self::F15 => "F15",
+            Self::Char(c) => char_dom_key_name(c),
+        }
+    }
+
+    /// CSS `code` identifier for CDP key events (best-effort; Chrome accepts
+    /// missing `code` on rawKeyDown/keyUp in most paths).
+    #[must_use]
+    pub fn code_name(self) -> &'static str {
+        match self {
+            Self::ArrowUp => "ArrowUp",
+            Self::ArrowDown => "ArrowDown",
+            Self::ArrowLeft => "ArrowLeft",
+            Self::ArrowRight => "ArrowRight",
+            Self::Enter => "Enter",
+            Self::Tab => "Tab",
+            Self::Escape => "Escape",
+            Self::Space => "Space",
+            Self::Backspace => "Backspace",
+            Self::Delete => "Delete",
+            Self::Home => "Home",
+            Self::End => "End",
+            Self::PageUp => "PageUp",
+            Self::PageDown => "PageDown",
+            Self::Insert => "Insert",
+            Self::F1 => "F1",
+            Self::F2 => "F2",
+            Self::F3 => "F3",
+            Self::F4 => "F4",
+            Self::F5 => "F5",
+            Self::F6 => "F6",
+            Self::F7 => "F7",
+            Self::F8 => "F8",
+            Self::F9 => "F9",
+            Self::F10 => "F10",
+            Self::F11 => "F11",
+            Self::F12 => "F12",
+            Self::F13 => "F13",
+            Self::F14 => "F14",
+            Self::F15 => "F15",
+            Self::Char(c) => char_code_name(c),
+        }
+    }
+}
+
+/// Statically allocated code names for printable characters. The set is the
+/// US-layout keyboard; anything else falls back to the generic name.
+/// Statically allocated DOM `key` names for printable characters (US
+/// layout; anything else falls back to a best-effort single-character
+/// static or "Unidentified").
+fn char_dom_key_name(c: char) -> &'static str {
+    match c {
+        'a'..='z' | 'A'..='Z' => match c.to_ascii_uppercase() as u8 - b'A' {
+            0 => "a",
+            1 => "b",
+            2 => "c",
+            3 => "d",
+            4 => "e",
+            5 => "f",
+            6 => "g",
+            7 => "h",
+            8 => "i",
+            9 => "j",
+            10 => "k",
+            11 => "l",
+            12 => "m",
+            13 => "n",
+            14 => "o",
+            15 => "p",
+            16 => "q",
+            17 => "r",
+            18 => "s",
+            19 => "t",
+            20 => "u",
+            21 => "v",
+            22 => "w",
+            23 => "x",
+            24 => "y",
+            25 => "z",
+            _ => "Unidentified",
+        },
+        '0'..='9' => match c {
+            '0' => "0",
+            '1' => "1",
+            '2' => "2",
+            '3' => "3",
+            '4' => "4",
+            '5' => "5",
+            '6' => "6",
+            '7' => "7",
+            '8' => "8",
+            _ => "9",
+        },
+        ';' => ";",
+        '=' => "=",
+        ',' => ",",
+        '-' => "-",
+        '.' => ".",
+        '/' => "/",
+        '`' => "`",
+        '[' => "[",
+        '\\' => "\\",
+        ']' => "]",
+        '\'' => "'",
+        _ => "Unidentified",
+    }
+}
+
+/// Statically allocated CSS `code` identifiers for printable characters
+/// (US layout; anything else falls back to "Unidentified").
+fn char_code_name(c: char) -> &'static str {
+    match c {
+        'a'..='z' | 'A'..='Z' => match c.to_ascii_uppercase() as u8 - b'A' {
+            0 => "KeyA",
+            1 => "KeyB",
+            2 => "KeyC",
+            3 => "KeyD",
+            4 => "KeyE",
+            5 => "KeyF",
+            6 => "KeyG",
+            7 => "KeyH",
+            8 => "KeyI",
+            9 => "KeyJ",
+            10 => "KeyK",
+            11 => "KeyL",
+            12 => "KeyM",
+            13 => "KeyN",
+            14 => "KeyO",
+            15 => "KeyP",
+            16 => "KeyQ",
+            17 => "KeyR",
+            18 => "KeyS",
+            19 => "KeyT",
+            20 => "KeyU",
+            21 => "KeyV",
+            22 => "KeyW",
+            23 => "KeyX",
+            24 => "KeyY",
+            25 => "KeyZ",
+            _ => "Unidentified",
+        },
+        '0'..='9' => match c {
+            '0' => "Digit0",
+            '1' => "Digit1",
+            '2' => "Digit2",
+            '3' => "Digit3",
+            '4' => "Digit4",
+            '5' => "Digit5",
+            '6' => "Digit6",
+            '7' => "Digit7",
+            '8' => "Digit8",
+            _ => "Digit9",
+        },
+        ';' => "Semicolon",
+        '=' => "Equal",
+        ',' => "Comma",
+        '-' => "Minus",
+        '.' => "Period",
+        '/' => "Slash",
+        '`' => "Backquote",
+        '[' => "BracketLeft",
+        '\\' => "Backslash",
+        ']' => "BracketRight",
+        '\'' => "Quote",
+        _ => "Unidentified",
+    }
+}
+
+fn dispatch_dom_key(key: BrowserKey, text: Option<&str>, shift: bool) -> std::borrow::Cow<'_, str> {
+    if let Some(text) = text {
+        let mut characters = text.chars();
+        if characters.next().is_some_and(|character| !character.is_control()) && characters.next().is_none() {
+            return std::borrow::Cow::Borrowed(text);
+        }
+    }
+    if shift && let Some(character) = key.printable_char_with_shift(true) {
+        return std::borrow::Cow::Owned(character.to_string());
+    }
+    std::borrow::Cow::Borrowed(key.dom_key_name())
+}
+
+/// Shift-adjusted character for the US-layout physical key map.
+#[must_use]
+pub const fn shifted_char(c: char) -> char {
+    match c {
+        'a'..='z' => c.to_ascii_uppercase(),
+        '1' => '!',
+        '2' => '@',
+        '3' => '#',
+        '4' => '$',
+        '5' => '%',
+        '6' => '^',
+        '7' => '&',
+        '8' => '*',
+        '9' => '(',
+        '0' => ')',
+        '-' => '_',
+        '=' => '+',
+        '[' => '{',
+        ']' => '}',
+        '\\' => '|',
+        ';' => ':',
+        '\'' => '"',
+        ',' => '<',
+        '.' => '>',
+        '/' => '?',
+        '`' => '~',
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifier_bits_match_cdp() {
+        assert_eq!(BrowserModifiers::none().cdp_bits(), 0);
+        let mods = BrowserModifiers {
+            alt: true,
+            ctrl: true,
+            meta: false,
+            shift: true,
+        };
+        assert_eq!(mods.cdp_bits(), 1 | 2 | 8);
+    }
+
+    #[test]
+    fn vk_codes() {
+        assert_eq!(BrowserKey::Enter.vk_code(), 0x0D);
+        assert_eq!(BrowserKey::F5.vk_code(), 0x74);
+        assert_eq!(BrowserKey::ArrowLeft.vk_code(), 0x25);
+        assert_eq!(BrowserKey::Char('a').vk_code(), 0x41);
+        assert_eq!(BrowserKey::Char('7').vk_code(), 0x37);
+    }
+
+    #[test]
+    fn mouse_params_shape() {
+        let (method, params) = BrowserInput::MousePress {
+            x: 10.0,
+            y: 20.0,
+            button: BrowserButton::Left,
+            click_count: 1,
+            buttons: 1,
+            modifiers: BrowserModifiers::none(),
+        }
+        .cdp();
+        assert_eq!(method, "Input.dispatchMouseEvent");
+        assert_eq!(params["type"], "mousePressed");
+        assert_eq!(params["button"], "left");
+        assert_eq!(params["x"], 10.0);
+
+        let (_, moved) = BrowserInput::MouseMove {
+            x: 30.0,
+            y: 40.0,
+            buttons: 1,
+            modifiers: BrowserModifiers {
+                shift: true,
+                ..BrowserModifiers::none()
+            },
+        }
+        .cdp();
+        assert_eq!(moved["type"], "mouseMoved");
+        assert_eq!(moved["modifiers"], 8);
+    }
+
+    #[test]
+    fn char_key_sends_keydown_with_text() {
+        let (method, params) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('h'),
+            text: Some("h".to_string()),
+            modifiers: BrowserModifiers::none(),
+            repeat: false,
+            edit_command: None,
+        }
+        .cdp();
+        assert_eq!(method, "Input.dispatchKeyEvent");
+        assert_eq!(params["type"], "keyDown");
+        assert_eq!(params["text"], "h");
+        assert_eq!(params["key"], "h");
+        assert_eq!(params["windowsVirtualKeyCode"], 0x48);
+        assert_eq!(params["autoRepeat"], false);
+    }
+
+    #[test]
+    fn non_printable_key_sends_raw_keydown() {
+        let (_, params) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Backspace,
+            text: None,
+            modifiers: BrowserModifiers::none(),
+            repeat: true,
+            edit_command: None,
+        }
+        .cdp();
+        assert_eq!(params["type"], "rawKeyDown");
+        assert!(params.get("text").is_none());
+        assert_eq!(params["autoRepeat"], true);
+    }
+
+    #[test]
+    fn unmodified_enter_sends_text_for_chromiums_keypress_pipeline() {
+        let (_, params) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Enter,
+            text: None,
+            modifiers: BrowserModifiers::none(),
+            repeat: false,
+            edit_command: None,
+        }
+        .cdp();
+
+        assert_eq!(params["type"], "keyDown");
+        assert_eq!(params["text"], "\r");
+        assert_eq!(params["key"], "Enter");
+    }
+
+    #[test]
+    fn shortcut_enter_remains_non_textual() {
+        for modifiers in [
+            BrowserModifiers {
+                ctrl: true,
+                ..BrowserModifiers::none()
+            },
+            BrowserModifiers {
+                alt: true,
+                ..BrowserModifiers::none()
+            },
+            BrowserModifiers {
+                meta: true,
+                ..BrowserModifiers::none()
+            },
+        ] {
+            let (_, params) = BrowserInput::KeyDown {
+                physical_key: None,
+                key: BrowserKey::Enter,
+                text: None,
+                modifiers,
+                repeat: false,
+                edit_command: None,
+            }
+            .cdp();
+
+            assert_eq!(params["type"], "rawKeyDown");
+            assert!(params.get("text").is_none());
+        }
+    }
+
+    #[test]
+    fn shifted_keys_report_effective_dom_key_and_physical_code() {
+        let modifiers = BrowserModifiers {
+            shift: true,
+            ..BrowserModifiers::none()
+        };
+        let (_, params) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('a'),
+            text: Some("A".to_string()),
+            modifiers,
+            repeat: false,
+            edit_command: None,
+        }
+        .cdp();
+        assert_eq!(params["key"], "A");
+        assert_eq!(params["code"], "KeyA");
+        assert_eq!(params["windowsVirtualKeyCode"], 0x41);
+
+        let (_, shortcut) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('1'),
+            text: None,
+            modifiers: BrowserModifiers {
+                ctrl: true,
+                ..modifiers
+            },
+            repeat: false,
+            edit_command: None,
+        }
+        .cdp();
+        assert_eq!(shortcut["key"], "!");
+        assert_eq!(shortcut["code"], "Digit1");
+    }
+
+    #[test]
+    fn physical_key_drives_code_and_virtual_key_without_changing_layout_text() {
+        let (_, key_down) = BrowserInput::KeyDown {
+            physical_key: Some(BrowserKey::Char('q')),
+            key: BrowserKey::Char('a'),
+            text: Some("a".to_string()),
+            modifiers: BrowserModifiers::none(),
+            repeat: false,
+            edit_command: None,
+        }
+        .cdp();
+        let (_, key_up) = BrowserInput::KeyUp {
+            physical_key: Some(BrowserKey::Char('q')),
+            key: BrowserKey::Char('a'),
+            text: Some("a".to_string()),
+            modifiers: BrowserModifiers::none(),
+        }
+        .cdp();
+
+        for params in [&key_down, &key_up] {
+            assert_eq!(params["key"], "a");
+            assert_eq!(params["code"], "KeyQ");
+            assert_eq!(params["windowsVirtualKeyCode"], 0x51);
+        }
+    }
+
+    #[test]
+    fn editing_keydowns_carry_chromium_edit_commands() {
+        let (_, params) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('x'),
+            text: None,
+            modifiers: BrowserModifiers {
+                meta: true,
+                ..BrowserModifiers::none()
+            },
+            repeat: false,
+            edit_command: Some(BrowserEditCommand::Cut),
+        }
+        .cdp();
+
+        assert_eq!(params["type"], "rawKeyDown");
+        assert_eq!(params["commands"], json!(["Cut"]));
+
+        let (_, select_all) = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('a'),
+            text: None,
+            modifiers: BrowserModifiers {
+                meta: true,
+                ..BrowserModifiers::none()
+            },
+            repeat: false,
+            edit_command: Some(BrowserEditCommand::SelectAll),
+        }
+        .cdp();
+        assert_eq!(select_all["commands"], json!(["SelectAll"]));
+    }
+
+    #[test]
+    fn only_copying_edit_commands_request_a_selection_snapshot() {
+        let cut = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('x'),
+            text: None,
+            modifiers: BrowserModifiers::none(),
+            repeat: false,
+            edit_command: Some(BrowserEditCommand::Cut),
+        };
+        let select_all = BrowserInput::KeyDown {
+            physical_key: None,
+            key: BrowserKey::Char('a'),
+            text: None,
+            modifiers: BrowserModifiers::none(),
+            repeat: false,
+            edit_command: Some(BrowserEditCommand::SelectAll),
+        };
+
+        assert!(cut.copies_selection());
+        assert!(!select_all.copies_selection());
+    }
+
+    #[test]
+    fn punctuation_uses_oem_virtual_keys_and_css_codes() {
+        let cases = [
+            (';', "Semicolon", 0xBA),
+            ('=', "Equal", 0xBB),
+            (',', "Comma", 0xBC),
+            ('-', "Minus", 0xBD),
+            ('.', "Period", 0xBE),
+            ('/', "Slash", 0xBF),
+            ('`', "Backquote", 0xC0),
+            ('[', "BracketLeft", 0xDB),
+            ('\\', "Backslash", 0xDC),
+            (']', "BracketRight", 0xDD),
+            ('\'', "Quote", 0xDE),
+        ];
+        for (character, code, virtual_key) in cases {
+            let key = BrowserKey::Char(character);
+            assert_eq!(key.code_name(), code);
+            assert_eq!(key.vk_code(), virtual_key);
+            assert_eq!(key.dom_key_name(), character.to_string());
+        }
+    }
+
+    #[test]
+    fn wheel_params_shape() {
+        let (method, params) = BrowserInput::Wheel {
+            x: 5.0,
+            y: 6.0,
+            delta_x: 0.0,
+            delta_y: 120.0,
+            modifiers: BrowserModifiers::none(),
+        }
+        .cdp();
+        assert_eq!(method, "Input.dispatchMouseEvent");
+        assert_eq!(params["type"], "mouseWheel");
+        assert_eq!(params["deltaY"], 120.0);
+    }
+
+    #[test]
+    fn insert_text_shape() {
+        let (method, params) = BrowserInput::InsertText {
+            text: "hello".to_string(),
+        }
+        .cdp();
+        assert_eq!(method, "Input.insertText");
+        assert_eq!(params["text"], "hello");
+    }
+}

--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -1,0 +1,700 @@
+//! File-based ownership/handoff manifest for browser panels.
+//!
+//! Each browser panel writes a small JSON file under
+//! `~/.horizon/runtime/browsers/<encoded-panel-local-id>.json` while it is
+//! alive.
+//! It is the shared channel between three parties:
+//!
+//! - the **panel driver** (writes `browser_ws`, `target_id`, `url`,
+//!   `title`, `user_active`, and the handoff `done` flag),
+//! - **external agents** (read discovery fields, heartbeat `owner`, write
+//!   a `handoff` request),
+//! - the **UI** (reads ownership for the chrome chip).
+//!
+//! File-based on purpose: no new IPC mechanism, works across process
+//! boundaries, and every field is observable with plain shell tooling.
+//! Every update to an existing manifest must use [`update`] (or implement its
+//! adjacent `<panel>.json.lock` protocol around both the read and the write).
+//! The lock file is a stable coordination inode guarded by the operating
+//! system, so a crashed holder releases the lock without any stale-file
+//! deletion race. This serializes read-modify-write transactions across the
+//! driver and agent processes so ownership/handoff fields cannot be lost.
+//! Driver startup uses [`initialize`] to create the manifest explicitly;
+//! later updates fail when teardown has removed it, so a delayed writer cannot
+//! resurrect a dead panel.
+
+use std::fs::{OpenOptions, TryLockError};
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use atomicwrites::{AllowOverwrite, AtomicFile};
+use serde::{Deserialize, Serialize};
+
+use crate::horizon_home::{HorizonHome, safe_local_id};
+
+/// How long an agent owner heartbeat stays fresh.
+pub const OWNER_TTL_MILLIS: i64 = 10_000;
+/// How long the driver's `user_active` signal stays true without another
+/// qualifying interaction.
+pub const USER_ACTIVE_TTL: Duration = Duration::from_secs(5);
+#[cfg(not(test))]
+const LOCK_WAIT: Duration = Duration::from_secs(2);
+// Concurrency tests intentionally serialize many fsync-backed replacements;
+// their purpose is transaction correctness, not a loaded runner's disk speed.
+#[cfg(test)]
+const LOCK_WAIT: Duration = Duration::from_secs(10);
+const LOCK_RETRY: Duration = Duration::from_millis(5);
+static HANDOFF_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ManifestOwner {
+    pub name: String,
+    /// PTY the agent runs on (e.g. `pts/14`), when discoverable. Lets the UI
+    /// map the owner back to the terminal panel that spawned it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tty: Option<String>,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ManifestHandoff {
+    /// Collision-resistant identity generated for each request (for example,
+    /// a UUID). A replacement request must always use a new value, even when
+    /// its reason and millisecond timestamp match the previous request.
+    #[serde(default)]
+    pub request_id: String,
+    pub reason: String,
+    pub requested_at: i64,
+    /// Set by the UI when the user clicks "hand back".
+    pub done: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+pub struct BrowserManifest {
+    pub panel_local_id: String,
+    /// Browser-level `DevTools` ws endpoint (what an agent connects to).
+    pub browser_ws: String,
+    /// The page target the panel is driving.
+    pub target_id: String,
+    pub url: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<ManifestOwner>,
+    pub user_active: bool,
+    pub user_active_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff: Option<ManifestHandoff>,
+    pub updated_at: i64,
+}
+
+impl BrowserManifest {
+    /// The owner, if it has heartbeat within [`OWNER_TTL_MILLIS`].
+    #[must_use]
+    pub fn live_owner(&self, now_millis: i64) -> Option<&ManifestOwner> {
+        self.owner
+            .as_ref()
+            .filter(|owner| timestamp_is_fresh(now_millis, owner.updated_at, OWNER_TTL_MILLIS))
+    }
+
+    #[must_use]
+    pub fn handoff_pending(&self) -> Option<&ManifestHandoff> {
+        self.handoff.as_ref().filter(|h| !h.done)
+    }
+
+    /// Whether the user-activity signal is both asserted and fresh.
+    #[must_use]
+    pub fn user_is_active(&self, now_millis: i64) -> bool {
+        let ttl_millis = i64::try_from(USER_ACTIVE_TTL.as_millis()).unwrap_or(i64::MAX);
+        self.user_active && timestamp_is_fresh(now_millis, self.user_active_at, ttl_millis)
+    }
+}
+
+fn timestamp_is_fresh(now_millis: i64, timestamp_millis: i64, ttl_millis: i64) -> bool {
+    let age_millis = now_millis.saturating_sub(timestamp_millis);
+    (0..=ttl_millis).contains(&age_millis)
+}
+
+#[must_use]
+pub fn now_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+/// Generate an opaque identity for one handoff request. The nanosecond clock,
+/// process id, and per-process counter keep identities distinct across rapid
+/// replacements and concurrent agent processes without another dependency.
+#[must_use]
+pub fn new_handoff_request_id() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let sequence = HANDOFF_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{:x}-{nanos:x}-{sequence:x}", std::process::id())
+}
+
+#[must_use]
+pub fn manifest_path_for_root(root: &Path, panel_local_id: &str) -> PathBuf {
+    let base = root.join("runtime").join("browsers");
+    // Local ids are normally generated by Horizon, but persisted state is
+    // untrusted and must never escape the runtime directory.
+    let safe = safe_local_id(panel_local_id);
+    base.join(format!("{safe}.json"))
+}
+
+#[must_use]
+pub fn default_manifest_path(panel_local_id: &str) -> PathBuf {
+    let home = HorizonHome::resolve();
+    manifest_path_for_root(home.root(), panel_local_id)
+}
+
+#[must_use]
+pub fn default_manifest_dir() -> PathBuf {
+    HorizonHome::resolve().browsers_manifest_dir()
+}
+
+/// Read the manifest for a panel, if present and parseable.
+#[must_use]
+pub fn read(panel_local_id: &str) -> Option<BrowserManifest> {
+    read_at(&default_manifest_path(panel_local_id))
+}
+
+#[must_use]
+pub fn read_at(path: &Path) -> Option<BrowserManifest> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// List panel local ids that currently have a valid, canonically named
+/// manifest.
+#[must_use]
+pub fn list_panels_in(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            let encoded_id = file_name.strip_suffix(".json")?;
+            let manifest = read_at(&entry.path())?;
+            (safe_local_id(&manifest.panel_local_id) == encoded_id).then_some(manifest.panel_local_id)
+        })
+        .collect()
+}
+
+/// Write a complete manifest atomically (temp file + rename), mode 0600.
+///
+/// The adjacent inter-process lock serializes the replacement itself, and the
+/// pid-unique temp file keeps a crashed write from corrupting the live
+/// manifest. Callers deriving the new value from an existing manifest must
+/// use [`update`] so the read is covered by the same lock.
+///
+/// # Errors
+/// Fails on filesystem errors.
+pub fn write(manifest: &BrowserManifest) -> std::io::Result<()> {
+    write_at(&default_manifest_path(&manifest.panel_local_id), manifest)
+}
+
+/// Write to an explicit path (used by tests).
+///
+/// The manifest carries a live CDP endpoint, so the temp file is created
+/// `0600` from the first byte — never world-readable under a common umask.
+///
+/// # Errors
+/// Fails on filesystem errors (including the permission tightening, which
+/// also covers a stale temp file left behind by a crashed run — `mode()`
+/// only applies at creation).
+pub fn write_at(path: &Path, manifest: &BrowserManifest) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _lock = ManifestLock::acquire(path)?;
+    write_at_locked(path, manifest)
+}
+
+/// Initialize a driver's manifest, preserving any agent-owned fields already
+/// written under the same lock.
+///
+/// Unlike [`update`], this operation may create a missing manifest. It is
+/// reserved for the single driver-start boundary.
+///
+/// # Errors
+/// Fails when the lock or manifest write cannot be completed.
+pub(crate) fn initialize(
+    panel_local_id: &str,
+    update: impl FnOnce(&mut BrowserManifest),
+) -> std::io::Result<BrowserManifest> {
+    initialize_at(&default_manifest_path(panel_local_id), panel_local_id, update)
+}
+
+fn initialize_at(
+    path: &Path,
+    panel_local_id: &str,
+    update: impl FnOnce(&mut BrowserManifest),
+) -> std::io::Result<BrowserManifest> {
+    mutate_at(path, panel_local_id, true, update)
+}
+
+/// Atomically read, mutate, and replace one manifest while holding the
+/// inter-process manifest lock.
+///
+/// # Errors
+/// Fails when the lock or manifest write cannot be completed.
+pub fn update(panel_local_id: &str, update: impl FnOnce(&mut BrowserManifest)) -> std::io::Result<BrowserManifest> {
+    update_at(&default_manifest_path(panel_local_id), panel_local_id, update)
+}
+
+fn update_at(
+    path: &Path,
+    panel_local_id: &str,
+    update: impl FnOnce(&mut BrowserManifest),
+) -> std::io::Result<BrowserManifest> {
+    mutate_at(path, panel_local_id, false, update)
+}
+
+fn mutate_at(
+    path: &Path,
+    panel_local_id: &str,
+    create_missing: bool,
+    update: impl FnOnce(&mut BrowserManifest),
+) -> std::io::Result<BrowserManifest> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _lock = ManifestLock::acquire(path)?;
+    let mut manifest = read_at(path)
+        .or_else(|| {
+            create_missing.then(|| BrowserManifest {
+                panel_local_id: panel_local_id.to_string(),
+                ..BrowserManifest::default()
+            })
+        })
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("browser manifest no longer exists: {}", path.display()),
+            )
+        })?;
+    update(&mut manifest);
+    write_at_locked(path, &manifest)?;
+    Ok(manifest)
+}
+
+fn write_at_locked(path: &Path, manifest: &BrowserManifest) -> std::io::Result<()> {
+    let raw = serde_json::to_string_pretty(manifest).map_err(|e| std::io::Error::other(e.to_string()))?;
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    AtomicFile::new(path, AllowOverwrite)
+        .write_with_options(|file| file.write_all(raw.as_bytes()), options)
+        .map_err(Into::into)
+}
+
+struct ManifestLock {
+    // The operating system releases the advisory lock when this handle is
+    // dropped, including after a process crash. The coordination file itself
+    // intentionally remains stable so contenders can never lock different
+    // inodes for the same manifest.
+    _file: std::fs::File,
+}
+
+impl ManifestLock {
+    fn acquire(manifest_path: &Path) -> std::io::Result<Self> {
+        Self::acquire_with_timeout(manifest_path, LOCK_WAIT)
+    }
+
+    fn acquire_with_timeout(manifest_path: &Path, timeout: Duration) -> std::io::Result<Self> {
+        let path = manifest_path.with_extension("json.lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)?;
+        let deadline = Instant::now() + timeout;
+        loop {
+            match file.try_lock() {
+                Ok(()) => return Ok(Self { _file: file }),
+                Err(TryLockError::WouldBlock) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("timed out waiting for manifest lock {}", path.display()),
+                        ));
+                    }
+                    std::thread::sleep(remaining.min(LOCK_RETRY));
+                    if Instant::now() >= deadline {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("timed out waiting for manifest lock {}", path.display()),
+                        ));
+                    }
+                }
+                Err(TryLockError::Error(error)) => return Err(error),
+            }
+        }
+    }
+}
+
+pub fn remove(panel_local_id: &str) {
+    let path = default_manifest_path(panel_local_id);
+    remove_at_with_warning(&path);
+}
+
+/// Remove a live manifest within the caller's remaining shutdown budget.
+/// Returns `false` if lock acquisition or removal cannot finish in time.
+#[must_use]
+pub(crate) fn remove_with_timeout(panel_local_id: &str, timeout: Duration) -> bool {
+    let path = default_manifest_path(panel_local_id);
+    match remove_at_with_timeout(&path, timeout) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(target: "browser", path = %path.display(), "failed to remove browser manifest: {error}");
+            false
+        }
+    }
+}
+
+/// Owns one driver's manifest from startup through every exit path.
+pub(crate) struct DriverManifestLifetime {
+    path: PathBuf,
+}
+
+impl DriverManifestLifetime {
+    /// Remove any stale predecessor manifest and arm cleanup for this run.
+    pub(crate) fn start(panel_local_id: &str) -> Self {
+        Self::start_at(default_manifest_path(panel_local_id))
+    }
+
+    fn start_at(path: PathBuf) -> Self {
+        remove_at_with_warning(&path);
+        Self { path }
+    }
+}
+
+impl Drop for DriverManifestLifetime {
+    fn drop(&mut self) {
+        remove_at_with_warning(&self.path);
+    }
+}
+
+fn remove_at_with_warning(path: &Path) {
+    if let Err(error) = remove_at(path) {
+        tracing::warn!(target: "browser", path = %path.display(), "failed to remove browser manifest: {error}");
+    }
+}
+
+fn remove_at(path: &Path) -> std::io::Result<()> {
+    remove_at_with_timeout(path, LOCK_WAIT)
+}
+
+fn remove_at_with_timeout(path: &Path, timeout: Duration) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _lock = ManifestLock::acquire_with_timeout(path, timeout)?;
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn test_root() -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir()
+            .join(format!("horizon-browser-mani{}", std::process::id()))
+            .join(format!("t{n}"));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    fn sample(id: &str) -> BrowserManifest {
+        BrowserManifest {
+            panel_local_id: id.to_string(),
+            browser_ws: "ws://127.0.0.1:1/devtools/browser/x".to_string(),
+            target_id: "T1".to_string(),
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            owner: None,
+            user_active: false,
+            user_active_at: 0,
+            handoff: None,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn write_read_roundtrip() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "abc-123");
+        let m = sample("abc-123");
+        write_at(&path, &m).unwrap();
+        let back = read_at(&path).unwrap();
+        assert_eq!(back, m);
+        assert!(list_panels_in(&root.join("runtime").join("browsers")).contains(&"abc-123".to_string()));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn teardown_removal_reuses_an_unlocked_coordination_file() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "orphaned-lock");
+        write_at(&path, &sample("orphaned-lock")).unwrap();
+        let lock_path = path.with_extension("json.lock");
+        std::fs::write(&lock_path, b"").unwrap();
+
+        remove_at(&path).unwrap();
+
+        assert!(!path.exists());
+        assert!(lock_path.exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn teardown_removal_honors_the_callers_lock_deadline() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "bounded-removal");
+        write_at(&path, &sample("bounded-removal")).unwrap();
+        let lock = ManifestLock::acquire(&path).unwrap();
+        let started = Instant::now();
+
+        let error = remove_at_with_timeout(&path, Duration::from_millis(20)).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert!(started.elapsed() < Duration::from_millis(500));
+        assert!(path.exists());
+        drop(lock);
+        remove_at(&path).unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn path_is_sanitized() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "../evil");
+        assert!(path.starts_with(&root));
+        assert!(!path.to_string_lossy().contains(".."));
+        assert_ne!(path, manifest_path_for_root(&root, "___evil"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn distinct_unsafe_ids_have_distinct_manifest_paths() {
+        let root = test_root();
+
+        assert_ne!(
+            manifest_path_for_root(&root, "a/b"),
+            manifest_path_for_root(&root, "a_b")
+        );
+        assert_ne!(manifest_path_for_root(&root, ""), manifest_path_for_root(&root, "_"));
+        assert_ne!(
+            manifest_path_for_root(&root, "Panel-A"),
+            manifest_path_for_root(&root, "panel-a")
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn unsafe_ids_list_as_the_original_id_and_reopen() {
+        let root = test_root();
+        let manifest_dir = root.join("runtime").join("browsers");
+        let original_id = "../unsafe panel";
+        let path = manifest_path_for_root(&root, original_id);
+        write_at(&path, &sample(original_id)).unwrap();
+
+        let listed = list_panels_in(&manifest_dir);
+
+        assert_eq!(listed, [original_id]);
+        assert_eq!(
+            read_at(&manifest_path_for_root(&root, &listed[0])),
+            Some(sample(original_id))
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn list_ignores_a_manifest_with_a_mismatched_filename() {
+        let root = test_root();
+        let manifest_dir = root.join("runtime").join("browsers");
+        let path = manifest_dir.join("wrong-id.json");
+        write_at(&path, &sample("actual-id")).unwrap();
+
+        assert!(list_panels_in(&manifest_dir).is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn owner_ttl_expires() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "p1");
+        let mut m = sample("p1");
+        let now = 1_000_000i64;
+        m.owner = Some(ManifestOwner {
+            name: "pi".to_string(),
+            tty: Some("pts/1".to_string()),
+            updated_at: now,
+        });
+        write_at(&path, &m).unwrap();
+        let read_back = read_at(&path).unwrap();
+        assert!(read_back.live_owner(now).is_some());
+        assert!(read_back.live_owner(now + OWNER_TTL_MILLIS).is_some());
+        assert!(read_back.live_owner(now + OWNER_TTL_MILLIS + 1).is_none());
+        assert!(read_back.live_owner(now - 1).is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn user_activity_requires_a_fresh_timestamp() {
+        let mut manifest = sample("active");
+        manifest.user_active = true;
+        manifest.user_active_at = 1_000;
+
+        assert!(manifest.user_is_active(5_999));
+        assert!(manifest.user_is_active(6_000));
+        assert!(!manifest.user_is_active(6_001));
+        assert!(!manifest.user_is_active(999));
+        manifest.user_active = false;
+        assert!(!manifest.user_is_active(1_001));
+    }
+
+    #[test]
+    fn concurrent_updates_preserve_independent_fields() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "race");
+        write_at(&path, &sample("race")).unwrap();
+
+        std::thread::scope(|scope| {
+            let title_path = path.clone();
+            scope.spawn(move || {
+                for value in 0..50 {
+                    update_at(&title_path, "race", |manifest| {
+                        manifest.title = format!("title-{value}");
+                    })
+                    .unwrap();
+                }
+            });
+            let activity_path = path.clone();
+            scope.spawn(move || {
+                for value in 0..50 {
+                    update_at(&activity_path, "race", |manifest| {
+                        manifest.user_active_at = value;
+                    })
+                    .unwrap();
+                }
+            });
+        });
+
+        let manifest = read_at(&path).unwrap();
+        assert_eq!(manifest.title, "title-49");
+        assert_eq!(manifest.user_active_at, 49);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn update_cannot_recreate_a_manifest_removed_while_waiting_for_its_lock() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "teardown-race");
+        write_at(&path, &sample("teardown-race")).unwrap();
+        let lock = ManifestLock::acquire(&path).unwrap();
+
+        let result = std::thread::scope(|scope| {
+            let update_path = path.clone();
+            let update = scope.spawn(move || {
+                update_at(&update_path, "teardown-race", |manifest| {
+                    manifest.title = "late update".to_string();
+                })
+            });
+            std::fs::remove_file(&path).unwrap();
+            drop(lock);
+            update.join().unwrap()
+        });
+
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn driver_initialization_is_the_explicit_create_boundary() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "initialize");
+
+        let manifest = initialize_at(&path, "initialize", |manifest| {
+            manifest.browser_ws = "ws://127.0.0.1:2/devtools/browser/y".to_string();
+        })
+        .unwrap();
+
+        assert_eq!(read_at(&path), Some(manifest));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn driver_lifetime_cleans_stale_and_new_manifests() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "lifetime");
+        write_at(&path, &sample("lifetime")).unwrap();
+
+        let lifetime = DriverManifestLifetime::start_at(path.clone());
+        assert!(!path.exists());
+        write_at(&path, &sample("lifetime")).unwrap();
+        drop(lifetime);
+
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn removing_a_missing_manifest_initializes_its_coordination_directory() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "missing");
+
+        remove_at(&path).unwrap();
+
+        assert!(!path.exists());
+        assert!(path.with_extension("json.lock").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn handoff_lifecycle() {
+        let root = test_root();
+        let path = manifest_path_for_root(&root, "p2");
+        write_at(&path, &sample("p2")).unwrap();
+        update_at(&path, "p2", |manifest| {
+            manifest.handoff = Some(ManifestHandoff {
+                request_id: "request-1".to_string(),
+                reason: "captcha".to_string(),
+                requested_at: now_millis(),
+                done: false,
+            });
+        })
+        .unwrap();
+        assert!(read_at(&path).unwrap().handoff_pending().is_some());
+        update_at(&path, "p2", |manifest| {
+            manifest.handoff.as_mut().unwrap().done = true;
+        })
+        .unwrap();
+        assert!(read_at(&path).unwrap().handoff_pending().is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn handoff_request_ids_are_unique_for_same_millisecond_requests() {
+        assert_ne!(new_handoff_request_id(), new_handoff_request_id());
+    }
+}

--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -7,9 +7,897 @@
 //! - `cdp` — `CDP` transport (websocket JSON-RPC)
 //! - `process` — Chrome binary discovery, spawn, kill
 //! - `frames` — JPEG decode + shared frame slot
+//! - `input` — core input model + CDP parameter mapping
+//! - `session` — the per-panel driver thread and its state machine
+//! - `manifest` — the file-based ownership/handoff channel shared with
+//!   external agents and the UI
 
 pub mod cdp;
 pub mod frames;
+pub mod input;
+pub mod manifest;
 pub mod process;
+mod profile;
+pub mod session;
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use std::sync::Arc;
 
 pub use frames::FrameSlot;
+pub use input::{BrowserButton, BrowserEditCommand, BrowserInput, BrowserKey, BrowserModifiers};
+pub use session::BrowserShutdownSignal;
+pub use session::{BrowserCommand, BrowserEvent, BrowserEventWaker, BrowserSession};
+
+use crate::horizon_home::HorizonHome;
+
+pub(crate) use profile::profile_dir_for_home;
+
+/// Default emulated viewport for a freshly created browser panel.
+pub const DEFAULT_VIEWPORT: (u32, u32) = (1280, 800);
+const FORCED_CHROME_SHUTDOWN_WAIT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Short human-facing title for a URL (hostname, or a non-empty fallback).
+#[must_use]
+pub fn panel_title_for_url(url: &str) -> String {
+    let input = url.trim();
+    if input.is_empty() {
+        return "Browser".to_string();
+    }
+    let Some((_, scheme_specific)) = input.split_once("://") else {
+        return input.to_string();
+    };
+    let authority = scheme_specific.split(['/', '?', '#']).next().unwrap_or_default();
+    let host_and_port = authority.rsplit('@').next().unwrap_or_default();
+    let host = if let Some(bracketed) = host_and_port.strip_prefix('[') {
+        bracketed.split_once(']').map_or("", |(host, _)| host)
+    } else {
+        host_and_port.split(':').next().unwrap_or_default()
+    };
+    if host.is_empty() {
+        input.to_string()
+    } else {
+        host.to_string()
+    }
+}
+
+/// `browser` section of the Horizon config.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BrowserConfig {
+    /// Explicit Chrome/Chromium executable (absolute path or PATH name).
+    /// When unset, a standard candidate list is scanned.
+    pub command: Option<String>,
+    /// Extra CLI arguments appended to every Chrome launch.
+    pub extra_args: Vec<String>,
+    /// JPEG quality 1-100 for screencast frames.
+    pub quality: u32,
+    /// Deliver every Nth screencast frame (1 = all frames, 2 = half rate).
+    /// Chrome's only frame-rate knob; useful on animation-heavy pages to
+    /// halve decode + texture-upload cost at a perceived 30 fps.
+    pub every_nth_frame: u32,
+    /// Override the per-panel profile root (default
+    /// `~/.horizon/browser-profiles/<panel_id>`).
+    pub profile_root: Option<PathBuf>,
+}
+
+impl Default for BrowserConfig {
+    fn default() -> Self {
+        Self {
+            command: None,
+            extra_args: Vec::new(),
+            quality: 60,
+            every_nth_frame: 1,
+            profile_root: None,
+        }
+    }
+}
+
+/// Coarse liveness of the panel's browser session.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum BrowserStatus {
+    #[default]
+    Starting,
+    Ready,
+    Error {
+        message: String,
+    },
+    Stopped {
+        code: Option<i32>,
+    },
+}
+
+impl BrowserStatus {
+    #[must_use]
+    pub const fn is_alive(&self) -> bool {
+        matches!(self, Self::Starting | Self::Ready)
+    }
+}
+
+/// Panel content for `PanelKind::Browser` panels.
+pub struct BrowserPanelState {
+    pub status: BrowserStatus,
+    /// Last URL Chrome actually committed. `Some("")` is a committed blank
+    /// target; `None` means the requested startup navigation is still only a
+    /// request and must not enter persistence.
+    pub url: Option<String>,
+    pub title: String,
+    pub loading: bool,
+    pub frame_slot: Arc<FrameSlot>,
+    session: Option<Box<BrowserSession>>,
+    /// Outlives the session handle so a final driver-side navigation can be
+    /// folded into persistence after browser teardown completes.
+    committed_url: session::CommittedUrl,
+    /// Driver teardown that must finish before Retry or application exit can
+    /// reuse/release this panel's Chrome profile.
+    teardown_signal: Option<Box<BrowserShutdownSignal>>,
+    /// One-click Retry waits for the prior Chrome profile lock to be released,
+    /// then starts this replacement automatically.
+    pending_relaunch: Option<PendingRelaunch>,
+    pub panel_local_id: String,
+    /// Initial URL requested at (re)start, for the URL bar.
+    pub requested_url: Option<String>,
+    /// Agent currently driving this panel (from manifest heartbeats).
+    pub owner: Option<String>,
+    /// Pending handoff request from the agent, with its reason.
+    pub handoff_reason: Option<String>,
+    /// Manifest failure from the most recent hand-back attempt.
+    pub handoff_error: Option<String>,
+    /// The driver is persisting the user's hand-back acknowledgement.
+    pub handoff_resolution_pending: bool,
+    /// Latest page selection copied by Chrome and not yet written to the host
+    /// clipboard by the UI.
+    pending_clipboard_text: Option<String>,
+    /// Most recent URL submission error; cleared after a committed navigation.
+    pub navigation_error: Option<String>,
+    config: BrowserConfig,
+}
+
+struct PendingRelaunch {
+    initial_url: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BrowserDrainOutput {
+    pub had_output: bool,
+    pub url_changed: bool,
+}
+
+impl BrowserPanelState {
+    /// Create the state and start the driver thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a relative profile root cannot be resolved from
+    /// the process launch directory.
+    pub fn start(
+        panel_local_id: impl Into<String>,
+        config: &BrowserConfig,
+        initial_url: Option<String>,
+    ) -> crate::error::Result<Self> {
+        let panel_local_id = panel_local_id.into();
+        let config = config.resolved_for_launch()?;
+        let mut state = Self {
+            status: BrowserStatus::Starting,
+            url: None,
+            title: String::new(),
+            loading: true,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: None,
+            pending_relaunch: None,
+            requested_url: initial_url.clone(),
+            panel_local_id: panel_local_id.clone(),
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config,
+        };
+        state.launch_session(initial_url);
+        Ok(state)
+    }
+
+    /// (Re)start the driver — used for the Retry action after a failure.
+    /// Resumes at the last-viewed URL when one is known, so a crashed
+    /// browser returns the user to where they were rather than the panel's
+    /// initial URL.
+    pub fn relaunch(&mut self) {
+        let initial_url = match &self.url {
+            Some(url) => (!url.is_empty()).then(|| url.clone()),
+            None => self.requested_url.clone().filter(|url| !url.is_empty()),
+        };
+        self.launch_session(initial_url);
+    }
+
+    /// URL shown in browser chrome. Before Chrome commits anything, preserve
+    /// the requested startup target as editable UI without treating it as
+    /// persisted browser history.
+    #[must_use]
+    pub fn display_url(&self) -> &str {
+        self.url.as_deref().unwrap_or_else(|| {
+            self.requested_url
+                .as_deref()
+                .filter(|url| *url != "about:blank")
+                .unwrap_or_default()
+        })
+    }
+
+    /// Last URL Chrome actually committed. `Some("")` means Chrome committed
+    /// a blank target; `None` means the requested startup navigation has not
+    /// committed and must not enter runtime persistence yet.
+    #[must_use]
+    pub fn committed_url_for_persistence(&self) -> Option<&str> {
+        self.url.as_deref()
+    }
+
+    /// Profile root this panel was launched with. Persisting it separately
+    /// keeps the profile reachable if the live config changes before the
+    /// panel is next saved.
+    #[must_use]
+    pub fn profile_root_for_persistence(&self) -> Option<&Path> {
+        self.config.profile_root.as_deref()
+    }
+
+    fn launch_session(&mut self, initial_url: Option<String>) {
+        self.navigation_error = None;
+        // Drop the previous driver (if any) and wait for its Chrome to be
+        // gone: the replacement reuses the same profile directory, and a
+        // second instance would lose the profile lock race.
+        if let Some(session) = self.session.take() {
+            self.teardown_signal = Some(Box::new(BrowserSession::shutdown_signal(*session)));
+        }
+        if !self.retry_ready() {
+            self.pending_relaunch = Some(PendingRelaunch { initial_url });
+            self.loading = true;
+            self.status = BrowserStatus::Starting;
+            return;
+        }
+        self.start_session(initial_url);
+    }
+
+    fn start_session(&mut self, initial_url: Option<String>) {
+        let session_config = session::BrowserSessionConfig {
+            browser: self.config.clone(),
+            panel_local_id: self.panel_local_id.clone(),
+            initial_url,
+            width: DEFAULT_VIEWPORT.0,
+            height: DEFAULT_VIEWPORT.1,
+            // Reuse the panel's slot across (re)starts: frame sequence
+            // numbers stay monotonic, so a retried session's first frame is
+            // never mistaken for an unchanged one by the UI's seq check.
+            frame_slot: Arc::clone(&self.frame_slot),
+        };
+        match session::start_session(session_config) {
+            Ok(handle) => {
+                self.committed_url = handle.committed_url();
+                self.clear_agent_state_for_relaunch();
+                self.status = BrowserStatus::Starting;
+                self.loading = true;
+                self.session = Some(Box::new(handle));
+            }
+            Err(message) => {
+                self.status = BrowserStatus::Error { message };
+            }
+        }
+    }
+
+    fn continue_pending_relaunch(&mut self) -> bool {
+        if self.pending_relaunch.is_none() || !self.retry_ready() {
+            return false;
+        }
+        let Some(pending) = self.pending_relaunch.take() else {
+            return false;
+        };
+        self.start_session(pending.initial_url);
+        true
+    }
+
+    fn clear_agent_state_for_relaunch(&mut self) {
+        self.owner = None;
+        self.handoff_reason = None;
+        self.handoff_error = None;
+        self.handoff_resolution_pending = false;
+    }
+
+    pub fn send(&self, command: BrowserCommand) {
+        let _ = self.try_send(command);
+    }
+
+    #[must_use]
+    pub fn needs_event_waker(&self) -> bool {
+        self.session.as_ref().is_some_and(|session| session.needs_event_waker())
+    }
+
+    pub fn set_event_waker(&self, callback: BrowserEventWaker) {
+        if let Some(session) = &self.session {
+            session.set_event_waker(callback);
+        }
+    }
+
+    /// Queue a command only when the driver session currently exists.
+    #[must_use]
+    pub fn try_send(&self, command: BrowserCommand) -> bool {
+        self.session.as_ref().is_some_and(|session| session.send(command))
+    }
+
+    /// Take page text copied by headless Chrome for the UI's host clipboard.
+    pub fn take_clipboard_text(&mut self) -> Option<String> {
+        self.pending_clipboard_text.take()
+    }
+
+    /// Tell the driver the user handed the panel back to the agent.
+    pub fn hand_back(&mut self) {
+        self.handoff_error = None;
+        if self
+            .session
+            .as_ref()
+            .is_some_and(|session| session.send(BrowserCommand::HandoffDone))
+        {
+            self.handoff_resolution_pending = true;
+        } else {
+            self.handoff_resolution_pending = false;
+            self.handoff_error = Some("browser driver unavailable; retry after recovery".to_string());
+        }
+    }
+
+    /// Stop the driver asynchronously (panel close during a session):
+    /// the driver finishes its Chrome teardown on its own thread.
+    pub fn stop(&mut self) {
+        if let Some(session) = self.session.take() {
+            let _ = session.send(BrowserCommand::Stop);
+        }
+        if matches!(self.status, BrowserStatus::Starting | BrowserStatus::Ready) {
+            self.status = BrowserStatus::Stopped { code: None };
+        }
+    }
+
+    /// Ask the driver to stop and remember its teardown-completion signal;
+    /// the app-shutdown paths join on it so exit cannot outrun the profile
+    /// lock.
+    pub fn request_shutdown(&mut self) {
+        self.pending_relaunch = None;
+        if let Some(session) = self.session.take() {
+            self.teardown_signal = Some(Box::new((*session).shutdown_signal()));
+        }
+        if matches!(self.status, BrowserStatus::Starting | BrowserStatus::Ready) {
+            self.status = BrowserStatus::Stopped { code: None };
+        }
+    }
+
+    /// Take the stored teardown-completion signal, if a shutdown was
+    /// requested and not yet joined.
+    pub(crate) fn take_shutdown_signal(&mut self) -> Option<BrowserShutdownSignal> {
+        self.teardown_signal.take().map(|signal| *signal)
+    }
+
+    /// Request driver shutdown and wait up to `timeout` for Chrome teardown.
+    #[must_use]
+    pub fn shutdown_with_timeout(&mut self, timeout: std::time::Duration) -> bool {
+        self.request_shutdown();
+        self.take_shutdown_signal()
+            .is_none_or(|signal| signal.wait(timeout) || signal.force_cleanup(FORCED_CHROME_SHUTDOWN_WAIT))
+    }
+
+    /// Permanently close this panel and remove its persistent Chrome profile
+    /// only after the driver has released the profile lock.
+    pub fn close_permanently(&mut self) -> BrowserShutdownSignal {
+        self.request_shutdown();
+        let profile_dir = session::profile_dir(&self.config, &self.panel_local_id);
+        if let Some(signal) = self.take_shutdown_signal() {
+            signal.with_profile_cleanup(profile_dir)
+        } else {
+            BrowserShutdownSignal::completed_with_profile_cleanup(profile_dir)
+        }
+    }
+
+    /// Whether a failed/stopped session has fully released its Chrome
+    /// process and profile, making Retry safe. Polling is non-blocking so the
+    /// recovery placeholder cannot freeze the UI.
+    pub fn retry_ready(&mut self) -> bool {
+        let Some(signal) = &self.teardown_signal else {
+            return true;
+        };
+        if signal.is_complete() {
+            self.teardown_signal = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Drain driver events into panel state, separating visible activity from
+    /// URL changes that must dirty the persisted runtime state.
+    pub fn drain_events(&mut self) -> BrowserDrainOutput {
+        let relaunched = self.continue_pending_relaunch();
+        let events = self
+            .session
+            .as_ref()
+            .map(|session| session.event_rx.try_iter().collect::<Vec<_>>())
+            .unwrap_or_default();
+        let mut output = BrowserDrainOutput {
+            had_output: relaunched,
+            ..BrowserDrainOutput::default()
+        };
+        for event in events {
+            match event {
+                BrowserEvent::Ready => {
+                    self.status = BrowserStatus::Ready;
+                    output.had_output = true;
+                }
+                BrowserEvent::Title(title) => {
+                    if self.title != title {
+                        self.title = title;
+                        output.had_output = true;
+                    }
+                }
+                BrowserEvent::UrlChanged(url) => {
+                    if self.url.as_deref() != Some(url.as_str()) {
+                        self.url = Some(url);
+                        output.url_changed = true;
+                    }
+                    self.navigation_error = None;
+                    output.had_output = true;
+                }
+                BrowserEvent::NavigationFailed(message) => {
+                    self.navigation_error = Some(message);
+                    output.had_output = true;
+                }
+                BrowserEvent::Loading(loading) => {
+                    self.loading = loading;
+                }
+                BrowserEvent::Frame { .. } => {
+                    self.frame_slot.release_notification();
+                    output.had_output = true;
+                }
+                BrowserEvent::Warning(message) => {
+                    self.frame_slot.clear();
+                    self.status = BrowserStatus::Error { message };
+                    output.had_output = true;
+                }
+                BrowserEvent::Stopped { code } => {
+                    if let Some(session) = self.session.take() {
+                        self.teardown_signal = Some(Box::new((*session).completion_signal()));
+                    }
+                    // Drop the stale frame so the placeholder (with Retry)
+                    // is shown instead of a frozen last frame.
+                    self.frame_slot.clear();
+                    // A startup/CDP failure arrives as Warning + Stopped;
+                    // keep the actionable error text instead of showing a
+                    // bare "stopped" state for it.
+                    let keep_error = matches!(self.status, BrowserStatus::Error { .. });
+                    if !keep_error || code.is_some() {
+                        self.status = BrowserStatus::Stopped { code };
+                    }
+                    if self.handoff_resolution_pending {
+                        self.handoff_resolution_pending = false;
+                        self.handoff_error =
+                            Some("browser stopped before the hand-back acknowledgement was saved".to_string());
+                    }
+                    output.had_output = true;
+                }
+                BrowserEvent::HandoffRequested(reason) => {
+                    self.handoff_reason = Some(reason);
+                    self.handoff_error = None;
+                    self.handoff_resolution_pending = false;
+                    output.had_output = true;
+                }
+                BrowserEvent::HandoffCleared => {
+                    self.handoff_error = None;
+                    self.handoff_resolution_pending = false;
+                    if self.handoff_reason.is_some() {
+                        self.handoff_reason = None;
+                        output.had_output = true;
+                    }
+                }
+                BrowserEvent::HandoffResolutionFailed(message) => {
+                    self.handoff_error = Some(message);
+                    self.handoff_resolution_pending = false;
+                    output.had_output = true;
+                }
+                BrowserEvent::ClipboardText(text) => {
+                    self.pending_clipboard_text = Some(text);
+                    output.had_output = true;
+                }
+                BrowserEvent::OwnerChanged(owner) => {
+                    if self.owner != owner {
+                        self.owner = owner;
+                        output.had_output = true;
+                    }
+                }
+            }
+        }
+        self.sync_committed_url(&mut output);
+        output
+    }
+
+    fn sync_committed_url(&mut self, output: &mut BrowserDrainOutput) {
+        let Some(url) = self.committed_url.snapshot() else {
+            return;
+        };
+        if self.url.as_deref() == Some(url.as_str()) {
+            return;
+        }
+        self.url = Some(url);
+        self.navigation_error = None;
+        output.url_changed = true;
+        output.had_output = true;
+    }
+}
+
+impl Drop for BrowserPanelState {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn schedule_profile_removal(profile_dir: PathBuf) -> std::sync::mpsc::Receiver<std::io::Result<()>> {
+    schedule_profile_removal_with(profile_dir, |profile_dir, completion_tx| {
+        std::thread::Builder::new()
+            .name("browser-profile-cleanup".into())
+            .spawn(move || {
+                let _ = completion_tx.send(remove_browser_profile(&profile_dir));
+            })
+            .map(|_| ())
+    })
+}
+
+fn schedule_profile_removal_with(
+    profile_dir: PathBuf,
+    spawn_worker: impl FnOnce(PathBuf, std::sync::mpsc::Sender<std::io::Result<()>>) -> std::io::Result<()>,
+) -> std::sync::mpsc::Receiver<std::io::Result<()>> {
+    let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+    if let Err(error) = spawn_worker(profile_dir, completion_tx.clone()) {
+        tracing::warn!("failed to start browser profile cleanup: {error}");
+        let _ = completion_tx.send(Err(error));
+    }
+    completion_rx
+}
+
+fn remove_browser_profile(profile_dir: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(profile_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Resolve the manifest directory for browser panels (UI + external agents).
+#[must_use]
+pub fn manifest_dir() -> PathBuf {
+    HorizonHome::resolve().browsers_manifest_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults() {
+        let config = BrowserConfig::default();
+        assert_eq!(config.quality, 60);
+        assert_eq!(config.every_nth_frame, 1);
+        assert!(config.command.is_none());
+    }
+
+    #[test]
+    fn panel_titles_extract_dns_and_bracketed_ipv6_hosts() {
+        assert_eq!(panel_title_for_url("https://example.com:8443/path"), "example.com");
+        assert_eq!(panel_title_for_url("http://[::1]:3000/path"), "::1");
+        assert_eq!(panel_title_for_url("https://user:secret@example.net/a"), "example.net");
+    }
+
+    #[test]
+    fn panel_titles_keep_non_empty_fallbacks_for_hostless_urls() {
+        assert_eq!(panel_title_for_url("file:///tmp/page.html"), "file:///tmp/page.html");
+        assert_eq!(panel_title_for_url("about:blank"), "about:blank");
+        assert_eq!(panel_title_for_url("  "), "Browser");
+    }
+
+    #[test]
+    fn status_transitions() {
+        assert!(BrowserStatus::default().is_alive());
+        assert!(BrowserStatus::Ready.is_alive());
+        assert!(!BrowserStatus::Stopped { code: None }.is_alive());
+        assert!(
+            !BrowserStatus::Error {
+                message: "x".to_string()
+            }
+            .is_alive()
+        );
+    }
+
+    #[test]
+    fn retry_stays_disabled_until_teardown_completes() {
+        let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Error {
+                message: "stopped".to_string(),
+            },
+            url: None,
+            title: String::new(),
+            loading: false,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: Some(Box::new(BrowserShutdownSignal::for_test(completion_rx))),
+            pending_relaunch: None,
+            panel_local_id: "retry-test".to_string(),
+            requested_url: None,
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config: BrowserConfig::default(),
+        };
+
+        assert!(!state.retry_ready());
+        assert_eq!(completion_tx.send(()), Ok(()));
+        assert!(state.retry_ready());
+        assert!(state.teardown_signal.is_none());
+    }
+
+    #[test]
+    fn shutdown_with_timeout_waits_for_driver_completion() {
+        let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+        let (start_tx, start_rx) = std::sync::mpsc::channel();
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Ready,
+            url: None,
+            title: String::new(),
+            loading: false,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: Some(Box::new(BrowserShutdownSignal::for_test(completion_rx))),
+            pending_relaunch: None,
+            panel_local_id: "shutdown-wait-test".to_string(),
+            requested_url: None,
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config: BrowserConfig::default(),
+        };
+        let completion = std::thread::spawn(move || {
+            let _ = start_rx.recv();
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            completion_tx.send(())
+        });
+        let started = std::time::Instant::now();
+        assert_eq!(start_tx.send(()), Ok(()));
+
+        assert!(state.shutdown_with_timeout(std::time::Duration::from_secs(1)));
+        assert!(started.elapsed() >= std::time::Duration::from_millis(20));
+        assert!(completion.join().is_ok_and(|result| result.is_ok()));
+    }
+
+    #[test]
+    fn queued_retry_launches_after_teardown_without_another_click() {
+        let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Starting,
+            url: None,
+            title: String::new(),
+            loading: true,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: Some(Box::new(BrowserShutdownSignal::for_test(completion_rx))),
+            pending_relaunch: Some(PendingRelaunch { initial_url: None }),
+            panel_local_id: "queued-retry-test".to_string(),
+            requested_url: None,
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config: BrowserConfig {
+                command: Some("/definitely/missing/chrome".to_string()),
+                ..BrowserConfig::default()
+            },
+        };
+
+        assert!(!state.continue_pending_relaunch());
+        assert_eq!(completion_tx.send(()), Ok(()));
+        assert!(state.continue_pending_relaunch());
+        assert!(state.pending_relaunch.is_none());
+        assert!(state.session.is_some());
+        state.request_shutdown();
+        if let Some(signal) = state.take_shutdown_signal() {
+            assert!(signal.wait(std::time::Duration::from_secs(2)));
+        }
+    }
+
+    #[test]
+    fn profile_cleanup_waits_for_driver_teardown() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let profile_dir = root.path().join("panel-profile");
+        std::fs::create_dir(&profile_dir).expect("profile dir");
+        std::fs::write(profile_dir.join("Preferences"), b"state").expect("profile state");
+        let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+
+        let signal = BrowserShutdownSignal::for_test(completion_rx).with_profile_cleanup(profile_dir.clone());
+        assert!(profile_dir.exists());
+        assert_eq!(completion_tx.send(()), Ok(()));
+        assert!(signal.wait(std::time::Duration::from_secs(1)));
+        assert!(!profile_dir.exists());
+    }
+
+    #[test]
+    fn failed_profile_cleanup_is_not_acknowledged_as_complete() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let profile_path = root.path().join("not-a-directory");
+        std::fs::write(&profile_path, b"profile placeholder").expect("profile placeholder");
+        let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+        let signal = BrowserShutdownSignal::for_test(completion_rx).with_profile_cleanup(profile_path.clone());
+        assert_eq!(completion_tx.send(()), Ok(()));
+
+        assert!(!signal.wait(std::time::Duration::from_secs(1)));
+        assert!(!signal.is_complete());
+        assert!(profile_path.exists());
+
+        std::fs::remove_file(&profile_path).expect("remove profile placeholder");
+        assert!(signal.force_cleanup(std::time::Duration::from_secs(1)));
+        assert!(!profile_path.exists());
+    }
+
+    #[test]
+    fn profile_cleanup_spawn_failure_leaves_filesystem_work_for_an_async_retry() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let profile_dir = root.path().join("panel-profile");
+        std::fs::create_dir(&profile_dir).expect("profile dir");
+        std::fs::write(profile_dir.join("Preferences"), b"state").expect("profile state");
+
+        let completion_rx = schedule_profile_removal_with(profile_dir.clone(), |_, _| {
+            Err(std::io::Error::other("worker unavailable"))
+        });
+
+        let outcome = completion_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("spawn failure is reported");
+        assert_eq!(
+            outcome.expect_err("cleanup was not run").kind(),
+            std::io::ErrorKind::Other
+        );
+        assert!(profile_dir.exists());
+    }
+
+    #[test]
+    fn failed_hand_back_keeps_the_retry_affordance() {
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Stopped { code: None },
+            url: None,
+            title: String::new(),
+            loading: false,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: None,
+            pending_relaunch: None,
+            panel_local_id: "handoff-test".to_string(),
+            requested_url: None,
+            owner: Some("agent".to_string()),
+            handoff_reason: Some("captcha".to_string()),
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config: BrowserConfig::default(),
+        };
+
+        state.hand_back();
+
+        assert_eq!(state.handoff_reason.as_deref(), Some("captcha"));
+        assert!(state.handoff_error.is_some());
+        assert!(!state.handoff_resolution_pending);
+    }
+
+    #[test]
+    fn committed_url_is_applied_after_the_session_event_receiver_is_gone() {
+        let committed_url = session::CommittedUrl::default();
+        committed_url.publish("https://example.com/final");
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Stopped { code: None },
+            url: Some("https://example.com/old".to_string()),
+            title: String::new(),
+            loading: false,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url,
+            teardown_signal: None,
+            pending_relaunch: None,
+            panel_local_id: "final-url-test".to_string(),
+            requested_url: None,
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: Some("stale error".to_string()),
+            config: BrowserConfig::default(),
+        };
+
+        let output = state.drain_events();
+
+        assert_eq!(state.url.as_deref(), Some("https://example.com/final"));
+        assert!(state.navigation_error.is_none());
+        assert!(output.url_changed);
+        assert!(output.had_output);
+    }
+
+    #[test]
+    fn requested_url_stays_out_of_persistence_until_chrome_commits() {
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Starting,
+            url: None,
+            title: String::new(),
+            loading: true,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: None,
+            pending_relaunch: None,
+            panel_local_id: "requested-url-test".to_string(),
+            requested_url: Some("https://example.com/requested".to_string()),
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config: BrowserConfig::default(),
+        };
+
+        assert_eq!(state.display_url(), "https://example.com/requested");
+        assert_eq!(state.committed_url_for_persistence(), None);
+
+        state.committed_url.publish("");
+        let output = state.drain_events();
+
+        assert_eq!(state.display_url(), "");
+        assert_eq!(state.committed_url_for_persistence(), Some(""));
+        assert!(output.url_changed);
+    }
+
+    #[test]
+    fn relaunch_clears_agent_state_from_the_stopped_driver() {
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Stopped { code: None },
+            url: None,
+            title: String::new(),
+            loading: false,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: None,
+            pending_relaunch: None,
+            panel_local_id: "relaunch-test".to_string(),
+            requested_url: None,
+            owner: Some("agent".to_string()),
+            handoff_reason: Some("captcha".to_string()),
+            handoff_error: Some("driver unavailable".to_string()),
+            handoff_resolution_pending: true,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            config: BrowserConfig::default(),
+        };
+
+        state.clear_agent_state_for_relaunch();
+
+        assert!(state.owner.is_none());
+        assert!(state.handoff_reason.is_none());
+        assert!(state.handoff_error.is_none());
+        assert!(!state.handoff_resolution_pending);
+    }
+}

--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -347,10 +347,17 @@ impl BrowserPanelState {
     }
 
     /// Stop the driver asynchronously (panel close during a session):
-    /// the driver finishes its Chrome teardown on its own thread.
+    /// the driver finishes its Chrome teardown on its own thread. The
+    /// teardown-completion signal is preserved (as in
+    /// [`Self::request_shutdown`]) so a live state keeps process control
+    /// over the stopping driver and undrained frame notifications are
+    /// released.
     pub fn stop(&mut self) {
+        // A queued Retry must not survive an explicit stop: drain_events
+        // would otherwise relaunch Chrome after the caller stopped it.
+        self.pending_relaunch = None;
         if let Some(session) = self.session.take() {
-            let _ = session.send(BrowserCommand::Stop);
+            self.teardown_signal = Some(Box::new((*session).shutdown_signal()));
         }
         if matches!(self.status, BrowserStatus::Starting | BrowserStatus::Ready) {
             self.status = BrowserStatus::Stopped { code: None };

--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -386,6 +386,11 @@ impl BrowserPanelState {
 
     /// Permanently close this panel and remove its persistent Chrome profile
     /// only after the driver has released the profile lock.
+    ///
+    /// The returned signal is what actually starts the profile deletion: it
+    /// must be polled or waited on (see [`BrowserShutdownSignal`]). Dropping
+    /// it leaves the profile on disk permanently.
+    #[must_use = "profile cleanup only starts when the returned signal is polled or waited on"]
     pub fn close_permanently(&mut self) -> BrowserShutdownSignal {
         self.request_shutdown();
         let profile_dir = session::profile_dir(&self.config, &self.panel_local_id);

--- a/crates/horizon-core/src/browser/process.rs
+++ b/crates/horizon-core/src/browser/process.rs
@@ -72,7 +72,7 @@ pub struct ChromeProcess {
 /// teardown. Keeping the `Child` handle, rather than only its PID, prevents a
 /// timeout cleanup from targeting a later process that reused the number.
 #[derive(Clone, Default)]
-pub struct ChromeProcessControl {
+pub(crate) struct ChromeProcessControl {
     inner: Arc<Mutex<ChromeProcessControlState>>,
 }
 
@@ -96,7 +96,7 @@ impl ChromeProcessControl {
         }
     }
 
-    pub fn mark_registration_settled(&self) {
+    pub(super) fn mark_registration_settled(&self) {
         self.inner
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -119,7 +119,7 @@ impl ChromeProcessControl {
     /// Whether no registered child remains alive. A driver completion signal
     /// is not sufficient: its final kill/reap can fail while this retained
     /// exact handle still owns a live Chrome process.
-    pub fn is_reaped(&self) -> bool {
+    pub(crate) fn is_reaped(&self) -> bool {
         let child = {
             let state = match self.inner.try_lock() {
                 Ok(state) => state,
@@ -239,7 +239,7 @@ impl ChromeProcess {
     ///
     /// # Errors
     /// Fails when the binary is missing or the process cannot start.
-    pub fn spawn(launch: &ChromeLaunch, control: ChromeProcessControl) -> Result<Self> {
+    pub(crate) fn spawn(launch: &ChromeLaunch, control: ChromeProcessControl) -> Result<Self> {
         validate_extra_args(&launch.extra_args)?;
         let command = resolve_binary(&launch.command)?;
         prepare_profile_dir(&launch.profile_dir)?;

--- a/crates/horizon-core/src/browser/profile.rs
+++ b/crates/horizon-core/src/browser/profile.rs
@@ -1,0 +1,96 @@
+//! Browser-profile path resolution and launch-time persistence invariants.
+
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+
+use super::BrowserConfig;
+
+impl BrowserConfig {
+    pub(super) fn resolved_for_launch(&self) -> std::io::Result<Self> {
+        let Some(configured_root) = &self.profile_root else {
+            return Ok(self.clone());
+        };
+        let expanded_root = crate::config::Config::expand_tilde(&configured_root.to_string_lossy());
+        let absolute_root = if expanded_root.is_absolute() {
+            expanded_root
+        } else {
+            std::env::current_dir()?.join(expanded_root)
+        };
+        let mut resolved = self.clone();
+        resolved.profile_root = Some(absolute_root);
+        Ok(resolved)
+    }
+
+    #[cfg(test)]
+    fn resolved_for_launch_at(&self, launch_dir: &Path) -> Self {
+        let mut resolved = self.clone();
+        resolved.profile_root = self.profile_root.as_ref().map(|configured_root| {
+            let expanded_root = crate::config::Config::expand_tilde(&configured_root.to_string_lossy());
+            if expanded_root.is_absolute() {
+                expanded_root
+            } else {
+                launch_dir.join(expanded_root)
+            }
+        });
+        resolved
+    }
+}
+
+pub(crate) fn profile_dir_for_home(
+    config: &BrowserConfig,
+    home: &crate::horizon_home::HorizonHome,
+    panel_local_id: &str,
+) -> PathBuf {
+    // The configured value is a root: every panel still gets its own safely
+    // encoded directory, or concurrent panels would share Chrome's lock.
+    match &config.profile_root {
+        Some(root) => crate::config::Config::expand_tilde(&root.to_string_lossy())
+            .join(crate::horizon_home::safe_local_id(panel_local_id)),
+        None => home.browser_profile_dir(panel_local_id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::BrowserPanelState;
+
+    #[test]
+    fn relative_profile_roots_are_anchored_once_to_the_launch_directory() {
+        #[cfg(windows)]
+        let launch_dir = Path::new(r"C:\horizon-launch");
+        #[cfg(not(windows))]
+        let launch_dir = Path::new("/horizon-launch");
+        let config = BrowserConfig {
+            profile_root: Some(PathBuf::from("profiles/browser")),
+            ..BrowserConfig::default()
+        };
+
+        let resolved = config.resolved_for_launch_at(launch_dir);
+
+        assert_eq!(resolved.profile_root, Some(launch_dir.join("profiles/browser")));
+        assert!(resolved.profile_root.is_some_and(|root| root.is_absolute()));
+    }
+
+    #[test]
+    fn panel_persists_the_absolute_root_resolved_before_driver_launch() {
+        let relative_root = PathBuf::from("relative-browser-profiles");
+        let expected_root = std::env::current_dir()
+            .expect("current test directory")
+            .join(&relative_root);
+        let config = BrowserConfig {
+            command: Some("/definitely/missing/horizon-test-chrome".to_string()),
+            profile_root: Some(relative_root),
+            ..BrowserConfig::default()
+        };
+
+        let mut panel = BrowserPanelState::start("relative-profile-panel", &config, None).expect("panel state");
+
+        assert_eq!(panel.profile_root_for_persistence(), Some(expected_root.as_path()));
+        panel.request_shutdown();
+        if let Some(signal) = panel.take_shutdown_signal() {
+            assert!(signal.wait(std::time::Duration::from_secs(2)));
+        }
+    }
+}

--- a/crates/horizon-core/src/browser/profile.rs
+++ b/crates/horizon-core/src/browser/profile.rs
@@ -7,9 +7,19 @@ use std::path::PathBuf;
 use super::BrowserConfig;
 
 impl BrowserConfig {
+    /// Chrome rejects `Page.startScreencast` quality outside its range,
+    /// which would otherwise fail every screencast start and drive the
+    /// restart state machine without producing frames. Clamp once here so
+    /// every consumer sees an in-range value.
+    fn clamped(&self) -> Self {
+        let mut resolved = self.clone();
+        resolved.quality = resolved.quality.clamp(1, 100);
+        resolved
+    }
+
     pub(super) fn resolved_for_launch(&self) -> std::io::Result<Self> {
         let Some(configured_root) = &self.profile_root else {
-            return Ok(self.clone());
+            return Ok(self.clamped());
         };
         let expanded_root = crate::config::Config::expand_tilde(&configured_root.to_string_lossy());
         let absolute_root = if expanded_root.is_absolute() {
@@ -17,7 +27,7 @@ impl BrowserConfig {
         } else {
             std::env::current_dir()?.join(expanded_root)
         };
-        let mut resolved = self.clone();
+        let mut resolved = self.clamped();
         resolved.profile_root = Some(absolute_root);
         Ok(resolved)
     }
@@ -71,6 +81,21 @@ mod tests {
 
         assert_eq!(resolved.profile_root, Some(launch_dir.join("profiles/browser")));
         assert!(resolved.profile_root.is_some_and(|root| root.is_absolute()));
+    }
+
+    #[test]
+    fn screencast_quality_is_clamped_to_the_chrome_range() {
+        for (configured, expected) in [(0_u32, 1_u32), (1, 1), (100, 100), (101, 100), (255, 100)] {
+            let config = BrowserConfig {
+                quality: configured,
+                ..BrowserConfig::default()
+            };
+            let resolved = config.resolved_for_launch().expect("no profile root to resolve");
+            assert_eq!(
+                resolved.quality, expected,
+                "quality {configured} should clamp to {expected}"
+            );
+        }
     }
 
     #[test]

--- a/crates/horizon-core/src/browser/session.rs
+++ b/crates/horizon-core/src/browser/session.rs
@@ -522,9 +522,18 @@ const TITLE_OBSERVER_SCRIPT: &str = r"(() => {
 /// Spawn the driver thread. Browser startup problems are reported through
 /// the event channel rather than failing here.
 ///
+/// The launch config is resolved on the calling thread (profile root
+/// anchoring, quality clamping) so direct callers of this low-level entry
+/// point behave identically to `BrowserPanelState::start` instead of
+/// resolving a relative profile root against the driver thread's working
+/// directory.
+///
 /// # Errors
-/// Fails only when the OS thread cannot be spawned.
+/// Fails when the launch config cannot be resolved or the OS thread cannot
+/// be spawned.
 pub fn start_session(config: BrowserSessionConfig) -> Result<BrowserSession, String> {
+    let mut config = config;
+    config.browser = config.browser.resolved_for_launch().map_err(|err| err.to_string())?;
     let frame_slot = config.frame_slot.clone();
     let (command_tx, command_rx) = mpsc::channel::<BrowserCommand>();
     let (raw_event_tx, event_rx) = mpsc::channel::<BrowserEvent>();

--- a/crates/horizon-core/src/browser/session.rs
+++ b/crates/horizon-core/src/browser/session.rs
@@ -183,14 +183,8 @@ impl BrowserShutdownSignal {
     #[must_use]
     pub(crate) fn wait(&self, timeout: Duration) -> bool {
         let deadline = Instant::now() + timeout;
-        if !self.driver_complete.load(Ordering::Acquire) {
-            if !matches!(
-                self.completion_rx.recv_timeout(timeout),
-                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected)
-            ) {
-                return false;
-            }
-            self.driver_complete.store(true, Ordering::Release);
+        if !self.wait_driver_completion(timeout) {
+            return false;
         }
         while !self.process_control.is_reaped() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
@@ -214,6 +208,12 @@ impl BrowserShutdownSignal {
         {
             return false;
         }
+        // The driver may still be running between Chrome's death and its own
+        // exit; wait for it before removing files it owns, or it could
+        // recreate the manifest after we delete it.
+        if !self.wait_driver_completion(deadline.saturating_duration_since(Instant::now())) {
+            return false;
+        }
         if let Some(panel_local_id) = &self.panel_local_id
             && !crate::browser::manifest::remove_with_timeout(
                 panel_local_id,
@@ -225,6 +225,22 @@ impl BrowserShutdownSignal {
         self.process_complete.store(true, Ordering::Release);
         self.retry_failed_profile_cleanup_now();
         self.wait_for_profile_cleanup(deadline.saturating_duration_since(Instant::now()))
+    }
+
+    /// Block until the driver thread has exited (its completion signal
+    /// fires) or the timeout elapses.
+    fn wait_driver_completion(&self, timeout: Duration) -> bool {
+        if self.driver_complete.load(Ordering::Acquire) {
+            return true;
+        }
+        let complete = matches!(
+            self.completion_rx.recv_timeout(timeout),
+            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected)
+        );
+        if complete {
+            self.driver_complete.store(true, Ordering::Release);
+        }
+        complete
     }
 
     fn process_is_complete(&self) -> bool {

--- a/crates/horizon-core/src/browser/session.rs
+++ b/crates/horizon-core/src/browser/session.rs
@@ -1,0 +1,913 @@
+//! The per-panel browser driver thread.
+//!
+//! One thread per browser panel, mirroring how terminal panels run their
+//! alacritty event loops: it owns the Chrome process and the browser-level
+//! CDP connection, decodes screencast frames into a shared
+//! [`FrameSlot`], and reports lightweight [`BrowserEvent`]s over an mpsc
+//! channel that the main thread drains each frame. Frame wake-ups are
+//! coalesced to one outstanding event while the slot keeps only the newest
+//! image. Input and navigation commands travel the other way over
+//! [`BrowserCommand`].
+//!
+//! CDP behaviors encoded here (validated against real Chrome in the L0
+//! spike):
+//! - flattened sessions: `sessionId` is a string; events carry it at the
+//!   top level; commands need it at the top level, and
+//!   `Page.screencastFrameAck` needs it in `params` as well.
+//! - screencasts are **change-driven**: frames only arrive when the page
+//!   repaints, so a static page costs nothing.
+//! - a cross-document navigation — especially one triggered by *another*
+//!   CDP client (e.g. agent CDP client) — temporarily breaks the
+//!   session's page binding and returns "Not attached to an active page".
+//!   Recovery is a backoff-retried `Page.startScreencast` (~100 ms steps),
+//!   with a full re-attach as the last resort.
+//! - the screencast is implicitly terminated by navigation, so it is
+//!   restarted on every top-level `Page.frameNavigated`.
+
+mod clipboard;
+mod commands;
+mod events;
+mod lifecycle;
+mod manifest_io;
+mod startup;
+
+use clipboard::ClipboardState;
+pub(super) use startup::profile_dir;
+use startup::run_driver;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
+
+use crate::browser::cdp::{CdpError, CdpLink};
+use crate::browser::frames::FrameSlot;
+use crate::browser::process::{ChromeProcess, ChromeProcessControl};
+use crate::browser::{BrowserConfig, BrowserInput};
+
+/// What the driver reports to the panel.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BrowserEvent {
+    /// Chrome is up and the page session is attached.
+    Ready,
+    Title(String),
+    UrlChanged(String),
+    NavigationFailed(String),
+    Loading(bool),
+    /// A new decoded frame is available in the panel's frame slot. The
+    /// sequence belongs to the frame that claimed the coalesced wake-up;
+    /// callers must read the slot for the newest frame.
+    Frame {
+        seq: u64,
+    },
+    /// Non-fatal problem surfaced to the panel body.
+    Warning(String),
+    /// The driver stopped.
+    Stopped {
+        code: Option<i32>,
+    },
+    /// An agent asked the user for the wheel.
+    HandoffRequested(String),
+    /// The handoff was resolved (user handed back or agent cancelled).
+    HandoffCleared,
+    /// A requested handoff acknowledgement could not be persisted.
+    HandoffResolutionFailed(String),
+    /// Selected page text copied by headless Chrome, ready for the host
+    /// clipboard bridge in the UI.
+    ClipboardText(String),
+    /// The agent owning this panel changed (`None` = no live owner).
+    OwnerChanged(Option<String>),
+}
+
+/// What the panel/UI asks the driver to do.
+#[derive(Clone, Debug)]
+pub enum BrowserCommand {
+    Navigate(String),
+    Reload,
+    Back,
+    Forward,
+    SetViewport {
+        width: u32,
+        height: u32,
+    },
+    Input(BrowserInput),
+    /// The user clicked "hand back to agent" in the panel.
+    HandoffDone,
+    Stop,
+}
+
+/// Everything the driver needs to start.
+#[derive(Clone, Debug)]
+pub struct BrowserSessionConfig {
+    pub browser: BrowserConfig,
+    pub panel_local_id: String,
+    pub initial_url: Option<String>,
+    pub width: u32,
+    pub height: u32,
+    /// The panel's frame slot, shared across driver (re)starts so frame
+    /// sequence numbers stay monotonic across sessions — a retry must not
+    /// re-emit sequence 1 and be mistaken for an unchanged frame.
+    pub frame_slot: Arc<FrameSlot>,
+}
+
+/// The panel-side handle to a running driver.
+pub struct BrowserSession {
+    command_tx: mpsc::Sender<BrowserCommand>,
+    stop_requested: Arc<AtomicBool>,
+    pub frame_slot: Arc<FrameSlot>,
+    pub event_rx: mpsc::Receiver<BrowserEvent>,
+    /// Resolved when the driver thread has finished tearing down Chrome.
+    completion_rx: mpsc::Receiver<()>,
+    event_wake: BrowserEventWake,
+    committed_url: CommittedUrl,
+    process_control: ChromeProcessControl,
+    panel_local_id: String,
+}
+
+/// Completion signal paired with an exact Chrome child handle. Normal paths
+/// only poll the receiver; a hard application-exit deadline can explicitly
+/// terminate/reap the owned process and remove its dead manifest.
+pub struct BrowserShutdownSignal {
+    completion_rx: mpsc::Receiver<()>,
+    driver_complete: AtomicBool,
+    process_complete: AtomicBool,
+    process_control: ChromeProcessControl,
+    panel_local_id: Option<String>,
+    profile_cleanup: Mutex<ProfileCleanupState>,
+}
+
+enum ProfileCleanupState {
+    NotRequired,
+    Pending(std::path::PathBuf),
+    Running {
+        profile_dir: std::path::PathBuf,
+        completion_rx: mpsc::Receiver<std::io::Result<()>>,
+    },
+    RetryPending {
+        profile_dir: std::path::PathBuf,
+        retry_at: Instant,
+    },
+}
+
+const PROFILE_CLEANUP_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+impl BrowserShutdownSignal {
+    pub(crate) fn with_profile_cleanup(self, profile_dir: std::path::PathBuf) -> Self {
+        *self
+            .profile_cleanup
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = ProfileCleanupState::Pending(profile_dir);
+        self
+    }
+
+    #[must_use]
+    pub fn completed_with_profile_cleanup(profile_dir: std::path::PathBuf) -> Self {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        drop(completion_tx);
+        let process_control = ChromeProcessControl::default();
+        process_control.mark_registration_settled();
+        Self {
+            completion_rx,
+            driver_complete: AtomicBool::new(true),
+            process_complete: AtomicBool::new(true),
+            process_control,
+            panel_local_id: None,
+            profile_cleanup: Mutex::new(ProfileCleanupState::Pending(profile_dir)),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn is_complete(&self) -> bool {
+        self.process_is_complete() && self.profile_cleanup_is_complete()
+    }
+
+    #[must_use]
+    pub(crate) fn wait(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        if !self.driver_complete.load(Ordering::Acquire) {
+            if !matches!(
+                self.completion_rx.recv_timeout(timeout),
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected)
+            ) {
+                return false;
+            }
+            self.driver_complete.store(true, Ordering::Release);
+        }
+        while !self.process_control.is_reaped() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        if !self.process_control.is_reaped() {
+            return false;
+        }
+        self.process_complete.store(true, Ordering::Release);
+        self.wait_for_profile_cleanup(deadline.saturating_duration_since(Instant::now()))
+    }
+
+    /// Emergency cleanup after the normal driver deadline. Returns only after
+    /// Chrome has been reaped (or no child was ever spawned) and any permanent
+    /// panel-close profile removal has finished.
+    #[must_use]
+    pub(crate) fn force_cleanup(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        if !self
+            .process_control
+            .terminate(deadline.saturating_duration_since(Instant::now()))
+        {
+            return false;
+        }
+        if let Some(panel_local_id) = &self.panel_local_id
+            && !crate::browser::manifest::remove_with_timeout(
+                panel_local_id,
+                deadline.saturating_duration_since(Instant::now()),
+            )
+        {
+            return false;
+        }
+        self.process_complete.store(true, Ordering::Release);
+        self.retry_failed_profile_cleanup_now();
+        self.wait_for_profile_cleanup(deadline.saturating_duration_since(Instant::now()))
+    }
+
+    fn process_is_complete(&self) -> bool {
+        if self.process_complete.load(Ordering::Acquire) {
+            return true;
+        }
+        let driver_complete = self.driver_complete.load(Ordering::Acquire)
+            || matches!(
+                self.completion_rx.try_recv(),
+                Ok(()) | Err(mpsc::TryRecvError::Disconnected)
+            );
+        if driver_complete {
+            self.driver_complete.store(true, Ordering::Release);
+        }
+        let complete = driver_complete && self.process_control.is_reaped();
+        if complete {
+            self.process_complete.store(true, Ordering::Release);
+        }
+        complete
+    }
+
+    fn profile_cleanup_is_complete(&self) -> bool {
+        let mut cleanup = self
+            .profile_cleanup
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        poll_profile_cleanup(&mut cleanup, None)
+    }
+
+    fn wait_for_profile_cleanup(&self, timeout: Duration) -> bool {
+        let mut cleanup = self
+            .profile_cleanup
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        poll_profile_cleanup(&mut cleanup, Some(timeout))
+    }
+
+    fn retry_failed_profile_cleanup_now(&self) {
+        let mut cleanup = self
+            .profile_cleanup
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::mem::replace(&mut *cleanup, ProfileCleanupState::NotRequired);
+        *cleanup = match previous {
+            ProfileCleanupState::RetryPending { profile_dir, .. } => ProfileCleanupState::Pending(profile_dir),
+            other => other,
+        };
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(completion_rx: mpsc::Receiver<()>) -> Self {
+        let process_control = ChromeProcessControl::default();
+        process_control.mark_registration_settled();
+        Self {
+            completion_rx,
+            driver_complete: AtomicBool::new(false),
+            process_complete: AtomicBool::new(false),
+            process_control,
+            panel_local_id: None,
+            profile_cleanup: Mutex::new(ProfileCleanupState::NotRequired),
+        }
+    }
+}
+
+fn start_profile_cleanup(cleanup: &mut ProfileCleanupState) {
+    let previous = std::mem::replace(cleanup, ProfileCleanupState::NotRequired);
+    let profile_dir = match previous {
+        ProfileCleanupState::Pending(profile_dir) => profile_dir,
+        ProfileCleanupState::RetryPending { profile_dir, retry_at } if Instant::now() >= retry_at => profile_dir,
+        other => {
+            *cleanup = other;
+            return;
+        }
+    };
+    let completion_rx = super::schedule_profile_removal(profile_dir.clone());
+    *cleanup = ProfileCleanupState::Running {
+        profile_dir,
+        completion_rx,
+    };
+}
+
+fn poll_profile_cleanup(cleanup: &mut ProfileCleanupState, timeout: Option<Duration>) -> bool {
+    start_profile_cleanup(cleanup);
+    let outcome = match cleanup {
+        ProfileCleanupState::NotRequired => return true,
+        ProfileCleanupState::Pending(_) | ProfileCleanupState::RetryPending { .. } => return false,
+        ProfileCleanupState::Running { completion_rx, .. } => match timeout {
+            Some(timeout) => match completion_rx.recv_timeout(timeout) {
+                Ok(result) => Some(result),
+                Err(mpsc::RecvTimeoutError::Timeout) => None,
+                Err(mpsc::RecvTimeoutError::Disconnected) => Some(Err(std::io::Error::other(
+                    "browser profile cleanup worker disconnected",
+                ))),
+            },
+            None => match completion_rx.try_recv() {
+                Ok(result) => Some(result),
+                Err(mpsc::TryRecvError::Empty) => None,
+                Err(mpsc::TryRecvError::Disconnected) => Some(Err(std::io::Error::other(
+                    "browser profile cleanup worker disconnected",
+                ))),
+            },
+        },
+    };
+    let Some(outcome) = outcome else {
+        return false;
+    };
+    match outcome {
+        Ok(()) => {
+            *cleanup = ProfileCleanupState::NotRequired;
+            true
+        }
+        Err(error) => {
+            let ProfileCleanupState::Running { profile_dir, .. } =
+                std::mem::replace(cleanup, ProfileCleanupState::NotRequired)
+            else {
+                return false;
+            };
+            tracing::warn!(path = %profile_dir.display(), "failed to remove browser profile: {error}");
+            *cleanup = ProfileCleanupState::RetryPending {
+                profile_dir,
+                retry_at: Instant::now() + PROFILE_CLEANUP_RETRY_DELAY,
+            };
+            false
+        }
+    }
+}
+
+/// Latest URL that the driver has observed Chrome commit. This survives the
+/// event receiver being dropped during shutdown so the panel can persist the
+/// driver's final state after teardown completes.
+#[derive(Clone, Default)]
+pub(super) struct CommittedUrl(Arc<Mutex<Option<String>>>);
+
+impl CommittedUrl {
+    pub(super) fn publish(&self, url: &str) {
+        *self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(url.to_string());
+    }
+
+    pub(super) fn snapshot(&self) -> Option<String> {
+        self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+    }
+}
+
+/// UI callback invoked after the driver queues an event. Keeping this generic
+/// avoids coupling core browser lifecycle code to egui while still allowing
+/// the native event loop to wake immediately from its idle backoff.
+pub type BrowserEventWaker = Arc<dyn Fn() + Send + Sync + 'static>;
+
+#[derive(Clone, Default)]
+struct BrowserEventWake {
+    callback: Arc<Mutex<Option<BrowserEventWaker>>>,
+}
+
+impl BrowserEventWake {
+    fn is_set(&self) -> bool {
+        self.callback
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+    }
+
+    fn set(&self, callback: BrowserEventWaker) {
+        *self.callback.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(callback);
+    }
+
+    fn wake(&self) {
+        let callback = self
+            .callback
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(callback) = callback {
+            callback();
+        }
+    }
+}
+
+struct BrowserEventSender {
+    tx: mpsc::Sender<BrowserEvent>,
+    wake: BrowserEventWake,
+    committed_url: CommittedUrl,
+}
+
+impl BrowserEventSender {
+    fn send(&self, event: BrowserEvent) -> Result<(), mpsc::SendError<BrowserEvent>> {
+        if let BrowserEvent::UrlChanged(url) = &event {
+            self.committed_url.publish(url);
+        }
+        self.tx.send(event)?;
+        self.wake.wake();
+        Ok(())
+    }
+}
+
+impl BrowserSession {
+    #[must_use]
+    pub fn send(&self, command: BrowserCommand) -> bool {
+        if matches!(command, BrowserCommand::Stop) {
+            self.stop_requested.store(true, Ordering::Release);
+        }
+        self.command_tx.send(command).is_ok()
+    }
+
+    pub fn set_event_waker(&self, callback: BrowserEventWaker) {
+        self.event_wake.set(callback);
+    }
+
+    #[must_use]
+    pub fn needs_event_waker(&self) -> bool {
+        !self.event_wake.is_set()
+    }
+
+    /// Send `Stop` and return the teardown-completion signal. The receiver
+    /// resolves once the driver has closed the `DevTools` connection, killed
+    /// Chrome, and removed the manifest.
+    #[must_use]
+    pub(crate) fn shutdown_signal(self) -> BrowserShutdownSignal {
+        self.stop_requested.store(true, Ordering::Release);
+        let _ = self.command_tx.send(BrowserCommand::Stop);
+        self.frame_slot.release_notification();
+        BrowserShutdownSignal {
+            completion_rx: self.completion_rx,
+            driver_complete: AtomicBool::new(false),
+            process_complete: AtomicBool::new(false),
+            process_control: self.process_control,
+            panel_local_id: Some(self.panel_local_id),
+            profile_cleanup: Mutex::new(ProfileCleanupState::NotRequired),
+        }
+    }
+
+    /// Return the existing teardown-completion signal after the driver has
+    /// already announced `Stopped`; no second stop request is necessary.
+    #[must_use]
+    pub(crate) fn completion_signal(self) -> BrowserShutdownSignal {
+        self.frame_slot.release_notification();
+        BrowserShutdownSignal {
+            completion_rx: self.completion_rx,
+            driver_complete: AtomicBool::new(false),
+            process_complete: AtomicBool::new(false),
+            process_control: self.process_control,
+            panel_local_id: Some(self.panel_local_id),
+            profile_cleanup: Mutex::new(ProfileCleanupState::NotRequired),
+        }
+    }
+
+    pub(super) fn committed_url(&self) -> CommittedUrl {
+        self.committed_url.clone()
+    }
+}
+
+fn publish_frame(event_tx: &BrowserEventSender, frame_slot: &FrameSlot, seq: u64) {
+    if frame_slot.claim_notification() && event_tx.send(BrowserEvent::Frame { seq }).is_err() {
+        frame_slot.release_notification();
+    }
+}
+
+const WS_URL_TIMEOUT: Duration = Duration::from_secs(15);
+const CALL_TIMEOUT: Duration = Duration::from_secs(5);
+const RESTART_BACKOFF: Duration = Duration::from_millis(250);
+const RESTART_BACKOFF_CAP: Duration = Duration::from_secs(1);
+const MAX_RESTART_ATTEMPTS: u32 = 8;
+const MANIFEST_MIN_INTERVAL: Duration = Duration::from_millis(200);
+const SIGNAL_MIN_INTERVAL: Duration = Duration::from_millis(250);
+/// Pointer-move storms rewrite the manifest on every event otherwise; the
+/// 5 s user-active TTL tolerates a 1 s refresh.
+const USER_ACTIVE_STAMP_INTERVAL: Duration = Duration::from_secs(1);
+/// Wait until a resize gesture settles before forcing one current-viewport
+/// screenshot. Chrome can update device metrics without emitting a
+/// screencast frame, which otherwise leaves the previous frame stretched.
+const VIEWPORT_CAPTURE_DELAY: Duration = Duration::from_millis(75);
+const VIEWPORT_RETRY_DELAY: Duration = Duration::from_millis(100);
+const TITLE_BINDING_NAME: &str = "__horizonBrowserTitleChanged";
+const TITLE_OBSERVER_SCRIPT: &str = r"(() => {
+    if (window !== top || window.__horizonBrowserTitleObserver) return;
+    let lastTitle;
+    const publish = () => {
+        const title = document.title;
+        if (title === lastTitle) return;
+        lastTitle = title;
+        window.__horizonBrowserTitleChanged(JSON.stringify({ title, href: location.href }));
+    };
+    const install = () => {
+        if (window.__horizonBrowserTitleObserver) return;
+        const root = document.head || document.documentElement;
+        if (!root) return;
+        const observer = new MutationObserver(publish);
+        observer.observe(root, { childList: true, characterData: true, subtree: true });
+        window.__horizonBrowserTitleObserver = observer;
+        publish();
+    };
+    if (document.documentElement) install();
+    else addEventListener('DOMContentLoaded', install, { once: true });
+})()";
+
+/// Spawn the driver thread. Browser startup problems are reported through
+/// the event channel rather than failing here.
+///
+/// # Errors
+/// Fails only when the OS thread cannot be spawned.
+pub fn start_session(config: BrowserSessionConfig) -> Result<BrowserSession, String> {
+    let frame_slot = config.frame_slot.clone();
+    let (command_tx, command_rx) = mpsc::channel::<BrowserCommand>();
+    let (raw_event_tx, event_rx) = mpsc::channel::<BrowserEvent>();
+    let event_wake = BrowserEventWake::default();
+    let committed_url = CommittedUrl::default();
+    let event_tx = BrowserEventSender {
+        tx: raw_event_tx,
+        wake: event_wake.clone(),
+        committed_url: committed_url.clone(),
+    };
+    let (completion_tx, completion_rx) = mpsc::channel::<()>();
+    let process_control = ChromeProcessControl::default();
+    let driver_process_control = process_control.clone();
+    let panel_local_id = config.panel_local_id.clone();
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    let driver_stop_requested = Arc::clone(&stop_requested);
+    let slot = Arc::clone(&frame_slot);
+    std::thread::Builder::new()
+        .name("browser-driver".into())
+        .spawn(move || {
+            run_driver(
+                &config,
+                &event_tx,
+                &command_rx,
+                &slot,
+                &driver_stop_requested,
+                completion_tx,
+                driver_process_control,
+            );
+        })
+        .map_err(|e| format!("failed to spawn browser driver: {e}"))?;
+    Ok(BrowserSession {
+        command_tx,
+        stop_requested,
+        frame_slot,
+        event_rx,
+        completion_rx,
+        event_wake,
+        committed_url,
+        process_control,
+        panel_local_id,
+    })
+}
+
+fn run_loop(
+    state: &mut DriverState,
+    chrome: &mut ChromeProcess,
+    link: &mut CdpLink,
+    command_rx: &mpsc::Receiver<BrowserCommand>,
+    frame_slot: &Arc<FrameSlot>,
+    event_tx: &BrowserEventSender,
+) {
+    loop {
+        // 1. Commands from the UI.
+        if state.drain_commands(link, command_rx, event_tx, frame_slot) {
+            state.capture_final_url(link, event_tx, frame_slot);
+            // Ask Chrome to exit cleanly so it marks its profile session
+            // complete (kill alone leaves a "crashed" state that makes the
+            // next launch restore stale tabs); the kill below is the
+            // fallback for an uncooperative process.
+            let outcome = link.call_and_drain(Duration::from_secs(1), "Browser.close", &serde_json::json!({}), None);
+            for message in outcome.drained {
+                state.handle_message(link, event_tx, frame_slot, message);
+            }
+            let _ = chrome.kill();
+            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+            break;
+        }
+
+        // 2. CDP messages: responses and events.
+        match link.read_one() {
+            Ok(Some(message)) => state.handle_message(link, event_tx, frame_slot, message),
+            Ok(None) => {}
+            Err(error) => {
+                // The connection is gone. Reconnecting a single panel's
+                // session is not worth the state surgery; surface the
+                // failure and stop — the panel offers Retry.
+                tracing::warn!(target: "browser", "cdp connection lost: {error}");
+                let _ = event_tx.send(BrowserEvent::Warning(format!("CDP connection lost: {error}")));
+                let _ = chrome.kill();
+                let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+                break;
+            }
+        }
+
+        // 3. Flush a pending throttled manifest write (the loop always
+        //    iterates, so a quiet page still gets its url/title flushed).
+        state.write_manifest(false);
+
+        // 3b. Delayed post-load title fetch.
+        state.tick_title_fetch(link, event_tx, frame_slot);
+
+        // 3c. Retry a transiently rejected viewport command, then capture one
+        //     fresh frame after the resize burst settles.
+        state.tick_viewport_resize(link, event_tx, frame_slot);
+        state.tick_viewport_capture(link);
+
+        // 4. Backoff-retried screencast restart / re-attach.
+        state.pending_restart_tick(link, event_tx, frame_slot);
+
+        // 5. Ownership / handoff signals from the manifest (agent side).
+        state.tick_signals(event_tx);
+
+        // 6. Chrome process liveness.
+        if let Some(status) = chrome.child_status() {
+            let _ = event_tx.send(BrowserEvent::Stopped { code: status.code() });
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Driver-side state machine for one page session.
+#[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)] // intentional: per-concern state flags
+struct DriverState {
+    config: BrowserSessionConfig,
+    browser_ws: String,
+    session_id: Option<String>,
+    target_id: Option<String>,
+    main_frame_id: Option<String>,
+    viewport_w: u32,
+    viewport_h: u32,
+    pending_viewport: Option<(u32, u32)>,
+    viewport_retry_at: Option<Instant>,
+    pending_viewport_capture_at: Option<Instant>,
+    viewport_capture_request_id: Option<u64>,
+    clipboard: ClipboardState,
+    url: String,
+    title: String,
+    initial_navigated: bool,
+    screencast_on: bool,
+    pending_restart_at: Option<Instant>,
+    /// Default execution context of the current document. After a
+    /// navigation, `Runtime.evaluate` without an explicit `contextId` can
+    /// still hit the old document's context for a while, so the title
+    /// fetch targets the latest default context explicitly.
+    title_context_id: Option<u64>,
+    /// `executionContextCreated` for the new document can land after
+    /// `loadEventFired`, so the post-load fetch is slightly delayed to let
+    /// the context tracking catch up first.
+    title_fetch_at: Option<Instant>,
+    /// Retries for a title fetch that still evaluated in the previous
+    /// document's execution context (detected via `location.href`).
+    title_fetch_retries: u32,
+    restart_attempts: u32,
+    pending_reattach: bool,
+    reattach_in_flight: bool,
+    reattach_request_id: Option<u64>,
+    /// Consecutive rejected re-attach attempts; surfaced as a retryable
+    /// error once re-attach clearly cannot succeed (dead target).
+    reattach_failures: u32,
+    last_manifest_write: Instant,
+    manifest_dirty: bool,
+    last_signal_check: Instant,
+    last_user_active_stamp: Option<Instant>,
+    owner_seen: Option<String>,
+    handoff_seen: Option<String>,
+    stop_requested: Arc<AtomicBool>,
+}
+
+impl DriverState {
+    fn new(config: &BrowserSessionConfig, browser_ws: &str, stop_requested: Arc<AtomicBool>) -> Self {
+        Self {
+            config: config.clone(),
+            browser_ws: browser_ws.to_string(),
+            session_id: None,
+            target_id: None,
+            main_frame_id: None,
+            viewport_w: config.width,
+            viewport_h: config.height,
+            pending_viewport: None,
+            viewport_retry_at: None,
+            pending_viewport_capture_at: None,
+            viewport_capture_request_id: None,
+            clipboard: ClipboardState::default(),
+            // The requested initial URL is not committed state. Chrome starts
+            // at about:blank and navigation may fail or be cancelled.
+            url: String::new(),
+            title: String::new(),
+            initial_navigated: false,
+            screencast_on: false,
+            pending_restart_at: None,
+            title_context_id: None,
+            title_fetch_at: None,
+            title_fetch_retries: 0,
+            restart_attempts: 0,
+            pending_reattach: false,
+            reattach_in_flight: false,
+            reattach_request_id: None,
+            reattach_failures: 0,
+            last_manifest_write: Instant::now(),
+            manifest_dirty: true,
+            last_signal_check: Instant::now(),
+            last_user_active_stamp: None,
+            owner_seen: None,
+            handoff_seen: None,
+            stop_requested,
+        }
+    }
+
+    /// `call_and_drain` plus full routing for everything drained while the
+    /// roundtrip is in flight: a `Page.screencastFrame` without an ack
+    /// stops the stream, dropping other drained events (title, load,
+    /// navigation commits) loses state Chrome already committed, and a
+    /// drained *response* may belong to another in-flight request (notably
+    /// a re-attach roundtrip) whose state machine would otherwise never
+    /// hear back.
+    fn call_and_ack(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        method: &str,
+        params: &serde_json::Value,
+        session: Option<&str>,
+    ) -> Result<serde_json::Value, crate::browser::cdp::CdpError> {
+        let stop_requested = Arc::clone(&self.stop_requested);
+        let outcome = link.call_and_drain_until(CALL_TIMEOUT, method, params, session, || {
+            stop_requested.load(Ordering::Acquire)
+        });
+        for message in outcome.drained {
+            self.handle_message(link, event_tx, frame_slot, message);
+        }
+        outcome.result
+    }
+
+    /// Freeze an in-flight navigation, route every event received while that
+    /// happens, then ask the target for its authoritative committed URL.
+    fn capture_final_url(&mut self, link: &mut CdpLink, event_tx: &BrowserEventSender, frame_slot: &Arc<FrameSlot>) {
+        if let Some(session_id) = self.session_id.clone() {
+            let outcome = link.call_and_drain(
+                Duration::from_secs(1),
+                "Page.stopLoading",
+                &serde_json::json!({}),
+                Some(session_id.as_str()),
+            );
+            for message in outcome.drained {
+                self.handle_message(link, event_tx, frame_slot, message);
+            }
+        }
+        let Some(target_id) = self.target_id.clone() else {
+            return;
+        };
+        let outcome = link.call_and_drain(
+            Duration::from_secs(1),
+            "Target.getTargetInfo",
+            &serde_json::json!({ "targetId": target_id }),
+            None,
+        );
+        for message in outcome.drained {
+            self.handle_message(link, event_tx, frame_slot, message);
+        }
+        let Some(target_url) = outcome.result.ok().and_then(|result| {
+            result
+                .pointer("/targetInfo/url")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        }) else {
+            return;
+        };
+        let url = normalized_committed_url(&target_url).to_string();
+        if self.url != url {
+            self.url = url;
+            self.manifest_dirty = true;
+            self.write_manifest(true);
+        }
+        let _ = event_tx.send(BrowserEvent::UrlChanged(self.url.clone()));
+    }
+
+    fn send_page_command(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        method: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value, CdpError> {
+        let Some(session) = self.session_id.clone() else {
+            return Err(CdpError::NoPageSession {
+                method: method.to_string(),
+            });
+        };
+        self.call_and_ack(link, event_tx, frame_slot, method, params, Some(session.as_str()))
+    }
+
+    fn navigate_to(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        url: &str,
+    ) {
+        let result = self.send_page_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Page.navigate",
+            &serde_json::json!({ "url": url }),
+        );
+        match result {
+            Ok(result) => {
+                if let Some(error) = result.get("errorText").and_then(serde_json::Value::as_str)
+                    && !error.is_empty()
+                {
+                    let _ = event_tx.send(BrowserEvent::NavigationFailed(format!(
+                        "could not navigate to {url}: {error}"
+                    )));
+                    return;
+                }
+                // The committed URL remains authoritative and arrives via a
+                // navigation event. Do not overwrite it with a merely
+                // requested value.
+                self.pending_restart_at = Some(Instant::now());
+                let _ = event_tx.send(BrowserEvent::Loading(true));
+            }
+            Err(error) => {
+                let _ = event_tx.send(BrowserEvent::NavigationFailed(format!(
+                    "could not navigate to {url}: {error}"
+                )));
+            }
+        }
+    }
+}
+
+fn normalized_committed_url(url: &str) -> &str {
+    if url.is_empty() || url == "about:blank" {
+        ""
+    } else {
+        url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn queued_browser_events_wake_the_registered_ui_callback() {
+        let wake_count = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::clone(&wake_count);
+        let wake = BrowserEventWake::default();
+        wake.set(Arc::new(move || {
+            counted.fetch_add(1, Ordering::Relaxed);
+        }));
+        let (tx, rx) = mpsc::channel();
+        let sender = BrowserEventSender {
+            tx,
+            wake,
+            committed_url: CommittedUrl::default(),
+        };
+
+        assert!(sender.send(BrowserEvent::Ready).is_ok());
+        assert_eq!(rx.recv(), Ok(BrowserEvent::Ready));
+        assert_eq!(wake_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn committed_url_survives_a_dropped_event_receiver() {
+        let committed_url = CommittedUrl::default();
+        let (tx, rx) = mpsc::channel();
+        let sender = BrowserEventSender {
+            tx,
+            wake: BrowserEventWake::default(),
+            committed_url: committed_url.clone(),
+        };
+        drop(rx);
+
+        assert!(
+            sender
+                .send(BrowserEvent::UrlChanged("https://example.com/final".to_string()))
+                .is_err()
+        );
+        assert_eq!(committed_url.snapshot().as_deref(), Some("https://example.com/final"));
+    }
+
+    #[test]
+    fn blank_target_is_an_empty_committed_url() {
+        assert_eq!(normalized_committed_url("about:blank"), "");
+        assert_eq!(normalized_committed_url(""), "");
+        assert_eq!(normalized_committed_url("https://example.com"), "https://example.com");
+    }
+}

--- a/crates/horizon-core/src/browser/session/clipboard.rs
+++ b/crates/horizon-core/src/browser/session/clipboard.rs
@@ -1,0 +1,275 @@
+//! Frame-aware page-selection capture for the host clipboard bridge.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::browser::cdp::{CdpErrorInfo, CdpEvent, CdpLink};
+
+use super::{BrowserEvent, BrowserEventSender, DriverState};
+
+// Evaluate inside each frame's own default execution context. Reaching into
+// `iframe.contentDocument` from the top document would fail for cross-origin
+// frames, and returning early for an active iframe avoids copying a stale
+// selection from an ancestor document.
+const SELECTED_TEXT_EXPRESSION: &str = r#"(() => {
+  if (!document.hasFocus()) return "";
+  const active = document.activeElement;
+  if (active?.tagName === "IFRAME") return "";
+  if (active && active.type !== "password" && typeof active.value === "string"
+      && Number.isInteger(active.selectionStart) && Number.isInteger(active.selectionEnd)) {
+    return active.value.slice(active.selectionStart, active.selectionEnd);
+  }
+  return document.getSelection()?.toString() || "";
+})()"#;
+
+#[derive(Debug, Default)]
+pub(super) struct ClipboardState {
+    request_ids: HashSet<u64>,
+    default_contexts: HashMap<String, HashSet<u64>>,
+    iframe_sessions: HashSet<String>,
+}
+
+impl ClipboardState {
+    fn evaluation_targets(&self, page_session: &str) -> Vec<(String, Option<u64>)> {
+        let sessions = std::iter::once(page_session).chain(self.iframe_sessions.iter().map(String::as_str));
+        let mut targets = Vec::new();
+        for session in sessions {
+            match self.default_contexts.get(session) {
+                Some(contexts) if !contexts.is_empty() => {
+                    targets.extend(contexts.iter().map(|context| (session.to_string(), Some(*context))));
+                }
+                _ => targets.push((session.to_string(), None)),
+            }
+        }
+        targets
+    }
+
+    fn reset(&mut self) {
+        self.request_ids.clear();
+        self.default_contexts.clear();
+        self.iframe_sessions.clear();
+    }
+}
+
+impl DriverState {
+    pub(super) fn request_clipboard_text(&mut self, link: &mut CdpLink) {
+        let Some(page_session) = self.session_id.as_deref() else {
+            return;
+        };
+        for (session, context_id) in self.clipboard.evaluation_targets(page_session) {
+            let mut params = serde_json::json!({
+                "expression": SELECTED_TEXT_EXPRESSION,
+                "returnByValue": true,
+            });
+            if let Some(context_id) = context_id {
+                params["contextId"] = serde_json::json!(context_id);
+            }
+            match link.send_request("Runtime.evaluate", &params, Some(session.as_str())) {
+                Ok(request_id) => {
+                    self.clipboard.request_ids.insert(request_id);
+                }
+                Err(error) => tracing::debug!(
+                    target: "browser",
+                    session,
+                    "clipboard selection capture failed: {error}"
+                ),
+            }
+        }
+    }
+
+    pub(super) fn handle_clipboard_response(
+        &mut self,
+        id: u64,
+        result: Option<&serde_json::Value>,
+        error: Option<&CdpErrorInfo>,
+        event_tx: &BrowserEventSender,
+    ) -> bool {
+        if !self.clipboard.request_ids.remove(&id) {
+            return false;
+        }
+        if let Some(error) = error {
+            tracing::debug!(target: "browser", "clipboard selection capture rejected: {error}");
+        } else if let Some(text) = clipboard_text_from_evaluation(result)
+            && !text.is_empty()
+        {
+            let _ = event_tx.send(BrowserEvent::ClipboardText(text.to_string()));
+        }
+        true
+    }
+
+    pub(super) fn note_clipboard_execution_context(&mut self, event: &CdpEvent<'_>) {
+        let Some(session) = event.session_id else {
+            return;
+        };
+        let tracked_session =
+            self.session_id.as_deref() == Some(session) || self.clipboard.iframe_sessions.contains(session);
+        if !tracked_session {
+            return;
+        }
+        match event.method {
+            "Runtime.executionContextCreated" => {
+                if let Some(context_id) = default_context_id(event.params) {
+                    self.clipboard
+                        .default_contexts
+                        .entry(session.to_string())
+                        .or_default()
+                        .insert(context_id);
+                }
+            }
+            "Runtime.executionContextDestroyed" => {
+                if let Some(context_id) = event
+                    .params
+                    .get("executionContextId")
+                    .and_then(serde_json::Value::as_u64)
+                    && let Some(contexts) = self.clipboard.default_contexts.get_mut(session)
+                {
+                    contexts.remove(&context_id);
+                }
+            }
+            "Runtime.executionContextsCleared" => {
+                self.clipboard.default_contexts.remove(session);
+            }
+            _ => {}
+        }
+    }
+
+    /// Record an auto-attached out-of-process iframe and enable its Runtime
+    /// domain so subsequent selection capture can target its default contexts.
+    /// Returns whether this was an iframe attachment consumed by this path.
+    pub(super) fn note_clipboard_target_attachment(&mut self, link: &mut CdpLink, event: &CdpEvent<'_>) -> bool {
+        if attached_target_type(event.params) != Some("iframe") {
+            return false;
+        }
+        let Some(session) = target_event_session_id(event.params, event.session_id) else {
+            return true;
+        };
+        if self.clipboard.iframe_sessions.insert(session.to_string()) {
+            if let Err(error) = link.send_request(
+                "Target.setAutoAttach",
+                &serde_json::json!({
+                    "autoAttach": true,
+                    "waitForDebuggerOnStart": false,
+                    "flatten": true,
+                }),
+                Some(session),
+            ) {
+                tracing::debug!(target: "browser", session, "failed to auto-attach nested iframe targets: {error}");
+            }
+            if let Err(error) = link.send_request("Runtime.enable", &serde_json::json!({}), Some(session)) {
+                tracing::debug!(target: "browser", session, "failed to enable iframe runtime: {error}");
+            }
+        }
+        true
+    }
+
+    pub(super) fn note_clipboard_target_detachment(&mut self, event: &CdpEvent<'_>) {
+        let Some(session) = target_event_session_id(event.params, event.session_id) else {
+            return;
+        };
+        self.clipboard.iframe_sessions.remove(session);
+        self.clipboard.default_contexts.remove(session);
+    }
+
+    pub(super) fn reset_clipboard_tracking(&mut self) {
+        self.clipboard.reset();
+    }
+}
+
+fn default_context_id(params: &serde_json::Value) -> Option<u64> {
+    let context = params.get("context")?;
+    context
+        .pointer("/auxData/isDefault")?
+        .as_bool()?
+        .then(|| context.get("id")?.as_u64())?
+}
+
+fn attached_target_type(params: &serde_json::Value) -> Option<&str> {
+    params.pointer("/targetInfo/type")?.as_str()
+}
+
+pub(super) fn target_event_session_id<'a>(
+    params: &'a serde_json::Value,
+    event_session: Option<&'a str>,
+) -> Option<&'a str> {
+    params
+        .get("sessionId")
+        .and_then(serde_json::Value::as_str)
+        .or(event_session)
+}
+
+fn clipboard_text_from_evaluation(result: Option<&serde_json::Value>) -> Option<&str> {
+    result?.pointer("/result/value")?.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::{ClipboardState, clipboard_text_from_evaluation, default_context_id, target_event_session_id};
+
+    #[test]
+    fn frame_targets_cover_page_contexts_and_out_of_process_iframe_sessions() {
+        let mut state = ClipboardState::default();
+        state.default_contexts.insert("page".to_string(), HashSet::from([7, 8]));
+        state.iframe_sessions.insert("oopif".to_string());
+        state.default_contexts.insert("oopif".to_string(), HashSet::from([11]));
+
+        let targets = state.evaluation_targets("page").into_iter().collect::<HashSet<_>>();
+
+        assert_eq!(
+            targets,
+            HashSet::from([
+                ("page".to_string(), Some(7)),
+                ("page".to_string(), Some(8)),
+                ("oopif".to_string(), Some(11)),
+            ])
+        );
+    }
+
+    #[test]
+    fn an_iframe_session_without_reported_contexts_uses_its_default_world() {
+        let mut state = ClipboardState::default();
+        state.iframe_sessions.insert("oopif".to_string());
+
+        let targets = state.evaluation_targets("page").into_iter().collect::<HashSet<_>>();
+
+        assert_eq!(
+            targets,
+            HashSet::from([("page".to_string(), None), ("oopif".to_string(), None)])
+        );
+    }
+
+    #[test]
+    fn only_default_execution_contexts_are_clipboard_candidates() {
+        let default = serde_json::json!({
+            "context": { "id": 7, "auxData": { "isDefault": true, "frameId": "child" } }
+        });
+        let isolated = serde_json::json!({
+            "context": { "id": 8, "auxData": { "isDefault": false, "frameId": "child" } }
+        });
+
+        assert_eq!(default_context_id(&default), Some(7));
+        assert_eq!(default_context_id(&isolated), None);
+        assert_eq!(default_context_id(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn target_events_prefer_the_attached_or_detached_session_parameter() {
+        let params = serde_json::json!({ "sessionId": "child" });
+
+        assert_eq!(target_event_session_id(&params, Some("parent")), Some("child"));
+        assert_eq!(
+            target_event_session_id(&serde_json::json!({}), Some("parent")),
+            Some("parent")
+        );
+    }
+
+    #[test]
+    fn clipboard_text_reads_runtime_evaluation_values_only() {
+        let value = serde_json::json!({ "result": { "type": "string", "value": "selected" } });
+        let exception = serde_json::json!({ "exceptionDetails": { "text": "failed" } });
+
+        assert_eq!(clipboard_text_from_evaluation(Some(&value)), Some("selected"));
+        assert_eq!(clipboard_text_from_evaluation(Some(&exception)), None);
+        assert_eq!(clipboard_text_from_evaluation(None), None);
+    }
+}

--- a/crates/horizon-core/src/browser/session/commands.rs
+++ b/crates/horizon-core/src/browser/session/commands.rs
@@ -1,6 +1,7 @@
 //! UI-command handling for the browser driver: navigation, viewport, input,
 //! activity stamping, and stop/handoff requests.
 
+use std::sync::mpsc::TryRecvError;
 use std::sync::{Arc, mpsc};
 use std::time::Instant;
 
@@ -22,7 +23,15 @@ impl DriverState {
         event_tx: &BrowserEventSender,
         frame_slot: &Arc<FrameSlot>,
     ) -> bool {
-        while let Ok(command) = command_rx.try_recv() {
+        loop {
+            let command = match command_rx.try_recv() {
+                Ok(command) => command,
+                Err(TryRecvError::Empty) => break,
+                // The last command sender dropped without sending Stop: no
+                // one left to service, so stop instead of spinning forever
+                // with the driver thread, Chrome, and profile lock alive.
+                Err(TryRecvError::Disconnected) => return true,
+            };
             match command {
                 BrowserCommand::Stop => return true,
                 BrowserCommand::Navigate(url) => self.navigate_to(link, event_tx, frame_slot, &url),

--- a/crates/horizon-core/src/browser/session/commands.rs
+++ b/crates/horizon-core/src/browser/session/commands.rs
@@ -1,0 +1,298 @@
+//! UI-command handling for the browser driver: navigation, viewport, input,
+//! activity stamping, and stop/handoff requests.
+
+use std::sync::{Arc, mpsc};
+use std::time::Instant;
+
+use crate::browser::cdp::CdpLink;
+use crate::browser::frames::FrameSlot;
+use crate::browser::manifest;
+
+use super::{
+    BrowserCommand, BrowserEventSender, DriverState, USER_ACTIVE_STAMP_INTERVAL, VIEWPORT_CAPTURE_DELAY,
+    VIEWPORT_RETRY_DELAY,
+};
+
+impl DriverState {
+    /// Process every pending UI command. Returns `true` when `Stop` arrived.
+    pub(super) fn drain_commands(
+        &mut self,
+        link: &mut CdpLink,
+        command_rx: &mpsc::Receiver<BrowserCommand>,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) -> bool {
+        while let Ok(command) = command_rx.try_recv() {
+            match command {
+                BrowserCommand::Stop => return true,
+                BrowserCommand::Navigate(url) => self.navigate_to(link, event_tx, frame_slot, &url),
+                BrowserCommand::Reload => {
+                    self.pending_restart_at = Some(Instant::now());
+                    let _ = self.send_page_command(link, event_tx, frame_slot, "Page.reload", &serde_json::json!({}));
+                }
+                BrowserCommand::Back => self.navigate_history(link, event_tx, frame_slot, -1),
+                BrowserCommand::Forward => self.navigate_history(link, event_tx, frame_slot, 1),
+                BrowserCommand::SetViewport { width, height } => {
+                    self.set_viewport(link, event_tx, frame_slot, width, height);
+                }
+                BrowserCommand::Input(input) => {
+                    // Input cannot block on a roundtrip: a detaching session
+                    // would otherwise stall every frame for the call timeout.
+                    let is_activity = input.is_activity();
+                    if input.copies_selection() {
+                        self.request_clipboard_text(link);
+                    }
+                    let (method, params) = input.cdp();
+                    if let Some(session) = self.session_id.clone() {
+                        let _ = link.send_request(method, &params, Some(session.as_str()));
+                    }
+                    if is_activity {
+                        self.stamp_user_active();
+                    }
+                }
+                BrowserCommand::HandoffDone => self.resolve_handoff(event_tx),
+            }
+        }
+        false
+    }
+
+    fn set_viewport(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        width: u32,
+        height: u32,
+    ) {
+        if !self.queue_viewport(width, height) {
+            return;
+        }
+        self.apply_pending_viewport(link, event_tx, frame_slot);
+    }
+
+    fn queue_viewport(&mut self, width: u32, height: u32) -> bool {
+        if width == 0 || height == 0 {
+            return false;
+        }
+        if (width, height) == (self.viewport_w, self.viewport_h) {
+            self.pending_viewport = None;
+            self.viewport_retry_at = None;
+            return false;
+        }
+        self.pending_viewport = Some((width, height));
+        self.viewport_retry_at = None;
+        true
+    }
+
+    pub(super) fn tick_viewport_resize(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        if self.pending_viewport.is_none() || self.viewport_retry_at.is_some_and(|retry_at| Instant::now() < retry_at) {
+            return;
+        }
+        self.apply_pending_viewport(link, event_tx, frame_slot);
+    }
+
+    fn apply_pending_viewport(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        let Some((width, height)) = self.pending_viewport else {
+            return;
+        };
+        match self.send_page_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Emulation.setDeviceMetricsOverride",
+            &serde_json::json!({
+                "width": width,
+                "height": height,
+                "deviceScaleFactor": 1,
+                "mobile": false,
+            }),
+        ) {
+            Ok(_) => {
+                self.commit_viewport(width, height);
+                self.pending_viewport_capture_at = Some(Instant::now() + VIEWPORT_CAPTURE_DELAY);
+            }
+            Err(error) => {
+                self.viewport_retry_at = Some(Instant::now() + VIEWPORT_RETRY_DELAY);
+                tracing::debug!(
+                    target: "browser",
+                    width,
+                    height,
+                    "viewport resize failed and will retry: {error}"
+                );
+            }
+        }
+    }
+
+    fn commit_viewport(&mut self, width: u32, height: u32) {
+        self.viewport_w = width;
+        self.viewport_h = height;
+        self.pending_viewport = None;
+        self.viewport_retry_at = None;
+    }
+
+    /// Chrome sometimes applies device metrics without emitting a new
+    /// screencast frame. Capture exactly once after a resize burst settles;
+    /// the asynchronous response is published by `handle_message`.
+    pub(super) fn tick_viewport_capture(&mut self, link: &mut CdpLink) {
+        if self.viewport_capture_request_id.is_some() {
+            return;
+        }
+        let Some(due) = self.pending_viewport_capture_at else {
+            return;
+        };
+        if Instant::now() < due {
+            return;
+        }
+        self.pending_viewport_capture_at = None;
+        let Some(session) = self.session_id.clone() else {
+            return;
+        };
+        match link.send_request(
+            "Page.captureScreenshot",
+            &serde_json::json!({
+                "format": "jpeg",
+                "quality": self.config.browser.quality,
+                "fromSurface": true,
+                "captureBeyondViewport": false,
+            }),
+            Some(session.as_str()),
+        ) {
+            Ok(request_id) => self.viewport_capture_request_id = Some(request_id),
+            Err(error) => tracing::debug!(target: "browser", "viewport frame capture failed: {error}"),
+        }
+    }
+
+    /// `History.back`/`forward` are JavaScript, not CDP: step through the
+    /// page's navigation history explicitly instead.
+    fn navigate_history(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        delta: i64,
+    ) {
+        let Some(session) = self.session_id.clone() else {
+            return;
+        };
+        let Ok(history) = self.call_and_ack(
+            link,
+            event_tx,
+            frame_slot,
+            "Page.getNavigationHistory",
+            &serde_json::json!({}),
+            Some(session.as_str()),
+        ) else {
+            return;
+        };
+        let Some(current) = history.get("currentIndex").and_then(serde_json::Value::as_i64) else {
+            return;
+        };
+        let Some(entries) = history.get("entries").and_then(serde_json::Value::as_array) else {
+            return;
+        };
+        let Some(last) = i64::try_from(entries.len()).ok().and_then(|len| len.checked_sub(1)) else {
+            return;
+        };
+        let target = (current + delta).clamp(0, last);
+        if target == current {
+            return;
+        }
+        let entry_index = usize::try_from(target).unwrap_or(0);
+        // Chrome returns `id`; the request calls the same value `entryId`.
+        let entry_value = &entries[entry_index];
+        let Some(entry_id) = entry_value
+            .get("entryId")
+            .or_else(|| entry_value.get("id"))
+            .and_then(serde_json::Value::as_i64)
+        else {
+            return;
+        };
+        self.pending_restart_at = Some(Instant::now());
+        let _ = self.send_page_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Page.navigateToHistoryEntry",
+            &serde_json::json!({ "entryId": entry_id }),
+        );
+    }
+
+    /// Stamp the manifest so an agent can tell the user is driving right now.
+    fn stamp_user_active(&mut self) {
+        if self
+            .last_user_active_stamp
+            .is_some_and(|last_stamp| last_stamp.elapsed() < USER_ACTIVE_STAMP_INTERVAL)
+        {
+            return;
+        }
+        let stamped_at = Instant::now();
+        match self.write_manifest_extra(true, |manifest| {
+            manifest.user_active = true;
+            manifest.user_active_at = manifest::now_millis();
+        }) {
+            Ok(()) => self.last_user_active_stamp = Some(stamped_at),
+            Err(error) => tracing::warn!(target: "browser", "failed to stamp user activity: {error}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    use crate::browser::frames::FrameSlot;
+    use crate::browser::{BrowserConfig, session::BrowserSessionConfig};
+
+    use super::DriverState;
+
+    fn driver_state() -> DriverState {
+        DriverState::new(
+            &BrowserSessionConfig {
+                browser: BrowserConfig::default(),
+                panel_local_id: "panel-1".to_string(),
+                initial_url: None,
+                width: 1280,
+                height: 800,
+                frame_slot: Arc::new(FrameSlot::new()),
+            },
+            "ws://127.0.0.1/devtools/browser/test",
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    #[test]
+    fn viewport_resize_becomes_authoritative_only_after_acknowledgement() {
+        let mut state = driver_state();
+
+        assert!(state.queue_viewport(900, 600));
+        assert_eq!((state.viewport_w, state.viewport_h), (1280, 800));
+        assert_eq!(state.pending_viewport, Some((900, 600)));
+
+        state.commit_viewport(900, 600);
+
+        assert_eq!((state.viewport_w, state.viewport_h), (900, 600));
+        assert_eq!(state.pending_viewport, None);
+    }
+
+    #[test]
+    fn latest_viewport_request_replaces_a_pending_retry() {
+        let mut state = driver_state();
+
+        assert!(state.queue_viewport(900, 600));
+        assert!(state.queue_viewport(720, 480));
+
+        assert_eq!((state.viewport_w, state.viewport_h), (1280, 800));
+        assert_eq!(state.pending_viewport, Some((720, 480)));
+    }
+}

--- a/crates/horizon-core/src/browser/session/events.rs
+++ b/crates/horizon-core/src/browser/session/events.rs
@@ -1,0 +1,562 @@
+//! CDP event handling for the driver state machine: target binding, page
+//! navigation and title tracking, and screencast lifecycle.
+//!
+//! Split out of the driver loop ([super]) — the event arms are the
+//! state machine's reactive half, while the parent module keeps the loop,
+//! command drain, and manifest/signal plumbing.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::browser::cdp::{CdpEvent, CdpLink, CdpMsg};
+use crate::browser::frames::FrameSlot;
+
+use super::clipboard::target_event_session_id;
+use super::{
+    BrowserEvent, BrowserEventSender, DriverState, TITLE_BINDING_NAME, normalized_committed_url, publish_frame,
+};
+
+impl DriverState {
+    pub(super) fn tick_title_fetch(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        let Some(due) = self.title_fetch_at else {
+            return;
+        };
+        if Instant::now() < due {
+            return;
+        }
+        self.title_fetch_at = None;
+        self.fetch_title(link, event_tx, frame_slot);
+    }
+
+    /// Best-effort current title for initial attach and navigation, where a
+    /// browser-level target-info change may not have been observed yet.
+    pub(super) fn fetch_title(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        let Some(session) = self.session_id.clone() else {
+            return;
+        };
+        // Fetch title and href together: after a navigation the session's
+        // execution context can still be the *previous* document's, so a
+        // bare `document.title` read can return the old page's title. The
+        // href check detects that and schedules a retry.
+        let params = match self.title_context_id {
+            Some(context_id) => serde_json::json!({
+                "expression": "JSON.stringify({ t: document.title, h: location.href })",
+                "returnByValue": true,
+                "contextId": context_id,
+            }),
+            None => serde_json::json!({
+                "expression": "JSON.stringify({ t: document.title, h: location.href })",
+                "returnByValue": true,
+            }),
+        };
+        let Ok(result) = self.call_and_ack(
+            link,
+            event_tx,
+            frame_slot,
+            "Runtime.evaluate",
+            &params,
+            Some(session.as_str()),
+        ) else {
+            return;
+        };
+        let Some(payload) = result.pointer("/result/value").and_then(|v| v.as_str()) else {
+            return;
+        };
+        let Ok(parsed) = serde_json::from_str::<serde_json::Value>(payload) else {
+            return;
+        };
+        let Some(href) = parsed.pointer("/h").and_then(|v| v.as_str()) else {
+            return;
+        };
+        if !href_matches_url(href, &self.url) {
+            if self.title_fetch_retries < 10 {
+                self.title_fetch_retries += 1;
+                self.title_fetch_at = Some(Instant::now() + Duration::from_millis(500));
+            }
+            return;
+        }
+        let Some(title) = parsed.pointer("/t").and_then(|v| v.as_str()) else {
+            return;
+        };
+        self.update_title(event_tx, title);
+    }
+
+    fn update_title(&mut self, event_tx: &BrowserEventSender, title: &str) {
+        if title == self.title {
+            return;
+        }
+        self.title = title.to_string();
+        self.manifest_dirty = true;
+        self.write_manifest(false);
+        let _ = event_tx.send(BrowserEvent::Title(title.to_string()));
+    }
+
+    /// Track the top-level document's default execution context for the
+    /// title fetch. Iframes also publish `isDefault` contexts, so their
+    /// `frameId` must not replace the context used for page metadata.
+    fn note_execution_context(&mut self, event: &CdpEvent<'_>) {
+        if event.method == "Runtime.executionContextCreated"
+            && let Some(id) = default_context_id_for_frame(event.params, self.main_frame_id.as_deref())
+        {
+            self.title_context_id = Some(id);
+        } else if event.method == "Runtime.executionContextsCleared" {
+            self.title_context_id = None;
+        } else if let Some(id) = event
+            .params
+            .get("executionContextId")
+            .and_then(serde_json::Value::as_u64)
+            && self.title_context_id == Some(id)
+        {
+            self.title_context_id = None;
+        }
+    }
+
+    pub(super) fn handle_message(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        message: CdpMsg,
+    ) {
+        if let Some(event) = message.event() {
+            self.handle_event(link, event_tx, frame_slot, event);
+            return;
+        }
+        let CdpMsg::Response { id, result, error, .. } = message else {
+            return;
+        };
+        if self.handle_clipboard_response(id, result.as_ref(), error.as_ref(), event_tx) {
+            return;
+        }
+        if self.viewport_capture_request_id == Some(id) {
+            self.viewport_capture_request_id = None;
+            if let Some(error) = error {
+                tracing::debug!(target: "browser", "viewport frame capture rejected: {error}");
+                return;
+            }
+            let Some(data) = result
+                .as_ref()
+                .and_then(|value| value.get("data"))
+                .and_then(serde_json::Value::as_str)
+            else {
+                return;
+            };
+            if let Some(seq) = frame_slot.store_base64_jpeg(data) {
+                publish_frame(event_tx, frame_slot, seq);
+            }
+            return;
+        }
+        // Fire-and-forget input/ack responses also carry ids; only the
+        // exact re-attach request may consume the in-flight flag.
+        if self.reattach_in_flight && Some(id) == self.reattach_request_id {
+            self.reattach_in_flight = false;
+            self.reattach_request_id = None;
+            if let Some(error) = error {
+                tracing::warn!(target: "browser", "re-attach rejected: {error}");
+                self.note_reattach_failure(event_tx, &error.to_string());
+                return;
+            }
+            self.reattach_failures = 0;
+            // The auto-attach event may already have re-bound us;
+            // only the first binder sets up the page.
+            if self.session_id.is_none()
+                && let Some(session) = result
+                    .as_ref()
+                    .and_then(|r| r.get("sessionId"))
+                    .and_then(|s| s.as_str())
+                && let Some(target) = self.target_id.clone()
+            {
+                self.attach_setup(link, event_tx, frame_slot, session, &target);
+            }
+            return;
+        }
+        if let Some(error) = error {
+            tracing::debug!(target: "browser", "cdp response error id={id}: {error}");
+        }
+    }
+
+    pub(super) fn handle_event(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        event: CdpEvent<'_>,
+    ) {
+        let on_page_session = event.session_id.is_some_and(|s| Some(s) == self.session_id.as_deref());
+        match event.method {
+            "Target.attachedToTarget" => {
+                if self.note_clipboard_target_attachment(link, &event) {
+                    return;
+                }
+                // Popups and agent-opened tabs must not steal the binding;
+                // it is only replaced after it dies or a forced re-attach.
+                if self.session_id.is_some() {
+                    return;
+                }
+                let Some(session) = event.session_id else {
+                    return;
+                };
+                let Some(target_id) = attached_bound_page_target(event.params, self.target_id.as_deref()) else {
+                    return;
+                };
+                self.attach_setup(link, event_tx, frame_slot, session, target_id);
+            }
+            "Target.detachedFromTarget" => {
+                self.note_clipboard_target_detachment(&event);
+                if target_event_session_id(event.params, event.session_id) == self.session_id.as_deref() {
+                    self.session_id = None;
+                    self.screencast_on = false;
+                    self.pending_viewport_capture_at = None;
+                    self.viewport_capture_request_id = None;
+                    self.reset_clipboard_tracking();
+                    // Drop the tracked context: the next title fetch must
+                    // use a fresh default context, not a dead contextId.
+                    self.title_context_id = None;
+                    self.main_frame_id = None;
+                    self.title_fetch_at = None;
+                    self.title_fetch_retries = 0;
+                    // Unexpected detach (the driver never detaches its own
+                    // page session): the target usually still exists —
+                    // re-bind instead of freezing. `pending_restart_tick`
+                    // acts on this on the next loop pass; a target that is
+                    // actually gone surfaces through targetDestroyed.
+                    self.pending_reattach = true;
+                }
+            }
+            "Target.targetDestroyed" => {
+                let destroyed = event.params.get("targetId").and_then(|t| t.as_str());
+                if self.forget_destroyed_bound_target(destroyed) {
+                    // External agents discover the page through this field.
+                    // Clear it synchronously so a destroyed target is not
+                    // advertised as a live endpoint after this event.
+                    self.write_manifest(true);
+                    // The page is gone (tab closed by another CDP client,
+                    // navigation to a new target, …). Re-attach has
+                    // nothing to bind to: surface a retryable error
+                    // instead of silently ignoring input on a frozen frame.
+                    frame_slot.clear();
+                    let _ = event_tx.send(BrowserEvent::Warning(
+                        "the page target was destroyed; retry to reattach".to_string(),
+                    ));
+                }
+            }
+            "Target.targetInfoChanged" => {
+                if let Some(title) = title_for_bound_target(event.params, self.target_id.as_deref()) {
+                    self.update_title(event_tx, title);
+                }
+            }
+            "Runtime.bindingCalled" => {
+                if on_page_session
+                    && let Some((title, href)) = title_from_binding(event.params)
+                    && href_matches_url(&href, &self.url)
+                {
+                    self.update_title(event_tx, &title);
+                }
+            }
+            "Page.frameNavigated" => self.handle_frame_navigated(event_tx, event, on_page_session),
+            "Page.navigatedWithinDocument" => {
+                self.handle_same_document_navigation(event_tx, event, on_page_session);
+            }
+            "Page.loadEventFired" => {
+                if on_page_session {
+                    let _ = event_tx.send(BrowserEvent::Loading(false));
+                    self.title_fetch_retries = 0;
+                    self.title_fetch_at = Some(Instant::now() + Duration::from_millis(400));
+                }
+            }
+            "Runtime.executionContextCreated"
+            | "Runtime.executionContextDestroyed"
+            | "Runtime.executionContextsCleared" => {
+                if on_page_session {
+                    self.note_execution_context(&event);
+                }
+                self.note_clipboard_execution_context(&event);
+            }
+            "Page.screencastFrame" => Self::handle_screencast_frame(link, event_tx, frame_slot, event),
+            _ => {}
+        }
+    }
+
+    fn forget_destroyed_bound_target(&mut self, destroyed: Option<&str>) -> bool {
+        let Some(destroyed) = destroyed else {
+            return false;
+        };
+        if self.target_id.as_deref() != Some(destroyed) {
+            return false;
+        }
+        self.session_id = None;
+        self.target_id = None;
+        self.main_frame_id = None;
+        self.screencast_on = false;
+        self.pending_viewport_capture_at = None;
+        self.viewport_capture_request_id = None;
+        self.reset_clipboard_tracking();
+        self.pending_reattach = false;
+        self.manifest_dirty = true;
+        true
+    }
+
+    fn handle_frame_navigated(&mut self, event_tx: &BrowserEventSender, event: CdpEvent<'_>, on_page_session: bool) {
+        if !on_page_session {
+            return;
+        }
+        // Subframe (iframe) navigations carry `frame.parentId`; only the top
+        // frame defines the panel's URL.
+        let Some(frame) = event.params.get("frame") else {
+            return;
+        };
+        if frame.get("parentId").is_some() {
+            return;
+        }
+        self.main_frame_id = frame.get("id").and_then(|id| id.as_str()).map(str::to_string);
+        if let Some(target_url) = frame.get("url").and_then(|url| url.as_str())
+            && normalized_committed_url(target_url) != self.url
+        {
+            self.url = normalized_committed_url(target_url).to_string();
+            self.manifest_dirty = true;
+        }
+        self.pending_restart_at = Some(Instant::now());
+        // A back/forward-cache restore can commit `frameNavigated` without a
+        // later `loadEventFired`. Always schedule the title read here so the
+        // panel cannot retain the destination page's title after history
+        // navigation. The href guard in `fetch_title` retries if the new
+        // execution context is not ready yet.
+        self.title_fetch_retries = 0;
+        self.title_fetch_at = Some(Instant::now() + Duration::from_millis(400));
+        self.write_manifest(true);
+        let _ = event_tx.send(BrowserEvent::UrlChanged(self.url.clone()));
+        let _ = event_tx.send(BrowserEvent::Loading(true));
+    }
+
+    fn handle_same_document_navigation(
+        &mut self,
+        event_tx: &BrowserEventSender,
+        event: CdpEvent<'_>,
+        on_page_session: bool,
+    ) {
+        if !on_page_session {
+            return;
+        }
+        let frame_id = event.params.get("frameId").and_then(|id| id.as_str());
+        if self.main_frame_id.as_deref() != frame_id {
+            return;
+        }
+        let Some(target_url) = event.params.get("url").and_then(|url| url.as_str()) else {
+            return;
+        };
+        let url = normalized_committed_url(target_url);
+        if url == self.url {
+            return;
+        }
+        self.url = url.to_string();
+        self.manifest_dirty = true;
+        self.write_manifest(true);
+        let _ = event_tx.send(BrowserEvent::UrlChanged(self.url.clone()));
+    }
+
+    /// Ack, then decode and store one screencast frame.
+    ///
+    /// The ack goes out first and on every path: Chrome holds the
+    /// screencast until each frame is acknowledged, so a malformed frame
+    /// must never stall an otherwise healthy stream.
+    fn handle_screencast_frame(
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &FrameSlot,
+        event: CdpEvent<'_>,
+    ) {
+        // Ack so the stream continues: params.sessionId echoes the frame's
+        // session identifier, the top-level sessionId scopes the call
+        // (flattened sessions).
+        let frame_session = event
+            .params
+            .get("sessionId")
+            .cloned()
+            .or_else(|| event.session_id.map(|s| serde_json::Value::String(s.to_string())));
+        let ack_params = match frame_session {
+            Some(value) => serde_json::json!({ "sessionId": value }),
+            None => serde_json::json!({}),
+        };
+        // Id'd request: Chrome silently drops CDP requests without an id.
+        let _ = link.send_request("Page.screencastFrameAck", &ack_params, event.session_id);
+        let Some(data) = event.params.get("data").and_then(|d| d.as_str()) else {
+            return;
+        };
+        if let Some(seq) = frame_slot.store_base64_jpeg(data) {
+            publish_frame(event_tx, frame_slot, seq);
+        } else {
+            tracing::warn!(target: "browser", "dropping undecodable screencast frame");
+        }
+    }
+}
+
+/// Tolerant URL comparison for the title-fetch href check: Chrome may
+/// append a trailing slash relative to the requested URL.
+fn href_matches_url(href: &str, url: &str) -> bool {
+    let href = href.trim_end_matches('/');
+    let url = url.trim_end_matches('/');
+    href == url
+}
+
+fn title_for_bound_target<'a>(params: &'a serde_json::Value, target_id: Option<&str>) -> Option<&'a str> {
+    let target_info = params.get("targetInfo")?;
+    let changed_target_id = target_info.get("targetId")?.as_str()?;
+    (Some(changed_target_id) == target_id)
+        .then(|| target_info.get("title").and_then(serde_json::Value::as_str))
+        .flatten()
+}
+
+fn attached_bound_page_target<'a>(params: &'a serde_json::Value, bound_target_id: Option<&str>) -> Option<&'a str> {
+    let target_info = params.get("targetInfo")?;
+    if target_info.get("type")?.as_str()? != "page" {
+        return None;
+    }
+    let attached_target_id = target_info.get("targetId")?.as_str()?;
+    (Some(attached_target_id) == bound_target_id).then_some(attached_target_id)
+}
+
+fn title_from_binding(params: &serde_json::Value) -> Option<(String, String)> {
+    if params.get("name")?.as_str()? != TITLE_BINDING_NAME {
+        return None;
+    }
+    let payload = params.get("payload")?.as_str()?;
+    let payload = serde_json::from_str::<serde_json::Value>(payload).ok()?;
+    let title = payload.get("title")?.as_str()?.to_string();
+    let href = payload.get("href")?.as_str()?.to_string();
+    Some((title, href))
+}
+
+fn default_context_id_for_frame(params: &serde_json::Value, main_frame_id: Option<&str>) -> Option<u64> {
+    let context = params.get("context")?;
+    let is_default = context.pointer("/auxData/isDefault")?.as_bool()?;
+    let frame_id = context.pointer("/auxData/frameId")?.as_str()?;
+    if !is_default || Some(frame_id) != main_frame_id {
+        return None;
+    }
+    context.get("id")?.as_u64()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    use crate::browser::frames::FrameSlot;
+    use crate::browser::{BrowserConfig, session::BrowserSessionConfig};
+
+    use super::{
+        DriverState, attached_bound_page_target, default_context_id_for_frame, title_for_bound_target,
+        title_from_binding,
+    };
+
+    fn driver_state() -> DriverState {
+        DriverState::new(
+            &BrowserSessionConfig {
+                browser: BrowserConfig::default(),
+                panel_local_id: "panel-1".to_string(),
+                initial_url: None,
+                width: 1280,
+                height: 800,
+                frame_slot: Arc::new(FrameSlot::new()),
+            },
+            "ws://127.0.0.1/devtools/browser/test",
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    #[test]
+    fn title_context_accepts_only_the_main_frames_default_context() {
+        let main = serde_json::json!({
+            "context": { "id": 7, "auxData": { "isDefault": true, "frameId": "main" } }
+        });
+        let iframe = serde_json::json!({
+            "context": { "id": 8, "auxData": { "isDefault": true, "frameId": "child" } }
+        });
+        let isolated = serde_json::json!({
+            "context": { "id": 9, "auxData": { "isDefault": false, "frameId": "main" } }
+        });
+
+        assert_eq!(default_context_id_for_frame(&main, Some("main")), Some(7));
+        assert_eq!(default_context_id_for_frame(&iframe, Some("main")), None);
+        assert_eq!(default_context_id_for_frame(&isolated, Some("main")), None);
+        assert_eq!(default_context_id_for_frame(&main, None), None);
+    }
+
+    #[test]
+    fn target_title_updates_only_match_the_bound_page() {
+        let params = serde_json::json!({
+            "targetInfo": { "targetId": "bound", "type": "page", "title": "Updated" }
+        });
+
+        assert_eq!(title_for_bound_target(&params, Some("bound")), Some("Updated"));
+        assert_eq!(title_for_bound_target(&params, Some("other")), None);
+        assert_eq!(title_for_bound_target(&params, None), None);
+    }
+
+    #[test]
+    fn auto_attach_accepts_only_the_already_bound_page() {
+        let page = serde_json::json!({
+            "targetInfo": { "targetId": "bound", "type": "page" }
+        });
+        let popup = serde_json::json!({
+            "targetInfo": { "targetId": "popup", "type": "page" }
+        });
+        let worker = serde_json::json!({
+            "targetInfo": { "targetId": "bound", "type": "worker" }
+        });
+
+        assert_eq!(attached_bound_page_target(&page, Some("bound")), Some("bound"));
+        assert_eq!(attached_bound_page_target(&popup, Some("bound")), None);
+        assert_eq!(attached_bound_page_target(&page, None), None);
+        assert_eq!(attached_bound_page_target(&worker, Some("bound")), None);
+    }
+
+    #[test]
+    fn destroying_the_bound_target_marks_its_manifest_identity_for_removal() {
+        let mut state = driver_state();
+        assert!(!state.forget_destroyed_bound_target(None));
+
+        state.target_id = Some("bound".to_string());
+        state.session_id = Some("session".to_string());
+        state.manifest_dirty = false;
+
+        assert!(!state.forget_destroyed_bound_target(Some("popup")));
+        assert_eq!(state.target_id.as_deref(), Some("bound"));
+        assert!(!state.manifest_dirty);
+
+        assert!(state.forget_destroyed_bound_target(Some("bound")));
+        assert_eq!(state.target_id, None);
+        assert_eq!(state.session_id, None);
+        assert!(state.manifest_dirty);
+        assert!(!state.pending_reattach);
+    }
+
+    #[test]
+    fn title_binding_accepts_only_the_horizon_payload() {
+        let params = serde_json::json!({
+            "name": "__horizonBrowserTitleChanged",
+            "payload": r#"{"title":"Updated","href":"https://example.test/page"}"#,
+        });
+        let other_binding = serde_json::json!({
+            "name": "pageBinding",
+            "payload": r#"{"title":"Wrong","href":"https://example.test/page"}"#,
+        });
+
+        assert_eq!(
+            title_from_binding(&params),
+            Some(("Updated".to_string(), "https://example.test/page".to_string()))
+        );
+        assert_eq!(title_from_binding(&other_binding), None);
+        assert_eq!(title_from_binding(&serde_json::json!({})), None);
+    }
+}

--- a/crates/horizon-core/src/browser/session/lifecycle.rs
+++ b/crates/horizon-core/src/browser/session/lifecycle.rs
@@ -1,0 +1,283 @@
+//! Page-session setup and screencast recovery lifecycle.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use crate::browser::cdp::CdpLink;
+use crate::browser::frames::FrameSlot;
+
+use super::{
+    BrowserEvent, BrowserEventSender, DriverState, MAX_RESTART_ATTEMPTS, RESTART_BACKOFF, RESTART_BACKOFF_CAP,
+    TITLE_BINDING_NAME, TITLE_OBSERVER_SCRIPT,
+};
+
+impl DriverState {
+    fn screencast_params(&self) -> serde_json::Value {
+        // Change-driven: frames only arrive when the page repaints, so a
+        // static page costs nothing. `everyNthFrame` is the only rate knob
+        // this Chrome build exposes; there is no maxFPS parameter.
+        serde_json::json!({
+            "format": "jpeg",
+            "quality": self.config.browser.quality,
+            "everyNthFrame": self.config.browser.every_nth_frame.max(1),
+        })
+    }
+
+    pub(super) fn attach_setup(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        session: &str,
+        target: &str,
+    ) -> bool {
+        if self.session_id.as_deref() != Some(session) {
+            self.reset_clipboard_tracking();
+        }
+        self.session_id = Some(session.to_string());
+        self.target_id = Some(target.to_string());
+        // Browser-level auto-attach does not recurse into site-isolated child
+        // targets. Enable it on the bound page session as well so OOPIF
+        // execution contexts remain available to frame-aware input bridges.
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Target.setAutoAttach",
+            &serde_json::json!({ "autoAttach": true, "waitForDebuggerOnStart": false, "flatten": true }),
+            Some(session),
+        ) {
+            return false;
+        }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Page.enable",
+            &serde_json::json!({}),
+            Some(session),
+        ) {
+            return false;
+        }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Runtime.enable",
+            &serde_json::json!({}),
+            Some(session),
+        ) {
+            return false;
+        }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Runtime.addBinding",
+            &serde_json::json!({ "name": TITLE_BINDING_NAME }),
+            Some(session),
+        ) {
+            return false;
+        }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Page.addScriptToEvaluateOnNewDocument",
+            &serde_json::json!({ "source": TITLE_OBSERVER_SCRIPT }),
+            Some(session),
+        ) {
+            return false;
+        }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Runtime.evaluate",
+            &serde_json::json!({ "expression": TITLE_OBSERVER_SCRIPT }),
+            Some(session),
+        ) {
+            return false;
+        }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Emulation.setDeviceMetricsOverride",
+            &serde_json::json!({
+                "width": self.viewport_w,
+                "height": self.viewport_h,
+                "deviceScaleFactor": 1,
+                "mobile": false,
+            }),
+            Some(session),
+        ) {
+            return false;
+        }
+        // A page that loaded before we attached (restart case) already has
+        // its title; a fresh about:blank fetch returns empty and is skipped.
+        self.fetch_title(link, event_tx, frame_slot);
+        if self.stop_requested.load(Ordering::Acquire) {
+            return false;
+        }
+        self.start_screencast(link, event_tx, frame_slot);
+        if self.stop_requested.load(Ordering::Acquire) {
+            return false;
+        }
+        self.write_manifest(true);
+        let _ = event_tx.send(BrowserEvent::Ready);
+        // One-shot: navigate to the panel's initial URL after first attach.
+        if !self.initial_navigated {
+            self.initial_navigated = true;
+            let initial_url = self.config.initial_url.clone();
+            if let Some(initial) = initial_url
+                && initial != "about:blank"
+            {
+                self.navigate_to(link, event_tx, frame_slot, &initial);
+            }
+        }
+        !self.stop_requested.load(Ordering::Acquire)
+    }
+
+    fn setup_command(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        method: &str,
+        params: &serde_json::Value,
+        session: Option<&str>,
+    ) -> bool {
+        match self.call_and_ack(link, event_tx, frame_slot, method, params, session) {
+            Ok(_) => !self.stop_requested.load(Ordering::Acquire),
+            Err(_) if self.stop_requested.load(Ordering::Acquire) => false,
+            Err(error) => {
+                self.session_id = None;
+                self.screencast_on = false;
+                self.reset_clipboard_tracking();
+                self.pending_reattach = self.target_id.is_some();
+                frame_slot.clear();
+                let message = format!("browser setup failed at {method}: {error}; retry to restart");
+                tracing::warn!(target: "browser", "{message}");
+                let _ = event_tx.send(BrowserEvent::Warning(message));
+                false
+            }
+        }
+    }
+
+    fn start_screencast(&mut self, link: &mut CdpLink, event_tx: &BrowserEventSender, frame_slot: &Arc<FrameSlot>) {
+        let Some(session) = self.session_id.clone() else {
+            return;
+        };
+        let params = self.screencast_params();
+        match self.call_and_ack(
+            link,
+            event_tx,
+            frame_slot,
+            "Page.startScreencast",
+            &params,
+            Some(session.as_str()),
+        ) {
+            Ok(_) => {
+                self.screencast_on = true;
+                self.restart_attempts = 0;
+                self.pending_restart_at = None;
+            }
+            Err(error) => self.note_screencast_failure(&error.to_string()),
+        }
+    }
+
+    /// Exponential backoff between screencast restarts, capped so a page
+    /// whose screencast is genuinely dead still re-attaches in a bounded
+    /// time. A navigation's brief screencast outage must not burn through
+    /// all restart attempts (that forces a full re-attach mid-load).
+    fn restart_backoff(&self) -> Duration {
+        let shift = self.restart_attempts.saturating_sub(1).min(4);
+        let millis = RESTART_BACKOFF
+            .as_millis()
+            .saturating_mul(1u128 << shift)
+            .min(RESTART_BACKOFF_CAP.as_millis());
+        // The value is capped by `RESTART_BACKOFF_CAP`, far below u64::MAX.
+        Duration::from_millis(u64::try_from(millis).unwrap_or(u64::MAX))
+    }
+
+    fn note_screencast_failure(&mut self, message: &str) {
+        self.screencast_on = false;
+        self.restart_attempts += 1;
+        tracing::debug!(
+            target: "browser",
+            "screencast start rejected (attempt {}): {message}",
+            self.restart_attempts
+        );
+        if self.restart_attempts >= MAX_RESTART_ATTEMPTS {
+            // The session's page binding is probably stale (another CDP
+            // client navigated away from under us). Force a re-attach.
+            self.restart_attempts = 0;
+            self.pending_reattach = true;
+        } else {
+            self.pending_restart_at = Some(Instant::now() + self.restart_backoff());
+        }
+    }
+
+    pub(super) fn note_reattach_failure(&mut self, event_tx: &BrowserEventSender, message: &str) {
+        self.reattach_failures += 1;
+        if self.reattach_failures >= 5 {
+            self.reattach_failures = 0;
+            self.pending_reattach = false;
+            self.pending_restart_at = None;
+            let _ = event_tx.send(BrowserEvent::Warning(format!(
+                "could not re-attach to the page: {message}; retry to restart"
+            )));
+        } else {
+            self.pending_reattach = true;
+            self.pending_restart_at = Some(Instant::now() + self.restart_backoff());
+        }
+    }
+
+    pub(super) fn pending_restart_tick(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        if self.pending_reattach && !self.reattach_in_flight {
+            // A rejected re-attach parked a backoff delay first.
+            if let Some(due) = self.pending_restart_at {
+                if Instant::now() < due {
+                    return;
+                }
+                self.pending_restart_at = None;
+            }
+            self.pending_reattach = false;
+            if let Some(ref target) = self.target_id {
+                self.reattach_in_flight = true;
+                self.session_id = None;
+                match link.send_request(
+                    "Target.attachToTarget",
+                    &serde_json::json!({ "targetId": target, "flatten": true }),
+                    None,
+                ) {
+                    Ok(request_id) => self.reattach_request_id = Some(request_id),
+                    Err(error) => {
+                        tracing::warn!(target: "browser", "re-attach request failed: {error}");
+                        self.reattach_in_flight = false;
+                        self.reattach_request_id = None;
+                        self.note_reattach_failure(event_tx, &error.to_string());
+                    }
+                }
+            }
+            return;
+        }
+        let Some(due) = self.pending_restart_at else {
+            return;
+        };
+        if Instant::now() < due {
+            return;
+        }
+        self.pending_restart_at = None;
+        if self.session_id.is_some() {
+            self.start_screencast(link, event_tx, frame_slot);
+        }
+    }
+}

--- a/crates/horizon-core/src/browser/session/manifest_io.rs
+++ b/crates/horizon-core/src/browser/session/manifest_io.rs
@@ -1,0 +1,254 @@
+//! Manifest transactions and agent/user handoff signals for the browser
+//! driver. The parent session module owns lifecycle/CDP state; this leaf keeps
+//! filesystem synchronization and TTL behavior out of that event loop.
+
+use std::time::Instant;
+
+use crate::browser::manifest::{self, BrowserManifest};
+
+use super::{BrowserEvent, BrowserEventSender, DriverState, MANIFEST_MIN_INTERVAL, SIGNAL_MIN_INTERVAL};
+
+impl DriverState {
+    /// User clicked "hand back": mark the pending handoff done so the
+    /// blocked agent process can continue.
+    pub(super) fn resolve_handoff(&mut self, event_tx: &BrowserEventSender) {
+        let expected_request_id = self.handoff_seen.clone();
+        let mut acknowledged = false;
+        let result = self.write_manifest_extra(true, |manifest| {
+            acknowledged = acknowledge_handoff(manifest, expected_request_id.as_deref());
+        });
+        match result.and_then(|()| {
+            acknowledged
+                .then_some(())
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "pending handoff no longer exists"))
+        }) {
+            Ok(()) => {
+                self.handoff_seen = None;
+                let _ = event_tx.send(BrowserEvent::HandoffCleared);
+            }
+            Err(error) => {
+                tracing::warn!(target: "browser", "failed to resolve handoff: {error}");
+                let _ = event_tx.send(BrowserEvent::HandoffResolutionFailed(error.to_string()));
+            }
+        }
+    }
+
+    /// Poll the manifest for agent-side signals (owner heartbeat, handoff
+    /// requests). Cheap file read, throttled.
+    pub(super) fn tick_signals(&mut self, tx: &BrowserEventSender) {
+        if self.last_signal_check.elapsed() < SIGNAL_MIN_INTERVAL {
+            return;
+        }
+        self.last_signal_check = Instant::now();
+        self.expire_user_active();
+        let Some(mut manifest) = manifest::read(&self.config.panel_local_id) else {
+            return;
+        };
+        if let Some(handoff) = manifest
+            .handoff_pending()
+            .filter(|handoff| handoff.request_id.is_empty())
+        {
+            let observed_reason = handoff.reason.clone();
+            let observed_requested_at = handoff.requested_at;
+            let request_id = manifest::new_handoff_request_id();
+            let Ok(updated) = manifest::update(&self.config.panel_local_id, |current| {
+                if let Some(current_handoff) = current.handoff.as_mut()
+                    && !current_handoff.done
+                    && current_handoff.request_id.is_empty()
+                    && current_handoff.reason == observed_reason
+                    && current_handoff.requested_at == observed_requested_at
+                {
+                    current_handoff.request_id.clone_from(&request_id);
+                }
+            }) else {
+                return;
+            };
+            manifest = updated;
+        }
+        let now = manifest::now_millis();
+        let owner = manifest.live_owner(now).map(|owner| owner.name.clone());
+        publish_owner_change(&mut self.owner_seen, owner, tx);
+        match manifest.handoff_pending() {
+            Some(handoff) if !handoff.request_id.is_empty() => {
+                if self.handoff_seen.as_deref() != Some(handoff.request_id.as_str()) {
+                    self.handoff_seen = Some(handoff.request_id.clone());
+                    let _ = tx.send(BrowserEvent::HandoffRequested(handoff.reason.clone()));
+                }
+            }
+            Some(_) => {}
+            None => {
+                if self.handoff_seen.is_some() {
+                    self.handoff_seen = None;
+                    let _ = tx.send(BrowserEvent::HandoffCleared);
+                }
+            }
+        }
+    }
+
+    /// Persist the shared manifest, preserving agent-owned fields. The
+    /// driver's in-memory state is authoritative for its fields; the on-disk
+    /// manifest is the base for `handoff` and `owner`.
+    pub(super) fn write_manifest_extra(
+        &mut self,
+        force: bool,
+        extra: impl FnOnce(&mut BrowserManifest),
+    ) -> std::io::Result<()> {
+        if !force && !self.manifest_dirty {
+            return Ok(());
+        }
+        if !force && self.last_manifest_write.elapsed() < MANIFEST_MIN_INTERVAL {
+            self.manifest_dirty = true;
+            return Ok(());
+        }
+        let local_id = &self.config.panel_local_id;
+        if !force && manifest::read(local_id).is_none() {
+            self.manifest_dirty = true;
+            return Ok(());
+        }
+        let update_result = manifest::update(local_id, |manifest| {
+            extra(manifest);
+            manifest.browser_ws.clone_from(&self.browser_ws);
+            manifest
+                .target_id
+                .clone_from(&self.target_id.clone().unwrap_or_default());
+            manifest.url.clone_from(&self.url);
+            manifest.title.clone_from(&self.title);
+            manifest.updated_at = manifest::now_millis();
+        });
+        match update_result {
+            Ok(_) => {
+                self.manifest_dirty = false;
+                self.last_manifest_write = Instant::now();
+                Ok(())
+            }
+            Err(error) => {
+                self.manifest_dirty = true;
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) fn write_manifest(&mut self, force: bool) {
+        if let Err(error) = self.write_manifest_extra(force, |_| {}) {
+            tracing::warn!(target: "browser", "failed to write browser manifest: {error}");
+        }
+    }
+
+    pub(super) fn initialize_manifest(&mut self) {
+        let local_id = &self.config.panel_local_id;
+        let initialize_result = manifest::initialize(local_id, |manifest| {
+            manifest.panel_local_id.clone_from(local_id);
+            manifest.user_active = false;
+            manifest.user_active_at = 0;
+            manifest.browser_ws.clone_from(&self.browser_ws);
+            manifest
+                .target_id
+                .clone_from(&self.target_id.clone().unwrap_or_default());
+            manifest.url.clone_from(&self.url);
+            manifest.title.clone_from(&self.title);
+            manifest.updated_at = manifest::now_millis();
+        });
+        match initialize_result {
+            Ok(_) => {
+                self.manifest_dirty = false;
+                self.last_manifest_write = Instant::now();
+            }
+            Err(error) => {
+                self.manifest_dirty = true;
+                tracing::warn!(target: "browser", "failed to initialize browser manifest: {error}");
+            }
+        }
+    }
+
+    fn expire_user_active(&mut self) {
+        let Some(last_stamp) = self.last_user_active_stamp else {
+            return;
+        };
+        if last_stamp.elapsed() < manifest::USER_ACTIVE_TTL {
+            return;
+        }
+        match self.write_manifest_extra(true, |manifest| manifest.user_active = false) {
+            Ok(()) => self.last_user_active_stamp = None,
+            Err(error) => tracing::warn!(target: "browser", "failed to expire user activity: {error}"),
+        }
+    }
+}
+
+fn acknowledge_handoff(manifest: &mut BrowserManifest, expected_request_id: Option<&str>) -> bool {
+    let Some(expected_request_id) = expected_request_id else {
+        return false;
+    };
+    let Some(handoff) = manifest
+        .handoff
+        .as_mut()
+        .filter(|handoff| !handoff.done && handoff.request_id == expected_request_id)
+    else {
+        return false;
+    };
+    handoff.done = true;
+    true
+}
+
+fn publish_owner_change(owner_seen: &mut Option<String>, owner: Option<String>, event_tx: &BrowserEventSender) {
+    if owner == *owner_seen {
+        return;
+    }
+    owner_seen.clone_from(&owner);
+    let _ = event_tx.send(BrowserEvent::OwnerChanged(owner));
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::browser::manifest::ManifestHandoff;
+
+    use super::*;
+
+    #[test]
+    fn acknowledgement_requires_a_manifest_handoff() {
+        let mut manifest = BrowserManifest::default();
+        assert!(!acknowledge_handoff(&mut manifest, Some("request-1")));
+
+        manifest.handoff = Some(ManifestHandoff {
+            request_id: "request-1".to_string(),
+            reason: "captcha".to_string(),
+            requested_at: 1,
+            done: false,
+        });
+        assert!(!acknowledge_handoff(&mut manifest, None));
+        assert!(!acknowledge_handoff(&mut manifest, Some("request-2")));
+        assert!(acknowledge_handoff(&mut manifest, Some("request-1")));
+        assert!(manifest.handoff.is_some_and(|handoff| handoff.done));
+    }
+
+    #[test]
+    fn acknowledgement_does_not_complete_a_replacement_handoff() {
+        let mut manifest = BrowserManifest {
+            handoff: Some(ManifestHandoff {
+                request_id: "replacement".to_string(),
+                reason: "replacement".to_string(),
+                requested_at: 1,
+                done: false,
+            }),
+            ..BrowserManifest::default()
+        };
+
+        assert!(!acknowledge_handoff(&mut manifest, Some("original")));
+        assert!(manifest.handoff.is_some_and(|handoff| !handoff.done));
+    }
+
+    #[test]
+    fn owner_change_keeps_and_publishes_the_live_owner() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let tx = super::super::BrowserEventSender {
+            tx,
+            wake: super::super::BrowserEventWake::default(),
+            committed_url: super::super::CommittedUrl::default(),
+        };
+        let mut owner_seen = None;
+
+        publish_owner_change(&mut owner_seen, Some("agent-1".to_string()), &tx);
+
+        assert_eq!(owner_seen.as_deref(), Some("agent-1"));
+        assert_eq!(rx.recv(), Ok(BrowserEvent::OwnerChanged(Some("agent-1".to_string()))));
+    }
+}

--- a/crates/horizon-core/src/browser/session/startup.rs
+++ b/crates/horizon-core/src/browser/session/startup.rs
@@ -1,0 +1,375 @@
+//! Chrome process startup and initial CDP target attachment.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
+
+use crate::browser::BrowserConfig;
+use crate::browser::cdp::CdpLink;
+use crate::browser::frames::FrameSlot;
+use crate::browser::manifest::DriverManifestLifetime;
+use crate::browser::process::{ChromeProcess, ChromeProcessControl};
+
+use super::{
+    BrowserCommand, BrowserEvent, BrowserEventSender, BrowserSessionConfig, CALL_TIMEOUT, DriverState, WS_URL_TIMEOUT,
+    run_loop,
+};
+
+/// Settles process registration and resolves the driver's teardown signal
+/// exactly once, on thread exit.
+struct DriverCompletion {
+    completion_tx: Option<mpsc::Sender<()>>,
+    process_control: ChromeProcessControl,
+}
+
+impl Drop for DriverCompletion {
+    fn drop(&mut self) {
+        self.process_control.mark_registration_settled();
+        if let Some(tx) = self.completion_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+fn cancel_startup_if_requested(
+    requested: &AtomicBool,
+    chrome: &mut ChromeProcess,
+    event_tx: &BrowserEventSender,
+) -> bool {
+    if !requested.load(Ordering::Acquire) {
+        return false;
+    }
+    let _ = chrome.kill();
+    let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+    true
+}
+
+struct DriverConnection {
+    chrome: ChromeProcess,
+    link: CdpLink,
+    ws_url: String,
+    target_id: String,
+    session_id: String,
+}
+
+fn initialize_driver(
+    config: &BrowserSessionConfig,
+    event_tx: &BrowserEventSender,
+    stop_requested: &AtomicBool,
+    process_control: ChromeProcessControl,
+) -> Option<DriverConnection> {
+    let launch = match build_launch(config) {
+        Ok(launch) => launch,
+        Err(message) => {
+            let _ = event_tx.send(BrowserEvent::Warning(message));
+            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+            return None;
+        }
+    };
+    if stop_requested.load(Ordering::Acquire) {
+        let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+        return None;
+    }
+    let mut chrome = match ChromeProcess::spawn(&launch, process_control) {
+        Ok(chrome) => chrome,
+        Err(error) => {
+            let _ = event_tx.send(BrowserEvent::Warning(format!("failed to start chrome: {error}")));
+            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+            return None;
+        }
+    };
+    let ws_url = match chrome.wait_ws_url(WS_URL_TIMEOUT, || stop_requested.load(Ordering::Acquire)) {
+        Ok(Some(url)) => url,
+        Ok(None) => {
+            let _ = chrome.kill();
+            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+            return None;
+        }
+        Err(error) => {
+            let _ = event_tx.send(BrowserEvent::Warning(format!("no DevTools endpoint: {error}")));
+            let _ = chrome.kill();
+            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+            return None;
+        }
+    };
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    let link = match CdpLink::connect(&ws_url) {
+        Ok(link) => link,
+        Err(error) => {
+            let _ = event_tx.send(BrowserEvent::Warning(format!("CDP connect failed: {error}")));
+            let _ = chrome.kill();
+            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+            return None;
+        }
+    };
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    initialize_target(event_tx, stop_requested, chrome, link, ws_url)
+}
+
+fn initialize_target(
+    event_tx: &BrowserEventSender,
+    stop_requested: &AtomicBool,
+    mut chrome: ChromeProcess,
+    mut link: CdpLink,
+    ws_url: String,
+) -> Option<DriverConnection> {
+    let _ = call_during_startup(
+        &mut link,
+        stop_requested,
+        "Target.setDiscoverTargets",
+        &serde_json::json!({ "discover": true }),
+    );
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    let _ = call_during_startup(
+        &mut link,
+        stop_requested,
+        "Target.setAutoAttach",
+        &serde_json::json!({ "autoAttach": true, "waitForDebuggerOnStart": false, "flatten": true }),
+    );
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    // setAutoAttach only covers *future* targets: attach explicitly to the
+    // page that Chrome opened at startup (creating one if it has none).
+    let existing_target = first_page_target(&mut link, stop_requested);
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    let Some(target_id) = existing_target.or_else(|| create_page_target(&mut link, stop_requested)) else {
+        if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+            return None;
+        }
+        let _ = event_tx.send(BrowserEvent::Warning("no page target found".to_string()));
+        let _ = chrome.kill();
+        let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+        return None;
+    };
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    let Some(session_id) = link
+        .call_and_drain_until(
+            CALL_TIMEOUT,
+            "Target.attachToTarget",
+            &serde_json::json!({ "targetId": target_id, "flatten": true }),
+            None,
+            || stop_requested.load(Ordering::Acquire),
+        )
+        .result
+        .ok()
+        .and_then(|result| result.get("sessionId").and_then(|s| s.as_str()).map(str::to_string))
+    else {
+        let _ = event_tx.send(BrowserEvent::Warning("initial attach failed".to_string()));
+        let _ = chrome.kill();
+        let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+        return None;
+    };
+    if cancel_startup_if_requested(stop_requested, &mut chrome, event_tx) {
+        return None;
+    }
+    Some(DriverConnection {
+        chrome,
+        link,
+        ws_url,
+        target_id,
+        session_id,
+    })
+}
+
+fn call_during_startup(
+    link: &mut CdpLink,
+    stop_requested: &AtomicBool,
+    method: &str,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, crate::browser::cdp::CdpError> {
+    link.call_and_drain_until(CALL_TIMEOUT, method, params, None, || {
+        stop_requested.load(Ordering::Acquire)
+    })
+    .result
+}
+
+pub(super) fn run_driver(
+    config: &BrowserSessionConfig,
+    event_tx: &BrowserEventSender,
+    command_rx: &mpsc::Receiver<BrowserCommand>,
+    frame_slot: &Arc<FrameSlot>,
+    stop_requested: &Arc<AtomicBool>,
+    completion_tx: mpsc::Sender<()>,
+    process_control: ChromeProcessControl,
+) {
+    let _completion = DriverCompletion {
+        completion_tx: Some(completion_tx),
+        process_control: process_control.clone(),
+    };
+    let _manifest_lifetime = DriverManifestLifetime::start(&config.panel_local_id);
+    let Some(mut connection) = initialize_driver(config, event_tx, stop_requested, process_control) else {
+        return;
+    };
+
+    let mut state = DriverState::new(config, &connection.ws_url, Arc::clone(stop_requested));
+    state.initialize_manifest();
+    if !state.attach_setup(
+        &mut connection.link,
+        event_tx,
+        frame_slot,
+        &connection.session_id,
+        &connection.target_id,
+    ) {
+        let _ = connection.chrome.kill();
+        let _ = event_tx.send(BrowserEvent::Stopped { code: None });
+        return;
+    }
+
+    run_loop(
+        &mut state,
+        &mut connection.chrome,
+        &mut connection.link,
+        command_rx,
+        frame_slot,
+        event_tx,
+    );
+    let _ = connection.chrome.kill();
+}
+
+/// First existing `page` target, if any.
+fn first_page_target(link: &mut CdpLink, stop_requested: &AtomicBool) -> Option<String> {
+    let result = call_during_startup(link, stop_requested, "Target.getTargets", &serde_json::json!({})).ok()?;
+    result
+        .get("targetInfos")
+        .and_then(|t| t.as_array())
+        .and_then(|targets| first_available_page_target_id(targets))
+        .map(str::to_string)
+}
+
+fn first_available_page_target_id(targets: &[serde_json::Value]) -> Option<&str> {
+    targets
+        .iter()
+        .find(|target| {
+            target.get("type").and_then(serde_json::Value::as_str) == Some("page")
+                && !target
+                    .get("attached")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+        })
+        .and_then(|target| target.get("targetId"))
+        .and_then(serde_json::Value::as_str)
+}
+
+/// Create a fresh page target as a fallback (browser opened without one).
+fn create_page_target(link: &mut CdpLink, stop_requested: &AtomicBool) -> Option<String> {
+    let result = call_during_startup(
+        link,
+        stop_requested,
+        "Target.createTarget",
+        &serde_json::json!({ "url": "about:blank" }),
+    )
+    .ok()?;
+    result.get("targetId").and_then(|t| t.as_str()).map(str::to_string)
+}
+
+fn build_launch(config: &BrowserSessionConfig) -> Result<crate::browser::process::ChromeLaunch, String> {
+    let command = crate::browser::process::resolve_binary_or_default(&config.browser.command)
+        .map(|p| p.to_string_lossy().to_string())
+        .map_err(|e| e.to_string())?;
+    let profile_dir = profile_dir(&config.browser, &config.panel_local_id);
+    Ok(crate::browser::process::ChromeLaunch {
+        command,
+        profile_dir,
+        width: config.width,
+        height: config.height,
+        extra_args: config.browser.extra_args.clone(),
+    })
+}
+
+pub(in crate::browser) fn profile_dir(config: &BrowserConfig, panel_local_id: &str) -> std::path::PathBuf {
+    let home = crate::horizon_home::HorizonHome::resolve();
+    super::super::profile_dir_for_home(config, &home, panel_local_id)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use crate::browser::BrowserConfig;
+    use crate::browser::frames::FrameSlot;
+
+    use super::super::{BrowserSessionConfig, start_session};
+    use super::{first_available_page_target_id, profile_dir};
+
+    #[test]
+    fn target_selection_skips_attached_pages() {
+        let targets = serde_json::json!([
+            { "targetId": "attached", "type": "page", "attached": true },
+            { "targetId": "worker", "type": "service_worker", "attached": false },
+            { "targetId": "available", "type": "page", "attached": false }
+        ]);
+
+        assert_eq!(
+            first_available_page_target_id(targets.as_array().expect("target list")),
+            Some("available")
+        );
+    }
+
+    #[test]
+    fn configured_profile_root_confines_unsafe_panel_ids() {
+        let config = BrowserConfig {
+            profile_root: Some("/tmp/horizon-browser-profiles".into()),
+            ..BrowserConfig::default()
+        };
+
+        assert_eq!(
+            profile_dir(&config, "../outside/profile"),
+            std::path::PathBuf::from("/tmp/horizon-browser-profiles/%2e2e2f6f7574736964652f70726f66696c65")
+        );
+        assert_ne!(profile_dir(&config, "a/b"), profile_dir(&config, "a_b"));
+        assert_ne!(profile_dir(&config, "Panel-A"), profile_dir(&config, "panel-a"));
+    }
+
+    #[test]
+    fn shutdown_cancels_devtools_endpoint_wait() {
+        let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("create temp dir: {error}"));
+        let browser = temp.path().join("delayed-browser");
+        let started = temp.path().join("started");
+        std::fs::write(
+            &browser,
+            format!("#!/bin/sh\nprintf started > '{}'\nexec sleep 30\n", started.display()),
+        )
+        .unwrap_or_else(|error| panic!("write delayed browser: {error}"));
+        let mut permissions = std::fs::metadata(&browser)
+            .unwrap_or_else(|error| panic!("read delayed browser metadata: {error}"))
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&browser, permissions)
+            .unwrap_or_else(|error| panic!("make delayed browser executable: {error}"));
+
+        let session = start_session(BrowserSessionConfig {
+            browser: BrowserConfig {
+                command: Some(browser.to_string_lossy().into_owned()),
+                profile_root: Some(temp.path().join("profiles")),
+                ..BrowserConfig::default()
+            },
+            panel_local_id: "startup-cancel".to_string(),
+            initial_url: None,
+            width: 320,
+            height: 200,
+            frame_slot: Arc::new(FrameSlot::new()),
+        })
+        .unwrap_or_else(|error| panic!("start browser session: {error}"));
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !started.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(started.exists(), "delayed browser did not start");
+
+        let completion = session.shutdown_signal();
+        assert!(completion.wait(Duration::from_secs(2)));
+    }
+}

--- a/crates/horizon-core/src/horizon_home.rs
+++ b/crates/horizon-core/src/horizon_home.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+const LOWER_HEX: &[u8; 16] = b"0123456789abcdef";
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HorizonHome {
     root: PathBuf,
@@ -83,6 +85,32 @@ impl HorizonHome {
     pub fn codex_skill_dir(&self) -> PathBuf {
         self.codex_integrations_dir().join("horizon-notify")
     }
+
+    #[must_use]
+    pub fn browsers_manifest_dir(&self) -> PathBuf {
+        self.root.join("runtime").join("browsers")
+    }
+
+    #[must_use]
+    pub fn browser_profile_dir(&self, local_id: &str) -> PathBuf {
+        self.root.join("browser-profiles").join(safe_local_id(local_id))
+    }
+}
+
+#[must_use]
+pub(crate) fn safe_local_id(local_id: &str) -> String {
+    // Always encode the exact UTF-8 bytes. Keeping an apparently safe ID
+    // verbatim would make identifiers that differ only by case collide on
+    // default macOS and Windows filesystems. The lowercase hexadecimal
+    // alphabet itself has no case variants, and the '%' prefix keeps the
+    // empty identifier distinct.
+    let mut encoded = String::with_capacity(1 + local_id.len() * 2);
+    encoded.push('%');
+    for byte in local_id.bytes() {
+        encoded.push(char::from(LOWER_HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(LOWER_HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
 }
 
 #[cfg(test)]
@@ -112,5 +140,45 @@ mod tests {
             home.claude_plugin_dir(),
             PathBuf::from("/tmp/horizon-home/plugins/claude-code")
         );
+        assert_eq!(
+            home.browsers_manifest_dir(),
+            PathBuf::from("/tmp/horizon-home/runtime/browsers")
+        );
+        assert_eq!(
+            home.browser_profile_dir("panel-1"),
+            PathBuf::from("/tmp/horizon-home/browser-profiles/%70616e656c2d31")
+        );
+        assert_eq!(
+            home.browser_profile_dir("../outside"),
+            PathBuf::from("/tmp/horizon-home/browser-profiles/%2e2e2f6f757473696465")
+        );
+        assert_eq!(
+            home.browser_profile_dir(""),
+            PathBuf::from("/tmp/horizon-home/browser-profiles/%")
+        );
+    }
+
+    #[test]
+    fn unsafe_local_ids_have_distinct_paths() {
+        let home = HorizonHome::from_root("/tmp/horizon-home".into());
+
+        assert_ne!(home.browser_profile_dir("a/b"), home.browser_profile_dir("a_b"));
+        assert_ne!(home.browser_profile_dir(""), home.browser_profile_dir("_"));
+        assert_ne!(home.browser_profile_dir("%"), home.browser_profile_dir("%25"));
+        assert_ne!(home.browser_profile_dir("Panel-A"), home.browser_profile_dir("panel-a"));
+    }
+
+    #[test]
+    fn every_local_id_uses_the_canonical_encoding() {
+        let home = HorizonHome::from_root("/tmp/horizon-home".into());
+
+        for local_id in ["panel-1", "CON", "nul", "Aux", "PRN", "COM1", "com9", "LPT1", "lpt9"] {
+            assert!(
+                home.browser_profile_dir(local_id)
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with('%')),
+                "{local_id} must use the canonical path encoding"
+            );
+        }
     }
 }

--- a/crates/horizon-ui/src/app/speech/worker.rs
+++ b/crates/horizon-ui/src/app/speech/worker.rs
@@ -729,7 +729,9 @@ mod tests {
                     let (sample_rate, channels, bits) = format.expect("fmt chunk before data");
                     assert_eq!(bits, 16, "fixture must be 16-bit PCM");
                     let samples: Vec<f32> = body
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|pair| f32::from(i16::from_le_bytes([pair[0], pair[1]])) / 32_768.0)
                         .collect();
                     return (samples, sample_rate, channels);

--- a/crates/horizon-ui/src/app/ssh_upload.rs
+++ b/crates/horizon-ui/src/app/ssh_upload.rs
@@ -408,8 +408,7 @@ fn transfer_speed_bytes_per_second(completed_bytes: u64, started_at: Instant, no
         return None;
     }
 
-    let elapsed_millis =
-        u64::try_from(now.saturating_duration_since(started_at).as_millis()).map_or(u64::MAX, |value| value);
+    let elapsed_millis = u64::try_from(now.saturating_duration_since(started_at).as_millis()).unwrap_or(u64::MAX);
     if elapsed_millis == 0 {
         return None;
     }


### PR DESCRIPTION
Per-panel driver thread over the CDP link from layer 1:
- session: startup (ws attach, viewport, screencast), command drain,
  event pump, lifecycle (crash restart with backoff, teardown)
- input: core input model (keys, mouse, wheel, clipboard, IME) + CDP mapping
- manifest: file-based ownership/handoff channel shared with agents
- profile: per-panel Chrome profile management
- deps: atomicwrites 0.4.4 (atomic 0600 manifest writes)
- restores layer-1 visibility narrowing now that in-crate consumers exist

Part of the browser-panel stack (layer 2 of 6).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>