### PR TITLE
chore(browser): converge stack tip with reviewed tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "surge-core"
 version = "1.0.0"
-source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.53#b72041bcdff079150c6a2b59ccaf4d624183c5e1"
+source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.54#f406779dcd4b31270b13459cc85b5fb8a3c485d9"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ tungstenite = "0.30.0"
 # JPEG decoder for CDP screencast frames (change-driven video stream).
 zune-jpeg = "0.5.15"
 base64 = "0.23.1"
-atomicwrites = "0.4.4"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 profiling = "1.0.18"
 serde = { version = "1.0.229", features = ["derive"] }
@@ -44,13 +43,19 @@ wgpu = { version = "30.0.0", default-features = false, features = ["std", "vulka
 egui_commonmark = { version = "0.25.0", default-features = false, features = ["pulldown_cmark"] }
 winit = "0.30.13"
 tempfile = "3.27.0"
+# `std::fs::rename` cannot atomically replace an existing file on Windows.
+# Browser manifests need replace-existing semantics without exposing a gap to
+# lock-free readers.
+atomicwrites = "0.4.4"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
 regex = "1.13.1"
 arboard = "3.6.1"
 tokio = { version = "1.53.1", features = ["rt", "macros"] }
-surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.0.0-beta.53", package = "surge-core" }
+# Mainline PR #300 advanced the resolved dependency to beta.54. Keep the
+# manifest pin aligned so unrelated lock regeneration cannot roll it back.
+surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.0.0-beta.54", package = "surge-core" }
 # Speech input (opt-in `speech` feature): local ASR via transcribe.cpp. The
 # -sys crate vendors the whole C++ tree, so cargo builds it from source —
 # needs only CMake + a C++ compiler, no git submodules.

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -21,7 +21,6 @@ profiling.workspace = true
 tungstenite.workspace = true
 zune-jpeg.workspace = true
 base64.workspace = true
-atomicwrites.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true
@@ -31,6 +30,7 @@ uuid.workspace = true
 comrak = { version = "0.54", default-features = false }
 git2.workspace = true
 regex.workspace = true
+atomicwrites.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/horizon-core/src/board/tests/core.rs
+++ b/crates/horizon-core/src/board/tests/core.rs
@@ -72,6 +72,54 @@ fn close_panel_removes_panel_attention() {
 }
 
 #[test]
+fn global_shutdown_inherits_browser_teardown_from_an_already_closed_panel() {
+    let mut board = Board::new();
+    let root = tempfile::tempdir().expect("temp dir");
+    let profile_dir = root.path().join("retired-browser-profile");
+    std::fs::create_dir(&profile_dir).expect("profile dir");
+    std::fs::write(profile_dir.join("Preferences"), b"state").expect("profile state");
+    let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+    board
+        .retired_browser_shutdown_signals
+        .push(crate::browser::BrowserShutdownSignal::for_test(completion_rx).with_profile_cleanup(profile_dir.clone()));
+
+    let progress = board.begin_async_shutdown();
+
+    assert_eq!(progress.panel_count(), 1);
+    assert!(!progress.browser_shutdown_is_complete());
+    assert!(completion_tx.send(()).is_ok());
+    assert!(progress.wait_for_browser_shutdown(Duration::from_secs(1)));
+    assert!(progress.is_complete());
+    assert!(!profile_dir.exists());
+}
+
+#[test]
+fn retired_browser_cleanup_remains_pollable_after_the_last_panel_closes() {
+    let mut board = Board::new();
+    let root = tempfile::tempdir().expect("temp dir");
+    let profile_dir = root.path().join("last-browser-profile");
+    std::fs::create_dir(&profile_dir).expect("profile dir");
+    let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+    board
+        .retired_browser_shutdown_signals
+        .push(crate::browser::BrowserShutdownSignal::for_test(completion_rx).with_profile_cleanup(profile_dir.clone()));
+
+    assert!(board.panels.is_empty());
+    assert!(board.has_pending_browser_cleanup());
+    let _ = board.process_output();
+    assert!(board.has_pending_browser_cleanup());
+    assert!(completion_tx.send(()).is_ok());
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(1);
+    while board.has_pending_browser_cleanup() && std::time::Instant::now() < deadline {
+        let _ = board.process_output();
+        std::thread::yield_now();
+    }
+
+    assert!(!board.has_pending_browser_cleanup());
+}
+
+#[test]
 fn resolve_attention_marks_item_resolved() {
     let mut board = Board::new();
     let workspace_id = board.create_workspace("frontend");

--- a/crates/horizon-core/src/browser/frames.rs
+++ b/crates/horizon-core/src/browser/frames.rs
@@ -136,6 +136,7 @@ impl FrameSlot {
 
     /// Claim the single outstanding UI wake-up for this slot. Further
     /// frames remain coalesced in `latest` until the UI releases the claim.
+    #[must_use]
     pub(crate) fn claim_notification(&self) -> bool {
         self.notification_pending
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/crates/horizon-core/src/browser/frames.rs
+++ b/crates/horizon-core/src/browser/frames.rs
@@ -136,7 +136,6 @@ impl FrameSlot {
 
     /// Claim the single outstanding UI wake-up for this slot. Further
     /// frames remain coalesced in `latest` until the UI releases the claim.
-    #[must_use]
     pub(crate) fn claim_notification(&self) -> bool {
         self.notification_pending
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/crates/horizon-ui/src/app/persistence.rs
+++ b/crates/horizon-ui/src/app/persistence.rs
@@ -98,3 +98,63 @@ impl HorizonApp {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use horizon_core::{Config, PanelKind, PanelState, RuntimeState, StartupDecision, WorkspaceState};
+
+    use super::super::test_support::test_app_with_config_and_startup;
+
+    #[test]
+    fn auto_save_persists_the_active_browser_profile_configuration() {
+        let profile_root = tempfile::tempdir().expect("profile temp dir");
+        let launched_root = profile_root.path().join("launched-profiles");
+        let current_root = profile_root.path().join("current-profiles");
+        let mut launched_config = Config::default();
+        launched_config.browser.command = Some(profile_root.path().join("missing-chrome").display().to_string());
+        launched_config.browser.profile_root = Some(launched_root.clone());
+        let startup_runtime = RuntimeState {
+            browser: launched_config.browser.clone(),
+            workspaces: vec![WorkspaceState {
+                local_id: "browser-workspace".to_string(),
+                panels: vec![PanelState {
+                    local_id: "browser-panel".to_string(),
+                    name: "Browser".to_string(),
+                    kind: PanelKind::Browser,
+                    ..PanelState::default()
+                }],
+                ..WorkspaceState::default()
+            }],
+            ..RuntimeState::default()
+        };
+        let (_temp, _ctx, mut app) = test_app_with_config_and_startup(
+            &launched_config,
+            StartupDecision::Ephemeral {
+                runtime_state: Box::new(startup_runtime.clone()),
+            },
+        );
+        let session = app
+            .session_store
+            .create_session_from_runtime(startup_runtime)
+            .expect("create persistent session");
+        app.activate_persistent_session(&session);
+        let mut current_config = launched_config.clone();
+        current_config.browser.profile_root = Some(current_root);
+        current_config.browser.quality = 73;
+        app.apply_runtime_config(&current_config);
+
+        assert!(app.auto_save_runtime_state());
+
+        let saved = RuntimeState::load(&session.runtime_state_path)
+            .expect("load saved runtime")
+            .expect("saved runtime exists");
+        assert_eq!(saved.browser, current_config.browser);
+        assert_eq!(
+            saved.workspaces[0].panels[0]
+                .browser_profile
+                .as_ref()
+                .and_then(|profile| profile.root.as_ref()),
+            Some(&launched_root)
+        );
+    }
+}

--- a/crates/horizon-ui/src/app/persistence.rs
+++ b/crates/horizon-ui/src/app/persistence.rs
@@ -52,13 +52,12 @@ impl HorizonApp {
             })
             .collect();
 
-        let mut runtime_state = RuntimeState::from_board_with_detached_workspaces(
+        let runtime_state = RuntimeState::from_board_with_detached_workspaces(
             &self.board,
             self.window_config.clone(),
             self.canvas_view,
             detached_workspaces,
         );
-        runtime_state.browser = self.template_config.browser.clone();
         if let Err(error) = self
             .session_store
             .save_runtime_state(&active_session.session_id, &runtime_state)
@@ -96,65 +95,5 @@ impl HorizonApp {
                 }
             }
         });
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use horizon_core::{Config, PanelKind, PanelState, RuntimeState, StartupDecision, WorkspaceState};
-
-    use super::super::test_support::test_app_with_config_and_startup;
-
-    #[test]
-    fn auto_save_persists_the_active_browser_profile_configuration() {
-        let profile_root = tempfile::tempdir().expect("profile temp dir");
-        let launched_root = profile_root.path().join("launched-profiles");
-        let current_root = profile_root.path().join("current-profiles");
-        let mut launched_config = Config::default();
-        launched_config.browser.command = Some(profile_root.path().join("missing-chrome").display().to_string());
-        launched_config.browser.profile_root = Some(launched_root.clone());
-        let startup_runtime = RuntimeState {
-            browser: launched_config.browser.clone(),
-            workspaces: vec![WorkspaceState {
-                local_id: "browser-workspace".to_string(),
-                panels: vec![PanelState {
-                    local_id: "browser-panel".to_string(),
-                    name: "Browser".to_string(),
-                    kind: PanelKind::Browser,
-                    ..PanelState::default()
-                }],
-                ..WorkspaceState::default()
-            }],
-            ..RuntimeState::default()
-        };
-        let (_temp, _ctx, mut app) = test_app_with_config_and_startup(
-            &launched_config,
-            StartupDecision::Ephemeral {
-                runtime_state: Box::new(startup_runtime.clone()),
-            },
-        );
-        let session = app
-            .session_store
-            .create_session_from_runtime(startup_runtime)
-            .expect("create persistent session");
-        app.activate_persistent_session(&session);
-        let mut current_config = launched_config.clone();
-        current_config.browser.profile_root = Some(current_root);
-        current_config.browser.quality = 73;
-        app.apply_runtime_config(&current_config);
-
-        assert!(app.auto_save_runtime_state());
-
-        let saved = RuntimeState::load(&session.runtime_state_path)
-            .expect("load saved runtime")
-            .expect("saved runtime exists");
-        assert_eq!(saved.browser, current_config.browser);
-        assert_eq!(
-            saved.workspaces[0].panels[0]
-                .browser_profile
-                .as_ref()
-                .and_then(|profile| profile.root.as_ref()),
-            Some(&launched_root)
-        );
     }
 }

--- a/crates/horizon-ui/src/browser_widget/chrome.rs
+++ b/crates/horizon-ui/src/browser_widget/chrome.rs
@@ -21,15 +21,32 @@ pub fn show(
     let chrome_row = ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 4.0;
         ui.set_min_height(CHROME_HEIGHT);
+        // Reserve the chip's natural width up front so the URL bar's
+        // expanding width cannot starve it (a trailing `right_to_left`
+        // scope gets zero remaining width and the chip renders invisibly).
+        let chip = ownership_chip_label(browser);
+        let chip_width = chip.as_ref().map_or(0.0, |(label, _)| {
+            ui.painter()
+                .layout_no_wrap(label.clone(), egui::FontId::proportional(10.0), egui::Color32::WHITE)
+                .size()
+                .x
+        });
         let mut clicked = false;
         clicked |= nav_button(ui, "←", "Back", browser, BrowserCommand::Back, interactive);
         clicked |= nav_button(ui, "→", "Forward", browser, BrowserCommand::Forward, interactive);
         clicked |= nav_button(ui, "⟳", "Reload", browser, BrowserCommand::Reload, interactive);
-        let (url_focused, url_clicked) = url_bar(ui, panel_id, browser, state, interactive);
+        // Measure after the nav buttons so the cap fits the real remainder.
+        // Without a chip the bar keeps its old full-width behavior.
+        let url_max_width = if chip.is_some() {
+            (ui.available_width() - chip_width - 8.0).max(80.0)
+        } else {
+            f32::INFINITY
+        };
+        let (url_focused, url_clicked) = url_bar(ui, panel_id, browser, state, interactive, url_max_width);
         clicked |= url_clicked;
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            ownership_chip(ui, browser);
-        });
+        if let Some((label, color)) = chip {
+            ui.label(RichText::new(label).size(10.0).color(color).strong());
+        }
         (url_focused, clicked)
     });
     let (url_focused, mut clicked) = chrome_row.inner;
