### PR TITLE
feat(browser): bound deterministic execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ Horizon-launched Codex and Claude agents receive the bundled `horizon-browser` M
 
 MCP is the only agent-facing browser contract. Audit journals live under `~/.horizon/audit/browsers/` and redact credentials, query values, and typed text (stored as a character count). See the [browser crate README](crates/horizon-browser/README.md) for backend and embedding details.
 
-For scripts, [`horizon-browser-cli`](crates/horizon-browser-cli/README.md) exposes the same MCP tools three ways: a quoted goal, a deterministic `run` plan, or `mcp` as a standalone stdio server. Deterministic `run` jobs remain model-free and persist a private job id, validated plan, and atomic lifecycle state; runs that reach plan execution also persist a final report.
+For scripts, [`horizon-browser-cli`](crates/horizon-browser-cli/README.md) exposes the same MCP tools three ways: a quoted goal, a deterministic `run` plan, or `mcp` as a standalone stdio server. Deterministic `run` jobs remain model-free and persist a private job id, validated plan, and atomic lifecycle state; runs that reach plan execution also persist a final report. Their MCP execution phase defaults to a 30-minute timeout, accepts an explicit `--timeout`, and preserves completed steps in timed-out partial reports. An in-flight mutation is never claimed safe to replay.
 
 ```bash
 cargo build -p horizon-browser-cli

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -6,8 +6,8 @@ modes:
 
 - a quoted goal (or explicit `do`) lets an optional local agent observe and
   adapt through the MCP tools;
-- `run` executes a bounded, fail-fast JSON plan and writes a structured report
-  to stdout or a private file;
+- `run` executes a fail-fast JSON plan with bounded MCP execution and writes a
+  structured report to stdout or a private file;
 - `mcp` runs the same local stdio MCP server that Horizon registers for agents.
   Outside Horizon it starts and owns an isolated browser automatically.
 
@@ -82,6 +82,7 @@ Build the binary, then pass it a plan path or `-` for stdin:
 cargo build -p horizon-browser-cli
 target/debug/horizon-browser run plan.json
 target/debug/horizon-browser run plan.json --output report.json
+target/debug/horizon-browser run plan.json --timeout 300
 ```
 
 A plan is a sequence of literal MCP tool names and arguments:
@@ -136,9 +137,25 @@ validated plan and atomic lifecycle state in a private directory under
 `~/.horizon/browser-jobs/`; runs that reach plan execution also save a final
 report. A state left as `running` is durable evidence that the runner stopped
 before recording a terminal outcome; automatic continuation is not enabled
-yet. Stdout contains only the report; diagnostics use stderr. A file report is
-created with owner-only permissions on Unix. An unsuccessful report produces a
-non-zero exit status.
+yet.
+
+Every deterministic run gives its MCP execution phase a deadline. The default
+is 1800 seconds; `--timeout` accepts 1 through 86400 whole seconds. The budget
+starts after plan input, validation, and initial durable-job setup. It covers
+MCP initialization, tool discovery, calls, and client/server shutdown. Plan
+input plus durable state, report, and requested-output writes are preparatory or
+post-processing I/O and can add wall-clock time outside that budget.
+
+A deadline during a tool call saves the completed prefix as a partial report
+and records `timed_out` in `state.json`; the state also records the configured
+`execution_timeout_seconds`. An already-dispatched browser mutation may still
+complete, so inspect the browser audit before retrying it; automatic replay
+remains disabled.
+
+Stdout contains only the report; diagnostics use stderr. A file report is
+created with owner-only permissions on Unix. Stable exit codes are 0 for
+success, 1 for execution failure, 2 for invalid CLI or plan input, and 124 for
+an execution deadline.
 
 Outside Horizon, `run` can discover and control existing live panels. When it
 runs in a Horizon agent terminal, it inherits `HORIZON_BROWSER_ACTOR`, so the

