### PR TITLE
feat(browser): own standalone host processes

### DIFF
--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -14,6 +18,7 @@ use thiserror::Error;
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const FORCED_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+const HOST_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct StandaloneOptions {
@@ -33,6 +38,143 @@ pub enum StandaloneError {
     Shutdown,
 }
 
+pub(crate) struct OwnedSession {
+    session: Option<BrowserSession>,
+    profile_root: PathBuf,
+}
+
+impl OwnedSession {
+    pub(crate) fn start(options: StandaloneOptions, home: &HorizonHome) -> Result<Self, StandaloneError> {
+        let (session, profile_root) = start(options, home)?;
+        Ok(Self {
+            session: Some(session),
+            profile_root,
+        })
+    }
+
+    pub(crate) fn shutdown(mut self) -> bool {
+        self.stop()
+    }
+
+    fn stop(&mut self) -> bool {
+        self.session.take().is_none_or(|session| {
+            let profile_root = std::mem::take(&mut self.profile_root);
+            let shutdown = session.shutdown_signal().with_profile_cleanup(profile_root);
+            shutdown.wait(SHUTDOWN_TIMEOUT) || shutdown.force_cleanup(FORCED_SHUTDOWN_TIMEOUT)
+        })
+    }
+}
+
+impl Drop for OwnedSession {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+#[doc(hidden)]
+pub struct OwnedHostProcess {
+    child: Child,
+    stdin: Option<ChildStdin>,
+}
+
+impl OwnedHostProcess {
+    /// Start an owned standalone MCP subprocess with private host state.
+    ///
+    /// # Errors
+    /// Returns when the subprocess cannot start, initialize, or publish its
+    /// first browser manifest before the startup deadline.
+    pub fn start(options: StandaloneOptions, home: &Path, stderr: File) -> Result<Self, StandaloneError> {
+        let executable = std::env::current_exe()
+            .map_err(|error| StandaloneError::Startup(format!("could not resolve horizon-browser: {error}")))?;
+        let mut command = Command::new(executable);
+        command.args(["mcp", "--standalone"]);
+        if let Some(backend) = options.backend {
+            command.args(["--backend", backend_name(backend)]);
+        }
+        if options.visible {
+            command.arg("--visible");
+        }
+        let mut child = command
+            .env("HOME", home)
+            .env("RUST_LOG", "off")
+            .env_remove("HORIZON_BROWSER_ACTOR")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .map_err(|error| StandaloneError::Startup(format!("could not start browser host: {error}")))?;
+        let Some(mut stdin) = child.stdin.take() else {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(StandaloneError::Startup(
+                "browser host stdin was unavailable".to_string(),
+            ));
+        };
+        let initialize = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"horizon-browser-job","version":"1"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+"#;
+        if let Err(error) = stdin.write_all(initialize).and_then(|()| stdin.flush()) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(StandaloneError::Startup(format!(
+                "could not initialize browser host: {error}"
+            )));
+        }
+        let mut host = Self {
+            child,
+            stdin: Some(stdin),
+        };
+        let manifests = home.join(".horizon").join("runtime").join("browsers");
+        let deadline = std::time::Instant::now() + STARTUP_TIMEOUT;
+        while std::time::Instant::now() < deadline {
+            if !manifest::list_panels_in(&manifests).is_empty() {
+                return Ok(host);
+            }
+            if let Some(status) = host
+                .child
+                .try_wait()
+                .map_err(|error| StandaloneError::Startup(format!("could not inspect browser host: {error}")))?
+            {
+                return Err(StandaloneError::Startup(format!(
+                    "browser host exited during startup ({status})"
+                )));
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = host.stop();
+        Err(StandaloneError::Startup(
+            "browser host did not publish a session within 30 seconds".to_string(),
+        ))
+    }
+
+    /// Close MCP stdin and wait for bounded browser/profile cleanup.
+    #[must_use]
+    pub fn shutdown(mut self) -> bool {
+        self.stop()
+    }
+
+    fn stop(&mut self) -> bool {
+        self.stdin.take();
+        let deadline = std::time::Instant::now() + HOST_EXIT_TIMEOUT;
+        while std::time::Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return status.success(),
+                Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                Err(_) => return false,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        false
+    }
+}
+
+impl Drop for OwnedHostProcess {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
 /// Start one browser session and serve the Horizon browser MCP contract until
 /// stdin closes.
 ///
@@ -41,10 +183,9 @@ pub enum StandaloneError {
 /// Returns when no requested backend can start, MCP transport fails, or the
 /// owned browser cannot be stopped within its bounded cleanup deadline.
 pub async fn serve(options: StandaloneOptions) -> Result<(), StandaloneError> {
-    let (session, profile_root) = start(options)?;
+    let session = OwnedSession::start(options, &HorizonHome::resolve())?;
     let mcp_result = horizon_browser_mcp::serve_stdio().await;
-    let shutdown = session.shutdown_signal().with_profile_cleanup(profile_root);
-    let stopped = shutdown.wait(SHUTDOWN_TIMEOUT) || shutdown.force_cleanup(FORCED_SHUTDOWN_TIMEOUT);
+    let stopped = session.shutdown();
     mcp_result?;
     if stopped {
         Ok(())
@@ -53,7 +194,10 @@ pub async fn serve(options: StandaloneOptions) -> Result<(), StandaloneError> {
     }
 }
 
-fn start(options: StandaloneOptions) -> Result<(BrowserSession, std::path::PathBuf), StandaloneError> {
+fn start(
+    options: StandaloneOptions,
+    home: &HorizonHome,
+) -> Result<(BrowserSession, std::path::PathBuf), StandaloneError> {
     if options.backend == Some(BackendKind::SafariWebDriver) && !options.visible {
         return Err(StandaloneError::Startup(
             "Safari has no headless mode; pass --visible or choose another backend".to_string(),
@@ -71,7 +215,7 @@ fn start(options: StandaloneOptions) -> Result<(BrowserSession, std::path::PathB
     );
     let mut last_error = None;
     for backend in candidates {
-        match start_backend(backend, options.visible) {
+        match start_backend(home, backend, options.visible) {
             Ok(session) => return Ok(session),
             Err(error) => last_error = Some(error),
         }
@@ -79,8 +223,11 @@ fn start(options: StandaloneOptions) -> Result<(BrowserSession, std::path::PathB
     Err(last_error.unwrap_or_else(|| StandaloneError::Startup("no compatible browser backend found".to_string())))
 }
 
-fn start_backend(backend: BackendKind, visible: bool) -> Result<(BrowserSession, std::path::PathBuf), StandaloneError> {
-    let home = HorizonHome::resolve();
+fn start_backend(
+    home: &HorizonHome,
+    backend: BackendKind,
+    visible: bool,
+) -> Result<(BrowserSession, std::path::PathBuf), StandaloneError> {
     let panel_id = standalone_panel_id();
     let profile_root = home.browser_profile_dir(&panel_id);
     let coordination = Arc::new(ManifestCoordination::default());
@@ -156,4 +303,12 @@ fn standalone_panel_id() -> String {
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_or(0, |duration| duration.as_nanos());
     format!("standalone-{}-{nanos:x}", std::process::id())
+}
+
+const fn backend_name(backend: BackendKind) -> &'static str {
+    match backend {
+        BackendKind::ChromiumCdp => "chromium",
+        BackendKind::FirefoxBidi => "firefox",
+        BackendKind::SafariWebDriver => "safari",
+    }
 }

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -84,6 +85,8 @@ impl OwnedHostProcess {
     /// Returns when the subprocess cannot start, initialize, or publish its
     /// first browser manifest before the startup deadline.
     pub fn start(options: StandaloneOptions, home: &Path, stderr: File) -> Result<Self, StandaloneError> {
+        let manifests = home.join(".horizon").join("runtime").join("browsers");
+        let existing_manifests = manifest::list_panels_in(&manifests).into_iter().collect::<HashSet<_>>();
         let executable = std::env::current_exe()
             .map_err(|error| StandaloneError::Startup(format!("could not resolve horizon-browser: {error}")))?;
         let mut command = Command::new(executable);
@@ -103,7 +106,7 @@ impl OwnedHostProcess {
             .stderr(Stdio::from(stderr))
             .spawn()
             .map_err(|error| StandaloneError::Startup(format!("could not start browser host: {error}")))?;
-        let Some(mut stdin) = child.stdin.take() else {
+        let Some(stdin) = child.stdin.take() else {
             let _ = child.kill();
             let _ = child.wait();
             return Err(StandaloneError::Startup(
@@ -113,21 +116,22 @@ impl OwnedHostProcess {
         let initialize = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"horizon-browser-job","version":"1"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized"}
 "#;
-        if let Err(error) = stdin.write_all(initialize).and_then(|()| stdin.flush()) {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(StandaloneError::Startup(format!(
-                "could not initialize browser host: {error}"
-            )));
-        }
+        let child_id = child.id();
         let mut host = Self {
             child,
             stdin: Some(stdin),
         };
-        let manifests = home.join(".horizon").join("runtime").join("browsers");
+        if let Some(stdin) = host.stdin.as_mut()
+            && let Err(error) = stdin.write_all(initialize).and_then(|()| stdin.flush())
+        {
+            let _ = host.stop();
+            return Err(StandaloneError::Startup(format!(
+                "could not initialize browser host: {error}"
+            )));
+        }
         let deadline = std::time::Instant::now() + STARTUP_TIMEOUT;
         while std::time::Instant::now() < deadline {
-            if !manifest::list_panels_in(&manifests).is_empty() {
+            if host_manifest_available(&manifests, &existing_manifests, child_id) {
                 return Ok(host);
             }
             if let Some(status) = host
@@ -160,13 +164,20 @@ impl OwnedHostProcess {
             match self.child.try_wait() {
                 Ok(Some(status)) => return status.success(),
                 Ok(None) => std::thread::sleep(Duration::from_millis(50)),
-                Err(_) => return false,
+                Err(_) => break,
             }
         }
         let _ = self.child.kill();
         let _ = self.child.wait();
         false
     }
+}
+
+fn host_manifest_available(manifests: &Path, existing: &HashSet<String>, child_id: u32) -> bool {
+    let expected_prefix = format!("standalone-{child_id}-");
+    manifest::list_panels_in(manifests)
+        .into_iter()
+        .any(|panel_id| panel_id.starts_with(&expected_prefix) && !existing.contains(&panel_id))
 }
 
 impl Drop for OwnedHostProcess {
@@ -316,6 +327,46 @@ const fn backend_name(backend: BackendKind) -> &'static str {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_readiness_ignores_stale_and_unrelated_manifests() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("create temp home: {error}"));
+        let manifests = home.path().join("runtime").join("browsers");
+        let stale = "standalone-42-before";
+        manifest::write_at(
+            &manifest::manifest_path_for_root(home.path(), stale),
+            &horizon_core::browser::manifest::BrowserManifest {
+                panel_local_id: stale.to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|error| panic!("write stale manifest: {error}"));
+        let existing = HashSet::from([stale.to_string()]);
+
+        assert!(!host_manifest_available(&manifests, &existing, 42));
+
+        let unrelated = "standalone-7-after";
+        manifest::write_at(
+            &manifest::manifest_path_for_root(home.path(), unrelated),
+            &horizon_core::browser::manifest::BrowserManifest {
+                panel_local_id: unrelated.to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|error| panic!("write unrelated manifest: {error}"));
+        assert!(!host_manifest_available(&manifests, &existing, 42));
+
+        let current = "standalone-42-after";
+        manifest::write_at(
+            &manifest::manifest_path_for_root(home.path(), current),
+            &horizon_core::browser::manifest::BrowserManifest {
+                panel_local_id: current.to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|error| panic!("write current manifest: {error}"));
+        assert!(host_manifest_available(&manifests, &existing, 42));
+    }
 
     #[test]
     fn owned_host_closes_stdin_before_waiting_for_exit() {

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -312,3 +312,21 @@ const fn backend_name(backend: BackendKind) -> &'static str {
         BackendKind::SafariWebDriver => "safari",
     }
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_host_closes_stdin_before_waiting_for_exit() {
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "cat >/dev/null"])
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|error| panic!("start stdin waiter: {error}"));
+        let stdin = child.stdin.take();
+        let host = OwnedHostProcess { child, stdin };
+
+        assert!(host.shutdown());
+    }
+}


### PR DESCRIPTION
## Purpose

Add bounded ownership for standalone browser sessions and MCP host subprocesses so prompt-driven jobs can start and clean up an isolated browser reliably.

Stacked on #327. This PR is intentionally limited to process/session lifecycle; prompt execution follows in later stack layers.

Closes part of #324.

## Behavior impact

- standalone MCP sessions clean up browser profiles through RAII on every exit path
- callers can own a private standalone host subprocess and close MCP stdin for graceful shutdown
- readiness ignores stale and unrelated manifests and accepts only the newly published manifest whose embedded PID matches the exact child
- cleanup has bounded graceful and forced fallbacks, including status-inspection errors
- host state stays isolated under the supplied home directory

## Validation — exact head 51ae9bf2b4672e9dd7a93e591bd87026d458c496

- full repository validation matrix: pass
- stale, unrelated, and exact-child manifest readiness tests: pass
- try_wait error forces kill and wait: pass
- current stack-top standalone-host cleanup smoke: pass
- independent review findings are fixed and resolved