### PR TITLE
fix(browser): harden startup handoff

### DIFF
--- a/crates/horizon-browser/README.md
+++ b/crates/horizon-browser/README.md
@@ -42,12 +42,16 @@ before attaching the caller's `about:blank` page, so it cannot enter caller
 history or frames. Firefox installs the same narrow value shim with WebDriver BiDi
 `script.addPreloadScript` before the initial navigation; startup fails instead
 of silently downgrading when that required BiDi command is rejected.
+Chromium panels minimizing common signals also use a reserved nonzero loopback
+DevTools port so Chromium does not enable its port-zero `AutomationControlled`
+behavior. Startup retries with a fresh reservation when another local process
+wins the required socket handoff. Callers that need the browser's unmodified
+behavior can select `AutomationDisclosurePolicy::BrowserDefault` on any
+backend; Chromium then retains its native port-zero automation signal.
 
 Safari's public automation surface cannot currently establish the same
 pre-document contract, so an active Safari session reports
-`AutomationDisclosureStatus::UnsupportedByBackend`. Callers that need the
-browser's unmodified behavior can select
-`AutomationDisclosurePolicy::BrowserDefault` on any backend.
+`AutomationDisclosureStatus::UnsupportedByBackend`.
 
 This policy minimizes a small set of common script-visible disclosures; it is
 not an undetectability or anti-bot guarantee. Pages can still infer automation

--- a/crates/horizon-browser/src/process.rs
+++ b/crates/horizon-browser/src/process.rs
@@ -4,6 +4,7 @@ mod control;
 
 #[cfg(any(windows, test))]
 use std::ffi::OsString;
+use std::net::{Ipv4Addr, TcpListener};
 use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use std::process::Child;
