### PR TITLE
fix(browser): complete browser_create only when the backend is ready and the first page committed

### DIFF
--- a/assets/plugins/claude-code/skills/horizon-browser/SKILL.md
+++ b/assets/plugins/claude-code/skills/horizon-browser/SKILL.md
@@ -12,7 +12,14 @@ the Horizon browser MCP server is not connected.
 
 Start with `browser_list` when the panel id is unknown. If it returns no panels,
 call `browser_create`; this opens a panel in the current agent's Horizon
-workspace and returns its ready panel id. If it returns a usable panel, reuse
+workspace and returns its ready panel id once the backend is ready and, when
+you passed a `url`, once that page committed (`navigation: committed`). A
+`navigation: pending` result means the panel is controllable but the first
+page had not committed within the bounded startup wait, so use `browser_wait`
+or `browser_panel` before reading it; `navigation: failed` means that page
+failed to load (`navigation_error` says why) and you must navigate again or
+fix the URL; `navigation: superseded` means the user navigated the panel
+first, so read `panel.url` before acting. If `browser_list` returns a usable panel, reuse
 that panel for iframe, popup, dialog, and consent interactions. Never create or
 reveal a helper panel as a workaround. Only when the user explicitly requests
 another independent browser session may you call `browser_create` with

--- a/assets/plugins/codex/skills/horizon-browser/SKILL.md
+++ b/assets/plugins/codex/skills/horizon-browser/SKILL.md
@@ -12,7 +12,14 @@ the Horizon browser MCP server is not connected.
 
 Start with `browser_list` when the panel id is unknown. If it returns no panels,
 call `browser_create`; this opens a panel in the current agent's Horizon
-workspace and returns its ready panel id. If it returns a usable panel, reuse
+workspace and returns its ready panel id once the backend is ready and, when
+you passed a `url`, once that page committed (`navigation: committed`). A
+`navigation: pending` result means the panel is controllable but the first
+page had not committed within the bounded startup wait, so use `browser_wait`
+or `browser_panel` before reading it; `navigation: failed` means that page
+failed to load (`navigation_error` says why) and you must navigate again or
+fix the URL; `navigation: superseded` means the user navigated the panel
+first, so read `panel.url` before acting. If `browser_list` returns a usable panel, reuse
 that panel for iframe, popup, dialog, and consent interactions. Never create or
 reveal a helper panel as a workaround. Only when the user explicitly requests
 another independent browser session may you call `browser_create` with

--- a/crates/horizon-browser-mcp/README.md
+++ b/crates/horizon-browser-mcp/README.md
@@ -34,7 +34,17 @@ shell commands, files, or other MCP servers.
   A panel's `visible` field is host presentation state, not proof that it is
   in the caller's workspace.
 - `browser_create` opens a panel in the calling agent's Horizon workspace and
-  returns only after it is ready and owned by that agent. It uses the configured
+  returns only after its backend is ready, it is owned by that agent, and,
+  when a `url` was given, that page has committed (`navigation: committed`,
+  with `panel.url` authoritative; the title is read after commit and may still
+  be empty or change). If the first page has not
+  committed within a bounded startup wait, the controllable panel is still
+  returned with `navigation: pending` instead of an empty URL presented as
+  ready; if that page failed to load, it is returned with `navigation: failed`
+  and the browser's `navigation_error` (an explicit `about:blank` counts as
+  committed); if the user navigated the panel before that page committed, it
+  is returned with `navigation: superseded` at the user's page. `startup_millis` reports the latency from the host accepting the
+  request until the panel was reported. It uses the configured
   backend unless explicitly overridden. Set `visible: false` to start a live
   background panel. If the same agent already owns a panel, creation is rejected
   unless the user explicitly requested another independent session and the call

