### PR TITLE
fix(workspace): refocus active workspace after align shortcut

### DIFF
--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -105,19 +105,17 @@ impl HorizonApp {
 
     /// Re-frame the workspace that was active before an interactive
     /// alignment, camera-only: the workspace/panel selection is preserved.
-    /// Falls back to the row head when no attached workspace is active; an
-    /// empty target uses its empty workspace frame (matching the focus/fit
-    /// paths) so the camera still lands on it.
-    pub(in crate::app) fn reframe_active_workspace_after_alignment(
-        &mut self,
-        ctx: &egui::Context,
-        alignment: &WorkspaceAlignment,
-    ) {
-        let workspace_id = self
+    /// An empty active workspace is reframed on its empty-frame position
+    /// (matching the focus/fit paths). When no attached workspace is active,
+    /// the row-head view established by the shared action is kept as-is.
+    pub(in crate::app) fn reframe_active_workspace_after_alignment(&mut self, ctx: &egui::Context) {
+        let Some(workspace_id) = self
             .board
             .active_workspace
             .filter(|workspace_id| !self.workspace_is_detached(*workspace_id))
-            .unwrap_or(alignment.leftmost_workspace);
+        else {
+            return;
+        };
         if let Some((pos, size)) = self.workspace_focus_frame(workspace_id) {
             self.pan_to_canvas_pos_aligned(ctx, pos, size, true);
         }

--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -102,6 +102,26 @@ impl HorizonApp {
         }
         Some(alignment)
     }
+
+    /// Re-frame the workspace that was active before an interactive
+    /// alignment, camera-only: the workspace/panel selection is preserved.
+    /// Falls back to the row head when no attached workspace is active, and
+    /// leaves the view untouched for an empty target (matching the shared
+    /// action's treatment of an empty row head).
+    pub(in crate::app) fn reframe_active_workspace_after_alignment(
+        &mut self,
+        ctx: &egui::Context,
+        alignment: &WorkspaceAlignment,
+    ) {
+        let workspace_id = self
+            .board
+            .active_workspace
+            .filter(|workspace_id| !self.workspace_is_detached(*workspace_id))
+            .unwrap_or(alignment.leftmost_workspace);
+        if let Some((min, max)) = self.board.workspace_bounds(workspace_id) {
+            self.focus_workspace_bounds(ctx, min, max, true);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -105,9 +105,9 @@ impl HorizonApp {
 
     /// Re-frame the workspace that was active before an interactive
     /// alignment, camera-only: the workspace/panel selection is preserved.
-    /// Falls back to the row head when no attached workspace is active, and
-    /// leaves the view untouched for an empty target (matching the shared
-    /// action's treatment of an empty row head).
+    /// Falls back to the row head when no attached workspace is active; an
+    /// empty target uses its empty workspace frame (matching the focus/fit
+    /// paths) so the camera still lands on it.
     pub(in crate::app) fn reframe_active_workspace_after_alignment(
         &mut self,
         ctx: &egui::Context,
@@ -118,8 +118,8 @@ impl HorizonApp {
             .active_workspace
             .filter(|workspace_id| !self.workspace_is_detached(*workspace_id))
             .unwrap_or(alignment.leftmost_workspace);
-        if let Some((min, max)) = self.board.workspace_bounds(workspace_id) {
-            self.focus_workspace_bounds(ctx, min, max, true);
+        if let Some((pos, size)) = self.workspace_focus_frame(workspace_id) {
+            self.pan_to_canvas_pos_aligned(ctx, pos, size, true);
         }
     }
 }

--- a/crates/horizon-ui/src/app/actions/command_palette.rs
+++ b/crates/horizon-ui/src/app/actions/command_palette.rs
@@ -96,10 +96,9 @@ impl HorizonApp {
             CommandId::AlignWorkspacesHorizontally => {
                 // The shared action settles the view on the row head; the
                 // interactive shortcut re-frames the workspace that was
-                // active before the alignment instead (falling back to the
-                // row head when no attached workspace is active).
-                if self.align_attached_workspaces_horizontally(ctx).is_some() {
-                    let _ = self.focus_active_workspace(ctx, true);
+                // active before the alignment instead.
+                if let Some(alignment) = self.align_attached_workspaces_horizontally(ctx) {
+                    self.reframe_active_workspace_after_alignment(ctx, &alignment);
                 }
             }
             CommandId::NewPanel => {

--- a/crates/horizon-ui/src/app/actions/command_palette.rs
+++ b/crates/horizon-ui/src/app/actions/command_palette.rs
@@ -97,8 +97,8 @@ impl HorizonApp {
                 // The shared action settles the view on the row head; the
                 // interactive shortcut re-frames the workspace that was
                 // active before the alignment instead.
-                if let Some(alignment) = self.align_attached_workspaces_horizontally(ctx) {
-                    self.reframe_active_workspace_after_alignment(ctx, &alignment);
+                if self.align_attached_workspaces_horizontally(ctx).is_some() {
+                    self.reframe_active_workspace_after_alignment(ctx);
                 }
             }
             CommandId::NewPanel => {

--- a/crates/horizon-ui/src/app/actions/command_palette.rs
+++ b/crates/horizon-ui/src/app/actions/command_palette.rs
@@ -94,7 +94,13 @@ impl HorizonApp {
                 let _ = self.zoom_canvas_at(canvas_rect, canvas_rect.center(), self.canvas_view.zoom / 1.1);
             }
             CommandId::AlignWorkspacesHorizontally => {
-                self.align_attached_workspaces_horizontally(ctx);
+                // The shared action settles the view on the row head; the
+                // interactive shortcut re-frames the workspace that was
+                // active before the alignment instead (falling back to the
+                // row head when no attached workspace is active).
+                if self.align_attached_workspaces_horizontally(ctx).is_some() {
+                    let _ = self.focus_active_workspace(ctx, true);
+                }
             }
             CommandId::NewPanel => {
                 let workspace_id = self.ensure_workspace_visible(ctx);

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
@@ -339,7 +339,18 @@ fn manual_alignment_refocuses_the_active_workspace_instead_of_the_row_head() {
         workspaces: vec![
             editor_workspace_state("left", [100.0, 300.0]),
             editor_workspace_state("middle", [700.0, 500.0]),
-            editor_workspace_state("right", [1_400.0, 900.0]),
+            // Two panels so the focused panel is not the workspace's last one:
+            // the reframe must not move the selection.
+            WorkspaceState {
+                local_id: "right".to_string(),
+                name: "right".to_string(),
+                position: Some([1_400.0, 900.0]),
+                panels: vec![
+                    editor_panel_state("right-panel", [1_420.0, 960.0]),
+                    editor_panel_state("right-panel-two", [1_420.0, 1_200.0]),
+                ],
+                ..WorkspaceState::default()
+            },
         ],
         ..RuntimeState::default()
     };
@@ -372,6 +383,57 @@ fn manual_alignment_refocuses_the_active_workspace_instead_of_the_row_head() {
         "the shortcut target must not be the row head"
     );
     assert_eq!(active_workspace_local_id(&app), Some("right"));
+    // Camera-only reframe: the focused panel is preserved.
+    assert_eq!(focused_panel_local_id(&app), Some("right-panel"));
+}
+
+#[test]
+fn manual_alignment_keeps_row_head_framing_when_active_workspace_is_detached() {
+    let runtime_state = RuntimeState {
+        canvas_view: Some(CanvasViewState::default()),
+        workspaces: vec![
+            editor_workspace_state("left", [100.0, 300.0]),
+            editor_workspace_state("right", [700.0, 500.0]),
+            editor_workspace_state("detached", [1_400.0, 900.0]),
+        ],
+        ..RuntimeState::default()
+    };
+    let (_temp, ctx, mut app) = test_app_with_startup(StartupDecision::Ephemeral {
+        runtime_state: Box::new(runtime_state),
+    });
+    app.theme_applied = true;
+    let detached_id = app
+        .board
+        .workspace_id_by_local_id("detached")
+        .expect("detached workspace");
+    let detached_local_id = app
+        .board
+        .workspace(detached_id)
+        .expect("detached workspace")
+        .local_id
+        .clone();
+    app.detached_workspaces.insert(
+        detached_local_id,
+        crate::app::DetachedWorkspaceViewportState::new(WindowConfig::default()),
+    );
+    app.board.active_workspace = Some(detached_id);
+    app.board.focused = app.board.panel_id_by_local_id("left-panel");
+
+    app.execute_command(&ctx, &CommandId::AlignWorkspacesHorizontally);
+
+    assert_horizontal_row(&app, "left", "right");
+    assert_position_near(workspace_position(&app, "detached"), [1_400.0, 900.0]);
+    let retarget = app
+        .pan_target
+        .take()
+        .expect("the shortcut should keep framing the row head");
+    let left_id = app.board.workspace_id_by_local_id("left").expect("left workspace");
+    let (left_min, left_max) = app.board.workspace_bounds(left_id).expect("left bounds");
+    app.focus_workspace_bounds(&ctx, left_min, left_max, true);
+    let expected = app.pan_target.take().expect("expected row head target");
+    assert_position_near([retarget.x, retarget.y], [expected.x, expected.y]);
+    assert_eq!(active_workspace_local_id(&app), Some("detached"));
+    assert_eq!(focused_panel_local_id(&app), Some("left-panel"));
 }
 
 #[test]

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
@@ -42,8 +42,28 @@ fn startup_frame_reuses_manual_organization_view() {
         workspace_position(&startup_app, "right"),
         workspace_position(&manual_app, "right"),
     );
-    let manual_target = manual_app.pan_target.expect("manual organization view target");
-    assert_position_near(startup_app.canvas_view.pan_offset, [manual_target.x, manual_target.y]);
+    // The shortcut additionally re-frames the active workspace after the
+    // shared action, so compare startup against the shared row-head target.
+    let retarget = manual_app.pan_target.take().expect("active workspace view target");
+    let left_id = manual_app
+        .board
+        .workspace_id_by_local_id("left")
+        .expect("left workspace");
+    let (left_min, left_max) = manual_app.board.workspace_bounds(left_id).expect("left bounds");
+    manual_app.focus_workspace_bounds(&manual_ctx, left_min, left_max, true);
+    let row_head_target = manual_app.pan_target.take().expect("shared organization view target");
+    assert_position_near(
+        startup_app.canvas_view.pan_offset,
+        [row_head_target.x, row_head_target.y],
+    );
+    let right_id = manual_app
+        .board
+        .workspace_id_by_local_id("right")
+        .expect("right workspace");
+    let (right_min, right_max) = manual_app.board.workspace_bounds(right_id).expect("right bounds");
+    manual_app.focus_workspace_bounds(&manual_ctx, right_min, right_max, true);
+    let active_target = manual_app.pan_target.take().expect("active workspace target");
+    assert_position_near([retarget.x, retarget.y], [active_target.x, active_target.y]);
     assert_eq!(startup_app.canvas_view.zoom.to_bits(), saved_view.zoom.to_bits());
     assert!(startup_app.pan_target.is_none());
 }
@@ -68,7 +88,16 @@ fn settled_manual_view_wins_over_pre_alignment_visible_anchor() {
     manual_app.theme_applied = true;
     run_frame_at_configured_size(&manual_ctx, &mut manual_app);
     manual_app.execute_command(&manual_ctx, &CommandId::AlignWorkspacesHorizontally);
-    let manual_target = manual_app.pan_target.take().expect("manual organization view target");
+    // The shortcut re-frames the active workspace after the shared action;
+    // the startup path settles on the shared row-head target instead.
+    let _shortcut_target = manual_app.pan_target.take().expect("shortcut view target");
+    let left_id = manual_app
+        .board
+        .workspace_id_by_local_id("left")
+        .expect("left workspace");
+    let (left_min, left_max) = manual_app.board.workspace_bounds(left_id).expect("left bounds");
+    manual_app.focus_workspace_bounds(&manual_ctx, left_min, left_max, true);
+    let manual_target = manual_app.pan_target.take().expect("row head organization view target");
     let mut settled_view = manual_app.canvas_view;
     settled_view.set_pan_offset([manual_target.x, manual_target.y]);
     manual_app.canvas_view = settled_view;
@@ -259,10 +288,12 @@ fn manual_alignment_still_runs_after_startup_one_shot() {
     app.execute_command(&ctx, &CommandId::AlignWorkspacesHorizontally);
 
     assert_horizontal_row(&app, "left", "right");
-    assert!(
-        app.pan_target.is_none(),
-        "the view already matches the shared organization target"
-    );
+    // The shortcut re-frames the active workspace instead of the row head.
+    let retarget = app.pan_target.take().expect("active workspace view target");
+    let (right_min, right_max) = app.board.workspace_bounds(right_id).expect("right bounds");
+    app.focus_workspace_bounds(&ctx, right_min, right_max, true);
+    let expected = app.pan_target.take().expect("expected active workspace target");
+    assert_position_near([retarget.x, retarget.y], [expected.x, expected.y]);
     assert!(app.runtime_dirty_since.is_some());
 }
 
@@ -288,8 +319,59 @@ fn manual_alignment_is_a_clean_no_op_when_row_and_view_are_already_aligned() {
 
     app.execute_command(&ctx, &CommandId::AlignWorkspacesHorizontally);
 
-    assert!(app.pan_target.is_none());
+    // The row stays put without a persistence pass, but the shortcut still
+    // re-frames the active workspace for the view.
+    let retarget = app.pan_target.take().expect("active workspace view target");
+    let right_id = app.board.workspace_id_by_local_id("right").expect("right workspace");
+    let (right_min, right_max) = app.board.workspace_bounds(right_id).expect("right bounds");
+    app.focus_workspace_bounds(&ctx, right_min, right_max, true);
+    let expected = app.pan_target.take().expect("expected active workspace target");
+    assert_position_near([retarget.x, retarget.y], [expected.x, expected.y]);
     assert!(app.runtime_dirty_since.is_none());
+}
+
+#[test]
+fn manual_alignment_refocuses_the_active_workspace_instead_of_the_row_head() {
+    let runtime_state = RuntimeState {
+        canvas_view: Some(CanvasViewState::default()),
+        active_workspace_local_id: Some("right".to_string()),
+        focused_panel_local_id: Some("right-panel".to_string()),
+        workspaces: vec![
+            editor_workspace_state("left", [100.0, 300.0]),
+            editor_workspace_state("middle", [700.0, 500.0]),
+            editor_workspace_state("right", [1_400.0, 900.0]),
+        ],
+        ..RuntimeState::default()
+    };
+    let (_temp, ctx, mut app) = test_app_with_startup(StartupDecision::Ephemeral {
+        runtime_state: Box::new(runtime_state),
+    });
+    app.theme_applied = true;
+
+    app.execute_command(&ctx, &CommandId::AlignWorkspacesHorizontally);
+
+    assert_horizontal_row(&app, "left", "middle");
+    assert!(workspace_position(&app, "right")[0] > workspace_position(&app, "middle")[0]);
+    let retarget = app
+        .pan_target
+        .take()
+        .expect("the shortcut should reframe the active workspace");
+    let active_id = app.board.workspace_id_by_local_id("right").expect("right workspace");
+    let (active_min, active_max) = app.board.workspace_bounds(active_id).expect("active bounds");
+    app.focus_workspace_bounds(&ctx, active_min, active_max, true);
+    let expected = app.pan_target.take().expect("expected active workspace target");
+    assert_position_near([retarget.x, retarget.y], [expected.x, expected.y]);
+
+    let row_head_id = app.board.workspace_id_by_local_id("left").expect("left workspace");
+    let (row_head_min, row_head_max) = app.board.workspace_bounds(row_head_id).expect("row head bounds");
+    app.focus_workspace_bounds(&ctx, row_head_min, row_head_max, true);
+    let row_head_target = app.pan_target.take().expect("row head target");
+    assert!(
+        (retarget.x - row_head_target.x).abs() > POSITION_TOLERANCE
+            || (retarget.y - row_head_target.y).abs() > POSITION_TOLERANCE,
+        "the shortcut target must not be the row head"
+    );
+    assert_eq!(active_workspace_local_id(&app), Some("right"));
 }
 
 #[test]

--- a/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
+++ b/crates/horizon-ui/src/app/lifecycle/startup_organization_tests/layout.rs
@@ -437,6 +437,55 @@ fn manual_alignment_keeps_row_head_framing_when_active_workspace_is_detached() {
 }
 
 #[test]
+fn manual_alignment_refocuses_an_empty_active_workspace_via_its_empty_frame() {
+    let runtime_state = RuntimeState {
+        canvas_view: Some(CanvasViewState::default()),
+        active_workspace_local_id: Some("right".to_string()),
+        // No persisted focus: restore then focuses the first visible panel
+        // (ws-left) while keeping the empty ws-right active — the exact
+        // state left behind after closing a workspace's last panel.
+        focused_panel_local_id: None,
+        workspaces: vec![
+            editor_workspace_state("left", [100.0, 300.0]),
+            WorkspaceState {
+                local_id: "right".to_string(),
+                name: "right".to_string(),
+                position: Some([1_400.0, 900.0]),
+                panels: vec![],
+                ..WorkspaceState::default()
+            },
+        ],
+        ..RuntimeState::default()
+    };
+    let (_temp, ctx, mut app) = test_app_with_startup(StartupDecision::Ephemeral {
+        runtime_state: Box::new(runtime_state),
+    });
+    app.theme_applied = true;
+
+    app.execute_command(&ctx, &CommandId::AlignWorkspacesHorizontally);
+
+    // The alignment equalizes frame tops; an empty workspace's frame top is
+    // its position, so compare frames rather than positions here.
+    let left_id = app.board.workspace_id_by_local_id("left").expect("left workspace");
+    let (left_min, _left_max) = app.board.workspace_bounds(left_id).expect("left bounds");
+    let left_frame_top = left_min[1] - WS_BG_PAD - WS_TITLE_HEIGHT;
+    let right_position = workspace_position(&app, "right");
+    assert!((left_frame_top - right_position[1]).abs() <= POSITION_TOLERANCE);
+    assert!(right_position[0] > workspace_position(&app, "left")[0]);
+    let active_id = app.board.workspace_id_by_local_id("right").expect("right workspace");
+    let retarget = app
+        .pan_target
+        .take()
+        .expect("the shortcut should reframe the empty active workspace");
+    let (pos, size) = app.workspace_focus_frame(active_id).expect("empty workspace frame");
+    app.pan_to_canvas_pos_aligned(&ctx, pos, size, true);
+    let expected = app.pan_target.take().expect("expected empty-frame target");
+    assert_position_near([retarget.x, retarget.y], [expected.x, expected.y]);
+    assert_eq!(active_workspace_local_id(&app), Some("right"));
+    assert_eq!(focused_panel_local_id(&app), Some("left-panel"));
+}
+
+#[test]
 fn already_aligned_startup_does_not_mark_runtime_dirty() {
     let runtime_state = RuntimeState {
         canvas_view: Some(CanvasViewState::default()),

--- a/crates/horizon-ui/src/app/view.rs
+++ b/crates/horizon-ui/src/app/view.rs
@@ -328,7 +328,7 @@ impl HorizonApp {
             .or_else(|| self.leftmost_workspace_id())
     }
 
-    fn workspace_focus_frame(&self, workspace_id: WorkspaceId) -> Option<(Pos2, Vec2)> {
+    pub(super) fn workspace_focus_frame(&self, workspace_id: WorkspaceId) -> Option<(Pos2, Vec2)> {
         if let Some((min, max)) = self.board.workspace_bounds(workspace_id) {
             return Some((
                 Pos2::new(min[0] - WS_BG_PAD, min[1] - WS_BG_PAD - WS_TITLE_HEIGHT),


### PR DESCRIPTION
## Purpose

`Ctrl+Shift+A` (Align Workspaces Horizontally) re-arranges the attached workspaces, but the camera always settled on the **leftmost (row head)** workspace — yanking the view away from whatever workspace you were actually working in.

## Behavior change

- After the interactive **Align Workspaces Horizontally** command (shortcut or command palette) succeeds, the view now re-frames the **active attached workspace** instead of the row head (left-aligned framing, same framing as before). When no attached workspace is active, it frames the row head exactly as before.
- **Camera-only**: the reframe targets through `workspace_focus_frame` + `pan_to_canvas_pos_aligned`, so `board.active_workspace` and `board.focused` are never touched (no silent terminal-focus jumps, per Copilot review). An empty active workspace (e.g. after closing its last panel) is reframed on its empty-frame position; when no attached workspace is active, the shared action's row-head view is kept exactly as-is (including its no-pan for an empty row head) — both per Copilot review.
- The **startup** organization path (`organize_workspaces_on_session_load`) is intentionally unchanged: it still settles on the organized row head while preserving the restored selection (#344). Only the interactive command path changes.

## Reproduction (before)

1. Three workspaces scattered on the canvas; workspace C (rightmost) focused/active.
2. Press `Ctrl+Shift+A` → workspaces align into a row, camera jumps to workspace A (leftmost).
3. After the fix, the same press lands the camera on workspace C, with the focused panel unchanged.

## Test evidence

- Regression test `manual_alignment_refocuses_the_active_workspace_instead_of_the_row_head`: three scattered workspaces, active = rightmost with a **non-last focused panel**; asserts the shortcut's pan target equals the active workspace's frame, is *not* the row head's, and that the workspace/panel selection is preserved.
- `manual_alignment_keeps_row_head_framing_when_active_workspace_is_detached`: active workspace is detached → camera frames the row head, detached geometry untouched, selection preserved.
- `manual_alignment_refocuses_an_empty_active_workspace_via_its_empty_frame`: active workspace is empty (last panel closed) → camera frames its empty frame, selection preserved.
- Updated the four existing manual-alignment/startup-parity tests that encoded the old row-head shortcut target; startup-path assertions (row head camera, preserved selection, settled-view parity) are all retained.
- Full matrix green on head `64becee` (rebased onto `74d6e2e`): `cargo fmt --check`, maintainability script, `cargo test --workspace`, `cargo test --workspace --features speech`, blocking/strict/pedantic Clippy tiers (all `-D warnings`; one unrelated pre-existing flaky browser-startup timing test in the speech tier passed on its rerun).

## UI smoke (Xvfb + openbox, isolated HOME, PID-scoped)

Seeded one session with three scattered workspaces (`ws-left` [100,300], `ws-middle` [700,500], `ws-right` [1400,900]); `ws-right` holds two panels with the **first** panel focused, active = `ws-right`.

- L1 baseline: restore shows scattered workspaces, selection on `ws-right`, camera at the leftmost side. ✅
- L2 `Ctrl+Shift+A` (final head `9d3b342`): row aligns (minimap shows the three frames in one row) and the camera frames **`ws-right`** left-aligned at the canvas edge — not `ws-left`; the focused panel stays `ws-right-panel notes` (first panel), not the workspace's last panel. ✅
- L3 repeat press: `compare -metric AE` = 0 (exact no-op, no drift/oscillation). ✅
- L5 regression: relaunch with `organize_workspaces_on_session_load: true` and scattered positions → startup aligns the row and the camera settles on the **row head (`ws-left`)** with selection still on `ws-right` — #344 startup behavior preserved. ✅

## Notes

- Rebased onto `origin/main` (`74d6e2e`, incl. #351/#357) after the initial worktree was cut from a stale local ref; the branch diff is exactly the four files above (the transient `Cargo.lock` surge re-resolution caused by main's pre-existing toml/lock mismatch was kept out of this PR).
- Copilot review findings addressed across three rounds: selection side effect (`9d3b342`), empty-active-workspace fallthrough (`fa77df1`), row-head fallback divergence (`dc8c32e`); all threads resolved, re-review requested.
