### PR TITLE
feat(browser): observe browser_wait inside the engine as one audited action

### DIFF
--- a/assets/plugins/claude-code/skills/horizon-browser/SKILL.md
+++ b/assets/plugins/claude-code/skills/horizon-browser/SKILL.md
@@ -53,7 +53,12 @@ change how long it waits; `timeout_millis` is raised to
 at least 1000 ms, and on Safari every wait returns once the page loaded or the
 bound elapsed. After navigation or
 interaction, verify the visible outcome with `browser_wait`, `browser_query`,
-or a new snapshot. Use `browser_evaluate` only when the semantic tools cannot
+or a new snapshot. `browser_wait` is one audited engine-side action that
+observes the page itself: it returns the matched nodes and `elapsed_millis`,
+and fails with a typed code (`wait_timeout`, `wait_navigation_invalidated`,
+`wait_ownership_lost`, `wait_handoff_pending`, `wait_superseded`) instead of looping on
+queries, so do not poll it in a tight loop; pick a `timeout_millis` that
+covers the expected change. Use `browser_evaluate` only when the semantic tools cannot
 answer the question.
 
 For HTTP or WebSocket observation, first inspect the panel's

--- a/assets/plugins/codex/skills/horizon-browser/SKILL.md
+++ b/assets/plugins/codex/skills/horizon-browser/SKILL.md
@@ -53,7 +53,12 @@ change how long it waits; `timeout_millis` is raised to
 at least 1000 ms, and on Safari every wait returns once the page loaded or the
 bound elapsed. After navigation or
 interaction, verify the visible outcome with `browser_wait`, `browser_query`,
-or a new snapshot. Use `browser_evaluate` only when the semantic tools cannot
+or a new snapshot. `browser_wait` is one audited engine-side action that
+observes the page itself: it returns the matched nodes and `elapsed_millis`,
+and fails with a typed code (`wait_timeout`, `wait_navigation_invalidated`,
+`wait_ownership_lost`, `wait_handoff_pending`, `wait_superseded`) instead of looping on
+queries, so do not poll it in a tight loop; pick a `timeout_millis` that
+covers the expected change. Use `browser_evaluate` only when the semantic tools cannot
 answer the question.
 
 For HTTP or WebSocket observation, first inspect the panel's

--- a/crates/horizon-browser-mcp/README.md
+++ b/crates/horizon-browser-mcp/README.md
@@ -74,7 +74,8 @@ shell commands, files, or other MCP servers.
 - `browser_wait` verifies present, visible, or hidden selector state as one
   audited engine-side action: the browser driver observes the page itself at
   a fixed cadence (no repeated query actions), evaluates the condition over
-  every match (up to the query maximum of 250) and returns at most 20 of
+  every element the selector matches (the page scan counts matches and
+  visible matches beyond the nodes it returns) and returns at most 20 of
   them with `elapsed_millis` and `polls`, and fails with a typed code when the bound
   elapses (`wait_timeout`), the page navigates (`wait_navigation_invalidated`),
   the lease is lost (`wait_ownership_lost`), or a handoff is pending

--- a/crates/horizon-browser-mcp/README.md
+++ b/crates/horizon-browser-mcp/README.md
@@ -71,7 +71,16 @@ shell commands, files, or other MCP servers.
   cross-origin policy prevents inspecting the frame document.
 - `browser_act` clicks, fills, scrolls, reloads, or traverses history. Set
   `count: 2` on a click for a backend-native trusted double-click.
-- `browser_wait` verifies present, visible, or hidden selector state.
+- `browser_wait` verifies present, visible, or hidden selector state as one
+  audited engine-side action: the browser driver observes the page itself at
+  a fixed cadence (no repeated query actions), evaluates the condition over
+  every match (up to the query maximum of 250) and returns at most 20 of
+  them with `elapsed_millis` and `polls`, and fails with a typed code when the bound
+  elapses (`wait_timeout`), the page navigates (`wait_navigation_invalidated`),
+  the lease is lost (`wait_ownership_lost`), or a handoff is pending
+  (`wait_handoff_pending`), or a later wait on the same panel replaces it
+  (`wait_superseded`). `timeout_millis` accepts 1000-60000 ms;
+  `poll_millis` is accepted for compatibility and ignored.
 - `browser_evaluate` evaluates an explicit size-bounded expression.
 - `browser_network` starts, inspects, or stops a bounded HTTP/WebSocket
   capture and returns an explicit private NDJSON path plus connection state,

