### PR TITLE
Preserve browser MCP startup after binary cleanup

### DIFF
--- a/crates/horizon-core/src/horizon_home.rs
+++ b/crates/horizon-core/src/horizon_home.rs
@@ -77,6 +77,15 @@ impl HorizonHome {
     }
 
     #[must_use]
+    pub fn claude_plugin_dir_for_host(&self, host_instance: &str) -> PathBuf {
+        self.root
+            .join("runtime")
+            .join("agent-plugins")
+            .join(safe_local_id(host_instance))
+            .join("claude-code")
+    }
+
+    #[must_use]
     pub fn codex_integrations_dir(&self) -> PathBuf {
         self.root.join("integrations").join("codex")
     }
@@ -119,6 +128,25 @@ impl HorizonHome {
 }
 
 #[must_use]
+pub fn browser_mcp_executable() -> Option<PathBuf> {
+    browser_mcp_executable_for_process(std::process::id(), std::env::current_exe().ok())
+}
+
+fn browser_mcp_executable_for_process(process_id: u32, current_executable: Option<PathBuf>) -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let process_executable = PathBuf::from(format!("/proc/{process_id}/exe"));
+        if process_executable.is_file() {
+            return Some(process_executable);
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = process_id;
+
+    current_executable
+}
+
+#[must_use]
 pub(crate) fn safe_local_id(local_id: &str) -> String {
     // Always encode the exact UTF-8 bytes. Keeping an apparently safe ID
     // verbatim would make identifiers that differ only by case collide on
@@ -138,7 +166,7 @@ pub(crate) fn safe_local_id(local_id: &str) -> String {
 mod tests {
     use std::path::PathBuf;
 
-    use super::HorizonHome;
+    use super::{HorizonHome, browser_mcp_executable_for_process};
 
     #[test]
     fn session_paths_live_under_horizon_home() {
@@ -160,6 +188,10 @@ mod tests {
         assert_eq!(
             home.claude_plugin_dir(),
             PathBuf::from("/tmp/horizon-home/plugins/claude-code")
+        );
+        assert_eq!(
+            home.claude_plugin_dir_for_host("host-a"),
+            PathBuf::from("/tmp/horizon-home/runtime/agent-plugins/%686f73742d61/claude-code")
         );
         assert_eq!(
             home.codex_browser_skill_dir(),
@@ -217,5 +249,27 @@ mod tests {
                 "{local_id} must use the canonical path encoding"
             );
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn browser_mcp_executable_uses_the_live_process_after_the_original_path_is_deleted() {
+        let deleted_path = PathBuf::from("/tmp/removed-worktree/target/release/horizon (deleted)");
+
+        let executable = browser_mcp_executable_for_process(std::process::id(), Some(deleted_path));
+
+        assert_eq!(
+            executable,
+            Some(PathBuf::from(format!("/proc/{}/exe", std::process::id())))
+        );
+    }
+
+    #[test]
+    fn browser_mcp_executable_falls_back_when_process_lookup_is_unavailable() {
+        let current_executable = PathBuf::from("/opt/horizon");
+
+        let executable = browser_mcp_executable_for_process(u32::MAX, Some(current_executable.clone()));
+
+        assert_eq!(executable, Some(current_executable));
     }
 }

--- a/crates/horizon-core/src/horizon_home.rs
+++ b/crates/horizon-core/src/horizon_home.rs
@@ -77,12 +77,18 @@ impl HorizonHome {
     }
 
     #[must_use]
+    pub fn agent_plugin_hosts_dir(&self) -> PathBuf {
+        self.root.join("runtime").join("agent-plugins")
+    }
+
+    #[must_use]
+    pub fn agent_plugin_host_dir(&self, host_instance: &str) -> PathBuf {
+        self.agent_plugin_hosts_dir().join(safe_local_id(host_instance))
+    }
+
+    #[must_use]
     pub fn claude_plugin_dir_for_host(&self, host_instance: &str) -> PathBuf {
-        self.root
-            .join("runtime")
-            .join("agent-plugins")
-            .join(safe_local_id(host_instance))
-            .join("claude-code")
+        self.agent_plugin_host_dir(host_instance).join("claude-code")
     }
 
     #[must_use]
@@ -192,6 +198,10 @@ mod tests {
         assert_eq!(
             home.claude_plugin_dir_for_host("host-a"),
             PathBuf::from("/tmp/horizon-home/runtime/agent-plugins/%686f73742d61/claude-code")
+        );
+        assert_eq!(
+            home.agent_plugin_host_dir("host-a"),
+            PathBuf::from("/tmp/horizon-home/runtime/agent-plugins/%686f73742d61")
         );
         assert_eq!(
             home.codex_browser_skill_dir(),

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -54,7 +54,7 @@ pub use error::{Error, Result};
 pub use git_changes::DiffViewer;
 pub use git_status::{DiffHunk, DiffLine, DiffLineKind, FileChange, FileDiff, FileStatus, GitStatus};
 pub use git_watcher::GitWatcher;
-pub use horizon_home::HorizonHome;
+pub use horizon_home::{HorizonHome, browser_mcp_executable};
 pub use managed_install::ManagedInstall;
 pub use panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind, PanelLayout, PanelOptions, PanelResume, browser_actor};
 pub use remote_hosts::{

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -904,8 +904,7 @@ pub fn browser_actor(local_id: &str) -> String {
 }
 
 fn horizon_codex_mcp_args() -> Vec<String> {
-    let Some(command) = std::env::current_exe()
-        .ok()
+    let Some(command) = crate::browser_mcp_executable()
         .and_then(|path| path.into_os_string().into_string().ok())
         .and_then(|path| serde_json::to_string(&path).ok())
     else {
@@ -926,7 +925,7 @@ fn horizon_codex_mcp_args() -> Vec<String> {
 }
 
 fn horizon_claude_plugin_args() -> Vec<String> {
-    let path = HorizonHome::resolve().claude_plugin_dir();
+    let path = HorizonHome::resolve().claude_plugin_dir_for_host(crate::browser::manifest::host_instance());
     if path.is_dir() {
         vec!["--plugin-dir".to_string(), path.display().to_string()]
     } else {
@@ -1024,6 +1023,8 @@ mod tests {
         assert!(command.contains("mcp_servers.horizon-browser.default_tools_approval_mode=\"approve\""));
         assert!(command.contains("--browser-mcp"));
         assert!(!command.contains("browser-cli"));
+        #[cfg(target_os = "linux")]
+        assert!(command.contains(&format!("/proc/{}/exe", std::process::id())));
     }
 
     #[test]

--- a/crates/horizon-ui/src/main.rs
+++ b/crates/horizon-ui/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> eframe::Result {
     }
 
     let horizon_home = HorizonHome::resolve();
-    plugin_install::install_agent_plugins(&horizon_home);
+    let _agent_plugin_host_lease = plugin_install::install_agent_plugins(&horizon_home);
 
     let cli_args = parse_cli_args();
     let resolved_config_path =

--- a/crates/horizon-ui/src/plugin_install.rs
+++ b/crates/horizon-ui/src/plugin_install.rs
@@ -1,3 +1,4 @@
+use std::fs::{OpenOptions, TryLockError};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -49,10 +50,74 @@ const BROWSER_SKILL_FILES: &[EmbeddedFile] = &[EmbeddedFile {
     )),
 }];
 
-pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) {
+pub(crate) struct AgentPluginHostLease {
+    host_dir: PathBuf,
+    lock_path: PathBuf,
+    lock_file: Option<std::fs::File>,
+}
+
+impl AgentPluginHostLease {
+    fn acquire(instance_dir: PathBuf) -> std::io::Result<Self> {
+        let lock_path = agent_plugin_host_lock_path(&instance_dir)?;
+        let plugin_root = instance_dir.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "agent plugin host directory has no parent",
+            )
+        })?;
+        std::fs::create_dir_all(plugin_root)?;
+        let lock_file = open_lock_file(&lock_path)?;
+        match lock_file.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    format!("agent plugin host is already active: {}", instance_dir.display()),
+                ));
+            }
+            Err(TryLockError::Error(error)) => return Err(error),
+        }
+        if let Err(error) = std::fs::create_dir_all(&instance_dir) {
+            drop(lock_file);
+            let _ = std::fs::remove_file(&lock_path);
+            return Err(error);
+        }
+        Ok(Self {
+            host_dir: instance_dir,
+            lock_path,
+            lock_file: Some(lock_file),
+        })
+    }
+}
+
+impl Drop for AgentPluginHostLease {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_dir_all(&self.host_dir)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(path = %self.host_dir.display(), %error, "failed to remove agent plugin host directory");
+        }
+        drop(self.lock_file.take());
+        if let Err(error) = std::fs::remove_file(&self.lock_path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(path = %self.lock_path.display(), %error, "failed to remove agent plugin host lock");
+        }
+    }
+}
+
+pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) -> Option<AgentPluginHostLease> {
     let user_home = std::env::var_os("HOME").map(PathBuf::from);
     let mcp_command = browser_mcp_executable().unwrap_or_else(|| PathBuf::from("horizon"));
+    let host_dir = horizon_home.agent_plugin_host_dir(manifest::host_instance());
     let claude_plugin_dir = horizon_home.claude_plugin_dir_for_host(manifest::host_instance());
+    let lease = match AgentPluginHostLease::acquire(host_dir.clone()) {
+        Ok(lease) => lease,
+        Err(error) => {
+            tracing::warn!(%error, "failed to acquire agent plugin host lease");
+            return None;
+        }
+    };
 
     match install_agent_plugins_impl(horizon_home, &claude_plugin_dir, user_home.as_deref(), &mcp_command) {
         Ok(updated_files) if updated_files > 0 => {
@@ -61,6 +126,86 @@ pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) {
         Ok(_) => {}
         Err(error) => tracing::warn!("failed to sync embedded Horizon agent plugins: {error}"),
     }
+
+    match prune_stale_agent_plugin_hosts(&host_dir) {
+        Ok(pruned_hosts) if pruned_hosts > 0 => {
+            tracing::info!(pruned_hosts, "pruned stale agent plugin hosts");
+        }
+        Ok(_) => {}
+        Err(error) => tracing::warn!(%error, "failed to prune stale agent plugin hosts"),
+    }
+
+    Some(lease)
+}
+
+fn agent_plugin_host_lock_path(instance_dir: &Path) -> std::io::Result<PathBuf> {
+    let plugin_root = instance_dir.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "agent plugin host directory has no parent",
+        )
+    })?;
+    let host_name = instance_dir.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "agent plugin host directory has no name",
+        )
+    })?;
+    let mut lock_name = host_name.to_os_string();
+    lock_name.push(".lock");
+    Ok(plugin_root.join(lock_name))
+}
+
+fn open_lock_file(path: &Path) -> std::io::Result<std::fs::File> {
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+}
+
+fn prune_stale_agent_plugin_hosts(current_instance_dir: &Path) -> std::io::Result<usize> {
+    let plugin_root = current_instance_dir.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "agent plugin host directory has no parent",
+        )
+    })?;
+    let prune_lock = open_lock_file(&plugin_root.join(".prune.lock"))?;
+    match prune_lock.try_lock() {
+        Ok(()) => {}
+        Err(TryLockError::WouldBlock) => return Ok(0),
+        Err(TryLockError::Error(error)) => return Err(error),
+    }
+
+    let mut pruned_hosts = 0usize;
+    for entry in std::fs::read_dir(plugin_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() || entry.path() == current_instance_dir {
+            continue;
+        }
+        let candidate_dir = entry.path();
+        let host_lock_path = agent_plugin_host_lock_path(&candidate_dir)?;
+        let host_lock = open_lock_file(&host_lock_path)?;
+        match host_lock.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => continue,
+            Err(TryLockError::Error(error)) => return Err(error),
+        }
+        match std::fs::remove_dir_all(&candidate_dir) {
+            Ok(()) => pruned_hosts += 1,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        drop(host_lock);
+        match std::fs::remove_file(host_lock_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(pruned_hosts)
 }
 
 fn install_agent_plugins_impl(
@@ -147,7 +292,8 @@ mod tests {
     use horizon_core::HorizonHome;
 
     use super::{
-        BROWSER_SKILL_FILES, EmbeddedFile, NOTIFY_SKILL_FILES, install_agent_plugins_impl, sync_file_if_changed,
+        AgentPluginHostLease, BROWSER_SKILL_FILES, EmbeddedFile, NOTIFY_SKILL_FILES, agent_plugin_host_lock_path,
+        install_agent_plugins_impl, open_lock_file, prune_stale_agent_plugin_hosts, sync_file_if_changed,
         sync_plugin_files,
     };
 
@@ -261,5 +407,65 @@ mod tests {
         assert!(!first_config.contains("/opt/horizon-b"));
         assert!(second_config.contains("/opt/horizon-b"));
         assert!(!second_config.contains("/opt/horizon-a"));
+    }
+
+    #[test]
+    fn agent_plugin_host_lease_removes_its_directory_and_lock_on_drop() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
+        let host_dir = horizon_home.agent_plugin_host_dir("host-a");
+        let lock_path = agent_plugin_host_lock_path(&host_dir).expect("lock path");
+
+        let lease = AgentPluginHostLease::acquire(host_dir.clone()).expect("host lease");
+        assert!(host_dir.is_dir());
+        assert!(lock_path.is_file());
+
+        drop(lease);
+
+        assert!(!host_dir.exists());
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn prune_stale_agent_plugin_hosts_keeps_active_hosts() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
+        let current_host_dir = horizon_home.agent_plugin_host_dir("current-host");
+        let active_host_dir = horizon_home.agent_plugin_host_dir("active-host");
+        let stale_host_dir = horizon_home.agent_plugin_host_dir("stale-host");
+        let current_lease = AgentPluginHostLease::acquire(current_host_dir.clone()).expect("current lease");
+        let active_lease = AgentPluginHostLease::acquire(active_host_dir.clone()).expect("active lease");
+        std::fs::create_dir_all(stale_host_dir.join("claude-code")).expect("stale host directory");
+
+        let pruned_hosts = prune_stale_agent_plugin_hosts(&current_host_dir).expect("prune stale hosts");
+
+        assert_eq!(pruned_hosts, 1);
+        assert!(current_host_dir.is_dir());
+        assert!(active_host_dir.is_dir());
+        assert!(!stale_host_dir.exists());
+
+        drop(active_lease);
+        drop(current_lease);
+    }
+
+    #[test]
+    fn prune_stale_agent_plugin_hosts_defers_to_another_pruner() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
+        let current_host_dir = horizon_home.agent_plugin_host_dir("current-host");
+        let stale_host_dir = horizon_home.agent_plugin_host_dir("stale-host");
+        let current_lease = AgentPluginHostLease::acquire(current_host_dir.clone()).expect("current lease");
+        std::fs::create_dir_all(&stale_host_dir).expect("stale host directory");
+        let prune_lock = open_lock_file(&horizon_home.agent_plugin_hosts_dir().join(".prune.lock"))
+            .expect("prune coordination file");
+        prune_lock.try_lock().expect("prune lock");
+
+        let pruned_hosts = prune_stale_agent_plugin_hosts(&current_host_dir).expect("deferred prune");
+
+        assert_eq!(pruned_hosts, 0);
+        assert!(stale_host_dir.is_dir());
+
+        drop(prune_lock);
+        drop(current_lease);
     }
 }