--- a/crates/horizon-browser-cli/src/execution_control.rs
+++ b/crates/horizon-browser-cli/src/execution_control.rs
@@ -1,0 +1,59 @@
+//! Deadline control for deterministic plan execution.
+
+use std::future::{Future, pending};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Why a deterministic plan stopped before reaching a terminal tool result.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStopReason {
+    /// The MCP execution deadline elapsed.
+    DeadlineExceeded,
+}
+
+impl ExecutionStopReason {
+    /// Stable operator-facing description of this stop condition.
+    pub const MESSAGE: &'static str = "execution deadline exceeded; an in-flight browser action may still complete";
+}
+
+/// One deadline shared across MCP initialization, tool calls, and shutdown.
+pub struct ExecutionControl {
+    deadline: Option<tokio::time::Instant>,
+}
+
+impl ExecutionControl {
+    pub(crate) const fn unbounded() -> Self {
+        Self { deadline: None }
+    }
+
+    /// Start an execution deadline from the current monotonic clock.
+    #[must_use]
+    pub fn with_timeout(timeout: Duration) -> Self {
+        let now = tokio::time::Instant::now();
+        Self {
+            deadline: Some(now.checked_add(timeout).unwrap_or(now)),
+        }
+    }
+
+    /// Await MCP work only while the execution deadline remains available.
+    ///
+    /// # Errors
+    /// Returns [`ExecutionStopReason::DeadlineExceeded`] when the deadline wins.
+    pub async fn wait<T>(&mut self, future: impl Future<Output = T>) -> Result<T, ExecutionStopReason> {
+        let deadline = self.deadline;
+        tokio::select! {
+            biased;
+            () = deadline_reached(deadline) => Err(ExecutionStopReason::DeadlineExceeded),
+            output = future => Ok(output),
+        }
+    }
+}
+
+async fn deadline_reached(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => pending::<()>().await,
+    }
+}

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -6,6 +6,7 @@
 //! add a second browser action API: it connects an MCP client to the same
 //! [`horizon_browser_mcp::HorizonBrowserMcp`] service used by agents.
 
+pub mod execution_control;
 pub mod job;
 pub mod run_state;
 pub mod standalone;
@@ -20,6 +21,8 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
+
+use execution_control::{ExecutionControl, ExecutionStopReason};
 
 const PLAN_VERSION: u32 = 1;
 const MAX_PLAN_STEPS: usize = 256;
@@ -61,9 +64,12 @@ pub struct ExecutionReport {
     pub completed_steps: usize,
     /// Ordered results. Tool arguments are deliberately excluded.
     pub steps: Vec<StepReport>,
-    /// Connection-level failure, when one happened after execution started.
+    /// Connection-level failure or execution-deadline description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Explicit stop condition when the execution deadline won.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<ExecutionStopReason>,
 }
 
 /// Result of one MCP tool call.