--- a/crates/horizon-browser-mcp/src/model.rs
+++ b/crates/horizon-browser-mcp/src/model.rs
@@ -500,10 +500,22 @@ pub(crate) struct WaitInput {
     pub(crate) selector: String,
     /// Desired selector state.
     pub(crate) state: WaitState,
-    /// Total wait timeout in milliseconds (1-60000, default 10000).
+    /// Total wait bound in milliseconds (1000-60000, default 10000); smaller
+    /// values are raised to 1000.
     pub(crate) timeout_millis: Option<u64>,
-    /// Delay between audited queries in milliseconds (100-2000, default 250).
+    /// Ignored: the engine observes the page itself at a fixed cadence. Kept
+    /// so older callers keep validating.
     pub(crate) poll_millis: Option<u64>,
+}
+
+impl From<WaitState> for horizon_browser::SelectorState {
+    fn from(state: WaitState) -> Self {
+        match state {
+            WaitState::Present => Self::Present,
+            WaitState::Visible => Self::Visible,
+            WaitState::Hidden => Self::Hidden,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -620,9 +632,38 @@ pub(crate) struct EvaluateOutput {
 #[derive(Debug, Serialize, JsonSchema)]
 pub(crate) struct WaitOutput {
     pub(crate) panel_id: String,
+    /// The single audited action id this wait ran as.
     pub(crate) action_id: String,
     pub(crate) state: String,
+    /// Page generation and revision of the reported nodes.
+    pub(crate) generation: u64,
+    pub(crate) revision: u64,
+    /// Nodes matching the selector when the condition was met.
     pub(crate) nodes: Vec<NodeOutput>,
+    /// Time from queuing the action until the condition was met.
+    pub(crate) elapsed_millis: u64,
+    /// Page observations the engine needed.
+    pub(crate) polls: u32,
+}
+
+impl WaitOutput {
+    pub(crate) fn from_outcome(panel_id: String, action_id: String, wait: horizon_browser::WaitOutcome) -> Self {
+        let state = match wait.state {
+            horizon_browser::SelectorState::Present => "present",
+            horizon_browser::SelectorState::Visible => "visible",
+            horizon_browser::SelectorState::Hidden => "hidden",
+        };
+        Self {
+            panel_id,
+            action_id,
+            state: state.to_string(),
+            generation: wait.generation,
+            revision: wait.revision,
+            nodes: wait.nodes.into_iter().map(NodeOutput::from).collect(),
+            elapsed_millis: wait.elapsed_millis,
+            polls: wait.polls,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/horizon-browser-mcp/src/server.rs
+++ b/crates/horizon-browser-mcp/src/server.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use horizon_browser::{BrowserControlAction, BrowserControlValue};
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
@@ -21,14 +19,12 @@ use crate::model::{
     ActInput, ActKind, ActionOutput, AuditInput, AuditOutput, BrowserListOutput, CreateInput, CreateOutput,
     EvaluateInput, EvaluateOutput, HandoffInput, HandoffOutput, NavigateInput, NavigateOutput, NetworkInput,
     NetworkOutput, NetworkWatchInput, NetworkWatchOutput, NodeOutput, NodesOutput, PanelInput, QueryInput,
-    SnapshotInput, SnapshotOutput, VisibilityInput, VisibilityOutput, WaitInput, WaitOutput, WaitState,
+    SnapshotInput, SnapshotOutput, VisibilityInput, VisibilityOutput, WaitInput, WaitOutput,
 };
 use crate::network_watch::NetworkWatchState;
 
 const DEFAULT_SNAPSHOT_NODES: u32 = 250;
 const DEFAULT_QUERY_RESULTS: u32 = 50;
-const DEFAULT_WAIT_TIMEOUT_MILLIS: u64 = 10_000;
-const DEFAULT_WAIT_POLL_MILLIS: u64 = 250;
 
 /// Stdio MCP service for live Horizon browser panels.
 #[derive(Clone, Debug)]
@@ -284,7 +280,7 @@ impl HorizonBrowserMcp {
 
     #[tool(
         name = "browser_wait",
-        description = "Wait for a CSS selector to become present, visible, or hidden using bounded audited queries."
+        description = "Wait for a CSS selector to become present, visible, or hidden as one audited engine-side action: the browser driver observes the page itself (no repeated queries) and returns the matched nodes and elapsed_millis, or a typed failure (wait_timeout, wait_navigation_invalidated when the page navigated, wait_ownership_lost, wait_handoff_pending, wait_superseded when a later wait on the same panel replaced it). timeout_millis is 1000-60000 (default 10000) and is enforced in full by the engine; poll_millis is accepted for compatibility and ignored."
     )]
     async fn browser_wait(&self, Parameters(input): Parameters<WaitInput>) -> Result<Json<WaitOutput>, String> {
         wait_for_selector(&self.controller, input).await.map(Json)
@@ -403,66 +399,48 @@ fn require_action_completed(action: ActKind, value: &BrowserControlValue) -> Res
     }
 }
 
+/// Shortest wait bound this server accepts; the engine observes on a 100 ms
+/// cadence and reports its typed timeout on a 250 ms coordination tick.
+const MIN_WAIT_TIMEOUT_MILLIS: u64 = 1_000;
+
+/// The wait this server applies to a `WaitForSelector` action.
+fn bounded_wait_timeout(timeout_millis: Option<u64>) -> u64 {
+    timeout_millis
+        .unwrap_or(horizon_browser::DEFAULT_WAIT_TIMEOUT_MILLIS)
+        .clamp(MIN_WAIT_TIMEOUT_MILLIS, MAX_ACTION_TIMEOUT_MILLIS)
+}
+
+/// One audited engine-side wait: the browser driver observes the selector
+/// itself and reports the matched nodes, the elapsed time, or a typed
+/// failure (`wait_timeout`, `wait_navigation_invalidated`,
+/// `wait_ownership_lost`, `wait_handoff_pending`, `wait_superseded`).
 async fn wait_for_selector(controller: &BrowserController, input: WaitInput) -> Result<WaitOutput, String> {
-    let timeout_millis = input
-        .timeout_millis
-        .unwrap_or(DEFAULT_WAIT_TIMEOUT_MILLIS)
-        .clamp(1, MAX_ACTION_TIMEOUT_MILLIS);
-    let poll_millis = input.poll_millis.unwrap_or(DEFAULT_WAIT_POLL_MILLIS).clamp(100, 2_000);
-    let started = Instant::now();
-    loop {
-        let remaining = timeout_millis.saturating_sub(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX));
-        if remaining == 0 {
-            return Err(format!(
-                "selector did not become {} within {timeout_millis} ms",
-                wait_state_name(input.state)
-            ));
-        }
-        let receipt = controller
-            .execute(
-                &input.panel_id,
-                BrowserControlAction::Query {
-                    selector: input.selector.clone(),
-                    max_results: DEFAULT_QUERY_RESULTS,
-                },
-                Some(remaining),
-            )
-            .await
-            .map_err(|error| error.to_string())?;
-        let BrowserControlValue::Nodes { nodes, .. } = receipt.value else {
-            return Err("browser returned an unexpected wait result".to_string());
-        };
-        if wait_satisfied(input.state, &nodes) {
-            return Ok(WaitOutput {
-                panel_id: input.panel_id,
-                action_id: receipt.action_id,
-                state: wait_state_name(input.state).to_string(),
-                nodes: nodes.into_iter().map(NodeOutput::from).collect(),
-            });
-        }
-        tokio::time::sleep(Duration::from_millis(poll_millis.min(remaining))).await;
+    let timeout_millis = bounded_wait_timeout(input.timeout_millis);
+    if let Some(poll_millis) = input.poll_millis {
+        tracing::debug!(target: "browser_mcp", poll_millis, "browser_wait poll_millis is ignored; the engine observes the page itself");
     }
-}
-
-fn wait_satisfied(state: WaitState, nodes: &[horizon_browser::BrowserNode]) -> bool {
-    match state {
-        WaitState::Present => !nodes.is_empty(),
-        WaitState::Visible => nodes.iter().any(|node| node.visible),
-        WaitState::Hidden => nodes.iter().all(|node| !node.visible),
-    }
-}
-
-const fn wait_state_name(state: WaitState) -> &'static str {
-    match state {
-        WaitState::Present => "present",
-        WaitState::Visible => "visible",
-        WaitState::Hidden => "hidden",
-    }
+    let receipt = controller
+        .execute_engine_bounded(
+            &input.panel_id,
+            BrowserControlAction::WaitForSelector {
+                selector: input.selector,
+                state: input.state.into(),
+                timeout_millis: Some(timeout_millis),
+            },
+            timeout_millis,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    let BrowserControlValue::Wait { wait } = receipt.value else {
+        return Err("browser returned an unexpected wait result".to_string());
+    };
+    Ok(WaitOutput::from_outcome(input.panel_id, receipt.action_id, wait))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::WaitState;
 
     #[test]
     fn server_exposes_only_the_mcp_contract() {
@@ -555,20 +533,28 @@ mod tests {
     }
 
     #[test]
-    fn wait_states_are_exact() {
-        let visible = horizon_browser::BrowserNode {
-            reference: "g1s1e1".to_string(),
-            role: "button".to_string(),
-            name: "Continue".to_string(),
-            text: String::new(),
-            visible: true,
-            enabled: true,
-            bounds: None,
-        };
-        assert!(wait_satisfied(WaitState::Present, std::slice::from_ref(&visible)));
-        assert!(wait_satisfied(WaitState::Visible, std::slice::from_ref(&visible)));
-        assert!(!wait_satisfied(WaitState::Hidden, &[visible]));
-        assert!(wait_satisfied(WaitState::Hidden, &[]));
+    fn wait_inputs_map_to_one_bounded_engine_action() {
+        assert_eq!(bounded_wait_timeout(None), 10_000);
+        assert_eq!(bounded_wait_timeout(Some(10)), 1_000, "bounds below 1 s are raised");
+        assert_eq!(bounded_wait_timeout(Some(600_000)), 60_000);
+        let state: horizon_browser::SelectorState = WaitState::Hidden.into();
+        assert_eq!(state, horizon_browser::SelectorState::Hidden);
+        let output = WaitOutput::from_outcome(
+            "panel".to_string(),
+            "action".to_string(),
+            horizon_browser::WaitOutcome {
+                state: horizon_browser::SelectorState::Visible,
+                generation: 2,
+                revision: 3,
+                nodes: Vec::new(),
+                elapsed_millis: 1_480,
+                polls: 15,
+            },
+        );
+        assert_eq!(output.state, "visible");
+        assert_eq!(output.elapsed_millis, 1_480);
+        assert_eq!(output.polls, 15);
+        assert_eq!((output.generation, output.revision), (2, 3));
     }
 
     #[test]

--- a/crates/horizon-browser-protocol/src/audit.rs
+++ b/crates/horizon-browser-protocol/src/audit.rs
@@ -112,6 +112,12 @@ pub enum BrowserAuditAction {
         selector_characters: usize,
         max_results: u32,
     },
+    WaitForSelector {
+        selector_characters: usize,
+        state: crate::SelectorState,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_millis: Option<u64>,
+    },
     Click {
         target: String,
         #[serde(default = "default_click_count")]
@@ -178,6 +184,15 @@ impl BrowserAuditAction {
             BrowserControlAction::Query { selector, max_results } => Self::Query {
                 selector_characters: selector.chars().count(),
                 max_results: *max_results,
+            },
+            BrowserControlAction::WaitForSelector {
+                selector,
+                state,
+                timeout_millis,
+            } => Self::WaitForSelector {
+                selector_characters: selector.chars().count(),
+                state: *state,
+                timeout_millis: *timeout_millis,
             },
             BrowserControlAction::Click { target, count } => Self::Click {
                 target: audit_target(target),
@@ -482,6 +497,20 @@ mod tests {
 
     #[test]
     fn semantic_audits_redact_selectors_scripts_and_fill_values() {
+        let wait = BrowserAuditAction::from_control(&BrowserControlAction::WaitForSelector {
+            selector: "input[value='secret']".to_string(),
+            state: crate::SelectorState::Hidden,
+            timeout_millis: Some(1_000),
+        });
+        assert_eq!(
+            wait,
+            BrowserAuditAction::WaitForSelector {
+                selector_characters: 21,
+                state: crate::SelectorState::Hidden,
+                timeout_millis: Some(1_000),
+            }
+        );
+        assert!(!serde_json::to_string(&wait).expect("encode").contains("secret"));
         let query = BrowserAuditAction::from_control(&BrowserControlAction::Query {
             selector: "input[value='secret']".to_string(),
             max_results: 2,

--- a/crates/horizon-browser-protocol/src/control.rs
+++ b/crates/horizon-browser-protocol/src/control.rs
@@ -6,6 +6,7 @@
 
 use crate::{
     BrowserCommand, BrowserInput, BrowserKey, BrowserNetworkCaptureOptions, BrowserNetworkOperation, BrowserTarget,
+    SelectorState,
 };
 
 const MAX_NAVIGATION_BYTES: usize = 8 * 1024;
@@ -20,6 +21,10 @@ pub const MAX_CLICK_COUNT: u32 = 3;
 pub const MAX_NAVIGATION_TIMEOUT_MILLIS: u64 = 60_000;
 /// Wait applied when a navigation action does not carry its own bound.
 pub const DEFAULT_NAVIGATION_TIMEOUT_MILLIS: u64 = 15_000;
+/// Longest bounded selector wait an engine performs for one action.
+pub const MAX_WAIT_TIMEOUT_MILLIS: u64 = 60_000;
+/// Selector wait applied when the action does not carry its own bound.
+pub const DEFAULT_WAIT_TIMEOUT_MILLIS: u64 = 10_000;
 
 /// How far a navigation action waits before it reports its outcome.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -106,6 +111,16 @@ pub enum BrowserControlAction {
         selector: String,
         max_results: u32,
     },
+    /// Observe a selector inside the engine until it reaches `state`, as one
+    /// audited action instead of repeated queries.
+    WaitForSelector {
+        selector: String,
+        state: SelectorState,
+        /// Bound in milliseconds; a `wait_timeout` failure reports the
+        /// elapsed time and the last observation when it elapses.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_millis: Option<u64>,
+    },
     /// Click the center of a visible element through the backend input path.
     Click {
         target: BrowserTarget,
@@ -157,6 +172,18 @@ impl BrowserControlAction {
                 validate_selector(selector)?;
                 validate_query_limit(*max_results)
             }
+            Self::WaitForSelector {
+                selector,
+                timeout_millis,
+                ..
+            } => {
+                validate_selector(selector)?;
+                match timeout_millis {
+                    Some(0) => Err("wait timeout must be at least 1 ms"),
+                    Some(value) if *value > MAX_WAIT_TIMEOUT_MILLIS => Err("wait timeout exceeds the engine bound"),
+                    _ => Ok(()),
+                }
+            }
             Self::Click { target, count } => {
                 validate_target(target)?;
                 validate_click_count(*count)
@@ -200,6 +227,7 @@ impl BrowserControlAction {
             Self::Input { input } => Some(BrowserCommand::Input(input.clone())),
             Self::Snapshot { .. }
             | Self::Query { .. }
+            | Self::WaitForSelector { .. }
             | Self::Click { .. }
             | Self::Fill { .. }
             | Self::Scroll { .. }
@@ -439,6 +467,39 @@ mod tests {
 
         assert!(invalid_point.validate().is_err());
         assert!(oversized.validate().is_err());
+    }
+
+    #[test]
+    fn wait_actions_validate_selector_and_bound_and_stay_semantic() {
+        let wait = BrowserControlAction::WaitForSelector {
+            selector: "#late".to_string(),
+            state: SelectorState::Visible,
+            timeout_millis: Some(2_500),
+        };
+        assert!(wait.validate().is_ok());
+        assert!(wait.to_command().is_none(), "waits run in the engine's semantic path");
+        assert_eq!(
+            serde_json::to_value(&wait).expect("encode"),
+            serde_json::json!({ "type": "wait_for_selector", "selector": "#late", "state": "visible", "timeout_millis": 2500 })
+        );
+        assert_eq!(
+            BrowserControlAction::WaitForSelector {
+                selector: "[".to_string(),
+                state: SelectorState::Present,
+                timeout_millis: Some(MAX_WAIT_TIMEOUT_MILLIS + 1),
+            }
+            .validate(),
+            Err("wait timeout exceeds the engine bound")
+        );
+        assert_eq!(
+            BrowserControlAction::WaitForSelector {
+                selector: String::new(),
+                state: SelectorState::Present,
+                timeout_millis: None,
+            }
+            .validate(),
+            Err("selector must not be empty")
+        );
     }
 
     #[test]

--- a/crates/horizon-browser-protocol/src/lib.rs
+++ b/crates/horizon-browser-protocol/src/lib.rs
@@ -17,8 +17,9 @@ pub use audit::{
 };
 pub use command::BrowserCommand;
 pub use control::{
-    AgentAction, BrowserControlAction, DEFAULT_CLICK_COUNT, DEFAULT_NAVIGATION_TIMEOUT_MILLIS, MAX_CLICK_COUNT,
-    MAX_NAVIGATION_TIMEOUT_MILLIS, MAX_QUERY_RESULTS, MAX_SNAPSHOT_NODES, NavigationWait, normalize_navigation_target,
+    AgentAction, BrowserControlAction, DEFAULT_CLICK_COUNT, DEFAULT_NAVIGATION_TIMEOUT_MILLIS,
+    DEFAULT_WAIT_TIMEOUT_MILLIS, MAX_CLICK_COUNT, MAX_NAVIGATION_TIMEOUT_MILLIS, MAX_QUERY_RESULTS, MAX_SNAPSHOT_NODES,
+    MAX_WAIT_TIMEOUT_MILLIS, NavigationWait, normalize_navigation_target,
 };
 pub use input::{BrowserButton, BrowserEditCommand, BrowserInput, BrowserKey, BrowserModifiers};
 pub use network::{
@@ -29,7 +30,7 @@ pub use network::{
 };
 pub use semantic::{
     AgentActionResult, BrowserActionOutcome, BrowserBounds, BrowserControlFailure, BrowserControlValue, BrowserNode,
-    BrowserSnapshot, BrowserTarget, NavigationOutcome, NavigationState,
+    BrowserSnapshot, BrowserTarget, NavigationOutcome, NavigationState, SelectorState, WaitOutcome,
 };
 
 /// Browser automation backend selected for a session.

--- a/crates/horizon-browser-protocol/src/semantic.rs
+++ b/crates/horizon-browser-protocol/src/semantic.rs
@@ -39,6 +39,45 @@ pub struct BrowserSnapshot {
     pub nodes: Vec<BrowserNode>,
 }
 
+/// Selector condition a wait action observes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectorState {
+    /// At least one element matches.
+    Present,
+    /// At least one matching element is rendered visible.
+    Visible,
+    /// No matching element is visible (an empty match set counts).
+    Hidden,
+}
+
+impl SelectorState {
+    #[must_use]
+    pub fn satisfied_by(self, nodes: &[BrowserNode]) -> bool {
+        match self {
+            Self::Present => !nodes.is_empty(),
+            Self::Visible => nodes.iter().any(|node| node.visible),
+            Self::Hidden => nodes.iter().all(|node| !node.visible),
+        }
+    }
+}
+
+/// Result of a satisfied wait action. Timeouts and cancellations are failed
+/// actions with typed codes (`wait_timeout`, `wait_navigation_invalidated`,
+/// `wait_ownership_lost`, `wait_handoff_pending`, `wait_superseded`).
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WaitOutcome {
+    pub state: SelectorState,
+    pub generation: u64,
+    pub revision: u64,
+    /// Nodes matching the selector when the condition was met.
+    pub nodes: Vec<BrowserNode>,
+    /// Time from the caller queuing the action until the condition was met.
+    pub elapsed_millis: u64,
+    /// Page observations the engine needed.
+    pub polls: u32,
+}
+
 /// Where a navigation action stood when its outcome was reported.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -86,6 +125,9 @@ pub enum BrowserControlValue {
     Accepted,
     Navigation {
         navigation: NavigationOutcome,
+    },
+    Wait {
+        wait: WaitOutcome,
     },
     Snapshot {
         snapshot: BrowserSnapshot,

--- a/crates/horizon-browser/src/lib.rs
+++ b/crates/horizon-browser/src/lib.rs
@@ -20,6 +20,7 @@ pub mod process;
 mod profile;
 mod semantic;
 pub mod session;
+mod wait;
 mod webdriver;
 mod websocket;
 
@@ -32,8 +33,9 @@ pub use error::BrowserError;
 pub use frames::{FrameData, FrameMetrics, FrameSlot, PageScrollState};
 pub use horizon_browser_protocol::{
     AgentAction, BackendAvailability, BackendCapabilities, BackendKind, BrowserControlAction, DEFAULT_CLICK_COUNT,
-    DEFAULT_NAVIGATION_TIMEOUT_MILLIS, FrameDelivery, MAX_CLICK_COUNT, MAX_NAVIGATION_TIMEOUT_MILLIS,
-    MAX_QUERY_RESULTS, MAX_SNAPSHOT_NODES, NavigationWait, normalize_navigation_target,
+    DEFAULT_NAVIGATION_TIMEOUT_MILLIS, DEFAULT_WAIT_TIMEOUT_MILLIS, FrameDelivery, MAX_CLICK_COUNT,
+    MAX_NAVIGATION_TIMEOUT_MILLIS, MAX_QUERY_RESULTS, MAX_SNAPSHOT_NODES, MAX_WAIT_TIMEOUT_MILLIS, NavigationWait,
+    normalize_navigation_target,
 };
 pub use input::{BrowserButton, BrowserEditCommand, BrowserInput, BrowserKey, BrowserModifiers};
 pub use network::{
@@ -44,7 +46,7 @@ pub use network::{
 };
 pub use semantic::{
     AgentActionResult, BrowserActionOutcome, BrowserBounds, BrowserControlFailure, BrowserControlValue, BrowserNode,
-    BrowserSnapshot, BrowserTarget, NavigationOutcome, NavigationState,
+    BrowserSnapshot, BrowserTarget, NavigationOutcome, NavigationState, SelectorState, WaitOutcome,
 };
 pub use session::{
     BrowserCommand, BrowserEvent, BrowserEventWaker, BrowserSession, BrowserSessionConfig, BrowserShutdownSignal,

--- a/crates/horizon-browser/src/navigation.rs
+++ b/crates/horizon-browser/src/navigation.rs
@@ -420,7 +420,7 @@ impl PendingNavigation {
 /// Whether a committed URL is the requested destination rather than a
 /// redirect. Browsers add or drop a trailing slash on bare origins, so that
 /// difference alone is not a redirect.
-fn same_destination(requested: &str, committed: &str) -> bool {
+pub(crate) fn same_destination(requested: &str, committed: &str) -> bool {
     requested == committed || bare_origin_variant(requested, committed) || bare_origin_variant(committed, requested)
 }
 

--- a/crates/horizon-browser/src/navigation.rs
+++ b/crates/horizon-browser/src/navigation.rs
@@ -164,6 +164,9 @@ impl PendingNavigation {
     /// navigation and dropped otherwise, so an earlier navigation still in
     /// flight cannot settle this one.
     pub(crate) fn attach_id(&mut self, id: Option<&str>, now: Instant) -> Option<NavigationResult> {
+        if let Some(expired) = self.tick(now) {
+            return Some(expired);
+        }
         self.dispatch_known = true;
         self.expected_id = id.map(str::to_string);
         // Keep the newest held signal that belongs to this navigation; every
@@ -216,6 +219,12 @@ impl PendingNavigation {
         }
     }
 
+    /// Whether an identified signal must wait for the dispatch reply before
+    /// the driver may apply page-wide side effects for it.
+    pub(crate) fn attribution_is_pending(&self, id: Option<&str>) -> bool {
+        !self.dispatch_known && id.is_some()
+    }
+
     /// A dispatch reply without an id means the backend ran a same-document
     /// navigation; an identified cross-document commit or failure cannot be
     /// ours then (it belongs to an earlier navigation still in flight).
@@ -235,6 +244,9 @@ impl PendingNavigation {
 
     /// Apply one signal; `Some` when the action is settled.
     pub(crate) fn observe(&mut self, signal: NavigationSignal<'_>, now: Instant) -> Option<NavigationResult> {
+        if let Some(expired) = self.tick(now) {
+            return Some(expired);
+        }
         let id = match signal {
             NavigationSignal::Committed { id, .. }
             | NavigationSignal::SameDocument { id, .. }
@@ -1060,6 +1072,50 @@ mod tests {
         let outcome = navigation(Some(Ok(pending.dispatched(now))));
         assert_eq!(outcome.state, NavigationState::Dispatched);
         assert!(outcome.loading);
+    }
+
+    #[test]
+    fn deadline_precedes_direct_and_deferred_protocol_signals() {
+        let now = Instant::now();
+        let after_deadline = now + Duration::from_secs(1);
+
+        let mut direct_commit = pending(NavigationWait::Commit, now);
+        let outcome = navigation(direct_commit.observe(
+            NavigationSignal::Committed {
+                url: "https://example.test/start",
+                id: None,
+            },
+            after_deadline,
+        ));
+        assert_eq!(outcome.state, NavigationState::TimedOut);
+        assert_eq!(outcome.committed_url, None);
+
+        let mut direct_failure = pending(NavigationWait::Commit, now);
+        let outcome = navigation(direct_failure.observe(
+            NavigationSignal::Failed {
+                message: "late failure",
+                id: None,
+            },
+            after_deadline,
+        ));
+        assert_eq!(outcome.state, NavigationState::TimedOut);
+
+        let mut deferred = pending(NavigationWait::Commit, now);
+        assert!(deferred.attribution_is_pending(Some("loader-b")));
+        assert!(
+            deferred
+                .observe(
+                    NavigationSignal::Committed {
+                        url: "https://example.test/start",
+                        id: Some("loader-b"),
+                    },
+                    now + Duration::from_millis(900),
+                )
+                .is_none()
+        );
+        let outcome = navigation(deferred.attach_id(Some("loader-b"), after_deadline));
+        assert_eq!(outcome.state, NavigationState::TimedOut);
+        assert_eq!(outcome.committed_url, None);
     }
 
     #[test]

--- a/crates/horizon-browser/src/semantic.rs
+++ b/crates/horizon-browser/src/semantic.rs
@@ -50,16 +50,14 @@ impl SemanticState {
     /// Parse a scan without registering references: the page generation and
     /// the nodes (with empty references) for judging a condition, leaving the
     /// reference map of the last registered snapshot or query untouched.
-    pub(crate) fn peek_nodes(
-        &self,
-        value: &Value,
-    ) -> Result<(u64, Vec<BrowserNode>, Option<String>), BrowserControlFailure> {
+    pub(crate) fn peek_nodes(&self, value: &Value) -> Result<PeekedScan, BrowserControlFailure> {
         let response: NodeScanResponse = serde_json::from_value(value.clone())
             .map_err(|error| BrowserControlFailure::new("invalid_result", format!("invalid page snapshot: {error}")))?;
         if let Some(error) = response.error {
             return Err(error);
         }
         let document_identity = response.document_identity;
+        let summary = response.summary;
         let nodes = response
             .nodes
             .into_iter()
@@ -73,7 +71,12 @@ impl SemanticState {
                 bounds: scanned.bounds.filter(valid_bounds),
             })
             .collect();
-        Ok((self.generation, nodes, document_identity))
+        Ok(PeekedScan {
+            generation: self.generation,
+            nodes,
+            summary,
+            document_identity,
+        })
     }
 
     pub(crate) fn register_nodes(
@@ -124,7 +127,28 @@ struct NodeScanResponse {
     #[serde(default, rename = "documentIdentity")]
     document_identity: Option<String>,
     #[serde(default)]
+    summary: Option<ScanSummary>,
+    #[serde(default)]
     error: Option<BrowserControlFailure>,
+}
+
+/// A scan parsed without registering references: the page generation, the
+/// returned nodes (with empty references), the selector-wide match summary
+/// when the scan had a selector, and the script-observed document identity.
+#[derive(Debug, Default)]
+pub(crate) struct PeekedScan {
+    pub(crate) generation: u64,
+    pub(crate) nodes: Vec<BrowserNode>,
+    pub(crate) summary: Option<ScanSummary>,
+    pub(crate) document_identity: Option<String>,
+}
+
+/// Match and visibility counts over every element a selector scan matched,
+/// beyond the capped nodes it returned.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+pub(crate) struct ScanSummary {
+    pub(crate) matched: usize,
+    pub(crate) visible: usize,
 }
 
 #[derive(Deserialize)]
@@ -296,12 +320,22 @@ const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
         };
     }
     const nodes = [];
+    // With a selector, match and visibility counts cover every match so a
+    // condition can be judged beyond the returned cap; a full-document
+    // snapshot keeps its early stop.
+    let matched = 0;
+    let visibleMatches = 0;
     for (const element of candidates) {
-        if (nodes.length >= maxNodes) break;
+        if (nodes.length >= maxNodes && selector === null) break;
         const style = getComputedStyle(element);
         const rect = element.getBoundingClientRect();
         const visible = style.display !== 'none' && style.visibility !== 'hidden' &&
             Number(style.opacity || 1) !== 0 && rect.width > 0 && rect.height > 0;
+        if (selector !== null) {
+            matched += 1;
+            if (visible) visibleMatches += 1;
+            if (nodes.length >= maxNodes) continue;
+        }
         const role = roleFor(element);
         const name = nameFor(element);
         const tag = element.tagName.toLowerCase();
@@ -315,7 +349,9 @@ const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
             bounds: visible ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height } : null,
         });
     }
-    return { nodes, documentIdentity };
+    return selector === null
+        ? { nodes, documentIdentity }
+        : { nodes, documentIdentity, summary: { matched, visible: visibleMatches } };
 }";
 
 const TARGET_RECT_FUNCTION: &str = r"function(selector, clear) {
@@ -423,15 +459,18 @@ mod tests {
     #[test]
     fn wait_peeks_preserve_the_script_observed_document_identity() {
         let state = SemanticState::default();
-        let (_, nodes, identity) = state
+        let peeked = state
             .peek_nodes(&serde_json::json!({
                 "nodes": [],
                 "documentIdentity": "[\"https://example.test/\",1234]"
             }))
             .unwrap_or_default();
 
-        assert!(nodes.is_empty());
-        assert_eq!(identity.as_deref(), Some("[\"https://example.test/\",1234]"));
+        assert!(peeked.nodes.is_empty());
+        assert_eq!(
+            peeked.document_identity.as_deref(),
+            Some("[\"https://example.test/\",1234]")
+        );
         assert!(scan_expression(None, 10).contains("documentIdentity"));
     }
 

--- a/crates/horizon-browser/src/semantic.rs
+++ b/crates/horizon-browser/src/semantic.rs
@@ -50,12 +50,16 @@ impl SemanticState {
     /// Parse a scan without registering references: the page generation and
     /// the nodes (with empty references) for judging a condition, leaving the
     /// reference map of the last registered snapshot or query untouched.
-    pub(crate) fn peek_nodes(&self, value: &Value) -> Result<(u64, Vec<BrowserNode>), BrowserControlFailure> {
+    pub(crate) fn peek_nodes(
+        &self,
+        value: &Value,
+    ) -> Result<(u64, Vec<BrowserNode>, Option<String>), BrowserControlFailure> {
         let response: NodeScanResponse = serde_json::from_value(value.clone())
             .map_err(|error| BrowserControlFailure::new("invalid_result", format!("invalid page snapshot: {error}")))?;
         if let Some(error) = response.error {
             return Err(error);
         }
+        let document_identity = response.document_identity;
         let nodes = response
             .nodes
             .into_iter()
@@ -69,7 +73,7 @@ impl SemanticState {
                 bounds: scanned.bounds.filter(valid_bounds),
             })
             .collect();
-        Ok((self.generation, nodes))
+        Ok((self.generation, nodes, document_identity))
     }
 
     pub(crate) fn register_nodes(
@@ -117,6 +121,8 @@ impl SemanticState {
 struct NodeScanResponse {
     #[serde(default)]
     nodes: Vec<ScannedNode>,
+    #[serde(default, rename = "documentIdentity")]
+    document_identity: Option<String>,
     #[serde(default)]
     error: Option<BrowserControlFailure>,
 }
@@ -218,6 +224,9 @@ fn json_string(value: &str) -> String {
 }
 
 const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
+    const documentIdentity = JSON.stringify([
+        String(location.href), Number(globalThis.performance?.timeOrigin || 0)
+    ]);
     const roleFor = (element) => {
         const explicit = element.getAttribute('role');
         if (explicit) return explicit.split(/\s+/)[0];
@@ -281,7 +290,10 @@ const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
     try {
         candidates = document.querySelectorAll(selector === null ? '*' : selector);
     } catch (error) {
-        return { nodes: [], error: { code: 'invalid_selector', message: compact(error?.message || error) } };
+        return {
+            nodes: [], documentIdentity,
+            error: { code: 'invalid_selector', message: compact(error?.message || error) }
+        };
     }
     const nodes = [];
     for (const element of candidates) {
@@ -303,7 +315,7 @@ const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
             bounds: visible ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height } : null,
         });
     }
-    return { nodes };
+    return { nodes, documentIdentity };
 }";
 
 const TARGET_RECT_FUNCTION: &str = r"function(selector, clear) {
@@ -406,6 +418,21 @@ mod tests {
         let expression = scan_expression(None, 10);
 
         assert!(expression.contains("if (tag === 'iframe') return 'iframe'"));
+    }
+
+    #[test]
+    fn wait_peeks_preserve_the_script_observed_document_identity() {
+        let state = SemanticState::default();
+        let (_, nodes, identity) = state
+            .peek_nodes(&serde_json::json!({
+                "nodes": [],
+                "documentIdentity": "[\"https://example.test/\",1234]"
+            }))
+            .unwrap_or_default();
+
+        assert!(nodes.is_empty());
+        assert_eq!(identity.as_deref(), Some("[\"https://example.test/\",1234]"));
+        assert!(scan_expression(None, 10).contains("documentIdentity"));
     }
 
     #[test]

--- a/crates/horizon-browser/src/semantic.rs
+++ b/crates/horizon-browser/src/semantic.rs
@@ -47,6 +47,31 @@ impl SemanticState {
         self.references.clear();
     }
 
+    /// Parse a scan without registering references: the page generation and
+    /// the nodes (with empty references) for judging a condition, leaving the
+    /// reference map of the last registered snapshot or query untouched.
+    pub(crate) fn peek_nodes(&self, value: &Value) -> Result<(u64, Vec<BrowserNode>), BrowserControlFailure> {
+        let response: NodeScanResponse = serde_json::from_value(value.clone())
+            .map_err(|error| BrowserControlFailure::new("invalid_result", format!("invalid page snapshot: {error}")))?;
+        if let Some(error) = response.error {
+            return Err(error);
+        }
+        let nodes = response
+            .nodes
+            .into_iter()
+            .map(|scanned| BrowserNode {
+                reference: String::new(),
+                role: truncate_utf8(scanned.role, MAX_NODE_STRING_BYTES),
+                name: truncate_utf8(scanned.name, MAX_NODE_STRING_BYTES),
+                text: truncate_utf8(scanned.text, MAX_NODE_STRING_BYTES),
+                visible: scanned.visible,
+                enabled: scanned.enabled,
+                bounds: scanned.bounds.filter(valid_bounds),
+            })
+            .collect();
+        Ok((self.generation, nodes))
+    }
+
     pub(crate) fn register_nodes(
         &mut self,
         value: Value,

--- a/crates/horizon-browser/src/semantic.rs
+++ b/crates/horizon-browser/src/semantic.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 pub use horizon_browser_protocol::{
     AgentActionResult, BrowserActionOutcome, BrowserBounds, BrowserControlFailure, BrowserControlValue, BrowserNode,
-    BrowserSnapshot, BrowserTarget, NavigationOutcome, NavigationState,
+    BrowserSnapshot, BrowserTarget, NavigationOutcome, NavigationState, SelectorState, WaitOutcome,
 };
 
 const MAX_CONTROL_RESULT_BYTES: usize = 1024 * 1024;
@@ -35,6 +35,12 @@ impl Default for SemanticState {
 }
 
 impl SemanticState {
+    /// Current page generation; it advances whenever a navigation invalidates
+    /// earlier references.
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+
     pub(crate) fn invalidate(&mut self) {
         self.generation = self.generation.wrapping_add(1).max(1);
         self.revision = 0;

--- a/crates/horizon-browser/src/semantic.rs
+++ b/crates/horizon-browser/src/semantic.rs
@@ -206,10 +206,22 @@ pub(crate) fn bounded_control_value(value: Value) -> Result<Value, BrowserContro
     }
 }
 
+/// A snapshot or query scan: it stops at `max_nodes` results.
 pub(crate) fn scan_expression(selector: Option<&str>, max_nodes: u32) -> String {
     let selector = selector.map_or_else(|| "null".to_string(), json_string);
     let semantic_only = selector == "null";
-    format!("({NODE_SCAN_FUNCTION})({selector}, {max_nodes}, {semantic_only})")
+    format!("({NODE_SCAN_FUNCTION})({selector}, {max_nodes}, {semantic_only}, false)")
+}
+
+/// A wait observation: the scan returns at most `max_nodes` results but
+/// keeps counting matches and visible matches over the whole match list, so
+/// the condition can be judged beyond the returned nodes. Only waits pay for
+/// the full pass; queries keep the early stop.
+pub(crate) fn wait_scan_expression(selector: &str, max_nodes: u32) -> String {
+    format!(
+        "({NODE_SCAN_FUNCTION})({}, {max_nodes}, false, true)",
+        json_string(selector)
+    )
 }
 
 pub(crate) fn target_rect_expression(selector: &str, clear: bool) -> String {
@@ -247,7 +259,7 @@ fn json_string(value: &str) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
-const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
+const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly, countMatches) {
     const documentIdentity = JSON.stringify([
         String(location.href), Number(globalThis.performance?.timeOrigin || 0)
     ]);
@@ -320,18 +332,18 @@ const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
         };
     }
     const nodes = [];
-    // With a selector, match and visibility counts cover every match so a
-    // condition can be judged beyond the returned cap; a full-document
-    // snapshot keeps its early stop.
+    // A wait asks for match and visibility counts over every match so its
+    // condition can be judged beyond the returned cap; snapshots and queries
+    // stop at the cap and never lay out the rest of the page.
     let matched = 0;
     let visibleMatches = 0;
     for (const element of candidates) {
-        if (nodes.length >= maxNodes && selector === null) break;
+        if (nodes.length >= maxNodes && !countMatches) break;
         const style = getComputedStyle(element);
         const rect = element.getBoundingClientRect();
         const visible = style.display !== 'none' && style.visibility !== 'hidden' &&
             Number(style.opacity || 1) !== 0 && rect.width > 0 && rect.height > 0;
-        if (selector !== null) {
+        if (countMatches) {
             matched += 1;
             if (visible) visibleMatches += 1;
             if (nodes.length >= maxNodes) continue;
@@ -349,9 +361,9 @@ const NODE_SCAN_FUNCTION: &str = r"function(selector, maxNodes, semanticOnly) {
             bounds: visible ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height } : null,
         });
     }
-    return selector === null
-        ? { nodes, documentIdentity }
-        : { nodes, documentIdentity, summary: { matched, visible: visibleMatches } };
+    return countMatches
+        ? { nodes, documentIdentity, summary: { matched, visible: visibleMatches } }
+        : { nodes, documentIdentity };
 }";
 
 const TARGET_RECT_FUNCTION: &str = r"function(selector, clear) {
@@ -437,7 +449,10 @@ mod tests {
         let expression = scan_expression(Some("button'); throw new Error('owned"), 10);
 
         assert!(expression.contains("\"button'); throw new Error('owned\""));
-        assert!(expression.ends_with(", 10, false)"));
+        assert!(expression.ends_with(", 10, false, false)"));
+        let wait = wait_scan_expression("button'); throw new Error('owned", 10);
+        assert!(wait.contains("\"button'); throw new Error('owned\""));
+        assert!(wait.ends_with(", 10, false, true)"));
     }
 
     #[test]
@@ -472,6 +487,14 @@ mod tests {
             Some("[\"https://example.test/\",1234]")
         );
         assert!(scan_expression(None, 10).contains("documentIdentity"));
+    }
+
+    #[test]
+    fn only_wait_scans_count_matches_past_the_cap() {
+        assert!(scan_expression(Some("button"), 10).ends_with("(\"button\", 10, false, false)"));
+        assert!(scan_expression(None, 10).ends_with("(null, 10, true, false)"));
+        assert!(wait_scan_expression("button", 20).ends_with("(\"button\", 20, false, true)"));
+        assert!(NODE_SCAN_FUNCTION.contains("if (nodes.length >= maxNodes && !countMatches) break;"));
     }
 
     #[test]

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -418,6 +418,9 @@ struct DriverState {
     /// Agent navigation whose typed outcome is settled by page events.
     pending_navigation: Option<crate::navigation::PendingNavigation>,
     pending_wait: Option<crate::wait::PendingWait>,
+    /// The top frame started a navigation (reload, history, page-initiated,
+    /// or command) whose commit or failure has not arrived yet.
+    top_frame_navigating: bool,
     /// In-flight `Page.navigate` request. The reply is routed asynchronously
     /// so a slow destination never blocks frames, input, or coordination.
     navigate_request_id: Option<u64>,
@@ -489,6 +492,7 @@ impl DriverState {
             navigation_failed: false,
             pending_navigation: None,
             pending_wait: None,
+            top_frame_navigating: false,
             navigate_request_id: None,
             screencast_request_id: None,
             clipboard: ClipboardState::default(),
@@ -770,6 +774,7 @@ impl DriverState {
 
     fn fail_navigation(&mut self, event_tx: &BrowserEventSender, message: &str) {
         self.navigation_failed = true;
+        self.top_frame_navigating = false;
         self.interaction_started_at = None;
         let _ = event_tx.send(BrowserEvent::NavigationFailed(message.to_string()));
         let _ = event_tx.send(BrowserEvent::Loading(false));

--- a/crates/horizon-browser/src/session.rs
+++ b/crates/horizon-browser/src/session.rs
@@ -37,6 +37,7 @@ mod network;
 mod semantic;
 mod shutdown;
 mod startup;
+mod wait;
 
 use clipboard::ClipboardState;
 pub(crate) use command_queue::CommandReceiver;
@@ -320,6 +321,7 @@ fn run_loop(
         let actions = state.tick_signals(event_tx);
         let _ = state.drain_agent_actions(link, event_tx, frame_slot, actions);
         state.tick_pending_navigation();
+        state.tick_pending_wait(link, event_tx, frame_slot);
 
         // 6. Chrome process liveness.
         if let Some(status) = chrome.child_status() {
@@ -415,6 +417,7 @@ struct DriverState {
     navigation_failed: bool,
     /// Agent navigation whose typed outcome is settled by page events.
     pending_navigation: Option<crate::navigation::PendingNavigation>,
+    pending_wait: Option<crate::wait::PendingWait>,
     /// In-flight `Page.navigate` request. The reply is routed asynchronously
     /// so a slow destination never blocks frames, input, or coordination.
     navigate_request_id: Option<u64>,
@@ -446,6 +449,9 @@ struct DriverState {
     last_signal_check: Instant,
     last_user_active_stamp: Option<Instant>,
     owner_seen: Option<String>,
+    /// Counts successful coordination reads; a deferred wait result is
+    /// released only under a later epoch than it was observed under.
+    signal_epoch: u64,
     handoff_seen: Option<String>,
     audit_sampler: crate::audit::BrowserAuditSampler,
     semantic: SemanticState,
@@ -482,6 +488,7 @@ impl DriverState {
             retain_frame_during_navigation: false,
             navigation_failed: false,
             pending_navigation: None,
+            pending_wait: None,
             navigate_request_id: None,
             screencast_request_id: None,
             clipboard: ClipboardState::default(),
@@ -505,6 +512,7 @@ impl DriverState {
             last_signal_check: Instant::now(),
             last_user_active_stamp: None,
             owner_seen: None,
+            signal_epoch: 0,
             handoff_seen: None,
             audit_sampler: crate::audit::BrowserAuditSampler::default(),
             semantic: SemanticState::default(),
@@ -596,6 +604,19 @@ impl DriverState {
         method: &str,
         params: &serde_json::Value,
     ) -> Result<serde_json::Value, CdpError> {
+        self.send_page_command_within(link, event_tx, frame_slot, method, params, CALL_TIMEOUT)
+    }
+
+    /// A page-session command that may block the driver for at most `timeout`.
+    pub(super) fn send_page_command_within(
+        &mut self,
+        link: &mut CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        method: &str,
+        params: &serde_json::Value,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, CdpError> {
         let Some(session) = self.session_id.clone() else {
             return Err(CdpError::NoPageSession {
                 method: method.to_string(),
@@ -604,7 +625,14 @@ impl DriverState {
         if method.starts_with("Runtime.") {
             self.ensure_page_runtime(link)?;
         }
-        self.call_and_ack(link, event_tx, frame_slot, method, params, Some(session.as_str()))
+        let stop_requested = Arc::clone(&self.stop_requested);
+        let outcome = link.call_and_drain_until(timeout, method, params, Some(session.as_str()), || {
+            stop_requested.load(Ordering::Acquire)
+        });
+        for message in outcome.drained {
+            self.handle_message(link, event_tx, frame_slot, message);
+        }
+        outcome.result
     }
 
     fn ensure_page_runtime(&mut self, link: &mut CdpLink) -> Result<(), CdpError> {

--- a/crates/horizon-browser/src/session/commands.rs
+++ b/crates/horizon-browser/src/session/commands.rs
@@ -53,8 +53,9 @@ impl DriverState {
     ) -> bool {
         for request in actions {
             // A blocking action later in the batch must not delay the typed
-            // timeout of a navigation dispatched earlier in it.
+            // timeout of a navigation or wait dispatched earlier in it.
             self.tick_pending_navigation();
+            self.tick_pending_wait(link, event_tx, frame_slot);
             if let Err(message) = request.action.validate() {
                 self.audit_agent_action(&request, BrowserAuditStatus::Rejected);
                 self.complete_agent_action(&request, Err(BrowserControlFailure::new("invalid_input", message)));
@@ -66,6 +67,15 @@ impl DriverState {
                 // completes here, everything else stays pending.
                 if let AgentActionExecution::Done(result) =
                     self.begin_agent_navigation(link, event_tx, frame_slot, &request)
+                {
+                    self.complete_agent_action(&request, result);
+                }
+                continue;
+            }
+            if matches!(request.action, crate::BrowserControlAction::WaitForSelector { .. }) {
+                // Waits are observed from the driver loop; only a wait that
+                // is already satisfied (or invalid) completes here.
+                if let AgentActionExecution::Done(result) = self.begin_agent_wait(link, event_tx, frame_slot, &request)
                 {
                     self.complete_agent_action(&request, result);
                 }

--- a/crates/horizon-browser/src/session/commands.rs
+++ b/crates/horizon-browser/src/session/commands.rs
@@ -128,13 +128,17 @@ impl DriverState {
             BrowserCommand::Reload => {
                 self.invalidate_scrollbar_layout();
                 self.supersede_pending_navigation(Instant::now());
+                // Marked before dispatch: events routed during the command's
+                // round trip (a fast reload's commit or stop) may already
+                // clear it, and must not be overwritten afterwards.
+                self.top_frame_navigating = true;
                 match self.send_page_command(link, event_tx, frame_slot, "Page.reload", &serde_json::json!({})) {
                     Ok(_) => {
-                        self.top_frame_navigating = true;
                         self.pending_restart_at = Some(Instant::now());
                         Ok(false)
                     }
                     Err(error) => {
+                        self.top_frame_navigating = false;
                         Err(self.page_command_failure(event_tx, "reload", "protocol_error", error.to_string()))
                     }
                 }
@@ -557,6 +561,9 @@ impl DriverState {
                 "CDP returned a history entry without an identifier".to_string(),
             ));
         };
+        // Marked before dispatch so events routed during the round trip can
+        // already clear it (see the reload command).
+        self.top_frame_navigating = true;
         match self.send_page_command(
             link,
             event_tx,
@@ -565,11 +572,11 @@ impl DriverState {
             &serde_json::json!({ "entryId": entry_id }),
         ) {
             Ok(_) => {
-                self.top_frame_navigating = true;
                 self.pending_restart_at = Some(Instant::now());
                 Ok(())
             }
             Err(error) => {
+                self.top_frame_navigating = false;
                 Err(self.page_command_failure(event_tx, "history traversal", "protocol_error", error.to_string()))
             }
         }

--- a/crates/horizon-browser/src/session/commands.rs
+++ b/crates/horizon-browser/src/session/commands.rs
@@ -130,6 +130,7 @@ impl DriverState {
                 self.supersede_pending_navigation(Instant::now());
                 match self.send_page_command(link, event_tx, frame_slot, "Page.reload", &serde_json::json!({})) {
                     Ok(_) => {
+                        self.top_frame_navigating = true;
                         self.pending_restart_at = Some(Instant::now());
                         Ok(false)
                     }
@@ -564,6 +565,7 @@ impl DriverState {
             &serde_json::json!({ "entryId": entry_id }),
         ) {
             Ok(_) => {
+                self.top_frame_navigating = true;
                 self.pending_restart_at = Some(Instant::now());
                 Ok(())
             }

--- a/crates/horizon-browser/src/session/events.rs
+++ b/crates/horizon-browser/src/session/events.rs
@@ -269,6 +269,16 @@ impl DriverState {
                     self.handle_lifecycle_event(event);
                 }
             }
+            "Page.frameStartedLoading" | "Page.frameStoppedLoading" => {
+                if on_page_session
+                    && event.params.get("frameId").and_then(|id| id.as_str()) == self.main_frame_id.as_deref()
+                {
+                    // Covers navigations no command of ours started (a link,
+                    // a meta refresh, a script) and the commands that do not
+                    // retain the frame; a stop without a commit ends it.
+                    self.top_frame_navigating = event.method == "Page.frameStartedLoading";
+                }
+            }
             "Runtime.executionContextCreated"
             | "Runtime.executionContextDestroyed"
             | "Runtime.executionContextsCleared" => {
@@ -317,6 +327,7 @@ impl DriverState {
         }
         self.invalidate_scrollbar_layout();
         self.semantic.invalidate();
+        self.top_frame_navigating = false;
         self.main_frame_id = frame.get("id").and_then(|id| id.as_str()).map(str::to_string);
         if let Some(unreachable_url) = frame
             .get("unreachableUrl")

--- a/crates/horizon-browser/src/session/events.rs
+++ b/crates/horizon-browser/src/session/events.rs
@@ -422,6 +422,11 @@ impl DriverState {
             return;
         }
         self.retain_frame_during_navigation = false;
+        // A same-document history traversal (a hash or history-state entry)
+        // completes here rather than through frameNavigated or
+        // frameStoppedLoading, so the top-frame navigation it started ends
+        // here too; otherwise every later wait would stay navigation-blocked.
+        self.top_frame_navigating = false;
         self.navigation_failed = false;
         self.invalidate_scrollbar_layout();
         let url = normalized_committed_url(target_url);

--- a/crates/horizon-browser/src/session/manifest_io.rs
+++ b/crates/horizon-browser/src/session/manifest_io.rs
@@ -13,6 +13,14 @@ use super::{
 };
 
 impl DriverState {
+    /// Make the next `tick_signals` re-read the manifest regardless of the
+    /// interval, so ownership and handoff state is current.
+    pub(super) fn request_signal_refresh(&mut self) {
+        self.last_signal_check = Instant::now()
+            .checked_sub(SIGNAL_MIN_INTERVAL)
+            .unwrap_or_else(Instant::now);
+    }
+
     /// User clicked "hand back": acknowledge only the exact request that the
     /// engine previously surfaced, so a replacement request cannot be lost.
     pub(super) fn resolve_handoff(&mut self, event_tx: &BrowserEventSender) {
@@ -63,6 +71,7 @@ impl DriverState {
                 return Vec::new();
             }
         };
+        self.signal_epoch = self.signal_epoch.wrapping_add(1);
         publish_owner_change(&mut self.owner_seen, signals.owner, event_tx);
         self.challenge_loop.observe_handoff_change(
             self.handoff_seen.as_deref(),

--- a/crates/horizon-browser/src/session/navigation.rs
+++ b/crates/horizon-browser/src/session/navigation.rs
@@ -114,10 +114,11 @@ impl DriverState {
     }
 
     pub(super) fn supersede_pending_navigation(&mut self, now: Instant) {
+        // Dispatch-only and timed-out actions can leave the asynchronous reply
+        // in flight after their logical result is gone. A replacement must not
+        // route that stale reply into its own navigation state.
+        self.navigate_request_id = None;
         if let Some(pending) = self.pending_navigation.take() {
-            // The superseded navigation's `Page.navigate` reply may still be
-            // in flight; a late rejection must not fail its replacement.
-            self.navigate_request_id = None;
             self.complete_agent_action(&pending.request, Ok(pending.superseded(now)));
         }
     }

--- a/crates/horizon-browser/src/session/semantic.rs
+++ b/crates/horizon-browser/src/session/semantic.rs
@@ -38,6 +38,10 @@ impl DriverState {
             BrowserControlAction::Query { selector, max_results } => {
                 self.semantic_query(link, event_tx, frame_slot, selector, *max_results)
             }
+            BrowserControlAction::WaitForSelector { .. } => Err(BrowserControlFailure::new(
+                "invalid_action_state",
+                "selector waits are observed from the driver loop",
+            )),
             BrowserControlAction::Click { target, count } => {
                 self.semantic_click(link, event_tx, frame_slot, target, *count)
             }
@@ -84,7 +88,7 @@ impl DriverState {
         })
     }
 
-    fn semantic_query(
+    pub(super) fn semantic_query(
         &mut self,
         link: &mut crate::cdp::CdpLink,
         event_tx: &BrowserEventSender,
@@ -92,11 +96,25 @@ impl DriverState {
         selector: &str,
         max_results: u32,
     ) -> Result<BrowserControlValue, BrowserControlFailure> {
-        let value = self.evaluate_json(
+        self.semantic_query_within(link, event_tx, frame_slot, selector, max_results, super::CALL_TIMEOUT)
+    }
+
+    /// A selector query whose page evaluation may block for at most `timeout`.
+    pub(super) fn semantic_query_within(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        selector: &str,
+        max_results: u32,
+        timeout: std::time::Duration,
+    ) -> Result<BrowserControlValue, BrowserControlFailure> {
+        let value = self.evaluate_json_within(
             link,
             event_tx,
             frame_slot,
             &scan_expression(Some(selector), max_results),
+            timeout,
         )?;
         let (generation, revision, nodes) = self.semantic.register_nodes(value)?;
         Ok(BrowserControlValue::Nodes {
@@ -187,8 +205,19 @@ impl DriverState {
         frame_slot: &Arc<FrameSlot>,
         expression: &str,
     ) -> Result<Value, BrowserControlFailure> {
+        self.evaluate_json_within(link, event_tx, frame_slot, expression, super::CALL_TIMEOUT)
+    }
+
+    fn evaluate_json_within(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        expression: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Value, BrowserControlFailure> {
         let result = self
-            .send_page_command(
+            .send_page_command_within(
                 link,
                 event_tx,
                 frame_slot,
@@ -199,6 +228,7 @@ impl DriverState {
                     "awaitPromise": true,
                     "userGesture": true,
                 }),
+                timeout,
             )
             .map_err(|error| BrowserControlFailure::new("protocol_error", error.to_string()))?;
         if let Some(exception) = result.get("exceptionDetails") {

--- a/crates/horizon-browser/src/session/semantic.rs
+++ b/crates/horizon-browser/src/session/semantic.rs
@@ -8,7 +8,7 @@ use crate::frames::FrameSlot;
 use crate::input::BrowserInputCdpExt;
 use crate::semantic::{
     bounded_control_value, check_script_error, parse_target_rect, scan_expression, scroll_expression,
-    target_rect_expression,
+    target_rect_expression, wait_scan_expression,
 };
 use crate::{
     AgentAction, BrowserButton, BrowserControlAction, BrowserControlFailure, BrowserControlValue, BrowserInput,
@@ -123,7 +123,7 @@ impl DriverState {
             link,
             event_tx,
             frame_slot,
-            &scan_expression(Some(selector), max_results),
+            &wait_scan_expression(selector, max_results),
             timeout,
         )?;
         let peeked = self.semantic.peek_nodes(&value)?;

--- a/crates/horizon-browser/src/session/semantic.rs
+++ b/crates/horizon-browser/src/session/semantic.rs
@@ -118,7 +118,7 @@ impl DriverState {
             &scan_expression(Some(selector), max_results),
             timeout,
         )?;
-        let (generation, nodes) = self.semantic.peek_nodes(&value)?;
+        let (generation, nodes, _) = self.semantic.peek_nodes(&value)?;
         Ok((generation, nodes, value))
     }
 

--- a/crates/horizon-browser/src/session/semantic.rs
+++ b/crates/horizon-browser/src/session/semantic.rs
@@ -110,7 +110,15 @@ impl DriverState {
         selector: &str,
         max_results: u32,
         timeout: std::time::Duration,
-    ) -> Result<(u64, Vec<crate::BrowserNode>, Value), BrowserControlFailure> {
+    ) -> Result<
+        (
+            u64,
+            Vec<crate::BrowserNode>,
+            Option<crate::semantic::ScanSummary>,
+            Value,
+        ),
+        BrowserControlFailure,
+    > {
         let value = self.evaluate_json_within(
             link,
             event_tx,
@@ -118,8 +126,8 @@ impl DriverState {
             &scan_expression(Some(selector), max_results),
             timeout,
         )?;
-        let (generation, nodes, _) = self.semantic.peek_nodes(&value)?;
-        Ok((generation, nodes, value))
+        let peeked = self.semantic.peek_nodes(&value)?;
+        Ok((peeked.generation, peeked.nodes, peeked.summary, value))
     }
 
     /// Register a previously peeked scan as the current references.

--- a/crates/horizon-browser/src/session/semantic.rs
+++ b/crates/horizon-browser/src/session/semantic.rs
@@ -99,6 +99,37 @@ impl DriverState {
         self.semantic_query_within(link, event_tx, frame_slot, selector, max_results, super::CALL_TIMEOUT)
     }
 
+    /// A selector scan that does not register references: for judging a wait
+    /// condition without disturbing refs a concurrent snapshot handed out.
+    /// Returns the page generation, the peeked nodes, and the raw scan.
+    pub(super) fn semantic_peek_within(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        selector: &str,
+        max_results: u32,
+        timeout: std::time::Duration,
+    ) -> Result<(u64, Vec<crate::BrowserNode>, Value), BrowserControlFailure> {
+        let value = self.evaluate_json_within(
+            link,
+            event_tx,
+            frame_slot,
+            &scan_expression(Some(selector), max_results),
+            timeout,
+        )?;
+        let (generation, nodes) = self.semantic.peek_nodes(&value)?;
+        Ok((generation, nodes, value))
+    }
+
+    /// Register a previously peeked scan as the current references.
+    pub(super) fn semantic_register_scan(
+        &mut self,
+        value: Value,
+    ) -> Result<(u64, u64, Vec<crate::BrowserNode>), BrowserControlFailure> {
+        self.semantic.register_nodes(value)
+    }
+
     /// A selector query whose page evaluation may block for at most `timeout`.
     pub(super) fn semantic_query_within(
         &mut self,

--- a/crates/horizon-browser/src/session/wait.rs
+++ b/crates/horizon-browser/src/session/wait.rs
@@ -103,16 +103,6 @@ impl DriverState {
         if let Some(result) = pending.tick(self.semantic.generation(), now) {
             return Some(result);
         }
-        // A satisfied observation completes only after the signals have been
-        // re-read and events drained: the guards above ran again first.
-        if let Some(scan) = pending.take_deferred(self.signal_epoch) {
-            // Register the released scan now, so the returned references are
-            // the current ones and no earlier observation disturbed the map.
-            return Some(match self.semantic_register_scan(scan) {
-                Ok((generation, revision, nodes)) => Ok(pending.outcome(generation, revision, nodes, now)),
-                Err(failure) => Err(failure),
-            });
-        }
         if self.navigation_in_flight() {
             // The document is changing under this wait; it can only be judged
             // against the new one, which is not what it was asked about.
@@ -121,6 +111,17 @@ impl DriverState {
         }
         if pending.blocked_by_navigation() {
             return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
+        }
+        // A satisfied observation completes only after the signals have been
+        // re-read, events drained, and no navigation started meanwhile: the
+        // guards above ran again first.
+        if let Some(scan) = pending.take_deferred(self.signal_epoch) {
+            // Register the released scan now, so the returned references are
+            // the current ones and no earlier observation disturbed the map.
+            return Some(match self.semantic_register_scan(scan) {
+                Ok((generation, revision, nodes)) => Ok(pending.outcome(generation, revision, nodes, now)),
+                Err(failure) => Err(failure),
+            });
         }
         if observe {
             return self.observe_wait(link, event_tx, frame_slot, pending, now);

--- a/crates/horizon-browser/src/session/wait.rs
+++ b/crates/horizon-browser/src/session/wait.rs
@@ -1,0 +1,176 @@
+//! Selector waits on the Chromium driver: one audited action observed from
+//! the driver loop at a bounded cadence instead of repeated agent queries.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::frames::FrameSlot;
+use crate::navigation::{AgentActionExecution, PendingNavigation, now_millis};
+use crate::wait::{PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
+use crate::{AgentAction, BrowserControlAction, BrowserControlFailure, BrowserControlValue};
+
+use super::{BrowserEventSender, DriverState};
+
+impl DriverState {
+    /// Start a `WaitForSelector` action: observe once now, then keep it
+    /// pending until the condition, the bound, or a cancellation.
+    pub(super) fn begin_agent_wait(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        request: &AgentAction,
+    ) -> AgentActionExecution {
+        let BrowserControlAction::WaitForSelector {
+            selector,
+            state,
+            timeout_millis,
+        } = &request.action
+        else {
+            return AgentActionExecution::Done(Err(BrowserControlFailure::new(
+                "invalid_action_state",
+                "a wait was requested for a non-wait action",
+            )));
+        };
+        let now = Instant::now();
+        let mut pending = PendingWait::new(
+            request.clone(),
+            selector.clone(),
+            *state,
+            *timeout_millis,
+            PendingNavigation::queued_for(request, now_millis()),
+            self.semantic.generation(),
+            now,
+        );
+        if let Some(expired) = pending.tick(self.semantic.generation(), now) {
+            // The bound elapsed while the action sat in the queue: report it
+            // without superseding a wait that is still valid.
+            return AgentActionExecution::Done(expired);
+        }
+        self.supersede_pending_wait(now);
+        // The first observation runs under the same guards as every later one:
+        // an already-expired bound, a lost lease, a pending handoff, or an
+        // uncommitted navigation must not let it succeed against the old page.
+        if let Some(result) = self.advance_wait(link, event_tx, frame_slot, &mut pending, now, true) {
+            return AgentActionExecution::Done(result);
+        }
+        tracing::debug!(target: "browser", action_id = %request.action_id, ?state, timeout_millis, "agent wait pending");
+        self.pending_wait = Some(pending);
+        AgentActionExecution::Pending
+    }
+
+    /// Advance the pending wait: cancel on a handoff, a lost lease, or a new
+    /// page generation; time out at the bound; otherwise observe when due.
+    pub(super) fn tick_pending_wait(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+    ) {
+        let Some(mut pending) = self.pending_wait.take() else {
+            return;
+        };
+        let now = Instant::now();
+        let observe = pending.poll_due(now);
+        let result = self.advance_wait(link, event_tx, frame_slot, &mut pending, now, observe);
+        match result {
+            Some(result) => {
+                tracing::debug!(target: "browser", action_id = %pending.request.action_id, ok = result.is_ok(), "agent wait settled");
+                self.complete_agent_action(&pending.request, result);
+            }
+            None => self.pending_wait = Some(pending),
+        }
+    }
+
+    /// Cancel on a handoff or lost lease, time out or invalidate at the bound
+    /// or a new page generation, otherwise observe when asked and no agent
+    /// navigation is still uncommitted.
+    fn advance_wait(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        pending: &mut PendingWait,
+        now: Instant,
+        observe: bool,
+    ) -> Option<WaitResult> {
+        if self.handoff_seen.is_some() {
+            return Some(pending.stopped(WaitStop::HandoffPending, now));
+        }
+        if self.owner_seen.as_deref() != Some(pending.request.actor.as_str()) {
+            return Some(pending.stopped(WaitStop::OwnershipLost, now));
+        }
+        if let Some(result) = pending.tick(self.semantic.generation(), now) {
+            return Some(result);
+        }
+        // A satisfied observation completes only after the signals have been
+        // re-read and events drained: the guards above ran again first.
+        if let Some(result) = pending.take_deferred(self.signal_epoch) {
+            return Some(result);
+        }
+        if self.navigation_in_flight() {
+            // The document is changing under this wait; it can only be judged
+            // against the new one, which is not what it was asked about.
+            pending.block_for_navigation();
+            return None;
+        }
+        if pending.blocked_by_navigation() {
+            return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
+        }
+        if observe {
+            return match self.observe_wait(link, event_tx, frame_slot, pending, now) {
+                Some(Ok(result)) => {
+                    pending.defer(Ok(result), self.signal_epoch);
+                    self.request_signal_refresh();
+                    None
+                }
+                other => other,
+            };
+        }
+        None
+    }
+
+    /// Whether a document is still uncommitted: a pending agent navigation,
+    /// or any navigation the driver started (agent, user, or timed-out
+    /// action) whose commit or failure has not arrived yet.
+    fn navigation_in_flight(&self) -> bool {
+        self.pending_navigation.is_some() || (self.retain_frame_during_navigation && !self.navigation_failed)
+    }
+
+    fn observe_wait(
+        &mut self,
+        link: &mut crate::cdp::CdpLink,
+        event_tx: &BrowserEventSender,
+        frame_slot: &Arc<FrameSlot>,
+        pending: &mut PendingWait,
+        now: Instant,
+    ) -> Option<WaitResult> {
+        // The evaluation may block; give it no more than the remaining bound
+        // and judge the result against a fresh clock afterwards.
+        let budget = pending.observation_budget(now);
+        let observed = self.semantic_query_within(
+            link,
+            event_tx,
+            frame_slot,
+            &pending.selector,
+            WAIT_QUERY_RESULTS,
+            budget,
+        );
+        let now = Instant::now();
+        match observed {
+            Ok(BrowserControlValue::Nodes {
+                generation,
+                revision,
+                nodes,
+            }) => pending.observe(generation, revision, nodes, now),
+            Ok(_) => None,
+            Err(failure) => pending.observe_failure(failure, now),
+        }
+    }
+
+    fn supersede_pending_wait(&mut self, now: Instant) {
+        if let Some(pending) = self.pending_wait.take() {
+            self.complete_agent_action(&pending.request, pending.stopped(WaitStop::Superseded, now));
+        }
+    }
+}

--- a/crates/horizon-browser/src/session/wait.rs
+++ b/crates/horizon-browser/src/session/wait.rs
@@ -160,7 +160,7 @@ impl DriverState {
         );
         let now = Instant::now();
         match observed {
-            Ok((generation, nodes, scan)) => match pending.observe(generation, &nodes, now) {
+            Ok((generation, nodes, summary, scan)) => match pending.observe(generation, &nodes, summary, now) {
                 Observation::Satisfied => {
                     pending.defer(scan, self.signal_epoch);
                     self.request_signal_refresh();

--- a/crates/horizon-browser/src/session/wait.rs
+++ b/crates/horizon-browser/src/session/wait.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use crate::frames::FrameSlot;
 use crate::navigation::{AgentActionExecution, PendingNavigation, now_millis};
-use crate::wait::{Observation, PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
+use crate::wait::{Observation, PendingWait, WAIT_MAX_RESULTS, WaitResult, WaitStop};
 use crate::{AgentAction, BrowserControlAction, BrowserControlFailure};
 
 use super::{BrowserEventSender, DriverState};
@@ -150,14 +150,8 @@ impl DriverState {
         // and judge the result against a fresh clock afterwards. The scan is
         // peeked, not registered: only the released scan becomes references.
         let budget = pending.observation_budget(now);
-        let observed = self.semantic_peek_within(
-            link,
-            event_tx,
-            frame_slot,
-            &pending.selector,
-            WAIT_QUERY_RESULTS,
-            budget,
-        );
+        let observed =
+            self.semantic_peek_within(link, event_tx, frame_slot, &pending.selector, WAIT_MAX_RESULTS, budget);
         let now = Instant::now();
         match observed {
             Ok((generation, nodes, summary, scan)) => match pending.observe(generation, &nodes, summary, now) {

--- a/crates/horizon-browser/src/session/wait.rs
+++ b/crates/horizon-browser/src/session/wait.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 
 use crate::frames::FrameSlot;
 use crate::navigation::{AgentActionExecution, PendingNavigation, now_millis};
-use crate::wait::{PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
-use crate::{AgentAction, BrowserControlAction, BrowserControlFailure, BrowserControlValue};
+use crate::wait::{Observation, PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
+use crate::{AgentAction, BrowserControlAction, BrowserControlFailure};
 
 use super::{BrowserEventSender, DriverState};
 
@@ -105,8 +105,13 @@ impl DriverState {
         }
         // A satisfied observation completes only after the signals have been
         // re-read and events drained: the guards above ran again first.
-        if let Some(result) = pending.take_deferred(self.signal_epoch) {
-            return Some(result);
+        if let Some(scan) = pending.take_deferred(self.signal_epoch) {
+            // Register the released scan now, so the returned references are
+            // the current ones and no earlier observation disturbed the map.
+            return Some(match self.semantic_register_scan(scan) {
+                Ok((generation, revision, nodes)) => Ok(pending.outcome(generation, revision, nodes, now)),
+                Err(failure) => Err(failure),
+            });
         }
         if self.navigation_in_flight() {
             // The document is changing under this wait; it can only be judged
@@ -118,14 +123,7 @@ impl DriverState {
             return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
         }
         if observe {
-            return match self.observe_wait(link, event_tx, frame_slot, pending, now) {
-                Some(Ok(result)) => {
-                    pending.defer(Ok(result), self.signal_epoch);
-                    self.request_signal_refresh();
-                    None
-                }
-                other => other,
-            };
+            return self.observe_wait(link, event_tx, frame_slot, pending, now);
         }
         None
     }
@@ -134,7 +132,9 @@ impl DriverState {
     /// or any navigation the driver started (agent, user, or timed-out
     /// action) whose commit or failure has not arrived yet.
     fn navigation_in_flight(&self) -> bool {
-        self.pending_navigation.is_some() || (self.retain_frame_during_navigation && !self.navigation_failed)
+        self.pending_navigation.is_some()
+            || self.top_frame_navigating
+            || (self.retain_frame_during_navigation && !self.navigation_failed)
     }
 
     fn observe_wait(
@@ -146,9 +146,10 @@ impl DriverState {
         now: Instant,
     ) -> Option<WaitResult> {
         // The evaluation may block; give it no more than the remaining bound
-        // and judge the result against a fresh clock afterwards.
+        // and judge the result against a fresh clock afterwards. The scan is
+        // peeked, not registered: only the released scan becomes references.
         let budget = pending.observation_budget(now);
-        let observed = self.semantic_query_within(
+        let observed = self.semantic_peek_within(
             link,
             event_tx,
             frame_slot,
@@ -158,12 +159,15 @@ impl DriverState {
         );
         let now = Instant::now();
         match observed {
-            Ok(BrowserControlValue::Nodes {
-                generation,
-                revision,
-                nodes,
-            }) => pending.observe(generation, revision, nodes, now),
-            Ok(_) => None,
+            Ok((generation, nodes, scan)) => match pending.observe(generation, &nodes, now) {
+                Observation::Satisfied => {
+                    pending.defer(scan, self.signal_epoch);
+                    self.request_signal_refresh();
+                    None
+                }
+                Observation::Waiting => None,
+                Observation::Done(result) => Some(result),
+            },
             Err(failure) => pending.observe_failure(failure, now),
         }
     }

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -73,6 +73,9 @@ pub(crate) struct PendingWait {
     /// was observed under; it is released, and only then registered as
     /// semantic references, once a later epoch proves a refresh ran.
     deferred: Option<(serde_json::Value, u64)>,
+    /// When the observation that satisfied the condition was judged; the
+    /// reported elapsed time ends there, not at the later release.
+    satisfied_at: Option<Instant>,
 }
 
 impl PendingWait {
@@ -99,6 +102,7 @@ impl PendingWait {
             consecutive_failures: 0,
             blocked_by_navigation: false,
             deferred: None,
+            satisfied_at: None,
         }
     }
 
@@ -133,6 +137,8 @@ impl PendingWait {
     }
 
     /// The satisfied outcome from the registered nodes of the released scan.
+    /// `elapsed_millis` ends when the condition was observed, not at the
+    /// later release after the coordination refresh.
     pub(crate) fn outcome(
         &self,
         generation: u64,
@@ -147,7 +153,7 @@ impl PendingWait {
                 generation,
                 revision,
                 nodes,
-                elapsed_millis: self.elapsed_millis(now),
+                elapsed_millis: self.elapsed_millis(self.satisfied_at.unwrap_or(now)),
                 polls: self.polls,
             },
         }
@@ -184,6 +190,7 @@ impl PendingWait {
         // Decide on every match the query returned; the released scan is
         // registered and capped by the driver.
         if self.state.satisfied_by(nodes) {
+            self.satisfied_at = Some(now);
             Observation::Satisfied
         } else {
             Observation::Waiting
@@ -275,9 +282,18 @@ fn observation_failure_is_transient(failure: &BrowserControlFailure) -> bool {
         return false;
     }
     let message = failure.message.to_ascii_lowercase();
-    ["context", "timed out", "timeout", "unloaded", "navigat"]
-        .iter()
-        .any(|needle| message.contains(needle))
+    // "temporarily unavailable" is the Unix read-deadline wording
+    // (`WouldBlock`) a bounded WebDriver observation surfaces as.
+    [
+        "context",
+        "timed out",
+        "timeout",
+        "temporarily unavailable",
+        "unloaded",
+        "navigat",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle))
 }
 
 #[cfg(test)]
@@ -362,7 +378,9 @@ mod tests {
             wait.observe(7, &[node(true)], now + Duration::from_millis(1_500)),
             Observation::Satisfied
         ));
-        let satisfied = released(&wait, vec![node(true)], now + Duration::from_millis(1_500));
+        // Released later, after the coordination refresh: the elapsed time
+        // still ends at the observation that met the condition.
+        let satisfied = released(&wait, vec![node(true)], now + Duration::from_millis(1_900));
         assert_eq!(satisfied.state, SelectorState::Visible);
         assert_eq!(satisfied.polls, 3);
         assert_eq!(satisfied.elapsed_millis, 1_500);
@@ -537,6 +555,18 @@ mod tests {
                 )
                 .is_none(),
             "an observation timeout is retried"
+        );
+        assert!(
+            pending_wait
+                .observe_failure(
+                    BrowserControlFailure::new(
+                        "javascript_error",
+                        "WebDriver HTTP I/O: Resource temporarily unavailable (os error 11)"
+                    ),
+                    now
+                )
+                .is_none(),
+            "a Unix read deadline on a bounded WebDriver observation is retried"
         );
         for (code, message) in [
             ("protocol_error", "CDP connection closed"),

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -136,6 +136,12 @@ impl PendingWait {
         }
     }
 
+    /// Whether the held scan has survived a later coordination refresh and
+    /// is ready for the driver's final document-identity guard.
+    pub(crate) fn deferred_ready(&self, signal_epoch: u64) -> bool {
+        matches!(self.deferred, Some((_, observed_epoch)) if observed_epoch != signal_epoch)
+    }
+
     /// The satisfied outcome from the registered nodes of the released scan.
     /// `elapsed_millis` ends when the condition was observed, not at the
     /// later release after the coordination refresh.

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -39,6 +39,17 @@ pub(crate) enum WaitStop {
 
 pub(crate) type WaitResult = Result<BrowserControlValue, BrowserControlFailure>;
 
+/// What one observation concluded.
+#[derive(Debug)]
+pub(crate) enum Observation {
+    /// The condition is not met yet.
+    Waiting,
+    /// The condition is met; the scan is deferred until the guards re-ran.
+    Satisfied,
+    /// The wait completed (invalidated or timed out) during the observation.
+    Done(WaitResult),
+}
+
 #[derive(Debug)]
 pub(crate) struct PendingWait {
     pub(crate) request: AgentAction,
@@ -55,12 +66,13 @@ pub(crate) struct PendingWait {
     /// that navigation settles the wait is invalidated, because the document
     /// it may now observe is not the one it was asked about.
     blocked_by_navigation: bool,
-    /// A satisfied observation held until the driver has re-read the
-    /// coordination signals and drained backend events, so a lease or
-    /// handoff change (or a navigation) during the blocking observation
-    /// still cancels the wait. Stored with the signal epoch it was observed
-    /// under; it is released only once a later epoch proves a refresh ran.
-    deferred: Option<(WaitResult, u64)>,
+    /// The raw scan of a satisfied observation, held until the driver has
+    /// re-read the coordination signals and drained backend events, so a
+    /// lease or handoff change (or a navigation) during the blocking
+    /// observation still cancels the wait. Stored with the signal epoch it
+    /// was observed under; it is released, and only then registered as
+    /// semantic references, once a later epoch proves a refresh ran.
+    deferred: Option<(serde_json::Value, u64)>,
 }
 
 impl PendingWait {
@@ -100,21 +112,44 @@ impl PendingWait {
         self.blocked_by_navigation
     }
 
-    /// Hold a satisfied result, observed under `signal_epoch`, until the
-    /// guards have been re-evaluated on fresher signals.
-    pub(crate) fn defer(&mut self, result: WaitResult, signal_epoch: u64) {
-        self.deferred = Some((result, signal_epoch));
+    /// Hold the raw scan of a satisfied observation, made under
+    /// `signal_epoch`, until the guards have been re-evaluated on fresher
+    /// signals.
+    pub(crate) fn defer(&mut self, scan: serde_json::Value, signal_epoch: u64) {
+        self.deferred = Some((scan, signal_epoch));
     }
 
-    /// The held result, once a coordination refresh newer than the one it
-    /// was observed under has run and the guards allowed it.
-    pub(crate) fn take_deferred(&mut self, signal_epoch: u64) -> Option<WaitResult> {
+    /// The held scan, once a coordination refresh newer than the one it was
+    /// observed under has run and the guards allowed it; the driver registers
+    /// it and builds the outcome with [`Self::outcome`].
+    pub(crate) fn take_deferred(&mut self, signal_epoch: u64) -> Option<serde_json::Value> {
         match self.deferred.take() {
-            Some((result, observed_epoch)) if observed_epoch != signal_epoch => Some(result),
+            Some((scan, observed_epoch)) if observed_epoch != signal_epoch => Some(scan),
             other => {
                 self.deferred = other;
                 None
             }
+        }
+    }
+
+    /// The satisfied outcome from the registered nodes of the released scan.
+    pub(crate) fn outcome(
+        &self,
+        generation: u64,
+        revision: u64,
+        mut nodes: Vec<BrowserNode>,
+        now: Instant,
+    ) -> BrowserControlValue {
+        nodes.truncate(WAIT_MAX_RESULTS as usize);
+        BrowserControlValue::Wait {
+            wait: WaitOutcome {
+                state: self.state,
+                generation,
+                revision,
+                nodes,
+                elapsed_millis: self.elapsed_millis(now),
+                polls: self.polls,
+            },
         }
     }
 
@@ -130,14 +165,8 @@ impl PendingWait {
             .clamp(MIN_OBSERVATION_BUDGET, MAX_OBSERVATION_BUDGET)
     }
 
-    /// Record one page observation; `Some` when the condition is met.
-    pub(crate) fn observe(
-        &mut self,
-        generation: u64,
-        revision: u64,
-        nodes: Vec<BrowserNode>,
-        now: Instant,
-    ) -> Option<WaitResult> {
+    /// Judge one page observation made without registering references.
+    pub(crate) fn observe(&mut self, generation: u64, nodes: &[BrowserNode], now: Instant) -> Observation {
         self.polls = self.polls.saturating_add(1);
         self.next_poll = now + WAIT_POLL_INTERVAL;
         self.last_match_count = nodes.len();
@@ -145,29 +174,20 @@ impl PendingWait {
         if generation != self.generation_at_start {
             // The page navigated while the query was in flight: these nodes
             // belong to another document.
-            return Some(self.stopped(WaitStop::NavigationInvalidated, now));
+            return Observation::Done(self.stopped(WaitStop::NavigationInvalidated, now));
         }
         // `now` is taken after the query returned: an observation that
         // overran the bound is a timeout, whatever it saw.
         if now >= self.deadline {
-            return Some(self.timed_out(now));
+            return Observation::Done(self.timed_out(now));
         }
-        // Decide on every match the query returned; report at most the cap.
-        if !self.state.satisfied_by(&nodes) {
-            return None;
+        // Decide on every match the query returned; the released scan is
+        // registered and capped by the driver.
+        if self.state.satisfied_by(nodes) {
+            Observation::Satisfied
+        } else {
+            Observation::Waiting
         }
-        let mut nodes = nodes;
-        nodes.truncate(WAIT_MAX_RESULTS as usize);
-        Some(Ok(BrowserControlValue::Wait {
-            wait: WaitOutcome {
-                state: self.state,
-                generation,
-                revision,
-                nodes,
-                elapsed_millis: self.elapsed_millis(now),
-                polls: self.polls,
-            },
-        }))
     }
 
     /// A failed observation. Only an execution-context replacement (a page
@@ -267,7 +287,7 @@ mod tests {
 
     fn node(visible: bool) -> BrowserNode {
         BrowserNode {
-            reference: "g1s1e1".to_string(),
+            reference: String::new(),
             role: "paragraph".to_string(),
             name: String::new(),
             text: "late".to_string(),
@@ -299,8 +319,19 @@ mod tests {
         )
     }
 
-    fn outcome(result: Option<WaitResult>) -> WaitOutcome {
-        match result.expect("settled").expect("satisfied") {
+    fn scan() -> serde_json::Value {
+        serde_json::json!({ "nodes": [] })
+    }
+
+    fn done(observation: Observation) -> WaitResult {
+        match observation {
+            Observation::Done(result) => result,
+            other => panic!("expected a completed wait, got {other:?}"),
+        }
+    }
+
+    fn released(wait: &PendingWait, nodes: Vec<BrowserNode>, now: Instant) -> WaitOutcome {
+        match wait.outcome(7, 1, nodes, now) {
             BrowserControlValue::Wait { wait } => wait,
             other => panic!("unexpected value {other:?}"),
         }
@@ -311,39 +342,52 @@ mod tests {
         let now = Instant::now();
         let mut wait = pending(SelectorState::Visible, 5_000, now);
         assert!(wait.poll_due(now));
-        assert!(wait.observe(7, 1, Vec::new(), now).is_none(), "no match keeps waiting");
+        assert!(
+            matches!(wait.observe(7, &[], now), Observation::Waiting),
+            "no match keeps waiting"
+        );
         assert!(
             !wait.poll_due(now + Duration::from_millis(50)),
             "observations are paced"
         );
         assert!(wait.poll_due(now + WAIT_POLL_INTERVAL));
         assert!(
-            wait.observe(7, 2, vec![node(false)], now + Duration::from_millis(100))
-                .is_none(),
+            matches!(
+                wait.observe(7, &[node(false)], now + Duration::from_millis(100)),
+                Observation::Waiting
+            ),
             "a hidden match does not satisfy visible"
         );
-        let satisfied = outcome(wait.observe(7, 3, vec![node(true)], now + Duration::from_millis(1_500)));
+        assert!(matches!(
+            wait.observe(7, &[node(true)], now + Duration::from_millis(1_500)),
+            Observation::Satisfied
+        ));
+        let satisfied = released(&wait, vec![node(true)], now + Duration::from_millis(1_500));
         assert_eq!(satisfied.state, SelectorState::Visible);
         assert_eq!(satisfied.polls, 3);
         assert_eq!(satisfied.elapsed_millis, 1_500);
         assert_eq!(satisfied.nodes.len(), 1);
 
         let mut hidden = pending(SelectorState::Hidden, 5_000, now);
-        assert!(hidden.observe(7, 1, vec![node(true)], now).is_none());
+        assert!(matches!(hidden.observe(7, &[node(true)], now), Observation::Waiting));
         assert!(
-            outcome(hidden.observe(7, 2, Vec::new(), now)).nodes.is_empty(),
+            matches!(hidden.observe(7, &[], now), Observation::Satisfied),
             "an empty match set is hidden"
         );
 
         let mut present = pending(SelectorState::Present, 5_000, now);
-        assert_eq!(outcome(present.observe(7, 1, vec![node(false)], now)).polls, 1);
+        assert!(matches!(
+            present.observe(7, &[node(false)], now),
+            Observation::Satisfied
+        ));
+        assert_eq!(released(&present, vec![node(false)], now).polls, 1);
     }
 
     #[test]
     fn timeouts_and_cancellations_are_typed_failures() {
         let now = Instant::now();
         let mut wait = pending(SelectorState::Present, 1_000, now);
-        assert!(wait.observe(7, 1, Vec::new(), now).is_none());
+        assert!(matches!(wait.observe(7, &[], now), Observation::Waiting));
         assert!(wait.tick(7, now + Duration::from_millis(999)).is_none());
         let timeout = wait
             .tick(7, now + Duration::from_millis(1_000))
@@ -403,16 +447,17 @@ mod tests {
         let mut nodes: Vec<BrowserNode> = (0..25).map(|_| node(false)).collect();
         nodes.push(node(true));
         let mut visible = pending(SelectorState::Visible, 1_000, now);
-        let result = visible
-            .observe(7, 1, nodes.clone(), now)
-            .expect("a visible match beyond the cap counts");
-        match result.expect("satisfied") {
-            BrowserControlValue::Wait { wait } => assert_eq!(wait.nodes.len(), WAIT_MAX_RESULTS as usize),
-            other => panic!("unexpected value {other:?}"),
-        }
+        assert!(
+            matches!(visible.observe(7, &nodes, now), Observation::Satisfied),
+            "a visible match beyond the cap counts"
+        );
+        assert_eq!(
+            released(&visible, nodes.clone(), now).nodes.len(),
+            WAIT_MAX_RESULTS as usize
+        );
         let mut hidden = pending(SelectorState::Hidden, 1_000, now);
         assert!(
-            hidden.observe(7, 1, nodes, now).is_none(),
+            matches!(hidden.observe(7, &nodes, now), Observation::Waiting),
             "a visible match beyond the cap keeps hidden unsatisfied"
         );
     }
@@ -421,7 +466,7 @@ mod tests {
     fn an_observation_from_another_page_generation_invalidates_the_wait() {
         let now = Instant::now();
         let mut pending = pending(SelectorState::Present, 1_000, now);
-        let result = pending.observe(7 + 1, 1, vec![node(true)], now).expect("settled");
+        let result = done(pending.observe(7 + 1, &[node(true)], now));
         assert_eq!(result.expect_err("invalidated").code, "wait_navigation_invalidated");
     }
 
@@ -442,8 +487,7 @@ mod tests {
         // the element, and a transient failure after the bound is one too.
         let late = now + Duration::from_millis(1_001);
         let mut overran = pending(SelectorState::Present, 1_000, now);
-        let result = overran.observe(7, 1, vec![node(true)], late).expect("settled");
-        let failure = result.expect_err("timed out");
+        let failure = done(overran.observe(7, &[node(true)], late)).expect_err("timed out");
         assert_eq!(failure.code, "wait_timeout");
         assert!(
             failure.message.contains("within the 1000 ms bound (elapsed 1001 ms"),
@@ -519,12 +563,20 @@ mod tests {
             .observe_failure(BrowserControlFailure::new("protocol_error", "evaluate timed out"), now)
             .expect("settled");
         assert_eq!(surfaced.expect_err("failed").code, "protocol_error");
+    }
 
-        // A satisfied result held for guard re-evaluation survives the
-        // deadline passing meanwhile; a navigation still invalidates it.
+    #[test]
+    fn a_satisfied_scan_is_released_only_after_a_later_signal_refresh() {
+        let now = Instant::now();
+        // The deferred scan survives the deadline passing meanwhile; a
+        // navigation still invalidates it; and it is released only under a
+        // later coordination-read epoch than it was observed under.
         let mut deferred = pending(SelectorState::Present, 1_000, now);
-        let result = deferred.observe(7, 1, vec![node(true)], now).expect("satisfied");
-        deferred.defer(result, 3);
+        assert!(matches!(
+            deferred.observe(7, &[node(true)], now),
+            Observation::Satisfied
+        ));
+        deferred.defer(scan(), 3);
         assert!(
             deferred.tick(7, now + Duration::from_secs(2)).is_none(),
             "the deadline does not apply to a held result"
@@ -539,5 +591,11 @@ mod tests {
         );
         assert!(deferred.take_deferred(4).is_some(), "a later refresh releases it");
         assert!(deferred.take_deferred(5).is_none());
+
+        // A wait blocked by an in-flight navigation remembers it.
+        let mut blocked = pending(SelectorState::Present, 1_000, now);
+        assert!(!blocked.blocked_by_navigation());
+        blocked.block_for_navigation();
+        assert!(blocked.blocked_by_navigation());
     }
 }

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -390,7 +390,7 @@ mod tests {
         assert!(matches!(wait.observe(7, &[], now), Observation::Waiting));
         assert!(wait.tick(7, now + Duration::from_millis(999)).is_none());
         let timeout = wait
-            .tick(7, now + Duration::from_millis(1_000))
+            .tick(7, now + Duration::from_secs(1))
             .expect("settled")
             .expect_err("timed out");
         assert_eq!(timeout.code, "wait_timeout");
@@ -474,7 +474,7 @@ mod tests {
     fn observations_are_budgeted_and_rechecked_against_the_deadline() {
         let now = Instant::now();
         let pending_wait = pending(SelectorState::Present, 1_000, now);
-        assert_eq!(pending_wait.observation_budget(now), Duration::from_millis(1_000));
+        assert_eq!(pending_wait.observation_budget(now), Duration::from_secs(1));
         assert_eq!(
             pending_wait.observation_budget(now + Duration::from_millis(900)),
             MIN_OBSERVATION_BUDGET,

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -1,0 +1,543 @@
+//! Backend-neutral bookkeeping for a selector wait observed inside the
+//! driver loop: one audited action that polls the page at a bounded cadence
+//! and settles on the selector state, the deadline, or a cancellation.
+
+use std::time::{Duration, Instant};
+
+use crate::{
+    AgentAction, BrowserControlFailure, BrowserControlValue, BrowserNode, DEFAULT_WAIT_TIMEOUT_MILLIS, SelectorState,
+    WaitOutcome,
+};
+
+/// Interval between page observations while a wait is pending.
+pub(crate) const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Bounds for one synchronous page observation: never shorter than a
+/// coordination tick, never longer than the drivers' own command timeout.
+pub(crate) const MIN_OBSERVATION_BUDGET: Duration = Duration::from_millis(250);
+pub(crate) const MAX_OBSERVATION_BUDGET: Duration = Duration::from_secs(5);
+/// Consecutive retryable observation failures tolerated before the wait
+/// surfaces the failure itself instead of retrying.
+pub(crate) const MAX_TRANSIENT_FAILURES: u32 = 5;
+/// Most matching nodes a wait reports in its outcome.
+pub(crate) const WAIT_MAX_RESULTS: u32 = 20;
+/// Matches the engine evaluates the condition over (the protocol's query
+/// maximum), so a visible match beyond the reported ones still counts.
+pub(crate) const WAIT_QUERY_RESULTS: u32 = crate::MAX_QUERY_RESULTS;
+
+/// Why a pending wait was cancelled before its condition was met.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WaitStop {
+    /// The page generation changed: earlier observations no longer apply.
+    NavigationInvalidated,
+    /// The requesting actor no longer holds the panel lease.
+    OwnershipLost,
+    /// A handoff to the user is pending; agent observation must stop.
+    HandoffPending,
+    /// A later wait on the same panel replaced this one.
+    Superseded,
+}
+
+pub(crate) type WaitResult = Result<BrowserControlValue, BrowserControlFailure>;
+
+#[derive(Debug)]
+pub(crate) struct PendingWait {
+    pub(crate) request: AgentAction,
+    pub(crate) selector: String,
+    state: SelectorState,
+    started: Instant,
+    deadline: Instant,
+    next_poll: Instant,
+    generation_at_start: u64,
+    polls: u32,
+    last_match_count: usize,
+    consecutive_failures: u32,
+    /// Set while an in-flight navigation kept this wait from observing; once
+    /// that navigation settles the wait is invalidated, because the document
+    /// it may now observe is not the one it was asked about.
+    blocked_by_navigation: bool,
+    /// A satisfied observation held until the driver has re-read the
+    /// coordination signals and drained backend events, so a lease or
+    /// handoff change (or a navigation) during the blocking observation
+    /// still cancels the wait. Stored with the signal epoch it was observed
+    /// under; it is released only once a later epoch proves a refresh ran.
+    deferred: Option<(WaitResult, u64)>,
+}
+
+impl PendingWait {
+    pub(crate) fn new(
+        request: AgentAction,
+        selector: String,
+        state: SelectorState,
+        timeout_millis: Option<u64>,
+        queued_for: Duration,
+        generation: u64,
+        now: Instant,
+    ) -> Self {
+        let started = now.checked_sub(queued_for).unwrap_or(now);
+        Self {
+            request,
+            selector,
+            state,
+            started,
+            deadline: started + Duration::from_millis(timeout_millis.unwrap_or(DEFAULT_WAIT_TIMEOUT_MILLIS)),
+            next_poll: now,
+            generation_at_start: generation,
+            polls: 0,
+            last_match_count: 0,
+            consecutive_failures: 0,
+            blocked_by_navigation: false,
+            deferred: None,
+        }
+    }
+
+    /// Record that an in-flight navigation is blocking observation.
+    pub(crate) fn block_for_navigation(&mut self) {
+        self.blocked_by_navigation = true;
+    }
+
+    /// Whether an in-flight navigation blocked this wait earlier.
+    pub(crate) fn blocked_by_navigation(&self) -> bool {
+        self.blocked_by_navigation
+    }
+
+    /// Hold a satisfied result, observed under `signal_epoch`, until the
+    /// guards have been re-evaluated on fresher signals.
+    pub(crate) fn defer(&mut self, result: WaitResult, signal_epoch: u64) {
+        self.deferred = Some((result, signal_epoch));
+    }
+
+    /// The held result, once a coordination refresh newer than the one it
+    /// was observed under has run and the guards allowed it.
+    pub(crate) fn take_deferred(&mut self, signal_epoch: u64) -> Option<WaitResult> {
+        match self.deferred.take() {
+            Some((result, observed_epoch)) if observed_epoch != signal_epoch => Some(result),
+            other => {
+                self.deferred = other;
+                None
+            }
+        }
+    }
+
+    pub(crate) fn poll_due(&self, now: Instant) -> bool {
+        now >= self.next_poll
+    }
+
+    /// How long one observation may block: the remaining bound, clamped so a
+    /// blocking evaluation cannot overrun the deadline by more than a tick.
+    pub(crate) fn observation_budget(&self, now: Instant) -> Duration {
+        self.deadline
+            .saturating_duration_since(now)
+            .clamp(MIN_OBSERVATION_BUDGET, MAX_OBSERVATION_BUDGET)
+    }
+
+    /// Record one page observation; `Some` when the condition is met.
+    pub(crate) fn observe(
+        &mut self,
+        generation: u64,
+        revision: u64,
+        nodes: Vec<BrowserNode>,
+        now: Instant,
+    ) -> Option<WaitResult> {
+        self.polls = self.polls.saturating_add(1);
+        self.next_poll = now + WAIT_POLL_INTERVAL;
+        self.last_match_count = nodes.len();
+        self.consecutive_failures = 0;
+        if generation != self.generation_at_start {
+            // The page navigated while the query was in flight: these nodes
+            // belong to another document.
+            return Some(self.stopped(WaitStop::NavigationInvalidated, now));
+        }
+        // `now` is taken after the query returned: an observation that
+        // overran the bound is a timeout, whatever it saw.
+        if now >= self.deadline {
+            return Some(self.timed_out(now));
+        }
+        // Decide on every match the query returned; report at most the cap.
+        if !self.state.satisfied_by(&nodes) {
+            return None;
+        }
+        let mut nodes = nodes;
+        nodes.truncate(WAIT_MAX_RESULTS as usize);
+        Some(Ok(BrowserControlValue::Wait {
+            wait: WaitOutcome {
+                state: self.state,
+                generation,
+                revision,
+                nodes,
+                elapsed_millis: self.elapsed_millis(now),
+                polls: self.polls,
+            },
+        }))
+    }
+
+    /// A failed observation. Only an execution-context replacement (a page
+    /// mid-navigation) or an observation that timed out is retried, and only
+    /// a few times in a row; every other failure (a closed backend, a missing
+    /// page session, an invalid result), and a persistent one, is returned as
+    /// the typed failure it is.
+    pub(crate) fn observe_failure(&mut self, failure: BrowserControlFailure, now: Instant) -> Option<WaitResult> {
+        self.polls = self.polls.saturating_add(1);
+        self.next_poll = now + WAIT_POLL_INTERVAL;
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        if !observation_failure_is_transient(&failure) || self.consecutive_failures >= MAX_TRANSIENT_FAILURES {
+            return Some(Err(failure));
+        }
+        (now >= self.deadline).then(|| self.timed_out(now))
+    }
+
+    /// Cancel or time out the wait; `Some` when it must be completed now. A
+    /// satisfied result held for guard re-evaluation is still invalidated by
+    /// a navigation, but the deadline no longer applies to it: it was met in
+    /// time.
+    pub(crate) fn tick(&self, generation: u64, now: Instant) -> Option<WaitResult> {
+        if generation != self.generation_at_start {
+            return Some(self.stopped(WaitStop::NavigationInvalidated, now));
+        }
+        if self.deferred.is_some() {
+            return None;
+        }
+        (now >= self.deadline).then(|| self.timed_out(now))
+    }
+
+    fn timed_out(&self, now: Instant) -> WaitResult {
+        let bound_millis =
+            u64::try_from(self.deadline.saturating_duration_since(self.started).as_millis()).unwrap_or(u64::MAX);
+        Err(BrowserControlFailure::new(
+            "wait_timeout",
+            format!(
+                "selector did not become {} within the {} ms bound (elapsed {} ms, {} observations, last match count {})",
+                state_name(self.state),
+                bound_millis,
+                self.elapsed_millis(now),
+                self.polls,
+                self.last_match_count
+            ),
+        ))
+    }
+
+    pub(crate) fn stopped(&self, stop: WaitStop, now: Instant) -> WaitResult {
+        let (code, reason) = match stop {
+            WaitStop::NavigationInvalidated => ("wait_navigation_invalidated", "the page navigated while waiting"),
+            WaitStop::OwnershipLost => ("wait_ownership_lost", "the agent lost the panel lease while waiting"),
+            WaitStop::HandoffPending => ("wait_handoff_pending", "a handoff to the user is pending"),
+            WaitStop::Superseded => ("wait_superseded", "a later wait replaced this one"),
+        };
+        Err(BrowserControlFailure::new(
+            code,
+            format!(
+                "{reason} after {} ms ({} observations)",
+                self.elapsed_millis(now),
+                self.polls
+            ),
+        ))
+    }
+
+    fn elapsed_millis(&self, now: Instant) -> u64 {
+        u64::try_from(now.saturating_duration_since(self.started).as_millis()).unwrap_or(u64::MAX)
+    }
+}
+
+const fn state_name(state: SelectorState) -> &'static str {
+    match state {
+        SelectorState::Present => "present",
+        SelectorState::Visible => "visible",
+        SelectorState::Hidden => "hidden",
+    }
+}
+
+/// Whether an observation failure is worth retrying: the drivers fold every
+/// backend error into `protocol_error` (Chromium) or `javascript_error`
+/// (`WebDriver`), so the message decides. A replaced execution context (the
+/// page is navigating) and an observation that timed out are transient; a
+/// closed backend, a missing page session, or a script error are not.
+fn observation_failure_is_transient(failure: &BrowserControlFailure) -> bool {
+    if !matches!(failure.code.as_str(), "protocol_error" | "javascript_error") {
+        return false;
+    }
+    let message = failure.message.to_ascii_lowercase();
+    ["context", "timed out", "timeout", "unloaded", "navigat"]
+        .iter()
+        .any(|needle| message.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BrowserControlAction;
+
+    fn node(visible: bool) -> BrowserNode {
+        BrowserNode {
+            reference: "g1s1e1".to_string(),
+            role: "paragraph".to_string(),
+            name: String::new(),
+            text: "late".to_string(),
+            visible,
+            enabled: true,
+            bounds: None,
+        }
+    }
+
+    fn pending(state: SelectorState, timeout_millis: u64, now: Instant) -> PendingWait {
+        let request = AgentAction {
+            action_id: "wait-1".to_string(),
+            actor: "horizon:agent".to_string(),
+            requested_at_millis: 0,
+            action: BrowserControlAction::WaitForSelector {
+                selector: "#late".to_string(),
+                state,
+                timeout_millis: Some(timeout_millis),
+            },
+        };
+        PendingWait::new(
+            request,
+            "#late".to_string(),
+            state,
+            Some(timeout_millis),
+            Duration::ZERO,
+            7,
+            now,
+        )
+    }
+
+    fn outcome(result: Option<WaitResult>) -> WaitOutcome {
+        match result.expect("settled").expect("satisfied") {
+            BrowserControlValue::Wait { wait } => wait,
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_wait_settles_when_the_selector_reaches_the_requested_state() {
+        let now = Instant::now();
+        let mut wait = pending(SelectorState::Visible, 5_000, now);
+        assert!(wait.poll_due(now));
+        assert!(wait.observe(7, 1, Vec::new(), now).is_none(), "no match keeps waiting");
+        assert!(
+            !wait.poll_due(now + Duration::from_millis(50)),
+            "observations are paced"
+        );
+        assert!(wait.poll_due(now + WAIT_POLL_INTERVAL));
+        assert!(
+            wait.observe(7, 2, vec![node(false)], now + Duration::from_millis(100))
+                .is_none(),
+            "a hidden match does not satisfy visible"
+        );
+        let satisfied = outcome(wait.observe(7, 3, vec![node(true)], now + Duration::from_millis(1_500)));
+        assert_eq!(satisfied.state, SelectorState::Visible);
+        assert_eq!(satisfied.polls, 3);
+        assert_eq!(satisfied.elapsed_millis, 1_500);
+        assert_eq!(satisfied.nodes.len(), 1);
+
+        let mut hidden = pending(SelectorState::Hidden, 5_000, now);
+        assert!(hidden.observe(7, 1, vec![node(true)], now).is_none());
+        assert!(
+            outcome(hidden.observe(7, 2, Vec::new(), now)).nodes.is_empty(),
+            "an empty match set is hidden"
+        );
+
+        let mut present = pending(SelectorState::Present, 5_000, now);
+        assert_eq!(outcome(present.observe(7, 1, vec![node(false)], now)).polls, 1);
+    }
+
+    #[test]
+    fn timeouts_and_cancellations_are_typed_failures() {
+        let now = Instant::now();
+        let mut wait = pending(SelectorState::Present, 1_000, now);
+        assert!(wait.observe(7, 1, Vec::new(), now).is_none());
+        assert!(wait.tick(7, now + Duration::from_millis(999)).is_none());
+        let timeout = wait
+            .tick(7, now + Duration::from_millis(1_000))
+            .expect("settled")
+            .expect_err("timed out");
+        assert_eq!(timeout.code, "wait_timeout");
+        assert!(timeout.message.contains("1 observations"), "{}", timeout.message);
+
+        let invalidated = wait.tick(8, now).expect("settled").expect_err("cancelled");
+        assert_eq!(invalidated.code, "wait_navigation_invalidated");
+        assert_eq!(
+            wait.stopped(WaitStop::OwnershipLost, now).expect_err("cancelled").code,
+            "wait_ownership_lost"
+        );
+        assert_eq!(
+            wait.stopped(WaitStop::HandoffPending, now).expect_err("cancelled").code,
+            "wait_handoff_pending"
+        );
+        assert_eq!(
+            wait.stopped(WaitStop::Superseded, now).expect_err("cancelled").code,
+            "wait_superseded"
+        );
+
+        let transient = BrowserControlFailure::new("javascript_error", "Execution context was destroyed");
+        assert!(
+            wait.observe_failure(transient, now).is_none(),
+            "transient failures are retried"
+        );
+        let invalid = BrowserControlFailure::new("invalid_selector", "bad selector");
+        assert_eq!(
+            wait.observe_failure(invalid, now)
+                .expect("settled")
+                .expect_err("failed")
+                .code,
+            "invalid_selector"
+        );
+
+        let queued = PendingWait::new(
+            wait.request.clone(),
+            "#late".to_string(),
+            SelectorState::Present,
+            Some(1_000),
+            Duration::from_millis(400),
+            7,
+            now,
+        );
+        assert!(queued.tick(7, now + Duration::from_millis(599)).is_none());
+        assert!(
+            queued.tick(7, now + Duration::from_millis(600)).is_some(),
+            "queue latency counts against the bound"
+        );
+    }
+
+    #[test]
+    fn the_condition_counts_every_match_and_the_outcome_is_capped() {
+        let now = Instant::now();
+        let mut nodes: Vec<BrowserNode> = (0..25).map(|_| node(false)).collect();
+        nodes.push(node(true));
+        let mut visible = pending(SelectorState::Visible, 1_000, now);
+        let result = visible
+            .observe(7, 1, nodes.clone(), now)
+            .expect("a visible match beyond the cap counts");
+        match result.expect("satisfied") {
+            BrowserControlValue::Wait { wait } => assert_eq!(wait.nodes.len(), WAIT_MAX_RESULTS as usize),
+            other => panic!("unexpected value {other:?}"),
+        }
+        let mut hidden = pending(SelectorState::Hidden, 1_000, now);
+        assert!(
+            hidden.observe(7, 1, nodes, now).is_none(),
+            "a visible match beyond the cap keeps hidden unsatisfied"
+        );
+    }
+
+    #[test]
+    fn an_observation_from_another_page_generation_invalidates_the_wait() {
+        let now = Instant::now();
+        let mut pending = pending(SelectorState::Present, 1_000, now);
+        let result = pending.observe(7 + 1, 1, vec![node(true)], now).expect("settled");
+        assert_eq!(result.expect_err("invalidated").code, "wait_navigation_invalidated");
+    }
+
+    #[test]
+    fn observations_are_budgeted_and_rechecked_against_the_deadline() {
+        let now = Instant::now();
+        let pending_wait = pending(SelectorState::Present, 1_000, now);
+        assert_eq!(pending_wait.observation_budget(now), Duration::from_millis(1_000));
+        assert_eq!(
+            pending_wait.observation_budget(now + Duration::from_millis(900)),
+            MIN_OBSERVATION_BUDGET,
+            "the last observation still gets a tick"
+        );
+        let long = pending(SelectorState::Present, 60_000, now);
+        assert_eq!(long.observation_budget(now), MAX_OBSERVATION_BUDGET);
+
+        // A query that returned after the bound is a timeout even when it saw
+        // the element, and a transient failure after the bound is one too.
+        let late = now + Duration::from_millis(1_001);
+        let mut overran = pending(SelectorState::Present, 1_000, now);
+        let result = overran.observe(7, 1, vec![node(true)], late).expect("settled");
+        let failure = result.expect_err("timed out");
+        assert_eq!(failure.code, "wait_timeout");
+        assert!(
+            failure.message.contains("within the 1000 ms bound (elapsed 1001 ms"),
+            "the message names the configured bound and the elapsed time separately: {}",
+            failure.message
+        );
+        let mut failed_late = pending(SelectorState::Present, 1_000, now);
+        let failure = BrowserControlFailure::new("protocol_error", "evaluate timed out");
+        assert_eq!(
+            failed_late
+                .observe_failure(failure, late)
+                .expect("settled")
+                .expect_err("timed out")
+                .code,
+            "wait_timeout"
+        );
+        let mut failed_early = pending(SelectorState::Present, 1_000, now);
+        assert!(
+            failed_early
+                .observe_failure(
+                    BrowserControlFailure::new("protocol_error", "Execution context was destroyed"),
+                    now
+                )
+                .is_none(),
+            "a transient failure inside the bound is retried"
+        );
+    }
+
+    #[test]
+    fn only_retryable_failures_are_retried_and_only_a_few_times() {
+        let now = Instant::now();
+        let mut pending_wait = pending(SelectorState::Present, 10_000, now);
+        assert!(
+            pending_wait
+                .observe_failure(
+                    BrowserControlFailure::new("javascript_error", "Execution context was destroyed"),
+                    now
+                )
+                .is_none(),
+            "a replaced execution context is retried"
+        );
+        assert!(
+            pending_wait
+                .observe_failure(
+                    BrowserControlFailure::new("protocol_error", "Runtime.evaluate timed out after 250 ms"),
+                    now
+                )
+                .is_none(),
+            "an observation timeout is retried"
+        );
+        for (code, message) in [
+            ("protocol_error", "CDP connection closed"),
+            ("protocol_error", "no page session for Runtime.evaluate"),
+            ("javascript_error", "ReferenceError: foo is not defined"),
+            ("invalid_result", "not a node list"),
+        ] {
+            let mut fresh = pending(SelectorState::Present, 10_000, now);
+            let surfaced = fresh
+                .observe_failure(BrowserControlFailure::new(code, message), now)
+                .expect("settled");
+            assert_eq!(surfaced.expect_err("failed").code, code, "{message} is permanent");
+        }
+
+        let mut persistent = pending(SelectorState::Present, 10_000, now);
+        for _ in 1..MAX_TRANSIENT_FAILURES {
+            assert!(
+                persistent
+                    .observe_failure(BrowserControlFailure::new("protocol_error", "evaluate timed out"), now)
+                    .is_none()
+            );
+        }
+        let surfaced = persistent
+            .observe_failure(BrowserControlFailure::new("protocol_error", "evaluate timed out"), now)
+            .expect("settled");
+        assert_eq!(surfaced.expect_err("failed").code, "protocol_error");
+
+        // A satisfied result held for guard re-evaluation survives the
+        // deadline passing meanwhile; a navigation still invalidates it.
+        let mut deferred = pending(SelectorState::Present, 1_000, now);
+        let result = deferred.observe(7, 1, vec![node(true)], now).expect("satisfied");
+        deferred.defer(result, 3);
+        assert!(
+            deferred.tick(7, now + Duration::from_secs(2)).is_none(),
+            "the deadline does not apply to a held result"
+        );
+        assert!(
+            deferred.tick(8, now + Duration::from_secs(2)).is_some(),
+            "a navigation still invalidates it"
+        );
+        assert!(
+            deferred.take_deferred(3).is_none(),
+            "no refresh has run since the observation"
+        );
+        assert!(deferred.take_deferred(4).is_some(), "a later refresh releases it");
+        assert!(deferred.take_deferred(5).is_none());
+    }
+}

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -4,6 +4,7 @@
 
 use std::time::{Duration, Instant};
 
+use crate::semantic::ScanSummary;
 use crate::{
     AgentAction, BrowserControlFailure, BrowserControlValue, BrowserNode, DEFAULT_WAIT_TIMEOUT_MILLIS, SelectorState,
     WaitOutcome,
@@ -177,11 +178,20 @@ impl PendingWait {
             .clamp(MIN_OBSERVATION_BUDGET, MAX_OBSERVATION_BUDGET)
     }
 
-    /// Judge one page observation made without registering references.
-    pub(crate) fn observe(&mut self, generation: u64, nodes: &[BrowserNode], now: Instant) -> Observation {
+    /// Judge one page observation made without registering references. The
+    /// scan's summary counts every match, beyond the capped nodes, so a
+    /// visible match past the cap still satisfies `visible` and keeps
+    /// `hidden` unsatisfied.
+    pub(crate) fn observe(
+        &mut self,
+        generation: u64,
+        nodes: &[BrowserNode],
+        summary: Option<ScanSummary>,
+        now: Instant,
+    ) -> Observation {
         self.polls = self.polls.saturating_add(1);
         self.next_poll = now + WAIT_POLL_INTERVAL;
-        self.last_match_count = nodes.len();
+        self.last_match_count = summary.map_or(nodes.len(), |summary| summary.matched);
         self.consecutive_failures = 0;
         if generation != self.generation_at_start {
             // The page navigated while the query was in flight: these nodes
@@ -193,9 +203,17 @@ impl PendingWait {
         if now >= self.deadline {
             return Observation::Done(self.timed_out(now));
         }
-        // Decide on every match the query returned; the released scan is
-        // registered and capped by the driver.
-        if self.state.satisfied_by(nodes) {
+        // Decide on every match the scan saw; the released scan is registered
+        // and capped by the driver.
+        let satisfied = match summary {
+            Some(summary) => match self.state {
+                SelectorState::Present => summary.matched > 0,
+                SelectorState::Visible => summary.visible > 0,
+                SelectorState::Hidden => summary.visible == 0,
+            },
+            None => self.state.satisfied_by(nodes),
+        };
+        if satisfied {
             self.satisfied_at = Some(now);
             Observation::Satisfied
         } else {
@@ -365,7 +383,7 @@ mod tests {
         let mut wait = pending(SelectorState::Visible, 5_000, now);
         assert!(wait.poll_due(now));
         assert!(
-            matches!(wait.observe(7, &[], now), Observation::Waiting),
+            matches!(wait.observe(7, &[], None, now), Observation::Waiting),
             "no match keeps waiting"
         );
         assert!(
@@ -375,13 +393,13 @@ mod tests {
         assert!(wait.poll_due(now + WAIT_POLL_INTERVAL));
         assert!(
             matches!(
-                wait.observe(7, &[node(false)], now + Duration::from_millis(100)),
+                wait.observe(7, &[node(false)], None, now + Duration::from_millis(100)),
                 Observation::Waiting
             ),
             "a hidden match does not satisfy visible"
         );
         assert!(matches!(
-            wait.observe(7, &[node(true)], now + Duration::from_millis(1_500)),
+            wait.observe(7, &[node(true)], None, now + Duration::from_millis(1_500)),
             Observation::Satisfied
         ));
         // Released later, after the coordination refresh: the elapsed time
@@ -393,15 +411,18 @@ mod tests {
         assert_eq!(satisfied.nodes.len(), 1);
 
         let mut hidden = pending(SelectorState::Hidden, 5_000, now);
-        assert!(matches!(hidden.observe(7, &[node(true)], now), Observation::Waiting));
+        assert!(matches!(
+            hidden.observe(7, &[node(true)], None, now),
+            Observation::Waiting
+        ));
         assert!(
-            matches!(hidden.observe(7, &[], now), Observation::Satisfied),
+            matches!(hidden.observe(7, &[], None, now), Observation::Satisfied),
             "an empty match set is hidden"
         );
 
         let mut present = pending(SelectorState::Present, 5_000, now);
         assert!(matches!(
-            present.observe(7, &[node(false)], now),
+            present.observe(7, &[node(false)], None, now),
             Observation::Satisfied
         ));
         assert_eq!(released(&present, vec![node(false)], now).polls, 1);
@@ -411,7 +432,7 @@ mod tests {
     fn timeouts_and_cancellations_are_typed_failures() {
         let now = Instant::now();
         let mut wait = pending(SelectorState::Present, 1_000, now);
-        assert!(matches!(wait.observe(7, &[], now), Observation::Waiting));
+        assert!(matches!(wait.observe(7, &[], None, now), Observation::Waiting));
         assert!(wait.tick(7, now + Duration::from_millis(999)).is_none());
         let timeout = wait
             .tick(7, now + Duration::from_secs(1))
@@ -472,7 +493,7 @@ mod tests {
         nodes.push(node(true));
         let mut visible = pending(SelectorState::Visible, 1_000, now);
         assert!(
-            matches!(visible.observe(7, &nodes, now), Observation::Satisfied),
+            matches!(visible.observe(7, &nodes, None, now), Observation::Satisfied),
             "a visible match beyond the cap counts"
         );
         assert_eq!(
@@ -481,16 +502,45 @@ mod tests {
         );
         let mut hidden = pending(SelectorState::Hidden, 1_000, now);
         assert!(
-            matches!(hidden.observe(7, &nodes, now), Observation::Waiting),
+            matches!(hidden.observe(7, &nodes, None, now), Observation::Waiting),
             "a visible match beyond the cap keeps hidden unsatisfied"
         );
+
+        // With the scan's summary, matches beyond the returned cap decide too:
+        // 300 matches of which only the 251st is visible.
+        let beyond = ScanSummary {
+            matched: 300,
+            visible: 1,
+        };
+        let capped: Vec<BrowserNode> = (0..250).map(|_| node(false)).collect();
+        let mut visible_beyond = pending(SelectorState::Visible, 1_000, now);
+        assert!(
+            matches!(
+                visible_beyond.observe(7, &capped, Some(beyond), now),
+                Observation::Satisfied
+            ),
+            "a visible match beyond the scan cap satisfies visible"
+        );
+        let mut hidden_beyond = pending(SelectorState::Hidden, 1_000, now);
+        assert!(
+            matches!(
+                hidden_beyond.observe(7, &capped, Some(beyond), now),
+                Observation::Waiting
+            ),
+            "a visible match beyond the scan cap keeps hidden unsatisfied"
+        );
+        let mut present_none = pending(SelectorState::Present, 1_000, now);
+        assert!(matches!(
+            present_none.observe(7, &[], Some(ScanSummary { matched: 0, visible: 0 }), now),
+            Observation::Waiting
+        ));
     }
 
     #[test]
     fn an_observation_from_another_page_generation_invalidates_the_wait() {
         let now = Instant::now();
         let mut pending = pending(SelectorState::Present, 1_000, now);
-        let result = done(pending.observe(7 + 1, &[node(true)], now));
+        let result = done(pending.observe(7 + 1, &[node(true)], None, now));
         assert_eq!(result.expect_err("invalidated").code, "wait_navigation_invalidated");
     }
 
@@ -511,7 +561,7 @@ mod tests {
         // the element, and a transient failure after the bound is one too.
         let late = now + Duration::from_millis(1_001);
         let mut overran = pending(SelectorState::Present, 1_000, now);
-        let failure = done(overran.observe(7, &[node(true)], late)).expect_err("timed out");
+        let failure = done(overran.observe(7, &[node(true)], None, late)).expect_err("timed out");
         assert_eq!(failure.code, "wait_timeout");
         assert!(
             failure.message.contains("within the 1000 ms bound (elapsed 1001 ms"),
@@ -609,7 +659,7 @@ mod tests {
         // later coordination-read epoch than it was observed under.
         let mut deferred = pending(SelectorState::Present, 1_000, now);
         assert!(matches!(
-            deferred.observe(7, &[node(true)], now),
+            deferred.observe(7, &[node(true)], None, now),
             Observation::Satisfied
         ));
         deferred.defer(scan(), 3);

--- a/crates/horizon-browser/src/wait.rs
+++ b/crates/horizon-browser/src/wait.rs
@@ -19,11 +19,14 @@ pub(crate) const MAX_OBSERVATION_BUDGET: Duration = Duration::from_secs(5);
 /// Consecutive retryable observation failures tolerated before the wait
 /// surfaces the failure itself instead of retrying.
 pub(crate) const MAX_TRANSIENT_FAILURES: u32 = 5;
-/// Most matching nodes a wait reports in its outcome.
+/// Most matching nodes a wait reports in its outcome; the observation scan
+/// returns no more than this while its summary counts every match.
 pub(crate) const WAIT_MAX_RESULTS: u32 = 20;
-/// Matches the engine evaluates the condition over (the protocol's query
-/// maximum), so a visible match beyond the reported ones still counts.
-pub(crate) const WAIT_QUERY_RESULTS: u32 = crate::MAX_QUERY_RESULTS;
+/// How long one pre-release document check (the drivers' final identity
+/// read before a held match is returned) may block. The condition was met
+/// in time, so this check is bounded by its own budget and retry count, not
+/// by the wait's remaining time.
+pub(crate) const RELEASE_CHECK_BUDGET: Duration = Duration::from_secs(1);
 
 /// Why a pending wait was cancelled before its condition was met.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -234,6 +237,16 @@ impl PendingWait {
             return Some(Err(failure));
         }
         (now >= self.deadline).then(|| self.timed_out(now))
+    }
+
+    /// A failed pre-release check on a held match. The condition was met in
+    /// time, so the wait deadline no longer applies: a retryable failure is
+    /// tried again on the next tick, up to [`MAX_TRANSIENT_FAILURES`] in a
+    /// row, and every other failure, or a persistent one, is returned as is.
+    pub(crate) fn release_check_failure(&mut self, failure: BrowserControlFailure) -> Option<WaitResult> {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        (!observation_failure_is_transient(&failure) || self.consecutive_failures >= MAX_TRANSIENT_FAILURES)
+            .then_some(Err(failure))
     }
 
     /// Cancel or time out the wait; `Some` when it must be completed now. A
@@ -649,6 +662,49 @@ mod tests {
             .observe_failure(BrowserControlFailure::new("protocol_error", "evaluate timed out"), now)
             .expect("settled");
         assert_eq!(surfaced.expect_err("failed").code, "protocol_error");
+    }
+
+    #[test]
+    fn a_failed_release_check_is_retried_without_the_wait_deadline() {
+        let now = Instant::now();
+        let mut held = pending(SelectorState::Present, 1_000, now);
+        assert!(matches!(
+            held.observe(7, &[node(true)], None, now),
+            Observation::Satisfied
+        ));
+        held.defer(scan(), 3);
+        let late = now + Duration::from_secs(3);
+        for _ in 1..MAX_TRANSIENT_FAILURES {
+            assert!(
+                held.release_check_failure(BrowserControlFailure::new(
+                    "javascript_error",
+                    "WebDriver HTTP I/O: Resource temporarily unavailable (os error 11)"
+                ))
+                .is_none(),
+                "a slow identity read past the deadline is retried, not timed out"
+            );
+        }
+        assert!(
+            held.tick(7, late).is_none(),
+            "the held match still ignores the deadline"
+        );
+        assert_eq!(held.polls, 1, "release checks are not observations");
+        let surfaced = held
+            .release_check_failure(BrowserControlFailure::new("javascript_error", "evaluate timed out"))
+            .expect("settled");
+        assert_eq!(surfaced.expect_err("failed").code, "javascript_error");
+
+        let mut permanent = pending(SelectorState::Present, 1_000, now);
+        assert!(matches!(
+            permanent.observe(7, &[node(true)], None, now),
+            Observation::Satisfied
+        ));
+        permanent.defer(scan(), 3);
+        let surfaced = permanent
+            .release_check_failure(BrowserControlFailure::new("invalid_result", "no document identity"))
+            .expect("settled");
+        assert_eq!(surfaced.expect_err("failed").code, "invalid_result");
+        assert!(RELEASE_CHECK_BUDGET > MIN_OBSERVATION_BUDGET);
     }
 
     #[test]

--- a/crates/horizon-browser/src/webdriver/http.rs
+++ b/crates/horizon-browser/src/webdriver/http.rs
@@ -50,6 +50,10 @@ impl HttpClient {
         self.request("GET", path, None, IO_TIMEOUT)
     }
 
+    pub(super) fn get_with_read_timeout(&self, path: &str, read_timeout: Duration) -> Result<Value, HttpError> {
+        self.request("GET", path, None, read_timeout)
+    }
+
     pub(super) fn post(&self, path: &str, body: &Value) -> Result<Value, HttpError> {
         self.request("POST", path, Some(body), IO_TIMEOUT)
     }

--- a/crates/horizon-browser/src/webdriver/service.rs
+++ b/crates/horizon-browser/src/webdriver/service.rs
@@ -38,6 +38,11 @@ impl Drop for SafariLease {
 }
 
 impl WebDriverService {
+    pub(super) fn delete_session(&self, session_id: &str) {
+        let path = format!("/session/{session_id}");
+        let _ = self.http.delete(&path);
+    }
+
     pub(super) fn start(
         config: &BrowserConfig,
         control: &ChromeProcessControl,

--- a/crates/horizon-browser/src/webdriver/session.rs
+++ b/crates/horizon-browser/src/webdriver/session.rs
@@ -167,10 +167,14 @@ struct Driver {
     /// Session page-load timeout a bounded classic navigation lowered and the
     /// loop still has to restore, once the typed outcome was published.
     classic_timeout_to_restore: Option<u64>,
-    /// While a bounded classic navigation (startup or agent action) is still
-    /// loading after its bound, page state is re-read every second until this
-    /// instant or until the URL changes; the navigation counts as in flight.
-    classic_refresh_until: Option<Instant>,
+    /// Script-observed identity of Safari's current document. Unlike its URL,
+    /// this changes on a same-URL reload and lets waits reject replacement
+    /// documents even though classic `WebDriver` emits no navigation events.
+    classic_document_identity: Option<String>,
+    /// A bounded classic navigation (startup or agent action) that is still
+    /// loading after its result deadline and must be polled to a document
+    /// replacement, URL change, or the page-load cutoff.
+    classic_refresh: Option<navigation::ClassicNavigationRefresh>,
     coordination_dirty: bool,
     last_coordination_write: Instant,
     last_signal_check: Instant,
@@ -225,6 +229,7 @@ pub(crate) fn run_webdriver(
         }
     };
     driver.initialize_coordination();
+    driver.initialize_classic_document_identity();
     let capabilities = driver.active_capabilities();
     frame_slot.publish_backend_capabilities(capabilities);
     let _ = event_tx.send(BrowserEvent::BackendReady(capabilities));
@@ -320,9 +325,11 @@ impl Driver {
             }
             Err(error) => return Err(format!("failed to create WebDriver session: {error}")),
         };
-        let new_session = parse_new_session_response(&response)?;
-        let session_id = new_session.id;
-        let ws_url = new_session.capabilities.get("webSocketUrl").and_then(Value::as_str);
+        let NewSession {
+            id: session_id,
+            capabilities,
+        } = parse_new_session_response(&response)?;
+        let ws_url = capabilities.get("webSocketUrl").and_then(Value::as_str);
         let mut bidi = match ws_url {
             Some(url) => match connect_bidi_with_startup_retry(url, stop_requested) {
                 Ok(link) => Some(link),
@@ -335,14 +342,12 @@ impl Driver {
             None => None,
         };
         if config.browser.backend == BackendKind::FirefoxBidi && bidi.is_none() {
-            let path = format!("/session/{session_id}");
-            let _ = service.http.delete(&path);
+            service.delete_session(&session_id);
             return Err("Firefox did not return the required WebDriver BiDi webSocketUrl".to_string());
         }
         let mut context_id = bidi.as_mut().and_then(discover_context);
         if config.browser.backend == BackendKind::FirefoxBidi && context_id.is_none() {
-            let path = format!("/session/{session_id}");
-            let _ = service.http.delete(&path);
+            service.delete_session(&session_id);
             return Err("Firefox BiDi returned no top-level browsing context".to_string());
         }
         if config.browser.backend == BackendKind::FirefoxBidi
@@ -350,8 +355,7 @@ impl Driver {
             && let Some(link) = bidi.as_mut()
             && let Err(error) = install_common_signal_preload(link)
         {
-            let path = format!("/session/{session_id}");
-            let _ = service.http.delete(&path);
+            service.delete_session(&session_id);
             return Err(format!(
                 "Firefox could not install pre-document automation disclosure minimization: {error}"
             ));
@@ -360,8 +364,7 @@ impl Driver {
             && let Err(error) = subscribe(link, config.browser.backend, context_id.as_deref())
         {
             if config.browser.backend == BackendKind::FirefoxBidi {
-                let path = format!("/session/{session_id}");
-                let _ = service.http.delete(&path);
+                service.delete_session(&session_id);
                 return Err(format!("Firefox BiDi event subscription failed: {error}"));
             }
             bidi = None;
@@ -391,7 +394,8 @@ impl Driver {
             pending_classic_history_start: None,
             refresh_pending_at: None,
             classic_timeout_to_restore: None,
-            classic_refresh_until: None,
+            classic_document_identity: None,
+            classic_refresh: None,
             coordination_dirty: true,
             last_coordination_write: Instant::now(),
             last_signal_check: Instant::now(),

--- a/crates/horizon-browser/src/webdriver/session.rs
+++ b/crates/horizon-browser/src/webdriver/session.rs
@@ -668,27 +668,31 @@ impl Driver {
         }
         if bidi_navigation_failed(method) {
             let navigation = params.get("navigation").and_then(Value::as_str);
-            if self
-                .pending_navigation
-                .as_ref()
-                .is_some_and(|pending| !pending.correlates(navigation))
-            {
-                // A superseded navigation failing late must not poison the
-                // state of the navigation that replaced it.
-                tracing::debug!(target: "browser", navigation, "ignoring failure of a superseded navigation");
-                return;
-            }
-            self.navigation_failed = true;
-            self.retain_frame_during_navigation = true;
-            self.frames.suspend_for_navigation();
-            self.frames.interaction_started_at = None;
             let url = params
                 .get("url")
                 .and_then(Value::as_str)
                 .unwrap_or("the requested page");
             let message = format!("could not navigate to {url}");
-            let _ = event_tx.send(BrowserEvent::NavigationFailed(message.clone()));
-            let _ = event_tx.send(BrowserEvent::Loading(false));
+            if let Some(pending) = self.pending_navigation.as_ref() {
+                if !pending.correlates(navigation) {
+                    // A superseded navigation failing late must not poison the
+                    // state of the navigation that replaced it.
+                    tracing::debug!(target: "browser", navigation, "ignoring failure of a superseded navigation");
+                    return;
+                }
+                if pending.attribution_is_pending(navigation) {
+                    // The dispatch reply has not named this navigation yet.
+                    // Hold the failure without changing page-wide state; the
+                    // reply either attributes it to this action or discards it
+                    // as a late failure from the navigation it replaced.
+                    self.observe_navigation_signal(crate::navigation::NavigationSignal::Failed {
+                        message: &message,
+                        id: navigation,
+                    });
+                    return;
+                }
+            }
+            self.apply_navigation_failure_state(event_tx, &message);
             self.observe_navigation_signal(crate::navigation::NavigationSignal::Failed {
                 message: &message,
                 id: navigation,

--- a/crates/horizon-browser/src/webdriver/session.rs
+++ b/crates/horizon-browser/src/webdriver/session.rs
@@ -29,6 +29,7 @@ mod safari;
 mod scrollbar;
 mod semantic;
 mod shutdown;
+mod wait;
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const PAGE_LOAD_TIMEOUT_MILLIS: u64 = 50_000;
@@ -157,6 +158,7 @@ struct Driver {
     navigation_failed: bool,
     /// Agent navigation whose typed outcome is settled by `BiDi` events.
     pending_navigation: Option<crate::navigation::PendingNavigation>,
+    pending_wait: Option<crate::wait::PendingWait>,
     /// In-flight `browsingContext.navigate` sent without waiting: Firefox
     /// answers it only once the destination responds.
     navigate_request_id: Option<u64>,
@@ -165,14 +167,18 @@ struct Driver {
     /// Session page-load timeout a bounded classic navigation lowered and the
     /// loop still has to restore, once the typed outcome was published.
     classic_timeout_to_restore: Option<u64>,
-    /// While a bounded startup navigation is still loading, page state is
-    /// re-read every second until this instant or until the URL changes.
-    startup_refresh_until: Option<Instant>,
+    /// While a bounded classic navigation (startup or agent action) is still
+    /// loading after its bound, page state is re-read every second until this
+    /// instant or until the URL changes; the navigation counts as in flight.
+    classic_refresh_until: Option<Instant>,
     coordination_dirty: bool,
     last_coordination_write: Instant,
     last_signal_check: Instant,
     last_user_active_stamp: Option<Instant>,
     owner_seen: Option<String>,
+    /// Counts successful coordination reads; a deferred wait result is
+    /// released only under a later epoch than it was observed under.
+    signal_epoch: u64,
     handoff_seen: Option<String>,
     audit_sampler: crate::audit::BrowserAuditSampler,
     semantic: SemanticState,
@@ -254,11 +260,12 @@ pub(crate) fn run_webdriver(
         driver.tick_safari_input(event_tx);
         for request in driver.tick_coordination(event_tx) {
             // A blocking action later in the batch must not delay the typed
-            // timeout of a navigation dispatched earlier in it, and a
+            // timeout of a navigation or wait dispatched earlier in it, and a
             // navigation that hit its bound earlier in the batch must have its
             // session timeout restored and page state refreshed before the
             // next request runs.
             driver.tick_pending_navigation();
+            driver.tick_pending_wait();
             driver.tick_classic_timeout_restore();
             driver.tick_page_state_refresh(event_tx);
             driver.service_agent_request(&request, event_tx);
@@ -281,6 +288,7 @@ pub(crate) fn run_webdriver(
         driver.tick_classic_timeout_restore();
         driver.tick_page_state_refresh(event_tx);
         driver.tick_pending_navigation();
+        driver.tick_pending_wait();
         driver.write_coordination(false);
         if let Some(status) = driver.service.process.child_status() {
             let _ = event_tx.send(BrowserEvent::Stopped { code: status.code() });
@@ -378,16 +386,18 @@ impl Driver {
             retain_frame_during_navigation: false,
             navigation_failed: false,
             pending_navigation: None,
+            pending_wait: None,
             navigate_request_id: None,
             pending_classic_history_start: None,
             refresh_pending_at: None,
             classic_timeout_to_restore: None,
-            startup_refresh_until: None,
+            classic_refresh_until: None,
             coordination_dirty: true,
             last_coordination_write: Instant::now(),
             last_signal_check: Instant::now(),
             last_user_active_stamp: None,
             owner_seen: None,
+            signal_epoch: 0,
             handoff_seen: None,
             audit_sampler: crate::audit::BrowserAuditSampler::default(),
             semantic: SemanticState::default(),
@@ -725,20 +735,6 @@ impl Driver {
         if !self.retain_frame_during_navigation {
             self.frames.invalidate();
         }
-    }
-
-    fn begin_navigation(&mut self) {
-        self.challenge_loop.document_navigation_started();
-        self.pending_classic_history_start = None;
-        self.semantic.invalidate();
-        self.generation = self.generation.wrapping_add(1);
-        self.retain_frame_during_navigation = true;
-        self.navigation_failed = false;
-        self.refresh_pending_at = None;
-        // A replacement navigation must not inherit the startup poll's cutoff.
-        self.startup_refresh_until = None;
-        self.scrollbar.reset();
-        self.frames.suspend_for_navigation();
     }
 }
 

--- a/crates/horizon-browser/src/webdriver/session/coordination.rs
+++ b/crates/horizon-browser/src/webdriver/session/coordination.rs
@@ -54,6 +54,12 @@ impl Driver {
         }
     }
 
+    /// Make the next `tick_coordination` re-read the manifest regardless of
+    /// the interval, so ownership and handoff state is current.
+    pub(super) fn request_signal_refresh(&mut self) {
+        self.last_signal_check = Instant::now().checked_sub(SIGNAL_INTERVAL).unwrap_or_else(Instant::now);
+    }
+
     pub(super) fn tick_coordination(&mut self, event_tx: &BrowserEventSender) -> Vec<AgentAction> {
         if self.last_signal_check.elapsed() < SIGNAL_INTERVAL {
             return Vec::new();
@@ -70,6 +76,7 @@ impl Driver {
                 return Vec::new();
             }
         };
+        self.signal_epoch = self.signal_epoch.wrapping_add(1);
         publish_owner_change(&mut self.owner_seen, signals.owner, event_tx);
         self.challenge_loop.observe_handoff_change(
             self.handoff_seen.as_deref(),
@@ -161,6 +168,12 @@ impl Driver {
         self.audit_agent_action(request, crate::BrowserAuditStatus::Dispatched);
         if matches!(request.action, crate::BrowserControlAction::Navigate { .. }) {
             if let crate::navigation::AgentActionExecution::Done(result) = self.navigate_action(request, event_tx) {
+                self.complete_agent_action(request, result);
+            }
+            return;
+        }
+        if matches!(request.action, crate::BrowserControlAction::WaitForSelector { .. }) {
+            if let crate::navigation::AgentActionExecution::Done(result) = self.begin_agent_wait(request) {
                 self.complete_agent_action(request, result);
             }
             return;

--- a/crates/horizon-browser/src/webdriver/session/navigation.rs
+++ b/crates/horizon-browser/src/webdriver/session/navigation.rs
@@ -127,15 +127,23 @@ impl Driver {
         let read_timeout = Duration::from_millis(remaining_millis.saturating_add(CLASSIC_BOUND_READ_MARGIN_MILLIS));
         self.begin_navigation();
         let _ = event_tx.send(BrowserEvent::Loading(true));
-        let result = self
-            .classic_navigation_post_within("url", &json!({ "url": &url }), read_timeout)
-            .and_then(|_| self.classic_get("url"))
+        let result = self.classic_navigation_post_within("url", &json!({ "url": &url }), read_timeout);
+        let now = Instant::now();
+        if result.is_ok() && pending.tick(now).is_some() {
+            return Ok(self.settle_classic_navigation_timeout(pending, now));
+        }
+        let get_timeout = pending.remaining(now).max(Duration::from_millis(1));
+        let result = result
+            .and_then(|_| self.classic_get_within("url", get_timeout))
             .and_then(|response| {
                 classic_navigation_committed(&response, &url, &previous_url)
                     .then_some(())
                     .ok_or_else(|| "browser did not commit a reachable URL".to_string())
             });
         let now = Instant::now();
+        if pending.tick(now).is_some() {
+            return Ok(self.settle_classic_navigation_timeout(pending, now));
+        }
         if let Err(error) = &result
             && classic_error_is_page_load_timeout(error)
         {
@@ -144,21 +152,7 @@ impl Driver {
             // own 10 s guards; against a hung driver they would eat the
             // controller's delivery headroom, so the loop runs them after the
             // result is written.
-            self.retain_frame_during_navigation = false;
-            self.navigation_failed = false;
-            self.classic_timeout_to_restore = Some(PAGE_LOAD_TIMEOUT_MILLIS);
-            self.refresh_pending_at = Some(now);
-            self.frames.demand();
-            // The classic navigation keeps running in the browser: it counts as
-            // in flight and the page state is polled until it commits or the
-            // page-load window passes. Classic WebDriver only reveals a commit
-            // through a URL change, so a same-URL navigation (a slow reload)
-            // is not tracked: its waits observe the current document instead
-            // of pausing for a commit that could never be recognised.
-            if url != previous_url {
-                self.classic_refresh_until = Some(now + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS));
-            }
-            return Ok(pending.settle_timed_out(None, now));
+            return Ok(self.settle_classic_navigation_timeout(pending, now));
         }
         if self
             .classic_post("timeouts", &json!({ "pageLoad": PAGE_LOAD_TIMEOUT_MILLIS }))
@@ -172,6 +166,19 @@ impl Driver {
             .map_err(|error| BrowserControlFailure::new("navigation_failed", error))?;
         let (committed, title) = (self.url.clone(), self.title.clone());
         Ok(pending.settle_loaded(&committed, &title, Instant::now()))
+    }
+
+    fn settle_classic_navigation_timeout(
+        &mut self,
+        pending: &mut PendingNavigation,
+        now: Instant,
+    ) -> crate::BrowserControlValue {
+        self.retain_frame_during_navigation = false;
+        self.navigation_failed = false;
+        self.classic_timeout_to_restore = Some(PAGE_LOAD_TIMEOUT_MILLIS);
+        self.refresh_pending_at = Some(now);
+        self.frames.demand();
+        pending.settle_timed_out(None, now)
     }
 
     /// Send `browsingContext.navigate` without waiting for its reply. Firefox
@@ -223,20 +230,26 @@ impl Driver {
             .pointer("/result/navigation")
             .and_then(Value::as_str)
             .filter(|id| !id.is_empty());
-        self.attach_navigation_id(navigation);
+        self.attach_navigation_id(navigation, event_tx);
     }
 
     fn fail_agent_navigation(&mut self, event_tx: &BrowserEventSender, message: &str) {
+        self.apply_navigation_failure_state(event_tx, message);
+        self.observe_navigation_signal(NavigationSignal::Failed { message, id: None });
+    }
+
+    pub(super) fn apply_navigation_failure_state(&mut self, event_tx: &BrowserEventSender, message: &str) {
         self.navigation_failed = true;
+        self.retain_frame_during_navigation = true;
+        self.frames.suspend_for_navigation();
         self.frames.interaction_started_at = None;
         let _ = event_tx.send(BrowserEvent::NavigationFailed(message.to_string()));
         let _ = event_tx.send(BrowserEvent::Loading(false));
-        self.observe_navigation_signal(NavigationSignal::Failed { message, id: None });
     }
 
     /// The `browsingContext.navigate` reply named the navigation; attribute
     /// any held-back event.
-    pub(super) fn attach_navigation_id(&mut self, navigation: Option<&str>) {
+    pub(super) fn attach_navigation_id(&mut self, navigation: Option<&str>, event_tx: &BrowserEventSender) {
         let now = Instant::now();
         let settled = self
             .pending_navigation
@@ -245,6 +258,9 @@ impl Driver {
         if let Some(result) = settled
             && let Some(pending) = self.pending_navigation.take()
         {
+            if let Err(failure) = &result {
+                self.apply_navigation_failure_state(event_tx, &failure.message);
+            }
             self.complete_agent_action(&pending.request, result);
         }
     }
@@ -297,11 +313,11 @@ impl Driver {
     }
 
     pub(super) fn supersede_pending_navigation(&mut self, now: Instant) {
+        // Dispatch-only and timed-out actions can leave the asynchronous reply
+        // in flight after their logical result is gone. A replacement must not
+        // route that stale reply into its own navigation state.
+        self.navigate_request_id = None;
         if let Some(pending) = self.pending_navigation.take() {
-            // The superseded navigation's `browsingContext.navigate` reply may
-            // still be in flight; a late rejection must not fail its
-            // replacement.
-            self.navigate_request_id = None;
             self.complete_agent_action(&pending.request, Ok(pending.superseded(now)));
         }
     }
@@ -533,6 +549,13 @@ impl Driver {
         self.service
             .http
             .post_with_read_timeout(&self.session_path(suffix), body, read_timeout)
+            .map_err(|error| error.to_string())
+    }
+
+    fn classic_get_within(&self, suffix: &str, read_timeout: Duration) -> Result<serde_json::Value, String> {
+        self.service
+            .http
+            .get_with_read_timeout(&self.session_path(suffix), read_timeout)
             .map_err(|error| error.to_string())
     }
 

--- a/crates/horizon-browser/src/webdriver/session/navigation.rs
+++ b/crates/horizon-browser/src/webdriver/session/navigation.rs
@@ -149,6 +149,15 @@ impl Driver {
             self.classic_timeout_to_restore = Some(PAGE_LOAD_TIMEOUT_MILLIS);
             self.refresh_pending_at = Some(now);
             self.frames.demand();
+            // The classic navigation keeps running in the browser: it counts as
+            // in flight and the page state is polled until it commits or the
+            // page-load window passes. Classic WebDriver only reveals a commit
+            // through a URL change, so a same-URL navigation (a slow reload)
+            // is not tracked: its waits observe the current document instead
+            // of pausing for a commit that could never be recognised.
+            if url != previous_url {
+                self.classic_refresh_until = Some(now + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS));
+            }
             return Ok(pending.settle_timed_out(None, now));
         }
         if self
@@ -360,13 +369,31 @@ impl Driver {
             self.navigation_failed = false;
             // The window counts from the navigation start, so the overall
             // failure cutoff stays at the normal page-load window.
-            self.startup_refresh_until = Some(started + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS));
+            self.classic_refresh_until = Some(started + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS));
             self.refresh_pending_at = Some(Instant::now() + Duration::from_secs(1));
             tracing::debug!(target: "browser", url = %url, "startup navigation still loading after its bound");
             return true;
         }
         let _ = self.finish_page(result, &format!("startup navigation to {url}"), event_tx);
         false
+    }
+
+    /// Reset per-navigation state when the driver starts or observes a
+    /// document navigation.
+    pub(super) fn begin_navigation(&mut self) {
+        self.challenge_loop.document_navigation_started();
+        self.pending_classic_history_start = None;
+        self.semantic.invalidate();
+        self.generation = self.generation.wrapping_add(1);
+        self.retain_frame_during_navigation = true;
+        self.navigation_failed = false;
+        self.refresh_pending_at = None;
+        // A replacement navigation supersedes a classic navigation that was
+        // still being polled to its commit; otherwise the marker would keep
+        // every later wait paused.
+        self.classic_refresh_until = None;
+        self.scrollbar.reset();
+        self.frames.suspend_for_navigation();
     }
 
     pub(super) fn navigate(&mut self, url: &str, event_tx: &BrowserEventSender) -> Result<(), String> {
@@ -496,7 +523,8 @@ impl Driver {
         self.classic_navigation_post_within(suffix, body, NAVIGATION_HTTP_TIMEOUT)
     }
 
-    fn classic_navigation_post_within(
+    /// A classic command whose response is awaited for at most `read_timeout`.
+    pub(super) fn classic_navigation_post_within(
         &self,
         suffix: &str,
         body: &serde_json::Value,
@@ -540,6 +568,11 @@ impl Driver {
         }
     }
 
+    /// A classic navigation that outlived its bound and has not committed yet.
+    pub(super) fn classic_navigation_in_flight(&self) -> bool {
+        self.classic_refresh_until.is_some()
+    }
+
     pub(super) fn tick_page_state_refresh(&mut self, event_tx: &BrowserEventSender) {
         let Some(refresh_at) = self.refresh_pending_at else {
             return;
@@ -550,15 +583,15 @@ impl Driver {
         self.refresh_pending_at = None;
         let previous_url = self.url.clone();
         self.refresh_page_state(event_tx);
-        if let Some(until) = self.startup_refresh_until {
+        if let Some(until) = self.classic_refresh_until {
             if self.url != previous_url {
-                self.startup_refresh_until = None;
+                self.classic_refresh_until = None;
                 self.frames.demand();
             } else if Instant::now() >= until {
                 // Classic WebDriver reports no later event, so a navigation
                 // that has not committed by the page-load window is failed
                 // explicitly instead of leaving the panel silently stale.
-                self.startup_refresh_until = None;
+                self.classic_refresh_until = None;
                 self.navigation_failed = true;
                 self.frames.interaction_started_at = None;
                 let _ = event_tx.send(BrowserEvent::NavigationFailed(

--- a/crates/horizon-browser/src/webdriver/session/navigation.rs
+++ b/crates/horizon-browser/src/webdriver/session/navigation.rs
@@ -22,6 +22,23 @@ use super::{
 /// the typed `timed_out` outcome after the read gives up.
 const CLASSIC_BOUND_READ_MARGIN_MILLIS: u64 = 2_000;
 
+pub(super) struct ClassicNavigationRefresh {
+    until: Instant,
+    previous_url: String,
+    previous_document_identity: Option<String>,
+}
+
+impl ClassicNavigationRefresh {
+    fn observed_commit(&self, current_url: &str, current_document_identity: Option<&str>) -> bool {
+        !crate::navigation::same_destination(&self.previous_url, current_url)
+            || self
+                .previous_document_identity
+                .as_deref()
+                .zip(current_document_identity)
+                .is_some_and(|(previous, current)| previous != current)
+    }
+}
+
 impl Driver {
     /// Run a `Navigate` agent action. Firefox `BiDi` dispatches with
     /// `wait: "none"` and settles from its navigation events or the bounded
@@ -130,7 +147,7 @@ impl Driver {
         let result = self.classic_navigation_post_within("url", &json!({ "url": &url }), read_timeout);
         let now = Instant::now();
         if result.is_ok() && pending.tick(now).is_some() {
-            return Ok(self.settle_classic_navigation_timeout(pending, now));
+            return Ok(self.settle_classic_navigation_timeout(pending, &previous_url, now));
         }
         let get_timeout = pending.remaining(now).max(Duration::from_millis(1));
         let result = result
@@ -142,7 +159,7 @@ impl Driver {
             });
         let now = Instant::now();
         if pending.tick(now).is_some() {
-            return Ok(self.settle_classic_navigation_timeout(pending, now));
+            return Ok(self.settle_classic_navigation_timeout(pending, &previous_url, now));
         }
         if let Err(error) = &result
             && classic_error_is_page_load_timeout(error)
@@ -152,7 +169,7 @@ impl Driver {
             // own 10 s guards; against a hung driver they would eat the
             // controller's delivery headroom, so the loop runs them after the
             // result is written.
-            return Ok(self.settle_classic_navigation_timeout(pending, now));
+            return Ok(self.settle_classic_navigation_timeout(pending, &previous_url, now));
         }
         if self
             .classic_post("timeouts", &json!({ "pageLoad": PAGE_LOAD_TIMEOUT_MILLIS }))
@@ -171,12 +188,18 @@ impl Driver {
     fn settle_classic_navigation_timeout(
         &mut self,
         pending: &mut PendingNavigation,
+        previous_url: &str,
         now: Instant,
     ) -> crate::BrowserControlValue {
         self.retain_frame_during_navigation = false;
         self.navigation_failed = false;
         self.classic_timeout_to_restore = Some(PAGE_LOAD_TIMEOUT_MILLIS);
         self.refresh_pending_at = Some(now);
+        self.classic_refresh = Some(ClassicNavigationRefresh {
+            until: now + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS),
+            previous_url: previous_url.to_string(),
+            previous_document_identity: self.classic_document_identity.clone(),
+        });
         self.frames.demand();
         pending.settle_timed_out(None, now)
     }
@@ -385,7 +408,11 @@ impl Driver {
             self.navigation_failed = false;
             // The window counts from the navigation start, so the overall
             // failure cutoff stays at the normal page-load window.
-            self.classic_refresh_until = Some(started + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS));
+            self.classic_refresh = Some(ClassicNavigationRefresh {
+                until: started + Duration::from_millis(PAGE_LOAD_TIMEOUT_MILLIS),
+                previous_url,
+                previous_document_identity: self.classic_document_identity.clone(),
+            });
             self.refresh_pending_at = Some(Instant::now() + Duration::from_secs(1));
             tracing::debug!(target: "browser", url = %url, "startup navigation still loading after its bound");
             return true;
@@ -407,7 +434,7 @@ impl Driver {
         // A replacement navigation supersedes a classic navigation that was
         // still being polled to its commit; otherwise the marker would keep
         // every later wait paused.
-        self.classic_refresh_until = None;
+        self.classic_refresh = None;
         self.scrollbar.reset();
         self.frames.suspend_for_navigation();
     }
@@ -579,6 +606,7 @@ impl Driver {
             self.observe_navigation_signal(crate::navigation::NavigationSignal::Title(&title));
         }
         let _ = event_tx.send(BrowserEvent::Loading(false));
+        let _ = self.refresh_classic_document_identity_within(Duration::from_secs(1));
     }
 
     /// Restore the session page-load timeout a bounded classic navigation
@@ -593,7 +621,7 @@ impl Driver {
 
     /// A classic navigation that outlived its bound and has not committed yet.
     pub(super) fn classic_navigation_in_flight(&self) -> bool {
-        self.classic_refresh_until.is_some()
+        self.classic_refresh.is_some()
     }
 
     pub(super) fn tick_page_state_refresh(&mut self, event_tx: &BrowserEventSender) {
@@ -604,17 +632,22 @@ impl Driver {
             return;
         }
         self.refresh_pending_at = None;
-        let previous_url = self.url.clone();
         self.refresh_page_state(event_tx);
-        if let Some(until) = self.classic_refresh_until {
-            if self.url != previous_url {
-                self.classic_refresh_until = None;
+        let refresh_state = self.classic_refresh.as_ref().map(|refresh| {
+            (
+                refresh.until,
+                refresh.observed_commit(&self.url, self.classic_document_identity.as_deref()),
+            )
+        });
+        if let Some((until, committed)) = refresh_state {
+            if committed {
+                self.classic_refresh = None;
                 self.frames.demand();
             } else if Instant::now() >= until {
                 // Classic WebDriver reports no later event, so a navigation
                 // that has not committed by the page-load window is failed
                 // explicitly instead of leaving the panel silently stale.
-                self.classic_refresh_until = None;
+                self.classic_refresh = None;
                 self.navigation_failed = true;
                 self.frames.interaction_started_at = None;
                 let _ = event_tx.send(BrowserEvent::NavigationFailed(
@@ -640,4 +673,22 @@ pub(super) fn classic_error_is_page_load_timeout(error: &str) -> bool {
     error.starts_with("WebDriver timeout:")
         || (error.starts_with("WebDriver HTTP I/O:")
             && (error.contains("timed out") || error.contains("temporarily unavailable")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClassicNavigationRefresh;
+
+    #[test]
+    fn refresh_detects_document_replacement_without_misreading_origin_slashes() {
+        let refresh = ClassicNavigationRefresh {
+            until: std::time::Instant::now(),
+            previous_url: "https://example.test".to_string(),
+            previous_document_identity: Some("old-document".to_string()),
+        };
+
+        assert!(!refresh.observed_commit("https://example.test/", Some("old-document")));
+        assert!(refresh.observed_commit("https://example.test/", Some("new-document")));
+        assert!(refresh.observed_commit("https://example.test/next", Some("old-document")));
+    }
 }

--- a/crates/horizon-browser/src/webdriver/session/semantic.rs
+++ b/crates/horizon-browser/src/webdriver/session/semantic.rs
@@ -34,6 +34,10 @@ impl Driver {
         match &request.action {
             BrowserControlAction::Snapshot { max_nodes } => self.semantic_snapshot(*max_nodes),
             BrowserControlAction::Query { selector, max_results } => self.semantic_query(selector, *max_results),
+            BrowserControlAction::WaitForSelector { .. } => Err(BrowserControlFailure::new(
+                "invalid_action_state",
+                "selector waits are observed from the driver loop",
+            )),
             BrowserControlAction::Click { target, count } => self.semantic_click(target, *count, event_tx),
             BrowserControlAction::Fill { target, value } => self.semantic_fill(target, value, event_tx),
             BrowserControlAction::Scroll {
@@ -70,12 +74,27 @@ impl Driver {
         })
     }
 
-    fn semantic_query(
+    pub(super) fn semantic_query(
         &mut self,
         selector: &str,
         max_results: u32,
     ) -> Result<BrowserControlValue, BrowserControlFailure> {
         let value = self.evaluate_json(&scan_expression(Some(selector), max_results))?;
+        self.register_query(value)
+    }
+
+    /// A selector query whose script call may block for at most `timeout`.
+    pub(super) fn semantic_query_within(
+        &mut self,
+        selector: &str,
+        max_results: u32,
+        timeout: std::time::Duration,
+    ) -> Result<BrowserControlValue, BrowserControlFailure> {
+        let value = self.evaluate_json_within(&scan_expression(Some(selector), max_results), Some(timeout))?;
+        self.register_query(value)
+    }
+
+    fn register_query(&mut self, value: Value) -> Result<BrowserControlValue, BrowserControlFailure> {
         let (generation, revision, nodes) = self.semantic.register_nodes(value)?;
         Ok(BrowserControlValue::Nodes {
             generation,
@@ -164,12 +183,20 @@ impl Driver {
     }
 
     fn evaluate_json(&self, expression: &str) -> Result<Value, BrowserControlFailure> {
-        let response = self
-            .classic_post(
-                "execute/sync",
-                &json!({ "script": format!("return ({expression});"), "args": [] }),
-            )
-            .map_err(|error| BrowserControlFailure::new("javascript_error", error))?;
+        self.evaluate_json_within(expression, None)
+    }
+
+    fn evaluate_json_within(
+        &self,
+        expression: &str,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<Value, BrowserControlFailure> {
+        let body = json!({ "script": format!("return ({expression});"), "args": [] });
+        let response = match timeout {
+            Some(timeout) => self.classic_navigation_post_within("execute/sync", &body, timeout),
+            None => self.classic_post("execute/sync", &body),
+        }
+        .map_err(|error| BrowserControlFailure::new("javascript_error", error))?;
         let value = webdriver_value(&response)
             .cloned()
             .ok_or_else(|| BrowserControlFailure::new("invalid_result", "WebDriver returned no script value"))?;

--- a/crates/horizon-browser/src/webdriver/session/semantic.rs
+++ b/crates/horizon-browser/src/webdriver/session/semantic.rs
@@ -93,11 +93,19 @@ impl Driver {
         selector: &str,
         max_results: u32,
         timeout: std::time::Duration,
-    ) -> Result<(u64, Vec<crate::BrowserNode>, Value), BrowserControlFailure> {
+    ) -> Result<
+        (
+            u64,
+            Vec<crate::BrowserNode>,
+            Option<crate::semantic::ScanSummary>,
+            Value,
+        ),
+        BrowserControlFailure,
+    > {
         let value = self.evaluate_json_within(&scan_expression(Some(selector), max_results), Some(timeout))?;
-        let (_, nodes, document_identity) = self.semantic.peek_nodes(&value)?;
-        self.record_classic_document_identity(document_identity);
-        Ok((self.semantic.generation(), nodes, value))
+        let peeked = self.semantic.peek_nodes(&value)?;
+        self.record_classic_document_identity(peeked.document_identity);
+        Ok((self.semantic.generation(), peeked.nodes, peeked.summary, value))
     }
 
     /// Register a previously peeked scan as the current references.

--- a/crates/horizon-browser/src/webdriver/session/semantic.rs
+++ b/crates/horizon-browser/src/webdriver/session/semantic.rs
@@ -14,6 +14,9 @@ use crate::{
 
 use super::{Driver, webdriver_value};
 
+const DOCUMENT_IDENTITY_EXPRESSION: &str =
+    "JSON.stringify([String(location.href), Number(globalThis.performance?.timeOrigin || 0)])";
+
 impl Driver {
     pub(super) fn execute_agent_action(
         &mut self,
@@ -92,8 +95,9 @@ impl Driver {
         timeout: std::time::Duration,
     ) -> Result<(u64, Vec<crate::BrowserNode>, Value), BrowserControlFailure> {
         let value = self.evaluate_json_within(&scan_expression(Some(selector), max_results), Some(timeout))?;
-        let (generation, nodes) = self.semantic.peek_nodes(&value)?;
-        Ok((generation, nodes, value))
+        let (_, nodes, document_identity) = self.semantic.peek_nodes(&value)?;
+        self.record_classic_document_identity(document_identity);
+        Ok((self.semantic.generation(), nodes, value))
     }
 
     /// Register a previously peeked scan as the current references.
@@ -211,5 +215,44 @@ impl Driver {
             .cloned()
             .ok_or_else(|| BrowserControlFailure::new("invalid_result", "WebDriver returned no script value"))?;
         bounded_control_value(value)
+    }
+
+    pub(super) fn initialize_classic_document_identity(&mut self) {
+        if self.config.browser.backend == BackendKind::SafariWebDriver {
+            let _ = self.refresh_classic_document_identity_within(std::time::Duration::from_secs(1));
+        }
+    }
+
+    pub(super) fn refresh_classic_document_identity_within(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<bool, BrowserControlFailure> {
+        if self.config.browser.backend != BackendKind::SafariWebDriver {
+            return Ok(false);
+        }
+        let value = self.evaluate_json_within(DOCUMENT_IDENTITY_EXPRESSION, Some(timeout))?;
+        let identity = value
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| BrowserControlFailure::new("invalid_result", "WebDriver returned no document identity"))?;
+        Ok(self.record_classic_document_identity(Some(identity)))
+    }
+
+    fn record_classic_document_identity(&mut self, identity: Option<String>) -> bool {
+        if self.config.browser.backend != BackendKind::SafariWebDriver {
+            return false;
+        }
+        let Some(identity) = identity else {
+            return false;
+        };
+        let changed = self
+            .classic_document_identity
+            .replace(identity.clone())
+            .is_some_and(|previous| previous != identity);
+        if changed {
+            self.semantic.invalidate();
+            self.advance_generation();
+        }
+        changed
     }
 }

--- a/crates/horizon-browser/src/webdriver/session/semantic.rs
+++ b/crates/horizon-browser/src/webdriver/session/semantic.rs
@@ -4,7 +4,7 @@ use serde_json::{Value, json};
 
 use crate::semantic::{
     bounded_control_value, check_script_error, parse_target_rect, scan_expression, scroll_expression,
-    target_rect_expression,
+    target_rect_expression, wait_scan_expression,
 };
 use crate::session::BrowserEventSender;
 use crate::{
@@ -102,7 +102,7 @@ impl Driver {
         ),
         BrowserControlFailure,
     > {
-        let value = self.evaluate_json_within(&scan_expression(Some(selector), max_results), Some(timeout))?;
+        let value = self.evaluate_json_within(&wait_scan_expression(selector, max_results), Some(timeout))?;
         let peeked = self.semantic.peek_nodes(&value)?;
         self.record_classic_document_identity(peeked.document_identity);
         Ok((self.semantic.generation(), peeked.nodes, peeked.summary, value))

--- a/crates/horizon-browser/src/webdriver/session/semantic.rs
+++ b/crates/horizon-browser/src/webdriver/session/semantic.rs
@@ -83,15 +83,25 @@ impl Driver {
         self.register_query(value)
     }
 
-    /// A selector query whose script call may block for at most `timeout`.
-    pub(super) fn semantic_query_within(
+    /// A selector scan that does not register references: for judging a wait
+    /// condition without disturbing refs a concurrent snapshot handed out.
+    pub(super) fn semantic_peek_within(
         &mut self,
         selector: &str,
         max_results: u32,
         timeout: std::time::Duration,
-    ) -> Result<BrowserControlValue, BrowserControlFailure> {
+    ) -> Result<(u64, Vec<crate::BrowserNode>, Value), BrowserControlFailure> {
         let value = self.evaluate_json_within(&scan_expression(Some(selector), max_results), Some(timeout))?;
-        self.register_query(value)
+        let (generation, nodes) = self.semantic.peek_nodes(&value)?;
+        Ok((generation, nodes, value))
+    }
+
+    /// Register a previously peeked scan as the current references.
+    pub(super) fn semantic_register_scan(
+        &mut self,
+        value: Value,
+    ) -> Result<(u64, u64, Vec<crate::BrowserNode>), BrowserControlFailure> {
+        self.semantic.register_nodes(value)
     }
 
     fn register_query(&mut self, value: Value) -> Result<BrowserControlValue, BrowserControlFailure> {

--- a/crates/horizon-browser/src/webdriver/session/wait.rs
+++ b/crates/horizon-browser/src/webdriver/session/wait.rs
@@ -138,7 +138,7 @@ impl Driver {
         let observed = self.semantic_peek_within(&pending.selector, WAIT_QUERY_RESULTS, budget);
         let now = Instant::now();
         match observed {
-            Ok((generation, nodes, scan)) => match pending.observe(generation, &nodes, now) {
+            Ok((generation, nodes, summary, scan)) => match pending.observe(generation, &nodes, summary, now) {
                 Observation::Satisfied => {
                     pending.defer(scan, self.signal_epoch);
                     self.request_signal_refresh();

--- a/crates/horizon-browser/src/webdriver/session/wait.rs
+++ b/crates/horizon-browser/src/webdriver/session/wait.rs
@@ -4,7 +4,7 @@
 use std::time::Instant;
 
 use crate::navigation::{AgentActionExecution, PendingNavigation, now_millis};
-use crate::wait::{Observation, PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
+use crate::wait::{Observation, PendingWait, RELEASE_CHECK_BUDGET, WAIT_MAX_RESULTS, WaitResult, WaitStop};
 use crate::{AgentAction, BrowserControlAction, BrowserControlFailure};
 
 use super::Driver;
@@ -96,9 +96,10 @@ impl Driver {
             // Safari's document identity immediately before releasing a held
             // match so a link click, script navigation, meta refresh, or
             // same-URL reload cannot return references from the old document.
-            let budget = pending.observation_budget(now);
-            if let Err(failure) = self.refresh_classic_document_identity_within(budget) {
-                return pending.observe_failure(failure, Instant::now());
+            // The condition was met in time: this check runs on its own
+            // budget and retry count, never against the elapsed wait bound.
+            if let Err(failure) = self.refresh_classic_document_identity_within(RELEASE_CHECK_BUDGET) {
+                return pending.release_check_failure(failure);
             }
             if let Some(result) = pending.tick(self.semantic.generation(), Instant::now()) {
                 return Some(result);
@@ -135,7 +136,7 @@ impl Driver {
         // and judge the result against a fresh clock afterwards. The scan is
         // peeked, not registered: only the released scan becomes references.
         let budget = pending.observation_budget(now);
-        let observed = self.semantic_peek_within(&pending.selector, WAIT_QUERY_RESULTS, budget);
+        let observed = self.semantic_peek_within(&pending.selector, WAIT_MAX_RESULTS, budget);
         let now = Instant::now();
         match observed {
             Ok((generation, nodes, summary, scan)) => match pending.observe(generation, &nodes, summary, now) {

--- a/crates/horizon-browser/src/webdriver/session/wait.rs
+++ b/crates/horizon-browser/src/webdriver/session/wait.rs
@@ -4,8 +4,8 @@
 use std::time::Instant;
 
 use crate::navigation::{AgentActionExecution, PendingNavigation, now_millis};
-use crate::wait::{PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
-use crate::{AgentAction, BrowserControlAction, BrowserControlFailure, BrowserControlValue};
+use crate::wait::{Observation, PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
+use crate::{AgentAction, BrowserControlAction, BrowserControlFailure};
 
 use super::Driver;
 
@@ -84,8 +84,13 @@ impl Driver {
         }
         // A satisfied observation completes only after the signals have been
         // re-read and BiDi events drained: the guards above ran again first.
-        if let Some(result) = pending.take_deferred(self.signal_epoch) {
-            return Some(result);
+        if let Some(scan) = pending.take_deferred(self.signal_epoch) {
+            // Register the released scan now, so the returned references are
+            // the current ones and no earlier observation disturbed the map.
+            return Some(match self.semantic_register_scan(scan) {
+                Ok((generation, revision, nodes)) => Ok(pending.outcome(generation, revision, nodes, now)),
+                Err(failure) => Err(failure),
+            });
         }
         if self.navigation_in_flight() {
             // The document is changing under this wait; it can only be judged
@@ -97,14 +102,7 @@ impl Driver {
             return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
         }
         if observe {
-            return match self.observe_wait(pending, now) {
-                Some(Ok(result)) => {
-                    pending.defer(Ok(result), self.signal_epoch);
-                    self.request_signal_refresh();
-                    None
-                }
-                other => other,
-            };
+            return self.observe_wait(pending, now);
         }
         None
     }
@@ -120,17 +118,21 @@ impl Driver {
 
     fn observe_wait(&mut self, pending: &mut PendingWait, now: Instant) -> Option<WaitResult> {
         // The script call may block; give it no more than the remaining bound
-        // and judge the result against a fresh clock afterwards.
+        // and judge the result against a fresh clock afterwards. The scan is
+        // peeked, not registered: only the released scan becomes references.
         let budget = pending.observation_budget(now);
-        let observed = self.semantic_query_within(&pending.selector, WAIT_QUERY_RESULTS, budget);
+        let observed = self.semantic_peek_within(&pending.selector, WAIT_QUERY_RESULTS, budget);
         let now = Instant::now();
         match observed {
-            Ok(BrowserControlValue::Nodes {
-                generation,
-                revision,
-                nodes,
-            }) => pending.observe(generation, revision, nodes, now),
-            Ok(_) => None,
+            Ok((generation, nodes, scan)) => match pending.observe(generation, &nodes, now) {
+                Observation::Satisfied => {
+                    pending.defer(scan, self.signal_epoch);
+                    self.request_signal_refresh();
+                    None
+                }
+                Observation::Waiting => None,
+                Observation::Done(result) => Some(result),
+            },
             Err(failure) => pending.observe_failure(failure, now),
         }
     }

--- a/crates/horizon-browser/src/webdriver/session/wait.rs
+++ b/crates/horizon-browser/src/webdriver/session/wait.rs
@@ -91,6 +91,19 @@ impl Driver {
         if pending.blocked_by_navigation() {
             return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
         }
+        if pending.deferred_ready(self.signal_epoch) {
+            // Classic WebDriver has no page-navigation event stream. Re-read
+            // Safari's document identity immediately before releasing a held
+            // match so a link click, script navigation, meta refresh, or
+            // same-URL reload cannot return references from the old document.
+            let budget = pending.observation_budget(now);
+            if let Err(failure) = self.refresh_classic_document_identity_within(budget) {
+                return pending.observe_failure(failure, Instant::now());
+            }
+            if let Some(result) = pending.tick(self.semantic.generation(), Instant::now()) {
+                return Some(result);
+            }
+        }
         // A satisfied observation completes only after the signals have been
         // re-read, events drained, and no navigation started meanwhile: the
         // guards above ran again first.

--- a/crates/horizon-browser/src/webdriver/session/wait.rs
+++ b/crates/horizon-browser/src/webdriver/session/wait.rs
@@ -1,0 +1,143 @@
+//! Selector waits on the `WebDriver` drivers: one audited action observed
+//! from the driver loop at a bounded cadence instead of repeated queries.
+
+use std::time::Instant;
+
+use crate::navigation::{AgentActionExecution, PendingNavigation, now_millis};
+use crate::wait::{PendingWait, WAIT_QUERY_RESULTS, WaitResult, WaitStop};
+use crate::{AgentAction, BrowserControlAction, BrowserControlFailure, BrowserControlValue};
+
+use super::Driver;
+
+impl Driver {
+    /// Start a `WaitForSelector` action: observe once now, then keep it
+    /// pending until the condition, the bound, or a cancellation.
+    pub(super) fn begin_agent_wait(&mut self, request: &AgentAction) -> AgentActionExecution {
+        let BrowserControlAction::WaitForSelector {
+            selector,
+            state,
+            timeout_millis,
+        } = &request.action
+        else {
+            return AgentActionExecution::Done(Err(BrowserControlFailure::new(
+                "invalid_action_state",
+                "a wait was requested for a non-wait action",
+            )));
+        };
+        let now = Instant::now();
+        let mut pending = PendingWait::new(
+            request.clone(),
+            selector.clone(),
+            *state,
+            *timeout_millis,
+            PendingNavigation::queued_for(request, now_millis()),
+            self.semantic.generation(),
+            now,
+        );
+        if let Some(expired) = pending.tick(self.semantic.generation(), now) {
+            // The bound elapsed while the action sat in the queue: report it
+            // without superseding a wait that is still valid.
+            return AgentActionExecution::Done(expired);
+        }
+        self.supersede_pending_wait(now);
+        // The first observation runs under the same guards as every later one:
+        // an already-expired bound, a lost lease, a pending handoff, or an
+        // uncommitted navigation must not let it succeed against the old page.
+        if let Some(result) = self.advance_wait(&mut pending, now, true) {
+            return AgentActionExecution::Done(result);
+        }
+        tracing::debug!(target: "browser", action_id = %request.action_id, ?state, timeout_millis, "agent wait pending");
+        self.pending_wait = Some(pending);
+        AgentActionExecution::Pending
+    }
+
+    /// Advance the pending wait: cancel on a handoff, a lost lease, or a new
+    /// page generation; time out at the bound; otherwise observe when due.
+    pub(super) fn tick_pending_wait(&mut self) {
+        let Some(mut pending) = self.pending_wait.take() else {
+            return;
+        };
+        let now = Instant::now();
+        let observe = pending.poll_due(now);
+        let result = self.advance_wait(&mut pending, now, observe);
+        match result {
+            Some(result) => {
+                tracing::debug!(target: "browser", action_id = %pending.request.action_id, ok = result.is_ok(), "agent wait settled");
+                self.complete_agent_action(&pending.request, result);
+            }
+            None => self.pending_wait = Some(pending),
+        }
+    }
+
+    /// Cancel on a handoff or lost lease, time out or invalidate at the bound
+    /// or a new page generation, otherwise observe when asked and no agent
+    /// navigation is still uncommitted.
+    fn advance_wait(&mut self, pending: &mut PendingWait, now: Instant, observe: bool) -> Option<WaitResult> {
+        if self.handoff_seen.is_some() {
+            return Some(pending.stopped(WaitStop::HandoffPending, now));
+        }
+        if self.owner_seen.as_deref() != Some(pending.request.actor.as_str()) {
+            return Some(pending.stopped(WaitStop::OwnershipLost, now));
+        }
+        if let Some(result) = pending.tick(self.semantic.generation(), now) {
+            return Some(result);
+        }
+        // A satisfied observation completes only after the signals have been
+        // re-read and BiDi events drained: the guards above ran again first.
+        if let Some(result) = pending.take_deferred(self.signal_epoch) {
+            return Some(result);
+        }
+        if self.navigation_in_flight() {
+            // The document is changing under this wait; it can only be judged
+            // against the new one, which is not what it was asked about.
+            pending.block_for_navigation();
+            return None;
+        }
+        if pending.blocked_by_navigation() {
+            return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
+        }
+        if observe {
+            return match self.observe_wait(pending, now) {
+                Some(Ok(result)) => {
+                    pending.defer(Ok(result), self.signal_epoch);
+                    self.request_signal_refresh();
+                    None
+                }
+                other => other,
+            };
+        }
+        None
+    }
+
+    /// Whether a document is still uncommitted: a pending agent navigation,
+    /// or any navigation the driver started (agent, user, or timed-out
+    /// action) whose completion or failure has not arrived yet.
+    fn navigation_in_flight(&self) -> bool {
+        self.pending_navigation.is_some()
+            || (self.retain_frame_during_navigation && !self.navigation_failed)
+            || self.classic_navigation_in_flight()
+    }
+
+    fn observe_wait(&mut self, pending: &mut PendingWait, now: Instant) -> Option<WaitResult> {
+        // The script call may block; give it no more than the remaining bound
+        // and judge the result against a fresh clock afterwards.
+        let budget = pending.observation_budget(now);
+        let observed = self.semantic_query_within(&pending.selector, WAIT_QUERY_RESULTS, budget);
+        let now = Instant::now();
+        match observed {
+            Ok(BrowserControlValue::Nodes {
+                generation,
+                revision,
+                nodes,
+            }) => pending.observe(generation, revision, nodes, now),
+            Ok(_) => None,
+            Err(failure) => pending.observe_failure(failure, now),
+        }
+    }
+
+    fn supersede_pending_wait(&mut self, now: Instant) {
+        if let Some(pending) = self.pending_wait.take() {
+            self.complete_agent_action(&pending.request, pending.stopped(WaitStop::Superseded, now));
+        }
+    }
+}

--- a/crates/horizon-browser/src/webdriver/session/wait.rs
+++ b/crates/horizon-browser/src/webdriver/session/wait.rs
@@ -82,16 +82,6 @@ impl Driver {
         if let Some(result) = pending.tick(self.semantic.generation(), now) {
             return Some(result);
         }
-        // A satisfied observation completes only after the signals have been
-        // re-read and BiDi events drained: the guards above ran again first.
-        if let Some(scan) = pending.take_deferred(self.signal_epoch) {
-            // Register the released scan now, so the returned references are
-            // the current ones and no earlier observation disturbed the map.
-            return Some(match self.semantic_register_scan(scan) {
-                Ok((generation, revision, nodes)) => Ok(pending.outcome(generation, revision, nodes, now)),
-                Err(failure) => Err(failure),
-            });
-        }
         if self.navigation_in_flight() {
             // The document is changing under this wait; it can only be judged
             // against the new one, which is not what it was asked about.
@@ -100,6 +90,17 @@ impl Driver {
         }
         if pending.blocked_by_navigation() {
             return Some(pending.stopped(WaitStop::NavigationInvalidated, now));
+        }
+        // A satisfied observation completes only after the signals have been
+        // re-read, events drained, and no navigation started meanwhile: the
+        // guards above ran again first.
+        if let Some(scan) = pending.take_deferred(self.signal_epoch) {
+            // Register the released scan now, so the returned references are
+            // the current ones and no earlier observation disturbed the map.
+            return Some(match self.semantic_register_scan(scan) {
+                Ok((generation, revision, nodes)) => Ok(pending.outcome(generation, revision, nodes, now)),
+                Err(failure) => Err(failure),
+            });
         }
         if observe {
             return self.observe_wait(pending, now);

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -31,6 +31,9 @@ back into large multi-purpose modules.
   navigation settlement (`session/navigation.rs`) belong in focused
   `session/` leaves. The backend-neutral pending-navigation state machine
   lives in `navigation.rs` so both drivers settle the same typed outcome.
+  Selector waits follow the same shape: the backend-neutral `PendingWait`
+  state machine lives in `wait.rs`, and each driver's observation loop glue
+  in `session/wait.rs` and `webdriver/session/wait.rs`.
 - `webdriver/session.rs` orchestrates Firefox and Safari. Host coordination
   belongs in `webdriver/session/coordination.rs`, synchronous navigation
   outcomes in `webdriver/session/navigation.rs`, and HTTP, action translation,

--- a/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
+++ b/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
@@ -104,11 +104,11 @@ What the create lane proves on every backend (`create_panel` in
 What the wait lane proves on every backend (`exercise_wait_outcomes`, stacked
 PR for #349):
 
-- On `delayed.html?delay=3000`, `browser_wait` for `#late-marker` (visible)
+- On `delayed.html?delay=4000`, `browser_wait` for `#late-marker` (visible)
   settles from the engine's own observation with one matched node,
-  `elapsed_millis` between 1200 and 8000 (about 3000 minus the gap between
-  the navigate returning and the wait being queued), and at least three
-  `polls`; `#early-marker` (hidden)
+  `elapsed_millis` at most 8000 and at least the remainder of the 4000 ms
+  fixture delay after the measured navigate wall time, minus one second of
+  slack (never below 300), and at least three `polls`; `#early-marker` (hidden)
   settles with `polls: 1`; a selector that never appears fails with the typed
   `wait_timeout` code at a 1.5 s bound; and the final JSON's `wait_outcomes`
   shows `audit_entries_per_wait` of exactly 3 for all three wait action ids;

--- a/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
+++ b/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
@@ -65,8 +65,10 @@ cargo build
 ```
 
 The engine tests must include `navigation::tests::*` (pending-navigation
-state machine) and the MCP test
-`server::tests::navigation_outcomes_map_to_typed_tool_results`.
+state machine), `wait::tests::*` (pending-wait state machine), the MCP tests
+`server::tests::navigation_outcomes_map_to_typed_tool_results` and
+`server::tests::wait_inputs_map_to_one_bounded_engine_action`, and the host
+test `create_readiness_waits_for_the_backend_and_the_committed_first_page`.
 
 ## 3. Official MCP gate per backend
 
@@ -89,6 +91,31 @@ Each run must end with `MCP gate passed`, `gate exit=0` semantics (the runner
 exits 0), zero `audit_permission_findings`, zero `network_capture_findings`,
 and an empty `surviving_browser_processes` list in the final JSON line. Keep
 the printed smoke root's `logs/` for the report and delete the root afterwards.
+
+What the create lane proves on every backend (`create_panel` in
+`scripts/browser-smoke/mcp_gate.py`, stacked PR for #348):
+
+- `browser_create` with the fixture URL returns `navigation: "committed"`,
+  the panel already reporting the committed `index.html` URL, an integer
+  `startup_millis`, and an immediate `browser_query` for `#smoke-input` finds
+  exactly one node. Record the printed `create_startup_millis` per backend in
+  the report (Firefox is expected to be the slowest, several seconds).
+
+What the wait lane proves on every backend (`exercise_wait_outcomes`, stacked
+PR for #349):
+
+- On `delayed.html?delay=3000`, `browser_wait` for `#late-marker` (visible)
+  settles from the engine's own observation with one matched node,
+  `elapsed_millis` between 1200 and 8000 (about 3000 minus the gap between
+  the navigate returning and the wait being queued), and at least three
+  `polls`; `#early-marker` (hidden)
+  settles with `polls: 1`; a selector that never appears fails with the typed
+  `wait_timeout` code at a 1.5 s bound; and the final JSON's `wait_outcomes`
+  shows `audit_entries_per_wait` of exactly 3 for all three wait action ids;
+  removal (`#removed-marker` hidden), an attribute change (`#attr-marker`
+  visible), and a style change (`#early-marker` hidden) are each observed as
+  a delayed transition on a fresh `delayed.html?delay=4000` load and reported
+  under `wait_outcomes.transitions` with three audit entries each.
 
 What the navigation lane proves on every backend (`exercise_navigation_outcomes`
 in `scripts/browser-smoke/mcp_gate.py`):
@@ -141,7 +168,7 @@ dimensions in the report; do not commit screenshots.
 Before execution, post on the PR:
 
 ```text
-SMOKE-TEST REQUEST Mac Studio/macOS — plan: docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md — scope: native build and matrix, Safari/Firefox/Chrome MCP gates with typed navigation outcomes, visual and lifecycle review
+SMOKE-TEST REQUEST Mac Studio/macOS — plan: docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md — scope: native build and matrix, Safari/Firefox/Chrome MCP gates with typed navigation outcomes, create readiness, and engine-side waits, visual and lifecycle review
 ```
 
 If a behavior change is pushed, rerun every affected lane on the new SHA.
@@ -151,9 +178,9 @@ Post the final report as:
 ```text
 SMOKE-TEST REPORT (Mac Studio/macOS <version>, <arch>, <final-sha>)
 - exact-head/native build and matrix: pass | fail — ...
-- Safari MCP gate (typed navigation outcomes): pass | fail — ...
-- Firefox MCP gate (typed navigation outcomes, bounded timeout): pass | fail — ...
-- Chrome MCP gate (typed navigation outcomes, bounded timeout): pass | fail — ...
+- Safari MCP gate (typed navigation outcomes, create readiness, engine-side waits): pass | fail — ... (create_startup_millis, wait_outcomes)
+- Firefox MCP gate (typed navigation outcomes, bounded timeout, create readiness, engine-side waits): pass | fail — ... (create_startup_millis, wait_outcomes)
+- Chrome MCP gate (typed navigation outcomes, bounded timeout, create readiness, engine-side waits): pass | fail — ... (create_startup_millis, wait_outcomes)
 - visual URL chip / redirect / slow page: pass | fail — ...
 - lifecycle and process isolation: pass | fail — ...
 Summary: <evidence locations, backend notes, remaining concerns>

--- a/docs/testing/browser-panel-gate.md
+++ b/docs/testing/browser-panel-gate.md
@@ -105,9 +105,10 @@ The reusable runner:
   where the classic navigation keeps running and the driver polls it to its
   commit);
 - proves `browser_wait` is one engine-side audited action: on `delayed.html`
-  a wait for the element that appears 3 s after load settles from the
-  engine's own observation with the matched node, an `elapsed_millis` near the
-  DOM change, and several `polls`; an already-hidden element settles on its
+  a wait for the element that appears 4 s after load settles from the
+  engine's own observation with the matched node, an `elapsed_millis` that
+  covers most of the remaining fixture delay after the measured navigate wall
+  time (the derived minimum is reported), and several `polls`; an already-hidden element settles on its
   first observation; a selector that never appears fails with the typed
   `wait_timeout` code at the bound; removal, an attribute change, and a style
   change are each observed as a delayed transition on a fresh load with a

--- a/docs/testing/browser-panel-gate.md
+++ b/docs/testing/browser-panel-gate.md
@@ -104,6 +104,15 @@ The reusable runner:
   Firefox inside the navigation lane; Safari in its retained slow-page lane,
   where the classic navigation keeps running and the driver polls it to its
   commit);
+- proves `browser_wait` is one engine-side audited action: on `delayed.html`
+  a wait for the element that appears 3 s after load settles from the
+  engine's own observation with the matched node, an `elapsed_millis` near the
+  DOM change, and several `polls`; an already-hidden element settles on its
+  first observation; a selector that never appears fails with the typed
+  `wait_timeout` code at the bound; removal, an attribute change, and a style
+  change are each observed as a delayed transition on a fresh load with a
+  4 s delay; and each wait action id owns exactly one
+  queued/dispatched/terminal audit lifecycle (reported as `wait_outcomes`);
 - disconnects the MCP stdio client, starts a fresh client with the same actor,
   rediscovers the exact live panel, and proves resumed snapshot plus complete
   audit states without restarting the browser;
@@ -568,6 +577,7 @@ Run once per host OS after the semantic gate:
 | `upload.html` + `upload.txt` | Native file-picker oracle and the documented host file-drop/workspace-open boundary |
 | `/redirect-to-next` (server route) | `302` to `next.html` for the typed `redirected` navigation outcome |
 | `/slow-navigation.html` (server route) | 11-second response for bounded `timed_out` navigation outcomes and the Safari delayed-navigation lane |
+| `delayed.html` | After load (`?delay=<ms>`, default 1.5 s) hides `#early-marker`, appends `#late-marker`, removes `#removed-marker`, and drops the `hidden` attribute of `#attr-marker`, for the engine-side `browser_wait` lanes |
 
 Keep selectors stable. When a browser behavior needs a new deterministic
 oracle, extend these fixtures and the gate together instead of creating another

--- a/scripts/browser-smoke/fixtures/delayed.html
+++ b/scripts/browser-smoke/fixtures/delayed.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Horizon Browser Smoke - Delayed Element</title>
+  </head>
+  <body>
+    <h1>Delayed element fixture</h1>
+    <p id="early-marker">visible until the delayed element arrives</p>
+    <p id="removed-marker">removed from the document after the delay</p>
+    <p id="attr-marker" hidden>shown by removing the hidden attribute after the delay</p>
+    <script>
+      // Deterministic DOM change after load (default 1.5 s, `?delay=<ms>`):
+      // the early marker hides and the late marker appears, so engine-side
+      // waits can be timed.
+      const delay = Number(new URLSearchParams(location.search).get("delay")) || 1500;
+      window.setTimeout(() => {
+        document.getElementById("early-marker").style.display = "none";
+        document.getElementById("removed-marker").remove();
+        document.getElementById("attr-marker").removeAttribute("hidden");
+        const late = document.createElement("p");
+        late.id = "late-marker";
+        late.textContent = "late element arrived";
+        document.body.appendChild(late);
+      }, delay);
+    </script>
+  </body>
+</html>

--- a/scripts/browser-smoke/fixtures/index.html
+++ b/scripts/browser-smoke/fixtures/index.html
@@ -158,7 +158,7 @@
         screen: [screen.width, screen.height],
         dpr: devicePixelRatio,
         renderer,
-        horizonNames: Object.getOwnPropertyNames(window).filter((name) => /horizon/i.test(name)),
+        horizonNames: Object.getOwnPropertyNames(window).filter((name) => /^[$_]*horizon/i.test(name)),
         webdriverDescriptorPresent: Boolean(webdriverDescriptor),
         webdriverGetterNative: typeof webdriverDescriptor?.get === 'function'
           && Function.prototype.toString.call(webdriverDescriptor.get).includes('[native code]')

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -510,6 +510,11 @@ def exercise_navigation_outcomes(
         verify_navigation_outcome(settled, "commit", "committed", f"{args.base_url}/{page}", redirected=False)
 
 
+# Milliseconds after load at which the delayed fixture mutates for the wait
+# lanes; the same figure the transition lanes use.
+DELAYED_FIXTURE_MILLIS = 4000
+
+
 def exercise_wait_outcomes(
     client: McpClient,
     args: argparse.Namespace,
@@ -520,20 +525,21 @@ def exercise_wait_outcomes(
     """Prove browser_wait is one engine-side audited action.
 
     The delayed fixture hides ``#early-marker`` and appends ``#late-marker``
-    3 s after load (``?delay=3000``). A wait for the late element must settle
+    4 s after load (``?delay=4000``). A wait for the late element must settle
     from the engine's own observation (one action id, several observations,
     elapsed close to the DOM change), an already-satisfied wait must settle on
     its first observation, and a wait that cannot be met must fail with the
     typed ``wait_timeout`` code at the bound. Audit counts per action id are
-    checked after the audit read. The lower elapsed bound tolerates result
-    delivery lag on a loaded host between the navigate returning and the wait
-    being queued; the measured gap is reported for diagnosis.
+    checked after the audit read. The wait is queued only after the navigate
+    result was delivered, so on a loaded host the engine can observe only the
+    remainder of the fixture delay: the lower elapsed bound is derived from
+    the measured navigate wall time, and that gap is reported for diagnosis.
     """
     navigate_started = time.monotonic()
     navigated = record_action(
         client,
         "browser_navigate",
-        {"panel_id": panel_id, "url": f"{args.base_url}/delayed.html?delay=3000", "timeout_millis": 15000},
+        {"panel_id": panel_id, "url": f"{args.base_url}/delayed.html?delay={DELAYED_FIXTURE_MILLIS}", "timeout_millis": 15000},
         action_ids,
     )
     navigate_wall_millis = int((time.monotonic() - navigate_started) * 1000)
@@ -549,8 +555,15 @@ def exercise_wait_outcomes(
     delayed_wall_millis = int((time.monotonic() - started) * 1000)
     if delayed["state"] != "visible" or len(delayed["nodes"]) != 1 or delayed["nodes"][0]["text"] != "late element arrived":
         raise AssertionError(delayed)
-    if not 1200 <= delayed["elapsed_millis"] <= 8000 or delayed["polls"] < 3:
-        raise AssertionError((delayed, navigated["elapsed_millis"], navigate_wall_millis))
+    # The DOM change lands about DELAYED_FIXTURE_MILLIS after load and the
+    # wait can only observe what is left of that once the navigate result has
+    # been delivered: require most of the remainder (one second of slack for
+    # queueing, the 100 ms cadence, and result delivery) and never less than a
+    # few observations.
+    expected_wait_millis = max(0, DELAYED_FIXTURE_MILLIS - navigate_wall_millis)
+    minimum_elapsed_millis = max(300, expected_wait_millis - 1000)
+    if not minimum_elapsed_millis <= delayed["elapsed_millis"] <= 8000 or delayed["polls"] < 3:
+        raise AssertionError((delayed, navigated["elapsed_millis"], navigate_wall_millis, minimum_elapsed_millis))
     hidden = record_action(
         client,
         "browser_wait",
@@ -611,6 +624,7 @@ def exercise_wait_outcomes(
         "transitions": transitions,
         "delayed_navigate_elapsed_millis": navigated["elapsed_millis"],
         "delayed_navigate_wall_millis": navigate_wall_millis,
+        "delayed_wait_minimum_elapsed_millis": minimum_elapsed_millis,
         "delayed_wait_action_id": delayed["action_id"],
         "delayed_wait_elapsed_millis": delayed["elapsed_millis"],
         "delayed_wait_wall_millis": delayed_wall_millis,

--- a/scripts/browser-smoke/mcp_gate.py
+++ b/scripts/browser-smoke/mcp_gate.py
@@ -510,6 +510,143 @@ def exercise_navigation_outcomes(
         verify_navigation_outcome(settled, "commit", "committed", f"{args.base_url}/{page}", redirected=False)
 
 
+def exercise_wait_outcomes(
+    client: McpClient,
+    args: argparse.Namespace,
+    panel_id: str,
+    action_ids: list[str],
+    failed_ids: list[str],
+) -> dict[str, Any]:
+    """Prove browser_wait is one engine-side audited action.
+
+    The delayed fixture hides ``#early-marker`` and appends ``#late-marker``
+    3 s after load (``?delay=3000``). A wait for the late element must settle
+    from the engine's own observation (one action id, several observations,
+    elapsed close to the DOM change), an already-satisfied wait must settle on
+    its first observation, and a wait that cannot be met must fail with the
+    typed ``wait_timeout`` code at the bound. Audit counts per action id are
+    checked after the audit read. The lower elapsed bound tolerates result
+    delivery lag on a loaded host between the navigate returning and the wait
+    being queued; the measured gap is reported for diagnosis.
+    """
+    navigate_started = time.monotonic()
+    navigated = record_action(
+        client,
+        "browser_navigate",
+        {"panel_id": panel_id, "url": f"{args.base_url}/delayed.html?delay=3000", "timeout_millis": 15000},
+        action_ids,
+    )
+    navigate_wall_millis = int((time.monotonic() - navigate_started) * 1000)
+    if navigated["state"] != "committed":
+        raise AssertionError(navigated)
+    started = time.monotonic()
+    delayed = record_action(
+        client,
+        "browser_wait",
+        {"panel_id": panel_id, "selector": "#late-marker", "state": "visible", "timeout_millis": 10000},
+        action_ids,
+    )
+    delayed_wall_millis = int((time.monotonic() - started) * 1000)
+    if delayed["state"] != "visible" or len(delayed["nodes"]) != 1 or delayed["nodes"][0]["text"] != "late element arrived":
+        raise AssertionError(delayed)
+    if not 1200 <= delayed["elapsed_millis"] <= 8000 or delayed["polls"] < 3:
+        raise AssertionError((delayed, navigated["elapsed_millis"], navigate_wall_millis))
+    hidden = record_action(
+        client,
+        "browser_wait",
+        {"panel_id": panel_id, "selector": "#early-marker", "state": "hidden"},
+        action_ids,
+    )
+    if hidden["polls"] != 1 or hidden["state"] != "hidden":
+        raise AssertionError(hidden)
+    started = time.monotonic()
+    _, timeout_error = client.call(
+        "browser_wait",
+        {"panel_id": panel_id, "selector": "#never-marker", "state": "present", "timeout_millis": 1500},
+        expect_error=True,
+    )
+    timed_out_wall_millis = int((time.monotonic() - started) * 1000)
+    if (
+        timeout_error is None
+        or "wait_timeout" not in timeout_error
+        or "did not become present within the 1500 ms bound" not in timeout_error
+    ):
+        raise AssertionError(timeout_error)
+    # The engine must wait the full 1500 ms bound: a bound that ran 250 ms
+    # short would fail here around 1250 ms.
+    if not 1450 <= timed_out_wall_millis <= 4000:
+        raise AssertionError(timed_out_wall_millis)
+    timed_out_id = failed_action_id(timeout_error)
+    failed_ids.append(timed_out_id)
+    # Removal, an attribute change, and a style change, each observed as a
+    # delayed transition on a fresh page load with a 4 s delay, so result
+    # delivery lag (up to about 2.5 s on a loaded host) cannot let the
+    # transition complete before the wait is queued.
+    transitions = {}
+    for key, selector, state in [
+        ("removal", "#removed-marker", "hidden"),
+        ("attribute", "#attr-marker", "visible"),
+        ("style", "#early-marker", "hidden"),
+    ]:
+        reloaded = record_action(
+            client,
+            "browser_navigate",
+            {"panel_id": panel_id, "url": f"{args.base_url}/delayed.html?delay=4000&t={key}", "timeout_millis": 15000},
+            action_ids,
+        )
+        if reloaded["state"] != "committed":
+            raise AssertionError(reloaded)
+        observed = record_action(
+            client,
+            "browser_wait",
+            {"panel_id": panel_id, "selector": selector, "state": state, "timeout_millis": 10000},
+            action_ids,
+        )
+        if observed["state"] != state or not 1500 <= observed["elapsed_millis"] <= 8000 or observed["polls"] < 3:
+            raise AssertionError((key, observed))
+        if state == "visible" and len(observed["nodes"]) != 1:
+            raise AssertionError((key, observed))
+        transitions[key] = {"action_id": observed["action_id"], "elapsed_millis": observed["elapsed_millis"], "polls": observed["polls"]}
+    return {
+        "transitions": transitions,
+        "delayed_navigate_elapsed_millis": navigated["elapsed_millis"],
+        "delayed_navigate_wall_millis": navigate_wall_millis,
+        "delayed_wait_action_id": delayed["action_id"],
+        "delayed_wait_elapsed_millis": delayed["elapsed_millis"],
+        "delayed_wait_wall_millis": delayed_wall_millis,
+        "delayed_wait_polls": delayed["polls"],
+        "satisfied_wait_action_id": hidden["action_id"],
+        "satisfied_wait_polls": hidden["polls"],
+        "timed_out_wait_action_id": timed_out_id,
+        "timed_out_wait_wall_millis": timed_out_wall_millis,
+    }
+
+
+def verify_wait_audit(entries: list[dict[str, Any]], waits: dict[str, Any]) -> dict[str, int]:
+    """Each engine-side wait must own exactly one queued/dispatched/terminal lifecycle."""
+    counts: dict[str, int] = {}
+    checks = [
+        ("delayed_wait_action_id", "completed"),
+        ("satisfied_wait_action_id", "completed"),
+        ("timed_out_wait_action_id", "failed"),
+    ]
+    for key, expected in checks:
+        action_id = waits[key]
+        statuses = [entry["status"] for entry in entries if entry["action_id"] == action_id]
+        if sorted(statuses) != sorted(["queued", "dispatched", expected]):
+            raise AssertionError((action_id, statuses))
+        kinds = {entry["action"].get("type") for entry in entries if entry["action_id"] == action_id}
+        if kinds != {"wait_for_selector"}:
+            raise AssertionError((action_id, kinds))
+        counts[key] = len(statuses)
+    for key, transition in waits["transitions"].items():
+        statuses = [entry["status"] for entry in entries if entry["action_id"] == transition["action_id"]]
+        if sorted(statuses) != sorted(["queued", "dispatched", "completed"]):
+            raise AssertionError((key, transition["action_id"], statuses))
+        counts[f"transition_{key}"] = len(statuses)
+    return counts
+
+
 def wait_for_panel_url(client: McpClient, panel_id: str, url: str, timeout_seconds: float) -> None:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -1163,6 +1300,7 @@ def exercise(client: McpClient, args: argparse.Namespace) -> dict[str, Any]:
         {"panel_id": panel_id, "selector": "#next-marker", "state": "visible"},
         action_ids,
     )
+    wait_outcomes = exercise_wait_outcomes(client, args, panel_id, action_ids, failed_ids)
     exercise_navigation_outcomes(client, args, panel_id, action_ids, failed_ids)
     record_action(client, "browser_act", {"panel_id": panel_id, "action": "back"}, action_ids)
     record_action(
@@ -1251,7 +1389,9 @@ def exercise(client: McpClient, args: argparse.Namespace) -> dict[str, Any]:
         )
         network_capture["active_close_path"] = active_close["path"]
 
-    audit_entries = len(verify_audit(client, panel_id, action_ids, failed_ids, double_click_id))
+    audit_records = verify_audit(client, panel_id, action_ids, failed_ids, double_click_id)
+    audit_entries = len(audit_records)
+    wait_outcomes["audit_entries_per_wait"] = verify_wait_audit(audit_records, wait_outcomes)
     handoff_request = None
     if args.handoff:
         handoff, _ = client.call(
@@ -1327,6 +1467,7 @@ def exercise(client: McpClient, args: argparse.Namespace) -> dict[str, Any]:
 
     return {
         "audit_entries": audit_entries,
+        "wait_outcomes": wait_outcomes,
         "backend": args.backend,
         "completed_actions": len(action_ids),
         "double_click": {"count": 2, "trusted": True},


### PR DESCRIPTION
## Purpose

Closes #349. `browser_wait` looped inside the MCP server: every 250 ms it queued a full `Query` action, so a 10 s wait produced up to 40 audited actions, 40 result files, and 40 manifest round trips, its `action_id` named only the last poll, and a timeout was a plain string with no audit record of the wait itself.

Stacked on #365 (typed navigation outcomes) and #366 (create readiness); this PR's own diff is the last commit.

## What changed

- **Protocol (`horizon-browser-protocol`).** New `BrowserControlAction::WaitForSelector { selector, state, timeout_millis }` with `SelectorState` (`present`, `visible`, `hidden`), validation (selector rules, bound 1..=60000 ms), a redacted audit shape (`selector_characters`, `state`, `timeout_millis`), and `BrowserControlValue::Wait { wait: WaitOutcome }` carrying the matched nodes, page generation/revision, `elapsed_millis`, and `polls`.
- **Engine (`horizon-browser`).** A backend-neutral `PendingWait` state machine (`wait.rs`) observed from each driver loop (`session/wait.rs`, `webdriver/session/wait.rs`): the driver runs one bounded, non-registering semantic scan every 100 ms while the action is pending (it never disturbs the reference map a concurrent snapshot handed out; the released scan is registered when the wait completes), never blocking between observations, and settles the single action id on the requested state, the bound (`wait_timeout`), a page generation change (`wait_navigation_invalidated`), a lost lease (`wait_ownership_lost`), a pending handoff (`wait_handoff_pending`), or a later wait on the same panel (`wait_superseded`). Observation pauses while any backend navigation is still in flight, each synchronous observation is bounded by the wait's remaining time (between one coordination tick and the drivers' 5 s command timeout) and judged against a clock read after it returned, transient script failures are retried, and an invalid selector fails at once. The bound is anchored at the caller's `requested_at_millis`, so queue latency counts against it. The wait's observation scan (and only it: snapshots and queries keep their early exit at the cap) counts every match and every visible match beyond the 20 nodes it returns and reports them as a `summary`; the wait judges `present`, `visible`, and `hidden` on those counts, so a visible match past the cap satisfies `visible` and keeps `hidden` unsatisfied. Safari's pre-release document-identity read runs on its own 1 s budget and transient retry count, never against the elapsed wait bound. Late protocol outcomes honor the action deadline (a commit or failure after the bound settles as `timed_out`), stale request ids are cleared across replacements, classic URL reads stay inside the remaining bound, Firefox holds unattributed late failures until the dispatch reply names them, and Safari tracks a script-observed document identity (URL plus `performance.timeOrigin`) so page-initiated and same-URL replacements invalidate waits and end classic navigation polling even though classic WebDriver emits no navigation events.
- **MCP (`horizon-browser-mcp`).** `browser_wait` issues exactly one `WaitForSelector` action with a 1000-60000 ms bound that the engine enforces in full; the controller's new `execute_engine_bounded` waits 500 ms longer for result delivery, so the typed failure always arrives first without shortening the caller's bound (the same path now carries `browser_navigate`'s bound, which previously ran 250 ms short) and returns `nodes`, `generation`, `revision`, `elapsed_millis`, and `polls`; timeouts and cancellations surface as typed failed actions. `poll_millis` is accepted for compatibility and ignored.
- **Gate and fixture.** `delayed.html` hides `#early-marker`, appends `#late-marker`, removes `#removed-marker`, and drops the `hidden` attribute of `#attr-marker` after a configurable delay. `exercise_wait_outcomes` proves the delayed match settles from the engine's observation (one node, `elapsed_millis` near the DOM change, several polls), an already-satisfied wait settles on its first observation, a never-appearing selector fails with `wait_timeout` at the bound, removal, attribute, and style changes are each observed as a delayed transition on a fresh 4 s load, and `verify_wait_audit` proves every wait action id (six per run) owns exactly one queued/dispatched/terminal lifecycle. The final JSON reports `wait_outcomes` with the measured latencies and audit counts.
- **Docs.** MCP README, both bundled skills, gate doc, maintainability doc, and the stacked macOS smoke plan.

## Behavior impact

- One audited action per `browser_wait`; the audit journal grows by 3 entries instead of up to 3 per 250 ms poll, and the manifest sees one queued action and one result.
- Timeouts are typed failed actions (`browser action <id> failed (wait_timeout): selector did not become visible within the 1500 ms bound (elapsed 1520 ms, 15 observations, last match count 0)`) instead of a bare string; callers that matched on the error text still see a non-success.
- A wait is cancelled with a typed code when the page navigates, the lease is lost, or a handoff is pending, instead of silently continuing to query a page the agent no longer controls.
- Smallest accepted bound is 1000 ms; the engine waits the full bound (previously the engine bound ran 250 ms short of the documented wait).

## Benchmark

Measured by the gate's `wait_outcomes` on the exact head `7e06027` (Linux, isolated Horizon, `--ephemeral`, task-owned Xvfb):

| Lane | Chromium | Firefox |
| --- | --- | --- |
| `browser_navigate delayed.html?delay=3000` (commit), engine elapsed | 258 ms | 267 ms |
| Delayed match (`#late-marker` visible, DOM change 3 s after load), engine elapsed / observations | 3017 ms / 26 | 3293 ms / 29 |
| Already-satisfied wait (`#early-marker` hidden), observations | 1 | 1 |
| Full timeout (`#never-marker`, 1500 ms bound), wall until the typed `wait_timeout` failure (the gate now requires at least 1450 ms) | 1550 ms | 1533 ms |
| Audit entries per wait action id (queued, dispatched, completed or failed), all three waits | 3, 3, 3 | 3, 3, 3 |
| Result files and queued actions per wait | 1 | 1 |

CPU and manifest traffic, 10 s wait that times out (`#never-marker`), Chromium, whole process tree (Horizon host, driver thread, Chromium, MCP server), two runs each, sampled from `/proc` utime+stime:

| Implementation | CPU seconds over the wait | Actions queued | Audit entries | Result files written |
| --- | --- | --- | --- | --- |
| Before: MCP loop, one `Query` action per 250 ms | 1.34, 1.36 | 20 | 60 | 20 |
| After: engine-side wait, one observation per 100 ms | 1.36, 1.42 | 1 | 3 | 1 |

CPU is flat within run-to-run noise although the page is observed 2.5 times as often, because each old poll also paid an MCP round trip, a manifest enqueue under the lock, a result file, and three audit writes; the 100 ms cadence therefore stays (an adaptive cadence would only trade detection latency for nothing measurable).

Before this change the same waits cost one audited `Query` action per 250 ms poll: about 12 actions (36 audit entries, 12 result files, 12 manifest round trips) for the 3 s match and about 6 for the 1.5 s timeout, with the `action_id` naming only the last poll and the timeout a bare string.

## Test evidence

Local, in this worktree at the exact head `7e06027` (six commits, the last two from the macOS smoke session: a test-only duration idiom and a one-line fixture fix scoping the disclosure probe to Horizon prefixes; stacked on #366 at `d255d22` and #365 at `19ebb83`; after #365 and #366 merged the stack was rebased onto main with byte-identical trees, this PR then at `a7ed58c` after two more review rounds then `69055ca` (two commits from the macOS smoke session for navigation deadlines, request-id hygiene, and Safari document identity, plus the selector-wide match summary), then `0b22a7a` (the summary pass limited to wait scans and the Safari release check freed from the wait bound), then `e777e63` (gate only: the delayed wait lane uses the 4 s fixture delay and derives its lower elapsed bound from the measured navigate wall time; the Rust tree is identical to `0b22a7a`), and now at `63d92ff` (one gate-doc paragraph; code, gate, and fixtures identical to `e777e63`); Linux, 48-core box), run serially with the other stacked heads so no other cargo job overlapped the gates:

- `cargo fmt --all -- --check`, `./scripts/check-maintainability.sh`: pass
- `RUSTFLAGS="-D warnings" cargo test --workspace` and `--features speech`: pass
- Blocking, strict, and pedantic clippy tiers: pass
- New tests: engine `wait::tests::*` (present, visible, and hidden conditions; poll cadence; bound anchored at the request time; navigation invalidation by page generation at the bound and on a mismatched observation; the condition judged over every match with the reported nodes capped; ownership, handoff, and supersession stops; transient failure retry; invalid selector fails at once), protocol `wait_actions_validate_and_redact` (validation, audit redaction, serde shape), MCP `wait_inputs_map_to_one_bounded_engine_action`
- Official gate `scripts/browser-smoke/run.py --ephemeral --skip-handoff` on the clean head (git_dirty false, rerun on `69055ca`, `0b22a7a`, and `e777e63` with the same result; on `e777e63` the delayed lane measured 4044 ms elapsed against a derived minimum of 2720 ms on Chromium and 4219 ms against 2698 ms on Firefox), **Chromium** and **Firefox**: MCP gate passed, exit 0, 53 completed actions and 202 to 203 audit entries each, no audit/capture/process findings; the `wait_outcomes` numbers above come from these runs. Review rounds: the first observation now runs under the same guards as later ticks and the condition is judged over every match (`a732ef9`); the engine gets the full documented bound with controller delivery headroom, and the benchmark above was added (`d9ad8b0`); a mismatched page generation at observation time invalidates the wait, observation pauses on any in-flight backend navigation, and the audit oracle covers all three waits (`023157d`); each observation is bounded by the wait's remaining time with a fresh deadline check afterwards, and `wait_superseded` is documented with the other codes (`e4e6e94`); a classic navigation that outlived its bound is polled to commit and counts as in flight, and the gate's timeout lane requires at least 1450 ms (`0eefbca`); a replacement navigation clears the classic in-flight marker, the controller waits out queue delay behind a blocking driver for engine-bounded actions (hard cap bound plus 60 s), and the timeout message names the configured bound (`32b9e3f`); a satisfied observation is held until signals are re-read and events drained, only script and protocol failures are retried (a few times), and queue delay is judged from the audit journal (round 7). The controller's engine-bounded path now lives in #365 (`c95b6db`, `5c54922`), so this PR's commit was re-applied as one squashed change on top of it; both drivers also tick the pending wait between the queued actions they service (round 8); only an execution-context replacement or an observation timeout is retried, a held satisfied result is no longer subject to the deadline, and removal, attribute, and style transitions are each observed as delayed lanes with their own audit checks (round 9); a same-URL classic navigation that hits its bound is not tracked as in flight because classic WebDriver reveals a commit only through a URL change, and the controller now waits for the engine's typed result up to the hard cap for engine-bounded actions (#365 `22978af`), so a blocking action in the same batch delays but never replaces the typed `wait_timeout` (round 10); a deferred satisfied result is released only under a later coordination-read epoch than it was observed under, so a lease or handoff change during the observation is seen first (round 11); a wait blocked by an in-flight navigation is invalidated once that navigation settles, an expired queued wait no longer supersedes a valid one, and the transition lanes use a 4 s delay (round 12); observations peek the scan without registering semantic references (only the released scan of a satisfied wait is registered, at release time), and the Chromium in-flight guard also covers reloads, history traversals, and page-initiated navigations from `Page.frameStartedLoading` (round 13, `71663c6`); the reload and history paths mark that flag before dispatch so events routed during the round trip are not overwritten (round 14, `9c1f558`); the in-flight and blocked checks run before a deferred match is released (round 15, `8ab9b6c`). On `9a4c905` the Chromium gate once failed before any assertion with `could not read browser action result: host coordination timed out` (a manifest lock wait on this 97 % full disk) and passed on immediate rerun. On `0eefbca` the Chromium gate once failed in the pre-existing network-capture lane (`records_dropped: 52` during the 4096-frame burst while the box carried an unrelated load spike) and passed on immediate rerun of the same head; the speech tier's known load-sensitive CLI timing test likewise passed on rerun
- An earlier run of this lane, with a 1.5 s fixture delay and while a full cargo test matrix ran concurrently on the same box, once saw the delayed element already present 306 ms after the wait was queued; the lane now uses the 4 s delay of the transition lanes, reports the navigate-to-wait gap, and requires most of the remainder of the fixture delay after the measured navigate wall time (one second of slack, never below 300 ms) so result-delivery lag on a loaded host cannot fail a correct engine, and the sequence passed 3 of 3 in a focused reproduction

Not run here: Safari and the macOS lanes; they are part of the stacked macOS smoke plan (`docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md`) run on the stacked head.

## macOS smoke

The macOS smoke report for this exact stacked head (`7e06027`) is posted on #365 and ends with `SMOKE-TEST: DONE`. Safari: delayed visible wait 2987 ms over 27 observations, typed 1.5 s timeout at 1548 ms, removal 4050 ms, attribute 4047 ms, style 3952 ms, three audit entries for all six wait ids. Firefox: 3287 ms over 28 observations, timeout 1555 ms, transitions 4508, 4273, and 3993 ms. Chromium: 3033 ms over 27 observations, timeout 1560 ms, transitions 4040, 4083, and 3992 ms. Zero audit or network findings; lifecycle and process isolation pass. The first Safari run exposed a gate-only false positive (native `SVGPathSegLinetoHorizontal*` globals matched the old substring probe), fixed on this branch as `7e06027` before the passing run. A targeted Safari rerun of the wait lanes was requested for `a7ed58c` (elapsed time now ends at the satisfying observation; Unix read deadlines on bounded WebDriver observations are retried; a same-document history traversal on Chromium clears the in-flight marker). A full Safari, Firefox, and Chromium gate is requested on the final head `63d92ff` (staged as `~/horizon-smoke/pr-367-63d92ff`; a run on `e777e63` is equivalent, since only a doc paragraph differs); its report gates the merge.

## Size

About 17 source/test files plus five docs and two gate files (about 990 changed lines), above the AGENTS.md 10-file threshold; landing as one PR was approved explicitly because a split would leave the protocol action and engine state machine as dead code.

## Notes

- `Cargo.lock` is intentionally untouched (pre-existing surge tag drift rewritten by every cargo run).
- Follow-up candidate: a MutationObserver-based in-page observer would remove the 100 ms cadence entirely; the current design keeps the driver loop non-blocking and works identically on Chromium CDP, Firefox BiDi, and classic WebDriver, which the in-page variant cannot (classic WebDriver has no non-blocking async script primitive).