@@ -37,6 +38,15 @@ pub enum ChromeError {
     DevtoolsTimeout(String),
     #[error("browser.extra_args cannot override engine-managed Chrome switch `{0}`")]
     ProtectedExtraArg(String),
+}
+
+impl ChromeError {
+    pub(crate) fn is_devtools_port_conflict(&self) -> bool {
+        match self {
+            Self::NoDevtools(stderr) | Self::DevtoolsTimeout(stderr) => stderr_reports_devtools_port_conflict(stderr),
+            Self::NoBinary | Self::Spawn(_) | Self::ProtectedExtraArg(_) => false,
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, ChromeError>;
@@ -91,7 +101,21 @@ impl ChromeProcess {
     pub(crate) fn spawn(launch: &ChromeLaunch, control: ChromeProcessControl) -> Result<Self> {
         let command = resolve_binary(&launch.command)?;
         prepare_profile_dir(&launch.profile_dir)?;
-        let args = launch_args(launch)?;
+        // Chromium treats `--remote-debugging-port=0` as an automation signal.
+        // Reserve a concrete loopback port only for the policy that minimizes
+        // common signals; browser-default mode must preserve Chromium's native
+        // port-zero behavior.
+        let devtools_listener = (launch.automation_disclosure == AutomationDisclosurePolicy::MinimizeCommonSignals)
+            .then(|| TcpListener::bind((Ipv4Addr::LOCALHOST, 0)))
+            .transpose()
+            .map_err(|error| devtools_port_error(&error))?;
+        let devtools_port = devtools_listener
+            .as_ref()
+            .map(TcpListener::local_addr)
+            .transpose()
+            .map_err(|error| devtools_port_error(&error))?
+            .map_or(0, |address| address.port());
+        let args = launch_args(launch, devtools_port)?;
 
         let mut command = Command::new(command);
         command.args(&args).stdout(Stdio::null()).stderr(Stdio::piped());
@@ -103,6 +127,10 @@ impl ChromeProcess {
             use std::os::unix::process::CommandExt;
             command.process_group(0);
         }
+        // Chromium must bind the socket itself. Release immediately before
+        // spawn; startup detects the documented DevTools bind failure and
+        // retries with a fresh reservation if another process wins this gap.
+        drop(devtools_listener);
         let mut child = spawn_process(command)?;
         let Some(stderr) = take_stderr(&mut child) else {
             let _ = kill_and_reap(&mut child, Duration::from_secs(3));
@@ -173,8 +201,12 @@ impl ChromeProcess {
                     return Ok(Some(url));
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {
+                    let stderr = self.stderr_tail_snapshot();
+                    if stderr_reports_devtools_port_conflict(&stderr) {
+                        return Err(ChromeError::NoDevtools(stderr));
+                    }
                     if self.child_status().is_some() {
-                        return Err(ChromeError::NoDevtools(self.stderr_tail_snapshot()));
+                        return Err(ChromeError::NoDevtools(stderr));
                     }
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -243,11 +275,29 @@ fn prepare_profile_dir(profile_dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn launch_args(launch: &ChromeLaunch) -> Result<Vec<String>> {
+fn devtools_port_error(error: &std::io::Error) -> ChromeError {
+    ChromeError::Spawn(std::io::Error::new(
+        error.kind(),
+        format!("failed to reserve a loopback Chrome DevTools port: {error}"),
+    ))
+}
+
+fn stderr_reports_devtools_port_conflict(stderr: &str) -> bool {
+    let stderr = stderr.to_ascii_lowercase();
+    [
+        "address already in use",
+        "cannot start http server for devtools",
+        "only one usage of each socket address",
+        "wsaeaddrinuse",
+    ]
+    .iter()
+    .any(|message| stderr.contains(message))
+}
+
+fn launch_args(launch: &ChromeLaunch, devtools_port: u16) -> Result<Vec<String>> {
     validate_extra_args(&launch.extra_args, launch.automation_disclosure)?;
     let mut args = vec![
-        // Port 0: the OS picks a free port; we learn it from stderr.
-        "--remote-debugging-port=0".to_string(),
+        format!("--remote-debugging-port={devtools_port}"),
         "--remote-debugging-address=127.0.0.1".to_string(),
         format!("--user-data-dir={}", launch.profile_dir.display()),
         "--no-first-run".to_string(),
@@ -841,9 +891,10 @@ mod tests {
             extra_args: Vec::new(),
             automation_disclosure: AutomationDisclosurePolicy::MinimizeCommonSignals,
         };
-        let args = launch_args(&launch).unwrap_or_default();
+        let args = launch_args(&launch, 49_152).unwrap_or_default();
 
         assert!(args.iter().any(|argument| argument == "--headless=new"));
+        assert!(args.iter().any(|argument| argument == "--remote-debugging-port=49152"));
         assert!(!args.iter().any(|argument| argument == "--disable-gpu"));
         assert!(
             args.iter()
@@ -853,7 +904,7 @@ mod tests {
     }
 
     #[test]
-    fn visible_launch_omits_the_headless_switch() {
+    fn browser_default_launch_preserves_the_port_zero_signal() {
         let launch = ChromeLaunch {
             command: "chrome".to_string(),
             profile_dir: PathBuf::from("profile"),
@@ -863,13 +914,25 @@ mod tests {
             extra_args: Vec::new(),
             automation_disclosure: AutomationDisclosurePolicy::BrowserDefault,
         };
+        let args = launch_args(&launch, 0).unwrap_or_default();
 
+        assert!(!args.iter().any(|argument| argument == "--headless=new"));
+        assert!(args.iter().any(|argument| argument == "--remote-debugging-port=0"));
+    }
+
+    #[test]
+    fn devtools_port_conflicts_are_retryable_startup_errors() {
         assert!(
-            !launch_args(&launch)
-                .unwrap_or_default()
-                .iter()
-                .any(|argument| argument == "--headless=new")
+            ChromeError::NoDevtools("bind() failed: Address already in use".to_string()).is_devtools_port_conflict()
         );
+        assert!(
+            ChromeError::DevtoolsTimeout("Only one usage of each socket address is permitted".to_string())
+                .is_devtools_port_conflict()
+        );
+        assert!(
+            ChromeError::NoDevtools("Cannot start http server for devtools.".to_string()).is_devtools_port_conflict()
+        );
+        assert!(!ChromeError::NoDevtools("profile is locked".to_string()).is_devtools_port_conflict());
     }
 
     #[test]
@@ -883,8 +946,9 @@ mod tests {
             extra_args: vec!["--enable-blink-features=ExperimentalFoo".to_string()],
             automation_disclosure: AutomationDisclosurePolicy::BrowserDefault,
         };
-        let args = launch_args(&launch).unwrap_or_default();
+        let args = launch_args(&launch, 0).unwrap_or_default();
 
+        assert!(args.iter().any(|argument| argument == "--remote-debugging-port=0"));
         assert!(
             args.iter()
                 .all(|argument| argument != "--disable-blink-features=AutomationControlled")

--- a/crates/horizon-browser/src/session/startup.rs
+++ b/crates/horizon-browser/src/session/startup.rs
@@ -8,13 +8,17 @@ use crate::disclosure::{
     CHROMIUM_DISCLOSURE_BOOTSTRAP_URL, CHROMIUM_USER_AGENT_METADATA_EXPRESSION, chromium_user_agent_needs_override,
 };
 use crate::frames::FrameSlot;
-use crate::process::{ChromeProcess, ChromeProcessControl};
+use crate::process::{ChromeError, ChromeProcess, ChromeProcessControl};
 use crate::{AutomationDisclosurePolicy, BrowserConfig};
 
 use super::{
     BrowserEvent, BrowserEventSender, BrowserSessionConfig, CALL_TIMEOUT, CommandReceiver, DriverState, WS_URL_TIMEOUT,
     run_loop,
 };
+
+const DEVTOOLS_PORT_STARTUP_ATTEMPTS: usize = 3;
+const DEVTOOLS_PORT_REAP_FAILURE: &str =
+    "failed to reap Chromium after a DevTools-port conflict; aborting retry to preserve exact process ownership";
 
 /// Settles process registration and resolves the driver's teardown signal
 /// exactly once, on thread exit.
@@ -58,7 +62,7 @@ fn initialize_driver(
     config: &BrowserSessionConfig,
     event_tx: &BrowserEventSender,
     stop_requested: &AtomicBool,
-    process_control: ChromeProcessControl,
+    process_control: &ChromeProcessControl,
 ) -> Option<DriverConnection> {
     let launch = match build_launch(config) {
         Ok(launch) => launch,
@@ -72,24 +76,14 @@ fn initialize_driver(
         let _ = event_tx.send(BrowserEvent::Stopped { code: None });
         return None;
     }
-    let mut chrome = match ChromeProcess::spawn(&launch, process_control) {
-        Ok(chrome) => chrome,
-        Err(error) => {
-            let _ = event_tx.send(BrowserEvent::Warning(format!("failed to start chrome: {error}")));
-            let _ = event_tx.send(BrowserEvent::Stopped { code: None });
-            return None;
-        }
-    };
-    let ws_url = match chrome.wait_ws_url(WS_URL_TIMEOUT, || stop_requested.load(Ordering::Acquire)) {
-        Ok(Some(url)) => url,
+    let (mut chrome, ws_url) = match start_chrome(&launch, stop_requested, process_control) {
+        Ok(Some(connection)) => connection,
         Ok(None) => {
-            let _ = chrome.kill();
             let _ = event_tx.send(BrowserEvent::Stopped { code: None });
             return None;
         }
-        Err(error) => {
-            let _ = event_tx.send(BrowserEvent::Warning(format!("no DevTools endpoint: {error}")));
-            let _ = chrome.kill();
+        Err(message) => {
+            let _ = event_tx.send(BrowserEvent::Warning(message));
             let _ = event_tx.send(BrowserEvent::Stopped { code: None });
             return None;
         }
@@ -110,6 +104,74 @@ fn initialize_driver(
         return None;
     }
     initialize_target(config, event_tx, stop_requested, chrome, link, ws_url)
+}
+
+fn start_chrome(
+    launch: &crate::process::ChromeLaunch,
+    stop_requested: &AtomicBool,
+    process_control: &ChromeProcessControl,
+) -> Result<Option<(ChromeProcess, String)>, String> {
+    run_chrome_startup_attempts(launch.automation_disclosure, || {
+        if stop_requested.load(Ordering::Acquire) {
+            return Ok(ChromeStartupAttempt::Cancelled);
+        }
+        let mut chrome = ChromeProcess::spawn(launch, process_control.clone())
+            .map_err(|error| format!("failed to start chrome: {error}"))?;
+        let outcome = match chrome.wait_ws_url(WS_URL_TIMEOUT, || stop_requested.load(Ordering::Acquire)) {
+            Ok(Some(url)) => ChromeStartupAttempt::Connected((chrome, url)),
+            Ok(None) => {
+                let _ = chrome.kill();
+                ChromeStartupAttempt::Cancelled
+            }
+            Err(error) => ChromeStartupAttempt::Failed {
+                error,
+                reaped: chrome.kill(),
+            },
+        };
+        Ok(outcome)
+    })
+}
+
+enum ChromeStartupAttempt<T> {
+    Connected(T),
+    Cancelled,
+    Failed { error: ChromeError, reaped: bool },
+}
+
+fn run_chrome_startup_attempts<T>(
+    automation_disclosure: AutomationDisclosurePolicy,
+    mut run_attempt: impl FnMut() -> Result<ChromeStartupAttempt<T>, String>,
+) -> Result<Option<T>, String> {
+    for attempt_number in 1..=DEVTOOLS_PORT_STARTUP_ATTEMPTS {
+        match run_attempt()? {
+            ChromeStartupAttempt::Connected(connection) => return Ok(Some(connection)),
+            ChromeStartupAttempt::Cancelled => return Ok(None),
+            ChromeStartupAttempt::Failed { error, reaped }
+                if automation_disclosure == AutomationDisclosurePolicy::MinimizeCommonSignals
+                    && error.is_devtools_port_conflict()
+                    && attempt_number < DEVTOOLS_PORT_STARTUP_ATTEMPTS =>
+            {
+                require_reaped_before_port_retry(reaped)?;
+                tracing::warn!(
+                    attempt = attempt_number,
+                    max_attempts = DEVTOOLS_PORT_STARTUP_ATTEMPTS,
+                    "Chromium DevTools port handoff collided; retrying with a fresh reservation"
+                );
+            }
+            ChromeStartupAttempt::Failed { error, .. } => {
+                return Err(format!("no DevTools endpoint: {error}"));
+            }
+        }
+    }
+    Err("Chromium exhausted its bounded DevTools-port startup attempts".to_string())
+}
+
+fn require_reaped_before_port_retry(reaped: bool) -> Result<(), &'static str> {
+    if reaped {
+        Ok(())
+    } else {
+        Err(DEVTOOLS_PORT_REAP_FAILURE)
+    }
 }
 
 fn initialize_target(
@@ -315,16 +377,17 @@ pub(super) fn run_driver(
     completion_tx: mpsc::Sender<()>,
     process_control: ChromeProcessControl,
 ) {
-    let _completion = DriverCompletion {
+    let completion_guard = DriverCompletion {
         completion_tx: Some(completion_tx),
-        process_control: process_control.clone(),
+        process_control,
     };
     let Some(_coordination_lifetime) = crate::coordination::CoordinationLifetime::start(config) else {
         let _ = event_tx.send(BrowserEvent::Warning(crate::coordination::PREPARE_FAILURE.to_string()));
         let _ = event_tx.send(BrowserEvent::Stopped { code: None });
         return;
     };
-    let Some(mut connection) = initialize_driver(config, event_tx, stop_requested, process_control) else {
+    let Some(mut connection) = initialize_driver(config, event_tx, stop_requested, &completion_guard.process_control)
+    else {
         return;
     };
 
@@ -412,6 +475,90 @@ fn build_launch(config: &BrowserSessionConfig) -> Result<crate::process::ChromeL
 
 pub(crate) fn profile_dir(config: &BrowserConfig, panel_local_id: &str) -> std::path::PathBuf {
     config.profile_dir(panel_local_id)
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use crate::AutomationDisclosurePolicy;
+    use crate::process::ChromeError;
+
+    use super::{ChromeStartupAttempt, DEVTOOLS_PORT_REAP_FAILURE, DEVTOOLS_PORT_STARTUP_ATTEMPTS};
+
+    fn port_conflict() -> ChromeError {
+        ChromeError::NoDevtools("Cannot start http server for devtools.".to_string())
+    }
+
+    #[test]
+    fn minimized_startup_retries_with_fresh_attempts_and_stops_at_the_bound() {
+        let mut attempts = 0;
+        let connection = super::run_chrome_startup_attempts(AutomationDisclosurePolicy::MinimizeCommonSignals, || {
+            attempts += 1;
+            if attempts < DEVTOOLS_PORT_STARTUP_ATTEMPTS {
+                Ok(ChromeStartupAttempt::Failed {
+                    error: port_conflict(),
+                    reaped: true,
+                })
+            } else {
+                Ok(ChromeStartupAttempt::Connected(attempts))
+            }
+        })
+        .unwrap_or_else(|error| panic!("retry startup: {error}"));
+
+        assert_eq!(connection, Some(DEVTOOLS_PORT_STARTUP_ATTEMPTS));
+        assert_eq!(attempts, DEVTOOLS_PORT_STARTUP_ATTEMPTS);
+
+        let mut bounded_attempts = 0;
+        let Err(error) =
+            super::run_chrome_startup_attempts::<()>(AutomationDisclosurePolicy::MinimizeCommonSignals, || {
+                bounded_attempts += 1;
+                Ok(ChromeStartupAttempt::Failed {
+                    error: port_conflict(),
+                    reaped: true,
+                })
+            })
+        else {
+            panic!("conflicting startup unexpectedly succeeded");
+        };
+
+        assert!(error.contains("Cannot start http server for devtools"));
+        assert_eq!(bounded_attempts, DEVTOOLS_PORT_STARTUP_ATTEMPTS);
+    }
+
+    #[test]
+    fn minimized_startup_aborts_before_retry_when_reap_fails() {
+        let mut attempts = 0;
+        let Err(error) =
+            super::run_chrome_startup_attempts::<()>(AutomationDisclosurePolicy::MinimizeCommonSignals, || {
+                attempts += 1;
+                Ok(ChromeStartupAttempt::Failed {
+                    error: port_conflict(),
+                    reaped: false,
+                })
+            })
+        else {
+            panic!("unreaped startup unexpectedly succeeded");
+        };
+
+        assert_eq!(error, DEVTOOLS_PORT_REAP_FAILURE);
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn browser_default_does_not_retry_devtools_conflicts() {
+        let mut attempts = 0;
+        let Err(error) = super::run_chrome_startup_attempts::<()>(AutomationDisclosurePolicy::BrowserDefault, || {
+            attempts += 1;
+            Ok(ChromeStartupAttempt::Failed {
+                error: port_conflict(),
+                reaped: true,
+            })
+        }) else {
+            panic!("browser-default startup unexpectedly succeeded");
+        };
+
+        assert!(error.contains("Cannot start http server for devtools"));
+        assert_eq!(attempts, 1);
+    }
 }
 
 #[cfg(all(test, unix))]


### PR DESCRIPTION
## Purpose

- reserve a concrete loopback DevTools port for Chromium when common automation signals are minimized
- retry a bounded number of times if another local process wins the socket handoff
- require the exact conflicted child to be reaped before any retry
- preserve Chromium's native port-zero behavior under `browser_default`

This is the focused startup-hardening follow-up to #351.

## Behavior impact

Chromium panels using `minimize_common_signals` now launch with a nonzero port reserved on `127.0.0.1`. The reservation is released immediately before spawn so Chromium can bind it; known bind-conflict diagnostics trigger at most three attempts, and retry aborts if exact-child cleanup cannot be proven. Firefox, Safari, and Chromium's `browser_default` policy retain their existing launch behavior.

## Test evidence

Exact head: `a91468f69ce1daee54f888fa8665b576ed43e317`

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- deterministic retry-controller tests: pass — successful reap creates fresh attempts, conflicts stop at three attempts, failed reap aborts before a second attempt, and browser-default stays one-shot
- Linux Chromium minimized-disclosure smoke: 43 actions and 4,113 captured frames, including visible handoff/hand-back and reconnect; exact child launched with a nonzero port bound only on loopback
- Linux Chromium browser-default smoke: 42 actions and 4,113 captured frames; exact child retained `--remote-debugging-port=0` and omitted the minimized-disclosure Blink switch
- Linux Firefox minimized and browser-default smokes: 42 actions and 4,113 captured frames in each lane
- all four live lanes exited normally with no audit or capture findings, remaining manifests, or surviving task-owned browser processes
