### PR TITLE
feat(theme): refine light palette and deepen dark accent

### DIFF
--- a/crates/horizon-ui/src/app/actions/support.rs
+++ b/crates/horizon-ui/src/app/actions/support.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use egui::text::{LayoutJob, TextFormat};
-use egui::{Button, Color32, FontId, Ui};
+use egui::{Button, FontId, Ui};
 use horizon_core::{PanelId, PanelKind, PresetConfig, WorkspaceId};
 
 use crate::command_palette::{PanelEntry, PresetEntry, WorkspaceEntry};
@@ -228,15 +228,12 @@ pub(super) fn command_palette_workspace_entries(
         .workspaces
         .iter()
         .filter(|workspace| !detached_workspace_ids.contains(&workspace.id))
-        .map(|workspace| {
-            let (r, g, b) = workspace.accent();
-            WorkspaceEntry {
-                id: workspace.id,
-                name: workspace.name.clone(),
-                color: Color32::from_rgb(r, g, b),
-                panel_count: workspace.panels.len(),
-                is_active: active_workspace == Some(workspace.id),
-            }
+        .map(|workspace| WorkspaceEntry {
+            id: workspace.id,
+            name: workspace.name.clone(),
+            color: theme::workspace_accent(workspace.color_idx),
+            panel_count: workspace.panels.len(),
+            is_active: active_workspace == Some(workspace.id),
         })
         .collect()
 }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -3,8 +3,8 @@ mod shortcut_actions;
 use std::collections::BTreeSet;
 
 use egui::{
-    Align, Button, Color32, Context, CornerRadius, Layout, Panel, Pos2, Rect, Stroke, Vec2, ViewportBuilder,
-    ViewportCommand, ViewportId,
+    Align, Button, Context, CornerRadius, Layout, Panel, Pos2, Rect, Stroke, Vec2, ViewportBuilder, ViewportCommand,
+    ViewportId,
 };
 use horizon_core::{CanvasViewState, WindowConfig, WorkspaceId};
 
@@ -393,11 +393,12 @@ impl HorizonApp {
         let workspace_collision_ids = self.workspace_collision_scope(Some(workspace_id));
 
         self.workspace_colors.clear();
-        self.workspace_colors
-            .extend(self.board.workspaces.iter().map(|workspace| {
-                let (r, g, b) = workspace.accent();
-                (workspace.id, Color32::from_rgb(r, g, b))
-            }));
+        self.workspace_colors.extend(
+            self.board
+                .workspaces
+                .iter()
+                .map(|workspace| (workspace.id, theme::workspace_accent(workspace.color_idx))),
+        );
 
         let mut panel_ids = self
             .board

--- a/crates/horizon-ui/src/app/file_drop_highlight.rs
+++ b/crates/horizon-ui/src/app/file_drop_highlight.rs
@@ -48,8 +48,5 @@ fn workspace_accent(board: &horizon_core::Board, workspace_id: horizon_core::Wor
         .workspaces
         .iter()
         .find(|ws| ws.id == workspace_id)
-        .map_or(theme::ACCENT(), |ws| {
-            let (r, g, b) = ws.accent();
-            Color32::from_rgb(r, g, b)
-        })
+        .map_or(theme::ACCENT(), |ws| theme::workspace_accent(ws.color_idx))
 }

--- a/crates/horizon-ui/src/app/minimap.rs
+++ b/crates/horizon-ui/src/app/minimap.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use egui::{Color32, Context, CornerRadius, Id, Painter, Pos2, Rect, Stroke, StrokeKind, Vec2};
+use egui::{Context, CornerRadius, Id, Painter, Pos2, Rect, Stroke, StrokeKind, Vec2};
 use horizon_core::{PanelId, WorkspaceId};
 
 use crate::theme;
@@ -148,8 +148,7 @@ fn paint_minimap_workspaces(
         if !scope_includes_workspace(app, scope, workspace.id) {
             continue;
         }
-        let (r, g, b) = workspace.accent();
-        let workspace_color = Color32::from_rgb(r, g, b);
+        let workspace_color = theme::workspace_accent(workspace.color_idx);
         let is_active =
             app.board.active_workspace == Some(workspace.id) || scope == MinimapScope::Workspace(workspace.id);
         let is_hovered = hovered_workspace == Some(workspace.id);
@@ -196,8 +195,7 @@ fn paint_minimap_panels(app: &HorizonApp, painter: &Painter, origin: Pos2, model
             .board
             .workspace(panel.workspace_id)
             .map_or(theme::ACCENT(), |workspace| {
-                let (r, g, b) = workspace.accent();
-                Color32::from_rgb(r, g, b)
+                theme::workspace_accent(workspace.color_idx)
             });
         let is_focused = app.board.focused == Some(panel.id);
 

--- a/crates/horizon-ui/src/app/minimap/labels.rs
+++ b/crates/horizon-ui/src/app/minimap/labels.rs
@@ -56,10 +56,9 @@ fn collect_minimap_workspace_labels<'a>(
             workspace_minimap_screen_rect(origin, model, workspace.id, workspace.position, workspace_bounds);
         let title_strip_rect = minimap_workspace_title_strip_rect(workspace_rect, model.scale_y);
 
-        let (r, g, b) = workspace.accent();
         labels.push(MinimapWorkspaceLabel {
             name: &workspace.name,
-            color: Color32::from_rgb(r, g, b),
+            color: theme::workspace_accent(workspace.color_idx),
             is_active,
             workspace_rect,
             title_strip_rect,

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -342,11 +342,12 @@ impl HorizonApp {
         // Reuse workspace color vec across frames (avoids per-frame String
         // clones — names are looked up lazily in the context menu).
         self.workspace_colors.clear();
-        self.workspace_colors
-            .extend(self.board.workspaces.iter().map(|workspace| {
-                let (r, g, b) = workspace.accent();
-                (workspace.id, Color32::from_rgb(r, g, b))
-            }));
+        self.workspace_colors.extend(
+            self.board
+                .workspaces
+                .iter()
+                .map(|workspace| (workspace.id, theme::workspace_accent(workspace.color_idx))),
+        );
 
         // Reuse panel ordering vec across frames. Collect into a local first,
         // then swap into the field, because the filter borrows self immutably
@@ -717,8 +718,7 @@ impl HorizonApp {
             // context menu is actually open, so the per-workspace iteration and
             // formatting cost is not paid on every frame.
             for workspace in &self.board.workspaces {
-                let (r, g, b) = workspace.accent();
-                let workspace_color = Color32::from_rgb(r, g, b);
+                let workspace_color = theme::workspace_accent(workspace.color_idx);
                 let is_current = current_workspace_id == workspace.id;
                 let label = if is_current {
                     format!("● {}", workspace.name)

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -720,14 +720,29 @@ impl HorizonApp {
             for workspace in &self.board.workspaces {
                 let workspace_color = theme::workspace_accent(workspace.color_idx);
                 let is_current = current_workspace_id == workspace.id;
-                let label = if is_current {
-                    format!("● {}", workspace.name)
-                } else {
-                    format!("  {}", workspace.name)
-                };
-                let text = egui::RichText::new(label)
-                    .color(if is_current { workspace_color } else { theme::FG_SOFT() })
-                    .size(12.0);
+                // The name stays in the theme's text color: some workspace
+                // accents do not hold 4.5:1 for 12 px text on the panel background.
+                let font_id = egui::FontId::new(12.0, egui::FontFamily::Proportional);
+                let mut job = egui::text::LayoutJob::default();
+                job.append(
+                    if is_current { "\u{25cf} " } else { "  " },
+                    0.0,
+                    egui::text::TextFormat {
+                        font_id: font_id.clone(),
+                        color: workspace_color,
+                        ..Default::default()
+                    },
+                );
+                job.append(
+                    &workspace.name,
+                    0.0,
+                    egui::text::TextFormat {
+                        font_id,
+                        color: if is_current { theme::FG() } else { theme::FG_SOFT() },
+                        ..Default::default()
+                    },
+                );
+                let text = egui::WidgetText::LayoutJob(std::sync::Arc::new(job));
                 if ui.add(egui::Button::new(text).frame(false)).clicked() {
                     outcome.workspace_assignment = Some(workspace.id);
                     ui.close();

--- a/crates/horizon-ui/src/app/sidebar.rs
+++ b/crates/horizon-ui/src/app/sidebar.rs
@@ -139,7 +139,6 @@ impl HorizonApp {
             .workspaces
             .iter()
             .map(|workspace| {
-                let (r, g, b) = workspace.accent();
                 let panels = workspace
                     .panels
                     .iter()
@@ -150,7 +149,7 @@ impl HorizonApp {
                 WorkspaceSidebarEntry {
                     id: workspace.id,
                     name: workspace.name.clone(),
-                    color: Color32::from_rgb(r, g, b),
+                    color: theme::workspace_accent(workspace.color_idx),
                     is_active: self.board.active_workspace == Some(workspace.id),
                     detached: self.workspace_is_detached(workspace.id),
                     panels,

--- a/crates/horizon-ui/src/app/workspace.rs
+++ b/crates/horizon-ui/src/app/workspace.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use egui::{Color32, Context, Pos2, Rect, Vec2};
 use horizon_core::{WorkspaceDockSide, WorkspaceId, WorkspaceLayout};
 
+use crate::theme;
+
 use super::util::{OverlayExclusion, workspace_label_width};
 use super::{HorizonApp, RenameEditAction, WS_BG_PAD, WS_EMPTY_SIZE, WS_LABEL_HEIGHT, WS_TITLE_HEIGHT};
 
@@ -291,8 +293,7 @@ impl HorizonApp {
                     return None;
                 }
 
-                let (r, g, b) = workspace.accent();
-                let color = Color32::from_rgb(r, g, b);
+                let color = theme::workspace_accent(workspace.color_idx);
                 let is_active = self.board.active_workspace == Some(workspace.id);
                 let (workspace_canvas_rect, screen_rect, is_empty) =
                     if let Some((min, max)) = workspace_bounds.get(&workspace.id).copied() {

--- a/crates/horizon-ui/src/git_changes_widget.rs
+++ b/crates/horizon-ui/src/git_changes_widget.rs
@@ -8,9 +8,24 @@ const FILE_ROW_SIZE: f32 = 11.0;
 const DIFF_FONT_SIZE: f32 = 11.0;
 const SUMMARY_SIZE: f32 = 11.0;
 const HEADER_HEIGHT: f32 = 28.0;
+const DIFF_LINE_TINT_ALPHA: u8 = 22;
 
-const DIFF_ADD_BG: Color32 = Color32::from_rgba_unmultiplied_const(166, 227, 161, 18);
-const DIFF_DEL_BG: Color32 = Color32::from_rgba_unmultiplied_const(243, 139, 168, 18);
+/// Diff line tint: derived from the active theme's green/red so both themes
+/// keep enough contrast against their panel background.
+fn diff_line_bg(kind: DiffLineKind) -> Color32 {
+    match kind {
+        DiffLineKind::Add => theme::alpha(theme::PALETTE_GREEN(), DIFF_LINE_TINT_ALPHA),
+        DiffLineKind::Delete => theme::alpha(theme::PALETTE_RED(), DIFF_LINE_TINT_ALPHA),
+        DiffLineKind::Context => Color32::TRANSPARENT,
+    }
+}
+
+fn branch_color() -> Color32 {
+    match theme::current_theme() {
+        theme::ResolvedTheme::Dark => Color32::from_rgb(203, 166, 247),
+        theme::ResolvedTheme::Light => Color32::from_rgb(139, 88, 226),
+    }
+}
 
 pub struct GitChangesView<'a> {
     panel: &'a mut Panel,
@@ -75,13 +90,13 @@ fn render_header(ui: &mut egui::Ui, status: &GitStatus) {
             // Branch badge
             if let Some(branch) = &status.branch {
                 let badge = egui::Frame::new()
-                    .fill(theme::alpha(Color32::from_rgb(203, 166, 247), 20))
+                    .fill(theme::alpha(branch_color(), 20))
                     .corner_radius(CornerRadius::same(4));
                 badge.show(ui, |ui| {
                     ui.label(
                         RichText::new(branch)
                             .font(FontId::monospace(10.0))
-                            .color(Color32::from_rgb(203, 166, 247)),
+                            .color(branch_color()),
                     );
                 });
             }
@@ -402,11 +417,7 @@ fn render_diff_line(ui: &mut egui::Ui, line: &horizon_core::DiffLine) {
     ui.allocate_rect(line_rect, egui::Sense::hover());
 
     // Background
-    let bg = match line.kind {
-        DiffLineKind::Add => DIFF_ADD_BG,
-        DiffLineKind::Delete => DIFF_DEL_BG,
-        DiffLineKind::Context => Color32::TRANSPARENT,
-    };
+    let bg = diff_line_bg(line.kind);
     if bg != Color32::TRANSPARENT {
         ui.painter().rect_filled(line_rect, CornerRadius::ZERO, bg);
     }

--- a/crates/horizon-ui/src/terminal_widget/render.rs
+++ b/crates/horizon-ui/src/terminal_widget/render.rs
@@ -468,6 +468,27 @@ mod tests {
     use alacritty_terminal::vte::ansi::{self, Color as TerminalColor, CursorShape, NamedColor};
     use egui::{Color32, FontId, Pos2, Rect, Shape, Vec2};
 
+    /// Restores the global theme on drop so a panicking assertion cannot leak
+    /// a test theme into the other tests running in parallel threads.
+    struct ThemeGuard {
+        previous: theme::ResolvedTheme,
+    }
+
+    impl ThemeGuard {
+        /// Set `active` as the global theme for the guard's lifetime.
+        fn set(active: theme::ResolvedTheme) -> Self {
+            let previous = theme::current_theme();
+            theme::set_theme(active);
+            Self { previous }
+        }
+    }
+
+    impl Drop for ThemeGuard {
+        fn drop(&mut self) {
+            theme::set_theme(self.previous);
+        }
+    }
+
     struct NoopProxy;
 
     impl EventListener for NoopProxy {
@@ -591,8 +612,7 @@ mod tests {
 
     #[test]
     fn dim_foreground_is_flattened_before_contrast_in_light_theme() {
-        let previous = theme::current_theme();
-        theme::set_theme(theme::ResolvedTheme::Light);
+        let _light = ThemeGuard::set(theme::ResolvedTheme::Light);
 
         let cell = Cell {
             fg: TerminalColor::Named(NamedColor::DimForeground),
@@ -609,7 +629,5 @@ mod tests {
         assert_eq!(bg, theme::PANEL_BG());
         assert_eq!(fg, expected);
         assert_eq!(fg.a(), u8::MAX);
-
-        theme::set_theme(previous);
     }
 }

--- a/crates/horizon-ui/src/terminal_widget/render.rs
+++ b/crates/horizon-ui/src/terminal_widget/render.rs
@@ -591,6 +591,7 @@ mod tests {
 
     #[test]
     fn dim_foreground_is_flattened_before_contrast_in_light_theme() {
+        let previous = theme::current_theme();
         theme::set_theme(theme::ResolvedTheme::Light);
 
         let cell = Cell {
@@ -608,5 +609,7 @@ mod tests {
         assert_eq!(bg, theme::PANEL_BG());
         assert_eq!(fg, expected);
         assert_eq!(fg.a(), u8::MAX);
+
+        theme::set_theme(previous);
     }
 }

--- a/crates/horizon-ui/src/theme.rs
+++ b/crates/horizon-ui/src/theme.rs
@@ -597,10 +597,14 @@ mod tests {
 
     #[test]
     fn light_terminal_palette_keeps_contrast_on_panel_background() {
+        // Matches the >= 4.2:1 contrast promised for the light terminal palette;
+        // this is stricter than the render-time floor in ensure_terminal_text_contrast.
+        const MIN_LIGHT_PALETTE_CONTRAST: f32 = 4.2;
+
         let panel_bg = palette_for(ResolvedTheme::Light).panel_bg;
         for color in palette_for(ResolvedTheme::Light).terminal_palette {
             assert!(
-                contrast_ratio(color, panel_bg) >= 3.6,
+                contrast_ratio(color, panel_bg) >= MIN_LIGHT_PALETTE_CONTRAST,
                 "terminal color {color:?} is too close to the light panel background",
             );
         }

--- a/crates/horizon-ui/src/theme.rs
+++ b/crates/horizon-ui/src/theme.rs
@@ -35,20 +35,20 @@ struct ThemePalette {
 const DARK_THEME: ThemePalette = ThemePalette {
     bg: Color32::from_rgb(7, 10, 16),
     bg_elevated: Color32::from_rgb(12, 16, 24),
-    panel_bg: Color32::from_rgb(15, 19, 28),
-    panel_bg_alt: Color32::from_rgb(21, 26, 37),
-    fg: Color32::from_rgb(224, 230, 241),
-    fg_soft: Color32::from_rgb(170, 181, 199),
-    fg_dim: Color32::from_rgb(108, 120, 142),
-    cursor: Color32::from_rgb(196, 223, 255),
-    grid_dot: Color32::from_rgb(28, 34, 46),
-    accent: Color32::from_rgb(116, 162, 247),
-    border_subtle: Color32::from_rgb(37, 46, 61),
-    border_strong: Color32::from_rgb(63, 78, 101),
+    panel_bg: Color32::from_rgb(16, 20, 30),
+    panel_bg_alt: Color32::from_rgb(22, 27, 39),
+    fg: Color32::from_rgb(228, 233, 244),
+    fg_soft: Color32::from_rgb(174, 185, 205),
+    fg_dim: Color32::from_rgb(112, 125, 150),
+    cursor: Color32::from_rgb(178, 200, 255),
+    grid_dot: Color32::from_rgb(29, 35, 48),
+    accent: Color32::from_rgb(106, 144, 255),
+    border_subtle: Color32::from_rgb(39, 48, 66),
+    border_strong: Color32::from_rgb(68, 84, 112),
     titlebar_bg: Color32::from_rgb(8, 11, 17),
     toolbar_bg: Color32::from_rgb(11, 15, 22),
-    canvas_cool_glow: Color32::from_rgba_unmultiplied_const(77, 112, 220, 20),
-    canvas_warm_glow: Color32::from_rgba_unmultiplied_const(255, 146, 80, 28),
+    canvas_cool_glow: Color32::from_rgba_unmultiplied_const(92, 122, 235, 22),
+    canvas_warm_glow: Color32::from_rgba_unmultiplied_const(255, 152, 86, 24),
     btn_close: Color32::from_rgb(235, 96, 88),
     palette_green: Color32::from_rgb(166, 227, 161),
     palette_red: Color32::from_rgb(243, 139, 168),
@@ -75,46 +75,61 @@ const DARK_THEME: ThemePalette = ThemePalette {
 };
 
 const LIGHT_THEME: ThemePalette = ThemePalette {
-    bg: Color32::from_rgb(247, 244, 239),
-    bg_elevated: Color32::from_rgb(253, 251, 247),
-    panel_bg: Color32::from_rgb(254, 253, 250),
-    panel_bg_alt: Color32::from_rgb(243, 240, 233),
-    fg: Color32::from_rgb(24, 28, 34),
-    fg_soft: Color32::from_rgb(77, 86, 96),
-    fg_dim: Color32::from_rgb(131, 143, 154),
-    cursor: Color32::from_rgb(94, 106, 210),
-    grid_dot: Color32::from_rgb(222, 216, 204),
-    accent: Color32::from_rgb(94, 106, 210),
-    border_subtle: Color32::from_rgb(229, 224, 213),
-    border_strong: Color32::from_rgb(202, 194, 177),
-    titlebar_bg: Color32::from_rgb(248, 246, 240),
-    toolbar_bg: Color32::from_rgb(248, 246, 240),
-    canvas_cool_glow: Color32::from_rgba_unmultiplied_const(94, 106, 210, 14),
-    canvas_warm_glow: Color32::from_rgba_unmultiplied_const(243, 158, 80, 22),
-    btn_close: Color32::from_rgb(214, 67, 67),
-    palette_green: Color32::from_rgb(5, 150, 105),
-    palette_red: Color32::from_rgb(210, 15, 57),
-    palette_yellow: Color32::from_rgb(217, 119, 6),
-    palette_cyan: Color32::from_rgb(8, 145, 178),
+    bg: Color32::from_rgb(243, 240, 234),
+    bg_elevated: Color32::from_rgb(250, 248, 243),
+    panel_bg: Color32::from_rgb(252, 251, 247),
+    panel_bg_alt: Color32::from_rgb(240, 236, 228),
+    fg: Color32::from_rgb(26, 30, 38),
+    fg_soft: Color32::from_rgb(80, 89, 100),
+    fg_dim: Color32::from_rgb(124, 134, 147),
+    cursor: Color32::from_rgb(64, 92, 210),
+    grid_dot: Color32::from_rgb(214, 207, 193),
+    accent: Color32::from_rgb(58, 86, 212),
+    border_subtle: Color32::from_rgb(219, 212, 199),
+    border_strong: Color32::from_rgb(178, 168, 147),
+    titlebar_bg: Color32::from_rgb(246, 243, 236),
+    toolbar_bg: Color32::from_rgb(246, 243, 236),
+    canvas_cool_glow: Color32::from_rgba_unmultiplied_const(94, 106, 210, 10),
+    canvas_warm_glow: Color32::from_rgba_unmultiplied_const(233, 168, 106, 12),
+    btn_close: Color32::from_rgb(207, 55, 66),
+    palette_green: Color32::from_rgb(18, 134, 84),
+    palette_red: Color32::from_rgb(199, 22, 54),
+    palette_yellow: Color32::from_rgb(163, 92, 0),
+    palette_cyan: Color32::from_rgb(0, 116, 146),
+    // Bright variants are the strong versions in light mode: emphasis on paper
+    // reads as deeper and more saturated, not as washed-out pastels.
     terminal_palette: [
-        Color32::from_rgb(92, 95, 119),
+        Color32::from_rgb(35, 38, 48),
         Color32::from_rgb(210, 15, 57),
-        Color32::from_rgb(64, 160, 43),
-        Color32::from_rgb(223, 142, 29),
-        Color32::from_rgb(30, 102, 245),
-        Color32::from_rgb(136, 57, 239),
-        Color32::from_rgb(4, 165, 229),
-        Color32::from_rgb(76, 79, 105),
-        Color32::from_rgb(124, 127, 147),
-        Color32::from_rgb(224, 108, 129),
-        Color32::from_rgb(83, 168, 66),
-        Color32::from_rgb(228, 160, 71),
-        Color32::from_rgb(79, 135, 255),
-        Color32::from_rgb(158, 84, 235),
-        Color32::from_rgb(54, 180, 231),
-        Color32::from_rgb(42, 47, 64),
+        Color32::from_rgb(21, 128, 61),
+        Color32::from_rgb(146, 94, 0),
+        Color32::from_rgb(27, 96, 232),
+        Color32::from_rgb(131, 52, 227),
+        Color32::from_rgb(0, 122, 158),
+        Color32::from_rgb(55, 60, 78),
+        Color32::from_rgb(104, 110, 130),
+        Color32::from_rgb(231, 26, 68),
+        Color32::from_rgb(13, 111, 53),
+        Color32::from_rgb(178, 101, 0),
+        Color32::from_rgb(20, 74, 209),
+        Color32::from_rgb(152, 42, 232),
+        Color32::from_rgb(0, 104, 133),
+        Color32::from_rgb(17, 20, 28),
     ],
 };
+
+/// Light-mode workspace accents: deep enough to hold contrast when blended
+/// into paper-white fills. Indices match `horizon_core::WORKSPACE_COLORS`.
+const WORKSPACE_ACCENTS_LIGHT: &[(u8, u8, u8)] = &[
+    (49, 108, 235), // blue
+    (24, 143, 88),  // green
+    (188, 128, 0),  // yellow
+    (214, 36, 84),  // red
+    (201, 87, 160), // pink
+    (0, 146, 168),  // teal
+    (139, 88, 226), // mauve
+    (219, 111, 40), // peach
+];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResolvedTheme {
@@ -377,6 +392,23 @@ fn palette_for(theme: ResolvedTheme) -> &'static ThemePalette {
     }
 }
 
+/// Theme-aware workspace accent for `color_idx` under the active theme.
+#[must_use]
+pub fn workspace_accent(color_idx: usize) -> Color32 {
+    workspace_accent_for(current_theme(), color_idx)
+}
+
+/// Theme-aware workspace accent for `color_idx` under `theme`.
+#[must_use]
+pub fn workspace_accent_for(theme: ResolvedTheme, color_idx: usize) -> Color32 {
+    let accents = match theme {
+        ResolvedTheme::Dark => horizon_core::WORKSPACE_COLORS,
+        ResolvedTheme::Light => WORKSPACE_ACCENTS_LIGHT,
+    };
+    let (r, g, b) = accents[color_idx % accents.len()];
+    Color32::from_rgb(r, g, b)
+}
+
 fn active_palette() -> &'static ThemePalette {
     palette_for(current_theme())
 }
@@ -544,7 +576,8 @@ fn contrast_ratio(a: Color32, b: Color32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        ResolvedTheme, alpha, bg_for, composite_over, contrast_ratio, ensure_terminal_text_contrast, resolve_theme,
+        ResolvedTheme, alpha, bg_for, composite_over, contrast_ratio, ensure_terminal_text_contrast, palette_for,
+        resolve_theme, workspace_accent_for,
     };
     use egui::{Color32, Theme};
     use horizon_core::AppearanceTheme;
@@ -560,6 +593,28 @@ mod tests {
     #[test]
     fn light_and_dark_backgrounds_differ() {
         assert_ne!(bg_for(ResolvedTheme::Dark), bg_for(ResolvedTheme::Light));
+    }
+
+    #[test]
+    fn light_terminal_palette_keeps_contrast_on_panel_background() {
+        let panel_bg = palette_for(ResolvedTheme::Light).panel_bg;
+        for color in palette_for(ResolvedTheme::Light).terminal_palette {
+            assert!(
+                contrast_ratio(color, panel_bg) >= 3.6,
+                "terminal color {color:?} is too close to the light panel background",
+            );
+        }
+    }
+
+    #[test]
+    fn workspace_accent_varies_by_theme() {
+        for idx in 0..horizon_core::WORKSPACE_COLORS.len() {
+            assert_ne!(
+                workspace_accent_for(ResolvedTheme::Dark, idx),
+                workspace_accent_for(ResolvedTheme::Light, idx),
+                "workspace accent {idx} should have distinct dark and light variants",
+            );
+        }
     }
 
     #[test]

--- a/crates/horizon-ui/src/usage_widget.rs
+++ b/crates/horizon-ui/src/usage_widget.rs
@@ -6,8 +6,19 @@ use horizon_core::{DailyUsage, Panel, ToolUsage, UsageSnapshot, format_cost, for
 
 use crate::{loading_spinner, theme};
 
-const CODEX_COLOR: Color32 = Color32::from_rgb(100, 200, 120);
-const OPENCODE_COLOR: Color32 = Color32::from_rgb(102, 214, 173);
+fn codex_color() -> Color32 {
+    match theme::current_theme() {
+        theme::ResolvedTheme::Dark => Color32::from_rgb(100, 200, 120),
+        theme::ResolvedTheme::Light => Color32::from_rgb(16, 124, 72),
+    }
+}
+
+fn opencode_color() -> Color32 {
+    match theme::current_theme() {
+        theme::ResolvedTheme::Dark => Color32::from_rgb(102, 214, 173),
+        theme::ResolvedTheme::Light => Color32::from_rgb(0, 112, 143),
+    }
+}
 const SECTION_FONT_SIZE: f32 = 11.0;
 const STAT_LABEL_SIZE: f32 = 12.0;
 const STAT_VALUE_SIZE: f32 = 14.0;
@@ -96,7 +107,7 @@ fn render_today_section(ui: &mut egui::Ui, snapshot: &UsageSnapshot) {
                 ui,
                 "Codex CLI",
                 &snapshot.codex,
-                CODEX_COLOR,
+                codex_color(),
                 false,
                 card_width,
                 card_height,
@@ -106,7 +117,7 @@ fn render_today_section(ui: &mut egui::Ui, snapshot: &UsageSnapshot) {
                 ui,
                 "OpenCode",
                 &snapshot.opencode,
-                OPENCODE_COLOR,
+                opencode_color(),
                 false,
                 card_width,
                 card_height,
@@ -128,7 +139,7 @@ fn render_today_section(ui: &mut egui::Ui, snapshot: &UsageSnapshot) {
             ui,
             "Codex CLI",
             &snapshot.codex,
-            CODEX_COLOR,
+            codex_color(),
             false,
             card_width,
             card_height,
@@ -138,7 +149,7 @@ fn render_today_section(ui: &mut egui::Ui, snapshot: &UsageSnapshot) {
             ui,
             "OpenCode",
             &snapshot.opencode,
-            OPENCODE_COLOR,
+            opencode_color(),
             false,
             card_width,
             card_height,
@@ -294,9 +305,9 @@ fn render_daily_chart_header(ui: &mut egui::Ui, date_width: f32, bar_area_width:
         ui.add_space(date_width + 8.0 + bar_area_width + 4.0);
         ui.label(RichText::new("Claude").size(10.0).color(theme::ACCENT()).strong());
         ui.add_space(8.0);
-        ui.label(RichText::new("Codex").size(10.0).color(CODEX_COLOR).strong());
+        ui.label(RichText::new("Codex").size(10.0).color(codex_color()).strong());
         ui.add_space(8.0);
-        ui.label(RichText::new("OpenCode").size(10.0).color(OPENCODE_COLOR).strong());
+        ui.label(RichText::new("OpenCode").size(10.0).color(opencode_color()).strong());
     });
 }
 
@@ -358,13 +369,13 @@ fn paint_daily_chart_bar(
     let bar_y = row_rect.center().y - BAR_HEIGHT / 2.0;
 
     paint_daily_chart_bar_segment(painter, bar_x, bar_y, claude_width, theme::ACCENT());
-    paint_daily_chart_bar_segment(painter, bar_x + claude_width, bar_y, codex_width, CODEX_COLOR);
+    paint_daily_chart_bar_segment(painter, bar_x + claude_width, bar_y, codex_width, codex_color());
     paint_daily_chart_bar_segment(
         painter,
         bar_x + claude_width + codex_width,
         bar_y,
         opencode_width,
-        OPENCODE_COLOR,
+        opencode_color(),
     );
 }
 


### PR DESCRIPTION
## Purpose

Light mode reused dark-mode-tuned colors on paper-white: washed-out titlebars and focus borders, near-invisible terminal bright variants, a muddy peach canvas glow, and hardcoded dark pastels in a few widgets. This PR redesigns the light palette and gives dark mode a richer accent, in the same design language.

## Behavior impact

Visual only. No config, layout, or interaction changes.

**Light mode**
- Terminal 16-color ANSI palette redesigned: deep-ink black, saturated primaries; bright variants are strong dark-saturated colors (emphasis on paper reads deeper, not paler). All 16 colors hold >= 4.2:1 contrast against the panel background, enforced by a new test.
- New light-mode workspace accents (deep blue/green/amber/rose/pink/teal/mauve/peach) resolved per theme at all 9 call sites (titlebar tint, focus borders, sidebar dots, chips, minimap, file-drop highlight, command palette) — previously dark pastels blended into near-invisible blue-gray on white.
- Tighter warm-paper surface separation, stronger borders, richer indigo accent/cursor, halved canvas glow alpha.
- Git diff add/delete tints, git branch badge, and usage-dashboard tool colors are now theme-aware instead of hardcoded dark pastels.

**Dark mode** (polish; Mocha terminal palette untouched)
- Richer electric-indigo accent (116,162,247 -> 106,144,255), slightly deeper/bluer surfaces and borders, brighter text, bluer cursor, cooler glow.

**Test fix**
- `dim_foreground_is_flattened_before_contrast_in_light_theme` leaked global Light theme state into other tests; it now saves and restores the previous theme.

## Screenshots

Before/after comparisons (same layout; dark "before" is the pre-change instance):

- Light mode: [light_compare.png](https://raw.githubusercontent.com/peters/horizon/assets/theme-refinement-screenshots/light_compare.png)
- Dark mode: [dark_compare.png](https://raw.githubusercontent.com/peters/horizon/assets/theme-refinement-screenshots/dark_compare.png)
- Terminal palette close-up: [terminal_compare.png](https://raw.githubusercontent.com/peters/horizon/assets/theme-refinement-screenshots/terminal_compare.png)

## Repro

`appearance.theme: light` in config (or Settings > Appearance), then open any terminal with ANSI color output. Compare titlebar/border tint, canvas glow, and terminal bright colors.

## Test evidence

In the exact branch/worktree to be pushed (head 3cbb336):

- `cargo fmt --all -- --check` — clean
- `./scripts/check-maintainability.sh` — pass
- `RUSTFLAGS="-D warnings" cargo test --workspace` — 395 core + 466 UI passed, 0 failed
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings` (blocking tier) — pass
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` (strict tier) — pass
- Pedantic tier: pre-existing `horizon-cursor` failure at main HEAD, untouched by this PR (advisory)
- Live UI smoke from this exact commit's debug binary: light and dark instances verified via screenshots (sidebar, chips, titlebars, terminal palette, minimap, canvas glow)

## Scope note

12 files / ~288 lines, one cohesive visual outcome. The 9 workspace-accent call sites are the plumbing that shares the theme-aware accent lookup; they cannot ship separately from the palette work.
