### PR TITLE
feat(layout): swap arranged panels on collision

### DIFF
--- a/crates/horizon-core/src/board/arrangement.rs
+++ b/crates/horizon-core/src/board/arrangement.rs
@@ -8,6 +8,7 @@ use crate::workspace::{Workspace, WorkspaceId};
 use super::{Board, WorkspaceLayout, vec2_eq};
 
 mod alignment;
+mod reordering;
 
 pub use alignment::WorkspaceAlignment;
 
@@ -225,8 +226,9 @@ impl Board {
     /// area so the arrangement fills the workspace frame instead of jumping
     /// elsewhere. Fitted sizes are clamped to the default panel size, so an
     /// arrangement can grow the frame; neighboring workspaces are pushed out
-    /// of the way like on panel resize. Dragging a panel by hand returns the
-    /// workspace to manual placement.
+    /// of the way like on panel resize. The UI keeps presets selected while
+    /// dragging by swapping occupied slots; direct manual moves return the
+    /// workspace to freeform placement.
     pub fn arrange_workspace(&mut self, id: WorkspaceId, layout: WorkspaceLayout) {
         let previous_frame = self.workspace_frame_rect(id);
         self.apply_workspace_layout(id, layout);

--- a/crates/horizon-core/src/board/arrangement/reordering.rs
+++ b/crates/horizon-core/src/board/arrangement/reordering.rs
@@ -1,0 +1,88 @@
+use crate::panel::PanelId;
+
+use super::super::Board;
+
+impl Board {
+    /// Return the visible sibling whose slot contains the center of an
+    /// arranged panel at `position`.
+    #[must_use]
+    pub fn arranged_panel_collision_target(&self, source: PanelId, position: [f32; 2]) -> Option<PanelId> {
+        if !position[0].is_finite() || !position[1].is_finite() {
+            return None;
+        }
+
+        let source_panel = self.panel(source)?;
+        if !source_panel.visible {
+            return None;
+        }
+        let workspace = self.workspace(source_panel.workspace_id)?;
+        workspace.layout?;
+        workspace.panel_index(source)?;
+
+        let center = [
+            position[0] + source_panel.layout.size[0] * 0.5,
+            position[1] + source_panel.layout.size[1] * 0.5,
+        ];
+        if !center[0].is_finite() || !center[1].is_finite() {
+            return None;
+        }
+
+        workspace.panels.iter().copied().find(|candidate_id| {
+            if *candidate_id == source {
+                return false;
+            }
+            self.panel(*candidate_id).is_some_and(|candidate| {
+                candidate.visible
+                    && candidate.workspace_id == source_panel.workspace_id
+                    && point_in_panel(center, candidate.layout.position, candidate.layout.size)
+            })
+        })
+    }
+
+    /// Swap two visible panel slots inside the same arranged workspace and
+    /// immediately reflow the preset without changing focus or layout mode.
+    pub fn swap_arranged_panels(&mut self, source: PanelId, target: PanelId) -> bool {
+        if source == target {
+            return false;
+        }
+
+        let Some(source_panel) = self.panel(source) else {
+            return false;
+        };
+        let workspace_id = source_panel.workspace_id;
+        let source_visible = source_panel.visible;
+        let target_is_eligible = self
+            .panel(target)
+            .is_some_and(|panel| panel.visible && panel.workspace_id == workspace_id);
+        if !source_visible || !target_is_eligible {
+            return false;
+        }
+
+        let Some(workspace) = self.workspace(workspace_id) else {
+            return false;
+        };
+        let Some(layout) = workspace.layout else {
+            return false;
+        };
+        let Some(source_index) = workspace.panel_index(source) else {
+            return false;
+        };
+        let Some(target_index) = workspace.panel_index(target) else {
+            return false;
+        };
+
+        let Some(workspace) = self.workspace_mut(workspace_id) else {
+            return false;
+        };
+        workspace.panels.swap(source_index, target_index);
+        self.apply_workspace_layout(workspace_id, layout);
+        true
+    }
+}
+
+fn point_in_panel(point: [f32; 2], position: [f32; 2], size: [f32; 2]) -> bool {
+    point[0] >= position[0]
+        && point[0] < position[0] + size[0]
+        && point[1] >= position[1]
+        && point[1] < position[1] + size[1]
+}

--- a/crates/horizon-core/src/board/tests/mod.rs
+++ b/crates/horizon-core/src/board/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::panel::{PanelKind, PanelOptions};
 mod alignment;
 mod core;
 mod layout;
+mod reordering;
 mod workspace;
 mod workspace_separation;
 

--- a/crates/horizon-core/src/board/tests/reordering.rs
+++ b/crates/horizon-core/src/board/tests/reordering.rs
@@ -1,0 +1,174 @@
+use crate::layout::TILE_GAP;
+use crate::{CanvasViewState, RuntimeState, WindowConfig};
+
+use super::super::*;
+use super::editor_panel_options;
+
+fn arranged_board(layout: WorkspaceLayout, count: usize) -> (Board, WorkspaceId, Vec<PanelId>) {
+    let mut board = Board::new();
+    let workspace_id = board.create_workspace("arranged");
+    let panel_ids = (0..count)
+        .map(|index| {
+            board
+                .create_panel(editor_panel_options(), workspace_id)
+                .unwrap_or_else(|error| panic!("panel {} should spawn: {error}", index + 1))
+        })
+        .collect();
+    board.arrange_workspace(workspace_id, layout);
+    (board, workspace_id, panel_ids)
+}
+
+#[test]
+fn collision_target_uses_the_dragged_panel_center_for_every_layout() {
+    for layout in WorkspaceLayout::ALL {
+        let (board, _, panel_ids) = arranged_board(layout, 4);
+        let source = panel_ids[0];
+        let target = panel_ids[3];
+        let target_position = board.panel(target).expect("target panel").layout.position;
+
+        assert_eq!(
+            board.arranged_panel_collision_target(source, target_position),
+            Some(target),
+            "{layout:?} should detect the slot under the dragged panel center"
+        );
+        assert_eq!(
+            board.arranged_panel_collision_target(source, [100_000.0, 100_000.0]),
+            None,
+            "{layout:?} should ignore empty canvas"
+        );
+    }
+}
+
+#[test]
+fn collision_target_ignores_the_gap_and_far_edge() {
+    let (board, _, panel_ids) = arranged_board(WorkspaceLayout::Columns, 2);
+    let source = board.panel(panel_ids[0]).expect("source panel");
+    let target = board.panel(panel_ids[1]).expect("target panel");
+    let source_size = source.layout.size;
+    let target_position = target.layout.position;
+
+    let gap_center_x = target_position[0] - TILE_GAP * 0.5;
+    let gap_position = [gap_center_x - source_size[0] * 0.5, target_position[1]];
+    assert_eq!(board.arranged_panel_collision_target(source.id, gap_position), None);
+
+    let far_edge_position = [
+        target_position[0] + target.layout.size[0] - source_size[0] * 0.5,
+        target_position[1],
+    ];
+    assert_eq!(
+        board.arranged_panel_collision_target(source.id, far_edge_position),
+        None
+    );
+}
+
+#[test]
+fn swapping_arranged_panels_preserves_layout_focus_size_and_slots() {
+    for layout in WorkspaceLayout::ALL {
+        let (mut board, workspace_id, panel_ids) = arranged_board(layout, 4);
+        let source = panel_ids[0];
+        let target = panel_ids[3];
+        assert!(board.resize_panel(source, [610.0, 390.0]));
+        board.focus(source);
+
+        let source_slot = board.panel(source).expect("source panel").layout.position;
+        let target_slot = board.panel(target).expect("target panel").layout.position;
+
+        assert!(board.swap_arranged_panels(source, target));
+
+        let workspace = board.workspace(workspace_id).expect("workspace");
+        assert_eq!(workspace.layout, Some(layout));
+        assert_eq!(workspace.panels, [target, panel_ids[1], panel_ids[2], source]);
+        assert_eq!(board.focused, Some(source));
+        assert!(vec2_eq(
+            board.panel(source).expect("source panel").layout.position,
+            target_slot
+        ));
+        assert!(vec2_eq(
+            board.panel(target).expect("target panel").layout.position,
+            source_slot
+        ));
+        for panel_id in panel_ids {
+            assert!(vec2_eq(
+                board.panel(panel_id).expect("panel").layout.size,
+                [610.0, 390.0]
+            ));
+        }
+    }
+}
+
+#[test]
+fn only_visible_siblings_in_an_arranged_workspace_can_swap() {
+    let (mut board, workspace_id, panel_ids) = arranged_board(WorkspaceLayout::Grid, 3);
+    let source = panel_ids[0];
+    let hidden = panel_ids[1];
+    let original_order = board.workspace(workspace_id).expect("workspace").panels.clone();
+    assert!(board.set_panel_visible(hidden, false));
+
+    assert_ne!(
+        board.arranged_panel_collision_target(source, board.panel(hidden).expect("hidden panel").layout.position),
+        Some(hidden)
+    );
+    assert!(!board.swap_arranged_panels(source, hidden));
+
+    let other_workspace = board.create_workspace("other");
+    let other = board
+        .create_panel(editor_panel_options(), other_workspace)
+        .expect("other panel should spawn");
+    assert!(!board.swap_arranged_panels(source, other));
+
+    assert!(board.clear_workspace_layout(workspace_id));
+    assert!(!board.swap_arranged_panels(source, panel_ids[2]));
+    assert_eq!(board.workspace(workspace_id).expect("workspace").panels, original_order);
+}
+
+#[test]
+fn sequential_grid_collisions_move_the_dragged_panel_through_slots() {
+    let (mut board, workspace_id, panel_ids) = arranged_board(WorkspaceLayout::Grid, 4);
+    let source = panel_ids[0];
+
+    for target in [panel_ids[1], panel_ids[3]] {
+        let target_position = board.panel(target).expect("target panel").layout.position;
+        assert_eq!(
+            board.arranged_panel_collision_target(source, target_position),
+            Some(target)
+        );
+        assert!(board.swap_arranged_panels(source, target));
+    }
+
+    assert_eq!(
+        board.workspace(workspace_id).expect("workspace").panels,
+        [panel_ids[1], panel_ids[3], panel_ids[2], source]
+    );
+    assert_eq!(
+        board.workspace(workspace_id).expect("workspace").layout,
+        Some(WorkspaceLayout::Grid)
+    );
+}
+
+#[test]
+fn swapped_slot_order_survives_runtime_state_round_trip() {
+    let (mut board, _, panel_ids) = arranged_board(WorkspaceLayout::Rows, 3);
+    assert!(board.swap_arranged_panels(panel_ids[0], panel_ids[2]));
+
+    let expected_local_ids = board.workspaces[0]
+        .panels
+        .iter()
+        .map(|panel_id| board.panel(*panel_id).expect("panel").local_id.clone())
+        .collect::<Vec<_>>();
+    let state = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    let saved_local_ids = state.workspaces[0]
+        .panels
+        .iter()
+        .map(|panel| panel.local_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(saved_local_ids, expected_local_ids);
+
+    let restored = Board::from_runtime_state(&state).expect("runtime state should restore");
+    let restored_local_ids = restored.workspaces[0]
+        .panels
+        .iter()
+        .map(|panel_id| restored.panel(*panel_id).expect("panel").local_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(restored_local_ids, expected_local_ids);
+    assert_eq!(restored.workspaces[0].layout, Some(WorkspaceLayout::Rows));
+}

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -92,6 +92,7 @@ enum CanvasPanSpaceKeyState {
 }
 
 use self::frame_stats::FrameStats;
+use self::panels::ArrangedPanelDrag;
 use self::session::{StartupBootstrapFailure, StartupBootstrapOutcome};
 use self::session_manager::RuntimeSessionManagerState;
 use self::settings::SettingsEditor;
@@ -198,6 +199,7 @@ pub struct HorizonApp {
     is_panning: bool,
     middle_pan_active: bool,
     canvas_pan_input_claimed: bool,
+    arranged_panel_drag: Option<ArrangedPanelDrag>,
     pending_space_pan_key: CanvasPanSpaceKeyState,
     observed_keyboard_inputs: input::ObservedKeyboardInputs,
     ime_commit_normalizer: input::ImeCommitNormalizer,
@@ -478,7 +480,7 @@ impl HorizonApp {
             pan_target: None,
             is_panning: false,
             middle_pan_active: false,
-            canvas_pan_input_claimed: false,
+            canvas_pan_input_claimed: false, arranged_panel_drag: None,
             pending_space_pan_key: CanvasPanSpaceKeyState::Idle,
             observed_keyboard_inputs,
             ime_commit_normalizer: input::ImeCommitNormalizer::default(),

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -496,7 +496,7 @@ impl HorizonApp {
         browser_events: &[egui::Event],
         scope: PanelRenderScope,
     ) -> bool {
-        self.clear_released_arranged_panel_drag(ctx, panel_id);
+        self.clear_inactive_arranged_panel_drag(ctx, panel_id);
         let Some(snapshot) = self.panel_snapshot(panel_id, canvas_rect) else {
             return false;
         };

--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -22,6 +22,7 @@ use super::util::primary_shortcut_label;
 use super::{HorizonApp, PANEL_PADDING, PANEL_TITLEBAR_HEIGHT, RESIZE_HANDLE_SIZE, RenameEditAction};
 
 mod interaction;
+pub(super) use interaction::ArrangedPanelDrag;
 
 #[derive(Clone, Copy)]
 pub(in crate::app) struct PanelScreenGeometry {
@@ -47,9 +48,16 @@ struct PanelSnapshot {
 }
 
 #[derive(Default)]
+struct PanelDragOutcome {
+    started: bool,
+    delta: Vec2,
+    stopped: bool,
+}
+
+#[derive(Default)]
 struct PanelUiOutcome {
     focus_requested: bool,
-    drag_delta: Vec2,
+    drag: PanelDragOutcome,
     resize_delta: Vec2,
     commit_terminal_resize: bool,
     workspace_assignment: Option<WorkspaceId>,
@@ -283,7 +291,11 @@ impl HorizonApp {
     }
 
     fn panel_screen_geometry(&self, panel: &Panel, canvas_rect: Rect) -> Option<PanelScreenGeometry> {
-        let canvas_position = Pos2::new(panel.layout.position[0], panel.layout.position[1]);
+        let canvas_position = self.arranged_panel_position(
+            panel.id,
+            panel.workspace_id,
+            Pos2::new(panel.layout.position[0], panel.layout.position[1]),
+        );
         let canvas_size = Vec2::new(panel.layout.size[0], panel.layout.size[1]);
         let screen_rect = clip_screen_rect_to_canvas(
             Rect::from_min_size(
@@ -484,6 +496,7 @@ impl HorizonApp {
         browser_events: &[egui::Event],
         scope: PanelRenderScope,
     ) -> bool {
+        self.clear_released_arranged_panel_drag(ctx, panel_id);
         let Some(snapshot) = self.panel_snapshot(panel_id, canvas_rect) else {
             return false;
         };
@@ -499,7 +512,11 @@ impl HorizonApp {
             .and_then(|panel| {
                 let geometry = self.panel_screen_geometry(panel, canvas_rect)?;
                 let terminal = panel.terminal();
-                let canvas_position = Pos2::new(panel.layout.position[0], panel.layout.position[1]);
+                let canvas_position = self.arranged_panel_position(
+                    panel.id,
+                    panel.workspace_id,
+                    Pos2::new(panel.layout.position[0], panel.layout.position[1]),
+                );
                 let canvas_size = Vec2::new(panel.layout.size[0], panel.layout.size[1]);
 
                 let workspace_accent = self

--- a/crates/horizon-ui/src/app/panels/interaction.rs
+++ b/crates/horizon-ui/src/app/panels/interaction.rs
@@ -44,11 +44,11 @@ impl ArrangedPanelDrag {
 }
 
 impl HorizonApp {
-    pub(super) fn clear_released_arranged_panel_drag(&mut self, ctx: &Context, panel_id: PanelId) {
-        let should_clear = self
-            .arranged_panel_drag
-            .is_some_and(|drag| drag.panel_id == panel_id && drag.viewport_id == ctx.viewport_id())
-            && !ctx.input(|input| input.pointer.primary_down());
+    pub(super) fn clear_inactive_arranged_panel_drag(&mut self, ctx: &Context, panel_id: PanelId) {
+        let should_clear = self.arranged_panel_drag.is_some_and(|drag| {
+            drag.panel_id == panel_id
+                && (drag.viewport_id != ctx.viewport_id() || !ctx.input(|input| input.pointer.primary_down()))
+        });
         if should_clear {
             self.arranged_panel_drag = None;
             ctx.request_repaint();
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn pointer_release_clears_only_the_drag_from_its_viewport() {
+    fn stale_viewport_or_pointer_release_clears_only_the_source_panel_drag() {
         let (_temp, mut app) = test_app();
         let panel_id = PanelId(7);
         let workspace_id = WorkspaceId(11);
@@ -421,8 +421,8 @@ mod tests {
             Pos2::ZERO,
         ));
 
-        app.clear_released_arranged_panel_drag(&root_ctx, panel_id);
-        assert!(app.arranged_panel_drag.is_some());
+        app.clear_inactive_arranged_panel_drag(&root_ctx, panel_id);
+        assert!(app.arranged_panel_drag.is_none());
 
         app.arranged_panel_drag = Some(ArrangedPanelDrag::new(
             panel_id,
@@ -430,10 +430,10 @@ mod tests {
             ViewportId::ROOT,
             Pos2::ZERO,
         ));
-        app.clear_released_arranged_panel_drag(&root_ctx, PanelId(8));
+        app.clear_inactive_arranged_panel_drag(&root_ctx, PanelId(8));
         assert!(app.arranged_panel_drag.is_some());
 
-        app.clear_released_arranged_panel_drag(&root_ctx, panel_id);
+        app.clear_inactive_arranged_panel_drag(&root_ctx, panel_id);
         assert!(app.arranged_panel_drag.is_none());
     }
 

--- a/crates/horizon-ui/src/app/panels/interaction.rs
+++ b/crates/horizon-ui/src/app/panels/interaction.rs
@@ -1,4 +1,4 @@
-use egui::{Context, Pos2, Rect, Vec2};
+use egui::{Context, Pos2, Rect, Vec2, ViewportId};
 use horizon_core::{PanelId, PanelKind, WorkspaceId};
 
 use crate::app::{HorizonApp, RenameEditAction, util::clamp_panel_size};
@@ -7,7 +7,73 @@ use crate::theme;
 
 use super::{PanelCommand, PanelFrame, PanelSnapshot, PanelUiOutcome, render_session_rebind_options};
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::app) struct ArrangedPanelDrag {
+    panel_id: PanelId,
+    workspace_id: WorkspaceId,
+    viewport_id: ViewportId,
+    preview_position: Pos2,
+}
+
+impl ArrangedPanelDrag {
+    fn new(panel_id: PanelId, workspace_id: WorkspaceId, viewport_id: ViewportId, preview_position: Pos2) -> Self {
+        Self {
+            panel_id,
+            workspace_id,
+            viewport_id,
+            preview_position,
+        }
+    }
+
+    fn matches(self, panel_id: PanelId, workspace_id: WorkspaceId, viewport_id: ViewportId) -> bool {
+        self.panel_id == panel_id && self.workspace_id == workspace_id && self.viewport_id == viewport_id
+    }
+
+    fn preview_for(self, panel_id: PanelId, workspace_id: WorkspaceId) -> Option<Pos2> {
+        (self.panel_id == panel_id && self.workspace_id == workspace_id).then_some(self.preview_position)
+    }
+
+    fn belongs_to(self, panel_id: PanelId, workspace_id: WorkspaceId) -> bool {
+        self.panel_id == panel_id && self.workspace_id == workspace_id
+    }
+
+    fn advance(&mut self, delta: Vec2) -> Pos2 {
+        self.preview_position += delta;
+        self.preview_position
+    }
+}
+
 impl HorizonApp {
+    pub(super) fn clear_released_arranged_panel_drag(&mut self, ctx: &Context, panel_id: PanelId) {
+        let should_clear = self
+            .arranged_panel_drag
+            .is_some_and(|drag| drag.panel_id == panel_id && drag.viewport_id == ctx.viewport_id())
+            && !ctx.input(|input| input.pointer.primary_down());
+        if should_clear {
+            self.arranged_panel_drag = None;
+            ctx.request_repaint();
+        }
+    }
+
+    pub(super) fn arranged_panel_position(&self, panel_id: PanelId, workspace_id: WorkspaceId, fallback: Pos2) -> Pos2 {
+        let Some(preview_position) = self
+            .arranged_panel_drag
+            .and_then(|drag| drag.preview_for(panel_id, workspace_id))
+        else {
+            return fallback;
+        };
+
+        if self
+            .board
+            .workspace(workspace_id)
+            .is_some_and(|workspace| workspace.layout.is_some())
+        {
+            preview_position
+        } else {
+            fallback
+        }
+    }
+
     pub(super) fn update_panel_interactions(
         is_renaming: bool,
         drag_response: &egui::Response,
@@ -26,8 +92,14 @@ impl HorizonApp {
         if !is_renaming && (drag_response.clicked() || drag_response.drag_started()) {
             outcome.focus_requested = true;
         }
+        if !is_renaming && drag_response.drag_started() {
+            outcome.drag.started = true;
+        }
         if !is_renaming && drag_response.dragged() {
-            outcome.drag_delta = drag_response.drag_delta();
+            outcome.drag.delta = drag_response.drag_delta();
+        }
+        if !is_renaming && drag_response.drag_stopped() {
+            outcome.drag.stopped = true;
         }
         if resize_response.dragged() {
             outcome.resize_delta = resize_response.drag_delta();
@@ -159,11 +231,13 @@ impl HorizonApp {
             RenameEditAction::None => {}
         }
 
-        if !self.canvas_pan_input_claimed && outcome.drag_delta != Vec2::ZERO {
-            let new_position = snapshot.canvas_position + outcome.drag_delta;
-            let _ = self.board.move_panel(panel_id, [new_position.x, new_position.y]);
-            self.mark_runtime_dirty();
-        }
+        self.apply_panel_drag(
+            ctx,
+            panel_id,
+            snapshot.current_workspace_id,
+            snapshot.canvas_position,
+            outcome,
+        );
         if !self.canvas_pan_input_claimed && outcome.resize_delta != Vec2::ZERO {
             let new_size = clamp_panel_size(snapshot.canvas_size + outcome.resize_delta);
             let _ = self.board.resize_panel_with_workspace_scope(
@@ -213,5 +287,247 @@ impl HorizonApp {
         }
 
         matches!(outcome.command, Some(PanelCommand::Close))
+    }
+
+    fn apply_panel_drag(
+        &mut self,
+        ctx: &Context,
+        panel_id: PanelId,
+        workspace_id: WorkspaceId,
+        canvas_position: Pos2,
+        outcome: &PanelUiOutcome,
+    ) {
+        let viewport_id = ctx.viewport_id();
+        let arranged = self
+            .board
+            .workspace(workspace_id)
+            .is_some_and(|workspace| workspace.layout.is_some());
+        let active_drag_matches = self
+            .arranged_panel_drag
+            .is_some_and(|drag| drag.matches(panel_id, workspace_id, viewport_id));
+        let drag_belongs_to_panel = self
+            .arranged_panel_drag
+            .is_some_and(|drag| drag.belongs_to(panel_id, workspace_id));
+
+        if drag_belongs_to_panel && !active_drag_matches {
+            self.arranged_panel_drag = None;
+            ctx.request_repaint();
+        }
+
+        if self.canvas_pan_input_claimed {
+            if drag_belongs_to_panel {
+                self.arranged_panel_drag = None;
+                ctx.request_repaint();
+            }
+            return;
+        }
+
+        if !arranged {
+            if drag_belongs_to_panel {
+                self.arranged_panel_drag = None;
+                ctx.request_repaint();
+            }
+            if outcome.drag.delta != Vec2::ZERO {
+                let new_position = canvas_position + outcome.drag.delta;
+                let _ = self.board.move_panel(panel_id, [new_position.x, new_position.y]);
+                self.mark_runtime_dirty();
+            }
+            return;
+        }
+
+        if outcome.drag.started || (outcome.drag.delta != Vec2::ZERO && !active_drag_matches) {
+            let canonical_position = self.board.panel(panel_id).map_or(canvas_position, |panel| {
+                Pos2::new(panel.layout.position[0], panel.layout.position[1])
+            });
+            self.arranged_panel_drag = Some(ArrangedPanelDrag::new(
+                panel_id,
+                workspace_id,
+                viewport_id,
+                canonical_position,
+            ));
+        }
+
+        if outcome.drag.delta != Vec2::ZERO {
+            // Egui reports the transformed Area's drag delta in canvas space,
+            // so applying it directly stays correct at every zoom level.
+            let preview_position = self
+                .arranged_panel_drag
+                .as_mut()
+                .filter(|drag| drag.matches(panel_id, workspace_id, viewport_id))
+                .map(|drag| drag.advance(outcome.drag.delta));
+            if let Some(preview_position) = preview_position {
+                let position = [preview_position.x, preview_position.y];
+                if let Some(target) = self.board.arranged_panel_collision_target(panel_id, position)
+                    && self.board.swap_arranged_panels(panel_id, target)
+                {
+                    self.mark_runtime_dirty();
+                }
+                ctx.request_repaint();
+            }
+        }
+
+        if outcome.drag.stopped
+            && self
+                .arranged_panel_drag
+                .is_some_and(|drag| drag.matches(panel_id, workspace_id, viewport_id))
+        {
+            self.arranged_panel_drag = None;
+            ctx.request_repaint();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use horizon_core::{Board, PanelKind, PanelOptions, WorkspaceLayout};
+
+    use super::super::PanelDragOutcome;
+    use crate::app::test_support::test_app;
+
+    use super::*;
+
+    fn editor_panel_options() -> PanelOptions {
+        PanelOptions {
+            kind: PanelKind::Editor,
+            ..PanelOptions::default()
+        }
+    }
+
+    #[test]
+    fn arranged_drag_tracks_only_its_panel_workspace_and_viewport() {
+        let panel_id = PanelId(7);
+        let workspace_id = WorkspaceId(11);
+        let mut drag = ArrangedPanelDrag::new(panel_id, workspace_id, ViewportId::ROOT, Pos2::new(120.0, 80.0));
+
+        assert_eq!(drag.preview_for(panel_id, workspace_id), Some(Pos2::new(120.0, 80.0)));
+        assert_eq!(drag.preview_for(PanelId(8), workspace_id), None);
+        assert_eq!(drag.preview_for(panel_id, WorkspaceId(12)), None);
+        assert!(drag.matches(panel_id, workspace_id, ViewportId::ROOT));
+        assert!(!drag.matches(panel_id, workspace_id, ViewportId::from_hash_of("detached")));
+
+        assert_eq!(drag.advance(Vec2::new(24.0, -16.0)), Pos2::new(144.0, 64.0));
+    }
+
+    #[test]
+    fn pointer_release_clears_only_the_drag_from_its_viewport() {
+        let (_temp, mut app) = test_app();
+        let panel_id = PanelId(7);
+        let workspace_id = WorkspaceId(11);
+        let root_ctx = Context::default();
+        app.arranged_panel_drag = Some(ArrangedPanelDrag::new(
+            panel_id,
+            workspace_id,
+            ViewportId::from_hash_of("detached"),
+            Pos2::ZERO,
+        ));
+
+        app.clear_released_arranged_panel_drag(&root_ctx, panel_id);
+        assert!(app.arranged_panel_drag.is_some());
+
+        app.arranged_panel_drag = Some(ArrangedPanelDrag::new(
+            panel_id,
+            workspace_id,
+            ViewportId::ROOT,
+            Pos2::ZERO,
+        ));
+        app.clear_released_arranged_panel_drag(&root_ctx, PanelId(8));
+        assert!(app.arranged_panel_drag.is_some());
+
+        app.clear_released_arranged_panel_drag(&root_ctx, panel_id);
+        assert!(app.arranged_panel_drag.is_none());
+    }
+
+    #[test]
+    fn arranged_drag_swaps_slots_without_clearing_the_layout() {
+        let (_temp, mut app) = test_app();
+        app.board = Board::new();
+        let workspace_id = app.board.create_workspace("grid");
+        let source = app
+            .board
+            .create_panel(editor_panel_options(), workspace_id)
+            .expect("source panel should spawn");
+        let target = app
+            .board
+            .create_panel(editor_panel_options(), workspace_id)
+            .expect("target panel should spawn");
+        app.board.arrange_workspace(workspace_id, WorkspaceLayout::Grid);
+        let source_position = app.board.panel(source).expect("source panel").layout.position;
+        let target_position = app.board.panel(target).expect("target panel").layout.position;
+        let outcome = PanelUiOutcome {
+            drag: PanelDragOutcome {
+                started: true,
+                delta: Vec2::new(
+                    target_position[0] - source_position[0],
+                    target_position[1] - source_position[1],
+                ),
+                ..PanelDragOutcome::default()
+            },
+            ..PanelUiOutcome::default()
+        };
+
+        app.apply_panel_drag(
+            &Context::default(),
+            source,
+            workspace_id,
+            Pos2::new(source_position[0], source_position[1]),
+            &outcome,
+        );
+
+        let workspace = app.board.workspace(workspace_id).expect("workspace");
+        assert_eq!(workspace.layout, Some(WorkspaceLayout::Grid));
+        assert_eq!(workspace.panels, [target, source]);
+        assert!(app.arranged_panel_drag.is_some());
+
+        app.apply_panel_drag(
+            &Context::default(),
+            source,
+            workspace_id,
+            Pos2::new(target_position[0], target_position[1]),
+            &PanelUiOutcome {
+                drag: PanelDragOutcome {
+                    stopped: true,
+                    ..PanelDragOutcome::default()
+                },
+                ..PanelUiOutcome::default()
+            },
+        );
+        assert!(app.arranged_panel_drag.is_none());
+    }
+
+    #[test]
+    fn default_layout_drag_keeps_freeform_movement() {
+        let (_temp, mut app) = test_app();
+        app.board = Board::new();
+        let workspace_id = app.board.create_workspace("freeform");
+        let panel_id = app
+            .board
+            .create_panel(editor_panel_options(), workspace_id)
+            .expect("panel should spawn");
+        assert!(app.board.clear_workspace_layout(workspace_id));
+        let original = app.board.panel(panel_id).expect("panel").layout.position;
+
+        app.apply_panel_drag(
+            &Context::default(),
+            panel_id,
+            workspace_id,
+            Pos2::new(original[0], original[1]),
+            &PanelUiOutcome {
+                drag: PanelDragOutcome {
+                    started: true,
+                    delta: Vec2::new(30.0, 20.0),
+                    ..PanelDragOutcome::default()
+                },
+                ..PanelUiOutcome::default()
+            },
+        );
+
+        assert_eq!(app.board.workspace(workspace_id).expect("workspace").layout, None);
+        let moved = app.board.panel(panel_id).expect("panel").layout.position;
+        assert!(
+            (moved[0] - original[0] - 30.0).abs() <= f32::EPSILON
+                && (moved[1] - original[1] - 20.0).abs() <= f32::EPSILON,
+            "expected the panel to move by [30, 20], got {moved:?} from {original:?}"
+        );
+        assert!(app.arranged_panel_drag.is_none());
     }
 }

--- a/crates/horizon-ui/src/app/session.rs
+++ b/crates/horizon-ui/src/app/session.rs
@@ -165,6 +165,7 @@ impl HorizonApp {
     }
 
     pub(super) fn apply_runtime_state(&mut self, runtime_state: &horizon_core::RuntimeState) {
+        self.arranged_panel_drag = None;
         self.window_config = runtime_state.window_or(&self.template_config.window).clone();
         self.detached_workspaces = runtime_state
             .detached_workspaces

--- a/crates/horizon-ui/src/app/session_manager.rs
+++ b/crates/horizon-ui/src/app/session_manager.rs
@@ -366,6 +366,7 @@ impl HorizonApp {
         let _ = self.auto_save_runtime_state();
         self.finish_session_switch();
         self.board = Board::new();
+        self.arranged_panel_drag = None;
         self.board.attention_enabled = self.template_config.features.attention_feed;
     }
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -41,7 +41,8 @@ back into large multi-purpose modules.
 - `board.rs` should stay orchestration-focused, with board-local submodules for
   attention flows, agent working-status detection, workspace and panel
   membership changes, arrangement/collision logic, geometry queries, and
-  shutdown state.
+  shutdown state. Preset slot collision and swapping lives in
+  `board/arrangement/reordering.rs`.
 - Large board test surfaces should live in `board/tests/` topic files so
   `board.rs` can stay focused on production orchestration.
 - `terminal.rs` should keep the terminal types and shared imports; lifecycle,


### PR DESCRIPTION
## Purpose

Keep Grid, Rows, and Columns active when a user drags one arranged panel onto another. The occupied slots now swap instead of converting the workspace to Default/freeform layout.

## Behavior impact

- Structured-layout drags show a transient preview while the pointer moves.
- When the dragged panel center enters another visible panel, their workspace order swaps and the selected arrangement is reapplied immediately.
- Releasing over empty canvas or a layout gap restores the canonical arranged slot.
- Default layout keeps the existing freeform drag behavior.
- Transient drag state is scoped to its viewport and cleared across release, canvas pan, session changes, detach, and reattach.

## Reproduction

Before this change, select Grid and drag a panel onto another panel; the workspace falls back to Default. After this change, the two Grid slots exchange while Grid remains selected. Rows and Columns behave the same way.

## Validation

Validated at `cf317123593ec5b59171f718ae93d0275e86ae03`:

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- blocking Clippy with `speech,trace-profiling`
- strict Clippy with unwrap/expect denial
- advisory pedantic Clippy
- focused core and UI tests for all arrangements, gaps, sequential swaps, invalid targets, persistence, viewport scoping, and Default regression

Live Linux/Xvfb smoke used an isolated config and task-owned windows. Grid, Rows, Columns, Default, gap release, resize/Fit, detached-window swapping, and reattachment all passed. The final rebased exact head repeated Grid collision plus detached swap/reattach; the preset remained selected, order persisted, and no stale drag preview remained.