@@ -81,6 +98,7 @@ fn url_bar(
     browser: &mut BrowserPanelState,
     state: &mut BrowserUiState,
     interactive: bool,
+    max_width: f32,
 ) -> (bool, bool) {
     let id = ui.make_persistent_id(("browser-url-bar", panel_id));
     let display_url = browser.display_url();
@@ -94,7 +112,7 @@ fn url_bar(
         TextEdit::singleline(&mut state.url_buffer)
             .id(id)
             .hint_text("https://…")
-            .desired_width(f32::INFINITY)
+            .desired_width(max_width)
             .font(egui::FontId::monospace(11.5)),
     );
     // egui's singleline TextEdit consumes Enter and drops its own focus
@@ -116,50 +134,54 @@ fn url_bar(
     (response.has_focus() || submitted, response.clicked())
 }
 
-fn ownership_chip(ui: &mut Ui, browser: &BrowserPanelState) {
-    let (label, color) = if browser.handoff_reason.is_some() {
-        (String::from("waiting"), theme::PALETTE_YELLOW())
-    } else if let Some(owner) = &browser.owner {
-        (format!("agent: {owner}"), theme::PALETTE_GREEN())
+/// The chip's label and color, or `None` when neither an agent owner nor a
+/// pending handoff should be surfaced.
+fn ownership_chip_label(browser: &BrowserPanelState) -> Option<(String, egui::Color32)> {
+    if browser.handoff_reason.is_some() {
+        Some((String::from("waiting"), theme::PALETTE_YELLOW()))
     } else {
-        return;
-    };
-    ui.label(RichText::new(label).size(10.0).color(color).strong());
+        browser
+            .owner
+            .as_ref()
+            .map(|owner| (format!("agent: {owner}"), theme::PALETTE_GREEN()))
+    }
 }
 
 fn handoff_banner(ui: &mut Ui, browser: &mut BrowserPanelState, reason: &str, interactive: bool) -> bool {
     let mut clicked = false;
     ui.scope(|ui| {
         ui.visuals_mut().override_text_color = Some(theme::PALETTE_YELLOW());
-        ui.vertical(|ui| {
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                let button_label = if browser.handoff_resolution_pending {
-                    "Handing back…"
-                } else {
-                    "Done — hand back to agent"
-                };
-                clicked = ui
-                    .add_enabled(
-                        interactive && !browser.handoff_resolution_pending,
-                        egui::Button::new(RichText::new(button_label).size(11.0))
-                            .fill(theme::blend(theme::PANEL_BG_ALT(), theme::PALETTE_YELLOW(), 0.2))
-                            .corner_radius(6),
-                    )
-                    .clicked();
-                ui.add(
-                    egui::Label::new(RichText::new(format!("🖐 Agent paused: {reason}")).size(12.0))
-                        .wrap_mode(TextWrapMode::Truncate),
+        // Single-line horizontal strip. Do not use a `right_to_left` row here:
+        // under a plain top-down parent the truncated label's wrap width
+        // collapses in egui 0.36, growing the banner to the full body height
+        // and hiding the page frame behind it.
+        ui.horizontal(|ui| {
+            ui.add(
+                egui::Label::new(RichText::new(format!("🖐 Agent paused: {reason}")).size(12.0))
+                    .wrap_mode(TextWrapMode::Truncate),
+            )
+            .on_hover_text(reason);
+            let button_label = if browser.handoff_resolution_pending {
+                "Handing back…"
+            } else {
+                "Done — hand back to agent"
+            };
+            clicked = ui
+                .add_enabled(
+                    interactive && !browser.handoff_resolution_pending,
+                    egui::Button::new(RichText::new(button_label).size(11.0))
+                        .fill(theme::blend(theme::PANEL_BG_ALT(), theme::PALETTE_YELLOW(), 0.2))
+                        .corner_radius(6),
                 )
-                .on_hover_text(reason);
-            });
-            if let Some(error) = &browser.handoff_error {
-                ui.label(
-                    RichText::new(format!("Could not hand back: {error}"))
-                        .size(10.5)
-                        .color(theme::PALETTE_RED()),
-                );
-            }
+                .clicked();
         });
+        if let Some(error) = &browser.handoff_error {
+            ui.label(
+                RichText::new(format!("Could not hand back: {error}"))
+                    .size(10.5)
+                    .color(theme::PALETTE_RED()),
+            );
+        }
     });
     if clicked {
         browser.hand_back();

--- a/crates/horizon-ui/src/browser_widget/chrome.rs
+++ b/crates/horizon-ui/src/browser_widget/chrome.rs
@@ -8,6 +8,9 @@ use crate::browser_widget::BrowserUiState;
 use crate::theme;
 
 const CHROME_HEIGHT: f32 = 30.0;
+/// The URL bar keeps at least this much width even when an owner chip is
+/// present on a narrow panel.
+const URL_MIN_WIDTH: f32 = 120.0;
 
 /// Draw the top strip. Returns whether the URL bar has focus and whether
 /// any chrome widget was clicked this frame (for panel-focus requests).
@@ -21,11 +24,11 @@ pub fn show(
     let chrome_row = ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 4.0;
         ui.set_min_height(CHROME_HEIGHT);
-        // Reserve the chip's natural width up front so the URL bar's
-        // expanding width cannot starve it (a trailing `right_to_left`
-        // scope gets zero remaining width and the chip renders invisibly).
+        // Reserve the chip's width up front so the URL bar's expanding
+        // width cannot starve it (a trailing `right_to_left` scope gets
+        // zero remaining width and the chip renders invisibly).
         let chip = ownership_chip_label(browser);
-        let chip_width = chip.as_ref().map_or(0.0, |(label, _)| {
+        let natural_chip_width = chip.as_ref().map_or(0.0, |(label, _)| {
             ui.painter()
                 .layout_no_wrap(label.clone(), egui::FontId::proportional(10.0), egui::Color32::WHITE)
                 .size()
@@ -36,16 +39,29 @@ pub fn show(
         clicked |= nav_button(ui, "→", "Forward", browser, BrowserCommand::Forward, interactive);
         clicked |= nav_button(ui, "⟳", "Reload", browser, BrowserCommand::Reload, interactive);
         // Measure after the nav buttons so the cap fits the real remainder.
-        // Without a chip the bar keeps its old full-width behavior.
+        // The owner name is an unrestricted external string: cap the chip to
+        // what the row can spare while keeping the URL bar a usable minimum
+        // width, and let the chip truncate (full name on hover). Without a
+        // chip the bar keeps its old full-width behavior.
+        let chip_width = if chip.is_some() {
+            natural_chip_width.min((ui.available_width() - URL_MIN_WIDTH - 8.0).max(0.0))
+        } else {
+            0.0
+        };
         let url_max_width = if chip.is_some() {
-            (ui.available_width() - chip_width - 8.0).max(0.0)
+            (ui.available_width() - chip_width - 8.0).max(URL_MIN_WIDTH)
         } else {
             f32::INFINITY
         };
         let (url_focused, url_clicked) = url_bar(ui, panel_id, browser, state, interactive, url_max_width);
         clicked |= url_clicked;
-        if let Some((label, color)) = chip {
-            ui.label(RichText::new(label).size(10.0).color(color).strong());
+        if let Some((label, color)) = &chip {
+            ui.add_sized(
+                egui::vec2(chip_width, CHROME_HEIGHT),
+                egui::Label::new(RichText::new(label.clone()).size(10.0).color(*color).strong())
+                    .wrap_mode(TextWrapMode::Truncate),
+            )
+            .on_hover_text(label.clone());
         }
         (url_focused, clicked)
     });

--- a/crates/horizon-ui/src/browser_widget/chrome.rs
+++ b/crates/horizon-ui/src/browser_widget/chrome.rs
@@ -38,7 +38,7 @@ pub fn show(
         // Measure after the nav buttons so the cap fits the real remainder.
         // Without a chip the bar keeps its old full-width behavior.
         let url_max_width = if chip.is_some() {
-            (ui.available_width() - chip_width - 8.0).max(80.0)
+            (ui.available_width() - chip_width - 8.0).max(0.0)
         } else {
             f32::INFINITY
         };
@@ -156,16 +156,28 @@ fn handoff_banner(ui: &mut Ui, browser: &mut BrowserPanelState, reason: &str, in
         // collapses in egui 0.36, growing the banner to the full body height
         // and hiding the page frame behind it.
         ui.horizontal(|ui| {
-            ui.add(
-                egui::Label::new(RichText::new(format!("🖐 Agent paused: {reason}")).size(12.0))
-                    .wrap_mode(TextWrapMode::Truncate),
-            )
-            .on_hover_text(reason);
             let button_label = if browser.handoff_resolution_pending {
                 "Handing back…"
             } else {
                 "Done — hand back to agent"
             };
+            let button_width = ui
+                .painter()
+                .layout_no_wrap(
+                    button_label.to_owned(),
+                    egui::FontId::proportional(11.0),
+                    egui::Color32::WHITE,
+                )
+                .size()
+                .x
+                + (ui.spacing().button_padding.x * 2.0);
+            let label_width = (ui.available_width() - button_width - ui.spacing().item_spacing.x).max(0.0);
+            ui.add_sized(
+                [label_width, 0.0],
+                egui::Label::new(RichText::new(format!("🖐 Agent paused: {reason}")).size(12.0))
+                    .wrap_mode(TextWrapMode::Truncate),
+            )
+            .on_hover_text(reason);
             clicked = ui
                 .add_enabled(
                     interactive && !browser.handoff_resolution_pending,


### PR DESCRIPTION
Converges the stack tip with the fully smoke-tested browser-panel tree,
plus the handoff-banner layout fix and the review follow-ups from the
Copilot passes.

- chrome: handoff banner is a single-line strip that allocates the
  "Done — hand back to agent" button first and constrains the (truncated)
  reason label to the remaining width — a long reason can no longer push
  the button out of the panel or collapse the body
- chrome: ownership chip width is reserved up front so the URL bar cannot
  starve it on narrow panels
- persistence: drop the runtime.browser clone and its superseded tests
  (the session-store migration in layer 3 already carries the browser
  config)
- board tests: forced browser shutdown state machine coverage
- surge-core pin aligned to v1.0.0-beta.54 (mainline #300 advanced the
  resolved dependency)
- frames: claim_notification marked #[must_use] (carried from the
  converged tree)

The stack tip is source-identical to the fully smoke-tested
browser-panel tree plus the fixes above; only transitive lock
resolution differs from the pre-convergence tip (mainline dependabot
drift). Validation: fmt, workspace tests ± `--features speech`,
blocking + strict clippy tiers, maintainability script — all green on
the exact head. Part of the browser-panel stack (layer 6 of 6).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
