### PR TITLE
test(browser): remove cancellation timing races

### DIFF
--- a/crates/horizon-browser-cli/src/run_preparation.rs
+++ b/crates/horizon-browser-cli/src/run_preparation.rs
@@ -129,16 +129,12 @@ async fn persist_cancelled_preparation(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
         mpsc,
     };
-    use std::time::Duration;
-
-    use horizon_browser_cli::execution_control::JobDeadline;
-
-    use super::*;
 
     struct DropFlag(Arc<AtomicBool>);
 
@@ -150,30 +146,30 @@ mod tests {
 
     #[tokio::test]
     async fn cancellation_drains_a_late_worker_result_before_returning() {
-        let (mut control, cancellation) = ExecutionControl::until(JobDeadline::after(Duration::from_millis(20)));
+        let (mut control, cancellation) = ExecutionControl::cancellable();
         let mut cancellation_probe = cancellation.probe();
-        let (started_sender, started_receiver) = mpsc::channel();
+        let (started_sender, started_receiver) = tokio::sync::oneshot::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
         let dropped = Arc::new(AtomicBool::new(false));
         let worker_dropped = Arc::clone(&dropped);
-        let interrupt = std::thread::spawn(move || {
-            started_receiver.recv().expect("worker start signal");
-            std::thread::sleep(Duration::from_millis(50));
-            cancellation.cancel();
+        let worker = tokio::spawn(async move {
+            await_worker(
+                &mut control,
+                &mut cancellation_probe,
+                "late-preparation-test",
+                move || {
+                    started_sender.send(()).expect("signal worker start");
+                    release_receiver.recv().expect("release worker result");
+                    DropFlag(worker_dropped)
+                },
+            )
+            .await
         });
 
-        let result = await_worker(
-            &mut control,
-            &mut cancellation_probe,
-            "late-preparation-test",
-            move || {
-                started_sender.send(()).expect("signal worker start");
-                std::thread::sleep(Duration::from_millis(100));
-                DropFlag(worker_dropped)
-            },
-        )
-        .await;
-
-        interrupt.join().expect("interrupt thread");
+        started_receiver.await.expect("worker start signal");
+        cancellation.cancel();
+        release_sender.send(()).expect("release worker result");
+        let result = worker.await.expect("join cancellation test");
         let WorkerCompletion::Cancelled { result, .. } = result.expect("cancelled worker result") else {
             panic!("cancellation did not drain the late worker result");
         };

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -305,27 +305,65 @@ fn interrupt_persists_cancelled_partial_report_and_exit_130() {
 
 #[cfg(unix)]
 #[test]
-fn interrupt_bounds_open_stdin_before_durable_setup() {
+fn interrupt_bounds_blocked_plan_input_before_durable_setup() {
     let root = tempfile::tempdir().expect("isolated root");
+    let plan_pipe = root.path().join("plan.pipe");
+    let writer_ready = root.path().join("writer-ready");
+    assert!(
+        Command::new("mkfifo")
+            .arg(&plan_pipe)
+            .status()
+            .expect("create plan FIFO")
+            .success()
+    );
     let mut child = Command::new(env!("CARGO_BIN_EXE_horizon-browser"))
-        .args(["run", "-", "--timeout", "30"])
+        .args(["run", plan_pipe.to_str().expect("UTF-8 FIFO path"), "--timeout", "30"])
         .env("HOME", root.path())
         .env("HORIZON_BROWSER_ACTOR", "browser-cli-test")
         .env("RUST_LOG", "off")
-        .stdin(Stdio::piped())
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("spawn stdin browser job");
-    let stdin = child.stdin.take().expect("open child stdin");
-    // Give the Tokio runtime enough time to install its first process-wide
-    // signal listener before testing cooperative handling. A shorter delay is
-    // racy on cold macOS arm64 runners and tests OS default delivery instead.
-    std::thread::sleep(Duration::from_secs(1));
+        .expect("spawn blocked-input browser job");
+    let mut writer = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("exec 3>\"$1\"\n: >\"$2\"\nexec sleep 30")
+        .arg("fifo-writer")
+        .arg(&plan_pipe)
+        .arg(&writer_ready)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn plan FIFO writer");
+    let readiness_deadline = Instant::now() + Duration::from_secs(5);
+    while !writer_ready.exists() {
+        let failure = if child.try_wait().expect("poll blocked-input browser job").is_some() {
+            Some("browser job exited before blocking on plan input")
+        } else if writer.try_wait().expect("poll plan FIFO writer").is_some() {
+            Some("plan FIFO writer exited before its reader was ready")
+        } else if Instant::now() >= readiness_deadline {
+            Some("browser job did not begin reading its plan before the readiness deadline")
+        } else {
+            None
+        };
+        if let Some(message) = failure {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = writer.kill();
+            let _ = writer.wait();
+            panic!("{message}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
     send_interrupt(child.id());
-    wait_for_exit(&mut child, "cancelled stdin browser job");
-    let output = child.wait_with_output().expect("collect cancelled stdin browser job");
-    drop(stdin);
+    wait_for_exit(&mut child, "cancelled blocked-input browser job");
+    let output = child
+        .wait_with_output()
+        .expect("collect cancelled blocked-input browser job");
+    let _ = writer.kill();
+    writer.wait().expect("reap plan FIFO writer");
 
     assert_eq!(output.status.code(), Some(130));
     assert!(output.stdout.is_empty());

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -318,7 +318,10 @@ fn interrupt_bounds_open_stdin_before_durable_setup() {
         .spawn()
         .expect("spawn stdin browser job");
     let stdin = child.stdin.take().expect("open child stdin");
-    std::thread::sleep(Duration::from_millis(100));
+    // Give the Tokio runtime enough time to install its first process-wide
+    // signal listener before testing cooperative handling. A shorter delay is
+    // racy on cold macOS arm64 runners and tests OS default delivery instead.
+    std::thread::sleep(Duration::from_secs(1));
     send_interrupt(child.id());
     wait_for_exit(&mut child, "cancelled stdin browser job");
     let output = child.wait_with_output().expect("collect cancelled stdin browser job");


### PR DESCRIPTION
## Purpose

Two cooperative-cancellation regressions added on the current main branch depend on cold-start and scheduler timing. The macOS arm64 CI lane failed the late-worker test, while a clean local workspace run failed the blocked-input SIGINT test by delivering SIGINT before Tokio installed its process-wide handler.

## Changes

- Coordinate the late preparation worker with channels so cancellation is already observable before its result is released; this preserves the intended biased cancellation assertion without wall-clock sleeps.
- Replace the process-level SIGINT startup delay with a FIFO reader/writer readiness handshake. The test interrupts only after the CLI has opened and is blocked reading the plan, so it exercises cooperative cancellation without relying on scheduler timing.

Production behavior is unchanged.

## Validation

- Late-worker regression: 50 consecutive passes
- FIFO blocked-input SIGINT regression: 20 consecutive passes
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- Blocking, strict, and advisory pedantic Clippy tiers
