### PR TITLE
fix(terminal): harden PTY detach/reattach

### DIFF
--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -490,10 +490,19 @@ impl BrowserPanelState {
                 }
                 BrowserEvent::UrlChanged(url) => {
                     if self.url.as_deref() != Some(url.as_str()) {
-                        self.url = Some(url);
+                        self.url = Some(url.clone());
                         output.url_changed = true;
                     }
                     self.navigation_error = None;
+                    // The sender publishes the committed URL before emitting
+                    // this event, so by the time sync_committed_url runs the
+                    // equality return hides the change; clear the pending
+                    // submission here (that sync stays as fallback for a
+                    // dropped event receiver). Blank commits are not
+                    // navigation results.
+                    if !url.is_empty() && url != "about:blank" {
+                        self.pending_user_navigation = None;
+                    }
                     output.had_output = true;
                 }
                 BrowserEvent::NavigationFailed(message) => {

--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -152,6 +152,10 @@ pub struct BrowserPanelState {
     pending_clipboard_text: Option<String>,
     /// Most recent URL submission error; cleared after a committed navigation.
     pub navigation_error: Option<String>,
+    /// User-typed navigation submitted while no driver session exists. Kept
+    /// as the display and relaunch target until a fresh session accepts it,
+    /// so the input is never silently discarded.
+    pending_user_navigation: Option<String>,
     config: BrowserConfig,
 }
 
@@ -197,6 +201,7 @@ impl BrowserPanelState {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config,
         };
         state.launch_session(initial_url);
@@ -208,18 +213,28 @@ impl BrowserPanelState {
     /// browser returns the user to where they were rather than the panel's
     /// initial URL.
     pub fn relaunch(&mut self) {
-        let initial_url = match &self.url {
-            Some(url) => (!url.is_empty()).then(|| url.clone()),
-            None => self.requested_url.clone().filter(|url| !url.is_empty()),
-        };
-        self.launch_session(initial_url);
+        self.launch_session(self.relaunch_target());
     }
 
-    /// URL shown in browser chrome. Before Chrome commits anything, preserve
-    /// the requested startup target as editable UI without treating it as
-    /// persisted browser history.
+    /// The URL the next relaunch should open: a navigation the user typed
+    /// while the driver was absent wins over the last committed URL, which
+    /// wins over the requested startup target.
+    fn relaunch_target(&self) -> Option<String> {
+        self.pending_user_navigation
+            .clone()
+            .or_else(|| self.url.clone().filter(|url| !url.is_empty()))
+            .or_else(|| self.requested_url.clone().filter(|url| !url.is_empty()))
+    }
+
+    /// URL shown in browser chrome. A navigation typed while the driver was
+    /// absent stays visible as the pending relaunch target; before Chrome
+    /// commits anything, preserve the requested startup target as editable
+    /// UI without treating it as persisted browser history.
     #[must_use]
     pub fn display_url(&self) -> &str {
+        if let Some(pending) = self.pending_user_navigation.as_deref().filter(|url| !url.is_empty()) {
+            return pending;
+        }
         self.url.as_deref().unwrap_or_else(|| {
             self.requested_url
                 .as_deref()
@@ -265,7 +280,9 @@ impl BrowserPanelState {
         let session_config = session::BrowserSessionConfig {
             browser: self.config.clone(),
             panel_local_id: self.panel_local_id.clone(),
-            initial_url,
+            // A navigation typed while the driver was absent takes precedence
+            // over the queued relaunch target: it is the freshest request.
+            initial_url: self.pending_user_navigation.clone().or(initial_url),
             width: DEFAULT_VIEWPORT.0,
             height: DEFAULT_VIEWPORT.1,
             // Reuse the panel's slot across (re)starts: frame sequence
@@ -276,6 +293,7 @@ impl BrowserPanelState {
         match session::start_session(session_config) {
             Ok(handle) => {
                 self.committed_url = handle.committed_url();
+                self.pending_user_navigation = None;
                 self.clear_agent_state_for_relaunch();
                 self.status = BrowserStatus::Starting;
                 self.loading = true;
@@ -324,6 +342,20 @@ impl BrowserPanelState {
     #[must_use]
     pub fn try_send(&self, command: BrowserCommand) -> bool {
         self.session.as_ref().is_some_and(|session| session.send(command))
+    }
+
+    /// Submit a user-typed navigation. Returns `true` when the driver
+    /// accepted it. When no session exists (stopped, or still waiting for a
+    /// prior teardown), the URL is retained as the display and relaunch
+    /// target and the failure is surfaced via `navigation_error` instead of
+    /// being silently discarded.
+    pub fn submit_navigation(&mut self, url: &str) -> bool {
+        if self.try_send(BrowserCommand::Navigate(url.to_string())) {
+            return true;
+        }
+        self.pending_user_navigation = Some(url.to_string());
+        self.navigation_error = Some("Browser is not running; press Retry to open the typed URL".to_string());
+        false
     }
 
     /// Take page text copied by headless Chrome for the UI's host clipboard.
@@ -630,6 +662,40 @@ mod tests {
     }
 
     #[test]
+    fn submission_without_a_driver_is_retained_and_surfaced() {
+        let mut state = BrowserPanelState {
+            status: BrowserStatus::Stopped { code: None },
+            url: Some("https://old.example/".to_string()),
+            title: String::new(),
+            loading: false,
+            frame_slot: Arc::new(FrameSlot::new()),
+            session: None,
+            committed_url: session::CommittedUrl::default(),
+            teardown_signal: None,
+            pending_relaunch: None,
+            panel_local_id: "submit-test".to_string(),
+            requested_url: None,
+            owner: None,
+            handoff_reason: None,
+            handoff_error: None,
+            handoff_resolution_pending: false,
+            pending_clipboard_text: None,
+            navigation_error: None,
+            pending_user_navigation: None,
+            config: BrowserConfig::default(),
+        };
+
+        assert!(!state.submit_navigation("https://typed.example/page"));
+        assert!(state.navigation_error.is_some());
+        // The typed URL stays visible in the URL bar even though the last
+        // committed URL is known, and becomes the relaunch target.
+        assert_eq!(state.display_url(), "https://typed.example/page");
+        assert_eq!(state.relaunch_target(), Some("https://typed.example/page".to_string()));
+        // Persistence semantics are untouched: only committed URLs persist.
+        assert_eq!(state.committed_url_for_persistence(), Some("https://old.example/"));
+    }
+
+    #[test]
     fn retry_stays_disabled_until_teardown_completes() {
         let (completion_tx, completion_rx) = std::sync::mpsc::channel();
         let mut state = BrowserPanelState {
@@ -652,6 +718,7 @@ mod tests {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config: BrowserConfig::default(),
         };
 
@@ -683,6 +750,7 @@ mod tests {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config: BrowserConfig::default(),
         };
         let completion = std::thread::spawn(move || {
@@ -719,6 +787,7 @@ mod tests {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config: BrowserConfig {
                 command: Some("/definitely/missing/chrome".to_string()),
                 ..BrowserConfig::default()
@@ -810,6 +879,7 @@ mod tests {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config: BrowserConfig::default(),
         };
 
@@ -842,6 +912,7 @@ mod tests {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: Some("stale error".to_string()),
+            pending_user_navigation: None,
             config: BrowserConfig::default(),
         };
 
@@ -873,6 +944,7 @@ mod tests {
             handoff_resolution_pending: false,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config: BrowserConfig::default(),
         };
 
@@ -907,6 +979,7 @@ mod tests {
             handoff_resolution_pending: true,
             pending_clipboard_text: None,
             navigation_error: None,
+            pending_user_navigation: None,
             config: BrowserConfig::default(),
         };
 

--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -293,7 +293,10 @@ impl BrowserPanelState {
         match session::start_session(session_config) {
             Ok(handle) => {
                 self.committed_url = handle.committed_url();
-                self.pending_user_navigation = None;
+                // The pending submission is only cleared once the session
+                // commits a navigation (see sync_committed_url): a startup
+                // that dies before navigate_to must keep it so Retry
+                // re-targets the user's request, not the stale URL.
                 self.clear_agent_state_for_relaunch();
                 self.status = BrowserStatus::Starting;
                 self.loading = true;
@@ -571,6 +574,12 @@ impl BrowserPanelState {
         };
         if self.url.as_deref() == Some(url.as_str()) {
             return;
+        }
+        // The driver committed a real navigation: the pending submission it
+        // was carrying is done (exact match or the post-redirect
+        // destination). about:blank commits are not navigation results.
+        if url != "about:blank" {
+            self.pending_user_navigation = None;
         }
         self.url = Some(url);
         self.navigation_error = None;

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -196,6 +196,55 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn dropping_a_finished_event_loop_does_not_wait_for_its_pty() {
+        let (dropped_tx, dropped_rx) = mpsc::sync_channel(1);
+
+        std::thread::spawn(move || {
+            let mut terminal = Terminal::spawn(TerminalSpawnOptions {
+                program: std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()),
+                args: Vec::new(),
+                cwd: None,
+                rows: 24,
+                cols: 80,
+                cell_width: 8,
+                cell_height: 16,
+                scrollback_limit: 256,
+                window_id: 42,
+                replay_bytes: Vec::new(),
+                env: HashMap::new(),
+                kitty_keyboard: true,
+            })
+            .expect("terminal should spawn");
+
+            terminal.request_shutdown();
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            while !terminal
+                .event_loop_handle
+                .as_ref()
+                .is_some_and(std::thread::JoinHandle::is_finished)
+                && std::time::Instant::now() < deadline
+            {
+                std::thread::yield_now();
+            }
+            assert!(
+                terminal
+                    .event_loop_handle
+                    .as_ref()
+                    .is_some_and(std::thread::JoinHandle::is_finished),
+                "event loop should stop before terminal teardown"
+            );
+
+            drop(terminal);
+            dropped_tx.send(()).expect("drop completion should send");
+        });
+
+        dropped_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("terminal drop should not wait for PTY teardown");
+    }
+
+    #[test]
     #[cfg(target_os = "linux")]
     fn current_cwd_for_pid_reads_procfs_cwd() {
         let cwd = current_cwd_for_pid(std::process::id()).expect("cwd");

--- a/crates/horizon-core/src/terminal/lifecycle.rs
+++ b/crates/horizon-core/src/terminal/lifecycle.rs
@@ -1,8 +1,96 @@
 use super::{
-    Arc, AtomicUsize, Cow, Duration, Error, EventLoop, FairMutex, Msg, Ordering, PtyOptions, ReplayRestoreState,
-    Result, Shell, Term, Terminal, TerminalDimensions, TerminalEventProxy, TerminalSpawnOptions, WindowSize,
-    drain_replay_events, mpsc, replay_terminal_bytes, term, tty,
+    Arc, AtomicUsize, Cow, Duration, Error, EventLoop, FairMutex, JoinHandle, Msg, Ordering, PtyOptions,
+    ReplayRestoreState, Result, Shell, Term, Terminal, TerminalDimensions, TerminalEventLoop, TerminalEventLoopState,
+    TerminalEventProxy, TerminalSpawnOptions, WindowSize, drain_replay_events, mpsc, replay_terminal_bytes, term, tty,
 };
+
+use std::sync::Mutex;
+
+type TerminalJoinHandle = JoinHandle<(TerminalEventLoop, TerminalEventLoopState)>;
+
+enum JoinStatus {
+    Complete,
+    Panicked,
+}
+
+enum TerminalJoinCompletion {
+    Notify(mpsc::SyncSender<JoinStatus>),
+    Count(Arc<AtomicUsize>),
+    Detached,
+}
+
+struct TerminalJoinTask {
+    handle: TerminalJoinHandle,
+    completion: TerminalJoinCompletion,
+}
+
+impl TerminalJoinTask {
+    fn run(self) {
+        // The successful join value owns the event loop and PTY, so evaluating
+        // this on the worker also keeps their destructors off the UI thread.
+        let status = if self.handle.join().is_ok() {
+            JoinStatus::Complete
+        } else {
+            JoinStatus::Panicked
+        };
+
+        match self.completion {
+            TerminalJoinCompletion::Notify(sender) => {
+                let _ = sender.send(status);
+            }
+            TerminalJoinCompletion::Count(completed) => {
+                if matches!(status, JoinStatus::Panicked) {
+                    tracing::warn!("terminal event loop panicked during asynchronous shutdown");
+                }
+                completed.fetch_add(1, Ordering::Relaxed);
+            }
+            TerminalJoinCompletion::Detached => {
+                if matches!(status, JoinStatus::Panicked) {
+                    tracing::warn!("terminal event loop panicked during detached shutdown");
+                }
+            }
+        }
+    }
+}
+
+// Static storage is intentionally never dropped. If the OS refuses to create
+// a join worker, keeping the task here prevents caller-thread PTY teardown; a
+// later successful worker spawn can still drain it.
+static PENDING_TERMINAL_JOINS: Mutex<Vec<TerminalJoinTask>> = Mutex::new(Vec::new());
+
+fn enqueue_before_worker_spawn<T>(
+    queue: &Mutex<Vec<T>>,
+    task: T,
+    spawn_worker: impl FnOnce() -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    queue
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(task);
+    spawn_worker()
+}
+
+fn schedule_terminal_join(task: TerminalJoinTask) -> std::io::Result<()> {
+    enqueue_before_worker_spawn(&PENDING_TERMINAL_JOINS, task, || {
+        std::thread::Builder::new()
+            .name("terminal-join".to_string())
+            .spawn(drain_pending_terminal_joins)
+            .map(drop)
+    })
+}
+
+fn drain_pending_terminal_joins() {
+    loop {
+        let task = PENDING_TERMINAL_JOINS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop();
+        let Some(task) = task else {
+            return;
+        };
+        task.run();
+    }
+}
 
 impl Terminal {
     /// Spawn a terminal session backed by `alacritty_terminal`.
@@ -113,25 +201,17 @@ impl Terminal {
 
     #[must_use]
     pub fn wait_for_shutdown(&mut self, timeout: Duration) -> bool {
-        enum JoinStatus {
-            Complete,
-            Panicked,
-        }
-
         let Some(event_loop_handle) = self.event_loop_handle.take() else {
             return true;
         };
 
         let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
-        std::thread::spawn(move || {
-            // Drop the joined event loop on this helper thread so PTY teardown
-            // cannot block the UI thread in `Pty::drop`.
-            let status = match event_loop_handle.join() {
-                Ok(_) => JoinStatus::Complete,
-                Err(_) => JoinStatus::Panicked,
-            };
-            let _ = shutdown_tx.send(status);
-        });
+        if let Err(error) = schedule_terminal_join(TerminalJoinTask {
+            handle: event_loop_handle,
+            completion: TerminalJoinCompletion::Notify(shutdown_tx),
+        }) {
+            tracing::warn!("failed to start terminal join worker; retained task for later cleanup: {error}");
+        }
 
         match shutdown_rx.recv_timeout(timeout) {
             Ok(JoinStatus::Complete) => true,
@@ -149,19 +229,18 @@ impl Terminal {
         self.wait_for_shutdown(timeout)
     }
 
-    /// Spawns a background thread to join the event-loop handle, incrementing
-    /// `completed` when done. Returns `true` if a join thread was spawned.
+    /// Queues the event-loop handle for a background join, incrementing
+    /// `completed` when done. Returns `true` if a handle was queued.
     pub(crate) fn begin_async_join(&mut self, completed: &Arc<AtomicUsize>) -> bool {
         let Some(handle) = self.event_loop_handle.take() else {
             return false;
         };
-        let done = Arc::clone(completed);
-        std::thread::spawn(move || {
-            // Join and drop on this helper thread so PTY teardown cannot block
-            // the UI thread.
-            let _ = handle.join();
-            done.fetch_add(1, Ordering::Relaxed);
-        });
+        if let Err(error) = schedule_terminal_join(TerminalJoinTask {
+            handle,
+            completion: TerminalJoinCompletion::Count(Arc::clone(completed)),
+        }) {
+            tracing::warn!("failed to start terminal join worker; retained task for later cleanup: {error}");
+        }
         true
     }
 }
@@ -170,9 +249,40 @@ impl Drop for Terminal {
     fn drop(&mut self) {
         self.request_shutdown();
 
-        // Detach the event loop thread instead of joining it; joining can
-        // block the main thread indefinitely if the child process is still
-        // starting up or the PTY is stuck on I/O.
-        drop(self.event_loop_handle.take());
+        let Some(handle) = self.event_loop_handle.take() else {
+            return;
+        };
+
+        // Queue ownership before the fallible worker spawn. A finished handle
+        // can own the returned event loop, whose PTY destructor may otherwise
+        // block this thread indefinitely while waiting for the child.
+        if let Err(error) = schedule_terminal_join(TerminalJoinTask {
+            handle,
+            completion: TerminalJoinCompletion::Detached,
+        }) {
+            tracing::warn!("failed to start terminal join worker; retained task for later cleanup: {error}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::enqueue_before_worker_spawn;
+
+    #[test]
+    fn failed_worker_spawn_retains_queued_ownership() {
+        let queue = Mutex::new(Vec::new());
+
+        let result = enqueue_before_worker_spawn(&queue, 42, || {
+            Err(std::io::Error::other("injected worker spawn failure"))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            *queue.lock().unwrap_or_else(std::sync::PoisonError::into_inner),
+            vec![42]
+        );
     }
 }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -191,7 +191,10 @@ impl HorizonApp {
             return;
         }
 
-        self.collect_detached_viewport_input(ctx);
+        // Keyboard/text events are collected exactly once, by
+        // handle_canvas_pan_in_rect below: a second pass would consume the
+        // one-shot frame keyboard metadata twice and re-run the stateful
+        // speech filter (leaking an orphan hotkey key-up).
         self.handle_detached_shortcuts(ctx, workspace_id);
         self.render_detached_toolbar(ui, workspace_id, workspace_local_id, &workspace_name);
 
@@ -356,11 +359,6 @@ impl HorizonApp {
         self.terminal_body_screen_rects = std::mem::take(&mut detached_state.terminal_body_screen_rects);
         self.panel_screen_order = std::mem::take(&mut detached_state.panel_screen_order);
         true
-    }
-
-    fn collect_detached_viewport_input(&mut self, ctx: &Context) {
-        let raw_events = ctx.input(|input| input.events.clone());
-        self.terminal_keyboard_events = self.terminal_events_for_viewport(ctx, &raw_events);
     }
 
     fn persist_detached_viewport_state(&mut self, workspace_local_id: &str) {
@@ -642,7 +640,13 @@ mod tests {
         input.viewports.entry(viewport_id).or_default();
 
         let _ = ctx
-            .run_ui(input, |ui| app.collect_detached_viewport_input(ui.ctx()))
+            .run_ui(input, |ui| {
+                app.handle_canvas_pan_in_rect(
+                    ui.ctx(),
+                    egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 600.0)),
+                    None,
+                );
+            })
             .discard_textures();
 
         let collected = app

--- a/crates/horizon-ui/src/browser_widget/chrome.rs
+++ b/crates/horizon-ui/src/browser_widget/chrome.rs
@@ -104,9 +104,12 @@ fn url_bar(
     if submitted {
         state.url_submit_enter_pending = !ui.input(|i| i.key_released(egui::Key::Enter));
         let url = state.url_buffer.trim().to_string();
-        if !url.is_empty() && browser.committed_url_for_persistence() != Some(url.as_str()) {
+        if !url.is_empty() && browser.display_url() != url {
             // A driver-less submission is retained as the relaunch target and
-            // surfaced via navigation_error instead of being dropped.
+            // surfaced via navigation_error instead of being dropped. The
+            // guard compares the displayed target (pending first), not the
+            // committed URL: resubmitting the persisted URL while a newer
+            // pending target is queued must replace it, not be skipped.
             browser.submit_navigation(&url);
         }
     }

--- a/crates/horizon-ui/src/browser_widget/chrome.rs
+++ b/crates/horizon-ui/src/browser_widget/chrome.rs
@@ -78,7 +78,7 @@ fn nav_widget_info(label: &str, enabled: bool) -> WidgetInfo {
 fn url_bar(
     ui: &mut Ui,
     panel_id: horizon_core::PanelId,
-    browser: &BrowserPanelState,
+    browser: &mut BrowserPanelState,
     state: &mut BrowserUiState,
     interactive: bool,
 ) -> (bool, bool) {
@@ -105,7 +105,9 @@ fn url_bar(
         state.url_submit_enter_pending = !ui.input(|i| i.key_released(egui::Key::Enter));
         let url = state.url_buffer.trim().to_string();
         if !url.is_empty() && browser.committed_url_for_persistence() != Some(url.as_str()) {
-            browser.send(BrowserCommand::Navigate(url));
+            // A driver-less submission is retained as the relaunch target and
+            // surfaced via navigation_error instead of being dropped.
+            browser.submit_navigation(&url);
         }
     }
     (response.has_focus() || submitted, response.clicked())


### PR DESCRIPTION
- terminal lifecycle: deterministic detach/reattach state handling
- guards against stale detach transitions

Part of the browser-panel stack (layer 5 of 6).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>