@@ -127,6 +133,9 @@ pub enum RunError {
     /// A plan names a tool the current MCP server does not publish.
     #[error("plan step `{step}` names unavailable MCP tool `{tool}`")]
     UnknownTool { step: String, tool: String },
+    /// The job stopped before step execution produced a report.
+    #[error("{}", ExecutionStopReason::MESSAGE)]
+    Stopped(ExecutionStopReason),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -162,6 +171,22 @@ impl Plan {
 /// # Errors
 /// Returns only for plan validation, MCP initialization, or unavailable tools.
 pub async fn execute_plan(plan: &Plan) -> Result<ExecutionReport, RunError> {
+    execute_plan_with_control(plan, &mut ExecutionControl::unbounded()).await
+}
+
+/// Execute a plan with one deadline across MCP initialization, calls, and shutdown.
+///
+/// A stop during tool execution returns a partial report containing only
+/// completed calls. A stop during initialization returns [`RunError::Stopped`]
+/// because no step report exists yet.
+///
+/// # Errors
+/// Returns for plan validation, MCP initialization, unavailable tools, or a
+/// stop before step execution begins.
+pub async fn execute_plan_with_control(
+    plan: &Plan,
+    control: &mut ExecutionControl,
+) -> Result<ExecutionReport, RunError> {
     validate_plan(plan)?;
     let (server_transport, client_transport) = tokio::io::duplex(MCP_BUFFER_BYTES);
     let mut server_task = tokio::spawn(async move {
@@ -172,22 +197,29 @@ pub async fn execute_plan(plan: &Plan) -> Result<ExecutionReport, RunError> {
         service.waiting().await.map_err(|error| error.to_string())?;
         Ok::<(), String>(())
     });
-    let mut client = match PlanClient.serve(client_transport).await {
-        Ok(client) => client,
-        Err(error) => {
+    let mut client = match control.wait(PlanClient.serve(client_transport)).await {
+        Ok(Ok(client)) => client,
+        Ok(Err(error)) => {
             server_task.abort();
-            let _ = server_task.await;
             return Err(RunError::Initialize(error.to_string()));
+        }
+        Err(reason) => {
+            server_task.abort();
+            return Err(RunError::Stopped(reason));
         }
     };
 
-    let tools = match client.list_tools(None).await {
-        Ok(tools) => tools,
-        Err(error) => {
-            let _ = client.close().await;
+    let tools = match control.wait(client.list_tools(None)).await {
+        Ok(Ok(tools)) => tools,
+        Ok(Err(error)) => {
+            drop(client);
             server_task.abort();
-            let _ = server_task.await;
             return Err(RunError::Initialize(error.to_string()));
+        }
+        Err(reason) => {
+            drop(client);
+            server_task.abort();
+            return Err(RunError::Stopped(reason));
         }
     }
     .tools
@@ -196,9 +228,8 @@ pub async fn execute_plan(plan: &Plan) -> Result<ExecutionReport, RunError> {
     .collect::<BTreeSet<_>>();
     for step in &plan.steps {
         if !tools.contains(&step.tool) {
-            let _ = client.close().await;
+            drop(client);
             server_task.abort();
-            let _ = server_task.await;
             return Err(RunError::UnknownTool {
                 step: step.id.clone(),
                 tool: step.tool.clone(),
@@ -206,18 +237,35 @@ pub async fn execute_plan(plan: &Plan) -> Result<ExecutionReport, RunError> {
         }
     }
 
-    let mut report = execute_steps(plan, &client).await;
-    if let Err(error) = client.close().await {
-        report.fail_connection(format!("MCP client shutdown failed: {error}"));
+    let mut report = execute_steps(plan, &client, control).await;
+    if report.stop_reason.is_some() {
+        drop(client);
+        server_task.abort();
+        return Ok(report);
     }
-    match tokio::time::timeout(MCP_SHUTDOWN_TIMEOUT, &mut server_task).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(error))) => report.fail_connection(format!("MCP server shutdown failed: {error}")),
-        Ok(Err(error)) => report.fail_connection(format!("MCP server task failed: {error}")),
-        Err(_) => {
+    match control.wait(client.close()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => report.fail_connection(format!("MCP client shutdown failed: {error}")),
+        Err(reason) => {
+            report.stop(reason);
             server_task.abort();
-            let _ = server_task.await;
+            return Ok(report);
+        }
+    }
+    match control
+        .wait(tokio::time::timeout(MCP_SHUTDOWN_TIMEOUT, &mut server_task))
+        .await
+    {
+        Ok(Ok(Ok(Ok(())))) => {}
+        Ok(Ok(Ok(Err(error)))) => report.fail_connection(format!("MCP server shutdown failed: {error}")),
+        Ok(Ok(Err(error))) => report.fail_connection(format!("MCP server task failed: {error}")),
+        Ok(Err(_)) => {
+            server_task.abort();
             report.fail_connection("MCP server did not stop within 5 seconds".to_string());
+        }
+        Err(reason) => {
+            server_task.abort();
+            report.stop(reason);
         }
     }
     Ok(report)
@@ -226,6 +274,7 @@ pub async fn execute_plan(plan: &Plan) -> Result<ExecutionReport, RunError> {
 async fn execute_steps(
     plan: &Plan,
     client: &rmcp::service::RunningService<rmcp::RoleClient, PlanClient>,
+    control: &mut ExecutionControl,
 ) -> ExecutionReport {
     let mut result_indexes = BTreeMap::new();
     let mut steps = Vec::with_capacity(plan.steps.len());
@@ -238,12 +287,13 @@ async fn execute_steps(
             }
         };
         let params = CallToolRequestParams::new(step.tool.clone()).with_arguments(arguments);
-        let result = match client.call_tool(params).await {
-            Ok(result) => result,
-            Err(error) => {
+        let result = match control.wait(client.call_tool(params)).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
                 steps.push(failed_step(step, format!("MCP call failed: {error}")));
                 break;
             }
+            Err(reason) => return stopped_report(steps, reason),
         };
         let structured = result.structured_content;
         if result.is_error.unwrap_or(false) {
@@ -277,6 +327,7 @@ async fn execute_steps(
         completed_steps: steps.len(),
         steps,
         error: None,
+        stop_reason: None,
     }
 }
 
@@ -286,6 +337,23 @@ impl ExecutionReport {
         if self.error.is_none() {
             self.error = Some(error);
         }
+    }
+
+    fn stop(&mut self, reason: ExecutionStopReason) {
+        self.ok = false;
+        self.error = Some(ExecutionStopReason::MESSAGE.to_string());
+        self.stop_reason = Some(reason);
+    }
+}
+
+fn stopped_report(steps: Vec<StepReport>, reason: ExecutionStopReason) -> ExecutionReport {
+    ExecutionReport {
+        version: PLAN_VERSION,
+        ok: false,
+        completed_steps: steps.len(),
+        steps,
+        error: Some(ExecutionStopReason::MESSAGE.to_string()),
+        stop_reason: Some(reason),
     }
 }
 

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -5,22 +5,27 @@ use std::fs::OpenOptions;
 use std::io::{self, Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::time::Duration;
 
 use horizon_browser::BackendKind;
 use horizon_browser_cli::{
     Plan,
+    execution_control::{ExecutionControl, ExecutionStopReason},
     job::JobOptions,
     run_state::{DurableExecutionReport, DurableRun},
     standalone::StandaloneOptions,
 };
 
 const MAX_PLAN_BYTES: u64 = 1024 * 1024;
+const DEFAULT_RUN_TIMEOUT_SECONDS: u64 = 30 * 60;
+const MAX_RUN_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
+const EXIT_TIMED_OUT: u8 = 124;
 const HELP: &str = r#"horizon-browser — run browser jobs through one MCP contract
 
 USAGE:
     horizon-browser "<GOAL>" [--backend <auto|chromium|firefox|safari>] [--visible] [--json]
     horizon-browser do "<GOAL>" [OPTIONS]
-    horizon-browser run <PLAN.json|-> [--output <REPORT.json|->]
+    horizon-browser run <PLAN.json|-> [--output <REPORT.json|->] [--timeout <SECONDS>]
     horizon-browser mcp [--standalone|--connect] [--backend <BACKEND>] [--visible]
 
 COMMANDS:
@@ -37,6 +42,7 @@ OPTIONS:
     --visible             Show a native browser window; jobs default headless.
     --json                Emit stable JSONL job progress and completion events.
     -o, --output <PATH>    Write the JSON report to PATH; '-' means stdout.
+    --timeout <SECONDS>    Bound MCP execution (default 1800, max 86400).
     -h, --help             Print this help.
     -V, --version          Print the version.
 "#;
@@ -45,6 +51,7 @@ enum Command {
     Run {
         plan: PathBuf,
         output: Option<PathBuf>,
+        timeout: Duration,
     },
     Do(JobOptions),
     Mcp {
@@ -69,7 +76,7 @@ async fn main() -> ExitCode {
         }
         Ok(Command::Do(options)) => run_job(&options),
         Ok(Command::Mcp { standalone, options }) => serve_mcp(standalone, options).await,
-        Ok(Command::Run { plan, output }) => run(plan, output.as_deref()).await,
+        Ok(Command::Run { plan, output, timeout }) => run(plan, output.as_deref(), timeout).await,
         Err(error) => {
             eprintln!("error: {error}\n\n{HELP}");
             ExitCode::from(2)
@@ -115,7 +122,7 @@ async fn serve_mcp(standalone: bool, options: StandaloneOptions) -> ExitCode {
     }
 }
 
-async fn run(plan_path: PathBuf, output_path: Option<&Path>) -> ExitCode {
+async fn run(plan_path: PathBuf, output_path: Option<&Path>, timeout: Duration) -> ExitCode {
     let bytes = match read_bounded(&plan_path) {
         Ok(bytes) => bytes,
         Err(error) => {
@@ -130,15 +137,32 @@ async fn run(plan_path: PathBuf, output_path: Option<&Path>) -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    let mut durable = match DurableRun::start(&plan) {
+    let mut durable = match DurableRun::start(&plan, timeout.as_secs()) {
         Ok(durable) => durable,
         Err(error) => {
             eprintln!("error: {error}");
             return ExitCode::FAILURE;
         }
     };
-    let report = match horizon_browser_cli::execute_plan(&plan).await {
+    let mut control = ExecutionControl::with_timeout(timeout);
+    let report = match horizon_browser_cli::execute_plan_with_control(&plan, &mut control).await {
         Ok(report) => report,
+        Err(horizon_browser_cli::RunError::Stopped(reason)) => {
+            if let Err(state_error) = durable.stop(reason) {
+                eprintln!(
+                    "error: {}; additionally could not persist stopped state: {state_error}",
+                    ExecutionStopReason::MESSAGE
+                );
+                return ExitCode::from(EXIT_TIMED_OUT);
+            }
+            eprintln!(
+                "error: {}; durable job {}: {}",
+                ExecutionStopReason::MESSAGE,
+                durable.job_id(),
+                durable.state_path().display()
+            );
+            return ExitCode::from(EXIT_TIMED_OUT);
+        }
         Err(error) => {
             if let Err(state_error) = durable.fail(&error.to_string()) {
                 eprintln!("error: {error}; additionally could not persist failure state: {state_error}");
@@ -152,16 +176,21 @@ async fn run(plan_path: PathBuf, output_path: Option<&Path>) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    let post_process_error_exit = report
+        .stop_reason
+        .map_or(ExitCode::FAILURE, |_| ExitCode::from(EXIT_TIMED_OUT));
     if let Err(error) = durable.finish(&report) {
         eprintln!("error: {error}");
-        return ExitCode::FAILURE;
+        return post_process_error_exit;
     }
     let report = durable.report(&report);
     if let Err(error) = write_report(&report, output_path) {
         eprintln!("error: {error}");
-        return ExitCode::FAILURE;
+        return post_process_error_exit;
     }
-    if report.execution.ok {
+    if report.execution.stop_reason.is_some() {
+        ExitCode::from(EXIT_TIMED_OUT)
+    } else if report.execution.ok {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE
@@ -281,6 +310,8 @@ fn parse_run(mut args: impl Iterator<Item = OsString>) -> Result<Command, String
         .map(PathBuf::from)
         .ok_or_else(|| "run requires a plan path or '-'".to_string())?;
     let mut output = None;
+    let mut timeout = Duration::from_secs(DEFAULT_RUN_TIMEOUT_SECONDS);
+    let mut timeout_seen = false;
     while let Some(argument) = args.next() {
         match argument.to_str() {
             Some("-o" | "--output") if output.is_none() => {
@@ -290,11 +321,25 @@ fn parse_run(mut args: impl Iterator<Item = OsString>) -> Result<Command, String
                 ));
             }
             Some("-o" | "--output") => return Err("--output may be specified only once".to_string()),
+            Some("--timeout") if !timeout_seen => {
+                timeout_seen = true;
+                timeout = parse_run_timeout(args.next().as_ref())?;
+            }
+            Some("--timeout") => return Err("--timeout may be specified only once".to_string()),
             Some(argument) => return Err(format!("unexpected run argument `{argument}`")),
             None => return Err("run argument is not valid UTF-8".to_string()),
         }
     }
-    Ok(Command::Run { plan, output })
+    Ok(Command::Run { plan, output, timeout })
+}
+
+fn parse_run_timeout(value: Option<&OsString>) -> Result<Duration, String> {
+    let seconds = value
+        .and_then(|value| value.to_str())
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| (1..=MAX_RUN_TIMEOUT_SECONDS).contains(seconds))
+        .ok_or_else(|| format!("--timeout requires whole seconds from 1 through {MAX_RUN_TIMEOUT_SECONDS}"))?;
+    Ok(Duration::from_secs(seconds))
 }
 
 fn read_bounded(path: &Path) -> Result<Vec<u8>, String> {
@@ -378,11 +423,15 @@ mod tests {
     fn command_parser_keeps_run_surface_small() {
         let command =
             parse_args(["run", "plan.json", "--output", "report.json"].map(OsString::from)).expect("valid run command");
-        let Command::Run { plan, output } = command else {
+        let Command::Run { plan, output, timeout } = command else {
             panic!("expected run command");
         };
         assert_eq!(plan, Path::new("plan.json"));
         assert_eq!(output.as_deref(), Some(Path::new("report.json")));
+        assert_eq!(timeout, Duration::from_secs(DEFAULT_RUN_TIMEOUT_SECONDS));
+        assert!(parse_args(["run", "plan.json", "--timeout", "0"].map(OsString::from)).is_err());
+        assert!(parse_args(["run", "plan.json", "--timeout", "86401"].map(OsString::from)).is_err());
+        assert!(parse_args(["run", "plan.json", "--timeout", "1", "--timeout", "2"].map(OsString::from)).is_err());
         assert!(parse_args(["run", "plan.json", "--actor", "spoof"].map(OsString::from)).is_err());
         assert!(parse_args(["mcp", "extra"].map(OsString::from)).is_err());
 

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::{ExecutionReport, Plan};
+use crate::{ExecutionReport, Plan, execution_control::ExecutionStopReason};
 
 const STATE_VERSION: u32 = 1;
 const PLAN_FILE: &str = "plan.json";
@@ -32,6 +32,9 @@ pub struct RunState {
     pub status: RunStatus,
     /// Unix timestamp in milliseconds when the job was created.
     pub created_at_millis: u64,
+    /// Configured MCP execution budget, excluding plan input and durable setup.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_timeout_seconds: Option<u64>,
     /// Unix timestamp in milliseconds when this state was last persisted.
     pub updated_at_millis: u64,
     /// Process that initially executed the job. This is diagnostic only.
@@ -59,6 +62,8 @@ pub enum RunStatus {
     Succeeded,
     /// A plan step, MCP connection, or runner operation failed.
     Failed,
+    /// The configured MCP execution deadline elapsed.
+    TimedOut,
 }
 
 /// CLI report envelope that makes the durable job discoverable to callers.
@@ -106,8 +111,9 @@ impl DurableRun {
     /// # Errors
     /// Returns when the private directory or either initial artifact cannot be
     /// created durably.
-    pub fn start(plan: &Plan) -> Result<Self, RunStateError> {
-        Self::start_in(&HorizonHome::resolve().root().join("browser-jobs"), plan)
+    pub fn start(plan: &Plan, execution_timeout_seconds: u64) -> Result<Self, RunStateError> {
+        let root = HorizonHome::resolve().root().join("browser-jobs");
+        Self::start_in(&root, plan, Some(execution_timeout_seconds))
     }
 
     /// Stable id of this durable run.
@@ -122,7 +128,7 @@ impl DurableRun {
         &self.state_path
     }
 
-    fn start_in(root: &Path, plan: &Plan) -> Result<Self, RunStateError> {
+    fn start_in(root: &Path, plan: &Plan, execution_timeout_seconds: Option<u64>) -> Result<Self, RunStateError> {
         ensure_private_directory(root)?;
         let job_id = format!("job-{}", Uuid::new_v4());
         let directory = root.join(&job_id);
@@ -133,6 +139,7 @@ impl DurableRun {
             job_id,
             status: RunStatus::Running,
             created_at_millis,
+            execution_timeout_seconds,
             updated_at_millis: created_at_millis,
             runner_pid: std::process::id(),
             plan_file: PLAN_FILE.to_string(),
@@ -167,10 +174,10 @@ impl DurableRun {
     /// Returns when either terminal artifact cannot be atomically persisted.
     pub fn finish(&mut self, execution: &ExecutionReport) -> Result<(), RunStateError> {
         self.write_json(REPORT_FILE, &self.report(execution), "report")?;
-        self.state.status = if execution.ok {
-            RunStatus::Succeeded
-        } else {
-            RunStatus::Failed
+        self.state.status = match execution.stop_reason {
+            Some(ExecutionStopReason::DeadlineExceeded) => RunStatus::TimedOut,
+            None if execution.ok => RunStatus::Succeeded,
+            None => RunStatus::Failed,
         };
         self.state.updated_at_millis = now_millis();
         self.state.report_file = Some(REPORT_FILE.to_string());
@@ -188,6 +195,17 @@ impl DurableRun {
         self.state.status = RunStatus::Failed;
         self.state.updated_at_millis = now_millis();
         self.state.error = Some(error.to_string());
+        self.persist_state()
+    }
+
+    /// Persist a terminal stop that happened before a step report existed.
+    ///
+    /// # Errors
+    /// Returns when the stopped state cannot be atomically persisted.
+    pub fn stop(&mut self, _reason: ExecutionStopReason) -> Result<(), RunStateError> {
+        self.state.status = RunStatus::TimedOut;
+        self.state.updated_at_millis = now_millis();
+        self.state.error = Some(ExecutionStopReason::MESSAGE.to_string());
         self.persist_state()
     }
 
@@ -272,17 +290,19 @@ mod tests {
             completed_steps: 0,
             steps: Vec::new(),
             error: None,
+            stop_reason: None,
         }
     }
 
     #[test]
     fn state_is_running_before_execution_and_terminal_after_report() {
         let root = tempfile::tempdir().expect("temporary job root");
-        let mut run = DurableRun::start_in(root.path(), &plan()).expect("start durable run");
+        let mut run = DurableRun::start_in(root.path(), &plan(), Some(30)).expect("start durable run");
         let running: RunState = serde_json::from_slice(&std::fs::read(&run.state_path).expect("running state"))
             .expect("decode running state");
         assert_eq!(running.status, RunStatus::Running);
         assert_eq!(running.completed_steps, 0);
+        assert_eq!(running.execution_timeout_seconds, Some(30));
         assert_eq!(running.plan_file, PLAN_FILE);
         assert_eq!(
             Plan::from_slice(&std::fs::read(run.directory.join(PLAN_FILE)).expect("saved plan"))
@@ -302,6 +322,7 @@ mod tests {
                 error: None,
             }],
             error: None,
+            stop_reason: None,
         };
         run.finish(&report).expect("finish durable run");
         let succeeded: RunState = serde_json::from_slice(&std::fs::read(&run.state_path).expect("terminal state"))
@@ -339,9 +360,26 @@ mod tests {
     }
 
     #[test]
+    fn state_accepts_jobs_created_before_execution_timeouts() {
+        let state: RunState = serde_json::from_value(json!({
+            "version": 1,
+            "job_id": "job-existing",
+            "status": "running",
+            "created_at_millis": 1,
+            "updated_at_millis": 1,
+            "runner_pid": 42,
+            "plan_file": "plan.json",
+            "completed_steps": 0
+        }))
+        .expect("decode existing durable state");
+
+        assert_eq!(state.execution_timeout_seconds, None);
+    }
+
+    #[test]
     fn initialization_failure_is_durable() {
         let root = tempfile::tempdir().expect("temporary job root");
-        let mut run = DurableRun::start_in(root.path(), &plan()).expect("start durable run");
+        let mut run = DurableRun::start_in(root.path(), &plan(), Some(30)).expect("start durable run");
         run.fail("adapter unavailable").expect("persist failure");
         let failed: RunState = serde_json::from_slice(&std::fs::read(&run.state_path).expect("failed state"))
             .expect("decode failed state");
@@ -357,7 +395,7 @@ mod tests {
         use std::os::unix::ffi::OsStringExt as _;
 
         let root = tempfile::tempdir().expect("temporary job root");
-        let mut run = DurableRun::start_in(root.path(), &plan()).expect("start durable run");
+        let mut run = DurableRun::start_in(root.path(), &plan(), Some(30)).expect("start durable run");
         run.directory = PathBuf::from(OsString::from_vec(b"home-\xff/.horizon/browser-jobs/job".to_vec()));
         run.state_path = run.directory.join(STATE_FILE);
 

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -30,6 +30,7 @@ fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
         .expect("decode job state");
     assert_eq!(state["job_id"], stdout_report["job_id"]);
     assert_eq!(state["status"], "succeeded");
+    assert_eq!(state["execution_timeout_seconds"], 1800);
     assert_eq!(state["completed_steps"], 1);
     assert_eq!(state["report_file"], "report.json");
     assert_eq!(
@@ -135,6 +136,35 @@ fn run_persists_preflight_failure_before_any_browser_action() {
 }
 
 #[test]
+fn run_deadline_persists_a_partial_report_and_stable_exit_code() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let (plan, _manifest_path) = write_blocking_plan(root.path());
+    let plan = plan.to_str().expect("UTF-8 path");
+    let output = run_command(root.path(), ["run", plan, "--timeout", "1"]);
+
+    assert_eq!(output.status.code(), Some(124));
+    assert!(
+        output.stderr.is_empty(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("deadline report");
+    assert_eq!(report["completed_steps"], 1);
+    assert_eq!(report["stop_reason"], "deadline_exceeded");
+    let job_dir = std::path::Path::new(report["job_dir"].as_str().expect("job directory"));
+    let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("deadline state"))
+        .expect("decode deadline state");
+    assert_eq!(state["status"], "timed_out");
+    assert_eq!(state["execution_timeout_seconds"], 1);
+    assert_eq!(state["completed_steps"], 1);
+    assert_eq!(state["report_file"], "report.json");
+    let output_dir = root.path().to_str().expect("UTF-8 root");
+    let failed_output = run_command(root.path(), ["run", plan, "--timeout", "1", "--output", output_dir]);
+    assert_eq!(failed_output.status.code(), Some(124));
+    assert!(String::from_utf8_lossy(&failed_output.stderr).contains("could not open report"));
+}
+
+#[test]
 fn mcp_subcommand_negotiates_and_publishes_the_browser_contract() {
     let root = tempfile::tempdir().expect("isolated root");
     let mut process = McpProcess::start(root.path());
@@ -222,6 +252,28 @@ fn run_process_local_command<const N: usize>(home: &std::path::Path, arguments: 
         .env("RUST_LOG", "off")
         .output()
         .expect("run process-local horizon-browser")
+}
+
+fn write_blocking_plan(home: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let panel_id = "blocked-panel";
+    let manifest_path = manifest::manifest_path_for_root(&home.join(".horizon"), panel_id);
+    manifest::write_at(
+        &manifest_path,
+        &BrowserManifest {
+            panel_local_id: panel_id.to_string(),
+            ..BrowserManifest::default()
+        },
+    )
+    .expect("write blocking browser manifest");
+    let plan = home.join("blocking-plan.json");
+    std::fs::write(
+        &plan,
+        format!(
+            r#"{{"version":1,"steps":[{{"id":"list","tool":"browser_list"}},{{"id":"snapshot","tool":"browser_snapshot","arguments":{{"panel_id":"{panel_id}","timeout_millis":60000}}}}]}}"#
+        ),
+    )
+    .expect("write blocking plan");
+    (plan, manifest_path)
 }
 
 struct McpProcess {


### PR DESCRIPTION
## Purpose

Add the execution-deadline slice of the durable browser job runner from issue #324.

## Behavior impact

- Gives deterministic MCP execution 1800 seconds by default, with an explicit 1-86400 second `--timeout`.
- Starts the monotonic budget after plan input, validation, and initial durable-job setup.
- Enforces one deadline through MCP initialization, tool discovery, tool calls, client close, and server shutdown.
- Persists the configured `execution_timeout_seconds`, the completed prefix, a `timed_out` terminal state, and stable exit code 124.
- Preserves exit code 124 when stopped-state, partial-report, or requested-output persistence fails, while still emitting the secondary error.
- Explicitly warns that an already-dispatched browser mutation may still complete and is not automatically safe to replay.
- Documents that preparatory input/setup and post-processing persistence are outside this execution budget.
- Leaves deadline-safe durable setup/activation, cooperative cancellation, and checkpoint/resume for the next serial issue slices.

## Scope

- One browser CLI subsystem.
- Five source/test files and 356 non-generated source/test changed lines.
- Seven changed files total, including user-facing documentation.

## Validation

Exact head: `0b9a4bb161ec596eb907bd25337326658d849c23`

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- Local independent full-diff review: no remaining actionable findings.
- Exact-head macOS arm64 smoke passed on `0b9a4bb161ec596eb907bd25337326658d849c23` with no fixes required.

Refs #324
