### PR TITLE
fix(workspace): match startup and shortcut organization

### DIFF
--- a/crates/horizon-core/src/board/arrangement.rs
+++ b/crates/horizon-core/src/board/arrangement.rs
@@ -622,6 +622,6 @@ fn resize_axis_push(a: [f32; 4], b: [f32; 4], axis: ResizeCollisionAxis, gap: f3
     }
 }
 
-fn rects_overlap(a: [f32; 4], b: [f32; 4]) -> bool {
+pub(super) fn rects_overlap(a: [f32; 4], b: [f32; 4]) -> bool {
     !(a[2] <= b[0] || b[2] <= a[0] || a[3] <= b[1] || b[3] <= a[1])
 }

--- a/crates/horizon-core/src/board/tests/mod.rs
+++ b/crates/horizon-core/src/board/tests/mod.rs
@@ -4,6 +4,7 @@ mod alignment;
 mod core;
 mod layout;
 mod workspace;
+mod workspace_separation;
 
 fn editor_panel_options() -> PanelOptions {
     PanelOptions {

--- a/crates/horizon-core/src/board/tests/workspace_separation.rs
+++ b/crates/horizon-core/src/board/tests/workspace_separation.rs
@@ -1,0 +1,72 @@
+use crate::layout::WS_COLLISION_GAP;
+
+use super::super::arrangement::rects_overlap;
+use super::super::*;
+use super::editor_panel_options;
+
+#[test]
+fn separating_overlapping_workspace_preserves_existing_freeform_layout() {
+    let mut board = Board::new();
+    let left = board.create_workspace_at("left", [0.0, 40.0]);
+    let reattached = board.create_workspace_at("reattached", [500.0, 40.0]);
+    let right = board.create_workspace_at("right", [900.0, 280.0]);
+
+    for workspace_id in [left, reattached, right] {
+        board
+            .create_panel(editor_panel_options(), workspace_id)
+            .expect("panel should spawn");
+    }
+
+    let left_frame = board.workspace_frame_rect(left).expect("left frame");
+    let reattached_frame = board.workspace_frame_rect(reattached).expect("reattached frame");
+    assert!(board.translate_workspace(
+        reattached,
+        [
+            left_frame[0] + 5.0 - reattached_frame[0],
+            left_frame[1] + 5.0 - reattached_frame[1],
+        ],
+    ));
+    assert!(rects_overlap(
+        board.workspace_frame_rect(reattached).expect("overlapping frame"),
+        left_frame,
+    ));
+    let right_frame = board.workspace_frame_rect(right).expect("right frame");
+    assert!(board.translate_workspace(
+        right,
+        [
+            left_frame[0] + 10.0 - right_frame[0],
+            left_frame[1] + 10.0 - right_frame[1],
+        ],
+    ));
+    let left_before = board.workspace(left).expect("left workspace").position;
+    let right_before = board.workspace(right).expect("right workspace").position;
+    assert!(rects_overlap(
+        left_frame,
+        board.workspace_frame_rect(right).expect("overlapping existing frame"),
+    ));
+
+    assert!(board.separate_workspace_from_overlaps_in_scope(reattached, &[left, reattached, right]));
+
+    let reattached_frame = board.workspace_frame_rect(reattached).expect("reattached frame");
+    let right_frame = board.workspace_frame_rect(right).expect("right frame");
+    assert_eq!(
+        board
+            .workspace(left)
+            .expect("left workspace")
+            .position
+            .map(f32::to_bits),
+        left_before.map(f32::to_bits)
+    );
+    assert_eq!(
+        board
+            .workspace(right)
+            .expect("right workspace")
+            .position
+            .map(f32::to_bits),
+        right_before.map(f32::to_bits)
+    );
+    assert!(!rects_overlap(reattached_frame, left_frame));
+    assert!(!rects_overlap(reattached_frame, right_frame));
+    assert!((reattached_frame[0] - (right_frame[2] + WS_COLLISION_GAP)).abs() <= f32::EPSILON);
+    assert!(!board.separate_workspace_from_overlaps_in_scope(reattached, &[left, reattached, right]));
+}

--- a/crates/horizon-core/src/board/workspaces.rs
+++ b/crates/horizon-core/src/board/workspaces.rs
@@ -5,6 +5,7 @@ use crate::panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelOptions};
 use crate::runtime_state::WorkspaceState;
 use crate::workspace::{Workspace, WorkspaceId};
 
+use super::arrangement::rects_overlap;
 use super::{Board, WorkspaceDockSide, vec2_eq};
 
 impl Board {
@@ -417,6 +418,79 @@ impl Board {
         true
     }
 
+    /// Moves a workspace to the right of its scope only when its current
+    /// frame overlaps another scoped workspace. Existing non-overlapping
+    /// freeform layouts are otherwise preserved.
+    pub fn separate_workspace_from_overlaps_in_scope(
+        &mut self,
+        id: WorkspaceId,
+        workspace_ids: &[WorkspaceId],
+    ) -> bool {
+        if !workspace_ids.contains(&id) {
+            return false;
+        }
+
+        let Some(source_frame) = self.workspace_frame_rect(id) else {
+            return false;
+        };
+        if !workspace_frame_is_valid(source_frame) {
+            return false;
+        }
+        let mut overlaps = false;
+        let mut rightmost_frame: Option<[f32; 4]> = None;
+
+        for workspace_id in workspace_ids.iter().copied().filter(|workspace_id| *workspace_id != id) {
+            let Some(frame) = self.workspace_frame_rect(workspace_id) else {
+                continue;
+            };
+            if !workspace_frame_is_valid(frame) {
+                continue;
+            }
+            overlaps |= rects_overlap(source_frame, frame);
+            if rightmost_frame.is_none_or(|rightmost| frame[2].total_cmp(&rightmost[2]).is_gt()) {
+                rightmost_frame = Some(frame);
+            }
+        }
+
+        if !overlaps {
+            return false;
+        }
+
+        let Some(anchor_frame) = rightmost_frame else {
+            return false;
+        };
+        let delta = [
+            anchor_frame[2] + WS_COLLISION_GAP - source_frame[0],
+            anchor_frame[1] - source_frame[1],
+        ];
+        let translated_frame = [
+            source_frame[0] + delta[0],
+            source_frame[1] + delta[1],
+            source_frame[2] + delta[0],
+            source_frame[3] + delta[1],
+        ];
+        let translated_position_is_finite = |position: [f32; 2]| {
+            [position[0] + delta[0], position[1] + delta[1]]
+                .iter()
+                .all(|component| component.is_finite())
+        };
+        if !delta.iter().all(|component| component.is_finite())
+            || !translated_frame.iter().all(|component| component.is_finite())
+            || !self
+                .workspace(id)
+                .is_some_and(|workspace| translated_position_is_finite(workspace.position))
+            || !self
+                .panels
+                .iter()
+                .filter(|panel| panel.workspace_id == id)
+                .all(|panel| translated_position_is_finite(panel.layout.position))
+        {
+            return false;
+        }
+
+        self.translate_workspace(id, delta)
+    }
+
     pub fn move_workspace_before(&mut self, id: WorkspaceId, anchor_id: WorkspaceId) -> bool {
         self.reorder_workspace_relative(id, anchor_id, false)
     }
@@ -509,4 +583,8 @@ impl Board {
         self.workspaces.insert(insert_index, source_workspace);
         true
     }
+}
+
+fn workspace_frame_is_valid(frame: [f32; 4]) -> bool {
+    frame.iter().all(|component| component.is_finite()) && frame[2] > frame[0] && frame[3] > frame[1]
 }

--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -88,10 +88,11 @@ pub(super) fn align_attached_workspaces(
 }
 
 impl HorizonApp {
-    pub(in crate::app) fn align_attached_workspaces_horizontally(&mut self, ctx: &egui::Context) {
-        let Some(alignment) = align_attached_workspaces(&mut self.board, &self.detached_workspaces) else {
-            return;
-        };
+    pub(in crate::app) fn align_attached_workspaces_horizontally(
+        &mut self,
+        ctx: &egui::Context,
+    ) -> Option<WorkspaceAlignment> {
+        let alignment = align_attached_workspaces(&mut self.board, &self.detached_workspaces)?;
 
         if let Some((min, max)) = self.board.workspace_bounds(alignment.leftmost_workspace) {
             self.focus_workspace_bounds(ctx, min, max, true);
@@ -99,6 +100,7 @@ impl HorizonApp {
         if alignment.positions_changed {
             self.mark_runtime_dirty();
         }
+        Some(alignment)
     }
 }
 

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -106,8 +106,6 @@ impl HorizonApp {
     }
 
     pub(super) fn render_detached_viewports(&mut self, ctx: &Context) {
-        self.process_pending_detached_reattach(ctx);
-
         let local_ids: Vec<_> = self.detached_workspaces.keys().cloned().collect();
         let mut stale_local_ids = Vec::new();
 
@@ -584,7 +582,9 @@ fn detached_viewport_builder(
 mod tests {
     use std::collections::BTreeSet;
 
-    use crate::app::test_support::{editor_workspace_state, test_app, test_app_with_config_and_startup};
+    use crate::app::test_support::{
+        editor_workspace_state, raw_input, run_app_frame_with_input, test_app, test_app_with_config_and_startup,
+    };
     use crate::app::{WS_BG_PAD, WS_TITLE_HEIGHT};
     use crate::test_egui::DiscardTextures;
     use egui::{Event, RawInput};
@@ -780,6 +780,45 @@ mod tests {
         assert!(!app.workspace_is_detached(detached));
         assert_attached_workspaces_form_organized_row(&mut app);
         assert!(app.runtime_dirty_since.is_some());
+    }
+
+    #[test]
+    fn pending_reattach_is_rendered_in_the_root_processing_frame() {
+        let config = Config::default();
+        let runtime_state = RuntimeState {
+            canvas_view: Some(CanvasViewState::default()),
+            detached_workspaces: vec![DetachedWorkspaceState {
+                workspace_local_id: "detached".to_string(),
+                window: WindowConfig::default(),
+            }],
+            workspaces: vec![
+                editor_workspace_state("left", [0.0, 40.0]),
+                editor_workspace_state("detached", [500.0, 40.0]),
+            ],
+            ..RuntimeState::default()
+        };
+        let (_temp, ctx, mut app) = test_app_with_config_and_startup(
+            &config,
+            StartupDecision::Ephemeral {
+                runtime_state: Box::new(runtime_state),
+            },
+        );
+        let detached = workspace_id(&app, "detached");
+        app.theme_applied = true;
+        app.initial_pan_done = true;
+        app.root_viewport_stabilizer = None;
+        app.pending_detached_reattach.insert("detached".to_string());
+        let size = [app.window_config.width, app.window_config.height];
+
+        run_app_frame_with_input(&ctx, &mut app, raw_input(size, None));
+
+        assert!(!app.workspace_is_detached(detached));
+        assert!(
+            app.workspace_screen_rects
+                .iter()
+                .any(|(workspace_id, _)| *workspace_id == detached),
+            "the returning workspace must render in the root frame that removes its child viewport"
+        );
     }
 
     #[test]

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -1,3 +1,4 @@
+mod reattach;
 mod shortcut_actions;
 
 use std::collections::BTreeSet;
@@ -82,14 +83,14 @@ impl HorizonApp {
     }
 
     pub(super) fn reattach_workspace(&mut self, workspace_id: WorkspaceId) {
-        let Some(workspace) = self.board.workspace(workspace_id) else {
+        let Some(workspace_local_id) = self
+            .board
+            .workspace(workspace_id)
+            .map(|workspace| workspace.local_id.clone())
+        else {
             return;
         };
-        if self.detached_workspaces.remove(&workspace.local_id).is_some() {
-            self.pending_detached_window_position_restore
-                .remove(&workspace.local_id);
-            self.mark_runtime_dirty();
-        }
+        self.schedule_detached_workspace_reattach(&workspace_local_id);
     }
 
     pub(super) fn focus_workspace_window(&self, ctx: &Context, workspace_id: WorkspaceId) -> bool {
@@ -105,7 +106,7 @@ impl HorizonApp {
     }
 
     pub(super) fn render_detached_viewports(&mut self, ctx: &Context) {
-        self.process_pending_detached_reattach();
+        self.process_pending_detached_reattach(ctx);
 
         let local_ids: Vec<_> = self.detached_workspaces.keys().cloned().collect();
         let mut stale_local_ids = Vec::new();
@@ -533,26 +534,6 @@ impl HorizonApp {
             self.mark_runtime_dirty();
         }
     }
-
-    fn process_pending_detached_reattach(&mut self) {
-        if self.pending_detached_reattach.is_empty() {
-            return;
-        }
-
-        // Remove pending viewports at the start of the root pass so egui
-        // simply stops emitting them this frame.
-        let pending = std::mem::take(&mut self.pending_detached_reattach);
-        let mut changed = false;
-        for workspace_local_id in pending {
-            changed |= self.detached_workspaces.remove(&workspace_local_id).is_some();
-            self.pending_detached_window_position_restore
-                .remove(&workspace_local_id);
-        }
-
-        if changed {
-            self.mark_runtime_dirty();
-        }
-    }
 }
 
 fn detached_viewport_id(workspace_local_id: &str) -> ViewportId {
@@ -603,12 +584,105 @@ fn detached_viewport_builder(
 mod tests {
     use std::collections::BTreeSet;
 
-    use crate::app::test_support::test_app;
+    use crate::app::test_support::{editor_workspace_state, test_app, test_app_with_config_and_startup};
+    use crate::app::{WS_BG_PAD, WS_TITLE_HEIGHT};
     use crate::test_egui::DiscardTextures;
     use egui::{Event, RawInput};
 
     use super::{consume_detached_position_restore, detached_viewport_builder, detached_viewport_id};
-    use horizon_core::WindowConfig;
+    use horizon_core::{
+        CanvasViewState, Config, DetachedWorkspaceState, RuntimeState, StartupDecision, WindowConfig, WorkspaceId,
+    };
+
+    const POSITION_TOLERANCE: f32 = 0.01;
+
+    fn reattach_test_app(
+        organize_workspaces_on_session_load: bool,
+    ) -> (tempfile::TempDir, egui::Context, super::HorizonApp) {
+        let mut config = Config::default();
+        config.features.organize_workspaces_on_session_load = organize_workspaces_on_session_load;
+        let runtime_state = RuntimeState {
+            detached_workspaces: vec![DetachedWorkspaceState {
+                workspace_local_id: "detached".to_string(),
+                window: WindowConfig::default(),
+            }],
+            workspaces: vec![
+                editor_workspace_state("left", [100.0, 300.0]),
+                editor_workspace_state("detached", [105.0, 305.0]),
+                editor_workspace_state("right", [700.0, 500.0]),
+            ],
+            ..RuntimeState::default()
+        };
+
+        let (temp, ctx, mut app) = test_app_with_config_and_startup(
+            &config,
+            StartupDecision::Ephemeral {
+                runtime_state: Box::new(runtime_state),
+            },
+        );
+        let left = workspace_id(&app, "left");
+        let detached = workspace_id(&app, "detached");
+        let left_frame = workspace_frame(&app, left);
+        let detached_frame = workspace_frame(&app, detached);
+        assert!(app.board.translate_workspace(
+            detached,
+            [
+                left_frame[0] + 5.0 - detached_frame[0],
+                left_frame[1] + 5.0 - detached_frame[1],
+            ],
+        ));
+        assert!(frames_overlap(workspace_frame(&app, detached), left_frame));
+        (temp, ctx, app)
+    }
+
+    fn workspace_frame(app: &super::HorizonApp, workspace_id: WorkspaceId) -> [f32; 4] {
+        let (min, max) = app.board.workspace_bounds(workspace_id).expect("workspace bounds");
+        [
+            min[0] - WS_BG_PAD,
+            min[1] - WS_BG_PAD - WS_TITLE_HEIGHT,
+            max[0] + WS_BG_PAD,
+            max[1] + WS_BG_PAD,
+        ]
+    }
+
+    fn workspace_id(app: &super::HorizonApp, local_id: &str) -> WorkspaceId {
+        app.board
+            .workspace_id_by_local_id(local_id)
+            .expect("workspace local id")
+    }
+
+    fn assert_attached_workspaces_form_organized_row(app: &mut super::HorizonApp) {
+        let mut frames: Vec<_> = app
+            .board
+            .workspaces
+            .iter()
+            .filter(|workspace| !app.workspace_is_detached(workspace.id))
+            .map(|workspace| workspace_frame(app, workspace.id))
+            .collect();
+        frames.sort_by(|left, right| left[0].total_cmp(&right[0]));
+
+        for pair in frames.windows(2) {
+            assert!(
+                (pair[0][1] - pair[1][1]).abs() <= POSITION_TOLERANCE,
+                "expected aligned frame tops, got {pair:?}"
+            );
+            assert!(
+                !frames_overlap(pair[0], pair[1]),
+                "expected separated frames, got {pair:?}"
+            );
+        }
+
+        let alignment = super::super::actions::align_attached_workspaces(&mut app.board, &app.detached_workspaces)
+            .expect("multiple attached workspaces");
+        assert!(
+            !alignment.positions_changed,
+            "reattachment must already match Ctrl+Shift+A"
+        );
+    }
+
+    fn frames_overlap(left: [f32; 4], right: [f32; 4]) -> bool {
+        !(left[2] <= right[0] || right[2] <= left[0] || left[3] <= right[1] || right[3] <= left[1])
+    }
 
     #[test]
     fn detached_viewport_builder_only_restores_window_state_when_requested() {
@@ -670,5 +744,76 @@ mod tests {
             .map(|input| input.event.clone())
             .collect::<Vec<_>>();
         assert_eq!(collected, events);
+    }
+
+    #[test]
+    fn direct_reattach_reuses_enabled_session_organization() {
+        let (_temp, ctx, mut app) = reattach_test_app(true);
+        app.apply_startup_workspace_organization(&ctx)
+            .expect("initial attached workspaces should organize");
+        let detached = workspace_id(&app, "detached");
+        app.canvas_view = CanvasViewState::new([4_000.0, -2_000.0], 1.0);
+        app.pan_target = None;
+
+        app.reattach_workspace(detached);
+        app.process_pending_detached_reattach(&ctx);
+
+        assert!(!app.workspace_is_detached(detached));
+        assert_attached_workspaces_form_organized_row(&mut app);
+        assert!(
+            app.pan_target.is_some(),
+            "reattachment should reuse the shortcut's view target"
+        );
+        assert!(app.runtime_dirty_since.is_some());
+    }
+
+    #[test]
+    fn deferred_reattach_reuses_enabled_session_organization() {
+        let (_temp, ctx, mut app) = reattach_test_app(true);
+        app.apply_startup_workspace_organization(&ctx)
+            .expect("initial attached workspaces should organize");
+        let detached = workspace_id(&app, "detached");
+        app.pending_detached_reattach.insert("detached".to_string());
+
+        app.process_pending_detached_reattach(&ctx);
+
+        assert!(!app.workspace_is_detached(detached));
+        assert_attached_workspaces_form_organized_row(&mut app);
+        assert!(app.runtime_dirty_since.is_some());
+    }
+
+    #[test]
+    fn reattach_separates_overlap_without_organizing_freeform_workspaces() {
+        let (_temp, ctx, mut app) = reattach_test_app(false);
+        let left = workspace_id(&app, "left");
+        let right = workspace_id(&app, "right");
+        let detached = workspace_id(&app, "detached");
+        let left_before = app.board.workspace(left).expect("left workspace").position;
+        let right_before = app.board.workspace(right).expect("right workspace").position;
+
+        app.reattach_workspace(detached);
+        app.process_pending_detached_reattach(&ctx);
+
+        assert!(!app.workspace_is_detached(detached));
+        assert_eq!(
+            app.board
+                .workspace(left)
+                .expect("left workspace")
+                .position
+                .map(f32::to_bits),
+            left_before.map(f32::to_bits)
+        );
+        assert_eq!(
+            app.board
+                .workspace(right)
+                .expect("right workspace")
+                .position
+                .map(f32::to_bits),
+            right_before.map(f32::to_bits)
+        );
+        let detached_frame = workspace_frame(&app, detached);
+        assert!(!frames_overlap(detached_frame, workspace_frame(&app, left)));
+        assert!(!frames_overlap(detached_frame, workspace_frame(&app, right)));
+        assert!(app.runtime_dirty_since.is_some());
     }
 }

--- a/crates/horizon-ui/src/app/detached_viewports.rs
+++ b/crates/horizon-ui/src/app/detached_viewports.rs
@@ -82,7 +82,7 @@ impl HorizonApp {
         self.mark_runtime_dirty();
     }
 
-    pub(super) fn reattach_workspace(&mut self, workspace_id: WorkspaceId) {
+    pub(super) fn reattach_workspace(&mut self, ctx: &Context, workspace_id: WorkspaceId) {
         let Some(workspace_local_id) = self
             .board
             .workspace(workspace_id)
@@ -90,7 +90,7 @@ impl HorizonApp {
         else {
             return;
         };
-        self.schedule_detached_workspace_reattach(&workspace_local_id);
+        self.schedule_detached_workspace_reattach(ctx, &workspace_local_id);
     }
 
     pub(super) fn focus_workspace_window(&self, ctx: &Context, workspace_id: WorkspaceId) -> bool {
@@ -163,8 +163,7 @@ impl HorizonApp {
             // Dropping the viewport immediately can make winit query a dead X11
             // handle before the backend prunes the child viewport on the next pass.
             ctx.send_viewport_cmd(ViewportCommand::CancelClose);
-            self.schedule_detached_workspace_reattach(workspace_local_id);
-            ctx.request_repaint_of(ViewportId::ROOT);
+            self.schedule_detached_workspace_reattach(ctx, workspace_local_id);
             return;
         }
         self.sync_detached_window_config(ctx, workspace_local_id);
@@ -331,8 +330,7 @@ impl HorizonApp {
                         )
                         .clicked()
                     {
-                        self.schedule_detached_workspace_reattach(workspace_local_id);
-                        ctx.request_repaint_of(ViewportId::ROOT);
+                        self.schedule_detached_workspace_reattach(ctx, workspace_local_id);
                     }
 
                     if ui
@@ -527,9 +525,10 @@ impl HorizonApp {
         }
     }
 
-    fn schedule_detached_workspace_reattach(&mut self, workspace_local_id: &str) {
+    fn schedule_detached_workspace_reattach(&mut self, ctx: &Context, workspace_local_id: &str) {
         if self.pending_detached_reattach.insert(workspace_local_id.to_string()) {
             self.mark_runtime_dirty();
+            ctx.request_repaint_of(ViewportId::ROOT);
         }
     }
 }
@@ -581,6 +580,8 @@ fn detached_viewport_builder(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::app::test_support::{
         editor_workspace_state, raw_input, run_app_frame_with_input, test_app, test_app_with_config_and_startup,
@@ -755,7 +756,7 @@ mod tests {
         app.canvas_view = CanvasViewState::new([4_000.0, -2_000.0], 1.0);
         app.pan_target = None;
 
-        app.reattach_workspace(detached);
+        app.reattach_workspace(&ctx, detached);
         app.process_pending_detached_reattach(&ctx);
 
         assert!(!app.workspace_is_detached(detached));
@@ -765,6 +766,24 @@ mod tests {
             "reattachment should reuse the shortcut's view target"
         );
         assert!(app.runtime_dirty_since.is_some());
+    }
+
+    #[test]
+    fn direct_reattach_requests_a_root_repaint_when_newly_queued() {
+        let (_temp, ctx, mut app) = reattach_test_app(false);
+        let detached = workspace_id(&app, "detached");
+        let repaint_requests = Arc::new(AtomicUsize::new(0));
+        let repaint_requests_for_callback = Arc::clone(&repaint_requests);
+        ctx.set_request_repaint_callback(move |info| {
+            if info.viewport_id == egui::ViewportId::ROOT && info.delay.is_zero() {
+                repaint_requests_for_callback.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        app.reattach_workspace(&ctx, detached);
+
+        assert!(app.pending_detached_reattach.contains("detached"));
+        assert!(repaint_requests.load(Ordering::Relaxed) > 0);
     }
 
     #[test]
@@ -830,7 +849,7 @@ mod tests {
         let left_before = app.board.workspace(left).expect("left workspace").position;
         let right_before = app.board.workspace(right).expect("right workspace").position;
 
-        app.reattach_workspace(detached);
+        app.reattach_workspace(&ctx, detached);
         app.process_pending_detached_reattach(&ctx);
 
         assert!(!app.workspace_is_detached(detached));

--- a/crates/horizon-ui/src/app/detached_viewports/reattach.rs
+++ b/crates/horizon-ui/src/app/detached_viewports/reattach.rs
@@ -1,0 +1,56 @@
+use egui::Context;
+
+use super::HorizonApp;
+
+impl HorizonApp {
+    pub(super) fn finish_workspace_reattachments(
+        &mut self,
+        ctx: &Context,
+        workspace_local_ids: impl IntoIterator<Item = String>,
+    ) {
+        let mut detached_state_changed = false;
+        let mut reattached_workspace_ids = Vec::new();
+
+        for workspace_local_id in workspace_local_ids {
+            if self.detached_workspaces.remove(&workspace_local_id).is_some() {
+                detached_state_changed = true;
+                if let Some(workspace_id) = self.board.workspace_id_by_local_id(&workspace_local_id) {
+                    reattached_workspace_ids.push(workspace_id);
+                }
+            }
+            self.pending_detached_window_position_restore
+                .remove(&workspace_local_id);
+        }
+
+        if !detached_state_changed {
+            return;
+        }
+
+        if reattached_workspace_ids.is_empty() {
+            self.mark_runtime_dirty();
+            return;
+        }
+
+        if self.template_config.features.organize_workspaces_on_session_load {
+            let _ = self.align_attached_workspaces_horizontally(ctx);
+        } else {
+            let workspace_ids = self.workspace_collision_scope(None);
+            for workspace_id in reattached_workspace_ids {
+                self.board
+                    .separate_workspace_from_overlaps_in_scope(workspace_id, &workspace_ids);
+            }
+        }
+        self.mark_runtime_dirty();
+    }
+
+    pub(super) fn process_pending_detached_reattach(&mut self, ctx: &Context) {
+        if self.pending_detached_reattach.is_empty() {
+            return;
+        }
+
+        // Remove pending viewports at the start of the root pass so egui
+        // simply stops emitting them this frame.
+        let pending = std::mem::take(&mut self.pending_detached_reattach);
+        self.finish_workspace_reattachments(ctx, pending);
+    }
+}

--- a/crates/horizon-ui/src/app/detached_viewports/reattach.rs
+++ b/crates/horizon-ui/src/app/detached_viewports/reattach.rs
@@ -43,7 +43,7 @@ impl HorizonApp {
         self.mark_runtime_dirty();
     }
 
-    pub(super) fn process_pending_detached_reattach(&mut self, ctx: &Context) {
+    pub(in crate::app) fn process_pending_detached_reattach(&mut self, ctx: &Context) {
         if self.pending_detached_reattach.is_empty() {
             return;
         }

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -261,6 +261,8 @@ impl HorizonApp {
 
     #[profiling::function]
     pub(super) fn render_active_view(&mut self, ui: &mut egui::Ui, root_interaction_suppressed: bool) {
+        self.process_pending_detached_reattach(ui.ctx());
+
         if self.fullscreen_panel.is_some() {
             self.render_fullscreen_panel(ui);
             // Detached windows are immediate viewports: egui closes any child

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
@@ -20,20 +20,36 @@ fn startup_frame_organizes_attached_workspaces_only_once() {
 }
 
 #[test]
-fn startup_frame_preserves_persisted_canvas_view() {
+fn startup_frame_reuses_manual_organization_view() {
     let saved_view = CanvasViewState::new([220.0, -80.0], 1.25);
-    let (_temp, ctx, mut app) = enabled_test_app(two_workspace_runtime(Some(saved_view)));
-    app.theme_applied = true;
+    let runtime_state = two_workspace_runtime(Some(saved_view));
+    let (_startup_temp, startup_ctx, mut startup_app) = enabled_test_app(runtime_state.clone());
+    startup_app.theme_applied = true;
+    let (_manual_temp, manual_ctx, mut manual_app) = test_app_with_startup(StartupDecision::Ephemeral {
+        runtime_state: Box::new(runtime_state),
+    });
+    manual_app.theme_applied = true;
 
-    run_frame_at_configured_size(&ctx, &mut app);
+    run_frame_at_configured_size(&startup_ctx, &mut startup_app);
+    run_frame_at_configured_size(&manual_ctx, &mut manual_app);
+    manual_app.execute_command(&manual_ctx, &CommandId::AlignWorkspacesHorizontally);
 
-    assert_eq!(app.canvas_view, saved_view);
-    assert!(app.pan_target.is_none());
-    assert_horizontal_row(&app, "left", "right");
+    assert_position_near(
+        workspace_position(&startup_app, "left"),
+        workspace_position(&manual_app, "left"),
+    );
+    assert_position_near(
+        workspace_position(&startup_app, "right"),
+        workspace_position(&manual_app, "right"),
+    );
+    let manual_target = manual_app.pan_target.expect("manual organization view target");
+    assert_position_near(startup_app.canvas_view.pan_offset, [manual_target.x, manual_target.y]);
+    assert_eq!(startup_app.canvas_view.zoom.to_bits(), saved_view.zoom.to_bits());
+    assert!(startup_app.pan_target.is_none());
 }
 
 #[test]
-fn startup_frame_keeps_a_visible_focused_workspace_on_screen() {
+fn startup_frame_preserves_selection_while_showing_the_organized_row_head() {
     let saved_view = CanvasViewState::new([-4_700.0, -250.0], 1.0);
     let runtime_state = RuntimeState {
         canvas_view: Some(saved_view),
@@ -51,7 +67,7 @@ fn startup_frame_keeps_a_visible_focused_workspace_on_screen() {
     run_frame_at_configured_size(&ctx, &mut app);
 
     assert_horizontal_row(&app, "left", "right");
-    assert_workspace_center_is_on_canvas(&ctx, &app, "right");
+    assert_workspace_center_is_on_canvas(&ctx, &app, "left");
     assert!(
         app.canvas_view
             .pan_offset
@@ -196,11 +212,16 @@ fn manual_alignment_still_runs_after_startup_one_shot() {
     run_frame_at_configured_size(&ctx, &mut app);
     let right_id = app.board.workspace_id_by_local_id("right").expect("right workspace");
     assert!(app.board.translate_workspace(right_id, [0.0, 137.0]));
+    app.runtime_dirty_since = None;
 
     app.execute_command(&ctx, &CommandId::AlignWorkspacesHorizontally);
 
     assert_horizontal_row(&app, "left", "right");
-    assert!(app.pan_target.is_some());
+    assert!(
+        app.pan_target.is_none(),
+        "the view already matches the shared organization target"
+    );
+    assert!(app.runtime_dirty_since.is_some());
 }
 
 #[test]
@@ -242,9 +263,17 @@ fn already_aligned_startup_does_not_mark_runtime_dirty() {
     let (_temp, ctx, mut app) = enabled_test_app(runtime_state);
     app.theme_applied = true;
     let workspace_ids: Vec<_> = app.board.workspaces.iter().map(|workspace| workspace.id).collect();
-    app.board
+    let alignment = app
+        .board
         .align_workspaces_horizontally(&workspace_ids)
         .expect("two workspaces");
+    let (min, max) = app
+        .board
+        .workspace_bounds(alignment.leftmost_workspace)
+        .expect("leftmost workspace bounds");
+    app.focus_workspace_bounds(&ctx, min, max, true);
+    let target = app.pan_target.take().expect("startup-compatible view target");
+    app.canvas_view.set_pan_offset([target.x, target.y]);
     app.runtime_dirty_since = None;
 
     run_frame_at_configured_size(&ctx, &mut app);
@@ -322,13 +351,15 @@ fn startup_organization_precedes_one_immediate_initial_pan() {
     assert_eq!(active_workspace_local_id(&app), Some("right"));
 
     let left_id = app.board.workspace_id_by_local_id("left").expect("left workspace");
-    let (min, _max) = app.board.workspace_bounds(left_id).expect("left bounds");
+    let (min, max) = app.board.workspace_bounds(left_id).expect("left bounds");
     let canvas_rect = app.canvas_rect(&ctx);
     let frame_left = min[0] - WS_BG_PAD;
     let frame_top = min[1] - WS_BG_PAD - WS_TITLE_HEIGHT;
-    let mapped = app
-        .canvas_view
-        .canvas_to_screen([canvas_rect.min.x, canvas_rect.min.y], [frame_left, frame_top]);
+    let frame_bottom = max[1] + WS_BG_PAD;
+    let mapped = app.canvas_view.canvas_to_screen(
+        [canvas_rect.min.x, canvas_rect.min.y],
+        [frame_left, f32::midpoint(frame_top, frame_bottom)],
+    );
     assert!((mapped[0] - (canvas_rect.min.x + 40.0)).abs() <= POSITION_TOLERANCE);
     assert!((mapped[1] - canvas_rect.center().y).abs() <= POSITION_TOLERANCE);
 
@@ -402,12 +433,12 @@ fn initial_pan_uses_the_row_head_selected_by_core_alignment() {
 
     run_frame_at_configured_size(&ctx, &mut app);
 
-    let (pos, _size) = workspace_frame(&app, "frame-left");
+    let (pos, size) = workspace_frame(&app, "frame-left");
     let (origin_left_pos, _size) = workspace_frame(&app, "origin-left");
     assert!(pos.x < origin_left_pos.x);
     assert!((pos.y - origin_left_pos.y).abs() <= POSITION_TOLERANCE);
     let canvas_rect = app.canvas_rect(&ctx);
-    let mapped = app.canvas_to_screen(canvas_rect, pos);
+    let mapped = app.canvas_to_screen(canvas_rect, Pos2::new(pos.x, pos.y + size.y * 0.5));
     let origin_left_frame = workspace_frame(&app, "origin-left");
     let origin_left_mapped = app.canvas_to_screen(canvas_rect, origin_left_frame.0);
     assert!(
@@ -421,7 +452,7 @@ fn initial_pan_uses_the_row_head_selected_by_core_alignment() {
     );
     assert!(
         (mapped.y - canvas_rect.center().y).abs() <= POSITION_TOLERANCE,
-        "expected frame-left y anchor {}, got {}",
+        "expected frame-left center y anchor {}, got {}",
         canvas_rect.center().y,
         mapped.y
     );
@@ -461,7 +492,7 @@ fn default_disabled_initial_pan_keeps_focus_and_camera_on_leftmost_workspace() {
 }
 
 #[test]
-fn enabled_initial_pan_repairs_an_unpersisted_fallback_selection() {
+fn enabled_organization_preserves_an_unpersisted_fallback_selection() {
     let runtime_state = RuntimeState {
         canvas_view: None,
         workspaces: vec![
@@ -476,7 +507,7 @@ fn enabled_initial_pan_repairs_an_unpersisted_fallback_selection() {
     run_frame_at_configured_size(&ctx, &mut app);
 
     assert_eq!(active_workspace_local_id(&app), Some("left"));
-    assert_eq!(focused_panel_local_id(&app), Some("left-panel"));
+    assert_eq!(focused_panel_local_id(&app), Some("right-panel"));
     assert_workspace_center_is_on_canvas(&ctx, &app, "left");
 }
 

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
@@ -49,6 +49,48 @@ fn startup_frame_reuses_manual_organization_view() {
 }
 
 #[test]
+fn settled_manual_view_wins_over_pre_alignment_visible_anchor() {
+    let mut runtime_state = RuntimeState {
+        canvas_view: Some(CanvasViewState::default()),
+        active_workspace_local_id: Some("focused".to_string()),
+        focused_panel_local_id: Some("focused-panel".to_string()),
+        workspaces: vec![
+            editor_workspace_state("left", [100.0, 300.0]),
+            editor_workspace_state("second", [105.0, 305.0]),
+            editor_workspace_state("third", [110.0, 310.0]),
+            editor_workspace_state("focused", [115.0, 315.0]),
+        ],
+        ..RuntimeState::default()
+    };
+    let (_manual_temp, manual_ctx, mut manual_app) = test_app_with_startup(StartupDecision::Ephemeral {
+        runtime_state: Box::new(runtime_state.clone()),
+    });
+    manual_app.theme_applied = true;
+    run_frame_at_configured_size(&manual_ctx, &mut manual_app);
+    manual_app.execute_command(&manual_ctx, &CommandId::AlignWorkspacesHorizontally);
+    let manual_target = manual_app.pan_target.take().expect("manual organization view target");
+    let mut settled_view = manual_app.canvas_view;
+    settled_view.set_pan_offset([manual_target.x, manual_target.y]);
+    manual_app.canvas_view = settled_view;
+
+    runtime_state.canvas_view = Some(settled_view);
+    let (_startup_temp, startup_ctx, mut startup_app) = enabled_test_app(runtime_state);
+    startup_app.theme_applied = true;
+    run_frame_at_configured_size(&startup_ctx, &mut startup_app);
+
+    for local_id in ["left", "second", "third", "focused"] {
+        assert_position_near(
+            workspace_position(&startup_app, local_id),
+            workspace_position(&manual_app, local_id),
+        );
+    }
+    assert_position_near(startup_app.canvas_view.pan_offset, settled_view.pan_offset);
+    assert_eq!(focused_panel_local_id(&startup_app), Some("focused-panel"));
+    assert_eq!(active_workspace_local_id(&startup_app), Some("focused"));
+    assert!(startup_app.pan_target.is_none());
+}
+
+#[test]
 fn startup_frame_preserves_selection_while_showing_the_organized_row_head() {
     let saved_view = CanvasViewState::new([-4_700.0, -250.0], 1.0);
     let runtime_state = RuntimeState {

--- a/crates/horizon-ui/src/app/lifecycle/startup_workspace.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_workspace.rs
@@ -10,14 +10,8 @@ impl HorizonApp {
             return None;
         }
 
-        let visible_anchor = if self.initial_pan_done {
-            self.startup_workspace_view_anchor(ctx)
-        } else {
-            None
-        };
-        let Some(alignment) =
-            super::super::actions::align_attached_workspaces(&mut self.board, &self.detached_workspaces)
-        else {
+        let visible_anchor = self.startup_workspace_view_anchor(ctx);
+        let Some(alignment) = self.align_attached_workspaces_horizontally(ctx) else {
             tracing::debug!("startup workspace organization skipped: no valid multi-workspace alignment");
             return None;
         };
@@ -27,14 +21,21 @@ impl HorizonApp {
             positions_changed = alignment.positions_changed,
             "startup workspace organization applied"
         );
-        if alignment.positions_changed {
-            if let Some((workspace_id, screen_anchor)) = visible_anchor {
-                self.restore_startup_workspace_view_anchor(ctx, workspace_id, screen_anchor);
-            } else if self.initial_pan_done && self.startup_workspace_view_anchor(ctx).is_none() {
-                let _ = self.align_initial_view_to_workspace(ctx, alignment.leftmost_workspace);
-            }
+
+        // The shortcut animates toward this same target. Session loading
+        // applies it immediately so the first interactive frame is already
+        // settled and cannot expose the pre-organization camera.
+        if let Some(target) = self.pan_target.take() {
+            self.canvas_view.set_pan_offset([target.x, target.y]);
             self.mark_runtime_dirty();
+        } else if alignment.positions_changed
+            && let Some((workspace_id, screen_anchor)) = visible_anchor
+        {
+            // An empty row head has no bounds from which the shared action can
+            // derive a target. Keep a previously visible workspace anchored.
+            self.restore_startup_workspace_view_anchor(ctx, workspace_id, screen_anchor);
         }
+        self.initial_pan_done = true;
         Some(alignment.leftmost_workspace)
     }
 

--- a/crates/horizon-ui/src/app/lifecycle/startup_workspace.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_workspace.rs
@@ -15,6 +15,7 @@ impl HorizonApp {
             tracing::debug!("startup workspace organization skipped: no valid multi-workspace alignment");
             return None;
         };
+        let row_head_has_bounds = self.board.workspace_bounds(alignment.leftmost_workspace).is_some();
 
         tracing::debug!(
             leftmost_workspace_id = alignment.leftmost_workspace.0,
@@ -28,7 +29,8 @@ impl HorizonApp {
         if let Some(target) = self.pan_target.take() {
             self.canvas_view.set_pan_offset([target.x, target.y]);
             self.mark_runtime_dirty();
-        } else if alignment.positions_changed
+        } else if !row_head_has_bounds
+            && alignment.positions_changed
             && let Some((workspace_id, screen_anchor)) = visible_anchor
         {
             // An empty row head has no bounds from which the shared action can

--- a/crates/horizon-ui/src/app/sidebar.rs
+++ b/crates/horizon-ui/src/app/sidebar.rs
@@ -689,7 +689,7 @@ impl HorizonApp {
             self.detach_workspace(workspace_id);
         }
         if let Some(workspace_id) = actions.reattach_workspace {
-            self.reattach_workspace(workspace_id);
+            self.reattach_workspace(ctx, workspace_id);
         }
 
         if let Some(panel_id) = actions.close_panel {


### PR DESCRIPTION
## Purpose

Fix the mismatch between automatic session-load organization and Ctrl+Shift+A, and prevent a detached workspace from returning with stale overlapping geometry.

## Behavior impact

- Session-load organization now invokes the same full action as Ctrl+Shift+A, including the same leftmost-workspace view target. Startup applies that target immediately so the first interactive frame is settled.
- Reattaching a workspace reruns the shared organization path when automatic organization is enabled.
- When automatic organization is disabled, reattachment preserves the existing freeform layout and moves only a returning workspace that actually overlaps another attached workspace.
- Pending child-window reattachments are finalized before root bounds and rendering, so the returning workspace is present in the first exposed root frame.
- Reattachment initiated from the root sidebar explicitly wakes the deferred root pass, including for idle workspaces.
- Persisted active-workspace and focused-panel selection, zoom, detached geometry, and one-shot startup behavior remain unchanged.

## Reproduction

Before this change, a restored multi-workspace session could open with a different camera than Ctrl+Shift+A. A detached workspace moved in its child window could also be reattached with stale canvas geometry and overlap another workspace until the shortcut was pressed. Root-sidebar reattachment could remain queued until unrelated activity woke the root view.

## Validation

All required local tiers passed on exact head `d69a0182613b1fcd1dd4b662b8c20009e2441f7c`, based on `883e5b575c213a7e2e431ee829c0457489cbf12c`:

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`

Regression coverage includes the already-settled-camera startup edge case, same-frame root rendering during deferred reattachment, the immediate root-sidebar repaint request, shared enabled organization, and collision-only freeform reattachment. The root-sidebar repaint regression was confirmed red before the fix and green afterward.

## UI smoke

Validated exact head `d69a0182613b1fcd1dd4b662b8c20009e2441f7c` on an isolated Linux X11 display with disposable config and state:

- Three initially overlapping workspaces opened in one non-overlapping horizontal row.
- After detaching the middle workspace, `Move to Main Window` was selected from the root-sidebar context menu. Without further Horizon input, the child disappeared and the workspace plus cleared sidebar badge appeared in the next captured root pass.
- Post-reattach Ctrl+Shift+A produced zero differing canvas pixels.
- The normal Alt+F4 close path exited cleanly.

The immediately preceding head also passed the broader exact-head UI lane: 1400x900 to 1200x760 resize stability, monotonic native detached-window drag, first-exposed-root-frame reattachment, and zero-pixel startup/shortcut parity. The final follow-up changes only the root-sidebar wake path, which was replayed on the current head above.

Temporary smoke plans, configs, screenshots, frame traces, and task-owned display processes were removed after validation.