--- a/crates/horizon-browser-mcp/src/controller.rs
+++ b/crates/horizon-browser-mcp/src/controller.rs
@@ -89,6 +89,10 @@ pub(crate) struct ActionReceipt {
 pub(crate) struct CreateReceipt {
     pub(crate) action_id: String,
     pub(crate) panel: BrowserPanel,
+    /// `None` when the host predates startup readiness.
+    pub(crate) navigation: Option<horizon_core::browser::manifest::CreateNavigation>,
+    pub(crate) navigation_error: Option<String>,
+    pub(crate) startup_millis: u64,
 }
 
 #[derive(Debug)]
@@ -275,7 +279,12 @@ impl BrowserController {
                 .map_err(|source| ControlError::internal_io("could not read browser create result", source))?
             {
                 return match result.outcome {
-                    BrowserCreateOutcome::Ready { panel_local_id } => {
+                    BrowserCreateOutcome::Ready {
+                        panel_local_id,
+                        navigation,
+                        navigation_error,
+                        startup_millis,
+                    } => {
                         self.ensure_claim(&panel_local_id)?;
                         let manifest = manifest::read(&panel_local_id).ok_or_else(|| {
                             ControlError::internal_io(
@@ -286,6 +295,9 @@ impl BrowserController {
                         Ok(CreateReceipt {
                             action_id,
                             panel: BrowserPanel::from_manifest(manifest, &self.actor),
+                            navigation,
+                            navigation_error,
+                            startup_millis,
                         })
                     }
                     BrowserCreateOutcome::Failed { code, message } => Err(ControlError::Browser {
@@ -295,7 +307,10 @@ impl BrowserController {
                     }),
                 };
             }
-            if started.elapsed() >= Duration::from_millis(timeout_millis) {
+            // The host decides readiness by the request's own deadline; the
+            // result then still travels through the locked manifest files,
+            // so give its delivery the same headroom as engine-bounded actions.
+            if started.elapsed() >= Duration::from_millis(timeout_millis + RESULT_DELIVERY_HEADROOM_MILLIS) {
                 return Err(ControlError::CreateTimeout {
                     action_id,
                     timeout_millis,

--- a/crates/horizon-browser-mcp/src/model.rs
+++ b/crates/horizon-browser-mcp/src/model.rs
@@ -154,12 +154,78 @@ pub(crate) struct CreateInput {
     pub(crate) timeout_millis: Option<u64>,
 }
 
+/// Where the requested first page stood when `browser_create` returned.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CreateNavigationState {
+    /// No `url` was requested; the panel is ready at a blank page.
+    NotRequested,
+    /// The requested page committed; `panel.url` is authoritative. The title
+    /// is read after commit and may still be empty or change, so read it from
+    /// `browser_panel` or a snapshot when you need it.
+    Committed,
+    /// The backend is ready and controllable, but the requested page had not
+    /// committed within the bounded startup wait; `panel.url` may still be
+    /// empty. Use `browser_wait` or `browser_panel` before reading the page.
+    /// Also reported when an older host did not record readiness for a
+    /// requested `url`.
+    Pending,
+    /// The backend is ready and controllable, but the requested page failed
+    /// to load; `navigation_error` carries the browser's message and the
+    /// panel stays at its blank document. Navigate again or fix the URL.
+    Failed,
+    /// The user navigated the panel before the requested page committed; the
+    /// panel is controllable at the user's page and the requested page is not
+    /// coming. Read `panel.url` before acting.
+    Superseded,
+}
+
+impl From<horizon_core::browser::manifest::CreateNavigation> for CreateNavigationState {
+    fn from(navigation: horizon_core::browser::manifest::CreateNavigation) -> Self {
+        match navigation {
+            horizon_core::browser::manifest::CreateNavigation::NotRequested => Self::NotRequested,
+            horizon_core::browser::manifest::CreateNavigation::Committed => Self::Committed,
+            horizon_core::browser::manifest::CreateNavigation::Pending => Self::Pending,
+            horizon_core::browser::manifest::CreateNavigation::Failed => Self::Failed,
+            horizon_core::browser::manifest::CreateNavigation::Superseded => Self::Superseded,
+        }
+    }
+}
+
+impl CreateNavigationState {
+    /// Resolve a host result that may predate startup readiness: an absent
+    /// state means the host did not record it, so a requested `url` is
+    /// conservatively `pending`, never `not_requested`.
+    pub(crate) fn resolve(
+        recorded: Option<horizon_core::browser::manifest::CreateNavigation>,
+        url_requested: bool,
+    ) -> Self {
+        recorded.map_or(
+            if url_requested {
+                Self::Pending
+            } else {
+                Self::NotRequested
+            },
+            Self::from,
+        )
+    }
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 pub(crate) struct CreateOutput {
     /// Auditable identity for the panel creation lifecycle.
     pub(crate) action_id: String,
     /// Ready panel state. Use `panel.panel_id` with all other browser tools.
     pub(crate) panel: BrowserPanel,
+    /// Whether the requested first page committed before this returned.
+    pub(crate) navigation: CreateNavigationState,
+    /// The browser's message when `navigation` is `failed`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) navigation_error: Option<String>,
+    /// Milliseconds from the host accepting the request until the panel was
+    /// ready and, when a `url` was given, its page committed or the bounded
+    /// startup wait elapsed.
+    pub(crate) startup_millis: u64,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/horizon-browser-mcp/src/server.rs
+++ b/crates/horizon-browser-mcp/src/server.rs
@@ -67,9 +67,11 @@ impl HorizonBrowserMcp {
 
     #[tool(
         name = "browser_create",
-        description = "Create a browser panel in the calling agent's Horizon workspace and wait until it is controllable. Use this when browser_list is empty. Reuse an existing panel for iframes, popups, dialogs, and consent flows; never create a helper panel for them. Only when the user explicitly requests an independent session, set allow_additional=true. Set visible=false for a live background panel; omit backend to use Horizon's configured browser. Bare hostnames default to HTTPS and explicit HTTP is preserved."
+        description = "Create a browser panel in the calling agent's Horizon workspace and wait until its backend is ready and, when url is given, that page has committed; if the page has not committed within a bounded startup wait the panel is still returned with navigation=pending, and if the first page failed to load it is returned with navigation=failed and navigation_error (the panel is controllable; navigate again). Use this when browser_list is empty. Reuse an existing panel for iframes, popups, dialogs, and consent flows; never create a helper panel for them. Only when the user explicitly requests an independent session, set allow_additional=true. Set visible=false for a live background panel; omit backend to use Horizon's configured browser. Bare hostnames default to HTTPS and explicit HTTP is preserved."
     )]
     async fn browser_create(&self, Parameters(input): Parameters<CreateInput>) -> Result<Json<CreateOutput>, String> {
+        // Matches the request normalization: a blank url is no navigation.
+        let url_requested = input.url.as_deref().is_some_and(|url| !url.trim().is_empty());
         let receipt = self
             .controller
             .create(
@@ -84,6 +86,9 @@ impl HorizonBrowserMcp {
         Ok(Json(CreateOutput {
             action_id: receipt.action_id,
             panel: receipt.panel,
+            navigation: crate::model::CreateNavigationState::resolve(receipt.navigation, url_requested),
+            navigation_error: receipt.navigation_error,
+            startup_millis: receipt.startup_millis,
         }))
     }
 

--- a/crates/horizon-browser/src/webdriver/session.rs
+++ b/crates/horizon-browser/src/webdriver/session.rs
@@ -32,6 +32,9 @@ mod shutdown;
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const PAGE_LOAD_TIMEOUT_MILLIS: u64 = 50_000;
+/// Page-load bound for the startup navigation, so the servicing loop starts
+/// even when the first page is slow.
+const STARTUP_PAGE_LOAD_TIMEOUT_MILLIS: u64 = 10_000;
 const NAVIGATION_HTTP_TIMEOUT: Duration = Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS + 5_000);
 const ACTIVE_FRAME_INTERVAL: Duration = Duration::from_millis(33);
 const ACTIVE_WINDOW: Duration = Duration::from_millis(900);
@@ -162,6 +165,9 @@ struct Driver {
     /// Session page-load timeout a bounded classic navigation lowered and the
     /// loop still has to restore, once the typed outcome was published.
     classic_timeout_to_restore: Option<u64>,
+    /// While a bounded startup navigation is still loading, page state is
+    /// re-read every second until this instant or until the URL changes.
+    startup_refresh_until: Option<Instant>,
     coordination_dirty: bool,
     last_coordination_write: Instant,
     last_signal_check: Instant,
@@ -216,13 +222,19 @@ pub(crate) fn run_webdriver(
     let capabilities = driver.active_capabilities();
     frame_slot.publish_backend_capabilities(capabilities);
     let _ = event_tx.send(BrowserEvent::BackendReady(capabilities));
-    let _ = event_tx.send(BrowserEvent::Ready);
-    if let Some(url) = config
+    let startup_navigation_pending = config
         .initial_url
         .as_deref()
         .filter(|url| !url.is_empty() && *url != "about:blank")
-    {
-        let _ = driver.navigate(url, event_tx);
+        .is_some_and(|url| driver.navigate_initial(url, event_tx));
+    // `Ready` means the servicing loop below is about to run: commands and
+    // agent actions are only usable from here on, so it must not be
+    // published before the (bounded) startup navigation returned. The host
+    // resets its loading flag on `Ready`, so a startup navigation that is
+    // still running is reported as loading again right after it.
+    let _ = event_tx.send(BrowserEvent::Ready);
+    if startup_navigation_pending {
+        let _ = event_tx.send(BrowserEvent::Loading(true));
     }
 
     while !stop_requested.load(Ordering::Acquire) {
@@ -370,6 +382,7 @@ impl Driver {
             pending_classic_history_start: None,
             refresh_pending_at: None,
             classic_timeout_to_restore: None,
+            startup_refresh_until: None,
             coordination_dirty: true,
             last_coordination_write: Instant::now(),
             last_signal_check: Instant::now(),
@@ -722,26 +735,10 @@ impl Driver {
         self.retain_frame_during_navigation = true;
         self.navigation_failed = false;
         self.refresh_pending_at = None;
+        // A replacement navigation must not inherit the startup poll's cutoff.
+        self.startup_refresh_until = None;
         self.scrollbar.reset();
         self.frames.suspend_for_navigation();
-    }
-
-    fn classic_get(&self, suffix: &str) -> Result<Value, String> {
-        self.service
-            .http
-            .get(&self.session_path(suffix))
-            .map_err(|error| error.to_string())
-    }
-
-    fn classic_post(&self, suffix: &str, body: &Value) -> Result<Value, String> {
-        self.service
-            .http
-            .post(&self.session_path(suffix), body)
-            .map_err(|error| error.to_string())
-    }
-
-    fn session_path(&self, suffix: &str) -> String {
-        format!("/session/{}/{}", self.session_id, suffix.trim_start_matches('/'))
     }
 }
 

--- a/crates/horizon-browser/src/webdriver/session/navigation.rs
+++ b/crates/horizon-browser/src/webdriver/session/navigation.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 
 use super::{
-    Driver, NAVIGATION_HTTP_TIMEOUT, PAGE_LOAD_TIMEOUT_MILLIS, PendingHistoryStart, classic_navigation_committed,
-    normalize_url, webdriver_value,
+    Driver, NAVIGATION_HTTP_TIMEOUT, PAGE_LOAD_TIMEOUT_MILLIS, PendingHistoryStart, STARTUP_PAGE_LOAD_TIMEOUT_MILLIS,
+    classic_navigation_committed, normalize_url, webdriver_value,
 };
 
 /// How much longer than a classic navigation's bound its HTTP read waits for
@@ -297,6 +297,78 @@ impl Driver {
         }
     }
 
+    /// The startup navigation. Firefox `BiDi` dispatches it asynchronously and
+    /// settles from its events; classic `WebDriver` would otherwise block the
+    /// driver for the whole 50 s page-load timeout before the servicing loop
+    /// starts, so it runs under a 10 s page-load bound: a slow page keeps
+    /// loading in the browser while commands and agent actions are already
+    /// serviced, and page state is re-read every second until it commits.
+    /// Returns whether the navigation is still running when this returns.
+    pub(super) fn navigate_initial(&mut self, url: &str, event_tx: &BrowserEventSender) -> bool {
+        if self.config.browser.backend == BackendKind::FirefoxBidi {
+            // Firefox answers `browsingContext.navigate` only once the
+            // destination responds; a synchronous call would fail a slow
+            // first page at the 5 s command timeout before the loop starts.
+            // Dispatch without waiting: the reply and the navigation events
+            // are serviced by the loop like any agent navigation.
+            return self.dispatch_bidi_navigate(url, event_tx).is_ok();
+        }
+        let url = normalize_navigation_target(url);
+        let previous_url = self.url.clone();
+        if let Err(error) = self.classic_post("timeouts", &json!({ "pageLoad": STARTUP_PAGE_LOAD_TIMEOUT_MILLIS })) {
+            // Navigating under an unknown bound could block the servicing
+            // loop for the full session timeout; fail the startup navigation
+            // instead, so the create reports it and the loop starts now.
+            self.navigation_failed = true;
+            let _ = event_tx.send(BrowserEvent::NavigationFailed(format!(
+                "could not apply the startup navigation bound: {error}"
+            )));
+            let _ = event_tx.send(BrowserEvent::Loading(false));
+            return false;
+        }
+        self.begin_navigation();
+        let _ = event_tx.send(BrowserEvent::Loading(true));
+        let started = Instant::now();
+        let result = self
+            .classic_navigation_post_within(
+                "url",
+                &json!({ "url": &url }),
+                Duration::from_millis(STARTUP_PAGE_LOAD_TIMEOUT_MILLIS + 5_000),
+            )
+            .and_then(|_| self.classic_get("url"))
+            .and_then(|response| {
+                classic_navigation_committed(&response, &url, &previous_url)
+                    .then_some(())
+                    .ok_or_else(|| "browser did not commit a reachable URL".to_string())
+            });
+        if self
+            .classic_post("timeouts", &json!({ "pageLoad": PAGE_LOAD_TIMEOUT_MILLIS }))
+            .is_err()
+        {
+            // The loop retries the restore so later navigations do not run
+            // under the startup bound.
+            self.classic_timeout_to_restore = Some(PAGE_LOAD_TIMEOUT_MILLIS);
+        }
+        let timed_out = result
+            .as_ref()
+            .is_err_and(|error| classic_error_is_page_load_timeout(error));
+        if timed_out {
+            // Still loading: keep the frame, report nothing failed, and poll
+            // the page state until the document commits or the normal
+            // page-load window passes.
+            self.retain_frame_during_navigation = false;
+            self.navigation_failed = false;
+            // The window counts from the navigation start, so the overall
+            // failure cutoff stays at the normal page-load window.
+            self.startup_refresh_until = Some(started + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS));
+            self.refresh_pending_at = Some(Instant::now() + Duration::from_secs(1));
+            tracing::debug!(target: "browser", url = %url, "startup navigation still loading after its bound");
+            return true;
+        }
+        let _ = self.finish_page(result, &format!("startup navigation to {url}"), event_tx);
+        false
+    }
+
     pub(super) fn navigate(&mut self, url: &str, event_tx: &BrowserEventSender) -> Result<(), String> {
         let url = normalize_navigation_target(url);
         // A non-agent navigation takes the page over: a pending agent
@@ -402,6 +474,24 @@ impl Driver {
         Ok(())
     }
 
+    pub(super) fn classic_get(&self, suffix: &str) -> Result<Value, String> {
+        self.service
+            .http
+            .get(&self.session_path(suffix))
+            .map_err(|error| error.to_string())
+    }
+
+    pub(super) fn classic_post(&self, suffix: &str, body: &Value) -> Result<Value, String> {
+        self.service
+            .http
+            .post(&self.session_path(suffix), body)
+            .map_err(|error| error.to_string())
+    }
+
+    pub(super) fn session_path(&self, suffix: &str) -> String {
+        format!("/session/{}/{}", self.session_id, suffix.trim_start_matches('/'))
+    }
+
     fn classic_navigation_post(&self, suffix: &str, body: &serde_json::Value) -> Result<serde_json::Value, String> {
         self.classic_navigation_post_within(suffix, body, NAVIGATION_HTTP_TIMEOUT)
     }
@@ -458,7 +548,31 @@ impl Driver {
             return;
         }
         self.refresh_pending_at = None;
+        let previous_url = self.url.clone();
         self.refresh_page_state(event_tx);
+        if let Some(until) = self.startup_refresh_until {
+            if self.url != previous_url {
+                self.startup_refresh_until = None;
+                self.frames.demand();
+            } else if Instant::now() >= until {
+                // Classic WebDriver reports no later event, so a navigation
+                // that has not committed by the page-load window is failed
+                // explicitly instead of leaving the panel silently stale.
+                self.startup_refresh_until = None;
+                self.navigation_failed = true;
+                self.frames.interaction_started_at = None;
+                let _ = event_tx.send(BrowserEvent::NavigationFailed(
+                    "the navigation did not commit within the page-load window".to_string(),
+                ));
+                let _ = event_tx.send(BrowserEvent::Loading(false));
+            } else {
+                // `refresh_page_state` reported the page as not loading; the
+                // startup navigation is still running, so say so until it
+                // commits or the window passes.
+                let _ = event_tx.send(BrowserEvent::Loading(true));
+                self.refresh_pending_at = Some(Instant::now() + Duration::from_secs(1));
+            }
+        }
     }
 }
 

--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -51,8 +51,9 @@ mod workspace;
 pub use agent::{claim, enqueue_action, heartbeat, release, request_handoff};
 pub use audit::{audit_path_for_root, default_audit_path, read_audit};
 pub use create::{
-    BrowserCreateAuditStatus, BrowserCreateOutcome, BrowserCreateRequest, BrowserCreateResult, claim_create_request,
-    complete_create_request, enqueue_create, list_create_requests, record_create_status, take_create_result,
+    BrowserCreateAuditStatus, BrowserCreateOutcome, BrowserCreateRequest, BrowserCreateResult, CreateNavigation,
+    claim_create_request, complete_create_request, enqueue_create, list_create_requests, record_create_status,
+    take_create_result,
 };
 pub use result::{action_result_path_for_root, default_action_result_path, take_action_result};
 pub use visibility::{

--- a/crates/horizon-core/src/browser/manifest/create.rs
+++ b/crates/horizon-core/src/browser/manifest/create.rs
@@ -51,20 +51,70 @@ pub struct BrowserCreateResult {
     pub outcome: BrowserCreateOutcome,
 }
 
+/// Where the requested startup navigation stood when creation completed.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CreateNavigation {
+    /// No initial URL was requested; the panel is ready at its blank page.
+    #[default]
+    NotRequested,
+    /// The requested page committed; the manifest URL is authoritative.
+    Committed,
+    /// The backend is ready but the requested page had not committed within
+    /// the bounded startup wait; the panel is controllable and still loading.
+    Pending,
+    /// The backend is ready but the requested page failed to load; the panel
+    /// is controllable at its previous (blank) document and
+    /// `navigation_error` carries the browser's message.
+    Failed,
+    /// The user navigated the panel before the requested page committed; the
+    /// panel is controllable at the user's page, and the requested page is
+    /// not coming.
+    Superseded,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum BrowserCreateOutcome {
-    Ready { panel_local_id: String },
-    Failed { code: String, message: String },
+    Ready {
+        panel_local_id: String,
+        /// Absent in results written by hosts that predate startup
+        /// readiness; readers must not treat that as proof that no URL was
+        /// requested.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        navigation: Option<CreateNavigation>,
+        /// The browser's message when `navigation` is `failed`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        navigation_error: Option<String>,
+        /// Milliseconds from the host accepting the request until the panel
+        /// was reported ready.
+        #[serde(default)]
+        startup_millis: u64,
+    },
+    Failed {
+        code: String,
+        message: String,
+    },
 }
 
 impl BrowserCreateResult {
     #[must_use]
-    pub fn ready(request: &BrowserCreateRequest, panel_local_id: String) -> Self {
+    pub fn ready(
+        request: &BrowserCreateRequest,
+        panel_local_id: String,
+        navigation: CreateNavigation,
+        navigation_error: Option<String>,
+        startup_millis: u64,
+    ) -> Self {
         Self {
             request_id: request.request_id.clone(),
             actor: request.actor.clone(),
-            outcome: BrowserCreateOutcome::Ready { panel_local_id },
+            outcome: BrowserCreateOutcome::Ready {
+                panel_local_id,
+                navigation: Some(navigation),
+                navigation_error,
+                startup_millis,
+            },
         }
     }
 
@@ -372,6 +422,42 @@ const fn default_visible() -> bool {
 mod tests {
     use super::*;
 
+    #[test]
+    fn ready_outcomes_keep_the_legacy_shape_and_default_the_navigation_state() {
+        let legacy: BrowserCreateOutcome =
+            serde_json::from_value(serde_json::json!({ "status": "ready", "panel_local_id": "panel" }))
+                .expect("legacy ready outcome decodes");
+        assert_eq!(
+            legacy,
+            BrowserCreateOutcome::Ready {
+                panel_local_id: "panel".to_string(),
+                navigation: None,
+                navigation_error: None,
+                startup_millis: 0,
+            },
+            "a legacy result leaves the navigation state unknown rather than claiming no URL was requested"
+        );
+        let encoded = serde_json::to_value(BrowserCreateOutcome::Ready {
+            panel_local_id: "panel".to_string(),
+            navigation: Some(CreateNavigation::Pending),
+            navigation_error: None,
+            startup_millis: 1234,
+        })
+        .expect("encode");
+        assert_eq!(encoded["navigation"], "pending");
+        assert_eq!(encoded["startup_millis"], 1234);
+        assert!(encoded.get("navigation_error").is_none());
+        let failed = serde_json::to_value(BrowserCreateOutcome::Ready {
+            panel_local_id: "panel".to_string(),
+            navigation: Some(CreateNavigation::Failed),
+            navigation_error: Some("could not navigate to https://down.test/".to_string()),
+            startup_millis: 900,
+        })
+        .expect("encode");
+        assert_eq!(failed["navigation"], "failed");
+        assert_eq!(failed["navigation_error"], "could not navigate to https://down.test/");
+    }
+
     fn root() -> tempfile::TempDir {
         tempfile::tempdir().expect("isolated create root")
     }
@@ -412,7 +498,13 @@ mod tests {
         );
         assert!(list_at(root.path()).expect("list claimed requests").is_empty());
 
-        let result = BrowserCreateResult::ready(&claimed, "browser-panel".to_string());
+        let result = BrowserCreateResult::ready(
+            &claimed,
+            "browser-panel".to_string(),
+            CreateNavigation::Committed,
+            None,
+            1_500,
+        );
         complete_at(root.path(), &result).expect("complete create");
         assert_eq!(
             take_at(root.path(), &request_id, actor).expect("take result"),

--- a/crates/horizon-core/src/browser/mod.rs
+++ b/crates/horizon-core/src/browser/mod.rs
@@ -106,6 +106,10 @@ pub struct BrowserPanelState {
     /// User-typed navigation kept as the display and retry target until the
     /// driver commits a reachable page, so the input is never discarded.
     pending_user_navigation: Option<String>,
+    /// User activity that can navigate (typed URL, back, forward, reload, a
+    /// click, a key press) so far; lets a pending create tell a user takeover
+    /// from the requested first page committing.
+    user_navigations: std::sync::atomic::AtomicU32,
     /// A backend selection changed since the last output drain and must be
     /// folded into the persisted runtime state exactly once.
     persisted_config_changed: bool,
@@ -160,6 +164,7 @@ impl BrowserPanelState {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: profile_root_resolved,
             config,
         };
@@ -341,7 +346,33 @@ impl BrowserPanelState {
     /// Queue a command only when the driver session currently exists.
     #[must_use]
     pub fn try_send(&self, command: BrowserCommand) -> bool {
-        self.session.as_ref().is_some_and(|session| session.send(command))
+        // Chrome commands, and the input that can navigate from inside the
+        // page (a click on a link, Enter in a form), count as user activity
+        // that may take a pending startup navigation over, but only once the
+        // driver accepted them; pointer moves and wheel events do not
+        // navigate on their own.
+        let may_navigate = matches!(
+            command,
+            BrowserCommand::Navigate(_)
+                | BrowserCommand::Back
+                | BrowserCommand::Forward
+                | BrowserCommand::Reload
+                | BrowserCommand::Input(
+                    horizon_browser::BrowserInput::MousePress { .. } | horizon_browser::BrowserInput::KeyDown { .. }
+                )
+        );
+        let accepted = self.session.as_ref().is_some_and(|session| session.send(command));
+        if accepted && may_navigate {
+            self.user_navigations.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        accepted
+    }
+
+    /// Number of user actions that can navigate (typed URL, back, forward,
+    /// reload, click, key press) on this panel so far.
+    #[must_use]
+    pub fn user_navigation_count(&self) -> u32 {
+        self.user_navigations.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Submit a user-typed navigation and retain it as the display/retry
@@ -711,6 +742,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -750,6 +782,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -783,6 +816,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -824,6 +858,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -863,6 +898,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig {
                 command: Some("/definitely/missing/chrome".to_string()),
@@ -936,6 +972,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -971,6 +1008,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: Some("stale error".to_string()),
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -1005,6 +1043,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };
@@ -1042,6 +1081,7 @@ mod tests {
             host_focus_request: None,
             navigation_error: None,
             pending_user_navigation: None,
+            user_navigations: std::sync::atomic::AtomicU32::new(0),
             persisted_config_changed: false,
             config: BrowserConfig::default(),
         };

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 
 use horizon_core::browser::manifest::{
     self, AgentIdentity, BrowserCreateAuditStatus, BrowserCreateRequest, BrowserCreateResult,
-    BrowserVisibilityAuditStatus, BrowserVisibilityRequest, BrowserVisibilityResult, HostStampOutcome,
-    ManifestWorkspace,
+    BrowserVisibilityAuditStatus, BrowserVisibilityRequest, BrowserVisibilityResult, CreateNavigation,
+    HostStampOutcome, ManifestWorkspace,
 };
 use horizon_core::browser::{BackendAvailability, BackendKind, BrowserStatus};
 use horizon_core::{Board, PanelId, PanelKind, PanelOptions, WorkspaceId, browser_actor};
@@ -15,6 +15,16 @@ use horizon_core::{Board, PanelId, PanelKind, PanelOptions, WorkspaceId, browser
 use super::HorizonApp;
 
 const CREATE_REQUEST_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// How long a create with an initial URL waits, after the backend is ready,
+/// for that page to commit before reporting the panel with
+/// `navigation: pending`. Bounded so creation never waits for a slow first
+/// page; the overall create deadline still caps it.
+const STARTUP_NAVIGATION_BUDGET: Duration = Duration::from_secs(10);
+/// Headroom kept before the create deadline for the host's own completion
+/// work (ownership update, audit, result write). Delivery of that result to
+/// the caller is covered separately by the MCP controller, which waits
+/// `RESULT_DELIVERY_HEADROOM_MILLIS` beyond the request deadline.
+const STARTUP_DEADLINE_HEADROOM: Duration = Duration::from_millis(750);
 
 #[derive(Default)]
 pub(super) struct BrowserCreateHostState {
@@ -30,6 +40,85 @@ struct PendingBrowserCreate {
     panel_id: PanelId,
     panel_local_id: String,
     backend: BackendKind,
+    /// When the host claimed the request, for the reported startup latency.
+    started_at: Instant,
+    /// When the backend first reported `Ready`, which starts the bounded
+    /// startup-navigation wait.
+    ready_since: Option<Instant>,
+    /// User navigations the panel had seen when the create started; more
+    /// means the user took the panel over before the first page committed.
+    user_navigations_at_start: u32,
+}
+
+/// Whether a pending create may complete, decided from the panel's live
+/// browser state rather than from the manifest file's existence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CreateReadiness {
+    Waiting,
+    Ready(CreateNavigation),
+}
+
+/// Live page state a pending create is judged on.
+#[derive(Clone, Copy)]
+struct PageReadiness<'a> {
+    status: &'a BrowserStatus,
+    /// URL the live panel reports as committed.
+    committed_url: Option<&'a str>,
+    /// URL in the manifest the agent reads.
+    manifest_url: &'a str,
+    /// The browser's navigation failure, when the last navigation failed.
+    navigation_error: Option<&'a str>,
+}
+
+/// The backend must report `Ready`. With an initial URL, the page must also
+/// have committed (in the live panel and in the manifest the agent reads);
+/// a failed first navigation is reported as `failed` at once, an explicit
+/// `about:blank` is the committed blank destination, and when the bounded
+/// startup wait or the create deadline is about to elapse the panel is
+/// reported with `navigation: pending`.
+fn create_readiness(
+    page: PageReadiness<'_>,
+    requested_url: Option<&str>,
+    user_navigated: bool,
+    ready_since: Option<Instant>,
+    deadline: Instant,
+    now: Instant,
+) -> CreateReadiness {
+    if *page.status != BrowserStatus::Ready {
+        return CreateReadiness::Waiting;
+    }
+    let Some(requested) = requested_url.filter(|url| !url.is_empty()) else {
+        return CreateReadiness::Ready(CreateNavigation::NotRequested);
+    };
+    if user_navigated {
+        // The user took the panel over before the requested page committed:
+        // whatever commits now is theirs, not the requested first page.
+        return CreateReadiness::Ready(CreateNavigation::Superseded);
+    }
+    if requested == "about:blank" {
+        // Both drivers skip navigating to the blank page and report it as an
+        // empty URL: the panel is already at the requested destination.
+        return CreateReadiness::Ready(CreateNavigation::Committed);
+    }
+    let committed = page.committed_url.is_some_and(|url| !url.is_empty());
+    // The manifest the agent reads is flushed on a cadence; during a redirect
+    // it can still name an earlier document while the live panel already
+    // holds the final one, so both must agree before the create reports the
+    // page as committed.
+    if committed && page.committed_url == Some(page.manifest_url) {
+        return CreateReadiness::Ready(CreateNavigation::Committed);
+    }
+    if page.navigation_error.is_some() && !committed {
+        return CreateReadiness::Ready(CreateNavigation::Failed);
+    }
+    let ready_since = ready_since.unwrap_or(now);
+    let budget_end = (ready_since + STARTUP_NAVIGATION_BUDGET)
+        .min(deadline.checked_sub(STARTUP_DEADLINE_HEADROOM).unwrap_or(deadline));
+    if now >= budget_end {
+        CreateReadiness::Ready(CreateNavigation::Pending)
+    } else {
+        CreateReadiness::Waiting
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -144,6 +233,9 @@ impl HorizonApp {
     }
 
     fn start_requested_browser(&mut self, request: BrowserCreateRequest, actor_panel: ActorPanel) {
+        // Startup latency counts everything the host does from accepting the
+        // request, including panel creation and the audit writes.
+        let started_at = Instant::now();
         if request.deadline_at_millis < manifest::now_millis() {
             complete_failure(
                 &request,
@@ -213,6 +305,9 @@ impl HorizonApp {
             panel_id,
             panel_local_id,
             backend,
+            started_at,
+            ready_since: None,
+            user_navigations_at_start: 0,
         });
         self.mark_runtime_dirty();
     }
@@ -353,12 +448,12 @@ impl HorizonApp {
         }
         let mut changed = false;
         let mut waiting = Vec::new();
-        for pending in std::mem::take(&mut self.browser_create_host.pending) {
+        for mut pending in std::mem::take(&mut self.browser_create_host.pending) {
             if browser_create_is_terminal(&self.board, &pending) {
                 changed = true;
                 continue;
             }
-            match finish_ready_browser_create(&self.board, &pending) {
+            match finish_ready_browser_create(&self.board, &mut pending) {
                 BrowserCreateCompletion::Waiting => waiting.push(pending),
                 BrowserCreateCompletion::Completed => changed = true,
                 BrowserCreateCompletion::Failed => {
@@ -490,10 +585,45 @@ fn backend_session_limit_reached(board: &Board, backend: BackendKind) -> bool {
     live >= usize::try_from(limit).unwrap_or(usize::MAX)
 }
 
-fn finish_ready_browser_create(board: &Board, pending: &PendingBrowserCreate) -> BrowserCreateCompletion {
-    if manifest::read(&pending.panel_local_id).is_none() {
+fn finish_ready_browser_create(board: &Board, pending: &mut PendingBrowserCreate) -> BrowserCreateCompletion {
+    let Some(browser) = board.panel(pending.panel_id).and_then(|panel| panel.browser()) else {
         return BrowserCreateCompletion::Waiting;
+    };
+    let now = Instant::now();
+    if browser.status == BrowserStatus::Ready {
+        pending.ready_since.get_or_insert(now);
     }
+    // The driver writes its manifest before the backend is ready and before
+    // the initial navigation commits, so the file's existence alone must not
+    // complete the create.
+    let Some(current) = manifest::read(&pending.panel_local_id) else {
+        return BrowserCreateCompletion::Waiting;
+    };
+    // The manifest read can be slow near a boundary; decide and measure on a
+    // clock read taken after it, keeping the earlier instant only for
+    // observing `Ready`.
+    let now = Instant::now();
+    let deadline = create_deadline(pending, now);
+    let CreateReadiness::Ready(navigation) = create_readiness(
+        PageReadiness {
+            status: &browser.status,
+            committed_url: browser.url.as_deref(),
+            manifest_url: &current.url,
+            navigation_error: browser.navigation_error.as_deref(),
+        },
+        pending.request.url.as_deref(),
+        browser.user_navigation_count() > pending.user_navigations_at_start,
+        pending.ready_since,
+        deadline,
+        now,
+    ) else {
+        return BrowserCreateCompletion::Waiting;
+    };
+    let navigation_error = (navigation == CreateNavigation::Failed)
+        .then(|| browser.navigation_error.clone())
+        .flatten();
+    let startup_millis =
+        u64::try_from(now.saturating_duration_since(pending.started_at).as_millis()).unwrap_or(u64::MAX);
     let Some(workspace) = board
         .panel(pending.panel_id)
         .and_then(|panel| browser_workspace(board, panel.workspace_id))
@@ -559,8 +689,18 @@ fn finish_ready_browser_create(board: &Board, pending: &PendingBrowserCreate) ->
     complete_result(&BrowserCreateResult::ready(
         &pending.request,
         pending.panel_local_id.clone(),
+        navigation,
+        navigation_error,
+        startup_millis,
     ));
     BrowserCreateCompletion::Completed
+}
+
+/// The create deadline as an `Instant`, derived from the request's wall-clock
+/// deadline relative to now.
+fn create_deadline(pending: &PendingBrowserCreate, now: Instant) -> Instant {
+    let remaining = pending.request.deadline_at_millis - manifest::now_millis();
+    now + Duration::from_millis(u64::try_from(remaining).unwrap_or(0))
 }
 
 fn browser_create_is_terminal(board: &Board, pending: &PendingBrowserCreate) -> bool {
@@ -664,6 +804,150 @@ mod tests {
             kind: PanelKind::Codex,
             ..PanelOptions::default()
         }
+    }
+
+    fn page<'a>(status: &'a BrowserStatus, committed: Option<&'a str>, manifest: &'a str) -> PageReadiness<'a> {
+        PageReadiness {
+            status,
+            committed_url: committed,
+            manifest_url: manifest,
+            navigation_error: None,
+        }
+    }
+
+    #[test]
+    fn create_readiness_waits_for_the_backend_and_the_committed_first_page() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(60);
+        let ready = BrowserStatus::Ready;
+        let example = Some("https://example.test/");
+        assert_eq!(
+            create_readiness(
+                page(&BrowserStatus::Starting, None, ""),
+                None,
+                false,
+                None,
+                deadline,
+                now
+            ),
+            CreateReadiness::Waiting,
+            "a manifest that exists before the backend is ready does not complete the create"
+        );
+        assert_eq!(
+            create_readiness(page(&ready, None, ""), None, false, Some(now), deadline, now),
+            CreateReadiness::Ready(CreateNavigation::NotRequested)
+        );
+        assert_eq!(
+            create_readiness(page(&ready, None, ""), example, false, Some(now), deadline, now),
+            CreateReadiness::Waiting,
+            "a requested page that has not committed keeps the create pending"
+        );
+        assert_eq!(
+            create_readiness(page(&ready, example, ""), example, false, Some(now), deadline, now),
+            CreateReadiness::Waiting,
+            "the manifest the agent reads must carry the committed URL too"
+        );
+        assert_eq!(
+            create_readiness(
+                page(&ready, Some("https://example.test/final"), "https://example.test/"),
+                example,
+                false,
+                Some(now),
+                deadline,
+                now
+            ),
+            CreateReadiness::Waiting,
+            "a manifest still naming the pre-redirect document is not committed yet"
+        );
+        assert_eq!(
+            create_readiness(
+                page(&ready, example, "https://example.test/"),
+                example,
+                false,
+                Some(now),
+                deadline,
+                now
+            ),
+            CreateReadiness::Ready(CreateNavigation::Committed)
+        );
+    }
+
+    #[test]
+    fn create_readiness_reports_blank_failed_and_superseded_first_pages() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(60);
+        let ready = BrowserStatus::Ready;
+        let example = Some("https://example.test/");
+        assert_eq!(
+            create_readiness(
+                page(&ready, None, ""),
+                Some("about:blank"),
+                false,
+                Some(now),
+                deadline,
+                now
+            ),
+            CreateReadiness::Ready(CreateNavigation::Committed),
+            "an explicit blank page is already the requested destination"
+        );
+        let failed = PageReadiness {
+            navigation_error: Some("could not navigate to https://down.test/"),
+            ..page(&ready, None, "")
+        };
+        assert_eq!(
+            create_readiness(failed, Some("https://down.test/"), false, Some(now), deadline, now),
+            CreateReadiness::Ready(CreateNavigation::Failed),
+            "a failed first navigation is reported at once instead of after the startup wait"
+        );
+        assert_eq!(
+            create_readiness(
+                page(&ready, Some("https://user.test/"), "https://user.test/"),
+                example,
+                true,
+                Some(now),
+                deadline,
+                now
+            ),
+            CreateReadiness::Ready(CreateNavigation::Superseded),
+            "a user navigation during startup is not the requested commit"
+        );
+        let late = now + STARTUP_NAVIGATION_BUDGET;
+        assert_eq!(
+            create_readiness(
+                page(&ready, None, ""),
+                Some("https://slow.test/"),
+                false,
+                Some(now),
+                deadline,
+                late
+            ),
+            CreateReadiness::Ready(CreateNavigation::Pending),
+            "after the bounded startup wait the panel is reported with a pending navigation"
+        );
+        let near_deadline = now + Duration::from_secs(3);
+        assert_eq!(
+            create_readiness(
+                page(&ready, None, ""),
+                Some("https://slow.test/"),
+                false,
+                Some(now),
+                near_deadline,
+                now + Duration::from_millis(2_300)
+            ),
+            CreateReadiness::Ready(CreateNavigation::Pending),
+            "the startup wait never runs into the create deadline"
+        );
+        assert_eq!(
+            create_readiness(
+                page(&ready, None, ""),
+                Some("https://slow.test/"),
+                false,
+                Some(now),
+                near_deadline,
+                now + Duration::from_millis(2_000)
+            ),
+            CreateReadiness::Waiting
+        );
     }
 
     #[test]

--- a/crates/horizon-ui/src/app/browser_requests.rs
+++ b/crates/horizon-ui/src/app/browser_requests.rs
@@ -818,7 +818,7 @@ mod tests {
     #[test]
     fn create_readiness_waits_for_the_backend_and_the_committed_first_page() {
         let now = Instant::now();
-        let deadline = now + Duration::from_secs(60);
+        let deadline = now + Duration::from_mins(1);
         let ready = BrowserStatus::Ready;
         let example = Some("https://example.test/");
         assert_eq!(
@@ -875,7 +875,7 @@ mod tests {
     #[test]
     fn create_readiness_reports_blank_failed_and_superseded_first_pages() {
         let now = Instant::now();
-        let deadline = now + Duration::from_secs(60);
+        let deadline = now + Duration::from_mins(1);
         let ready = BrowserStatus::Ready;
         let example = Some("https://example.test/");
         assert_eq!(
@@ -944,7 +944,7 @@ mod tests {
                 false,
                 Some(now),
                 near_deadline,
-                now + Duration::from_millis(2_000)
+                now + Duration::from_secs(2)
             ),
             CreateReadiness::Waiting
         );

--- a/docs/testing/browser-panel-gate.md
+++ b/docs/testing/browser-panel-gate.md
@@ -86,7 +86,9 @@ The reusable runner:
 - launches the exact Horizon binary with an agent panel and no Browser panel;
 - invokes only the fourteen public `browser_*` MCP tools;
 - proves empty discovery followed by an audited hidden `browser_create` in the
-  requesting agent's workspace, controls it while hidden, shows it through
+  requesting agent's workspace whose result already reports the committed
+  first page (`navigation: committed`, `startup_millis`) and is queryable
+  immediately, controls it while hidden, shows it through
   `browser_visibility`, then checks schemas, navigation,
   snapshot/query/ref lifetime, trusted
   single and double click, Unicode fill, scroll, history, wait/evaluate,

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -250,6 +250,22 @@ def create_panel(client: McpClient, args: argparse.Namespace) -> tuple[dict[str,
         or panel["visible"]
     ):
         raise AssertionError(created)
+    # Creation with a URL completes only after the backend is ready and that
+    # page committed, so the ready panel already reports the committed page
+    # and the very next semantic call can inspect it.
+    if (
+        created.get("navigation") != "committed"
+        or panel["url"] != f"{args.base_url}/index.html"
+        or not isinstance(created.get("startup_millis"), int)
+    ):
+        raise AssertionError(f"browser_create returned before its first page committed: {created}")
+    print(json.dumps({"create_startup_millis": created["startup_millis"], "backend": args.backend}), flush=True)
+    first_query, _ = client.call(
+        "browser_query",
+        {"panel_id": panel["panel_id"], "selector": "#smoke-input"},
+    )
+    if first_query is None or len(first_query["nodes"]) != 1:
+        raise AssertionError(f"the created page was not queryable immediately after browser_create: {first_query}")
     audit, _ = client.call(
         "browser_audit",
         {"panel_id": panel["panel_id"], "action_id": action_id, "limit": 10},


### PR DESCRIPTION
## Purpose

Closes #348. `browser_create` completed as soon as the driver's manifest file existed. Both drivers write that file before the backend reports `Ready` and before the initial navigation commits (Firefox and Safari even report `Ready` before they start it), so a create with a URL could return an empty URL and title that an immediate `browser_panel` call already contradicted, and the agent had no signal to wait on.

Stacked on #365 (typed navigation outcomes); this PR's own diff is the last commit.

## What changed

- **Host readiness (`horizon-ui`, `app/browser_requests.rs`).** The host now decides readiness from the panel's live browser state instead of the manifest's existence: the backend must report `Ready`, and when a URL was requested the first page must have committed both in the panel and in the manifest the agent reads. If the first page has not committed within a bounded startup wait (10 s after `Ready`, always inside the create deadline), the controllable panel is still returned with `navigation: pending` instead of an empty URL presented as ready. The result carries the navigation state and the observed startup latency.
- **Result shape (`horizon-core`).** `BrowserCreateOutcome::Ready` gains `navigation` (`not_requested`, `committed`, `pending`) and `startup_millis`, both with serde defaults so older results still decode.
- **MCP output (`horizon-browser-mcp`).** `browser_create` returns `navigation` and `startup_millis` next to the panel, and its description states that `committed` means the panel already reports the first page, so the agent can act immediately without a `browser_wait`.
- **Gate (`scripts/browser-smoke/mcp_gate.py`).** `create_panel` asserts `navigation == "committed"`, that the returned panel already reports the fixture URL, that `startup_millis` is an integer (printed as `create_startup_millis`), and that an immediate `browser_query` for `#smoke-input` finds exactly one node.
- **Docs.** MCP README, both bundled skills, and the gate doc describe the readiness contract.
- **Review round (`6ccc903`).** Copilot pointed out four gaps: a legacy result without the field was reported as `not_requested` (the field is now optional and an absent state resolves from the server's own input, `pending` for a requested URL); a first navigation the browser had already reported as failed waited the full budget and came back `pending` (now `navigation: failed` with the browser's `navigation_error` at once); an explicit `about:blank` waited the budget (now the committed blank destination); and `startup_millis` started after panel creation and the audit writes (now from the host accepting the request). The second round (`e1bf627`) bases the legacy fallback on a non-blank trimmed `url` and documents that the title is read after commit and may still change. The third round moves WebDriver `Ready` after the startup navigation and bounds Safari's classic startup navigation to 10 s (with page-state polling until the document commits), because Safari otherwise blocked in that navigation for up to 50 s before its servicing loop started and a `pending` result would have named a panel that could not yet service actions; this is Safari-only behavior and is verified by the macOS smoke plan. The fourth round (`62e4458`) dispatches the Firefox BiDi startup navigation asynchronously (the same non-waiting dispatch agent navigations use), because the synchronous command call's 5 s timeout would have reported a slow first page as failed before `Ready`. The fifth round (`eb86ab7`) keeps the panel reported as loading while the startup poll is rescheduled, and the sixth (`6e913c9`) re-emits the loading state right after `Ready` when the startup navigation is still running, because the host resets its loading flag on `Ready`. The seventh (`cfbbbc2`) reports `committed` only when the live panel URL and the manifest URL agree, because the manifest is flushed on a cadence and could still name a pre-redirect document. The eighth (`8c1a539`) recognises a startup page-load timeout by the WebDriver timeout error or the guarding HTTP read timeout instead of by elapsed time, so a genuine failure returned late is reported as `failed`. The Chromium gate once failed on this head in the pre-existing network-capture lane (`records_dropped` during the 4096-frame burst on this 96 % full disk) and passed on immediate rerun. Pre-existing load-sensitive CLI deadline tests (`run_timeout_starts_after_stdin_plan_validation`, `run_deadline_persists_a_partial_report_and_stable_exit_code`, `initialization_write_failure_reaps_the_child`) each failed once across the validation runs and passed on immediate rerun of the same head.

## Behavior impact

- `browser_create` with a URL returns only once the page committed, reports `navigation: failed` plus `navigation_error` as soon as the browser reports the first page failed, or reports `navigation: pending` after the bounded startup wait; `navigation: superseded` when the user navigated the panel first; a create without a URL reports `navigation: not_requested`.
- Create latency grows by the backend's real startup and first commit time; the Firefox gate measured about 6.6 s on Linux, Chromium about 0.6 s.
- No change to `browser_create` inputs or to the panel payload.

## Test evidence

Local, in this worktree at the exact head `d255d22` (one squashed commit plus a test-only duration-idiom commit from the macOS smoke session, rebased onto #365 at `19ebb83`; after #365 merged as `2ae3383` the branch was rebased onto main as `4e96de5` with a byte-identical tree, so the validation below and the macOS smoke apply to it unchanged; Linux, 48-core box):

- `cargo fmt --all -- --check`, `./scripts/check-maintainability.sh`: pass
- `RUSTFLAGS="-D warnings" cargo test --workspace` and `--features speech`: pass
- Blocking, strict, and pedantic clippy tiers: pass
- New tests: core `ready_outcomes_keep_the_legacy_shape_and_default_the_navigation_state` (a legacy result decodes with an absent state, `failed` carries the error), UI `create_readiness_waits_for_the_backend_and_the_committed_first_page` (waits for `Ready`, then for the panel and manifest commit, `about:blank` is committed, a failed first page is `failed` at once, `pending` at the budget or deadline, `not_requested` without a URL)
- Official gate `scripts/browser-smoke/run.py --ephemeral --skip-handoff` on the clean head (git_dirty false), **Chromium** and **Firefox** on Linux under a task-owned Xvfb: MCP gate passed, exit 0, 50 completed actions and 190 audit entries each, no audit/capture/process findings; `create_startup_millis` 635 (Chromium) and 4401 to 6604 (Firefox, two runs), with the immediate post-create query finding the input.

Not run here: Safari and the macOS lanes; they are part of the stacked macOS smoke plan (`docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md`) run on the stacked head.

## macOS smoke

The macOS smoke report for the stacked head (`7e06027`, with this PR at `d255d22`) is posted on #365 and ends with `SMOKE-TEST: DONE`: native matrix pass; Safari, Firefox, and Chromium MCP gates pass with `create_startup_millis` of 882, 1587, and 4415 ms respectively, the create lane's committed first page, and zero audit or network findings; lifecycle and process isolation pass. The Mac session also contributed the Rust 1.97 duration-idiom test fix on this branch.

## Size

7 source/test files, about 420 lines including the review round: within the AGENTS.md thresholds.

## Notes

- `Cargo.lock` is intentionally untouched (pre-existing surge tag drift rewritten by every cargo run).
