### PR TITLE
fix(browser): re-stamp browser manifests on the frame a panel moves

### DIFF
--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -61,8 +61,9 @@ pub use visibility::{
     record_visibility_status, take_visibility_result,
 };
 pub use workspace::{
-    AgentIdentity, HOST_INSTANCE_ENV, ManifestWorkspace, OUTSIDE_WORKSPACE_MESSAGE, actor_is_workspace_scoped,
-    host_instance, publish_requested_panel, read_audit_for, sync_host_state, sync_host_state_in, valid_host_instance,
+    AgentIdentity, HOST_INSTANCE_ENV, HostStampOutcome, ManifestWorkspace, OUTSIDE_WORKSPACE_MESSAGE,
+    actor_is_workspace_scoped, host_instance, publish_requested_panel, read_audit_for, sync_host_state,
+    sync_host_state_in, valid_host_instance,
 };
 
 /// How long an agent owner heartbeat stays fresh.

--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -62,7 +62,7 @@ pub use visibility::{
 };
 pub use workspace::{
     AgentIdentity, HOST_INSTANCE_ENV, ManifestWorkspace, OUTSIDE_WORKSPACE_MESSAGE, actor_is_workspace_scoped,
-    host_instance, publish_requested_panel, read_audit_for, sync_host_state, valid_host_instance,
+    host_instance, publish_requested_panel, read_audit_for, sync_host_state, sync_host_state_in, valid_host_instance,
 };
 
 /// How long an agent owner heartbeat stays fresh.

--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -238,8 +238,20 @@ pub fn read(panel_local_id: &str) -> Option<BrowserManifest> {
 
 #[must_use]
 pub fn read_at(path: &Path) -> Option<BrowserManifest> {
-    let raw = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&raw).ok()
+    try_read_at(path).ok().flatten()
+}
+
+/// Read a manifest, distinguishing an absent file (`Ok(None)`) from a read
+/// or parse failure, which callers that must retry later need to see.
+fn try_read_at(path: &Path) -> std::io::Result<Option<BrowserManifest>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    serde_json::from_str(&raw)
+        .map(Some)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
 }
 
 /// List panel local ids that currently have a valid, canonically named

--- a/crates/horizon-core/src/browser/manifest/workspace.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace.rs
@@ -170,6 +170,25 @@ pub fn sync_host_state(panel_local_id: &str, visible: bool, workspace: &Manifest
     )
 }
 
+/// Like [`sync_host_state`], addressing the manifest under `root` instead of
+/// the process default Horizon home.
+///
+/// # Errors
+/// Same as [`sync_host_state`].
+pub fn sync_host_state_in(
+    root: &Path,
+    panel_local_id: &str,
+    visible: bool,
+    workspace: &ManifestWorkspace,
+) -> std::io::Result<bool> {
+    sync_host_state_at(
+        &manifest_path_for_root(root, panel_local_id),
+        panel_local_id,
+        visible,
+        workspace,
+    )
+}
+
 fn sync_host_state_at(
     path: &Path,
     panel_local_id: &str,

--- a/crates/horizon-core/src/browser/manifest/workspace.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace.rs
@@ -20,14 +20,25 @@ use horizon_browser::BrowserAuditEntry;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BrowserManifest, ManifestLock, audit, default_manifest_path, manifest_path_for_root, mutate_at, now_millis,
-    read_at, update_at,
+    BrowserManifest, ManifestLock, audit, default_manifest_path, manifest_path_for_root, mutate_at, now_millis, read_at,
 };
 use crate::horizon_home::HorizonHome;
 
 /// Error text shared by every locked transaction that refuses an identity
 /// outside the panel's workspace.
 pub const OUTSIDE_WORKSPACE_MESSAGE: &str = "agent is outside this browser panel's workspace";
+
+/// What a host-state sync did to one manifest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HostStampOutcome {
+    /// Presentation or membership changed and the manifest was rewritten.
+    Written,
+    /// The manifest already carried this host state; nothing was written.
+    Unchanged,
+    /// The manifest records another host's driver (or none), so this host
+    /// must not stamp it. Distinct from an I/O failure, which is an error.
+    NotOwned,
+}
 const OTHER_HOST_MESSAGE: &str = "browser panel's driver runs in another Horizon host";
 /// Environment variable through which Horizon tells an agent process, and
 /// the MCP server it starts, which host process injected its identity.
@@ -156,12 +167,17 @@ impl ManifestWorkspace {
 }
 
 /// Stamp host-owned presentation and placement state on a live manifest,
-/// writing only when something differs. Returns whether a write happened.
+/// writing only when something differs.
 ///
 /// # Errors
 /// Returns `NotFound` when the panel is not live, or another error when the
