### PR TITLE
fix(agent): use native terminal scrollback

### DIFF
--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -859,6 +859,11 @@ pub(super) fn agent_env(kind: PanelKind) -> HashMap<String, String> {
     if kind.is_agent() {
         env.insert("HORIZON".to_string(), "1".to_string());
     }
+    if kind == PanelKind::Claude {
+        // Keep the conversation in Horizon's terminal history so its scrollbar
+        // and history meter remain usable instead of hiding it in a fullscreen buffer.
+        env.insert("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN".to_string(), "1".to_string());
+    }
     env
 }
 
@@ -896,6 +901,20 @@ pub(super) fn kitty_keyboard_for_kind(kind: PanelKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn claude_uses_horizon_native_scrollback() {
+        let claude_env = agent_env(PanelKind::Claude);
+
+        assert_eq!(
+            claude_env
+                .get("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert!(!agent_env(PanelKind::Codex).contains_key("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN"));
+        assert!(!agent_env(PanelKind::Shell).contains_key("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN"));
+    }
 
     #[test]
     fn shell_launch_args_adds_login_flag_when_requested() {


### PR DESCRIPTION
## Purpose
Keep the affected coding-agent panel conversation in Horizon terminal history so the history meter and scrollbar expose earlier output.

## Behavior impact
- opts the affected embedded agent out of its private fullscreen buffer on fresh launch and restart
- lets Horizon retain and navigate the conversation through its existing native history path
- leaves every other panel kind unchanged

## Test evidence
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- RUSTFLAGS="-D warnings" cargo test --workspace --features speech
- cargo clippy --all-targets --features speech,trace-profiling -- -D warnings
- strict Clippy panic-path lane
- focused environment-scoping regression test
- independent local review: no actionable findings
- exact-head isolated Linux/Xvfb smoke: the candidate injected the override only into its task-owned agent child; a 140-line response produced 110/24k history; plain wheel and direct scrollbar navigation moved to earlier lines and returned to the tail; resize preserved rendering and navigation; normal cleanup left the pre-existing live process untouched

## Advisory baseline
The pedantic Clippy command reports the existing excessive-bools lint in crates/horizon-cursor/src/hotkey.rs. That file is byte-identical to origin/main and is outside this focused change.