### PR TITLE
fix(ui): scroll the canvas to newly created and sidebar-selected panels

### DIFF
--- a/crates/horizon-ui/src/app/actions/command_palette.rs
+++ b/crates/horizon-ui/src/app/actions/command_palette.rs
@@ -99,7 +99,7 @@ impl HorizonApp {
             CommandId::NewPanel => {
                 let workspace_id = self.ensure_workspace_visible(ctx);
                 if let Some(preset) = self.presets.first().cloned() {
-                    self.add_panel_to_workspace(workspace_id, preset, None);
+                    self.add_panel_to_workspace(ctx, workspace_id, preset, None);
                 } else {
                     self.create_panel(ctx);
                 }
@@ -112,7 +112,7 @@ impl HorizonApp {
                         .board
                         .active_workspace
                         .unwrap_or_else(|| self.ensure_workspace_visible(ctx));
-                    self.add_panel_to_workspace(workspace_id, preset, None);
+                    self.add_panel_to_workspace(ctx, workspace_id, preset, None);
                 }
             }
             CommandId::ToggleSettings => self.toggle_settings(),

--- a/crates/horizon-ui/src/app/actions/panels.rs
+++ b/crates/horizon-ui/src/app/actions/panels.rs
@@ -17,8 +17,9 @@ fn normalize_new_panel_resume(options: &mut PanelOptions) {
 impl HorizonApp {
     pub(in crate::app) fn create_panel(&mut self, ctx: &egui::Context) {
         let workspace_id = self.ensure_workspace_visible(ctx);
-        if let Err(error) = self.create_panel_with_options(PanelOptions::default(), workspace_id) {
-            tracing::error!("failed to create panel: {error}");
+        match self.create_panel_with_options(PanelOptions::default(), workspace_id) {
+            Ok(panel_id) => self.reveal_new_panel(ctx, workspace_id, panel_id),
+            Err(error) => tracing::error!("failed to create panel: {error}"),
         }
     }
 
@@ -32,6 +33,22 @@ impl HorizonApp {
         normalize_new_panel_resume(&mut options);
         options.transcript_root.clone_from(&self.transcript_root);
         self.board.create_panel(options, workspace_id)
+    }
+
+    /// Reveal a newly created panel the same way the sidebar reveals a
+    /// selected panel: detached workspaces get their OS window focused,
+    /// attached canvases pan/zoom to the panel.
+    pub(in crate::app) fn reveal_new_panel(
+        &mut self,
+        ctx: &egui::Context,
+        workspace_id: WorkspaceId,
+        panel_id: PanelId,
+    ) {
+        if self.focus_workspace_window(ctx, workspace_id) {
+            self.board.focus(panel_id);
+            return;
+        }
+        self.reveal_panel_visible(ctx, panel_id);
     }
 
     pub(in crate::app) fn close_panel(&mut self, panel_id: PanelId) {
@@ -110,6 +127,7 @@ impl HorizonApp {
 
     pub(in crate::app) fn add_panel_to_workspace(
         &mut self,
+        ctx: &egui::Context,
         workspace_id: WorkspaceId,
         preset: PresetConfig,
         canvas_pos: Option<[f32; 2]>,
@@ -117,8 +135,9 @@ impl HorizonApp {
         if workspace_cwd(&self.board, workspace_id).is_some() || !preset.requires_workspace_cwd() {
             let mut options = preset.to_panel_options();
             options.position = add_panel_position(&self.board, workspace_id, canvas_pos);
-            if let Err(error) = self.create_panel_with_options(options, workspace_id) {
-                tracing::error!("failed to create panel: {error}");
+            match self.create_panel_with_options(options, workspace_id) {
+                Ok(panel_id) => self.reveal_new_panel(ctx, workspace_id, panel_id),
+                Err(error) => tracing::error!("failed to create panel: {error}"),
             }
             self.mark_runtime_dirty();
         } else {
@@ -146,7 +165,7 @@ impl HorizonApp {
 
 #[cfg(test)]
 mod tests {
-    use horizon_core::{PanelKind, PanelOptions, PanelResume};
+    use horizon_core::{PanelKind, PanelOptions, PanelResume, PresetConfig, RuntimeState, StartupDecision};
 
     use super::normalize_new_panel_resume;
 
@@ -201,6 +220,69 @@ mod tests {
             PanelResume::Session {
                 session_id: "session-1".to_string(),
             }
+        );
+    }
+
+    fn shell_preset() -> PresetConfig {
+        PresetConfig {
+            name: "shell".to_string(),
+            alias: None,
+            kind: PanelKind::Shell,
+            command: None,
+            args: Vec::new(),
+            resume: PanelResume::Fresh,
+            ssh_connection: None,
+        }
+    }
+
+    #[test]
+    fn new_panel_reveals_it_when_the_view_is_panned_away() {
+        use crate::app::test_support::{raw_input, run_app_frame_with_input, test_app_with_startup};
+
+        let (_temp, ctx, mut app) = test_app_with_startup(StartupDecision::Ephemeral {
+            runtime_state: Box::new(RuntimeState::default()),
+        });
+        // Establish the viewport so canvas math matches the assertion below.
+        run_app_frame_with_input(&ctx, &mut app, raw_input([1600.0, 1000.0], Some([0.0, 0.0])));
+
+        let workspace_id = app.board.create_workspace("far");
+        {
+            let workspace = app.board.workspace_mut(workspace_id).expect("workspace");
+            workspace.position = [6000.0, 4000.0];
+            workspace.cwd = Some(std::path::PathBuf::from("/tmp"));
+        }
+        app.add_panel_to_workspace(&ctx, workspace_id, shell_preset(), None);
+
+        // The user pans the canvas away from the workspace.
+        app.canvas_view.set_pan_offset([0.0, 0.0]);
+
+        app.add_panel_to_workspace(&ctx, workspace_id, shell_preset(), None);
+        let new_panel = app
+            .board
+            .workspace(workspace_id)
+            .and_then(|workspace| workspace.panels.last().copied())
+            .expect("new panel");
+
+        // Like a sidebar selection: the view moves to the new panel and the
+        // panel is focused.
+        let pan_moved = app.canvas_view.pan_offset[0].abs() + app.canvas_view.pan_offset[1].abs();
+        assert!(pan_moved > 1.0, "view should have panned to the new panel");
+        assert_eq!(app.board.focused, Some(new_panel));
+
+        run_app_frame_with_input(&ctx, &mut app, raw_input([1600.0, 1000.0], Some([0.0, 0.0])));
+        let canvas_rect = app.canvas_rect(&ctx);
+        let panel = app.board.panel(new_panel).expect("panel");
+        let screen_min = app.canvas_to_screen(
+            canvas_rect,
+            egui::Pos2::new(panel.layout.position[0], panel.layout.position[1]),
+        );
+        let screen_rect = egui::Rect::from_min_size(
+            screen_min,
+            app.canvas_size_to_screen(egui::Vec2::new(panel.layout.size[0], panel.layout.size[1])),
+        );
+        assert!(
+            canvas_rect.intersects(screen_rect),
+            "new panel should be visible after creation: panel screen {screen_rect:?} vs canvas {canvas_rect:?}"
         );
     }
 }

--- a/crates/horizon-ui/src/app/actions/panels.rs
+++ b/crates/horizon-ui/src/app/actions/panels.rs
@@ -36,8 +36,9 @@ impl HorizonApp {
     }
 
     /// Reveal a newly created panel the same way the sidebar reveals a
-    /// selected panel: detached workspaces get their OS window focused,
-    /// attached canvases pan/zoom to the panel.
+    /// selected panel: detached workspaces get their OS window focused, the
+    /// panel re-focused so the helper stays self-contained, and attached
+    /// canvases pan/zoom to the panel.
     pub(in crate::app) fn reveal_new_panel(
         &mut self,
         ctx: &egui::Context,

--- a/crates/horizon-ui/src/app/actions/pickers.rs
+++ b/crates/horizon-ui/src/app/actions/pickers.rs
@@ -34,8 +34,9 @@ impl HorizonApp {
                 super::update_workspace_cwd(self.board.workspace_mut(workspace_id), path);
                 let mut options = preset.to_panel_options();
                 options.position = Some(canvas_pos);
-                if let Err(error) = self.create_panel_with_options(options, workspace_id) {
-                    tracing::error!("failed to create panel: {error}");
+                match self.create_panel_with_options(options, workspace_id) {
+                    Ok(panel_id) => self.reveal_new_panel(ctx, workspace_id, panel_id),
+                    Err(error) => tracing::error!("failed to create panel: {error}"),
                 }
             }
             DirPickerPurpose::AddPanel {
@@ -46,8 +47,9 @@ impl HorizonApp {
                 super::update_workspace_cwd(self.board.workspace_mut(workspace_id), path);
                 let mut options = preset.to_panel_options();
                 options.position = super::add_panel_position(&self.board, workspace_id, canvas_pos);
-                if let Err(error) = self.create_panel_with_options(options, workspace_id) {
-                    tracing::error!("failed to create panel: {error}");
+                match self.create_panel_with_options(options, workspace_id) {
+                    Ok(panel_id) => self.reveal_new_panel(ctx, workspace_id, panel_id),
+                    Err(error) => tracing::error!("failed to create panel: {error}"),
                 }
             }
         }
@@ -163,7 +165,7 @@ impl HorizonApp {
                 preset,
                 canvas_pos,
             } => {
-                self.add_panel_to_workspace(workspace_id, preset, canvas_pos);
+                self.add_panel_to_workspace(ctx, workspace_id, preset, canvas_pos);
             }
             PresetPickerAction::ChooseDirectory {
                 workspace_id,
@@ -180,8 +182,9 @@ impl HorizonApp {
                 let workspace_id = self.create_workspace_at_visible(ctx, &name, canvas_pos);
                 let mut options = preset.to_panel_options();
                 options.position = Some(canvas_pos);
-                if let Err(error) = self.create_panel_with_options(options, workspace_id) {
-                    tracing::error!("failed to create panel: {error}");
+                match self.create_panel_with_options(options, workspace_id) {
+                    Ok(panel_id) => self.reveal_new_panel(ctx, workspace_id, panel_id),
+                    Err(error) => tracing::error!("failed to create panel: {error}"),
                 }
                 self.mark_runtime_dirty();
             }

--- a/crates/horizon-ui/src/app/canvas.rs
+++ b/crates/horizon-ui/src/app/canvas.rs
@@ -178,7 +178,7 @@ impl HorizonApp {
                                 if ui.add(super::util::chrome_button("New Terminal")).clicked() {
                                     if let Some(preset) = self.presets.first().cloned() {
                                         let workspace_id = self.ensure_workspace_visible(ctx);
-                                        self.add_panel_to_workspace(workspace_id, preset, None);
+                                        self.add_panel_to_workspace(ctx, workspace_id, preset, None);
                                     } else {
                                         self.create_panel(ctx);
                                     }

--- a/crates/horizon-ui/src/app/file_drop.rs
+++ b/crates/horizon-ui/src/app/file_drop.rs
@@ -312,8 +312,9 @@ impl HorizonApp {
                 size: Some(editor_panel_size_for_file(&path)),
                 ..PanelOptions::default()
             };
-            if let Err(error) = self.create_panel_with_options(options, workspace_id) {
-                tracing::error!("failed to create editor panel from dropped file: {error}");
+            match self.create_panel_with_options(options, workspace_id) {
+                Ok(panel_id) => self.reveal_new_panel(ctx, workspace_id, panel_id),
+                Err(error) => tracing::error!("failed to create editor panel from dropped file: {error}"),
             }
             self.mark_runtime_dirty();
         }

--- a/crates/horizon-ui/src/app/remote_hosts.rs
+++ b/crates/horizon-ui/src/app/remote_hosts.rs
@@ -150,7 +150,7 @@ impl HorizonApp {
 
         match self.create_panel_with_options(options, workspace_id) {
             Ok(panel_id) => {
-                self.reveal_panel_visible(ctx, panel_id);
+                self.reveal_new_panel(ctx, workspace_id, panel_id);
                 self.mark_runtime_dirty();
             }
             Err(error) => {

--- a/crates/horizon-ui/src/app/sidebar.rs
+++ b/crates/horizon-ui/src/app/sidebar.rs
@@ -291,17 +291,13 @@ impl HorizonApp {
             // With the accordion the panel rows are collapsed, so selecting a
             // workspace reveals its selected panel instead of panning to the
             // whole workspace. Single-panel workspaces behave the same in
-            // both modes.
-            let reveal = if accordion || workspace.panels.len() <= 1 {
-                self.workspace_reveal_panel(workspace.id, &workspace.panels)
-            } else {
-                None
-            };
-            if let Some(panel_id) = reveal {
-                actions.focus_panel = Some(panel_id);
-                actions.pan_to_panel = Some(panel_id);
-            } else {
-                actions.pan_to_workspace = Some(workspace.id);
+            // both modes; flat multi-panel rows keep panning to bounds.
+            match self.workspace_row_reveal(accordion, workspace.id, &workspace.panels) {
+                Some(panel_id) => {
+                    actions.focus_panel = Some(panel_id);
+                    actions.pan_to_panel = Some(panel_id);
+                }
+                None => actions.pan_to_workspace = Some(workspace.id),
             }
         }
         Self::show_workspace_context_menu(&row_response, workspace, actions);
@@ -313,6 +309,22 @@ impl HorizonApp {
             }
         }
         ui.add_space(8.0);
+    }
+
+    /// The panel a workspace-row click reveals. Accordion rows (where panel
+    /// rows are collapsed) and single-panel workspaces reveal a panel;
+    /// flat multi-panel rows return `None` so the click keeps its original
+    /// pan-to-workspace-bounds behavior.
+    fn workspace_row_reveal(
+        &self,
+        accordion: bool,
+        workspace_id: WorkspaceId,
+        panels: &[SidebarPanelEntry],
+    ) -> Option<PanelId> {
+        if !accordion && panels.len() > 1 {
+            return None;
+        }
+        self.workspace_reveal_panel(workspace_id, panels)
     }
 
     /// The panel a workspace-row click reveals: the focused panel when it
@@ -935,6 +947,8 @@ mod tests {
         assert!((width - 43.0).abs() <= f32::EPSILON);
     }
 
+    // `is_focused` is decorative in these tests: the reveal helpers read the
+    // board's own focus state, not the sidebar entry flag.
     fn sidebar_entry(id: horizon_core::PanelId, is_focused: bool) -> SidebarPanelEntry {
         SidebarPanelEntry {
             id,
@@ -999,5 +1013,42 @@ mod tests {
         app.board.focused = None;
         assert_eq!(app.workspace_reveal_panel(workspace, &panels), Some(first));
         assert_eq!(app.workspace_reveal_panel(other, &[]), None);
+    }
+
+    #[test]
+    fn workspace_row_reveal_gate_covers_accordion_and_panel_count() {
+        let (_temp, mut app) = crate::app::test_support::test_app();
+        let workspace = app.board.create_workspace("a");
+        let first = app
+            .board
+            .create_panel(editor_panel_options("first"), workspace)
+            .expect("panel");
+        let second = app
+            .board
+            .create_panel(editor_panel_options("second"), workspace)
+            .expect("panel");
+        let solo = app.board.create_workspace("solo");
+        let only = app
+            .board
+            .create_panel(editor_panel_options("only"), solo)
+            .expect("panel");
+        let empty = app.board.create_workspace("empty");
+
+        // Creation leaves focus on the last created panel (`only`), so put
+        // it back in `workspace` for the focused-in-workspace case.
+        app.board.focus(second);
+        let two = [sidebar_entry(first, false), sidebar_entry(second, true)];
+        let one = [sidebar_entry(only, false)];
+
+        // Accordion rows always reveal a panel: focused-in-workspace for
+        // multi-panel, the only panel for single-panel, nothing for empty.
+        assert_eq!(app.workspace_row_reveal(true, workspace, &two), Some(second));
+        assert_eq!(app.workspace_row_reveal(true, solo, &one), Some(only));
+        assert_eq!(app.workspace_row_reveal(true, empty, &[]), None);
+
+        // Flat rows only reveal single-panel workspaces; multi-panel rows
+        // keep panning to the workspace bounds (None).
+        assert_eq!(app.workspace_row_reveal(false, solo, &one), Some(only));
+        assert_eq!(app.workspace_row_reveal(false, workspace, &two), None);
     }
 }

--- a/crates/horizon-ui/src/app/sidebar.rs
+++ b/crates/horizon-ui/src/app/sidebar.rs
@@ -288,9 +288,18 @@ impl HorizonApp {
         self.handle_sidebar_workspace_drag(ui, workspace, row_rect, &row_response, drag_state, click_target_hovered);
 
         if row_clicked {
-            if workspace.panels.len() == 1 {
-                actions.focus_panel = Some(workspace.panels[0].id);
-                actions.pan_to_panel = Some(workspace.panels[0].id);
+            // With the accordion the panel rows are collapsed, so selecting a
+            // workspace reveals its selected panel instead of panning to the
+            // whole workspace. Single-panel workspaces behave the same in
+            // both modes.
+            let reveal = if accordion || workspace.panels.len() <= 1 {
+                self.workspace_reveal_panel(workspace.id, &workspace.panels)
+            } else {
+                None
+            };
+            if let Some(panel_id) = reveal {
+                actions.focus_panel = Some(panel_id);
+                actions.pan_to_panel = Some(panel_id);
             } else {
                 actions.pan_to_workspace = Some(workspace.id);
             }
@@ -304,6 +313,15 @@ impl HorizonApp {
             }
         }
         ui.add_space(8.0);
+    }
+
+    /// The panel a workspace-row click reveals: the focused panel when it
+    /// belongs to the workspace, otherwise the workspace's first panel.
+    fn workspace_reveal_panel(&self, workspace_id: WorkspaceId, panels: &[SidebarPanelEntry]) -> Option<PanelId> {
+        self.board
+            .focused
+            .filter(|panel_id| self.board.panel_workspace_id(*panel_id) == Some(workspace_id))
+            .or_else(|| panels.first().map(|panel| panel.id))
     }
 
     fn handle_sidebar_workspace_drag(
@@ -861,8 +879,8 @@ fn paint_panel_row_bg(ui: &mut egui::Ui, item_rect: Rect, workspace_color: Color
 #[cfg(test)]
 mod tests {
     use super::{
-        SidebarWorkspaceInsert, sidebar_workspace_drop_should_dock, sidebar_workspace_insert_dock_side,
-        sidebar_workspace_name_width, sidebar_workspace_shows_panels,
+        SidebarPanelEntry, SidebarWorkspaceInsert, sidebar_workspace_drop_should_dock,
+        sidebar_workspace_insert_dock_side, sidebar_workspace_name_width, sidebar_workspace_shows_panels,
     };
     use horizon_core::WorkspaceDockSide;
 
@@ -915,5 +933,71 @@ mod tests {
         let width = sidebar_workspace_name_width(143.0, true);
         assert!(width < 48.0);
         assert!((width - 43.0).abs() <= f32::EPSILON);
+    }
+
+    fn sidebar_entry(id: horizon_core::PanelId, is_focused: bool) -> SidebarPanelEntry {
+        SidebarPanelEntry {
+            id,
+            title: "panel".to_string(),
+            kind: horizon_core::PanelKind::Editor,
+            is_focused,
+            attention: None,
+        }
+    }
+
+    fn editor_panel_options(name: &str) -> horizon_core::PanelOptions {
+        horizon_core::PanelOptions {
+            name: Some(name.to_string()),
+            kind: horizon_core::PanelKind::Editor,
+            command: Some("seed".to_string()),
+            ..horizon_core::PanelOptions::default()
+        }
+    }
+
+    #[test]
+    fn workspace_reveal_panel_prefers_the_focused_panel_of_the_workspace() {
+        let (_temp, mut app) = crate::app::test_support::test_app();
+        let workspace = app.board.create_workspace("a");
+        let first = app
+            .board
+            .create_panel(editor_panel_options("first"), workspace)
+            .expect("panel");
+        let second = app
+            .board
+            .create_panel(editor_panel_options("second"), workspace)
+            .expect("panel");
+        app.board.focus(second);
+
+        let panels = [sidebar_entry(first, false), sidebar_entry(second, true)];
+        assert_eq!(app.workspace_reveal_panel(workspace, &panels), Some(second));
+    }
+
+    #[test]
+    fn workspace_reveal_panel_falls_back_to_first_panel() {
+        let (_temp, mut app) = crate::app::test_support::test_app();
+        let workspace = app.board.create_workspace("a");
+        let other = app.board.create_workspace("b");
+        let first = app
+            .board
+            .create_panel(editor_panel_options("first"), workspace)
+            .expect("panel");
+        let second = app
+            .board
+            .create_panel(editor_panel_options("second"), workspace)
+            .expect("panel");
+        let outsider = app
+            .board
+            .create_panel(editor_panel_options("other"), other)
+            .expect("panel");
+
+        // Focus lives in another workspace -> the workspace's first panel.
+        app.board.focus(outsider);
+        let panels = [sidebar_entry(first, false), sidebar_entry(second, false)];
+        assert_eq!(app.workspace_reveal_panel(workspace, &panels), Some(first));
+
+        // No focus at all -> first panel; no panels -> nothing to reveal.
+        app.board.focused = None;
+        assert_eq!(app.workspace_reveal_panel(workspace, &panels), Some(first));
+        assert_eq!(app.workspace_reveal_panel(other, &[]), None);
     }
 }


### PR DESCRIPTION
## Purpose

Two canvas-navigation gaps:

1. **New panels didn't scroll into view.** Creating a panel (welcome "New Terminal", Quick Nav / `Ctrl+Shift+N`, preset picker, dir-picker completions, file drop, SSH panels) left the view wherever the user had panned it, so the new panel was often off-screen.
2. **Accordion sidebar: selecting a workspace didn't reveal a panel.** With `features.sidebar_accordion` on, the panel rows are collapsed, so clicking a workspace row only panned to the workspace bounds — there was no way to reach a specific panel's reveal.

## Behavior

- All user-initiated panel creation now reveals the new panel through the same path as a sidebar panel selection (shared `HorizonApp::reveal_new_panel`): detached workspaces get their OS window focused, attached canvases pan/zoom to the panel (workspace left-aligned, zooms out only as needed, oversized panels bottom-aligned). Side effect: a new SSH panel in a detached "Remote Sessions" workspace now focuses that window instead of no-op-panning the main canvas.
- With the accordion sidebar enabled, a workspace-row click reveals the workspace's selected panel — the focused panel when focus is already in that workspace, otherwise its first panel. Single-panel rows behave identically in both modes; flat multi-panel rows keep panning to workspace bounds (gate folded into `workspace_row_reveal` with a combination test).

## Test evidence

- New tests (all passing): `new_panel_reveals_it_when_the_view_is_panned_away` (app-level: workspace far off-screen, view panned away, panel created → view moves, panel focused, panel visible in canvas after a frame), `workspace_row_reveal_gate_covers_accordion_and_panel_count` (accordion × single/multi/empty + flat × single/multi), and `workspace_reveal_panel_*` (focused-in-workspace wins, first-panel fallback, empty workspace → none).
- Full local matrix green on this head: `cargo fmt --check`, maintainability guardrail, `cargo test --workspace` (470 + 395), blocking clippy (`--all-targets --features speech,trace-profiling -D warnings`), strict clippy (`-D unwrap_used -D expect_used`).
- Manually smoke-tested on a live desktop (debug build, accordion enabled): panel creation reveals from a panned-away view; accordion workspace selection scrolls to the selected panel.
- Independent local code review (2 lanes): merge-OK, no blockers/majors; the actionable minor (untested accordion gate) is addressed by the second commit. Residual risk recorded: the detached-workspace branch of `reveal_new_panel` is untested because the test harness cannot materialize a detached OS viewport — it mirrors the pre-existing sidebar detached path, so risk is low.
