### PR TITLE
fix(browser): keep address bar stable across focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "transcribe-cpp",
- "url",
  "wgpu",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ rusqlite = { version = "0.40.2", features = ["bundled"] }
 uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
 regex = "1.13.1"
-url = "2.5.8"
 arboard = "3.6.1"
 tokio = { version = "1.53.1", features = ["rt", "macros"] }
 surge-core = { git = "https://github.com/fintermobilityas/surge.git", tag = "v1.0.0-beta.54", package = "surge-core" }

--- a/crates/horizon-ui/Cargo.toml
+++ b/crates/horizon-ui/Cargo.toml
@@ -38,7 +38,6 @@ tracing-subscriber.workspace = true
 profiling.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true
-url.workspace = true
 tempfile.workspace = true
 alacritty_terminal.workspace = true
 egui_commonmark.workspace = true

--- a/crates/horizon-ui/src/browser_widget/chrome.rs
+++ b/crates/horizon-ui/src/browser_widget/chrome.rs
@@ -9,7 +9,6 @@ use egui::{
 use horizon_core::browser::{
     BackendAvailability, BackendKind, BrowserCommand, BrowserPanelState, normalize_navigation_target,
 };
-use url::Url;
 
 use crate::browser_widget::BrowserUiState;
 use crate::theme;
@@ -176,12 +175,8 @@ fn url_bar(
 ) -> (bool, bool) {
     let id = ui.make_persistent_id(("browser-url-bar", panel_id));
     let was_focused = ui.memory(|memory| memory.focused() == Some(id));
-    refresh_compact_url(state, browser.display_url());
     // Keep the buffer in sync with the live URL while unfocused.
-    if !was_focused && state.url_buffer != state.compact_url {
-        state.url_buffer.clear();
-        state.url_buffer.push_str(&state.compact_url);
-    }
+    sync_url_buffer(&mut state.url_buffer, browser.display_url(), was_focused);
     let response = ui.add_enabled(
         interactive,
         TextEdit::singleline(&mut state.url_buffer)
@@ -190,12 +185,10 @@ fn url_bar(
             .desired_width(max_width)
             .font(egui::FontId::monospace(11.5)),
     );
-    // Match native browser chrome: the compact, scheme-less form is for
-    // passive display only. Reveal the canonical URL when the user focuses
-    // the field so security-sensitive details remain directly inspectable.
+    // Focusing selects the stable canonical URL without rewriting it. Page
+    // interaction can move focus away from the field, and that transition
+    // must not make scrolling look like navigation.
     if response.gained_focus() && !response.changed() {
-        state.url_buffer.clear();
-        state.url_buffer.push_str(browser.display_url());
         let mut edit_state = TextEdit::load_state(ui.ctx(), id).unwrap_or_default();
         edit_state.cursor.set_char_range(Some(CCursorRange::two(
             CCursor::default(),
@@ -224,37 +217,14 @@ fn url_bar(
     (response.has_focus() || submitted, response.clicked())
 }
 
-fn refresh_compact_url(state: &mut BrowserUiState, canonical_url: &str) -> bool {
-    if state.compact_url_source == canonical_url {
+fn sync_url_buffer(url_buffer: &mut String, canonical_url: &str, was_focused: bool) -> bool {
+    if was_focused || url_buffer == canonical_url {
         return false;
     }
 
-    state.compact_url.clear();
-    state.compact_url.push_str(compact_address_bar_url(canonical_url));
-    state.compact_url_source.clear();
-    state.compact_url_source.push_str(canonical_url);
+    url_buffer.clear();
+    url_buffer.push_str(canonical_url);
     true
-}
-
-fn compact_address_bar_url(url: &str) -> &str {
-    let Some(compact) = url.strip_prefix("https://") else {
-        return url;
-    };
-    let authority_end = compact.find(['/', '?', '#']).unwrap_or(compact.len());
-    if authority_end == 0 {
-        return url;
-    }
-    let Ok(parsed) = Url::parse(url) else {
-        return url;
-    };
-    if parsed.host_str().is_none_or(str::is_empty) {
-        return url;
-    }
-    if parsed.path() == "/" && parsed.query().is_none() && parsed.fragment().is_none() {
-        compact.strip_suffix('/').unwrap_or(compact)
-    } else {
-        compact
-    }
 }
 
 /// The chip's label and color, or `None` when neither an agent owner nor a
@@ -326,57 +296,22 @@ fn handoff_banner(ui: &mut Ui, browser: &mut BrowserPanelState, reason: &str, in
 
 #[cfg(test)]
 mod tests {
-    use super::{compact_address_bar_url, nav_widget_info, refresh_compact_url};
-    use crate::browser_widget::BrowserUiState;
+    use super::{nav_widget_info, sync_url_buffer};
 
     #[test]
-    fn unfocused_address_bar_compacts_secure_urls() {
-        assert_eq!(
-            compact_address_bar_url("https://example.com/path?q=1#result"),
-            "example.com/path?q=1#result"
-        );
-        assert_eq!(compact_address_bar_url("https://example.com/"), "example.com");
-        assert_eq!(
-            compact_address_bar_url("https://example.com/path/"),
-            "example.com/path/"
-        );
-        assert_eq!(compact_address_bar_url("https://example.com?q=/"), "example.com?q=/");
-        assert_eq!(compact_address_bar_url("https://example.com#/"), "example.com#/");
-        assert_eq!(compact_address_bar_url("https://example.com/?q=1"), "example.com/?q=1");
-        assert_eq!(
-            compact_address_bar_url("http://example.com/path"),
-            "http://example.com/path"
-        );
-        assert_eq!(compact_address_bar_url("about:blank"), "about:blank");
-        assert_eq!(
-            compact_address_bar_url("file:///tmp/page.html"),
-            "file:///tmp/page.html"
-        );
-        assert_eq!(compact_address_bar_url(""), "");
-        assert_eq!(
-            compact_address_bar_url("https:///missing-host"),
-            "https:///missing-host"
-        );
-        assert_eq!(compact_address_bar_url("https://user@/"), "https://user@/");
-        assert_eq!(compact_address_bar_url("https://:443/"), "https://:443/");
-        assert_eq!(
-            compact_address_bar_url("https://?q=missing-host"),
-            "https://?q=missing-host"
-        );
-    }
+    fn address_bar_focus_transition_preserves_the_displayed_url() {
+        let mut buffer = String::new();
+        let original = "https://example.com/path?q=1#result";
 
-    #[test]
-    fn compact_url_cache_refreshes_only_when_the_canonical_url_changes() {
-        let mut state = BrowserUiState::default();
+        assert!(sync_url_buffer(&mut buffer, original, false));
+        assert_eq!(buffer, original);
+        assert!(!sync_url_buffer(&mut buffer, original, true));
+        assert!(!sync_url_buffer(&mut buffer, original, false));
+        assert_eq!(buffer, original);
 
-        assert!(refresh_compact_url(&mut state, "https://example.com/"));
-        assert_eq!(state.compact_url_source, "https://example.com/");
-        assert_eq!(state.compact_url, "example.com");
-        assert!(!refresh_compact_url(&mut state, "https://example.com/"));
-
-        assert!(refresh_compact_url(&mut state, "http://example.com/"));
-        assert_eq!(state.compact_url_source, "http://example.com/");
-        assert_eq!(state.compact_url, "http://example.com/");
+        let navigated = "https://example.com/next";
+        assert!(sync_url_buffer(&mut buffer, navigated, false));
+        assert_eq!(buffer, navigated);
     }
 
     #[test]

--- a/crates/horizon-ui/src/browser_widget/mod.rs
+++ b/crates/horizon-ui/src/browser_widget/mod.rs
@@ -55,13 +55,8 @@ pub struct BrowserUiState {
     captured_clicks: [Option<BrowserPointerClick>; 3],
     /// Most recent completed click, used to identify double/triple clicks.
     last_click: Option<BrowserPointerClick>,
-    /// URL bar buffer (follows the panel URL while unfocused).
+    /// Canonical URL bar buffer (follows the panel URL while unfocused).
     url_buffer: String,
-    /// Canonical URL that produced `compact_url`. Comparing this stable key on
-    /// each frame keeps URL parsing out of pointer-only redraws.
-    compact_url_source: String,
-    /// Validated scheme-less HTTPS form for passive address-bar display.
-    compact_url: String,
     /// Enter submitted in the URL bar; its later key-up must not leak to the
     /// previously focused page element after the text edit drops focus.
     url_submit_enter_pending: bool,


### PR DESCRIPTION
## Purpose

Keep the browser address bar visually stable when focus moves between the URL field and the page, including during scrolling.

Before this change, the displayed value switched between a scheme-less compact URL and the full canonical URL when focus changed. That made scrolling or clicking back into the address field look like navigation even though the page had not navigated.

## Behavior impact

- Always displays the canonical URL instead of changing presentation on focus transitions.
- Preserves select-all-on-focus and normalized navigation submission.
- Removes the now-unused direct url dependency from horizon-ui.

## Test evidence

- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- RUSTFLAGS="-D warnings" cargo test --workspace --features speech
- cargo clippy --all-targets --features speech,trace-profiling -- -D warnings
- cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic
- Firefox exact-head smoke on isolated Xvfb: 42 browser actions passed, scrollY reached 976 with the URL unchanged, address-bar crops across the focus transition were pixel-identical, Fit/resize was visually inspected, and no browser processes survived cleanup.

Runtime smoke: Linux/X11 with Firefox via the repository browser harness.