### PR TITLE
fix(browser): close remaining automation-environment leaks

### DIFF
--- a/crates/horizon-browser/README.md
+++ b/crates/horizon-browser/README.md
@@ -34,20 +34,23 @@ multiple concurrent sessions.
 `BrowserConfig::default()` uses
 `AutomationDisclosurePolicy::MinimizeCommonSignals`. Chromium avoids
 automation-only launch switches, suppresses Blink's standard automation flag,
-installs a pre-document `navigator.webdriver` compatibility shim, and removes
-only the `HeadlessChrome` user-agent token while preserving Chromium-owned
-Client Hint brands, platform, architecture, and versions. The engine reads
-those native values on a network-free temporary target and closes that target
+and removes only the `HeadlessChrome` user-agent token and Client Hint brand
+while preserving Chromium-owned platform, architecture, versions, and GREASE
+brands. It does not install a script-defined `navigator.webdriver` getter,
+because that accessor is itself a detection signal. The engine reads native
+Client Hint values on a network-free temporary target and closes that target
 before attaching the caller's `about:blank` page, so it cannot enter caller
-history or frames. Firefox installs the same narrow value shim with WebDriver BiDi
-`script.addPreloadScript` before the initial navigation; startup fails instead
-of silently downgrading when that required BiDi command is rejected.
-Chromium panels minimizing common signals also use a reserved nonzero loopback
-DevTools port so Chromium does not enable its port-zero `AutomationControlled`
-behavior. Startup retries with a fresh reservation when another local process
-wins the required socket handoff. Callers that need the browser's unmodified
-behavior can select `AutomationDisclosurePolicy::BrowserDefault` on any
-backend; Chromium then retains its native port-zero automation signal.
+history or frames. Title updates use protocol target metadata rather than a
+page-JS binding. Firefox installs a narrow `navigator.webdriver` value shim
+with WebDriver BiDi `script.addPreloadScript` before the initial navigation;
+startup fails instead of silently downgrading when that required BiDi command
+is rejected. Chromium panels minimizing common signals also use a reserved
+nonzero loopback DevTools port so Chromium does not enable its port-zero
+`AutomationControlled` behavior. Startup retries with a fresh reservation when
+another local process wins the required socket handoff. Callers that need the
+browser's unmodified behavior can select
+`AutomationDisclosurePolicy::BrowserDefault` on any backend; Chromium then
+retains its native port-zero automation signal.
 
 Safari's public automation surface cannot currently establish the same
 pre-document contract, so an active Safari session reports

--- a/crates/horizon-browser/src/disclosure.rs
+++ b/crates/horizon-browser/src/disclosure.rs
@@ -39,9 +39,11 @@ impl AutomationDisclosurePolicy {
     }
 }
 
-/// A callable `WebDriver` `BiDi` preload function. It changes only the standard
-/// `navigator.webdriver` value and deliberately avoids broad fingerprint
-/// spoofing that would create internally inconsistent browser properties.
+/// A callable `WebDriver` `BiDi` preload function used by Firefox. Chromium
+/// relies on `--disable-blink-features=AutomationControlled` instead of this
+/// getter, because a script-defined `navigator.webdriver` accessor is itself a
+/// detection signal. The function changes only the standard value and
+/// deliberately avoids broad fingerprint spoofing.
 pub(crate) const COMMON_SIGNAL_PRELOAD_FUNCTION: &str = r#"() => {
     const prototype = globalThis.Navigator && globalThis.Navigator.prototype;
     if (!prototype) return;
@@ -72,10 +74,6 @@ pub(crate) const CHROMIUM_USER_AGENT_METADATA_EXPRESSION: &str = r#"navigator.us
 /// A temporary hidden target uses this network-free page to read the browser's
 /// own metadata before any caller-supplied page is allowed to execute.
 pub(crate) const CHROMIUM_DISCLOSURE_BOOTSTRAP_URL: &str = "chrome://version/";
-
-pub(crate) fn cdp_preload_source() -> String {
-    format!("({COMMON_SIGNAL_PRELOAD_FUNCTION})()")
-}
 
 pub(crate) fn chromium_user_agent_needs_override(browser_version: &serde_json::Value) -> Result<bool, &'static str> {
     browser_version
@@ -118,8 +116,25 @@ pub(crate) fn chromium_user_agent_override(
     }
     Ok(Some(serde_json::json!({
         "userAgent": user_agent.replace("HeadlessChrome/", "Chrome/"),
-        "userAgentMetadata": metadata,
+        "userAgentMetadata": rewrite_headless_chrome_brands(metadata),
     })))
+}
+
+/// Rename only the `HeadlessChrome` Client Hint brand. Platform, architecture,
+/// versions, GREASE brands, and other native fields stay browser-owned.
+fn rewrite_headless_chrome_brands(metadata: &serde_json::Map<String, serde_json::Value>) -> serde_json::Value {
+    let mut rewritten = serde_json::Value::Object(metadata.clone());
+    for field in ["brands", "fullVersionList"] {
+        let Some(serde_json::Value::Array(list)) = rewritten.get_mut(field) else {
+            continue;
+        };
+        for entry in list {
+            if entry.get("brand").and_then(serde_json::Value::as_str) == Some("HeadlessChrome") {
+                entry["brand"] = serde_json::Value::String("Chrome".to_string());
+            }
+        }
+    }
+    rewritten
 }
 
 #[cfg(test)]
@@ -139,11 +154,10 @@ mod tests {
     }
 
     #[test]