--- a/crates/horizon-ui/src/plugin_install.rs
+++ b/crates/horizon-ui/src/plugin_install.rs
@@ -1,7 +1,8 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use horizon_core::HorizonHome;
+use horizon_core::browser::manifest;
+use horizon_core::{HorizonHome, browser_mcp_executable};
 
 struct EmbeddedFile {
     relative_path: &'static str,
@@ -50,9 +51,10 @@ const BROWSER_SKILL_FILES: &[EmbeddedFile] = &[EmbeddedFile {
 
 pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) {
     let user_home = std::env::var_os("HOME").map(PathBuf::from);
-    let mcp_command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("horizon"));
+    let mcp_command = browser_mcp_executable().unwrap_or_else(|| PathBuf::from("horizon"));
+    let claude_plugin_dir = horizon_home.claude_plugin_dir_for_host(manifest::host_instance());
 
-    match install_agent_plugins_impl(horizon_home, user_home.as_deref(), &mcp_command) {
+    match install_agent_plugins_impl(horizon_home, &claude_plugin_dir, user_home.as_deref(), &mcp_command) {
         Ok(updated_files) if updated_files > 0 => {
             tracing::info!(updated_files, "synced embedded Horizon agent plugins");
         }
@@ -63,14 +65,15 @@ pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) {
 
 fn install_agent_plugins_impl(
     horizon_home: &HorizonHome,
+    claude_plugin_dir: &Path,
     user_home: Option<&Path>,
     mcp_command: &Path,
 ) -> std::io::Result<usize> {
     let mut updated_files = 0usize;
 
-    updated_files += sync_plugin_files(&horizon_home.claude_plugin_dir(), CLAUDE_PLUGIN_FILES)?;
+    updated_files += sync_plugin_files(claude_plugin_dir, CLAUDE_PLUGIN_FILES)?;
     updated_files += usize::from(sync_file_if_changed(
-        &horizon_home.claude_plugin_dir().join(".mcp.json"),
+        &claude_plugin_dir.join(".mcp.json"),
         &claude_mcp_config(mcp_command)?,
     )?);
     updated_files += sync_plugin_files(&horizon_home.codex_skill_dir(), NOTIFY_SKILL_FILES)?;
@@ -196,9 +199,15 @@ mod tests {
         let temp = tempfile::tempdir().expect("temp dir");
         let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
         let user_home = temp.path().join("user-home");
+        let claude_plugin_dir = horizon_home.claude_plugin_dir_for_host("host-a");
 
-        let updated = install_agent_plugins_impl(&horizon_home, Some(&user_home), Path::new("/opt/horizon"))
-            .expect("install plugins");
+        let updated = install_agent_plugins_impl(
+            &horizon_home,
+            &claude_plugin_dir,
+            Some(&user_home),
+            Path::new("/opt/horizon"),
+        )
+        .expect("install plugins");
 
         assert!(updated > 0);
         assert_eq!(
@@ -228,9 +237,29 @@ mod tests {
         );
         assert!(BROWSER_SKILL_FILES[0].content.contains("browser_visibility"));
         assert!(BROWSER_SKILL_FILES[0].content.contains("browser_network_watch"));
-        let mcp_config = std::fs::read_to_string(horizon_home.claude_plugin_dir().join(".mcp.json"))
+        let mcp_config = std::fs::read_to_string(claude_plugin_dir.join(".mcp.json"))
             .expect("Claude MCP config should be installed");
         assert!(mcp_config.contains("/opt/horizon"));
         assert!(mcp_config.contains("--browser-mcp"));
+    }
+
+    #[test]
+    fn install_agent_plugins_keeps_mcp_commands_isolated_per_horizon_host() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
+        let first_plugin_dir = horizon_home.claude_plugin_dir_for_host("host-a");
+        let second_plugin_dir = horizon_home.claude_plugin_dir_for_host("host-b");
+
+        install_agent_plugins_impl(&horizon_home, &first_plugin_dir, None, Path::new("/opt/horizon-a"))
+            .expect("install first host plugin");
+        install_agent_plugins_impl(&horizon_home, &second_plugin_dir, None, Path::new("/opt/horizon-b"))
+            .expect("install second host plugin");
+
+        let first_config = std::fs::read_to_string(first_plugin_dir.join(".mcp.json")).expect("first host config");
+        let second_config = std::fs::read_to_string(second_plugin_dir.join(".mcp.json")).expect("second host config");
+        assert!(first_config.contains("/opt/horizon-a"));
+        assert!(!first_config.contains("/opt/horizon-b"));
+        assert!(second_config.contains("/opt/horizon-b"));
+        assert!(!second_config.contains("/opt/horizon-a"));
     }
 }


### PR DESCRIPTION
## Summary

- Resolve the browser MCP command through the live host executable on Linux, keeping new client startups valid even if the original build artifact is removed.
- Preserve the existing executable lookup fallback on other platforms.
- Isolate generated agent plugin descriptors by host instance so concurrent hosts cannot overwrite each other's MCP command.
- Hold an OS-backed lease for each host descriptor, remove it on normal shutdown, and prune only inactive stale hosts after crashes.
- Add regression coverage for deleted executables, lookup fallback, launch configuration, descriptor isolation, shutdown cleanup, and concurrent pruning.

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`

## Browser evidence

Not applicable: this changes process launch reliability and generated integration paths, with no browser-visible UI change.
