### PR TITLE
docs(testing): record the merged browser navigation stack and its post-merge gate

### DIFF
--- a/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
+++ b/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
@@ -8,6 +8,11 @@ exact PR head named in the request. Do not merge until the report ends with
 the repository as the execution record; append findings to the report, do not
 rewrite the procedure.
 
+Status: the stack has merged to `main` as #365 (`2ae3383`, issue #350), #366
+(`9e2f719`, issue #348), and #367 (`82d070c`, issue #349), each after a
+`SMOKE-TEST: DONE` report. Section 6 records the post-merge verification of
+the merged tree.
+
 ## Safety contract
 
 - Do not stop, signal, reuse, or automate a pre-existing Horizon process, and
@@ -186,3 +191,18 @@ SMOKE-TEST REPORT (Mac Studio/macOS <version>, <arch>, <final-sha>)
 Summary: <evidence locations, backend notes, remaining concerns>
 SMOKE-TEST: DONE
 ```
+
+## 6. Post-merge verification on main
+
+The #367 report noted one Firefox gate attempt discarded after the Mac's temp
+volume hit `ENOSPC` before the wait lane; the clean rerun passed, but the host
+was left with about 3 GiB free. After the host was cleaned (merged-PR
+worktrees and their build outputs, stale smoke roots, and the Homebrew cache
+removed; about 55 GiB free afterwards), the full gate is rerun once more on
+the merged tree so the closing record was produced on a healthy host.
+
+Run sections 1 to 4 unchanged against the exact head named in the request on
+this PR. That head differs from `main` at `82d070c` only by this document:
+the gate script, the fixtures, and every Rust source are byte-identical to
+the merged tree, so the run verifies what shipped. Post the report on this
+PR in the section 5 format, naming both the PR head and `82d070c`.

--- a/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
+++ b/docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md
@@ -196,10 +196,10 @@ SMOKE-TEST: DONE
 
 The #367 report noted one Firefox gate attempt discarded after the Mac's temp
 volume hit `ENOSPC` before the wait lane; the clean rerun passed, but the host
-was left with about 3 GiB free. After the host was cleaned (merged-PR
+was left with about 3 GiB free. The host has since been cleaned (merged-PR
 worktrees and their build outputs, stale smoke roots, and the Homebrew cache
-removed; about 55 GiB free afterwards), the full gate is rerun once more on
-the merged tree so the closing record was produced on a healthy host.
+removed; about 55 GiB free afterwards). Rerun the full gate once more on the
+merged tree so that the closing record comes from a healthy host.
 
 Run sections 1 to 4 unchanged against the exact head named in the request on
 this PR. That head differs from `main` at `82d070c` only by this document:


### PR DESCRIPTION
## Purpose

Closing record for the merged browser navigation stack (#365 for #350, #366 for #348, #367 for #349). The macOS host that produced the #367 smoke report hit `ENOSPC` during one Firefox attempt; the clean rerun passed, but the host was left with about 3 GiB free. The host has been cleaned (about 55 GiB free now) and the full three-backend gate is rerun on the merged tree so the closing record comes from a healthy host.

## What changed

- `docs/testing/2026-09-02-macos-browser-navigation-outcome-smoke.md`: a status paragraph naming the three squash commits, and a new section 6 describing the post-merge verification. No code, gate, or fixture changes: the Rust tree, `scripts/browser-smoke`, and the fixtures are byte-identical to `main` at `82d070c`.

## Verification

- `./scripts/check-maintainability.sh`: pass.
- Docs only; the CI run on this PR covers format, maintainability, clippy tiers, and tests on the unchanged tree.
- macOS smoke: a `SMOKE-TEST REQUEST` on this PR asks for the full Safari, Firefox, and Chromium gate on the exact PR head; the report is the deliverable of this PR and must end with `SMOKE-TEST: DONE` before merge.