-/// locked manifest transaction fails.
-pub fn sync_host_state(panel_local_id: &str, visible: bool, workspace: &ManifestWorkspace) -> std::io::Result<bool> {
+/// locked manifest transaction fails. A manifest owned by another host's
+/// driver is reported as [`HostStampOutcome::NotOwned`], not as an error.
+pub fn sync_host_state(
+    panel_local_id: &str,
+    visible: bool,
+    workspace: &ManifestWorkspace,
+) -> std::io::Result<HostStampOutcome> {
     sync_host_state_at(
         &default_manifest_path(panel_local_id),
         panel_local_id,
@@ -180,7 +196,7 @@ pub fn sync_host_state_in(
     panel_local_id: &str,
     visible: bool,
     workspace: &ManifestWorkspace,
-) -> std::io::Result<bool> {
+) -> std::io::Result<HostStampOutcome> {
     sync_host_state_at(
         &manifest_path_for_root(root, panel_local_id),
         panel_local_id,
@@ -194,7 +210,7 @@ fn sync_host_state_at(
     panel_local_id: &str,
     visible: bool,
     workspace: &ManifestWorkspace,
-) -> std::io::Result<bool> {
+) -> std::io::Result<HostStampOutcome> {
     let hidden = !visible;
     let current = read_at(path).ok_or_else(|| {
         std::io::Error::new(
@@ -202,18 +218,23 @@ fn sync_host_state_at(
             format!("browser manifest is not live: {}", path.display()),
         )
     })?;
-    require_driver_host(&current, workspace)?;
-    if current.hidden == hidden && current.workspace.as_ref() == Some(workspace) {
-        return Ok(false);
+    if !driver_host_matches(&current, workspace) {
+        return Ok(HostStampOutcome::NotOwned);
     }
-    let mut outcome = Ok(());
-    update_at(path, panel_local_id, |manifest| {
-        outcome = require_driver_host(manifest, workspace);
-        if outcome.is_ok() {
+    if current.hidden == hidden && current.workspace.as_ref() == Some(workspace) {
+        return Ok(HostStampOutcome::Unchanged);
+    }
+    let mut outcome = HostStampOutcome::NotOwned;
+    mutate_at(path, panel_local_id, false, |manifest| {
+        if driver_host_matches(manifest, workspace) {
             stamp(manifest, hidden, workspace, now_millis());
+            outcome = HostStampOutcome::Written;
+            true
+        } else {
+            false
         }
     })?;
-    outcome.map(|()| true)
+    Ok(outcome)
 }
 
 /// Stamp a freshly created panel and assign its requested owner in one locked
@@ -309,10 +330,14 @@ fn stamp(manifest: &mut BrowserManifest, hidden: bool, workspace: &ManifestWorks
     manifest.updated_at = now;
 }
 
+fn driver_host_matches(manifest: &BrowserManifest, workspace: &ManifestWorkspace) -> bool {
+    manifest.host.as_deref() == Some(workspace.host_instance.as_str())
+}
+
 /// Only the process running the panel's driver may stamp it; a manifest
 /// without a recorded host (older driver) is never stamped.
 fn require_driver_host(manifest: &BrowserManifest, workspace: &ManifestWorkspace) -> std::io::Result<()> {
-    if manifest.host.as_deref() == Some(workspace.host_instance.as_str()) {
+    if driver_host_matches(manifest, workspace) {
         Ok(())
     } else {
         Err(std::io::Error::new(

--- a/crates/horizon-core/src/browser/manifest/workspace.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace.rs
@@ -20,7 +20,8 @@ use horizon_browser::BrowserAuditEntry;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BrowserManifest, ManifestLock, audit, default_manifest_path, manifest_path_for_root, mutate_at, now_millis, read_at,
+    BrowserManifest, ManifestLock, audit, default_manifest_path, manifest_path_for_root, mutate_at, now_millis,
+    read_at, try_read_at,
 };
 use crate::horizon_home::HorizonHome;
 
@@ -212,7 +213,9 @@ fn sync_host_state_at(
     workspace: &ManifestWorkspace,
 ) -> std::io::Result<HostStampOutcome> {
     let hidden = !visible;
-    let current = read_at(path).ok_or_else(|| {
+    // Only an absent file is "not live"; a read or parse failure propagates
+    // so callers that retry later do not mistake it for a missing panel.
+    let current = try_read_at(path)?.ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
             format!("browser manifest is not live: {}", path.display()),

--- a/crates/horizon-core/src/browser/manifest/workspace/tests.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::browser::manifest::write_at;
+use crate::browser::manifest::{update_at, write_at};
 
 const HOST_A: &str = "host-a";
 const HOST_B: &str = "host-b";
@@ -147,13 +147,22 @@ fn host_state_sync_writes_only_when_presentation_or_membership_changes() {
     write_at(&path, &driver_manifest(Some(HOST_A))).expect("write manifest");
     let workspace = stamp(HOST_A, &["horizon:agent-a"]);
 
-    assert!(sync_host_state_at(&path, "panel", true, &workspace).expect("stamp"));
+    assert_eq!(
+        sync_host_state_at(&path, "panel", true, &workspace).expect("stamp"),
+        HostStampOutcome::Written
+    );
     let stamped = read_at(&path).expect("read stamped");
     assert!(!stamped.hidden);
     assert_eq!(stamped.workspace.as_ref(), Some(&workspace));
-    assert!(!sync_host_state_at(&path, "panel", true, &workspace).expect("steady state"));
+    assert_eq!(
+        sync_host_state_at(&path, "panel", true, &workspace).expect("steady state"),
+        HostStampOutcome::Unchanged
+    );
 
-    assert!(sync_host_state_at(&path, "panel", false, &workspace).expect("hide"));
+    assert_eq!(
+        sync_host_state_at(&path, "panel", false, &workspace).expect("hide"),
+        HostStampOutcome::Written
+    );
     assert!(read_at(&path).expect("read hidden").hidden);
 
     // The member holds the lease and a pending handoff when the host moves
@@ -173,14 +182,18 @@ fn host_state_sync_writes_only_when_presentation_or_membership_changes() {
         });
     })
     .expect("seed lease and handoff");
-    assert!(
-        !sync_host_state_at(&path, "panel", false, &workspace).expect("same placement"),
+    assert_eq!(
+        sync_host_state_at(&path, "panel", false, &workspace).expect("same placement"),
+        HostStampOutcome::Unchanged,
         "an unchanged placement keeps the lease and handoff"
     );
     assert!(read_at(&path).expect("read").handoff_pending().is_some());
 
     let moved = ManifestWorkspace::new(HOST_A, "ws-b", vec!["horizon:agent-b".to_string()]);
-    assert!(sync_host_state_at(&path, "panel", false, &moved).expect("move"));
+    assert_eq!(
+        sync_host_state_at(&path, "panel", false, &moved).expect("move"),
+        HostStampOutcome::Written
+    );
     let after_move = read_at(&path).expect("read moved");
     assert!(after_move.authorizes(AgentIdentity::new("horizon:agent-b", Some(HOST_A))));
     assert!(!after_move.authorizes(member()));
@@ -195,10 +208,9 @@ fn host_state_sync_writes_only_when_presentation_or_membership_changes() {
 
     let other_host = stamp(HOST_B, &["horizon:agent-a"]);
     assert_eq!(
-        sync_host_state_at(&path, "panel", false, &other_host)
-            .expect_err("another live host must not rewrite the stamp")
-            .kind(),
-        std::io::ErrorKind::PermissionDenied
+        sync_host_state_at(&path, "panel", false, &other_host).expect("foreign host is reported, not an error"),
+        HostStampOutcome::NotOwned,
+        "another live host must not rewrite the stamp"
     );
     assert!(
         read_at(&path)
@@ -210,10 +222,9 @@ fn host_state_sync_writes_only_when_presentation_or_membership_changes() {
     let legacy = manifest_path_for_root(root.path(), "legacy");
     write_at(&legacy, &driver_manifest(None)).expect("write legacy manifest");
     assert_eq!(
-        sync_host_state_at(&legacy, "legacy", true, &workspace)
-            .expect_err("a manifest without a recorded host is never stamped")
-            .kind(),
-        std::io::ErrorKind::PermissionDenied
+        sync_host_state_at(&legacy, "legacy", true, &workspace).expect("host-less manifest is reported, not an error"),
+        HostStampOutcome::NotOwned,
+        "a manifest without a recorded host is never stamped"
     );
 
     let missing = manifest_path_for_root(root.path(), "missing");

--- a/crates/horizon-core/src/browser/manifest/workspace/tests.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace/tests.rs
@@ -227,6 +227,24 @@ fn host_state_sync_writes_only_when_presentation_or_membership_changes() {
         "a manifest without a recorded host is never stamped"
     );
 
+    let corrupt = manifest_path_for_root(root.path(), "corrupt");
+    std::fs::write(&corrupt, b"{ not json").expect("write corrupt manifest");
+    assert_eq!(
+        sync_host_state_at(&corrupt, "corrupt", true, &workspace)
+            .expect_err("a corrupt manifest is a read failure, not a missing panel")
+            .kind(),
+        std::io::ErrorKind::InvalidData
+    );
+    let unreadable = manifest_path_for_root(root.path(), "unreadable");
+    std::fs::create_dir_all(&unreadable).expect("directory where a manifest is expected");
+    assert_ne!(
+        sync_host_state_at(&unreadable, "unreadable", true, &workspace)
+            .expect_err("an unreadable manifest path is a read failure")
+            .kind(),
+        std::io::ErrorKind::NotFound,
+        "only an absent file is reported as not live"
+    );
+
     let missing = manifest_path_for_root(root.path(), "missing");
     assert_eq!(
         sync_host_state_at(&missing, "missing", true, &workspace)

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -46,8 +46,6 @@ impl HorizonApp {
     pub(super) fn poll_browser_create_requests(&mut self) -> bool {
         let mut changed = self.finish_pending_browser_creates();
         let now = Instant::now();
-        let placement = placement_fingerprint(&self.board);
-        let placement_changed = self.browser_create_host.stamped_placement != Some(placement);
         let poll_due = self
             .browser_create_host
             .last_request_poll
@@ -55,14 +53,26 @@ impl HorizonApp {
         if poll_due {
             self.browser_create_host.last_request_poll = Some(now);
             changed |= self.poll_host_requests();
-        }
-        // Moving or hiding a panel must revoke the old workspace's access
-        // now, not up to one tick later.
-        if poll_due || placement_changed {
-            self.browser_create_host.stamped_placement = Some(placement);
+            self.browser_create_host.stamped_placement = Some(placement_fingerprint(&self.board));
             changed |= self.sync_browser_manifest_host_state();
+        } else {
+            changed |= self.restamp_browser_manifests_for_placement();
         }
         changed
+    }
+
+    /// Re-stamp the manifests as soon as the board placement they depend on
+    /// changes. This runs at the end of every frame, after queued workspace
+    /// changes and the moves made while rendering, so moving or hiding a
+    /// panel revokes the old workspace's access before the frame ends rather
+    /// than on a later tick.
+    pub(super) fn restamp_browser_manifests_for_placement(&mut self) -> bool {
+        let placement = placement_fingerprint(&self.board);
+        if self.browser_create_host.stamped_placement == Some(placement) {
+            return false;
+        }
+        self.browser_create_host.stamped_placement = Some(placement);
+        self.sync_browser_manifest_host_state()
     }
 
     fn poll_host_requests(&mut self) -> bool {
@@ -651,17 +661,25 @@ mod tests {
         assert_eq!(app.browser_create_host.stamped_placement, Some(stamped));
 
         app.board.assign_panel_to_workspace(agent_id, beta);
-        app.poll_browser_create_requests();
+        app.restamp_browser_manifests_for_placement();
         assert_eq!(
             app.browser_create_host.last_request_poll,
             Some(first_poll),
-            "a placement change does not advance the request poll cadence"
+            "the end-of-frame re-stamp does not advance the request poll cadence"
         );
+        let after_move = app.browser_create_host.stamped_placement;
         assert_ne!(
-            app.browser_create_host.stamped_placement,
+            after_move,
             Some(stamped),
             "a placement change re-stamps on the same frame"
         );
+
+        app.poll_browser_create_requests();
+        assert_eq!(
+            app.browser_create_host.stamped_placement, after_move,
+            "the next frame's poll finds the placement already stamped"
+        );
+        assert_eq!(app.browser_create_host.last_request_poll, Some(first_poll));
     }
 
     #[test]

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 
 use horizon_core::browser::manifest::{
     self, AgentIdentity, BrowserCreateAuditStatus, BrowserCreateRequest, BrowserCreateResult,
-    BrowserVisibilityAuditStatus, BrowserVisibilityRequest, BrowserVisibilityResult, ManifestWorkspace,
+    BrowserVisibilityAuditStatus, BrowserVisibilityRequest, BrowserVisibilityResult, HostStampOutcome,
+    ManifestWorkspace,
 };
 use horizon_core::browser::{BackendAvailability, BackendKind, BrowserStatus};
 use horizon_core::{Board, PanelId, PanelKind, PanelOptions, WorkspaceId, browser_actor};
@@ -417,8 +418,9 @@ fn browser_placements(board: &Board) -> Vec<BrowserPlacement> {
 
 /// Stamp each placement's manifest under `root`. Manifests that are not live
 /// yet, or that another host's driver owns, are not this host's to stamp and
-/// do not make the sync incomplete; any other failure does, so the caller
-/// retries on the next frame.
+/// do not make the sync incomplete; every I/O failure does (including a
+/// permission failure on the lock or the write), so the caller retries on
+/// the next frame.
 fn sync_manifest_host_state(root: &Path, placements: &[BrowserPlacement]) -> HostStateSync {
     let mut sync = HostStateSync {
         changed: false,
@@ -426,12 +428,12 @@ fn sync_manifest_host_state(root: &Path, placements: &[BrowserPlacement]) -> Hos
     };
     for placement in placements {
         match manifest::sync_host_state_in(root, &placement.local_id, placement.visible, &placement.workspace) {
-            Ok(true) => sync.changed = true,
-            Ok(false) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-                tracing::debug!(panel_id = %placement.local_id, %error, "browser manifest belongs to another Horizon host");
+            Ok(HostStampOutcome::Written) => sync.changed = true,
+            Ok(HostStampOutcome::Unchanged) => {}
+            Ok(HostStampOutcome::NotOwned) => {
+                tracing::debug!(panel_id = %placement.local_id, "browser manifest belongs to another Horizon host");
             }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => {
                 sync.complete = false;
                 tracing::warn!(panel_id = %placement.local_id, %error, "could not synchronize browser host state");
@@ -623,7 +625,13 @@ fn publish_manifest_host_state(
     visible: bool,
     workspace: &ManifestWorkspace,
 ) -> std::io::Result<()> {
-    manifest::sync_host_state(panel_local_id, visible, workspace).map(|_| ())
+    match manifest::sync_host_state(panel_local_id, visible, workspace)? {
+        HostStampOutcome::Written | HostStampOutcome::Unchanged => Ok(()),
+        HostStampOutcome::NotOwned => Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "browser panel's driver runs in another Horizon host",
+        )),
+    }
 }
 
 fn complete_visibility_failure(request: &BrowserVisibilityRequest, code: &str, message: &str) {

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -67,12 +67,13 @@ impl HorizonApp {
             .browser_create_host
             .last_request_poll
             .is_none_or(|last| now.saturating_duration_since(last) >= CREATE_REQUEST_POLL_INTERVAL);
+        // Placement changes are handled once per frame, after rendering, by
+        // `restamp_browser_manifests_for_placement`; the tick only keeps the
+        // cadence-based stamp.
         if poll_due {
             self.browser_create_host.last_request_poll = Some(now);
             changed |= self.poll_host_requests();
             changed |= self.stamp_current_placement();
-        } else {
-            changed |= self.restamp_browser_manifests_for_placement();
         }
         changed
     }
@@ -440,9 +441,12 @@ fn sync_manifest_host_state(root: &Path, placements: &[BrowserPlacement]) -> Hos
     sync
 }
 
-/// Everything the workspace stamps depend on: which workspace each browser
-/// and agent panel sits in, and whether each browser panel is shown. Cheap
-/// enough to compute every frame; it hashes no strings and touches no files.
+/// Everything the workspace stamps depend on: the persisted identity of each
+/// browser and agent panel, the persisted identity of the workspace it sits
+/// in, and whether each browser panel is shown. Persisted ids rather than
+/// board ids, because activating another session replaces the board and
+/// restarts its numeric ids. Cheap enough to compute once per frame; it
+/// touches no files.
 fn placement_fingerprint(board: &Board) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     for panel in &board.panels {
@@ -450,8 +454,11 @@ fn placement_fingerprint(board: &Board) -> u64 {
         if !browser && !panel.kind.is_agent() {
             continue;
         }
-        panel.id.hash(&mut hasher);
-        panel.workspace_id.hash(&mut hasher);
+        panel.local_id.hash(&mut hasher);
+        board
+            .workspace(panel.workspace_id)
+            .map(|workspace| workspace.local_id.as_str())
+            .hash(&mut hasher);
         browser.hash(&mut hasher);
         (browser && panel.visible).hash(&mut hasher);
     }
@@ -690,6 +697,20 @@ mod tests {
             with_agent,
             "moving back restores the fingerprint"
         );
+
+        // A replacement board (another session) restarts numeric ids; its
+        // persisted ids differ, so its fingerprint must differ too.
+        let mut replacement = Board::new();
+        let other_alpha = replacement.create_workspace("alpha");
+        replacement.create_workspace("beta");
+        replacement
+            .create_panel(agent_options(), other_alpha)
+            .expect("agent panel in the replacement board");
+        assert_ne!(
+            placement_fingerprint(&replacement),
+            with_agent,
+            "identically shaped boards with different persisted ids never share a fingerprint"
+        );
     }
 
     #[test]
@@ -788,9 +809,13 @@ mod tests {
         app.poll_browser_create_requests();
         assert_eq!(
             app.browser_create_host.stamped_placement, after_move,
-            "the next frame's poll finds the placement already stamped"
+            "the next frame's poll leaves the placement to the end-of-frame check"
         );
         assert_eq!(app.browser_create_host.last_request_poll, Some(first_poll));
+        assert!(
+            !app.restamp_browser_manifests_for_placement(),
+            "an unchanged placement is not re-stamped again"
+        );
     }
 
     #[test]

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -1,5 +1,6 @@
 //! Host-side handling for agent-requested browser panel lifecycle changes.
 
+use std::hash::{Hash, Hasher};
 use std::time::{Duration, Instant};
 
 use horizon_core::browser::manifest::{
@@ -17,6 +18,9 @@ const CREATE_REQUEST_POLL_INTERVAL: Duration = Duration::from_millis(500);
 pub(super) struct BrowserCreateHostState {
     last_request_poll: Option<Instant>,
     pending: Vec<PendingBrowserCreate>,
+    /// Board placement the manifests were last stamped for; a change
+    /// re-stamps on the same frame instead of waiting for the next tick.
+    stamped_placement: Option<u64>,
 }
 
 struct PendingBrowserCreate {
@@ -42,15 +46,27 @@ impl HorizonApp {
     pub(super) fn poll_browser_create_requests(&mut self) -> bool {
         let mut changed = self.finish_pending_browser_creates();
         let now = Instant::now();
-        if self
+        let placement = placement_fingerprint(&self.board);
+        let placement_changed = self.browser_create_host.stamped_placement != Some(placement);
+        let poll_due = self
             .browser_create_host
             .last_request_poll
-            .is_some_and(|last| now.saturating_duration_since(last) < CREATE_REQUEST_POLL_INTERVAL)
-        {
-            return changed;
+            .is_none_or(|last| now.saturating_duration_since(last) >= CREATE_REQUEST_POLL_INTERVAL);
+        if poll_due {
+            self.browser_create_host.last_request_poll = Some(now);
+            changed |= self.poll_host_requests();
         }
-        self.browser_create_host.last_request_poll = Some(now);
+        // Moving or hiding a panel must revoke the old workspace's access
+        // now, not up to one tick later.
+        if poll_due || placement_changed {
+            self.browser_create_host.stamped_placement = Some(placement);
+            changed |= self.sync_browser_manifest_host_state();
+        }
+        changed
+    }
 
+    fn poll_host_requests(&mut self) -> bool {
+        let mut changed = false;
         let requests = match manifest::list_create_requests() {
             Ok(requests) => requests,
             Err(error) => {
@@ -81,9 +97,7 @@ impl HorizonApp {
             changed = true;
             self.start_requested_browser(request, actor_panel);
         }
-        changed |= self.poll_browser_visibility_requests();
-        changed |= self.sync_browser_manifest_host_state();
-        changed
+        changed | self.poll_browser_visibility_requests()
     }
 
     fn start_requested_browser(&mut self, request: BrowserCreateRequest, actor_panel: ActorPanel) {
@@ -365,6 +379,24 @@ fn browser_workspace(board: &Board, workspace_id: WorkspaceId) -> Option<Manifes
     ))
 }
 
+/// Everything the workspace stamps depend on: which workspace each browser
+/// and agent panel sits in, and whether each browser panel is shown. Cheap
+/// enough to compute every frame; it hashes no strings and touches no files.
+fn placement_fingerprint(board: &Board) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for panel in &board.panels {
+        let browser = panel.kind == PanelKind::Browser;
+        if !browser && !panel.kind.is_agent() {
+            continue;
+        }
+        panel.id.hash(&mut hasher);
+        panel.workspace_id.hash(&mut hasher);
+        browser.hash(&mut hasher);
+        (browser && panel.visible).hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 /// Requests name the host that launched the agent; a second Horizon process
 /// hosting a copy of the same session must leave them alone.
 fn launched_by_this_host(host_instance: Option<&str>) -> bool {
@@ -542,6 +574,95 @@ fn complete_visibility_result(result: &BrowserVisibilityResult) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::test_support::test_app;
+
+    fn agent_options() -> PanelOptions {
+        let (command, args) = if cfg!(windows) {
+            ("cmd.exe", vec!["/C".to_string(), "exit 0".to_string()])
+        } else {
+            ("/bin/sh", vec!["-c".to_string(), "exit 0".to_string()])
+        };
+        PanelOptions {
+            command: Some(command.to_string()),
+            args,
+            kind: PanelKind::Codex,
+            ..PanelOptions::default()
+        }
+    }
+
+    #[test]
+    fn placement_fingerprint_follows_membership_not_unrelated_panels() {
+        let mut board = Board::new();
+        let alpha = board.create_workspace("alpha");
+        let beta = board.create_workspace("beta");
+        let empty = placement_fingerprint(&board);
+        let agent_id = board.create_panel(agent_options(), alpha).expect("agent panel");
+        let with_agent = placement_fingerprint(&board);
+        assert_ne!(
+            empty, with_agent,
+            "an agent panel joining a workspace changes the stamp inputs"
+        );
+
+        let shell_id = board
+            .create_panel(
+                PanelOptions {
+                    kind: PanelKind::Shell,
+                    ..agent_options()
+                },
+                alpha,
+            )
+            .expect("shell panel");
+        assert_eq!(
+            placement_fingerprint(&board),
+            with_agent,
+            "shell panels do not take part in browser authorization"
+        );
+        board.assign_panel_to_workspace(shell_id, beta);
+        assert_eq!(placement_fingerprint(&board), with_agent);
+
+        board.assign_panel_to_workspace(agent_id, beta);
+        let moved = placement_fingerprint(&board);
+        assert_ne!(with_agent, moved, "moving an agent panel changes the stamp inputs");
+        board.assign_panel_to_workspace(agent_id, alpha);
+        assert_eq!(
+            placement_fingerprint(&board),
+            with_agent,
+            "moving back restores the fingerprint"
+        );
+    }
+
+    #[test]
+    fn a_placement_change_restamps_before_the_next_poll_tick() {
+        let (_temp, mut app) = test_app();
+        let alpha = app.board.create_workspace("alpha");
+        let beta = app.board.create_workspace("beta");
+        let agent_id = app.board.create_panel(agent_options(), alpha).expect("agent panel");
+
+        app.poll_browser_create_requests();
+        let first_poll = app.browser_create_host.last_request_poll.expect("first tick polls");
+        let stamped = app.browser_create_host.stamped_placement.expect("first tick stamps");
+
+        app.poll_browser_create_requests();
+        assert_eq!(
+            app.browser_create_host.last_request_poll,
+            Some(first_poll),
+            "an unchanged board waits for the poll interval"
+        );
+        assert_eq!(app.browser_create_host.stamped_placement, Some(stamped));
+
+        app.board.assign_panel_to_workspace(agent_id, beta);
+        app.poll_browser_create_requests();
+        assert_eq!(
+            app.browser_create_host.last_request_poll,
+            Some(first_poll),
+            "a placement change does not advance the request poll cadence"
+        );
+        assert_ne!(
+            app.browser_create_host.stamped_placement,
+            Some(stamped),
+            "a placement change re-stamps on the same frame"
+        );
+    }
 
     #[test]
     fn only_the_exact_horizon_actor_matches_a_panel() {

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -1,6 +1,7 @@
 //! Host-side handling for agent-requested browser panel lifecycle changes.
 
 use std::hash::{Hash, Hasher};
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use horizon_core::browser::manifest::{
@@ -42,6 +43,22 @@ enum BrowserCreateCompletion {
     Failed,
 }
 
+/// One browser panel's host-owned state as the board currently has it.
+struct BrowserPlacement {
+    local_id: String,
+    visible: bool,
+    workspace: ManifestWorkspace,
+}
+
+/// Outcome of stamping every browser manifest: whether any file changed and
+/// whether every manifest this host owns is now current. An incomplete sync
+/// keeps the placement fingerprint uncommitted so the next frame retries.
+#[derive(Clone, Copy)]
+struct HostStateSync {
+    changed: bool,
+    complete: bool,
+}
+
 impl HorizonApp {
     pub(super) fn poll_browser_create_requests(&mut self) -> bool {
         let mut changed = self.finish_pending_browser_creates();
@@ -53,8 +70,7 @@ impl HorizonApp {
         if poll_due {
             self.browser_create_host.last_request_poll = Some(now);
             changed |= self.poll_host_requests();
-            self.browser_create_host.stamped_placement = Some(placement_fingerprint(&self.board));
-            changed |= self.sync_browser_manifest_host_state();
+            changed |= self.stamp_current_placement();
         } else {
             changed |= self.restamp_browser_manifests_for_placement();
         }
@@ -67,12 +83,27 @@ impl HorizonApp {
     /// panel revokes the old workspace's access before the frame ends rather
     /// than on a later tick.
     pub(super) fn restamp_browser_manifests_for_placement(&mut self) -> bool {
-        let placement = placement_fingerprint(&self.board);
-        if self.browser_create_host.stamped_placement == Some(placement) {
+        if self.browser_create_host.stamped_placement == Some(placement_fingerprint(&self.board)) {
             return false;
         }
-        self.browser_create_host.stamped_placement = Some(placement);
-        self.sync_browser_manifest_host_state()
+        self.stamp_current_placement()
+    }
+
+    /// Stamp every owned manifest for the current placement and remember the
+    /// placement only if all of them are current, so a failed write is
+    /// retried on the next frame instead of waiting for the next tick.
+    fn stamp_current_placement(&mut self) -> bool {
+        let placement = placement_fingerprint(&self.board);
+        let sync = self.sync_browser_manifest_host_state();
+        self.browser_create_host.stamped_placement = sync.complete.then_some(placement);
+        sync.changed
+    }
+
+    /// Root of the Horizon home whose manifests this host stamps. Production
+    /// constructs the session store from `HorizonHome::resolve()`, the same
+    /// root the drivers and the MCP server use for their default paths.
+    fn host_manifest_root(&self) -> &Path {
+        self.session_store.home().root()
     }
 
     fn poll_host_requests(&mut self) -> bool {
@@ -310,30 +341,8 @@ impl HorizonApp {
     /// Keep every live browser manifest's host-owned presentation and
     /// workspace membership current, so MCP authorization follows panel moves
     /// and visibility changes made through the UI.
-    fn sync_browser_manifest_host_state(&self) -> bool {
-        let mut changed = false;
-        for panel in self
-            .board
-            .panels
-            .iter()
-            .filter(|panel| panel.kind == PanelKind::Browser)
-        {
-            let Some(workspace) = browser_workspace(&self.board, panel.workspace_id) else {
-                continue;
-            };
-            match manifest::sync_host_state(&panel.local_id, panel.visible, &workspace) {
-                Ok(true) => changed = true,
-                Ok(false) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-                    tracing::debug!(panel_id = %panel.local_id, %error, "browser manifest belongs to another Horizon host");
-                }
-                Err(error) => {
-                    tracing::warn!(panel_id = %panel.local_id, %error, "could not synchronize browser host state");
-                }
-            }
-        }
-        changed
+    fn sync_browser_manifest_host_state(&self) -> HostStateSync {
+        sync_manifest_host_state(self.host_manifest_root(), &browser_placements(&self.board))
     }
 
     fn finish_pending_browser_creates(&mut self) -> bool {
@@ -387,6 +396,48 @@ fn browser_workspace(board: &Board, workspace_id: WorkspaceId) -> Option<Manifes
         &workspace.local_id,
         actors,
     ))
+}
+
+/// The host-owned state of every browser panel on the board, in board order.
+fn browser_placements(board: &Board) -> Vec<BrowserPlacement> {
+    board
+        .panels
+        .iter()
+        .filter(|panel| panel.kind == PanelKind::Browser)
+        .filter_map(|panel| {
+            browser_workspace(board, panel.workspace_id).map(|workspace| BrowserPlacement {
+                local_id: panel.local_id.clone(),
+                visible: panel.visible,
+                workspace,
+            })
+        })
+        .collect()
+}
+
+/// Stamp each placement's manifest under `root`. Manifests that are not live
+/// yet, or that another host's driver owns, are not this host's to stamp and
+/// do not make the sync incomplete; any other failure does, so the caller
+/// retries on the next frame.
+fn sync_manifest_host_state(root: &Path, placements: &[BrowserPlacement]) -> HostStateSync {
+    let mut sync = HostStateSync {
+        changed: false,
+        complete: true,
+    };
+    for placement in placements {
+        match manifest::sync_host_state_in(root, &placement.local_id, placement.visible, &placement.workspace) {
+            Ok(true) => sync.changed = true,
+            Ok(false) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                tracing::debug!(panel_id = %placement.local_id, %error, "browser manifest belongs to another Horizon host");
+            }
+            Err(error) => {
+                sync.complete = false;
+                tracing::warn!(panel_id = %placement.local_id, %error, "could not synchronize browser host state");
+            }
+        }
+    }
+    sync
 }
 
 /// Everything the workspace stamps depend on: which workspace each browser
@@ -638,6 +689,66 @@ mod tests {
             placement_fingerprint(&board),
             with_agent,
             "moving back restores the fingerprint"
+        );
+    }
+
+    #[test]
+    fn restamping_rewrites_a_live_manifest_for_the_new_membership() {
+        let root = tempfile::tempdir().expect("isolated horizon home");
+        let mut board = Board::new();
+        let alpha = board.create_workspace("alpha");
+        let beta = board.create_workspace("beta");
+        let agent_id = board.create_panel(agent_options(), alpha).expect("agent panel");
+        let actor = browser_actor(&board.panel(agent_id).expect("agent panel").local_id);
+        let path = manifest::manifest_path_for_root(root.path(), "browser-1");
+        manifest::write_at(
+            &path,
+            &manifest::BrowserManifest {
+                panel_local_id: "browser-1".to_string(),
+                host: Some(manifest::host_instance().to_string()),
+                ..manifest::BrowserManifest::default()
+            },
+        )
+        .expect("write live manifest");
+        let placements = |board: &Board, visible: bool| {
+            vec![BrowserPlacement {
+                local_id: "browser-1".to_string(),
+                visible,
+                workspace: browser_workspace(board, alpha).expect("alpha workspace"),
+            }]
+        };
+
+        let first = sync_manifest_host_state(root.path(), &placements(&board, true));
+        assert!(first.changed && first.complete);
+        let stamped = manifest::read_at(&path).expect("stamped manifest");
+        assert!(stamped.authorizes(AgentIdentity::new(&actor, Some(manifest::host_instance()))));
+        assert!(!stamped.hidden);
+
+        board.assign_panel_to_workspace(agent_id, beta);
+        let moved = sync_manifest_host_state(root.path(), &placements(&board, false));
+        assert!(moved.changed && moved.complete);
+        let restamped = manifest::read_at(&path).expect("re-stamped manifest");
+        assert!(
+            !restamped.authorizes(AgentIdentity::new(&actor, Some(manifest::host_instance()))),
+            "the agent that left the workspace is no longer authorized"
+        );
+        assert!(restamped.hidden, "visibility follows the board");
+
+        let steady = sync_manifest_host_state(root.path(), &placements(&board, false));
+        assert!(
+            !steady.changed && steady.complete,
+            "an unchanged placement writes nothing"
+        );
+
+        let missing = vec![BrowserPlacement {
+            local_id: "not-live-yet".to_string(),
+            visible: true,
+            workspace: browser_workspace(&board, alpha).expect("alpha workspace"),
+        }];
+        let sync = sync_manifest_host_state(root.path(), &missing);
+        assert!(
+            !sync.changed && sync.complete,
+            "a manifest that is not live yet is not this host's to stamp"
         );
     }
 

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -68,13 +68,13 @@ impl HorizonApp {
             .browser_create_host
             .last_request_poll
             .is_none_or(|last| now.saturating_duration_since(last) >= CREATE_REQUEST_POLL_INTERVAL);
-        // Placement changes are handled once per frame, after rendering, by
-        // `restamp_browser_manifests_for_placement`; the tick only keeps the
-        // cadence-based stamp.
+        // Every stamp happens once per frame, after rendering, in
+        // `restamp_browser_manifests_for_placement`; the tick only requests
+        // the cadence-based one by forgetting the last stamped placement.
         if poll_due {
             self.browser_create_host.last_request_poll = Some(now);
             changed |= self.poll_host_requests();
-            changed |= self.stamp_current_placement();
+            self.browser_create_host.stamped_placement = None;
         }
         changed
     }
@@ -790,7 +790,12 @@ mod tests {
 
         app.poll_browser_create_requests();
         let first_poll = app.browser_create_host.last_request_poll.expect("first tick polls");
-        let stamped = app.browser_create_host.stamped_placement.expect("first tick stamps");
+        assert!(
+            app.browser_create_host.stamped_placement.is_none(),
+            "the tick only requests a stamp; the end-of-frame check performs it"
+        );
+        app.restamp_browser_manifests_for_placement();
+        let stamped = app.browser_create_host.stamped_placement.expect("end of frame stamps");
 
         app.poll_browser_create_requests();
         assert_eq!(

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -702,7 +702,7 @@ mod tests {
         // persisted ids differ, so its fingerprint must differ too.
         let mut replacement = Board::new();
         let other_alpha = replacement.create_workspace("alpha");
-        replacement.create_workspace("beta");
+        let _beta = replacement.create_workspace("beta");
         replacement
             .create_panel(agent_options(), other_alpha)
             .expect("agent panel in the replacement board");

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -628,6 +628,8 @@ impl eframe::App for HorizonApp {
         }
         self.render_speech_notice(ctx);
         self.finalize_frame(ctx, had_panel_output, workspace_count_before, panel_count_before);
+        // Last, after every phase that can move or hide a panel this frame.
+        self.restamp_browser_manifests_for_placement();
     }
 
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {


### PR DESCRIPTION
## Purpose

Follow-up to #361 (#359). The host refreshed workspace stamps only on its 500 ms coordination tick, so after a browser or agent panel moved between workspaces (or a browser panel was hidden or shown) the old workspace's agent kept access until the next tick.

## What changed

- `browser_requests.rs` keeps a fingerprint of the board placement the stamps depend on: the persisted local id of each browser and agent panel, the persisted local id of the workspace it sits in, and whether each browser panel is shown. Persisted ids rather than board ids, because activating another session replaces the board and restarts its numeric ids (`b11dde8`). No file I/O; computed once per frame.
- `restamp_browser_manifests_for_placement` runs the manifest host-state sync whenever the fingerprint changes; `update()` calls it last in the frame, after `finalize_frame`, so it runs after queued workspace changes and after the sidebar/drag moves made during rendering (`2a6e40c`). The 500 ms poll only forgets the last stamped placement, so the end-of-frame call is the single place that stamps (once per frame, cadence or change) and a failed sync is retried on the next frame rather than twice in one (`930e013`). Create/visibility request polling is unchanged.
- The sync reports whether every manifest this host owns is current. `manifest::sync_host_state` now returns a typed `HostStampOutcome` (`Written`, `Unchanged`, `NotOwned`), so a manifest owned by another host's driver is told apart from a filesystem permission failure; only `NotOwned` and a genuinely absent manifest leave the sync complete, and every I/O error keeps the fingerprint uncommitted so the next frame retries (`8980079`, `7b34a15`). A fallible `try_read_at` reserves `NotFound` for an absent file; a corrupt or unreadable manifest propagates as an error instead of being mistaken for a not-yet-live panel (`9b85246`).
- The host stamps manifests under its own `HorizonHome` root via the new `manifest::sync_host_state_in`. Production builds the session store from `HorizonHome::resolve()`, the same root the drivers and the MCP server use for their default paths, so behavior is unchanged; it makes the sync testable against a temp home.

## Behavior impact

- Moving a panel between workspaces, or hiding/showing a browser panel through the UI, re-stamps the affected manifests before that frame ends, so the revocation that #361 introduced now takes effect immediately instead of within 500 ms.
- Per-frame cost is one hash over the browser and agent panels' ids and workspace ids; no additional file reads unless placement changed (or a previous sync was incomplete).

## Test evidence

Local, in this worktree at the exact head `930e013` (Linux, 48-core box); results for every earlier pushed head were identical:

- `cargo fmt --all -- --check`, `./scripts/check-maintainability.sh`: pass
- `RUSTFLAGS="-D warnings" cargo test --workspace` and `--features speech`: pass (all 7 matrix tiers green)
- Blocking, strict, and pedantic clippy tiers: pass
- Unit tests: `placement_fingerprint_follows_membership_not_unrelated_panels` (an agent move changes the fingerprint; shell panels and moving back do not; an identically shaped replacement board with fresh numeric ids never shares a fingerprint); `a_placement_change_restamps_before_the_next_poll_tick` (the tick only requests a stamp and the end-of-frame check performs it; an unchanged board waits for the interval; after a move the end-of-frame method re-stamps without advancing the request-poll cadence); `restamping_rewrites_a_live_manifest_for_the_new_membership` (a live manifest under a temp home is stamped for the agent's workspace, a move rewrites it so the moved agent is no longer authorized and visibility follows the board, an unchanged placement writes nothing, and a not-yet-live manifest does not make the sync incomplete)
- Two-workspace real-host MCP smoke (isolated HOME, `--ephemeral`, task-owned Xvfb + openbox, real Chromium): 26/26 checks pass, Horizon exits 0, no leftover processes
- Official gate `scripts/browser-smoke/run.py --backend chromium --ephemeral --skip-handoff` on the clean head (git_dirty false): MCP gate passed, exit 0, no audit, capture, or process findings

Not run: macOS/Windows lanes (no platform-specific code) and an automated UI drag between workspaces. A Browser-kind board panel cannot be created in a unit test without starting a real driver thread against the process HOME, so the manifest assertion runs the same sync the app calls, fed by the board's placement, against a temp home.