-    fn cdp_source_invokes_the_same_preload_function_used_by_bidi() {
-        let source = cdp_preload_source();
-        assert!(source.starts_with('('));
-        assert!(source.ends_with(")()"));
-        assert!(source.contains(COMMON_SIGNAL_PRELOAD_FUNCTION));
+    fn firefox_preload_only_patches_navigator_webdriver() {
+        assert!(COMMON_SIGNAL_PRELOAD_FUNCTION.contains("webdriver"));
+        assert!(COMMON_SIGNAL_PRELOAD_FUNCTION.contains("get: () => false"));
+        assert!(!COMMON_SIGNAL_PRELOAD_FUNCTION.contains("userAgent"));
     }
 
     #[test]
@@ -157,8 +171,16 @@ mod tests {
                 "value": {
                     "architecture": "x86",
                     "bitness": "64",
-                    "brands": [{ "brand": "Chromium", "version": "151" }],
-                    "fullVersionList": [{ "brand": "Chromium", "version": "151.0.7922.108" }],
+                    "brands": [
+                        { "brand": "HeadlessChrome", "version": "151" },
+                        { "brand": "Chromium", "version": "151" },
+                        { "brand": "Not.A/Brand", "version": "24" }
+                    ],
+                    "fullVersionList": [
+                        { "brand": "HeadlessChrome", "version": "151.0.7922.108" },
+                        { "brand": "Chromium", "version": "151.0.7922.108" },
+                        { "brand": "Not.A/Brand", "version": "24.0.0.0" }
+                    ],
                     "mobile": false,
                     "model": "",
                     "platform": "Linux",
@@ -175,7 +197,25 @@ mod tests {
             override_params["userAgent"],
             "Mozilla/5.0 Chrome-ish Chrome/151.0.7922.108 Safari/537.36"
         );
-        assert_eq!(override_params["userAgentMetadata"], metadata["result"]["value"]);
+        assert_eq!(
+            override_params["userAgentMetadata"]["brands"],
+            serde_json::json!([
+                { "brand": "Chrome", "version": "151" },
+                { "brand": "Chromium", "version": "151" },
+                { "brand": "Not.A/Brand", "version": "24" }
+            ])
+        );
+        assert_eq!(
+            override_params["userAgentMetadata"]["fullVersionList"],
+            serde_json::json!([
+                { "brand": "Chrome", "version": "151.0.7922.108" },
+                { "brand": "Chromium", "version": "151.0.7922.108" },
+                { "brand": "Not.A/Brand", "version": "24.0.0.0" }
+            ])
+        );
+        assert_eq!(override_params["userAgentMetadata"]["platform"], "Linux");
+        assert_eq!(override_params["userAgentMetadata"]["architecture"], "x86");
+        assert!(!override_params.to_string().contains("HeadlessChrome"));
     }
 
     #[test]

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -655,6 +655,7 @@ impl DriverState {
     fn reset_runtime_enable_state(&mut self) {
         self.runtime_enable_requested.clear();
         self.runtime_enable_inflight.clear();
+        self.clipboard.pending_capture = false;
     }
 
     fn navigate_to(

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -159,28 +159,6 @@ const USER_ACTIVE_TTL: Duration = Duration::from_secs(5);
 const VIEWPORT_CAPTURE_DELAY: Duration = Duration::from_millis(75);
 const VIEWPORT_RETRY_DELAY: Duration = Duration::from_millis(100);
 const SCROLLBAR_LAYOUT_RETRY_DELAY: Duration = Duration::from_millis(100);
-const TITLE_BINDING_NAME: &str = "__horizonBrowserTitleChanged";
-const TITLE_OBSERVER_SCRIPT: &str = r"(() => {
-    if (window !== top || window.__horizonBrowserTitleObserver) return;
-    let lastTitle;
-    const publish = () => {
-        const title = document.title;
-        if (title === lastTitle) return;
-        lastTitle = title;
-        window.__horizonBrowserTitleChanged(JSON.stringify({ title, href: location.href }));
-    };
-    const install = () => {
-        if (window.__horizonBrowserTitleObserver) return;
-        const root = document.head || document.documentElement;
-        if (!root) return;
-        const observer = new MutationObserver(publish);
-        observer.observe(root, { childList: true, characterData: true, subtree: true });
-        window.__horizonBrowserTitleObserver = observer;
-        publish();
-    };
-    if (document.documentElement) install();
-    else addEventListener('DOMContentLoaded', install, { once: true });
-})()";
 
 /// Spawn the driver thread. Browser startup problems are reported through
 /// the event channel rather than failing here.
@@ -439,18 +417,13 @@ struct DriverState {
     initial_navigated: bool,
     screencast_on: bool,
     pending_restart_at: Option<Instant>,
-    /// Default execution context of the current document. After a
-    /// navigation, `Runtime.evaluate` without an explicit `contextId` can
-    /// still hit the old document's context for a while, so the title
-    /// fetch targets the latest default context explicitly.
-    title_context_id: Option<u64>,
-    /// `executionContextCreated` for the new document can land after
-    /// `loadEventFired`, so the post-load fetch is slightly delayed to let
-    /// the context tracking catch up first.
+    /// Delayed `Target.getTargetInfo` read after navigation. Title updates
+    /// come from protocol target metadata, not a page-JS binding.
     title_fetch_at: Option<Instant>,
-    /// Retries for a title fetch that still evaluated in the previous
-    /// document's execution context (detected via `location.href`).
-    title_fetch_retries: u32,
+    /// `Runtime.enable` is deferred until snapshot, evaluate, clipboard, or
+    /// scrollbar scrolling actually needs it. Enabling it at attach is a
+    /// script-visible CDP signal.
+    runtime_enabled: bool,
     restart_attempts: u32,
     pending_reattach: bool,
     reattach_in_flight: bool,
@@ -506,9 +479,8 @@ impl DriverState {
             initial_navigated: false,
             screencast_on: false,
             pending_restart_at: None,
-            title_context_id: None,
             title_fetch_at: None,
-            title_fetch_retries: 0,
+            runtime_enabled: false,
             restart_attempts: 0,
             pending_reattach: false,
             reattach_in_flight: false,
@@ -615,7 +587,36 @@ impl DriverState {
                 method: method.to_string(),
             });
         };
+        if method.starts_with("Runtime.") {
+            self.ensure_page_runtime(link, event_tx, frame_slot)?;
+        }
         self.call_and_ack(link, event_tx, frame_slot, method, params, Some(session.as_str()))
+    }
+
+    fn ensure_page_runtime(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) -> Result<(), CdpError> {
+        if self.runtime_enabled {
+            return Ok(());
+        }
+        let Some(session) = self.session_id.clone() else {
+            return Err(CdpError::NoPageSession {
+                method: "Runtime.enable".to_string(),
+            });
+        };
+        self.call_and_ack(
+            link,
+            event_tx,
+            frame_slot,
+            "Runtime.enable",
+            &serde_json::json!({}),
+            Some(session.as_str()),
+        )?;
+        self.runtime_enabled = true;
+        Ok(())
     }
 
     fn navigate_to(

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -46,7 +46,7 @@ pub use horizon_browser_protocol::BrowserCommand;
 pub use shutdown::BrowserShutdownSignal;
 use startup::run_driver;
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
@@ -424,6 +424,8 @@ struct DriverState {
     /// scrollbar scrolling actually needs it. Enabling it at attach is a
     /// script-visible CDP signal.
     runtime_enabled: bool,
+    runtime_enable_requested: HashSet<String>,
+    runtime_enable_inflight: HashMap<u64, String>,
     restart_attempts: u32,
     pending_reattach: bool,
     reattach_in_flight: bool,
@@ -481,6 +483,8 @@ impl DriverState {
             pending_restart_at: None,
             title_fetch_at: None,
             runtime_enabled: false,
+            runtime_enable_requested: HashSet::new(),
+            runtime_enable_inflight: HashMap::new(),
             restart_attempts: 0,
             pending_reattach: false,
             reattach_in_flight: false,
@@ -588,35 +592,67 @@ impl DriverState {
             });
         };
         if method.starts_with("Runtime.") {
-            self.ensure_page_runtime(link, event_tx, frame_slot)?;
+            self.ensure_page_runtime(link)?;
         }
         self.call_and_ack(link, event_tx, frame_slot, method, params, Some(session.as_str()))
     }
 
-    fn ensure_page_runtime(
-        &mut self,
-        link: &mut CdpLink,
-        event_tx: &BrowserEventSender,
-        frame_slot: &Arc<FrameSlot>,
-    ) -> Result<(), CdpError> {
-        if self.runtime_enabled {
-            return Ok(());
-        }
-        let Some(session) = self.session_id.clone() else {
+    fn ensure_page_runtime(&mut self, link: &mut CdpLink) -> Result<(), CdpError> {
+        if self.session_id.is_none() {
             return Err(CdpError::NoPageSession {
                 method: "Runtime.enable".to_string(),
             });
-        };
-        self.call_and_ack(
-            link,
-            event_tx,
-            frame_slot,
-            "Runtime.enable",
-            &serde_json::json!({}),
-            Some(session.as_str()),
-        )?;
-        self.runtime_enabled = true;
+        }
+        self.request_runtime_for_sessions(link);
         Ok(())
+    }
+
+    fn request_runtime_for_sessions(&mut self, link: &mut CdpLink) {
+        let Some(page_session) = self.session_id.clone() else {
+            return;
+        };
+        self.queue_runtime_enable(link, &page_session);
+        let iframe_sessions: Vec<String> = self.clipboard.iframe_sessions.iter().cloned().collect();
+        for session in iframe_sessions {
+            self.queue_runtime_enable(link, &session);
+        }
+    }
+
+    fn queue_runtime_enable(&mut self, link: &mut CdpLink, session: &str) {
+        if self.runtime_enable_requested.contains(session) {
+            return;
+        }
+        match link.send_request("Runtime.enable", &serde_json::json!({}), Some(session)) {
+            Ok(request_id) => {
+                self.runtime_enable_requested.insert(session.to_string());
+                self.runtime_enable_inflight.insert(request_id, session.to_string());
+            }
+            Err(error) => tracing::debug!(
+                target: "browser",
+                session,
+                "Runtime.enable request failed: {error}"
+            ),
+        }
+    }
+
+    fn handle_runtime_enable_response(&mut self, id: u64, error: Option<&crate::cdp::CdpErrorInfo>) -> bool {
+        let Some(session) = self.runtime_enable_inflight.remove(&id) else {
+            return false;
+        };
+        if error.is_some() {
+            self.runtime_enable_requested.remove(&session);
+            return true;
+        }
+        if self.session_id.as_deref() == Some(session.as_str()) {
+            self.runtime_enabled = true;
+        }
+        true
+    }
+
+    fn reset_runtime_enable_state(&mut self) {
+        self.runtime_enabled = false;
+        self.runtime_enable_requested.clear();
+        self.runtime_enable_inflight.clear();
     }
 
     fn navigate_to(

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -649,6 +649,14 @@ impl DriverState {
         true
     }
 
+    fn forget_runtime_session(&mut self, session: &str) {
+        forget_tracked_runtime_session(
+            &mut self.runtime_enable_requested,
+            &mut self.runtime_enable_inflight,
+            session,
+        );
+    }
+
     fn reset_runtime_enable_state(&mut self) {
         self.runtime_enabled = false;
         self.runtime_enable_requested.clear();
@@ -728,6 +736,11 @@ fn normalized_committed_url(url: &str) -> &str {
     }
 }
 
+fn forget_tracked_runtime_session(requested: &mut HashSet<String>, inflight: &mut HashMap<u64, String>, session: &str) {
+    requested.remove(session);
+    inflight.retain(|_, tracked| tracked != session);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -754,5 +767,16 @@ mod tests {
         }));
         assert!(!is_user_activity(&BrowserCommand::HandoffDone));
         assert!(!is_user_activity(&BrowserCommand::Stop));
+    }
+
+    #[test]
+    fn forgetting_a_runtime_session_drops_requested_and_inflight_entries() {
+        let mut requested = HashSet::from(["page".to_string(), "oopif".to_string()]);
+        let mut inflight = HashMap::from([(7, "oopif".to_string()), (8, "page".to_string())]);
+
+        forget_tracked_runtime_session(&mut requested, &mut inflight, "oopif");
+
+        assert_eq!(requested, HashSet::from(["page".to_string()]));
+        assert_eq!(inflight, HashMap::from([(8, "page".to_string())]));
     }
 }

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -423,7 +423,6 @@ struct DriverState {
     /// `Runtime.enable` is deferred until snapshot, evaluate, clipboard, or
     /// scrollbar scrolling actually needs it. Enabling it at attach is a
     /// script-visible CDP signal.
-    runtime_enabled: bool,
     runtime_enable_requested: HashSet<String>,
     runtime_enable_inflight: HashMap<u64, String>,
     restart_attempts: u32,
@@ -482,7 +481,6 @@ impl DriverState {
             screencast_on: false,
             pending_restart_at: None,
             title_fetch_at: None,
-            runtime_enabled: false,
             runtime_enable_requested: HashSet::new(),
             runtime_enable_inflight: HashMap::new(),
             restart_attempts: 0,
@@ -643,9 +641,6 @@ impl DriverState {
             self.runtime_enable_requested.remove(&session);
             return true;
         }
-        if self.session_id.as_deref() == Some(session.as_str()) {
-            self.runtime_enabled = true;
-        }
         true
     }
 
@@ -658,7 +653,6 @@ impl DriverState {
     }
 
     fn reset_runtime_enable_state(&mut self) {
-        self.runtime_enabled = false;
         self.runtime_enable_requested.clear();
         self.runtime_enable_inflight.clear();
     }

--- a/crates/horizon-browser/src/session/clipboard.rs
+++ b/crates/horizon-browser/src/session/clipboard.rs
@@ -165,6 +165,7 @@ impl DriverState {
         };
         self.clipboard.iframe_sessions.remove(session);
         self.clipboard.default_contexts.remove(session);
+        self.forget_runtime_session(session);
     }
 
     pub(super) fn reset_clipboard_tracking(&mut self) {

--- a/crates/horizon-browser/src/session/clipboard.rs
+++ b/crates/horizon-browser/src/session/clipboard.rs
@@ -26,6 +26,7 @@ pub(super) struct ClipboardState {
     request_ids: HashSet<u64>,
     default_contexts: HashMap<String, HashSet<u64>>,
     pub(super) iframe_sessions: HashSet<String>,
+    pub(super) pending_capture: bool,
 }
 
 impl ClipboardState {
@@ -47,16 +48,57 @@ impl ClipboardState {
         self.request_ids.clear();
         self.default_contexts.clear();
         self.iframe_sessions.clear();
+        self.pending_capture = false;
     }
+}
+
+fn clipboard_capture_is_ready(
+    page_session: &str,
+    iframe_sessions: &HashSet<String>,
+    default_contexts: &HashMap<String, HashSet<u64>>,
+    requested: &HashSet<String>,
+    inflight: &HashMap<u64, String>,
+) -> bool {
+    if !requested.contains(page_session) || inflight.values().any(|session| session == page_session) {
+        return false;
+    }
+    if default_contexts.get(page_session).is_none_or(HashSet::is_empty) {
+        return false;
+    }
+    iframe_sessions.iter().all(|session| {
+        !inflight.values().any(|tracked| tracked == session)
+            && (!requested.contains(session)
+                || default_contexts
+                    .get(session)
+                    .is_some_and(|contexts| !contexts.is_empty()))
+    })
 }
 
 impl DriverState {
     pub(super) fn request_clipboard_text(&mut self, link: &mut CdpLink) {
+        self.clipboard.pending_capture = true;
         self.request_runtime_for_sessions(link);
-        let Some(page_session) = self.session_id.as_deref() else {
+        self.flush_pending_clipboard(link);
+    }
+
+    pub(super) fn flush_pending_clipboard(&mut self, link: &mut CdpLink) {
+        if !self.clipboard.pending_capture {
+            return;
+        }
+        let Some(page_session) = self.session_id.clone() else {
             return;
         };
-        for (session, context_id) in self.clipboard.evaluation_targets(page_session) {
+        if !clipboard_capture_is_ready(
+            &page_session,
+            &self.clipboard.iframe_sessions,
+            &self.clipboard.default_contexts,
+            &self.runtime_enable_requested,
+            &self.runtime_enable_inflight,
+        ) {
+            return;
+        }
+        self.clipboard.pending_capture = false;
+        for (session, context_id) in self.clipboard.evaluation_targets(&page_session) {
             let mut params = serde_json::json!({
                 "expression": SELECTED_TEXT_EXPRESSION,
                 "returnByValue": true,
@@ -201,9 +243,12 @@ fn clipboard_text_from_evaluation(result: Option<&serde_json::Value>) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
-    use super::{ClipboardState, clipboard_text_from_evaluation, default_context_id, target_event_session_id};
+    use super::{
+        ClipboardState, clipboard_capture_is_ready, clipboard_text_from_evaluation, default_context_id,
+        target_event_session_id,
+    };
 
     #[test]
     fn frame_targets_cover_page_contexts_and_out_of_process_iframe_sessions() {
@@ -270,5 +315,33 @@ mod tests {
         assert_eq!(clipboard_text_from_evaluation(Some(&value)), Some("selected"));
         assert_eq!(clipboard_text_from_evaluation(Some(&exception)), None);
         assert_eq!(clipboard_text_from_evaluation(None), None);
+    }
+
+    #[test]
+    fn clipboard_capture_waits_for_enable_and_page_contexts() {
+        let iframe_sessions = HashSet::from(["oopif".to_string()]);
+        let contexts = HashMap::from([("page".to_string(), HashSet::from([7]))]);
+        let requested = HashSet::from(["page".to_string(), "oopif".to_string()]);
+        let inflight = HashMap::from([(1, "oopif".to_string())]);
+
+        assert!(!clipboard_capture_is_ready(
+            "page",
+            &iframe_sessions,
+            &contexts,
+            &requested,
+            &inflight
+        ));
+
+        let ready_contexts = HashMap::from([
+            ("page".to_string(), HashSet::from([7, 8])),
+            ("oopif".to_string(), HashSet::from([11])),
+        ]);
+        assert!(clipboard_capture_is_ready(
+            "page",
+            &iframe_sessions,
+            &ready_contexts,
+            &requested,
+            &HashMap::new()
+        ));
     }
 }

--- a/crates/horizon-browser/src/session/clipboard.rs
+++ b/crates/horizon-browser/src/session/clipboard.rs
@@ -2,7 +2,10 @@
 
 use std::collections::{HashMap, HashSet};
 
+use std::sync::Arc;
+
 use crate::cdp::{CdpErrorInfo, CdpEvent, CdpLink};
+use crate::frames::FrameSlot;
 
 use super::{BrowserEvent, BrowserEventSender, DriverState};
 
@@ -51,7 +54,15 @@ impl ClipboardState {
 }
 
 impl DriverState {
-    pub(super) fn request_clipboard_text(&mut self, link: &mut CdpLink) {
+    pub(super) fn request_clipboard_text(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        if self.ensure_page_runtime(link, event_tx, frame_slot).is_err() {
+            return;
+        }
         let Some(page_session) = self.session_id.as_deref() else {
             return;
         };

--- a/crates/horizon-browser/src/session/clipboard.rs
+++ b/crates/horizon-browser/src/session/clipboard.rs
@@ -2,10 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use std::sync::Arc;
-
 use crate::cdp::{CdpErrorInfo, CdpEvent, CdpLink};
-use crate::frames::FrameSlot;
 
 use super::{BrowserEvent, BrowserEventSender, DriverState};
 
@@ -28,7 +25,7 @@ const SELECTED_TEXT_EXPRESSION: &str = r#"(() => {
 pub(super) struct ClipboardState {
     request_ids: HashSet<u64>,
     default_contexts: HashMap<String, HashSet<u64>>,
-    iframe_sessions: HashSet<String>,
+    pub(super) iframe_sessions: HashSet<String>,
 }
 
 impl ClipboardState {
@@ -54,15 +51,8 @@ impl ClipboardState {
 }
 
 impl DriverState {
-    pub(super) fn request_clipboard_text(
-        &mut self,
-        link: &mut CdpLink,
-        event_tx: &BrowserEventSender,
-        frame_slot: &Arc<FrameSlot>,
-    ) {
-        if self.ensure_page_runtime(link, event_tx, frame_slot).is_err() {
-            return;
-        }
+    pub(super) fn request_clipboard_text(&mut self, link: &mut CdpLink) {
+        self.request_runtime_for_sessions(link);
         let Some(page_session) = self.session_id.as_deref() else {
             return;
         };
@@ -143,8 +133,8 @@ impl DriverState {
         }
     }
 
-    /// Record an auto-attached out-of-process iframe and enable its Runtime
-    /// domain so subsequent selection capture can target its default contexts.
+    /// Record an auto-attached out-of-process iframe. Runtime stays disabled
+    /// until clipboard or evaluation actually needs those sessions.
     /// Returns whether this was an iframe attachment consumed by this path.
     pub(super) fn note_clipboard_target_attachment(&mut self, link: &mut CdpLink, event: &CdpEvent<'_>) -> bool {
         if attached_target_type(event.params) != Some("iframe") {
@@ -153,8 +143,8 @@ impl DriverState {
         let Some(session) = target_event_session_id(event.params, event.session_id) else {
             return true;
         };
-        if self.clipboard.iframe_sessions.insert(session.to_string()) {
-            if let Err(error) = link.send_request(
+        if self.clipboard.iframe_sessions.insert(session.to_string())
+            && let Err(error) = link.send_request(
                 "Target.setAutoAttach",
                 &serde_json::json!({
                     "autoAttach": true,
@@ -162,12 +152,9 @@ impl DriverState {
                     "flatten": true,
                 }),
                 Some(session),
-            ) {
-                tracing::debug!(target: "browser", session, "failed to auto-attach nested iframe targets: {error}");
-            }
-            if let Err(error) = link.send_request("Runtime.enable", &serde_json::json!({}), Some(session)) {
-                tracing::debug!(target: "browser", session, "failed to enable iframe runtime: {error}");
-            }
+            )
+        {
+            tracing::debug!(target: "browser", session, "failed to auto-attach nested iframe targets: {error}");
         }
         true
     }

--- a/crates/horizon-browser/src/session/commands.rs
+++ b/crates/horizon-browser/src/session/commands.rs
@@ -125,13 +125,13 @@ impl DriverState {
                 Ok(false)
             }
             BrowserCommand::Input(input) => {
-                if self.handle_vertical_scrollbar_input(link, event_tx, frame_slot, &input) {
+                if self.handle_vertical_scrollbar_input(link, &input) {
                     return Ok(false);
                 }
                 // Input cannot block on a roundtrip: a detaching session
                 // would otherwise stall every frame for the call timeout.
                 if input.copies_selection() {
-                    self.request_clipboard_text(link, event_tx, frame_slot);
+                    self.request_clipboard_text(link);
                 }
                 let refresh_scrollbar_layout = matches!(input, BrowserInput::Wheel { .. });
                 let (method, params) = input.cdp();
@@ -167,13 +167,7 @@ impl DriverState {
         BrowserControlFailure::new(code, message)
     }
 
-    fn handle_vertical_scrollbar_input(
-        &mut self,
-        link: &mut CdpLink,
-        event_tx: &BrowserEventSender,
-        frame_slot: &Arc<FrameSlot>,
-        input: &BrowserInput,
-    ) -> bool {
+    fn handle_vertical_scrollbar_input(&mut self, link: &mut CdpLink, input: &BrowserInput) -> bool {
         match input {
             BrowserInput::MousePress {
                 x,
@@ -198,7 +192,7 @@ impl DriverState {
                         self.vertical_scrollbar_drag = Some(drag);
                     }
                     Some(ScrollbarPress::PageTo(target)) => {
-                        self.scroll_page_to(link, event_tx, frame_slot, target);
+                        self.scroll_page_to(link, target);
                     }
                     None => return false,
                 }
@@ -211,7 +205,7 @@ impl DriverState {
                     .vertical_scrollbar_drag
                     .map(|drag| drag.target_scroll_y(*y))
                     .unwrap_or_default();
-                self.scroll_page_to(link, event_tx, frame_slot, target);
+                self.scroll_page_to(link, target);
                 true
             }
             BrowserInput::MouseRelease {
@@ -221,23 +215,15 @@ impl DriverState {
             } if self.vertical_scrollbar_drag.is_some() => {
                 let drag = self.vertical_scrollbar_drag.take();
                 let target = drag.map(|drag| drag.target_scroll_y(*y)).unwrap_or_default();
-                self.scroll_page_to(link, event_tx, frame_slot, target);
+                self.scroll_page_to(link, target);
                 true
             }
             _ => false,
         }
     }
 
-    fn scroll_page_to(
-        &mut self,
-        link: &mut CdpLink,
-        event_tx: &BrowserEventSender,
-        frame_slot: &Arc<FrameSlot>,
-        target: f64,
-    ) {
-        if self.ensure_page_runtime(link, event_tx, frame_slot).is_err() {
-            return;
-        }
+    fn scroll_page_to(&mut self, link: &mut CdpLink, target: f64) {
+        self.request_runtime_for_sessions(link);
         let expression = format!("window.scrollTo(window.scrollX, {target:.3})");
         let Some(session) = self.session_id.clone() else {
             return;

--- a/crates/horizon-browser/src/session/commands.rs
+++ b/crates/horizon-browser/src/session/commands.rs
@@ -125,13 +125,13 @@ impl DriverState {
                 Ok(false)
             }
             BrowserCommand::Input(input) => {
-                if self.handle_vertical_scrollbar_input(link, &input) {
+                if self.handle_vertical_scrollbar_input(link, event_tx, frame_slot, &input) {
                     return Ok(false);
                 }
                 // Input cannot block on a roundtrip: a detaching session
                 // would otherwise stall every frame for the call timeout.
                 if input.copies_selection() {
-                    self.request_clipboard_text(link);
+                    self.request_clipboard_text(link, event_tx, frame_slot);
                 }
                 let refresh_scrollbar_layout = matches!(input, BrowserInput::Wheel { .. });
                 let (method, params) = input.cdp();
@@ -167,7 +167,13 @@ impl DriverState {
         BrowserControlFailure::new(code, message)
     }
 
-    fn handle_vertical_scrollbar_input(&mut self, link: &mut CdpLink, input: &BrowserInput) -> bool {
+    fn handle_vertical_scrollbar_input(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        input: &BrowserInput,
+    ) -> bool {
         match input {
             BrowserInput::MousePress {
                 x,
@@ -192,7 +198,7 @@ impl DriverState {
                         self.vertical_scrollbar_drag = Some(drag);
                     }
                     Some(ScrollbarPress::PageTo(target)) => {
-                        self.scroll_page_to(link, target);
+                        self.scroll_page_to(link, event_tx, frame_slot, target);
                     }
                     None => return false,
                 }
@@ -205,7 +211,7 @@ impl DriverState {
                     .vertical_scrollbar_drag
                     .map(|drag| drag.target_scroll_y(*y))
                     .unwrap_or_default();
-                self.scroll_page_to(link, target);
+                self.scroll_page_to(link, event_tx, frame_slot, target);
                 true
             }
             BrowserInput::MouseRelease {
@@ -215,14 +221,23 @@ impl DriverState {
             } if self.vertical_scrollbar_drag.is_some() => {
                 let drag = self.vertical_scrollbar_drag.take();
                 let target = drag.map(|drag| drag.target_scroll_y(*y)).unwrap_or_default();
-                self.scroll_page_to(link, target);
+                self.scroll_page_to(link, event_tx, frame_slot, target);
                 true
             }
             _ => false,
         }
     }
 
-    fn scroll_page_to(&mut self, link: &mut CdpLink, target: f64) {
+    fn scroll_page_to(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        target: f64,
+    ) {
+        if self.ensure_page_runtime(link, event_tx, frame_slot).is_err() {
+            return;
+        }
         let expression = format!("window.scrollTo(window.scrollX, {target:.3})");
         let Some(session) = self.session_id.clone() else {
             return;
@@ -244,6 +259,15 @@ impl DriverState {
             }
             self.schedule_scrollbar_layout_refresh(SCROLLBAR_LAYOUT_RETRY_DELAY);
         }
+    }
+
+    pub(super) fn viewport_override_params(width: u32, height: u32) -> serde_json::Value {
+        serde_json::json!({
+            "width": width,
+            "height": height,
+            "deviceScaleFactor": 0,
+            "mobile": false,
+        })
     }
 
     pub(super) fn invalidate_scrollbar_layout(&mut self) {
@@ -382,14 +406,7 @@ impl DriverState {
             event_tx,
             frame_slot,
             "Emulation.setDeviceMetricsOverride",
-            &serde_json::json!({
-                "width": width,
-                "height": height,
-                "screenWidth": width,
-                "screenHeight": height,
-                "deviceScaleFactor": 1,
-                "mobile": false,
-            }),
+            &Self::viewport_override_params(width, height),
         ) {
             Ok(_) => {
                 self.commit_viewport(width, height);
@@ -627,6 +644,18 @@ mod tests {
             panic!("test metrics should describe a valid layout");
         };
         layout
+    }
+
+    #[test]
+    fn viewport_override_does_not_claim_the_panel_is_the_display() {
+        let params = DriverState::viewport_override_params(1280, 800);
+
+        assert_eq!(params["width"], 1280);
+        assert_eq!(params["height"], 800);
+        assert_eq!(params["deviceScaleFactor"], 0);
+        assert_eq!(params["mobile"], serde_json::Value::Bool(false));
+        assert!(params.get("screenWidth").is_none());
+        assert!(params.get("screenHeight").is_none());
     }
 
     #[test]

--- a/crates/horizon-browser/src/session/events.rs
+++ b/crates/horizon-browser/src/session/events.rs
@@ -110,6 +110,7 @@ impl DriverState {
             return;
         }
         if self.handle_runtime_enable_response(id, error.as_ref()) {
+            self.flush_pending_clipboard(link);
             return;
         }
         if self.handle_scrollbar_layout_response(id, result.as_ref(), error.is_some()) {
@@ -257,6 +258,7 @@ impl DriverState {
             | "Runtime.executionContextDestroyed"
             | "Runtime.executionContextsCleared" => {
                 self.note_clipboard_execution_context(&event);
+                self.flush_pending_clipboard(link);
             }
             "Page.screencastFrame" => self.handle_screencast_frame(link, event_tx, frame_slot, event),
             _ => {}

--- a/crates/horizon-browser/src/session/events.rs
+++ b/crates/horizon-browser/src/session/events.rs
@@ -109,6 +109,9 @@ impl DriverState {
         if self.handle_clipboard_response(id, result.as_ref(), error.as_ref(), event_tx) {
             return;
         }
+        if self.handle_runtime_enable_response(id, error.as_ref()) {
+            return;
+        }
         if self.handle_scrollbar_layout_response(id, result.as_ref(), error.is_some()) {
             if let Some(error) = error {
                 tracing::debug!(target: "browser", "scrollbar layout request rejected: {error}");
@@ -207,7 +210,7 @@ impl DriverState {
                     self.reset_clipboard_tracking();
                     self.main_frame_id = None;
                     self.title_fetch_at = None;
-                    self.runtime_enabled = false;
+                    self.reset_runtime_enable_state();
                     // Unexpected detach (the driver never detaches its own
                     // page session): the target usually still exists —
                     // re-bind instead of freezing. `pending_restart_tick`
@@ -276,7 +279,7 @@ impl DriverState {
         self.invalidate_scrollbar_layout();
         self.reset_clipboard_tracking();
         self.pending_reattach = false;
-        self.runtime_enabled = false;
+        self.reset_runtime_enable_state();
         self.manifest_dirty = true;
         true
     }

--- a/crates/horizon-browser/src/session/events.rs
+++ b/crates/horizon-browser/src/session/events.rs
@@ -14,9 +14,7 @@ use crate::challenge::{DocumentCommit, REJECTION_MESSAGE};
 use crate::frames::FrameSlot;
 
 use super::clipboard::target_event_session_id;
-use super::{
-    BrowserEvent, BrowserEventSender, DriverState, TITLE_BINDING_NAME, normalized_committed_url, publish_frame,
-};
+use super::{BrowserEvent, BrowserEventSender, DriverState, normalized_committed_url, publish_frame};
 
 impl DriverState {
     pub(super) fn tick_title_fetch(
@@ -43,57 +41,29 @@ impl DriverState {
         event_tx: &BrowserEventSender,
         frame_slot: &Arc<FrameSlot>,
     ) {
-        let Some(session) = self.session_id.clone() else {
+        let Some(target_id) = self.target_id.clone() else {
             return;
-        };
-        // Fetch title and href together: after a navigation the session's
-        // execution context can still be the *previous* document's, so a
-        // bare `document.title` read can return the old page's title. The
-        // href check detects that and schedules a retry.
-        let params = match self.title_context_id {
-            Some(context_id) => serde_json::json!({
-                "expression": "JSON.stringify({ t: document.title, h: location.href })",
-                "returnByValue": true,
-                "contextId": context_id,
-            }),
-            None => serde_json::json!({
-                "expression": "JSON.stringify({ t: document.title, h: location.href })",
-                "returnByValue": true,
-            }),
         };
         let Ok(result) = self.call_and_ack(
             link,
             event_tx,
             frame_slot,
-            "Runtime.evaluate",
-            &params,
-            Some(session.as_str()),
+            "Target.getTargetInfo",
+            &serde_json::json!({ "targetId": target_id }),
+            None,
         ) else {
             return;
         };
-        let Some(payload) = result.pointer("/result/value").and_then(|v| v.as_str()) else {
-            return;
-        };
-        let Ok(parsed) = serde_json::from_str::<serde_json::Value>(payload) else {
-            return;
-        };
-        let Some(href) = parsed.pointer("/h").and_then(|v| v.as_str()) else {
-            return;
-        };
-        if !href_matches_url(href, &self.url) {
-            if self.title_fetch_retries < 10 {
-                self.title_fetch_retries += 1;
-                self.title_fetch_at = Some(Instant::now() + Duration::from_millis(500));
-            }
+        if self.retain_frame_during_navigation {
             return;
         }
-        self.update_url_from_page(event_tx, href);
-        let Some(title) = parsed.pointer("/t").and_then(|v| v.as_str()) else {
+        let Some(title) = result.pointer("/targetInfo/title").and_then(serde_json::Value::as_str) else {
             return;
         };
         self.update_title(event_tx, title);
     }
 
+    #[cfg(test)]
     fn update_url_from_page(&mut self, event_tx: &BrowserEventSender, href: &str) {
         let href = normalized_committed_url(href);
         if href == self.url {
@@ -120,26 +90,6 @@ impl DriverState {
         self.manifest_dirty = true;
         self.write_manifest(false);
         let _ = event_tx.send(BrowserEvent::Title(title.to_string()));
-    }
-
-    /// Track the top-level document's default execution context for the
-    /// title fetch. Iframes also publish `isDefault` contexts, so their
-    /// `frameId` must not replace the context used for page metadata.
-    fn note_execution_context(&mut self, event: &CdpEvent<'_>) {
-        if event.method == "Runtime.executionContextCreated"
-            && let Some(id) = default_context_id_for_frame(event.params, self.main_frame_id.as_deref())
-        {
-            self.title_context_id = Some(id);
-        } else if event.method == "Runtime.executionContextsCleared" {
-            self.title_context_id = None;
-        } else if let Some(id) = event
-            .params
-            .get("executionContextId")
-            .and_then(serde_json::Value::as_u64)
-            && self.title_context_id == Some(id)
-        {
-            self.title_context_id = None;
-        }
     }
 
     pub(super) fn handle_message(
@@ -255,12 +205,9 @@ impl DriverState {
                     self.viewport_capture_request_id = None;
                     self.invalidate_scrollbar_layout();
                     self.reset_clipboard_tracking();
-                    // Drop the tracked context: the next title fetch must
-                    // use a fresh default context, not a dead contextId.
-                    self.title_context_id = None;
                     self.main_frame_id = None;
                     self.title_fetch_at = None;
-                    self.title_fetch_retries = 0;
+                    self.runtime_enabled = false;
                     // Unexpected detach (the driver never detaches its own
                     // page session): the target usually still exists —
                     // re-bind instead of freezing. `pending_restart_tick`
@@ -293,16 +240,6 @@ impl DriverState {
                     self.update_title(event_tx, title);
                 }
             }
-            "Runtime.bindingCalled" => {
-                if !self.retain_frame_during_navigation
-                    && on_page_session
-                    && let Some((title, href)) = title_from_binding(event.params)
-                    && href_matches_url(&href, &self.url)
-                {
-                    self.update_url_from_page(event_tx, &href);
-                    self.update_title(event_tx, &title);
-                }
-            }
             "Page.frameNavigated" => self.handle_frame_navigated(event_tx, event, on_page_session),
             "Page.navigatedWithinDocument" => {
                 self.handle_same_document_navigation(event_tx, event, on_page_session);
@@ -310,16 +247,12 @@ impl DriverState {
             "Page.loadEventFired" => {
                 if on_page_session {
                     let _ = event_tx.send(BrowserEvent::Loading(false));
-                    self.title_fetch_retries = 0;
                     self.title_fetch_at = Some(Instant::now() + Duration::from_millis(400));
                 }
             }
             "Runtime.executionContextCreated"
             | "Runtime.executionContextDestroyed"
             | "Runtime.executionContextsCleared" => {
-                if on_page_session {
-                    self.note_execution_context(&event);
-                }
                 self.note_clipboard_execution_context(&event);
             }
             "Page.screencastFrame" => self.handle_screencast_frame(link, event_tx, frame_slot, event),
@@ -343,6 +276,7 @@ impl DriverState {
         self.invalidate_scrollbar_layout();
         self.reset_clipboard_tracking();
         self.pending_reattach = false;
+        self.runtime_enabled = false;
         self.manifest_dirty = true;
         true
     }
@@ -396,9 +330,7 @@ impl DriverState {
         // A back/forward-cache restore can commit `frameNavigated` without a
         // later `loadEventFired`. Always schedule the title read here so the
         // panel cannot retain the destination page's title after history
-        // navigation. The href guard in `fetch_title` retries if the new
-        // execution context is not ready yet.
-        self.title_fetch_retries = 0;
+        // navigation.
         self.title_fetch_at = Some(Instant::now() + Duration::from_millis(400));
         self.write_manifest(true);
         match document_commit {
@@ -553,27 +485,6 @@ fn attached_bound_page_target<'a>(params: &'a serde_json::Value, bound_target_id
     (Some(attached_target_id) == bound_target_id).then_some(attached_target_id)
 }
 
-fn title_from_binding(params: &serde_json::Value) -> Option<(String, String)> {
-    if params.get("name")?.as_str()? != TITLE_BINDING_NAME {
-        return None;
-    }
-    let payload = params.get("payload")?.as_str()?;
-    let payload = serde_json::from_str::<serde_json::Value>(payload).ok()?;
-    let title = payload.get("title")?.as_str()?.to_string();
-    let href = payload.get("href")?.as_str()?.to_string();
-    Some((title, href))
-}
-
-fn default_context_id_for_frame(params: &serde_json::Value, main_frame_id: Option<&str>) -> Option<u64> {
-    let context = params.get("context")?;
-    let is_default = context.pointer("/auxData/isDefault")?.as_bool()?;
-    let frame_id = context.pointer("/auxData/frameId")?.as_str()?;
-    if !is_default || Some(frame_id) != main_frame_id {
-        return None;
-    }
-    context.get("id")?.as_u64()
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicBool;
@@ -584,10 +495,7 @@ mod tests {
     use crate::session::{BrowserEvent, BrowserEventSender, BrowserEventWake, CommittedUrl};
     use crate::{BrowserConfig, session::BrowserSessionConfig};
 
-    use super::{
-        DriverState, attached_bound_page_target, default_context_id_for_frame, href_matches_url,
-        title_for_bound_target, title_from_binding,
-    };
+    use super::{DriverState, attached_bound_page_target, href_matches_url, title_for_bound_target};
 
     fn driver_state() -> DriverState {
         DriverState::new(
@@ -605,24 +513,6 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
         )
-    }
-
-    #[test]
-    fn title_context_accepts_only_the_main_frames_default_context() {
-        let main = serde_json::json!({
-            "context": { "id": 7, "auxData": { "isDefault": true, "frameId": "main" } }
-        });
-        let iframe = serde_json::json!({
-            "context": { "id": 8, "auxData": { "isDefault": true, "frameId": "child" } }
-        });
-        let isolated = serde_json::json!({
-            "context": { "id": 9, "auxData": { "isDefault": false, "frameId": "main" } }
-        });
-
-        assert_eq!(default_context_id_for_frame(&main, Some("main")), Some(7));
-        assert_eq!(default_context_id_for_frame(&iframe, Some("main")), None);
-        assert_eq!(default_context_id_for_frame(&isolated, Some("main")), None);
-        assert_eq!(default_context_id_for_frame(&main, None), None);
     }
 
     #[test]
@@ -825,25 +715,6 @@ mod tests {
         assert_eq!(rx.recv(), Ok(BrowserEvent::UrlChanged(URL.to_string())));
         assert_eq!(rx.recv(), Ok(BrowserEvent::Loading(true)));
         assert_eq!(rx.try_recv(), Err(mpsc::TryRecvError::Empty));
-    }
-
-    #[test]
-    fn title_binding_accepts_only_the_horizon_payload() {
-        let params = serde_json::json!({
-            "name": "__horizonBrowserTitleChanged",
-            "payload": r#"{"title":"Updated","href":"https://example.test/page"}"#,
-        });
-        let other_binding = serde_json::json!({
-            "name": "pageBinding",
-            "payload": r#"{"title":"Wrong","href":"https://example.test/page"}"#,
-        });
-
-        assert_eq!(
-            title_from_binding(&params),
-            Some(("Updated".to_string(), "https://example.test/page".to_string()))
-        );
-        assert_eq!(title_from_binding(&other_binding), None);
-        assert_eq!(title_from_binding(&serde_json::json!({})), None);
     }
 
     #[test]

--- a/crates/horizon-browser/src/session/lifecycle.rs
+++ b/crates/horizon-browser/src/session/lifecycle.rs
@@ -6,12 +6,11 @@ use std::time::{Duration, Instant};
 
 use crate::AutomationDisclosurePolicy;
 use crate::cdp::CdpLink;
-use crate::disclosure::{cdp_preload_source, chromium_user_agent_needs_override, chromium_user_agent_override};
+use crate::disclosure::{chromium_user_agent_needs_override, chromium_user_agent_override};
 use crate::frames::FrameSlot;
 
 use super::{
     BrowserEvent, BrowserEventSender, DriverState, MAX_RESTART_ATTEMPTS, RESTART_BACKOFF, RESTART_BACKOFF_CAP,
-    TITLE_BINDING_NAME, TITLE_OBSERVER_SCRIPT,
 };
 
 impl DriverState {
@@ -37,6 +36,7 @@ impl DriverState {
         if self.session_id.as_deref() != Some(session) {
             self.reset_clipboard_tracking();
             self.invalidate_scrollbar_layout();
+            self.runtime_enabled = false;
         }
         self.session_id = Some(session.to_string());
         self.target_id = Some(target.to_string());
@@ -58,17 +58,18 @@ impl DriverState {
         if !self.resolve_main_frame_id(link, event_tx, frame_slot, session) {
             return false;
         }
-        let observation_setup_commands = [
-            // Observe only top-level response metadata so a completed user
-            // handoff can report a repeated Cloudflare challenge. The driver
-            // receives response headers but never emits them or request bodies.
-            ("Network.enable", serde_json::json!({})),
-            ("Runtime.enable", serde_json::json!({})),
-        ];
-        for (method, params) in observation_setup_commands {
-            if !self.setup_command(link, event_tx, frame_slot, method, &params, Some(session)) {
-                return false;
-            }
+        // Observe only top-level response metadata so a completed user
+        // handoff can report a repeated Cloudflare challenge. The driver
+        // receives response headers but never emits them or request bodies.
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Network.enable",
+            &serde_json::json!({}),
+            Some(session),
+        ) {
+            return false;
         }
         self.restore_network_capture(link, event_tx, frame_slot, session);
         if self.config.browser.automation_disclosure == AutomationDisclosurePolicy::MinimizeCommonSignals
@@ -76,36 +77,20 @@ impl DriverState {
         {
             return false;
         }
-        let remaining_setup_commands = [
-            ("Runtime.addBinding", serde_json::json!({ "name": TITLE_BINDING_NAME })),
-            (
-                "Page.addScriptToEvaluateOnNewDocument",
-                serde_json::json!({ "source": TITLE_OBSERVER_SCRIPT }),
-            ),
-            (
-                "Runtime.evaluate",
-                serde_json::json!({ "expression": TITLE_OBSERVER_SCRIPT }),
-            ),
-            (
-                "Emulation.setDeviceMetricsOverride",
-                serde_json::json!({
-                    "width": self.viewport_w,
-                    "height": self.viewport_h,
-                    "screenWidth": self.viewport_w,
-                    "screenHeight": self.viewport_h,
-                    "deviceScaleFactor": 1,
-                    "mobile": false,
-                }),
-            ),
-        ];
-        for (method, params) in remaining_setup_commands {
-            if !self.setup_command(link, event_tx, frame_slot, method, &params, Some(session)) {
-                return false;
-            }
+        if !self.setup_command(
+            link,
+            event_tx,
+            frame_slot,
+            "Emulation.setDeviceMetricsOverride",
+            &Self::viewport_override_params(self.viewport_w, self.viewport_h),
+            Some(session),
+        ) {
+            return false;
         }
         // Never expose the internal metadata-bootstrap page in a screencast.
-        // The disclosure shim and UA override are already active before this
-        // first caller-supplied navigation can execute page author script.
+        // Native automation-flag suppression and any UA override are already
+        // active before this first caller-supplied navigation can execute
+        // page author script.
         self.navigate_initial_url(link, event_tx, frame_slot);
         // A page that loaded before we attached (restart case) already has
         // its title; a fresh about:blank fetch returns empty and is skipped.
@@ -212,7 +197,7 @@ impl DriverState {
         };
         let user_agent_override = match chromium_user_agent_override(&version, user_agent_metadata) {
             Ok(value) => value,
-            Err(error) => return self.setup_failure(event_tx, frame_slot, "Runtime.evaluate", error),
+            Err(error) => return self.setup_failure(event_tx, frame_slot, "Emulation.setUserAgentOverride", error),
         };
         if let Some(params) = user_agent_override
             && !self.setup_command(
@@ -225,20 +210,6 @@ impl DriverState {
             )
         {
             return false;
-        }
-        for (method, params) in [
-            (
-                "Page.addScriptToEvaluateOnNewDocument",
-                serde_json::json!({ "source": cdp_preload_source() }),
-            ),
-            (
-                "Runtime.evaluate",
-                serde_json::json!({ "expression": cdp_preload_source() }),
-            ),
-        ] {
-            if !self.setup_command(link, event_tx, frame_slot, method, &params, Some(session)) {
-                return false;
-            }
         }
         true
     }

--- a/crates/horizon-browser/src/session/lifecycle.rs
+++ b/crates/horizon-browser/src/session/lifecycle.rs
@@ -36,7 +36,7 @@ impl DriverState {
         if self.session_id.as_deref() != Some(session) {
             self.reset_clipboard_tracking();
             self.invalidate_scrollbar_layout();
-            self.runtime_enabled = false;
+            self.reset_runtime_enable_state();
         }
         self.session_id = Some(session.to_string());
         self.target_id = Some(target.to_string());

--- a/crates/horizon-browser/src/webdriver/session.rs
+++ b/crates/horizon-browser/src/webdriver/session.rs
@@ -432,7 +432,6 @@ impl Driver {
                 &json!({
                     "context": self.context_id,
                     "viewport": { "width": width, "height": height },
-                    "devicePixelRatio": 1.0,
                 }),
                 event_tx,
             )

--- a/crates/horizon-browser/src/webdriver/session/network.rs
+++ b/crates/horizon-browser/src/webdriver/session/network.rs
@@ -6,6 +6,9 @@
 //! Rust side writes through the same bounded, non-blocking capture pipeline as
 //! Chromium CDP.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -578,8 +581,8 @@ impl Driver {
         options: &BrowserNetworkCaptureOptions,
         event_tx: &BrowserEventSender,
     ) -> Result<(), BrowserControlFailure> {
-        let channel = format!("horizon-network-{capture_id}");
-        let control_key = format!("__horizonNetworkCapture_{capture_id}");
+        let channel = firefox_page_channel(capture_id);
+        let control_key = firefox_page_control_key(capture_id);
         let function = page_bridge_function(&control_key, options);
         let channel_argument = json!({
             "type": "channel",
@@ -739,6 +742,18 @@ impl Driver {
     }
 }
 
+fn firefox_page_control_key(capture_id: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    capture_id.hash(&mut hasher);
+    format!("_{:016x}", hasher.finish())
+}
+
+fn firefox_page_channel(capture_id: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    capture_id.hash(&mut hasher);
+    format!("ws-{:016x}", hasher.finish())
+}
+
 fn page_bridge_function(control_key: &str, options: &BrowserNetworkCaptureOptions) -> String {
     PAGE_BRIDGE_TEMPLATE
         .replace(
@@ -831,6 +846,24 @@ mod tests {
         assert!(source.contains("const includeSent = false"));
         assert!(source.contains("const maxPayloadBytes = 1234"));
         assert!(!source.contains("__MAX_PAYLOAD_BYTES__"));
+        assert!(!source.to_ascii_lowercase().contains("horizon"));
+    }
+
+    #[test]
+    fn firefox_page_bridge_names_are_not_horizon_branded() {
+        let capture_id = "panel-capture-1";
+        let control_key = firefox_page_control_key(capture_id);
+        let channel = firefox_page_channel(capture_id);
+
+        assert!(control_key.starts_with('_'));
+        assert_ne!(control_key, firefox_page_control_key("other-capture"));
+        assert!(!control_key.to_ascii_lowercase().contains("horizon"));
+        assert!(!channel.to_ascii_lowercase().contains("horizon"));
+        assert!(
+            !page_bridge_function(&control_key, &BrowserNetworkCaptureOptions::default())
+                .to_ascii_lowercase()
+                .contains("horizon")
+        );
     }
 
     #[test]

--- a/scripts/browser-smoke/fixtures/index.html
+++ b/scripts/browser-smoke/fixtures/index.html
@@ -131,6 +131,7 @@
     const consentFrame = document.querySelector('#consent-frame');
     const consentUrl = new URL('/next.html', location.href);
     consentUrl.hostname = location.hostname === '127.0.0.1' ? 'localhost' : '127.0.0.1';
+    const consentOrigin = consentUrl.origin;
     consentFrame.src = consentUrl.href;
 
     async function collectFingerprint() {
@@ -147,6 +148,7 @@
         earlyWebdriver: window.__earlyWebdriver === true ? true : (window.__earlyWebdriver === false ? false : null),
         currentWebdriver: navigator.webdriver === true ? true : (navigator.webdriver === false ? false : null),
         iframeWebdriver: window.__iframeWebdriver === true ? true : (window.__iframeWebdriver === false ? false : null),
+        crossOriginWebdriver: window.__crossOriginWebdriver === true ? true : (window.__crossOriginWebdriver === false ? false : null),
         userAgent: navigator.userAgent,
         brands: uaData?.brands || [],
         high,
@@ -166,6 +168,11 @@
 
     addEventListener('message', (event) => {
       if (event.data?.kind === 'probe-ready') collectFingerprint();
+      if (event.origin === consentOrigin && event.data?.kind === 'cross-origin-probe') {
+        window.__crossOriginWebdriver = event.data.webdriver;
+        window.__crossOriginProbeReady = true;
+        collectFingerprint();
+      }
     });
     collectFingerprint();
     publishStatus();

--- a/scripts/browser-smoke/fixtures/index.html
+++ b/scripts/browser-smoke/fixtures/index.html
@@ -157,6 +157,7 @@
         dpr: devicePixelRatio,
         renderer,
         horizonNames: Object.getOwnPropertyNames(window).filter((name) => /horizon/i.test(name)),
+        webdriverDescriptorPresent: Boolean(webdriverDescriptor),
         webdriverGetterNative: typeof webdriverDescriptor?.get === 'function'
           && Function.prototype.toString.call(webdriverDescriptor.get).includes('[native code]')
       };

--- a/scripts/browser-smoke/fixtures/index.html
+++ b/scripts/browser-smoke/fixtures/index.html
@@ -127,7 +127,7 @@
     });
 
     const frame = document.querySelector('#probe-frame');
-    frame.srcdoc = '<!doctype html><script>parent.__iframeWebdriver = navigator.webdriver; parent.postMessage({kind:"probe-ready"}, "*");<\/script>';
+    frame.srcdoc = '<!doctype html><script>parent.__iframeWebdriver = navigator.webdriver; parent.__iframeProbeReady = true; parent.postMessage({kind:"probe-ready"}, "*");<\/script>';
     const consentFrame = document.querySelector('#consent-frame');
     const consentUrl = new URL('/next.html', location.href);
     consentUrl.hostname = location.hostname === '127.0.0.1' ? 'localhost' : '127.0.0.1';
@@ -142,10 +142,11 @@
       const high = await Promise.resolve(
         uaData?.getHighEntropyValues?.(['architecture', 'bitness', 'platformVersion', 'fullVersionList']) || {}
       );
+      const webdriverDescriptor = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver');
       window.__fingerprint = {
-        earlyWebdriver: window.__earlyWebdriver,
-        currentWebdriver: navigator.webdriver,
-        iframeWebdriver: window.__iframeWebdriver,
+        earlyWebdriver: window.__earlyWebdriver === true ? true : (window.__earlyWebdriver === false ? false : null),
+        currentWebdriver: navigator.webdriver === true ? true : (navigator.webdriver === false ? false : null),
+        iframeWebdriver: window.__iframeWebdriver === true ? true : (window.__iframeWebdriver === false ? false : null),
         userAgent: navigator.userAgent,
         brands: uaData?.brands || [],
         high,
@@ -154,7 +155,10 @@
         viewport: [innerWidth, innerHeight],
         screen: [screen.width, screen.height],
         dpr: devicePixelRatio,
-        renderer
+        renderer,
+        horizonNames: Object.getOwnPropertyNames(window).filter((name) => /horizon/i.test(name)),
+        webdriverGetterNative: typeof webdriverDescriptor?.get === 'function'
+          && Function.prototype.toString.call(webdriverDescriptor.get).includes('[native code]')
       };
       document.querySelector('#fingerprint').textContent = JSON.stringify(window.__fingerprint, null, 2);
     }

--- a/scripts/browser-smoke/fixtures/next.html
+++ b/scripts/browser-smoke/fixtures/next.html
@@ -16,5 +16,10 @@
     <button id="back-button" type="button" onclick="history.back()">Back</button>
     <a id="alternate-link" href="/alternate.html">Alternate latency page</a>
   </main>
+  <script>
+    if (window.parent !== window) {
+      parent.postMessage({kind: "cross-origin-probe", webdriver: navigator.webdriver}, "*");
+    }
+  </script>
 </body>
 </html>

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -300,7 +300,7 @@ def wait_for_fingerprint(
     panel_id: str,
     action_ids: list[str],
 ) -> dict[str, Any]:
-    expression = "({fingerprint: window.__fingerprint ?? null, iframe: window.__iframeWebdriver ?? null})"
+    expression = "({fingerprint: window.__fingerprint ?? null, iframeReady: window.__iframeProbeReady === true})"
     deadline = time.monotonic() + 10
     value: Any = None
     while time.monotonic() < deadline:
@@ -311,10 +311,18 @@ def wait_for_fingerprint(
             action_ids,
         )
         value = result["value"]
-        if isinstance(value, dict) and isinstance(value.get("fingerprint"), dict) and value.get("iframe") is not None:
+        if (
+            isinstance(value, dict)
+            and isinstance(value.get("fingerprint"), dict)
+            and value.get("iframeReady") is True
+        ):
             return value["fingerprint"]
         time.sleep(0.1)
     raise AssertionError(f"fingerprint did not settle: {value}")
+
+
+def _webdriver_hidden(value: Any) -> bool:
+    return value in {False, None}
 
 
 def verify_disclosure(fingerprint: dict[str, Any], backend: str, policy: str) -> None:
@@ -326,11 +334,25 @@ def verify_disclosure(fingerprint: dict[str, Any], backend: str, policy: str) ->
     if policy == "browser_default":
         if observed != [True, True, True]:
             raise AssertionError(f"browser-default disclosure mismatch: {fingerprint}")
-    elif backend in {"chromium", "firefox"} and observed != [False, False, False]:
-        raise AssertionError(f"common-signal minimization mismatch: {fingerprint}")
+    elif backend == "firefox":
+        if observed != [False, False, False]:
+            raise AssertionError(f"common-signal minimization mismatch: {fingerprint}")
+    elif backend == "chromium":
+        if not all(_webdriver_hidden(value) for value in observed):
+            raise AssertionError(f"common-signal minimization mismatch: {fingerprint}")
+    horizon_names = fingerprint.get("horizonNames") or []
+    if horizon_names:
+        raise AssertionError(f"page advertised Horizon identifiers: {fingerprint}")
     if policy == "minimize_common_signals" and backend == "chromium":
         if "HeadlessChrome" in str(fingerprint.get("userAgent")):
             raise AssertionError(f"headless token remained: {fingerprint}")
+        brands = list(fingerprint.get("brands") or []) + list(
+            (fingerprint.get("high") or {}).get("fullVersionList") or []
+        )
+        if any(isinstance(entry, dict) and entry.get("brand") == "HeadlessChrome" for entry in brands):
+            raise AssertionError(f"headless client-hint brand remained: {fingerprint}")
+        if any(value is False for value in observed) and fingerprint.get("webdriverGetterNative") is not True:
+            raise AssertionError(f"chromium webdriver getter was not native: {fingerprint}")
 
 
 def failed_action_id(error: str) -> str:

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -330,6 +330,16 @@ def _webdriver_hidden(value: Any) -> bool:
     return value in {False, None}
 
 
+def _positive_pair(value: Any, name: str, fingerprint: dict[str, Any]) -> tuple[float, float]:
+    if not (
+        isinstance(value, list)
+        and len(value) == 2
+        and all(isinstance(item, (int, float)) and not isinstance(item, bool) and item > 0 for item in value)
+    ):
+        raise AssertionError(f"{name} geometry was missing or invalid: {fingerprint}")
+    return float(value[0]), float(value[1])
+
+
 def verify_disclosure(fingerprint: dict[str, Any], backend: str, policy: str) -> None:
     observed = [
         fingerprint.get("earlyWebdriver"),
@@ -349,6 +359,13 @@ def verify_disclosure(fingerprint: dict[str, Any], backend: str, policy: str) ->
     horizon_names = fingerprint.get("horizonNames") or []
     if horizon_names:
         raise AssertionError(f"page advertised Horizon identifiers: {fingerprint}")
+    viewport = _positive_pair(fingerprint.get("viewport"), "viewport", fingerprint)
+    screen = _positive_pair(fingerprint.get("screen"), "screen", fingerprint)
+    dpr = fingerprint.get("dpr")
+    if not isinstance(dpr, (int, float)) or isinstance(dpr, bool) or dpr <= 0:
+        raise AssertionError(f"device pixel ratio was missing or invalid: {fingerprint}")
+    if viewport == screen:
+        raise AssertionError(f"viewport claimed the display size: {fingerprint}")
     if policy == "minimize_common_signals" and backend == "chromium":
         if "HeadlessChrome" in str(fingerprint.get("userAgent")):
             raise AssertionError(f"headless token remained: {fingerprint}")

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -349,9 +349,12 @@ def verify_disclosure(fingerprint: dict[str, Any], backend: str, policy: str) ->
         brands = list(fingerprint.get("brands") or []) + list(
             (fingerprint.get("high") or {}).get("fullVersionList") or []
         )
-        if any(isinstance(entry, dict) and entry.get("brand") == "HeadlessChrome" for entry in brands):
+        brand_names = [entry.get("brand") for entry in brands if isinstance(entry, dict)]
+        if "HeadlessChrome" in brand_names:
             raise AssertionError(f"headless client-hint brand remained: {fingerprint}")
-        if any(value is False for value in observed) and fingerprint.get("webdriverGetterNative") is not True:
+        if not any(name in {"Chrome", "Chromium"} for name in brand_names):
+            raise AssertionError(f"client-hint brands omitted Chrome/Chromium: {fingerprint}")
+        if fingerprint.get("webdriverDescriptorPresent") is True and fingerprint.get("webdriverGetterNative") is not True:
             raise AssertionError(f"chromium webdriver getter was not native: {fingerprint}")
 
 

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -300,7 +300,11 @@ def wait_for_fingerprint(
     panel_id: str,
     action_ids: list[str],
 ) -> dict[str, Any]:
-    expression = "({fingerprint: window.__fingerprint ?? null, iframeReady: window.__iframeProbeReady === true})"
+    expression = (
+        "({fingerprint: window.__fingerprint ?? null, "
+        "iframeReady: window.__iframeProbeReady === true, "
+        "crossOriginReady: window.__crossOriginProbeReady === true})"
+    )
     deadline = time.monotonic() + 10
     value: Any = None
     while time.monotonic() < deadline:
@@ -315,6 +319,7 @@ def wait_for_fingerprint(
             isinstance(value, dict)
             and isinstance(value.get("fingerprint"), dict)
             and value.get("iframeReady") is True
+            and value.get("crossOriginReady") is True
         ):
             return value["fingerprint"]
         time.sleep(0.1)
@@ -330,12 +335,13 @@ def verify_disclosure(fingerprint: dict[str, Any], backend: str, policy: str) ->
         fingerprint.get("earlyWebdriver"),
         fingerprint.get("currentWebdriver"),
         fingerprint.get("iframeWebdriver"),
+        fingerprint.get("crossOriginWebdriver"),
     ]
     if policy == "browser_default":
-        if observed != [True, True, True]:
+        if observed != [True, True, True, True]:
             raise AssertionError(f"browser-default disclosure mismatch: {fingerprint}")
     elif backend == "firefox":
-        if observed != [False, False, False]:
+        if observed != [False, False, False, False]:
             raise AssertionError(f"common-signal minimization mismatch: {fingerprint}")
     elif backend == "chromium":
         if not all(_webdriver_hidden(value) for value in observed):


### PR DESCRIPTION
Closes #358

## Purpose

- Stop advertising Horizon or a headless/WebDriver environment on the page JS surface after a panel attaches.
- Keep the original Chromium/Firefox session, profile, and network path; this does not change the #351 challenge-loop detector.

## Behavior impact

- Chromium title updates come from `Target.getTargetInfo` / `Target.targetInfoChanged` instead of `window.__horizonBrowserTitleChanged`.
- Chromium no longer installs a script-defined `navigator.webdriver` getter; it keeps `--disable-blink-features=AutomationControlled`. Firefox still installs the BiDi preload.
- Headless Chromium Client Hint `brands` / `fullVersionList` rename only `HeadlessChrome` to `Chrome` and keep browser-owned platform, architecture, and versions.
- Viewport overrides no longer claim the panel size is the display, and Firefox no longer forces `devicePixelRatio: 1.0`.
- `Runtime.enable` is deferred until snapshot, evaluate, clipboard, or scrollbar scrolling needs it, including tracked iframe sessions. The input path queues enable as an ordered fire-and-forget request instead of `call_and_ack`. Detached iframe sessions are dropped from Runtime tracking.
- Firefox WebSocket capture uses a per-capture hashed page key instead of a Horizon-prefixed global.

Safari is unchanged. Headed-but-offscreen Chromium remains a separate design.

## Validation

Exact head: `834f26dd6531fb264508c0c863324b1ee882d142`

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- strict unwrap/expect Clippy tier
- advisory pedantic Clippy tier

Linux X11 disclosure smoke on that head, `--skip-handoff --ephemeral`, task-owned Xvfb `:104`:

- Chromium `minimize_common_signals` and `browser_default`: MCP gate passed, 42 completed actions, trusted double-click, 4113 frames, `candidate_status: 0`, `mcp_status: 0`, `git_dirty: false`
- Firefox `minimize_common_signals` and `browser_default`: same gate and exit status, including the cross-origin consent-frame `navigator.webdriver` probe

Each candidate window was closed through `alt+F4`. Safari and headed-but-offscreen Chromium are out of this landing.

