### PR TITLE
feat(cloud): add Azure Container Apps workers

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 use std::{collections::HashSet, fmt};
 use thiserror::Error;
 use uuid::Uuid;
+pub mod azure;
 pub mod runpod;
 mod validation;
 pub const CLOUD_RUN_PROTOCOL_VERSION: u32 = 1;

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -21,6 +21,7 @@ const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
 const MIN_LEASE_SECONDS: u32 = 300;
 const MAX_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
 const LEASE_CLOCK_SKEW_SECONDS: i64 = 120;
+const CONSUMPTION_PROFILE: &str = "Consumption";
 #[derive(Clone)]
 pub struct AzureAccessToken(String);
 impl AzureAccessToken {
@@ -118,8 +119,7 @@ impl AzureClient {
         Ok(Self { profile, transport })
     }
     /// # Errors
-    /// Fails closed on invalid configuration, identity drift, duplicate executions,
-    /// provider errors, or an exceeded hourly price.
+    /// Fails closed on invalid configuration, identity drift, duplicate executions, provider errors, or price.
     pub fn ensure_worker(
         &self,
         workflow_id: CloudWorkflowId,
@@ -155,6 +155,7 @@ impl AzureClient {
             let existing = self.execution_for(&job, &worker.resource_id)?;
             // The persisted job is the at-most-once fence; retries only reconcile its execution.
             let execution = if created && existing.is_none() && job.ready_to_start() {
+                status_from_resource(&job, &worker, None)?;
                 self.transport.start(&name)?
             } else {
                 existing
@@ -338,6 +339,7 @@ struct ApiIdentity {
 #[serde(default, rename_all = "camelCase")]
 struct ApiProperties {
     environment_id: String,
+    workload_profile_name: String,
     provisioning_state: Option<String>,
     configuration: ApiConfiguration,
     template: ApiTemplate,
@@ -413,7 +415,7 @@ fn create_request(
         {"name": TERMINATE_ENV, "value": deadline}
     ]);
     let properties = serde_json::json!({
-        "environmentId": profile.environment_id,
+        "environmentId": profile.environment_id, "workloadProfileName": CONSUMPTION_PROFILE,
         "configuration": {
             "triggerType": "Manual", "replicaTimeout": target.lease_seconds, "replicaRetryLimit": 0,
             "manualTriggerConfig": {"parallelism": 1, "replicaCompletionCount": 1},
@@ -440,10 +442,9 @@ fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
             .get(..prefix.len())
             .is_some_and(|value| value.eq_ignore_ascii_case(&prefix))
         && valid_location(&profile.location)
-        && profile.cpu_millicores >= 250
+        && (250..=4_000).contains(&profile.cpu_millicores)
         && profile.cpu_millicores.is_multiple_of(250)
-        && profile.memory_mib >= 512
-        && profile.memory_mib.is_multiple_of(256)
+        && profile.memory_mib == profile.cpu_millicores / 250 * 512
         && profile.hourly_cost_micros > 0;
     valid.then_some(()).ok_or(AzureError::InvalidProfile)
 }
@@ -576,6 +577,7 @@ fn basic_identity_matches(
 }
 fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, profile: &AzureProfile) -> bool {
     let config = &job.properties.configuration;
+    let workload_profile = &job.properties.workload_profile_name;
     let containers = job.properties.template.containers.as_deref().unwrap_or_default();
     let public_image = config.registries.as_deref().unwrap_or_default().is_empty()
         && job.identity.as_ref().is_none_or(|identity| {
@@ -583,6 +585,7 @@ fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, prof
                 && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
         });
     config.trigger_type.eq_ignore_ascii_case("Manual")
+        && workload_profile.eq_ignore_ascii_case(CONSUMPTION_PROFILE)
         && config.replica_timeout == lease_seconds
         && config.replica_retry_limit == 0
         && config.manual_trigger_config.parallelism == 1

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -59,13 +59,9 @@ pub struct AzureWorker {
     pub job_id: CloudJobId,
     pub resource_id: String,
     pub name: String,
-    pub profile: String,
-    pub environment_id: String,
-    pub image: String,
-    pub disk_gib: u32,
-    pub lease_seconds: u32,
+    pub target: WorkerTarget,
+    pub profile: AzureProfile,
     pub delete_after: String,
-    pub hourly_cost_micros: u64,
 }
 impl AzureWorker {
     /// # Errors
@@ -73,18 +69,13 @@ impl AzureWorker {
     pub fn validate(&self) -> Result<(), AzureError> {
         let name = resource_name(self.workflow_id, self.job_id);
         let valid = self.name == name
-            && valid_arm_id(&self.resource_id)
-            && self
-                .resource_id
-                .to_ascii_lowercase()
-                .ends_with(&format!("/providers/microsoft.app/jobs/{name}"))
-            && valid_text(&self.profile, 191)
-            && valid_arm_id(&self.environment_id)
-            && valid_immutable_image(&self.image)
-            && self.disk_gib > 0
-            && (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&self.lease_seconds)
+            && validate_target(&self.target, &self.profile).is_ok()
             && valid_deadline(&self.delete_after)
-            && self.hourly_cost_micros > 0;
+            && self.resource_id.eq_ignore_ascii_case(&resource_id(
+                &self.profile.subscription_id,
+                &self.profile.resource_group,
+                &self.name,
+            ));
         valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
     }
 }
@@ -137,7 +128,7 @@ impl AzureClient {
     ) -> Result<AzureEnsure, AzureError> {
         validate_target(target, &self.profile)?;
         let name = resource_name(workflow_id, job_id);
-        let (job, created) = if let Some(job) = self.transport.get(&name)? {
+        let (mut job, created) = if let Some(job) = self.transport.get(&name)? {
             (job, false)
         } else {
             enforce_cost(target, self.profile.hourly_cost_micros)?;
@@ -153,8 +144,14 @@ impl AzureClient {
         if !recovered_deadline_valid(&worker.delete_after, target.lease_seconds) {
             return self.cleanup_creation_failure(&name, workflow_id, job_id, AzureError::ResourceIdentityMismatch);
         }
+        if created && !job.ready_to_start() {
+            job = match self.await_created_job(&worker) {
+                Ok(job) => job,
+                Err(error) => return self.cleanup_creation_failure(&name, workflow_id, job_id, error),
+            };
+        }
         let result = (|| {
-            enforce_cost(target, worker.hourly_cost_micros)?;
+            enforce_cost(target, worker.profile.hourly_cost_micros)?;
             let existing = self.execution_for(&job, &worker.resource_id)?;
             // The persisted job is the at-most-once fence; retries only reconcile its execution.
             let execution = if created && existing.is_none() && job.ready_to_start() {
@@ -162,7 +159,7 @@ impl AzureClient {
             } else {
                 existing
             };
-            status_from_resource(&job, &worker, execution.as_ref(), &self.profile)
+            status_from_resource(&job, &worker, execution.as_ref())
         })();
         let status = match result {
             Ok(status) => status,
@@ -185,7 +182,7 @@ impl AzureClient {
             return Ok(None);
         };
         let execution = self.execution_for(&job, &worker.resource_id)?;
-        status_from_resource(&job, worker, execution.as_ref(), &self.profile).map(Some)
+        status_from_resource(&job, worker, execution.as_ref()).map(Some)
     }
     /// # Errors
     /// Refuses deletion when persisted or provider identity differs.
@@ -194,7 +191,7 @@ impl AzureClient {
         let Some(job) = self.transport.get(&worker.name)? else {
             return Ok(AzureCleanup::AlreadyAbsent);
         };
-        status_from_resource(&job, worker, None, &self.profile)?;
+        status_from_resource(&job, worker, None)?;
         self.transport.delete(&worker.name)
     }
     fn validate_scope(&self, worker: &AzureWorker) -> Result<(), AzureError> {
@@ -223,6 +220,20 @@ impl AzureClient {
             Ok(None)
         }
     }
+    fn await_created_job(&self, worker: &AzureWorker) -> Result<ApiJob, AzureError> {
+        let name = worker.name.as_str();
+        for delay_millis in [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000] {
+            std::thread::sleep(std::time::Duration::from_millis(delay_millis));
+            let job = self.transport.get(name)?.ok_or(AzureError::ResourceIdentityMismatch)?;
+            status_from_resource(&job, worker, None)?;
+            if job.ready_to_start() {
+                return Ok(job);
+            }
+        }
+        Err(AzureError::RequestFailed {
+            operation: "job provisioning",
+        })
+    }
     fn cleanup_creation_failure<T>(
         &self,
         name: &str,
@@ -237,7 +248,7 @@ impl AzureClient {
             .flatten()
             .is_some_and(|job| basic_identity_matches(&job, workflow_id, job_id, &self.profile));
         if !owned || self.transport.delete(name).is_err() {
-            return Err(AzureError::CreationCleanupFailed {
+            return Err(AzureError::CleanupFailed {
                 resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
             });
         }
@@ -247,7 +258,7 @@ impl AzureClient {
                 return Err(error);
             }
         }
-        Err(AzureError::CreationCleanupFailed {
+        Err(AzureError::CleanupFailed {
             resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
         })
     }
@@ -279,8 +290,8 @@ pub enum AzureError {
     UnexpectedStatus { operation: &'static str, status: u16 },
     #[error("Azure returned a malformed response during {operation}")]
     InvalidResponse { operation: &'static str },
-    #[error("Azure job creation failed identity verification and exact cleanup also failed")]
-    CreationCleanupFailed { resource_id: String },
+    #[error("Azure worker operation failed and exact cleanup also failed")]
+    CleanupFailed { resource_id: String },
     #[error("Azure hourly cost {actual} exceeded configured maximum {maximum}")]
     HourlyCostRejected { actual: u64, maximum: u64 },
 }
@@ -485,13 +496,9 @@ fn worker_from_job(
         job_id,
         resource_id: resource_id(&profile.subscription_id, &profile.resource_group, &job.name),
         name: job.name.clone(),
-        profile: profile.name.clone(),
-        environment_id: profile.environment_id.clone(),
-        image: target.image.clone(),
-        disk_gib: target.disk_gib,
-        lease_seconds: target.lease_seconds,
+        target: target.clone(),
+        profile: profile.clone(),
         delete_after,
-        hourly_cost_micros: profile.hourly_cost_micros,
     };
     worker.validate()?;
     Ok(worker)
@@ -500,20 +507,20 @@ fn status_from_resource(
     job: &ApiJob,
     worker: &AzureWorker,
     execution: Option<&ApiExecution>,
-    profile: &AzureProfile,
 ) -> Result<AzureWorkerStatus, AzureError> {
     worker.validate()?;
     let containers = job.properties.template.containers.as_deref().unwrap_or_default();
+    let (target, profile) = (&worker.target, &worker.profile);
     let owned = basic_identity_matches(job, worker.workflow_id, worker.job_id, profile)
         && job.id.eq_ignore_ascii_case(&worker.resource_id)
         && job
             .properties
             .environment_id
-            .eq_ignore_ascii_case(&worker.environment_id)
-        && job_configuration_matches(job, &worker.image, worker.lease_seconds, profile)
-        && tag_matches(job, PROFILE_TAG, &worker.profile)
-        && tag_matches(job, DISK_TAG, &worker.disk_gib.to_string())
-        && tag_matches(job, COST_TAG, &worker.hourly_cost_micros.to_string())
+            .eq_ignore_ascii_case(&profile.environment_id)
+        && job_configuration_matches(job, &target.image, target.lease_seconds, profile)
+        && tag_matches(job, PROFILE_TAG, &profile.name)
+        && tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
+        && tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
         && tag_matches(job, DEADLINE_TAG, &worker.delete_after)
         && containers.len() == 1
         && env_matches(&containers[0], WORKFLOW_ENV, &worker.workflow_id.to_string())
@@ -626,11 +633,11 @@ fn tag_matches(job: &ApiJob, key: &str, expected: &str) -> bool {
     job.tags.get(key).is_some_and(|value| value == expected)
 }
 fn env_matches(container: &ApiContainer, name: &str, expected: &str) -> bool {
-    container
-        .env
-        .iter()
-        .find(|entry| entry.name == name)
+    let mut entries = container.env.iter().filter(|entry| entry.name == name);
+    entries
+        .next()
         .is_some_and(|entry| entry.value.as_deref() == Some(expected))
+        && entries.next().is_none()
 }
 fn execution_belongs_to(execution_id: &str, job_resource_id: &str) -> bool {
     execution_id.len() > job_resource_id.len() + "/executions/".len()

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -1,0 +1,705 @@
+//! Azure Container Apps Jobs lifecycle adapter for durable cloud work.
+use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget, validation::valid_worker_image};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fmt};
+use thiserror::Error;
+mod http;
+#[cfg(test)]
+mod tests;
+const OWNER_TAG: &str = "horizon-owned-by";
+const WORKFLOW_TAG: &str = "horizon-workflow-id";
+const JOB_TAG: &str = "horizon-job-id";
+const PROTOCOL_TAG: &str = "horizon-protocol-version";
+const PROFILE_TAG: &str = "horizon-profile";
+const DEADLINE_TAG: &str = "horizon-delete-after";
+const COST_TAG: &str = "horizon-hourly-cost-micros";
+const DISK_TAG: &str = "horizon-disk-gib";
+const WORKFLOW_ENV: &str = "HORIZON_WORKFLOW_ID";
+const JOB_ENV: &str = "HORIZON_JOB_ID";
+const PROTOCOL_ENV: &str = "HORIZON_CLOUD_PROTOCOL_VERSION";
+const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
+const MIN_LEASE_SECONDS: u32 = 300;
+const MAX_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
+#[derive(Clone)]
+pub struct AzureAccessToken(String);
+impl AzureAccessToken {
+    /// # Errors
+    /// Rejects empty, oversized, whitespace-containing, or non-ASCII tokens.
+    pub fn new(value: impl Into<String>) -> Result<Self, AzureError> {
+        let value = value.into();
+        let valid = !value.is_empty()
+            && value.len() <= 16_384
+            && value.is_ascii()
+            && value
+                .bytes()
+                .all(|byte| !byte.is_ascii_whitespace() && !byte.is_ascii_control());
+        valid.then_some(Self(value)).ok_or(AzureError::InvalidAccessToken)
+    }
+    pub(super) fn expose(&self) -> &str {
+        &self.0
+    }
+}
+impl fmt::Debug for AzureAccessToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AzureAccessToken(<redacted>)")
+    }
+}
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AzureRegistry {
+    pub server: String,
+    pub identity_id: String,
+}
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AzureProfile {
+    pub name: String,
+    pub subscription_id: String,
+    pub resource_group: String,
+    pub environment_id: String,
+    pub location: String,
+    pub cpu_millicores: u32,
+    pub memory_mib: u32,
+    pub ephemeral_disk_gib: u32,
+    pub hourly_cost_micros: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry: Option<AzureRegistry>,
+}
+/// Persistable Azure identity sufficient for recovery and exact cleanup.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AzureWorker {
+    pub workflow_id: CloudWorkflowId,
+    pub job_id: CloudJobId,
+    pub resource_id: String,
+    pub name: String,
+    pub profile: String,
+    pub environment_id: String,
+    pub image: String,
+    pub disk_gib: u32,
+    pub lease_seconds: u32,
+    pub delete_after: String,
+    pub hourly_cost_micros: u64,
+}
+impl AzureWorker {
+    /// # Errors
+    /// Rejects malformed or internally inconsistent worker identities.
+    pub fn validate(&self) -> Result<(), AzureError> {
+        let name = resource_name(self.workflow_id, self.job_id);
+        let valid = self.name == name
+            && valid_arm_id(&self.resource_id)
+            && self
+                .resource_id
+                .to_ascii_lowercase()
+                .ends_with(&format!("/providers/microsoft.app/jobs/{name}"))
+            && valid_text(&self.profile, 191)
+            && valid_arm_id(&self.environment_id)
+            && valid_immutable_image(&self.image)
+            && self.disk_gib > 0
+            && (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&self.lease_seconds)
+            && valid_deadline(&self.delete_after)
+            && self.hourly_cost_micros > 0;
+        valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
+    }
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AzureLifecycle {
+    Provisioning,
+    Running,
+    Succeeded,
+    Failed,
+    Stopped,
+    Unknown,
+}
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AzureWorkerStatus {
+    pub worker: AzureWorker,
+    pub lifecycle: AzureLifecycle,
+    pub execution_id: Option<String>,
+}
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AzureEnsure {
+    Created(AzureWorkerStatus),
+    Reused(AzureWorkerStatus),
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AzureCleanup {
+    Deleted,
+    DeletionPending,
+    AlreadyAbsent,
+}
+/// Blocking Azure ARM client. Call it from a worker thread when used by an async UI.
+pub struct AzureClient {
+    profile: AzureProfile,
+    transport: Box<dyn Transport>,
+}
+impl AzureClient {
+    /// # Errors
+    /// Rejects an invalid profile or control-plane URL.
+    pub fn new(token: &AzureAccessToken, profile: AzureProfile) -> Result<Self, AzureError> {
+        validate_profile(&profile)?;
+        let transport = Box::new(http::AzureHttp::new(token, &profile));
+        Ok(Self { profile, transport })
+    }
+    /// # Errors
+    /// Fails closed on invalid configuration, identity drift, duplicate executions,
+    /// provider errors, or an exceeded hourly price.
+    pub fn ensure_worker(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+    ) -> Result<AzureEnsure, AzureError> {
+        validate_target(target, &self.profile)?;
+        let name = resource_name(workflow_id, job_id);
+        let (job, created) = if let Some(job) = self.transport.get(&name)? {
+            (job, false)
+        } else {
+            enforce_cost(target, self.profile.hourly_cost_micros)?;
+            let request = create_request(workflow_id, job_id, target, &self.profile)?;
+            (self.transport.create(&name, &request)?, true)
+        };
+        let worker = match worker_from_job(&job, workflow_id, job_id, target, &self.profile) {
+            Ok(worker) => worker,
+            Err(error) if created => return self.cleanup_creation_failure(&name, workflow_id, job_id, error),
+            Err(error) => return Err(error),
+        };
+        let result = (|| {
+            enforce_cost(target, worker.hourly_cost_micros)?;
+            let existing = self.execution_for(&job, &worker.resource_id)?;
+            let execution = if existing.is_none() && job.ready_to_start() {
+                self.transport.start(&name)?
+            } else {
+                existing
+            };
+            status_from_resource(&job, &worker, execution.as_ref())
+        })();
+        let status = match result {
+            Ok(status) => status,
+            Err(error) if created || matches!(&error, AzureError::HourlyCostRejected { .. }) => {
+                return self.cleanup_creation_failure(&name, workflow_id, job_id, error);
+            }
+            Err(error) => return Err(error),
+        };
+        Ok(if created {
+            AzureEnsure::Created(status)
+        } else {
+            AzureEnsure::Reused(status)
+        })
+    }
+    /// # Errors
+    /// Fails closed if the persisted or provider identity has drifted.
+    pub fn inspect_worker(&self, worker: &AzureWorker) -> Result<Option<AzureWorkerStatus>, AzureError> {
+        self.validate_scope(worker)?;
+        let Some(job) = self.transport.get(&worker.name)? else {
+            return Ok(None);
+        };
+        let execution = self.execution_for(&job, &worker.resource_id)?;
+        status_from_resource(&job, worker, execution.as_ref()).map(Some)
+    }
+    /// # Errors
+    /// Refuses deletion when persisted or provider identity differs.
+    pub fn delete_worker(&self, worker: &AzureWorker) -> Result<AzureCleanup, AzureError> {
+        self.validate_scope(worker)?;
+        let Some(job) = self.transport.get(&worker.name)? else {
+            return Ok(AzureCleanup::AlreadyAbsent);
+        };
+        status_from_resource(&job, worker, None)?;
+        self.transport.delete(&worker.name)
+    }
+    fn validate_scope(&self, worker: &AzureWorker) -> Result<(), AzureError> {
+        worker.validate()?;
+        let expected = resource_id(
+            &self.profile.subscription_id,
+            &self.profile.resource_group,
+            &worker.name,
+        );
+        let valid = worker.resource_id.eq_ignore_ascii_case(&expected);
+        valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
+    }
+    fn single_execution(&self, name: &str, resource_id: &str) -> Result<Option<ApiExecution>, AzureError> {
+        let executions = self.transport.executions(name)?;
+        if executions.len() > 1 {
+            return Err(AzureError::AmbiguousExecutions {
+                resource_id: resource_id.to_string(),
+                count: executions.len(),
+            });
+        }
+        Ok(executions.into_iter().next())
+    }
+    fn execution_for(&self, job: &ApiJob, resource_id: &str) -> Result<Option<ApiExecution>, AzureError> {
+        if job.ready_to_start() {
+            self.single_execution(&job.name, resource_id)
+        } else {
+            Ok(None)
+        }
+    }
+    fn cleanup_creation_failure<T>(
+        &self,
+        name: &str,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        error: AzureError,
+    ) -> Result<T, AzureError> {
+        let owned = self
+            .transport
+            .get(name)
+            .ok()
+            .flatten()
+            .is_some_and(|job| basic_identity_matches(&job, workflow_id, job_id, &self.profile));
+        if !owned || self.transport.delete(name).is_err() {
+            return Err(AzureError::CreationCleanupFailed {
+                resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
+            });
+        }
+        for delay_millis in [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000] {
+            std::thread::sleep(std::time::Duration::from_millis(delay_millis));
+            if matches!(self.transport.get(name), Ok(None)) {
+                return Err(error);
+            }
+        }
+        Err(AzureError::CreationCleanupFailed {
+            resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
+        })
+    }
+    #[cfg(test)]
+    fn with_transport(profile: AzureProfile, transport: impl Transport + 'static) -> Self {
+        Self {
+            profile,
+            transport: Box::new(transport),
+        }
+    }
+}
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum AzureError {
+    #[error("Azure access token is invalid")]
+    InvalidAccessToken,
+    #[error("Azure worker profile is invalid")]
+    InvalidProfile,
+    #[error("Azure worker target is invalid")]
+    InvalidTarget,
+    #[error("persisted Azure worker identity is invalid")]
+    InvalidPersistedWorker,
+    #[error("Azure returned an invalid or mismatched resource identity")]
+    ResourceIdentityMismatch,
+    #[error("Azure returned {count} executions for {resource_id}")]
+    AmbiguousExecutions { resource_id: String, count: usize },
+    #[error("Azure request failed during {operation}")]
+    RequestFailed { operation: &'static str },
+    #[error("Azure returned HTTP {status} during {operation}")]
+    UnexpectedStatus { operation: &'static str, status: u16 },
+    #[error("Azure returned a malformed response during {operation}")]
+    InvalidResponse { operation: &'static str },
+    #[error("Azure job creation failed identity verification and exact cleanup also failed")]
+    CreationCleanupFailed { resource_id: String },
+    #[error("Azure hourly cost {actual} exceeded configured maximum {maximum}")]
+    HourlyCostRejected { actual: u64, maximum: u64 },
+}
+type CreateJobRequest = serde_json::Value;
+trait Transport: Send + Sync {
+    fn get(&self, name: &str) -> Result<Option<ApiJob>, AzureError>;
+    fn create(&self, name: &str, request: &CreateJobRequest) -> Result<ApiJob, AzureError>;
+    fn executions(&self, name: &str) -> Result<Vec<ApiExecution>, AzureError>;
+    fn start(&self, name: &str) -> Result<Option<ApiExecution>, AzureError>;
+    fn delete(&self, name: &str) -> Result<AzureCleanup, AzureError>;
+}
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct Registry {
+    server: String,
+    identity: String,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiJob {
+    id: String,
+    name: String,
+    location: String,
+    tags: BTreeMap<String, String>,
+    identity: Option<ApiIdentity>,
+    properties: ApiProperties,
+}
+impl ApiJob {
+    fn ready_to_start(&self) -> bool {
+        self.properties
+            .provisioning_state
+            .as_deref()
+            .is_some_and(|state| state.eq_ignore_ascii_case("Succeeded"))
+    }
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiIdentity {
+    #[serde(rename = "type")]
+    kind: String,
+    user_assigned_identities: BTreeMap<String, serde_json::Value>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiProperties {
+    environment_id: String,
+    provisioning_state: Option<String>,
+    configuration: ApiConfiguration,
+    template: ApiTemplate,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiConfiguration {
+    replica_timeout: u32,
+    trigger_type: String,
+    registries: Vec<Registry>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct ApiTemplate {
+    containers: Vec<ApiContainer>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct ApiContainer {
+    name: String,
+    image: String,
+    env: Vec<ApiEnv>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiEnv {
+    name: String,
+    value: Option<String>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct ApiExecution {
+    id: String,
+    properties: ApiExecutionProperties,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiExecutionProperties {
+    status: Option<String>,
+}
+fn create_request(
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    target: &WorkerTarget,
+    profile: &AzureProfile,
+) -> Result<CreateJobRequest, AzureError> {
+    let deadline = deletion_deadline(target.lease_seconds)?;
+    let tags = serde_json::json!({
+        OWNER_TAG: "horizon", WORKFLOW_TAG: workflow_id.to_string(), JOB_TAG: job_id.to_string(),
+        PROTOCOL_TAG: super::CLOUD_RUN_PROTOCOL_VERSION.to_string(), PROFILE_TAG: profile.name,
+        DEADLINE_TAG: deadline, COST_TAG: profile.hourly_cost_micros.to_string(),
+        DISK_TAG: target.disk_gib.to_string()
+    });
+    let env = serde_json::json!([
+        {"name": WORKFLOW_ENV, "value": workflow_id.to_string()},
+        {"name": JOB_ENV, "value": job_id.to_string()},
+        {"name": PROTOCOL_ENV, "value": super::CLOUD_RUN_PROTOCOL_VERSION.to_string()},
+        {"name": TERMINATE_ENV, "value": deadline}
+    ]);
+    let (identity, registries, identity_settings) = profile.registry.as_ref().map_or_else(
+        || (serde_json::json!({"type": "None"}), Vec::new(), Vec::new()),
+        |registry| {
+            (
+                serde_json::json!({
+                    "type": "UserAssigned", "userAssignedIdentities": {&registry.identity_id: {}}
+                }),
+                vec![serde_json::json!({"server": registry.server, "identity": registry.identity_id})],
+                vec![serde_json::json!({"identity": registry.identity_id, "lifecycle": "None"})],
+            )
+        },
+    );
+    let properties = serde_json::json!({
+        "environmentId": profile.environment_id,
+        "configuration": {
+            "triggerType": "Manual", "replicaTimeout": target.lease_seconds, "replicaRetryLimit": 0,
+            "manualTriggerConfig": {"parallelism": 1, "replicaCompletionCount": 1},
+            "registries": registries, "identitySettings": identity_settings
+        },
+        "template": {"containers": [{
+            "name": "worker", "image": target.image, "env": env,
+            "resources": {"cpu": f64::from(profile.cpu_millicores) / 1_000.0,
+                          "memory": format!("{}Mi", profile.memory_mib)}
+        }]}
+    });
+    Ok(serde_json::json!({
+        "location": profile.location, "tags": tags, "identity": identity, "properties": properties
+    }))
+}
+fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
+    let prefix = format!("/subscriptions/{}/", profile.subscription_id);
+    let valid = valid_text(&profile.name, 191)
+        && valid_subscription(&profile.subscription_id)
+        && valid_resource_group(&profile.resource_group)
+        && valid_arm_id(&profile.environment_id)
+        && profile
+            .environment_id
+            .get(..prefix.len())
+            .is_some_and(|value| value.eq_ignore_ascii_case(&prefix))
+        && valid_location(&profile.location)
+        && profile.cpu_millicores >= 250
+        && profile.cpu_millicores.is_multiple_of(250)
+        && profile.memory_mib >= 512
+        && profile.memory_mib.is_multiple_of(128)
+        && profile.ephemeral_disk_gib > 0
+        && profile.hourly_cost_micros > 0
+        && profile
+            .registry
+            .as_ref()
+            .is_none_or(|registry| valid_registry_server(&registry.server) && valid_arm_id(&registry.identity_id));
+    valid.then_some(()).ok_or(AzureError::InvalidProfile)
+}
+fn validate_target(target: &WorkerTarget, profile: &AzureProfile) -> Result<(), AzureError> {
+    validate_profile(profile)?;
+    let registry_matches = profile.registry.as_ref().is_none_or(|registry| {
+        target
+            .image
+            .split_once('/')
+            .is_some_and(|(server, _)| server.eq_ignore_ascii_case(&registry.server))
+    });
+    let valid = target.provider == CloudProvider::Azure
+        && target.profile == profile.name
+        && (1..=profile.ephemeral_disk_gib).contains(&target.disk_gib)
+        && (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&target.lease_seconds)
+        && target.max_hourly_cost_micros != Some(0)
+        && valid_immutable_image(&target.image)
+        && registry_matches;
+    valid.then_some(()).ok_or(AzureError::InvalidTarget)
+}
+fn enforce_cost(target: &WorkerTarget, actual: u64) -> Result<(), AzureError> {
+    let Some(maximum) = target.max_hourly_cost_micros else {
+        return Ok(());
+    };
+    if actual > maximum {
+        return Err(AzureError::HourlyCostRejected { actual, maximum });
+    }
+    Ok(())
+}
+fn worker_from_job(
+    job: &ApiJob,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    target: &WorkerTarget,
+    profile: &AzureProfile,
+) -> Result<AzureWorker, AzureError> {
+    if !basic_identity_matches(job, workflow_id, job_id, profile)
+        || !tag_matches(job, PROFILE_TAG, &profile.name)
+        || !tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
+        || !tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
+        || !job.location.eq_ignore_ascii_case(&profile.location)
+        || !job_configuration_matches(job, target, profile)
+    {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    let delete_after = job
+        .tags
+        .get(DEADLINE_TAG)
+        .filter(|value| valid_deadline(value))
+        .cloned()
+        .ok_or(AzureError::ResourceIdentityMismatch)?;
+    let worker = AzureWorker {
+        workflow_id,
+        job_id,
+        resource_id: resource_id(&profile.subscription_id, &profile.resource_group, &job.name),
+        name: job.name.clone(),
+        profile: profile.name.clone(),
+        environment_id: profile.environment_id.clone(),
+        image: target.image.clone(),
+        disk_gib: target.disk_gib,
+        lease_seconds: target.lease_seconds,
+        delete_after,
+        hourly_cost_micros: profile.hourly_cost_micros,
+    };
+    worker.validate()?;
+    Ok(worker)
+}
+fn status_from_resource(
+    job: &ApiJob,
+    worker: &AzureWorker,
+    execution: Option<&ApiExecution>,
+) -> Result<AzureWorkerStatus, AzureError> {
+    worker.validate()?;
+    let containers = job.properties.template.containers.as_slice();
+    let owned = job.id.eq_ignore_ascii_case(&worker.resource_id)
+        && job.name == worker.name
+        && job
+            .properties
+            .environment_id
+            .eq_ignore_ascii_case(&worker.environment_id)
+        && job.properties.configuration.replica_timeout == worker.lease_seconds
+        && tag_matches(job, OWNER_TAG, "horizon")
+        && tag_matches(job, WORKFLOW_TAG, &worker.workflow_id.to_string())
+        && tag_matches(job, JOB_TAG, &worker.job_id.to_string())
+        && tag_matches(job, PROTOCOL_TAG, &super::CLOUD_RUN_PROTOCOL_VERSION.to_string())
+        && tag_matches(job, PROFILE_TAG, &worker.profile)
+        && tag_matches(job, DISK_TAG, &worker.disk_gib.to_string())
+        && tag_matches(job, COST_TAG, &worker.hourly_cost_micros.to_string())
+        && tag_matches(job, DEADLINE_TAG, &worker.delete_after)
+        && containers.len() == 1
+        && containers[0].name == "worker"
+        && containers[0].image == worker.image
+        && env_matches(&containers[0], WORKFLOW_ENV, &worker.workflow_id.to_string())
+        && env_matches(&containers[0], JOB_ENV, &worker.job_id.to_string())
+        && env_matches(
+            &containers[0],
+            PROTOCOL_ENV,
+            &super::CLOUD_RUN_PROTOCOL_VERSION.to_string(),
+        )
+        && env_matches(&containers[0], TERMINATE_ENV, &worker.delete_after);
+    if !owned {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    if let Some(execution) = execution
+        && !execution_belongs_to(&execution.id, &worker.resource_id)
+    {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    Ok(AzureWorkerStatus {
+        worker: worker.clone(),
+        lifecycle: lifecycle(job, execution),
+        execution_id: execution.map(|value| value.id.clone()),
+    })
+}
+fn lifecycle(job: &ApiJob, execution: Option<&ApiExecution>) -> AzureLifecycle {
+    let Some(execution) = execution else {
+        return match job.properties.provisioning_state.as_deref() {
+            Some(state) if matches_ci(state, &["Failed", "Canceled"]) => AzureLifecycle::Failed,
+            Some(state) if state.eq_ignore_ascii_case("Deleting") => AzureLifecycle::Stopped,
+            Some(_) => AzureLifecycle::Provisioning,
+            None => AzureLifecycle::Unknown,
+        };
+    };
+    match execution.properties.status.as_deref() {
+        Some(state) if matches_ci(state, &["Running", "Processing"]) => AzureLifecycle::Running,
+        Some(state) if state.eq_ignore_ascii_case("Succeeded") => AzureLifecycle::Succeeded,
+        Some(state) if matches_ci(state, &["Failed", "Degraded"]) => AzureLifecycle::Failed,
+        Some(state) if state.eq_ignore_ascii_case("Stopped") => AzureLifecycle::Stopped,
+        Some(_) | None => AzureLifecycle::Unknown,
+    }
+}
+fn basic_identity_matches(
+    job: &ApiJob,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    profile: &AzureProfile,
+) -> bool {
+    let name = resource_name(workflow_id, job_id);
+    job.name == name
+        && job
+            .id
+            .eq_ignore_ascii_case(&resource_id(&profile.subscription_id, &profile.resource_group, &name))
+        && tag_matches(job, OWNER_TAG, "horizon")
+        && tag_matches(job, WORKFLOW_TAG, &workflow_id.to_string())
+        && tag_matches(job, JOB_TAG, &job_id.to_string())
+        && tag_matches(job, PROTOCOL_TAG, &super::CLOUD_RUN_PROTOCOL_VERSION.to_string())
+}
+fn job_configuration_matches(job: &ApiJob, target: &WorkerTarget, profile: &AzureProfile) -> bool {
+    let config = &job.properties.configuration;
+    let containers = job.properties.template.containers.as_slice();
+    let registry_matches = profile.registry.as_ref().map_or_else(
+        || {
+            config.registries.is_empty()
+                && job.identity.as_ref().is_none_or(|identity| {
+                    identity.user_assigned_identities.is_empty()
+                        && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
+                })
+        },
+        |registry| {
+            config.registries
+                == [Registry {
+                    server: registry.server.clone(),
+                    identity: registry.identity_id.clone(),
+                }]
+                && job.identity.as_ref().is_some_and(|identity| {
+                    identity.kind.eq_ignore_ascii_case("UserAssigned")
+                        && identity.user_assigned_identities.len() == 1
+                        && identity
+                            .user_assigned_identities
+                            .keys()
+                            .any(|id| id.eq_ignore_ascii_case(&registry.identity_id))
+                })
+        },
+    );
+    config.trigger_type.eq_ignore_ascii_case("Manual")
+        && config.replica_timeout == target.lease_seconds
+        && containers.len() == 1
+        && containers[0].name == "worker"
+        && containers[0].image == target.image
+        && registry_matches
+}
+fn resource_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {
+    let workflow = workflow_id.to_string().replace('-', "");
+    let job = job_id.to_string().replace('-', "");
+    format!("hz-{}-{}", &workflow[..12], &job[..12])
+}
+fn resource_id(subscription: &str, resource_group: &str, name: &str) -> String {
+    format!("/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.App/jobs/{name}")
+}
+fn deletion_deadline(lease_seconds: u32) -> Result<String, AzureError> {
+    time::OffsetDateTime::now_utc()
+        .checked_add(time::Duration::seconds(i64::from(lease_seconds)))
+        .ok_or(AzureError::InvalidTarget)?
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(|_| AzureError::InvalidTarget)
+}
+fn tag_matches(job: &ApiJob, key: &str, expected: &str) -> bool {
+    job.tags.get(key).is_some_and(|value| value == expected)
+}
+fn env_matches(container: &ApiContainer, name: &str, expected: &str) -> bool {
+    container
+        .env
+        .iter()
+        .find(|entry| entry.name == name)
+        .is_some_and(|entry| entry.value.as_deref() == Some(expected))
+}
+fn execution_belongs_to(execution_id: &str, job_resource_id: &str) -> bool {
+    execution_id.len() > job_resource_id.len() + "/executions/".len()
+        && execution_id
+            .get(..job_resource_id.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(job_resource_id))
+        && execution_id[job_resource_id.len()..].starts_with("/executions/")
+}
+fn matches_ci(value: &str, options: &[&str]) -> bool {
+    options.iter().any(|option| value.eq_ignore_ascii_case(option))
+}
+fn valid_immutable_image(value: &str) -> bool {
+    valid_worker_image(value)
+        && value
+            .rsplit_once("@sha256:")
+            .is_some_and(|(_, digest)| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}
+fn valid_deadline(value: &str) -> bool {
+    time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).is_ok()
+}
+fn valid_subscription(value: &str) -> bool {
+    uuid::Uuid::parse_str(value).is_ok()
+}
+fn valid_resource_group(value: &str) -> bool {
+    valid_text(value, 90)
+        && !value.ends_with('.')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._-()".contains(&byte))
+}
+fn valid_location(value: &str) -> bool {
+    valid_text(value, 90) && value.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+}
+fn valid_registry_server(value: &str) -> bool {
+    valid_text(value, 253)
+        && value.contains('.')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+}
+fn valid_arm_id(value: &str) -> bool {
+    value.starts_with("/subscriptions/")
+        && valid_text(value, 2_048)
+        && !value.contains(['?', '#'])
+        && value.bytes().all(|byte| !byte.is_ascii_whitespace())
+}
+fn valid_text(value: &str, maximum: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= maximum
+        && value.trim() == value
+        && value.is_ascii()
+        && !value.chars().any(char::is_control)
+}

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -138,16 +138,16 @@ impl AzureClient {
         };
         let worker = match worker_from_job(&job, workflow_id, job_id, target, &self.profile) {
             Ok(worker) => worker,
-            Err(error) if created => return self.cleanup_creation_failure(&name, workflow_id, job_id, error),
+            Err(error) if created => return self.cleanup_creation_failure(&name, None, error),
             Err(error) => return Err(error),
         };
         if !recovered_deadline_valid(&worker.delete_after, target.lease_seconds) {
-            return self.cleanup_creation_failure(&name, workflow_id, job_id, AzureError::ResourceIdentityMismatch);
+            return self.cleanup_creation_failure(&name, Some(&worker), AzureError::ResourceIdentityMismatch);
         }
         if created && !job.ready_to_start() {
             job = match self.await_created_job(&worker) {
                 Ok(job) => job,
-                Err(error) => return self.cleanup_creation_failure(&name, workflow_id, job_id, error),
+                Err(error) => return self.cleanup_creation_failure(&name, Some(&worker), error),
             };
         }
         let result = (|| {
@@ -164,7 +164,7 @@ impl AzureClient {
         let status = match result {
             Ok(status) => status,
             Err(error) if created || matches!(&error, AzureError::HourlyCostRejected { .. }) => {
-                return self.cleanup_creation_failure(&name, workflow_id, job_id, error);
+                return self.cleanup_creation_failure(&name, Some(&worker), error);
             }
             Err(error) => return Err(error),
         };
@@ -224,7 +224,9 @@ impl AzureClient {
         let name = worker.name.as_str();
         for delay_millis in [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000] {
             std::thread::sleep(std::time::Duration::from_millis(delay_millis));
-            let job = self.transport.get(name)?.ok_or(AzureError::ResourceIdentityMismatch)?;
+            let Some(job) = self.transport.get(name)? else {
+                continue;
+            };
             status_from_resource(&job, worker, None)?;
             if job.ready_to_start() {
                 return Ok(job);
@@ -237,20 +239,22 @@ impl AzureClient {
     fn cleanup_creation_failure<T>(
         &self,
         name: &str,
-        workflow_id: CloudWorkflowId,
-        job_id: CloudJobId,
+        worker: Option<&AzureWorker>,
         error: AzureError,
     ) -> Result<T, AzureError> {
-        let owned = self
-            .transport
-            .get(name)
-            .ok()
-            .flatten()
-            .is_some_and(|job| basic_identity_matches(&job, workflow_id, job_id, &self.profile));
-        if !owned || self.transport.delete(name).is_err() {
-            return Err(AzureError::CleanupFailed {
-                resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
-            });
+        let cleanup_failed = || AzureError::CleanupFailed {
+            resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
+        };
+        let Some(worker) = worker else {
+            return Err(cleanup_failed());
+        };
+        let job = match self.transport.get(name) {
+            Ok(Some(job)) => job,
+            Ok(None) => return Err(error),
+            Err(_) => return Err(cleanup_failed()),
+        };
+        if status_from_resource(&job, worker, None).is_err() || self.transport.delete(name).is_err() {
+            return Err(cleanup_failed());
         }
         for delay_millis in [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000] {
             std::thread::sleep(std::time::Duration::from_millis(delay_millis));
@@ -258,9 +262,7 @@ impl AzureClient {
                 return Err(error);
             }
         }
-        Err(AzureError::CleanupFailed {
-            resource_id: resource_id(&self.profile.subscription_id, &self.profile.resource_group, name),
-        })
+        Err(cleanup_failed())
     }
     #[cfg(test)]
     fn with_transport(profile: AzureProfile, transport: impl Transport + 'static) -> Self {
@@ -307,11 +309,6 @@ trait Transport: Send + Sync {
     fn start(&self, name: &str) -> Result<Option<ApiExecution>, AzureError>;
     fn delete(&self, name: &str) -> Result<AzureCleanup, AzureError>;
 }
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-struct Registry {
-    server: String,
-    identity: String,
-}
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 struct ApiJob {
@@ -352,7 +349,7 @@ struct ApiConfiguration {
     replica_retry_limit: u32,
     trigger_type: String,
     manual_trigger_config: ApiManualTriggerConfig,
-    registries: Option<Vec<Registry>>,
+    registries: Option<Vec<serde_json::Value>>,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -1,9 +1,11 @@
 //! Azure Container Apps Jobs lifecycle adapter for durable cloud work.
 use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget, validation::valid_worker_image};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt};
+use std::fmt;
 use thiserror::Error;
 mod http;
+mod model;
+use model::{ApiExecution, ApiJob, CreateJobRequest, create_request, status_from_resource, worker_from_job};
 #[cfg(test)]
 mod tests;
 const OWNER_TAG: &str = "horizon-owned-by";
@@ -22,6 +24,7 @@ const MIN_LEASE_SECONDS: u32 = 300;
 const MAX_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
 const LEASE_CLOCK_SKEW_SECONDS: i64 = 120;
 const CONSUMPTION_PROFILE: &str = "Consumption";
+const JOB_POLL_BACKOFF_MS: [u64; 8] = [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000];
 #[derive(Clone)]
 pub struct AzureAccessToken(String);
 impl AzureAccessToken {
@@ -210,27 +213,20 @@ impl AzureClient {
         Ok(executions.into_iter().next())
     }
     fn execution_for(&self, job: &ApiJob, resource_id: &str) -> Result<Option<ApiExecution>, AzureError> {
-        if job.ready_to_start() {
-            self.single_execution(&job.name, resource_id)
-        } else {
-            Ok(None)
+        if !job.ready_to_start() {
+            return Ok(None);
         }
+        self.single_execution(&job.name, resource_id)
     }
     fn await_created_job(&self, worker: &AzureWorker) -> Result<ApiJob, AzureError> {
-        let name = worker.name.as_str();
-        for delay_millis in [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000] {
-            std::thread::sleep(std::time::Duration::from_millis(delay_millis));
-            let Some(job) = self.transport.get(name)? else {
-                continue;
-            };
-            status_from_resource(&job, worker, None)?;
-            if job.ready_to_start() {
-                return Ok(job);
-            }
-        }
-        Err(AzureError::RequestFailed {
-            operation: "job provisioning",
-        })
+        await_job(
+            || self.transport.get(&worker.name),
+            |job| {
+                status_from_resource(job, worker, None)?;
+                Ok(job.ready_to_start())
+            },
+            "job provisioning",
+        )
     }
     fn cleanup_creation_failure<T>(
         &self,
@@ -252,7 +248,7 @@ impl AzureClient {
         if status_from_resource(&job, worker, None).is_err() || self.transport.delete(name).is_err() {
             return Err(cleanup_failed());
         }
-        for delay_millis in [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000] {
+        for delay_millis in JOB_POLL_BACKOFF_MS {
             std::thread::sleep(std::time::Duration::from_millis(delay_millis));
             if matches!(self.transport.get(name), Ok(None)) {
                 return Err(error);
@@ -262,11 +258,24 @@ impl AzureClient {
     }
     #[cfg(test)]
     fn with_transport(profile: AzureProfile, transport: impl Transport + 'static) -> Self {
-        Self {
-            profile,
-            transport: Box::new(transport),
+        let transport = Box::new(transport);
+        Self { profile, transport }
+    }
+}
+fn await_job(
+    mut inspect: impl FnMut() -> Result<Option<ApiJob>, AzureError>,
+    mut ready: impl FnMut(&ApiJob) -> Result<bool, AzureError>,
+    operation: &'static str,
+) -> Result<ApiJob, AzureError> {
+    for delay_millis in JOB_POLL_BACKOFF_MS {
+        std::thread::sleep(std::time::Duration::from_millis(delay_millis));
+        if let Some(job) = inspect()?
+            && ready(&job)?
+        {
+            return Ok(job);
         }
     }
+    Err(AzureError::RequestFailed { operation })
 }
 #[derive(Debug, Error, Eq, PartialEq)]
 pub enum AzureError {
@@ -288,12 +297,11 @@ pub enum AzureError {
     UnexpectedStatus { operation: &'static str, status: u16 },
     #[error("Azure returned a malformed response during {operation}")]
     InvalidResponse { operation: &'static str },
-    #[error("Azure worker operation failed and exact cleanup also failed")]
+    #[error("Azure worker operation failed and exact cleanup also failed for {resource_id}")]
     CleanupFailed { resource_id: String },
     #[error("Azure hourly cost {actual} exceeded configured maximum {maximum}")]
     HourlyCostRejected { actual: u64, maximum: u64 },
 }
-type CreateJobRequest = serde_json::Value;
 struct CreateResult {
     job: ApiJob,
     created: bool,
@@ -305,132 +313,10 @@ trait Transport: Send + Sync {
     fn start(&self, name: &str) -> Result<Option<ApiExecution>, AzureError>;
     fn delete(&self, name: &str) -> Result<AzureCleanup, AzureError>;
 }
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiJob {
-    id: String,
-    name: String,
-    location: String,
-    tags: BTreeMap<String, String>,
-    identity: Option<ApiIdentity>,
-    properties: ApiProperties,
-}
-impl ApiJob {
-    fn ready_to_start(&self) -> bool {
-        self.properties
-            .provisioning_state
-            .as_deref()
-            .is_some_and(|state| state.eq_ignore_ascii_case("Succeeded"))
-    }
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiIdentity {
-    #[serde(rename = "type")]
-    kind: String,
-    user_assigned_identities: BTreeMap<String, serde_json::Value>,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiProperties {
-    environment_id: String,
-    workload_profile_name: String,
-    provisioning_state: Option<String>,
-    configuration: ApiConfiguration,
-    template: ApiTemplate,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiConfiguration {
-    replica_timeout: u32,
-    replica_retry_limit: u32,
-    trigger_type: String,
-    manual_trigger_config: ApiManualTriggerConfig,
-    registries: Option<Vec<serde_json::Value>>,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiManualTriggerConfig {
-    parallelism: u32,
-    replica_completion_count: u32,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-struct ApiTemplate {
-    containers: Option<Vec<ApiContainer>>,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-struct ApiContainer {
-    name: String,
-    image: String,
-    env: Vec<ApiEnv>,
-    resources: ApiResources,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-struct ApiResources {
-    cpu: f64,
-    memory: String,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiEnv {
-    name: String,
-    value: Option<String>,
-    secret_ref: Option<String>,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-struct ApiExecution {
-    id: String,
-    properties: ApiExecutionProperties,
-}
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct ApiExecutionProperties {
-    status: Option<String>,
-}
-fn create_request(
-    workflow_id: CloudWorkflowId,
-    job_id: CloudJobId,
-    target: &WorkerTarget,
-    profile: &AzureProfile,
-) -> Result<CreateJobRequest, AzureError> {
-    let deadline = deletion_deadline(target.lease_seconds)?;
-    let tags = serde_json::json!({
-        OWNER_TAG: "horizon", WORKFLOW_TAG: workflow_id.to_string(), JOB_TAG: job_id.to_string(),
-        PROTOCOL_TAG: super::CLOUD_RUN_PROTOCOL_VERSION.to_string(), PROFILE_TAG: profile.name,
-        DEADLINE_TAG: deadline, COST_TAG: profile.hourly_cost_micros.to_string(),
-        DISK_TAG: target.disk_gib.to_string()
-    });
-    let env = serde_json::json!([
-        {"name": WORKFLOW_ENV, "value": workflow_id.to_string()},
-        {"name": JOB_ENV, "value": job_id.to_string()},
-        {"name": PROTOCOL_ENV, "value": super::CLOUD_RUN_PROTOCOL_VERSION.to_string()},
-        {"name": TERMINATE_ENV, "value": deadline}
-    ]);
-    let properties = serde_json::json!({
-        "environmentId": profile.environment_id, "workloadProfileName": CONSUMPTION_PROFILE,
-        "configuration": {
-            "triggerType": "Manual", "replicaTimeout": target.lease_seconds, "replicaRetryLimit": 0,
-            "manualTriggerConfig": {"parallelism": 1, "replicaCompletionCount": 1},
-            "registries": [], "identitySettings": []
-        },
-        "template": {"containers": [{
-            "name": "worker", "image": target.image, "env": env,
-            "resources": {"cpu": f64::from(profile.cpu_millicores) / 1_000.0,
-                          "memory": format!("{:.2}Gi", f64::from(profile.memory_mib) / 1_024.0)}
-        }]}
-    });
-    Ok(serde_json::json!({
-        "location": profile.location, "tags": tags, "identity": {"type": "None"}, "properties": properties
-    }))
-}
 fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
     let prefix = format!("/subscriptions/{}/", profile.subscription_id);
     let valid = valid_text(&profile.name, 191)
-        && valid_subscription(&profile.subscription_id)
+        && uuid::Uuid::parse_str(&profile.subscription_id).is_ok()
         && valid_resource_group(&profile.resource_group)
         && valid_arm_id(&profile.environment_id)
         && profile
@@ -456,144 +342,12 @@ fn validate_target(target: &WorkerTarget, profile: &AzureProfile) -> Result<(), 
     valid.then_some(()).ok_or(AzureError::InvalidTarget)
 }
 fn enforce_cost(target: &WorkerTarget, actual: u64) -> Result<(), AzureError> {
-    let Some(maximum) = target.max_hourly_cost_micros else {
-        return Ok(());
-    };
-    if actual > maximum {
-        return Err(AzureError::HourlyCostRejected { actual, maximum });
+    let maximum = target.max_hourly_cost_micros.ok_or(AzureError::InvalidTarget)?;
+    if actual <= maximum {
+        Ok(())
+    } else {
+        Err(AzureError::HourlyCostRejected { actual, maximum })
     }
-    Ok(())
-}
-fn worker_from_job(
-    job: &ApiJob,
-    workflow_id: CloudWorkflowId,
-    job_id: CloudJobId,
-    target: &WorkerTarget,
-    profile: &AzureProfile,
-) -> Result<AzureWorker, AzureError> {
-    if !basic_identity_matches(job, workflow_id, job_id, profile)
-        || !tag_matches(job, PROFILE_TAG, &profile.name)
-        || !tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
-        || !tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
-        || !job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
-        || !job_configuration_matches(job, &target.image, target.lease_seconds, profile)
-    {
-        return Err(AzureError::ResourceIdentityMismatch);
-    }
-    let delete_after = job
-        .tags
-        .get(DEADLINE_TAG)
-        .filter(|value| valid_deadline(value))
-        .cloned()
-        .ok_or(AzureError::ResourceIdentityMismatch)?;
-    let worker = AzureWorker {
-        workflow_id,
-        job_id,
-        resource_id: resource_id(&profile.subscription_id, &profile.resource_group, &job.name),
-        name: job.name.clone(),
-        target: target.clone(),
-        profile: profile.clone(),
-        delete_after,
-    };
-    worker.validate()?;
-    Ok(worker)
-}
-fn status_from_resource(
-    job: &ApiJob,
-    worker: &AzureWorker,
-    execution: Option<&ApiExecution>,
-) -> Result<AzureWorkerStatus, AzureError> {
-    worker.validate()?;
-    let containers = job.properties.template.containers.as_deref().unwrap_or_default();
-    let (target, profile) = (&worker.target, &worker.profile);
-    let owned = basic_identity_matches(job, worker.workflow_id, worker.job_id, profile)
-        && job.id.eq_ignore_ascii_case(&worker.resource_id)
-        && job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
-        && job
-            .properties
-            .environment_id
-            .eq_ignore_ascii_case(&profile.environment_id)
-        && job_configuration_matches(job, &target.image, target.lease_seconds, profile)
-        && tag_matches(job, PROFILE_TAG, &profile.name)
-        && tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
-        && tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
-        && tag_matches(job, DEADLINE_TAG, &worker.delete_after)
-        && containers.len() == 1
-        && env_matches(&containers[0], WORKFLOW_ENV, &worker.workflow_id.to_string())
-        && env_matches(&containers[0], JOB_ENV, &worker.job_id.to_string())
-        && env_matches(
-            &containers[0],
-            PROTOCOL_ENV,
-            &super::CLOUD_RUN_PROTOCOL_VERSION.to_string(),
-        )
-        && env_matches(&containers[0], TERMINATE_ENV, &worker.delete_after);
-    if !owned {
-        return Err(AzureError::ResourceIdentityMismatch);
-    }
-    if let Some(execution) = execution
-        && !execution_belongs_to(&execution.id, &worker.resource_id)
-    {
-        return Err(AzureError::ResourceIdentityMismatch);
-    }
-    Ok(AzureWorkerStatus {
-        worker: worker.clone(),
-        lifecycle: lifecycle(job, execution),
-        execution_id: execution.map(|value| value.id.clone()),
-    })
-}
-fn lifecycle(job: &ApiJob, execution: Option<&ApiExecution>) -> AzureLifecycle {
-    let Some(execution) = execution else {
-        return match job.properties.provisioning_state.as_deref() {
-            Some(state) if matches_ci(state, &["Failed", "Canceled"]) => AzureLifecycle::Failed,
-            Some(state) if state.eq_ignore_ascii_case("Deleting") => AzureLifecycle::Stopped,
-            Some(_) => AzureLifecycle::Provisioning,
-            None => AzureLifecycle::Unknown,
-        };
-    };
-    match execution.properties.status.as_deref() {
-        Some(state) if matches_ci(state, &["Running", "Processing"]) => AzureLifecycle::Running,
-        Some(state) if state.eq_ignore_ascii_case("Succeeded") => AzureLifecycle::Succeeded,
-        Some(state) if matches_ci(state, &["Failed", "Degraded"]) => AzureLifecycle::Failed,
-        Some(state) if state.eq_ignore_ascii_case("Stopped") => AzureLifecycle::Stopped,
-        Some(_) | None => AzureLifecycle::Unknown,
-    }
-}
-fn basic_identity_matches(
-    job: &ApiJob,
-    workflow_id: CloudWorkflowId,
-    job_id: CloudJobId,
-    profile: &AzureProfile,
-) -> bool {
-    let name = resource_name(workflow_id, job_id);
-    let id = resource_id(&profile.subscription_id, &profile.resource_group, &name);
-    job.name == name
-        && job.id.eq_ignore_ascii_case(&id)
-        && tag_matches(job, OWNER_TAG, "horizon")
-        && tag_matches(job, WORKFLOW_TAG, &workflow_id.to_string())
-        && tag_matches(job, JOB_TAG, &job_id.to_string())
-        && tag_matches(job, PROTOCOL_TAG, &super::CLOUD_RUN_PROTOCOL_VERSION.to_string())
-}
-fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, profile: &AzureProfile) -> bool {
-    let config = &job.properties.configuration;
-    let workload_profile = &job.properties.workload_profile_name;
-    let containers = job.properties.template.containers.as_deref().unwrap_or_default();
-    let public_image = config.registries.as_deref().unwrap_or_default().is_empty()
-        && job.identity.as_ref().is_none_or(|identity| {
-            identity.user_assigned_identities.is_empty()
-                && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
-        });
-    config.trigger_type.eq_ignore_ascii_case("Manual")
-        && workload_profile.eq_ignore_ascii_case(CONSUMPTION_PROFILE)
-        && config.replica_timeout == lease_seconds
-        && config.replica_retry_limit == 0
-        && config.manual_trigger_config.parallelism == 1
-        && config.manual_trigger_config.replica_completion_count == 1
-        && containers.len() == 1
-        && containers[0].name == "worker"
-        && containers[0].image == image
-        && (containers[0].resources.cpu - f64::from(profile.cpu_millicores) / 1_000.0).abs() < f64::EPSILON
-        && memory_matches(&containers[0].resources.memory, profile.memory_mib)
-        && public_image
 }
 fn resource_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {
     let workflow = workflow_id.to_string().replace('-', "");
@@ -621,32 +375,6 @@ fn recovered_deadline_valid(value: &str, lease_seconds: u32) -> bool {
 fn ephemeral_disk_limit(cpu_millicores: u32) -> u32 {
     (cpu_millicores / 250).checked_next_power_of_two().unwrap_or(8).min(8)
 }
-fn memory_matches(value: &str, expected_mib: u32) -> bool {
-    value
-        .strip_suffix("Gi")
-        .and_then(|amount| amount.parse::<f64>().ok())
-        .is_some_and(|amount| (amount - f64::from(expected_mib) / 1_024.0).abs() < f64::EPSILON)
-}
-fn tag_matches(job: &ApiJob, key: &str, expected: &str) -> bool {
-    job.tags.get(key).is_some_and(|value| value == expected)
-}
-fn env_matches(container: &ApiContainer, name: &str, expected: &str) -> bool {
-    let mut entries = container.env.iter().filter(|entry| entry.name == name);
-    entries
-        .next()
-        .is_some_and(|entry| entry.value.as_deref() == Some(expected) && entry.secret_ref.is_none())
-        && entries.next().is_none()
-}
-fn execution_belongs_to(execution_id: &str, job_resource_id: &str) -> bool {
-    execution_id.len() > job_resource_id.len() + "/executions/".len()
-        && execution_id
-            .get(..job_resource_id.len())
-            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(job_resource_id))
-        && execution_id[job_resource_id.len()..].starts_with("/executions/")
-}
-fn matches_ci(value: &str, options: &[&str]) -> bool {
-    options.iter().any(|option| value.eq_ignore_ascii_case(option))
-}
 fn valid_immutable_image(value: &str) -> bool {
     valid_worker_image(value)
         && value
@@ -655,9 +383,6 @@ fn valid_immutable_image(value: &str) -> bool {
 }
 fn valid_deadline(value: &str) -> bool {
     time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).is_ok()
-}
-fn valid_subscription(value: &str) -> bool {
-    uuid::Uuid::parse_str(value).is_ok()
 }
 fn valid_resource_group(value: &str) -> bool {
     valid_text(value, 90)

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -69,14 +69,11 @@ impl AzureWorker {
     /// Rejects malformed or internally inconsistent worker identities.
     pub fn validate(&self) -> Result<(), AzureError> {
         let name = resource_name(self.workflow_id, self.job_id);
+        let expected = resource_id(&self.profile.subscription_id, &self.profile.resource_group, &self.name);
         let valid = self.name == name
             && validate_target(&self.target, &self.profile).is_ok()
             && valid_deadline(&self.delete_after)
-            && self.resource_id.eq_ignore_ascii_case(&resource_id(
-                &self.profile.subscription_id,
-                &self.profile.resource_group,
-                &self.name,
-            ));
+            && self.resource_id.eq_ignore_ascii_case(&expected);
         valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
     }
 }
@@ -197,11 +194,9 @@ impl AzureClient {
     }
     fn validate_scope(&self, worker: &AzureWorker) -> Result<(), AzureError> {
         worker.validate()?;
-        let valid = worker.resource_id.eq_ignore_ascii_case(&resource_id(
-            &self.profile.subscription_id,
-            &self.profile.resource_group,
-            &worker.name,
-        ));
+        let profile = &self.profile;
+        let expected = resource_id(&profile.subscription_id, &profile.resource_group, &worker.name);
+        let valid = worker.resource_id.eq_ignore_ascii_case(&expected);
         valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
     }
     fn single_execution(&self, name: &str, resource_id: &str) -> Result<Option<ApiExecution>, AzureError> {
@@ -383,6 +378,7 @@ struct ApiResources {
 struct ApiEnv {
     name: String,
     value: Option<String>,
+    secret_ref: Option<String>,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
@@ -441,7 +437,8 @@ fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
             .environment_id
             .get(..prefix.len())
             .is_some_and(|value| value.eq_ignore_ascii_case(&prefix))
-        && valid_location(&profile.location)
+        && valid_text(&profile.location, 90)
+        && profile.location.bytes().all(|byte| byte.is_ascii_alphanumeric())
         && (250..=4_000).contains(&profile.cpu_millicores)
         && profile.cpu_millicores.is_multiple_of(250)
         && profile.memory_mib == profile.cpu_millicores / 250 * 512
@@ -511,6 +508,7 @@ fn status_from_resource(
     let (target, profile) = (&worker.target, &worker.profile);
     let owned = basic_identity_matches(job, worker.workflow_id, worker.job_id, profile)
         && job.id.eq_ignore_ascii_case(&worker.resource_id)
+        && job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
         && job
             .properties
             .environment_id
@@ -636,7 +634,7 @@ fn env_matches(container: &ApiContainer, name: &str, expected: &str) -> bool {
     let mut entries = container.env.iter().filter(|entry| entry.name == name);
     entries
         .next()
-        .is_some_and(|entry| entry.value.as_deref() == Some(expected))
+        .is_some_and(|entry| entry.value.as_deref() == Some(expected) && entry.secret_ref.is_none())
         && entries.next().is_none()
 }
 fn execution_belongs_to(execution_id: &str, job_resource_id: &str) -> bool {
@@ -667,9 +665,6 @@ fn valid_resource_group(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || b"._-()".contains(&byte))
-}
-fn valid_location(value: &str) -> bool {
-    valid_text(value, 90) && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 fn valid_arm_id(value: &str) -> bool {
     value.starts_with("/subscriptions/")

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -20,6 +20,7 @@ const PROTOCOL_ENV: &str = "HORIZON_CLOUD_PROTOCOL_VERSION";
 const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
 const MIN_LEASE_SECONDS: u32 = 300;
 const MAX_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
+const LEASE_CLOCK_SKEW_SECONDS: i64 = 120;
 #[derive(Clone)]
 pub struct AzureAccessToken(String);
 impl AzureAccessToken {
@@ -27,12 +28,7 @@ impl AzureAccessToken {
     /// Rejects empty, oversized, whitespace-containing, or non-ASCII tokens.
     pub fn new(value: impl Into<String>) -> Result<Self, AzureError> {
         let value = value.into();
-        let valid = !value.is_empty()
-            && value.len() <= 16_384
-            && value.is_ascii()
-            && value
-                .bytes()
-                .all(|byte| !byte.is_ascii_whitespace() && !byte.is_ascii_control());
+        let valid = valid_text(&value, 16_384) && value.bytes().all(|byte| !byte.is_ascii_whitespace());
         valid.then_some(Self(value)).ok_or(AzureError::InvalidAccessToken)
     }
     pub(super) fn expose(&self) -> &str {
@@ -46,12 +42,6 @@ impl fmt::Debug for AzureAccessToken {
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct AzureRegistry {
-    pub server: String,
-    pub identity_id: String,
-}
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct AzureProfile {
     pub name: String,
     pub subscription_id: String,
@@ -60,10 +50,7 @@ pub struct AzureProfile {
     pub location: String,
     pub cpu_millicores: u32,
     pub memory_mib: u32,
-    pub ephemeral_disk_gib: u32,
     pub hourly_cost_micros: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub registry: Option<AzureRegistry>,
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -155,22 +142,27 @@ impl AzureClient {
         } else {
             enforce_cost(target, self.profile.hourly_cost_micros)?;
             let request = create_request(workflow_id, job_id, target, &self.profile)?;
-            (self.transport.create(&name, &request)?, true)
+            let created = self.transport.create(&name, &request)?;
+            (created.job, created.created)
         };
         let worker = match worker_from_job(&job, workflow_id, job_id, target, &self.profile) {
             Ok(worker) => worker,
             Err(error) if created => return self.cleanup_creation_failure(&name, workflow_id, job_id, error),
             Err(error) => return Err(error),
         };
+        if !recovered_deadline_valid(&worker.delete_after, target.lease_seconds) {
+            return self.cleanup_creation_failure(&name, workflow_id, job_id, AzureError::ResourceIdentityMismatch);
+        }
         let result = (|| {
             enforce_cost(target, worker.hourly_cost_micros)?;
             let existing = self.execution_for(&job, &worker.resource_id)?;
-            let execution = if existing.is_none() && job.ready_to_start() {
+            // The persisted job is the at-most-once fence; retries only reconcile its execution.
+            let execution = if created && existing.is_none() && job.ready_to_start() {
                 self.transport.start(&name)?
             } else {
                 existing
             };
-            status_from_resource(&job, &worker, execution.as_ref())
+            status_from_resource(&job, &worker, execution.as_ref(), &self.profile)
         })();
         let status = match result {
             Ok(status) => status,
@@ -193,7 +185,7 @@ impl AzureClient {
             return Ok(None);
         };
         let execution = self.execution_for(&job, &worker.resource_id)?;
-        status_from_resource(&job, worker, execution.as_ref()).map(Some)
+        status_from_resource(&job, worker, execution.as_ref(), &self.profile).map(Some)
     }
     /// # Errors
     /// Refuses deletion when persisted or provider identity differs.
@@ -202,17 +194,16 @@ impl AzureClient {
         let Some(job) = self.transport.get(&worker.name)? else {
             return Ok(AzureCleanup::AlreadyAbsent);
         };
-        status_from_resource(&job, worker, None)?;
+        status_from_resource(&job, worker, None, &self.profile)?;
         self.transport.delete(&worker.name)
     }
     fn validate_scope(&self, worker: &AzureWorker) -> Result<(), AzureError> {
         worker.validate()?;
-        let expected = resource_id(
+        let valid = worker.resource_id.eq_ignore_ascii_case(&resource_id(
             &self.profile.subscription_id,
             &self.profile.resource_group,
             &worker.name,
-        );
-        let valid = worker.resource_id.eq_ignore_ascii_case(&expected);
+        ));
         valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
     }
     fn single_execution(&self, name: &str, resource_id: &str) -> Result<Option<ApiExecution>, AzureError> {
@@ -294,9 +285,13 @@ pub enum AzureError {
     HourlyCostRejected { actual: u64, maximum: u64 },
 }
 type CreateJobRequest = serde_json::Value;
+struct CreateResult {
+    job: ApiJob,
+    created: bool,
+}
 trait Transport: Send + Sync {
     fn get(&self, name: &str) -> Result<Option<ApiJob>, AzureError>;
-    fn create(&self, name: &str, request: &CreateJobRequest) -> Result<ApiJob, AzureError>;
+    fn create(&self, name: &str, request: &CreateJobRequest) -> Result<CreateResult, AzureError>;
     fn executions(&self, name: &str) -> Result<Vec<ApiExecution>, AzureError>;
     fn start(&self, name: &str) -> Result<Option<ApiExecution>, AzureError>;
     fn delete(&self, name: &str) -> Result<AzureCleanup, AzureError>;
@@ -343,8 +338,16 @@ struct ApiProperties {
 #[serde(default, rename_all = "camelCase")]
 struct ApiConfiguration {
     replica_timeout: u32,
+    replica_retry_limit: u32,
     trigger_type: String,
+    manual_trigger_config: ApiManualTriggerConfig,
     registries: Option<Vec<Registry>>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ApiManualTriggerConfig {
+    parallelism: u32,
+    replica_completion_count: u32,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
@@ -357,6 +360,13 @@ struct ApiContainer {
     name: String,
     image: String,
     env: Vec<ApiEnv>,
+    resources: ApiResources,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct ApiResources {
+    cpu: f64,
+    memory: String,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -394,24 +404,12 @@ fn create_request(
         {"name": PROTOCOL_ENV, "value": super::CLOUD_RUN_PROTOCOL_VERSION.to_string()},
         {"name": TERMINATE_ENV, "value": deadline}
     ]);
-    let (identity, registries, identity_settings) = profile.registry.as_ref().map_or_else(
-        || (serde_json::json!({"type": "None"}), Vec::new(), Vec::new()),
-        |registry| {
-            (
-                serde_json::json!({
-                    "type": "UserAssigned", "userAssignedIdentities": {&registry.identity_id: {}}
-                }),
-                vec![serde_json::json!({"server": registry.server, "identity": registry.identity_id})],
-                vec![serde_json::json!({"identity": registry.identity_id, "lifecycle": "None"})],
-            )
-        },
-    );
     let properties = serde_json::json!({
         "environmentId": profile.environment_id,
         "configuration": {
             "triggerType": "Manual", "replicaTimeout": target.lease_seconds, "replicaRetryLimit": 0,
             "manualTriggerConfig": {"parallelism": 1, "replicaCompletionCount": 1},
-            "registries": registries, "identitySettings": identity_settings
+            "registries": [], "identitySettings": []
         },
         "template": {"containers": [{
             "name": "worker", "image": target.image, "env": env,
@@ -420,7 +418,7 @@ fn create_request(
         }]}
     });
     Ok(serde_json::json!({
-        "location": profile.location, "tags": tags, "identity": identity, "properties": properties
+        "location": profile.location, "tags": tags, "identity": {"type": "None"}, "properties": properties
     }))
 }
 fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
@@ -438,29 +436,17 @@ fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
         && profile.cpu_millicores.is_multiple_of(250)
         && profile.memory_mib >= 512
         && profile.memory_mib.is_multiple_of(256)
-        && profile.ephemeral_disk_gib > 0
-        && profile.hourly_cost_micros > 0
-        && profile
-            .registry
-            .as_ref()
-            .is_none_or(|registry| valid_registry_server(&registry.server) && valid_arm_id(&registry.identity_id));
+        && profile.hourly_cost_micros > 0;
     valid.then_some(()).ok_or(AzureError::InvalidProfile)
 }
 fn validate_target(target: &WorkerTarget, profile: &AzureProfile) -> Result<(), AzureError> {
     validate_profile(profile)?;
-    let registry_matches = profile.registry.as_ref().is_none_or(|registry| {
-        target
-            .image
-            .split_once('/')
-            .is_some_and(|(server, _)| server.eq_ignore_ascii_case(&registry.server))
-    });
     let valid = target.provider == CloudProvider::Azure
         && target.profile == profile.name
-        && (1..=profile.ephemeral_disk_gib).contains(&target.disk_gib)
+        && (1..=ephemeral_disk_limit(profile.cpu_millicores)).contains(&target.disk_gib)
         && (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&target.lease_seconds)
-        && target.max_hourly_cost_micros != Some(0)
-        && valid_immutable_image(&target.image)
-        && registry_matches;
+        && target.max_hourly_cost_micros.is_some_and(|maximum| maximum > 0)
+        && valid_immutable_image(&target.image);
     valid.then_some(()).ok_or(AzureError::InvalidTarget)
 }
 fn enforce_cost(target: &WorkerTarget, actual: u64) -> Result<(), AzureError> {
@@ -484,7 +470,7 @@ fn worker_from_job(
         || !tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
         || !tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
         || !job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
-        || !job_configuration_matches(job, target, profile)
+        || !job_configuration_matches(job, &target.image, target.lease_seconds, profile)
     {
         return Err(AzureError::ResourceIdentityMismatch);
     }
@@ -514,27 +500,22 @@ fn status_from_resource(
     job: &ApiJob,
     worker: &AzureWorker,
     execution: Option<&ApiExecution>,
+    profile: &AzureProfile,
 ) -> Result<AzureWorkerStatus, AzureError> {
     worker.validate()?;
     let containers = job.properties.template.containers.as_deref().unwrap_or_default();
-    let owned = job.id.eq_ignore_ascii_case(&worker.resource_id)
-        && job.name == worker.name
+    let owned = basic_identity_matches(job, worker.workflow_id, worker.job_id, profile)
+        && job.id.eq_ignore_ascii_case(&worker.resource_id)
         && job
             .properties
             .environment_id
             .eq_ignore_ascii_case(&worker.environment_id)
-        && job.properties.configuration.replica_timeout == worker.lease_seconds
-        && tag_matches(job, OWNER_TAG, "horizon")
-        && tag_matches(job, WORKFLOW_TAG, &worker.workflow_id.to_string())
-        && tag_matches(job, JOB_TAG, &worker.job_id.to_string())
-        && tag_matches(job, PROTOCOL_TAG, &super::CLOUD_RUN_PROTOCOL_VERSION.to_string())
+        && job_configuration_matches(job, &worker.image, worker.lease_seconds, profile)
         && tag_matches(job, PROFILE_TAG, &worker.profile)
         && tag_matches(job, DISK_TAG, &worker.disk_gib.to_string())
         && tag_matches(job, COST_TAG, &worker.hourly_cost_micros.to_string())
         && tag_matches(job, DEADLINE_TAG, &worker.delete_after)
         && containers.len() == 1
-        && containers[0].name == "worker"
-        && containers[0].image == worker.image
         && env_matches(&containers[0], WORKFLOW_ENV, &worker.workflow_id.to_string())
         && env_matches(&containers[0], JOB_ENV, &worker.job_id.to_string())
         && env_matches(
@@ -581,48 +562,33 @@ fn basic_identity_matches(
     profile: &AzureProfile,
 ) -> bool {
     let name = resource_name(workflow_id, job_id);
+    let id = resource_id(&profile.subscription_id, &profile.resource_group, &name);
     job.name == name
-        && job
-            .id
-            .eq_ignore_ascii_case(&resource_id(&profile.subscription_id, &profile.resource_group, &name))
+        && job.id.eq_ignore_ascii_case(&id)
         && tag_matches(job, OWNER_TAG, "horizon")
         && tag_matches(job, WORKFLOW_TAG, &workflow_id.to_string())
         && tag_matches(job, JOB_TAG, &job_id.to_string())
         && tag_matches(job, PROTOCOL_TAG, &super::CLOUD_RUN_PROTOCOL_VERSION.to_string())
 }
-fn job_configuration_matches(job: &ApiJob, target: &WorkerTarget, profile: &AzureProfile) -> bool {
+fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, profile: &AzureProfile) -> bool {
     let config = &job.properties.configuration;
     let containers = job.properties.template.containers.as_deref().unwrap_or_default();
-    let registry_matches = profile.registry.as_ref().map_or_else(
-        || {
-            config.registries.as_deref().unwrap_or_default().is_empty()
-                && job.identity.as_ref().is_none_or(|identity| {
-                    identity.user_assigned_identities.is_empty()
-                        && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
-                })
-        },
-        |registry| {
-            config.registries.as_deref()
-                == Some(&[Registry {
-                    server: registry.server.clone(),
-                    identity: registry.identity_id.clone(),
-                }])
-                && job.identity.as_ref().is_some_and(|identity| {
-                    identity.kind.eq_ignore_ascii_case("UserAssigned")
-                        && identity.user_assigned_identities.len() == 1
-                        && identity
-                            .user_assigned_identities
-                            .keys()
-                            .any(|id| id.eq_ignore_ascii_case(&registry.identity_id))
-                })
-        },
-    );
+    let public_image = config.registries.as_deref().unwrap_or_default().is_empty()
+        && job.identity.as_ref().is_none_or(|identity| {
+            identity.user_assigned_identities.is_empty()
+                && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
+        });
     config.trigger_type.eq_ignore_ascii_case("Manual")
-        && config.replica_timeout == target.lease_seconds
+        && config.replica_timeout == lease_seconds
+        && config.replica_retry_limit == 0
+        && config.manual_trigger_config.parallelism == 1
+        && config.manual_trigger_config.replica_completion_count == 1
         && containers.len() == 1
         && containers[0].name == "worker"
-        && containers[0].image == target.image
-        && registry_matches
+        && containers[0].image == image
+        && (containers[0].resources.cpu - f64::from(profile.cpu_millicores) / 1_000.0).abs() < f64::EPSILON
+        && memory_matches(&containers[0].resources.memory, profile.memory_mib)
+        && public_image
 }
 fn resource_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {
     let workflow = workflow_id.to_string().replace('-', "");
@@ -638,6 +604,23 @@ fn deletion_deadline(lease_seconds: u32) -> Result<String, AzureError> {
         .ok_or(AzureError::InvalidTarget)?
         .format(&time::format_description::well_known::Rfc3339)
         .map_err(|_| AzureError::InvalidTarget)
+}
+fn recovered_deadline_valid(value: &str, lease_seconds: u32) -> bool {
+    let Ok(deadline) = time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339) else {
+        return false;
+    };
+    let now = time::OffsetDateTime::now_utc();
+    deadline >= now - time::Duration::seconds(LEASE_CLOCK_SKEW_SECONDS)
+        && deadline <= now + time::Duration::seconds(i64::from(lease_seconds) + LEASE_CLOCK_SKEW_SECONDS)
+}
+fn ephemeral_disk_limit(cpu_millicores: u32) -> u32 {
+    (cpu_millicores / 250).checked_next_power_of_two().unwrap_or(8).min(8)
+}
+fn memory_matches(value: &str, expected_mib: u32) -> bool {
+    value
+        .strip_suffix("Gi")
+        .and_then(|amount| amount.parse::<f64>().ok())
+        .is_some_and(|amount| (amount - f64::from(expected_mib) / 1_024.0).abs() < f64::EPSILON)
 }
 fn tag_matches(job: &ApiJob, key: &str, expected: &str) -> bool {
     job.tags.get(key).is_some_and(|value| value == expected)
@@ -680,13 +663,6 @@ fn valid_resource_group(value: &str) -> bool {
 }
 fn valid_location(value: &str) -> bool {
     valid_text(value, 90) && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
-}
-fn valid_registry_server(value: &str) -> bool {
-    valid_text(value, 253)
-        && value.contains('.')
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
 }
 fn valid_arm_id(value: &str) -> bool {
     value.starts_with("/subscriptions/")

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -65,7 +65,6 @@ pub struct AzureProfile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub registry: Option<AzureRegistry>,
 }
-/// Persistable Azure identity sufficient for recovery and exact cleanup.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AzureWorker {
@@ -128,7 +127,6 @@ pub enum AzureCleanup {
     DeletionPending,
     AlreadyAbsent,
 }
-/// Blocking Azure ARM client. Call it from a worker thread when used by an async UI.
 pub struct AzureClient {
     profile: AzureProfile,
     transport: Box<dyn Transport>,
@@ -346,12 +344,12 @@ struct ApiProperties {
 struct ApiConfiguration {
     replica_timeout: u32,
     trigger_type: String,
-    registries: Vec<Registry>,
+    registries: Option<Vec<Registry>>,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct ApiTemplate {
-    containers: Vec<ApiContainer>,
+    containers: Option<Vec<ApiContainer>>,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
@@ -418,7 +416,7 @@ fn create_request(
         "template": {"containers": [{
             "name": "worker", "image": target.image, "env": env,
             "resources": {"cpu": f64::from(profile.cpu_millicores) / 1_000.0,
-                          "memory": format!("{}Mi", profile.memory_mib)}
+                          "memory": format!("{:.2}Gi", f64::from(profile.memory_mib) / 1_024.0)}
         }]}
     });
     Ok(serde_json::json!({
@@ -439,7 +437,7 @@ fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
         && profile.cpu_millicores >= 250
         && profile.cpu_millicores.is_multiple_of(250)
         && profile.memory_mib >= 512
-        && profile.memory_mib.is_multiple_of(128)
+        && profile.memory_mib.is_multiple_of(256)
         && profile.ephemeral_disk_gib > 0
         && profile.hourly_cost_micros > 0
         && profile
@@ -485,7 +483,7 @@ fn worker_from_job(
         || !tag_matches(job, PROFILE_TAG, &profile.name)
         || !tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
         || !tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
-        || !job.location.eq_ignore_ascii_case(&profile.location)
+        || !job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
         || !job_configuration_matches(job, target, profile)
     {
         return Err(AzureError::ResourceIdentityMismatch);
@@ -518,7 +516,7 @@ fn status_from_resource(
     execution: Option<&ApiExecution>,
 ) -> Result<AzureWorkerStatus, AzureError> {
     worker.validate()?;
-    let containers = job.properties.template.containers.as_slice();
+    let containers = job.properties.template.containers.as_deref().unwrap_or_default();
     let owned = job.id.eq_ignore_ascii_case(&worker.resource_id)
         && job.name == worker.name
         && job
@@ -594,21 +592,21 @@ fn basic_identity_matches(
 }
 fn job_configuration_matches(job: &ApiJob, target: &WorkerTarget, profile: &AzureProfile) -> bool {
     let config = &job.properties.configuration;
-    let containers = job.properties.template.containers.as_slice();
+    let containers = job.properties.template.containers.as_deref().unwrap_or_default();
     let registry_matches = profile.registry.as_ref().map_or_else(
         || {
-            config.registries.is_empty()
+            config.registries.as_deref().unwrap_or_default().is_empty()
                 && job.identity.as_ref().is_none_or(|identity| {
                     identity.user_assigned_identities.is_empty()
                         && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
                 })
         },
         |registry| {
-            config.registries
-                == [Registry {
+            config.registries.as_deref()
+                == Some(&[Registry {
                     server: registry.server.clone(),
                     identity: registry.identity_id.clone(),
-                }]
+                }])
                 && job.identity.as_ref().is_some_and(|identity| {
                     identity.kind.eq_ignore_ascii_case("UserAssigned")
                         && identity.user_assigned_identities.len() == 1
@@ -681,7 +679,7 @@ fn valid_resource_group(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || b"._-()".contains(&byte))
 }
 fn valid_location(value: &str) -> bool {
-    valid_text(value, 90) && value.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    valid_text(value, 90) && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 fn valid_registry_server(value: &str) -> bool {
     valid_text(value, 253)

--- a/crates/horizon-core/src/cloud_run/azure/http.rs
+++ b/crates/horizon-core/src/cloud_run/azure/http.rs
@@ -1,5 +1,6 @@
 use super::{
-    ApiExecution, ApiJob, AzureAccessToken, AzureCleanup, AzureError, AzureProfile, CreateJobRequest, Transport,
+    ApiExecution, ApiJob, AzureAccessToken, AzureCleanup, AzureError, AzureProfile, CreateJobRequest, CreateResult,
+    Transport,
 };
 use std::time::Duration;
 use url::Url;
@@ -61,13 +62,14 @@ impl Transport for AzureHttp {
         }
         decode_json(response, &[200], "job inspection").map(Some)
     }
-    fn create(&self, name: &str, request: &CreateJobRequest) -> Result<ApiJob, AzureError> {
+    fn create(&self, name: &str, request: &CreateJobRequest) -> Result<CreateResult, AzureError> {
         let url = self.job_url(name, None)?;
         let response = self
             .authorize(self.agent.put(url.as_str()))
             .send_json(request)
             .map_err(request_failed("job creation"))?;
-        decode_json(response, &[200, 201], "job creation")
+        let created = response.status().as_u16() == 201;
+        decode_json(response, &[200, 201], "job creation").map(|job| CreateResult { job, created })
     }
     fn executions(&self, name: &str) -> Result<Vec<ApiExecution>, AzureError> {
         let url = self.job_url(name, Some("executions"))?;

--- a/crates/horizon-core/src/cloud_run/azure/http.rs
+++ b/crates/horizon-core/src/cloud_run/azure/http.rs
@@ -1,0 +1,135 @@
+use super::{
+    ApiExecution, ApiJob, AzureAccessToken, AzureCleanup, AzureError, AzureProfile, CreateJobRequest, Transport,
+};
+use std::time::Duration;
+use url::Url;
+const API_VERSION: &str = "2025-07-01";
+const API_BASE: &str = "https://management.azure.com/";
+const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub(super) struct AzureHttp {
+    agent: ureq::Agent,
+    authorization: String,
+    subscription_id: String,
+    resource_group: String,
+}
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExecutionList {
+    value: Vec<ApiExecution>,
+    next_link: Option<String>,
+}
+impl AzureHttp {
+    pub(super) fn new(token: &AzureAccessToken, profile: &AzureProfile) -> Self {
+        let config = ureq::Agent::config_builder()
+            .https_only(true)
+            .http_status_as_error(false)
+            .max_redirects(0)
+            .timeout_global(Some(REQUEST_TIMEOUT))
+            .user_agent(concat!("horizon/", env!("CARGO_PKG_VERSION")))
+            .build();
+        Self {
+            agent: ureq::Agent::new_with_config(config),
+            authorization: format!("Bearer {}", token.expose()),
+            subscription_id: profile.subscription_id.clone(),
+            resource_group: profile.resource_group.clone(),
+        }
+    }
+    fn job_url(&self, name: &str, suffix: Option<&str>) -> Result<Url, AzureError> {
+        let suffix = suffix.map_or_else(String::new, |value| format!("/{value}"));
+        Url::parse(&format!(
+            "{API_BASE}subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/jobs/{name}{suffix}?api-version={API_VERSION}",
+            self.subscription_id, self.resource_group
+        ))
+        .map_err(|_| AzureError::InvalidResponse {
+            operation: "URL construction",
+        })
+    }
+    fn authorize<B>(&self, request: ureq::RequestBuilder<B>) -> ureq::RequestBuilder<B> {
+        request.header("Authorization", &self.authorization)
+    }
+}
+impl Transport for AzureHttp {
+    fn get(&self, name: &str) -> Result<Option<ApiJob>, AzureError> {
+        let url = self.job_url(name, None)?;
+        let response = self
+            .authorize(self.agent.get(url.as_str()))
+            .call()
+            .map_err(request_failed("job inspection"))?;
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        decode_json(response, &[200], "job inspection").map(Some)
+    }
+    fn create(&self, name: &str, request: &CreateJobRequest) -> Result<ApiJob, AzureError> {
+        let url = self.job_url(name, None)?;
+        let response = self
+            .authorize(self.agent.put(url.as_str()))
+            .send_json(request)
+            .map_err(request_failed("job creation"))?;
+        decode_json(response, &[200, 201], "job creation")
+    }
+    fn executions(&self, name: &str) -> Result<Vec<ApiExecution>, AzureError> {
+        let url = self.job_url(name, Some("executions"))?;
+        let response = self
+            .authorize(self.agent.get(url.as_str()))
+            .call()
+            .map_err(request_failed("execution lookup"))?;
+        let result: ExecutionList = decode_json(response, &[200], "execution lookup")?;
+        if result.next_link.is_some() {
+            return Err(AzureError::InvalidResponse {
+                operation: "execution lookup",
+            });
+        }
+        Ok(result.value)
+    }
+    fn start(&self, name: &str) -> Result<Option<ApiExecution>, AzureError> {
+        let url = self.job_url(name, Some("start"))?;
+        let response = self
+            .authorize(self.agent.post(url.as_str()))
+            .send_empty()
+            .map_err(request_failed("job start"))?;
+        if response.status().as_u16() == 202 {
+            return Ok(None);
+        }
+        decode_json(response, &[200], "job start").map(Some)
+    }
+    fn delete(&self, name: &str) -> Result<AzureCleanup, AzureError> {
+        let url = self.job_url(name, None)?;
+        let response = self
+            .authorize(self.agent.delete(url.as_str()))
+            .call()
+            .map_err(request_failed("job deletion"))?;
+        match response.status().as_u16() {
+            200 | 204 => Ok(AzureCleanup::Deleted),
+            202 => Ok(AzureCleanup::DeletionPending),
+            404 => Ok(AzureCleanup::AlreadyAbsent),
+            status => Err(AzureError::UnexpectedStatus {
+                operation: "job deletion",
+                status,
+            }),
+        }
+    }
+}
+fn request_failed(operation: &'static str) -> impl FnOnce(ureq::Error) -> AzureError {
+    move |_| AzureError::RequestFailed { operation }
+}
+fn decode_json<T>(
+    mut response: ureq::http::Response<ureq::Body>,
+    expected: &[u16],
+    operation: &'static str,
+) -> Result<T, AzureError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let status = response.status().as_u16();
+    if !expected.contains(&status) {
+        return Err(AzureError::UnexpectedStatus { operation, status });
+    }
+    response
+        .body_mut()
+        .with_config()
+        .limit(RESPONSE_LIMIT_BYTES)
+        .read_json()
+        .map_err(|_| AzureError::InvalidResponse { operation })
+}

--- a/crates/horizon-core/src/cloud_run/azure/http.rs
+++ b/crates/horizon-core/src/cloud_run/azure/http.rs
@@ -69,9 +69,7 @@ impl Transport for AzureHttp {
             .send_json(request)
             .map_err(request_failed("job creation"))?;
         if response.status().as_u16() == 412 {
-            let job = self.get(name)?.ok_or(AzureError::RequestFailed {
-                operation: "job creation",
-            })?;
+            let job = super::await_job(|| self.get(name), |_| Ok(true), "job creation")?;
             return Ok(CreateResult { job, created: false });
         }
         let created = response.status().as_u16() == 201;

--- a/crates/horizon-core/src/cloud_run/azure/http.rs
+++ b/crates/horizon-core/src/cloud_run/azure/http.rs
@@ -65,9 +65,15 @@ impl Transport for AzureHttp {
     fn create(&self, name: &str, request: &CreateJobRequest) -> Result<CreateResult, AzureError> {
         let url = self.job_url(name, None)?;
         let response = self
-            .authorize(self.agent.put(url.as_str()))
+            .authorize(self.agent.put(url.as_str()).header("If-None-Match", "*"))
             .send_json(request)
             .map_err(request_failed("job creation"))?;
+        if response.status().as_u16() == 412 {
+            let job = self.get(name)?.ok_or(AzureError::RequestFailed {
+                operation: "job creation",
+            })?;
+            return Ok(CreateResult { job, created: false });
+        }
         let created = response.status().as_u16() == 201;
         decode_json(response, &[200, 201], "job creation").map(|job| CreateResult { job, created })
     }

--- a/crates/horizon-core/src/cloud_run/azure/model.rs
+++ b/crates/horizon-core/src/cloud_run/azure/model.rs
@@ -1,0 +1,276 @@
+use super::super::{CloudJobId, CloudWorkflowId, WorkerTarget};
+use super::{
+    AzureError, AzureLifecycle, AzureProfile, AzureWorker, AzureWorkerStatus, CONSUMPTION_PROFILE, COST_TAG,
+    DEADLINE_TAG, DISK_TAG, JOB_ENV, JOB_TAG, OWNER_TAG, PROFILE_TAG, PROTOCOL_ENV, PROTOCOL_TAG, TERMINATE_ENV,
+    WORKFLOW_ENV, WORKFLOW_TAG, resource_id, resource_name, valid_deadline,
+};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+pub(super) type CreateJobRequest = serde_json::Value;
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct ApiJob {
+    pub(super) id: String,
+    pub(super) name: String,
+    pub(super) location: String,
+    pub(super) tags: BTreeMap<String, String>,
+    pub(super) identity: Option<ApiIdentity>,
+    pub(super) properties: ApiProperties,
+}
+impl ApiJob {
+    pub(super) fn ready_to_start(&self) -> bool {
+        self.properties
+            .provisioning_state
+            .as_deref()
+            .is_some_and(|state| state.eq_ignore_ascii_case("Succeeded"))
+    }
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct ApiIdentity {
+    #[serde(rename = "type")]
+    pub(super) kind: String,
+    pub(super) user_assigned_identities: BTreeMap<String, serde_json::Value>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct ApiProperties {
+    pub(super) environment_id: String,
+    pub(super) workload_profile_name: String,
+    pub(super) provisioning_state: Option<String>,
+    pub(super) configuration: ApiConfiguration,
+    pub(super) template: ApiTemplate,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct ApiConfiguration {
+    pub(super) replica_timeout: u32,
+    pub(super) replica_retry_limit: u32,
+    pub(super) trigger_type: String,
+    pub(super) manual_trigger_config: ApiManualTriggerConfig,
+    pub(super) registries: Option<Vec<serde_json::Value>>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct ApiManualTriggerConfig {
+    pub(super) parallelism: u32,
+    pub(super) replica_completion_count: u32,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct ApiTemplate {
+    pub(super) containers: Option<Vec<ApiContainer>>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct ApiContainer {
+    pub(super) name: String,
+    pub(super) image: String,
+    pub(super) env: Vec<ApiEnv>,
+    pub(super) resources: ApiResources,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct ApiResources {
+    pub(super) cpu: f64,
+    pub(super) memory: String,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct ApiEnv {
+    pub(super) name: String,
+    pub(super) value: Option<String>,
+    pub(super) secret_ref: Option<String>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct ApiExecution {
+    pub(super) id: String,
+    pub(super) properties: ApiExecutionProperties,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct ApiExecutionProperties {
+    pub(super) status: Option<String>,
+}
+pub(super) fn create_request(
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    target: &WorkerTarget,
+    profile: &AzureProfile,
+) -> Result<CreateJobRequest, AzureError> {
+    let deadline = super::deletion_deadline(target.lease_seconds)?;
+    let tags = serde_json::json!({
+        OWNER_TAG: "horizon", WORKFLOW_TAG: workflow_id.to_string(), JOB_TAG: job_id.to_string(),
+        PROTOCOL_TAG: super::super::CLOUD_RUN_PROTOCOL_VERSION.to_string(), PROFILE_TAG: profile.name,
+        DEADLINE_TAG: deadline, COST_TAG: profile.hourly_cost_micros.to_string(), DISK_TAG: target.disk_gib.to_string()
+    });
+    let env = serde_json::json!([
+        {"name": WORKFLOW_ENV, "value": workflow_id.to_string()},
+        {"name": JOB_ENV, "value": job_id.to_string()},
+        {"name": PROTOCOL_ENV, "value": super::super::CLOUD_RUN_PROTOCOL_VERSION.to_string()},
+        {"name": TERMINATE_ENV, "value": deadline}
+    ]);
+    let properties = serde_json::json!({
+        "environmentId": profile.environment_id, "workloadProfileName": CONSUMPTION_PROFILE,
+        "configuration": {
+            "triggerType": "Manual", "replicaTimeout": target.lease_seconds, "replicaRetryLimit": 0,
+            "manualTriggerConfig": {"parallelism": 1, "replicaCompletionCount": 1},
+            "registries": [], "identitySettings": []
+        },
+        "template": {"containers": [{
+            "name": "worker", "image": target.image, "env": env,
+            "resources": {"cpu": f64::from(profile.cpu_millicores) / 1_000.0,
+                          "memory": format!("{:.2}Gi", f64::from(profile.memory_mib) / 1_024.0)}
+        }]}
+    });
+    Ok(serde_json::json!({
+        "location": profile.location, "tags": tags, "identity": {"type": "None"}, "properties": properties
+    }))
+}
+pub(super) fn worker_from_job(
+    job: &ApiJob,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    target: &WorkerTarget,
+    profile: &AzureProfile,
+) -> Result<AzureWorker, AzureError> {
+    if !basic_identity_matches(job, workflow_id, job_id, profile)
+        || !tag_matches(job, PROFILE_TAG, &profile.name)
+        || !tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
+        || !tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
+        || !job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
+        || !job_configuration_matches(job, &target.image, target.lease_seconds, profile)
+    {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    let delete_after = job
+        .tags
+        .get(DEADLINE_TAG)
+        .filter(|value| valid_deadline(value))
+        .cloned()
+        .ok_or(AzureError::ResourceIdentityMismatch)?;
+    let worker = AzureWorker {
+        workflow_id,
+        job_id,
+        resource_id: resource_id(&profile.subscription_id, &profile.resource_group, &job.name),
+        name: job.name.clone(),
+        target: target.clone(),
+        profile: profile.clone(),
+        delete_after,
+    };
+    worker.validate()?;
+    Ok(worker)
+}
+pub(super) fn status_from_resource(
+    job: &ApiJob,
+    worker: &AzureWorker,
+    execution: Option<&ApiExecution>,
+) -> Result<AzureWorkerStatus, AzureError> {
+    worker.validate()?;
+    let properties = &job.properties;
+    let containers = properties.template.containers.as_deref().unwrap_or_default();
+    let (target, profile) = (&worker.target, &worker.profile);
+    let protocol = super::super::CLOUD_RUN_PROTOCOL_VERSION.to_string();
+    let owned = basic_identity_matches(job, worker.workflow_id, worker.job_id, profile)
+        && job.id.eq_ignore_ascii_case(&worker.resource_id)
+        && job.location.replace(' ', "").eq_ignore_ascii_case(&profile.location)
+        && properties.environment_id.eq_ignore_ascii_case(&profile.environment_id)
+        && job_configuration_matches(job, &target.image, target.lease_seconds, profile)
+        && tag_matches(job, PROFILE_TAG, &profile.name)
+        && tag_matches(job, DISK_TAG, &target.disk_gib.to_string())
+        && tag_matches(job, COST_TAG, &profile.hourly_cost_micros.to_string())
+        && tag_matches(job, DEADLINE_TAG, &worker.delete_after)
+        && containers.len() == 1
+        && env_matches(&containers[0], WORKFLOW_ENV, &worker.workflow_id.to_string())
+        && env_matches(&containers[0], JOB_ENV, &worker.job_id.to_string())
+        && env_matches(&containers[0], PROTOCOL_ENV, &protocol)
+        && env_matches(&containers[0], TERMINATE_ENV, &worker.delete_after);
+    if !owned {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    if let Some(execution) = execution
+        && !execution_belongs_to(&execution.id, &worker.resource_id)
+    {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    Ok(AzureWorkerStatus {
+        worker: worker.clone(),
+        lifecycle: lifecycle(job, execution),
+        execution_id: execution.map(|value| value.id.clone()),
+    })
+}
+fn lifecycle(job: &ApiJob, execution: Option<&ApiExecution>) -> AzureLifecycle {
+    let Some(execution) = execution else {
+        return match job.properties.provisioning_state.as_deref() {
+            Some(state) if matches_ci(state, &["Failed", "Canceled"]) => AzureLifecycle::Failed,
+            Some(state) if state.eq_ignore_ascii_case("Deleting") => AzureLifecycle::Stopped,
+            Some(_) => AzureLifecycle::Provisioning,
+            None => AzureLifecycle::Unknown,
+        };
+    };
+    match execution.properties.status.as_deref() {
+        Some(state) if matches_ci(state, &["Running", "Processing"]) => AzureLifecycle::Running,
+        Some(state) if state.eq_ignore_ascii_case("Succeeded") => AzureLifecycle::Succeeded,
+        Some(state) if matches_ci(state, &["Failed", "Degraded"]) => AzureLifecycle::Failed,
+        Some(state) if state.eq_ignore_ascii_case("Stopped") => AzureLifecycle::Stopped,
+        Some(_) | None => AzureLifecycle::Unknown,
+    }
+}
+fn basic_identity_matches(
+    job: &ApiJob,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    profile: &AzureProfile,
+) -> bool {
+    let name = resource_name(workflow_id, job_id);
+    let id = resource_id(&profile.subscription_id, &profile.resource_group, &name);
+    job.name == name
+        && job.id.eq_ignore_ascii_case(&id)
+        && tag_matches(job, OWNER_TAG, "horizon")
+        && tag_matches(job, WORKFLOW_TAG, &workflow_id.to_string())
+        && tag_matches(job, JOB_TAG, &job_id.to_string())
+        && tag_matches(job, PROTOCOL_TAG, &super::super::CLOUD_RUN_PROTOCOL_VERSION.to_string())
+}
+fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, profile: &AzureProfile) -> bool {
+    let config = &job.properties.configuration;
+    let workload_profile = &job.properties.workload_profile_name;
+    let containers = job.properties.template.containers.as_deref().unwrap_or_default();
+    let public_image = config.registries.as_deref().unwrap_or_default().is_empty()
+        && job.identity.as_ref().is_none_or(|identity| {
+            identity.user_assigned_identities.is_empty()
+                && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
+        });
+    config.trigger_type.eq_ignore_ascii_case("Manual")
+        && workload_profile.eq_ignore_ascii_case(CONSUMPTION_PROFILE)
+        && config.replica_timeout == lease_seconds
+        && config.replica_retry_limit == 0
+        && config.manual_trigger_config.parallelism == 1
+        && config.manual_trigger_config.replica_completion_count == 1
+        && containers.len() == 1
+        && containers[0].name == "worker"
+        && containers[0].image == image
+        && (containers[0].resources.cpu - f64::from(profile.cpu_millicores) / 1_000.0).abs() < f64::EPSILON
+        && memory_matches(&containers[0].resources.memory, profile.memory_mib)
+        && public_image
+}
+fn memory_matches(value: &str, expected_mib: u32) -> bool {
+    value
+        .strip_suffix("Gi")
+        .and_then(|amount| amount.parse::<f64>().ok())
+        .is_some_and(|amount| (amount - f64::from(expected_mib) / 1_024.0).abs() < f64::EPSILON)
+}
+fn tag_matches(job: &ApiJob, key: &str, expected: &str) -> bool {
+    job.tags.get(key).is_some_and(|value| value == expected)
+}
+fn env_matches(container: &ApiContainer, name: &str, expected: &str) -> bool {
+    let mut entries = container.env.iter().filter(|entry| entry.name == name);
+    entries
+        .next()
+        .is_some_and(|entry| entry.value.as_deref() == Some(expected) && entry.secret_ref.is_none())
+        && entries.next().is_none()
+}
+pub(super) fn execution_belongs_to(execution_id: &str, job_resource_id: &str) -> bool {
+    execution_id.len() > job_resource_id.len() + "/executions/".len()
+        && execution_id
+            .get(..job_resource_id.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(job_resource_id))
+        && execution_id[job_resource_id.len()..].starts_with("/executions/")
+}
+fn matches_ci(value: &str, options: &[&str]) -> bool {
+    options.iter().any(|option| value.eq_ignore_ascii_case(option))
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -103,12 +103,12 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
     assert!(matches!(created, Ok(AzureEnsure::Created(_))));
     let reused = client.ensure_worker(workflow_id, job_id, &target);
     assert!(matches!(reused, Ok(AzureEnsure::Reused(_))));
-    assert_eq!(transport.0.lock().expect("state").requests.len(), 1);
-    transport.0.lock().expect("state").job = None;
-    transport.0.lock().expect("state").create_is_new = false;
-    let raced = client.ensure_worker(workflow_id, job_id, &target);
-    assert!(matches!(raced, Ok(AzureEnsure::Reused(_))));
-    assert_eq!(transport.0.lock().expect("state").starts, 1);
+    let state = transport.0.lock().expect("state");
+    assert_eq!((state.requests.len(), state.starts), (1, 1));
+    drop(state);
+    let mut visibility = [None, Some(job.clone())].into_iter();
+    let adopted = await_job(|| Ok(visibility.next().flatten()), |_| Ok(true), "job creation").expect("adopt winner");
+    assert_eq!(adopted.id, job.id);
 }
 #[test]
 fn validation_and_cost_fail_before_creation() {

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -9,18 +9,22 @@ struct FakeState {
     requests: Vec<CreateJobRequest>,
     executions: Vec<ApiExecution>,
     start_response: Option<ApiExecution>,
+    create_is_new: bool,
     starts: usize,
 }
 impl Transport for FakeTransport {
     fn get(&self, _name: &str) -> Result<Option<ApiJob>, AzureError> {
         Ok(self.0.lock().expect("state").job.clone())
     }
-    fn create(&self, _name: &str, request: &CreateJobRequest) -> Result<ApiJob, AzureError> {
+    fn create(&self, _name: &str, request: &CreateJobRequest) -> Result<CreateResult, AzureError> {
         let mut state = self.0.lock().expect("state");
         state.requests.push(request.clone());
         let job = state.create_response.clone().expect("create response");
         state.job = Some(job.clone());
-        Ok(job)
+        Ok(CreateResult {
+            job,
+            created: state.create_is_new,
+        })
     }
     fn executions(&self, _name: &str) -> Result<Vec<ApiExecution>, AzureError> {
         Ok(self.0.lock().expect("state").executions.clone())
@@ -52,14 +56,7 @@ fn profile() -> AzureProfile {
         location: "swedencentral".to_string(),
         cpu_millicores: 500,
         memory_mib: 1_024,
-        ephemeral_disk_gib: 20,
         hourly_cost_micros: 42_000,
-        registry: Some(AzureRegistry {
-            server: "registry.example".to_string(),
-            identity_id: format!(
-                "/subscriptions/{subscription}/resourceGroups/horizon-workers/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"
-            ),
-        }),
     }
 }
 fn target() -> WorkerTarget {
@@ -68,7 +65,7 @@ fn target() -> WorkerTarget {
         profile: "general-build".to_string(),
         image: "registry.example/build/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             .to_string(),
-        disk_gib: 16,
+        disk_gib: 2,
         lease_seconds: 3_600,
         max_hourly_cost_micros: Some(100_000),
     }
@@ -81,14 +78,6 @@ fn api_job(workflow: CloudWorkflowId, job: CloudJobId, target: &WorkerTarget, pr
     value["properties"]["provisioningState"] = "Succeeded".into();
     serde_json::from_value(value).expect("API job")
 }
-fn execution(job: &ApiJob, status: &str) -> ApiExecution {
-    ApiExecution {
-        id: format!("{}/executions/{}-abcde", job.id, job.name),
-        properties: ApiExecutionProperties {
-            status: Some(status.to_string()),
-        },
-    }
-}
 #[test]
 fn creation_is_bounded_and_retries_reuse_one_execution() {
     let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
@@ -98,7 +87,7 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
     {
         let mut state = transport.0.lock().expect("state");
         state.create_response = Some(job.clone());
-        state.start_response = Some(execution(&job, "Processing"));
+        state.create_is_new = true;
     }
     let client = AzureClient::with_transport(profile, transport.clone());
     let AzureEnsure::Created(status) = client
@@ -107,23 +96,23 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
     else {
         panic!("new worker must be created");
     };
-    assert_eq!(status.lifecycle, AzureLifecycle::Running);
-    assert!(status.execution_id.is_some());
+    assert_eq!(status.lifecycle, AzureLifecycle::Provisioning);
+    assert!(status.execution_id.is_none());
     assert!(matches!(
         client.ensure_worker(workflow_id, job_id, &target),
         Ok(AzureEnsure::Reused(_))
     ));
     let state = transport.0.lock().expect("state");
-    let request = state.requests.first().expect("request");
-    assert_eq!(request["properties"]["configuration"]["replicaTimeout"], 3_600);
-    let resources = &request["properties"]["template"]["containers"][0]["resources"];
-    assert_eq!(resources["memory"], "1.00Gi");
-    assert_eq!(request["identity"]["type"], "UserAssigned");
-    assert_eq!(
-        request["properties"]["configuration"]["identitySettings"][0]["lifecycle"],
-        "None"
-    );
+    assert_eq!(state.requests.len(), 1);
     assert_eq!(state.starts, 1);
+    drop(state);
+    transport.0.lock().expect("state").job = None;
+    transport.0.lock().expect("state").create_is_new = false;
+    assert!(matches!(
+        client.ensure_worker(workflow_id, job_id, &target),
+        Ok(AzureEnsure::Reused(_))
+    ));
+    assert_eq!(transport.0.lock().expect("state").starts, 1);
 }
 #[test]
 fn validation_and_cost_fail_before_creation() {
@@ -131,15 +120,28 @@ fn validation_and_cost_fail_before_creation() {
     let (mut target, profile) = (target(), profile());
     target.max_hourly_cost_micros = Some(41_999);
     let transport = FakeTransport::default();
-    let error = AzureClient::with_transport(profile.clone(), transport.clone())
+    let client = AzureClient::with_transport(profile.clone(), transport.clone());
+    let error = client
         .ensure_worker(workflow_id, job_id, &target)
         .expect_err("cost rejected");
     assert!(matches!(error, AzureError::HourlyCostRejected { .. }));
     assert!(transport.0.lock().expect("state").requests.is_empty());
     target.max_hourly_cost_micros = None;
-    target.disk_gib = 21;
     assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
-    target.disk_gib = 16;
+    target.max_hourly_cost_micros = Some(100_000);
+    target.disk_gib = 3;
+    assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
+    target.disk_gib = 2;
+    for deadline in ["2020-01-01T00:00:00Z", "2999-01-01T00:00:00Z"] {
+        let mut job = api_job(workflow_id, job_id, &target, &profile);
+        job.tags.insert(DEADLINE_TAG.to_string(), deadline.to_string());
+        transport.0.lock().expect("state").job = Some(job);
+        assert_eq!(
+            client.ensure_worker(workflow_id, job_id, &target),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+        assert!(transport.0.lock().expect("state").job.is_none());
+    }
     target.image = "registry.example/build/worker:latest".to_string();
     assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
 }
@@ -149,6 +151,14 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     let (target, profile) = (target(), profile());
     let good = api_job(workflow_id, job_id, &target, &profile);
     let worker = worker_from_job(&good, workflow_id, job_id, &target, &profile).expect("worker");
+    let mut oversized = good.clone();
+    oversized.properties.template.containers.as_mut().expect("containers")[0]
+        .resources
+        .cpu = 1.0;
+    assert_eq!(
+        worker_from_job(&oversized, workflow_id, job_id, &target, &profile),
+        Err(AzureError::ResourceIdentityMismatch)
+    );
     let mut wrong = good.clone();
     wrong.tags.insert(JOB_TAG.to_string(), CloudJobId::new().to_string());
     let transport = FakeTransport::default();

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -116,6 +116,8 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
     let state = transport.0.lock().expect("state");
     let request = state.requests.first().expect("request");
     assert_eq!(request["properties"]["configuration"]["replicaTimeout"], 3_600);
+    let resources = &request["properties"]["template"]["containers"][0]["resources"];
+    assert_eq!(resources["memory"], "1.00Gi");
     assert_eq!(request["identity"]["type"], "UserAssigned");
     assert_eq!(
         request["properties"]["configuration"]["identitySettings"][0]["lifecycle"],

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use AzureCleanup::{AlreadyAbsent, Deleted};
 use std::sync::{Arc, Mutex};
 #[derive(Clone, Default)]
 struct FakeTransport(Arc<Mutex<FakeState>>);
@@ -44,10 +45,7 @@ impl Transport for FakeTransport {
     }
     fn delete(&self, _name: &str) -> Result<AzureCleanup, AzureError> {
         let mut state = self.0.lock().expect("state");
-        Ok(state
-            .job
-            .take()
-            .map_or(AzureCleanup::AlreadyAbsent, |_| AzureCleanup::Deleted))
+        Ok(state.job.take().map_or(AlreadyAbsent, |_| Deleted))
     }
 }
 fn profile() -> AzureProfile {
@@ -82,6 +80,9 @@ fn api_job(workflow: CloudWorkflowId, job: CloudJobId, target: &WorkerTarget, pr
     value["name"] = name.into();
     value["properties"]["provisioningState"] = "Succeeded".into();
     serde_json::from_value(value).expect("API job")
+}
+fn assert_mismatch<T>(result: Result<T, AzureError>) {
+    assert_eq!(result.err(), Some(AzureError::ResourceIdentityMismatch));
 }
 #[test]
 fn creation_is_bounded_and_retries_reuse_one_execution() {
@@ -130,8 +131,7 @@ fn validation_and_cost_fail_before_creation() {
         job.tags.insert(DEADLINE_TAG.to_string(), deadline.to_string());
         job.properties.template.containers.as_mut().expect("containers")[0].env[3].value = Some(deadline.to_string());
         transport.0.lock().expect("state").job = Some(job);
-        let result = client.ensure_worker(workflow_id, job_id, &target);
-        assert_eq!(result, Err(AzureError::ResourceIdentityMismatch));
+        assert_mismatch(client.ensure_worker(workflow_id, job_id, &target));
         assert!(transport.0.lock().expect("state").job.is_none());
     }
     target.image = "registry.example/build/worker:latest".to_string();
@@ -147,10 +147,16 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     let worker = worker_from_job(&good, workflow_id, job_id, &target, &profile).expect("worker");
     let mut wrong_profile = good.clone();
     wrong_profile.properties.workload_profile_name = "Dedicated".to_string();
-    let mismatch = worker_from_job(&wrong_profile, workflow_id, job_id, &target, &profile);
-    assert_eq!(mismatch, Err(AzureError::ResourceIdentityMismatch));
+    assert_mismatch(worker_from_job(&wrong_profile, workflow_id, job_id, &target, &profile));
+    wrong_profile.properties.workload_profile_name = CONSUMPTION_PROFILE.to_string();
+    wrong_profile.location = "eastus".to_string();
+    assert_mismatch(status_from_resource(&wrong_profile, &worker, None));
     let mut wrong = good.clone();
+    wrong.properties.template.containers.as_mut().expect("containers")[0].env[1].secret_ref =
+        Some("job-override".to_string());
+    assert_mismatch(status_from_resource(&wrong, &worker, None));
     let containers = wrong.properties.template.containers.as_mut().expect("containers");
+    containers[0].env[1].secret_ref = None;
     let duplicate = containers[0].env[1].clone();
     containers[0].env.push(duplicate);
     let transport = FakeTransport::default();

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -112,7 +112,7 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
 #[test]
 fn validation_and_cost_fail_before_creation() {
     let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
-    let (mut target, profile) = (target(), profile());
+    let (mut target, mut profile) = (target(), profile());
     target.max_hourly_cost_micros = Some(41_999);
     let transport = FakeTransport::default();
     let client = AzureClient::with_transport(profile.clone(), transport.clone());
@@ -136,6 +136,8 @@ fn validation_and_cost_fail_before_creation() {
     }
     target.image = "registry.example/build/worker:latest".to_string();
     assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
+    (profile.cpu_millicores, profile.memory_mib) = (4_250, 8_704);
+    assert_eq!(validate_profile(&profile), Err(AzureError::InvalidProfile));
 }
 #[test]
 fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
@@ -143,22 +145,21 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     let (target, profile) = (target(), profile());
     let good = api_job(workflow_id, job_id, &target, &profile);
     let worker = worker_from_job(&good, workflow_id, job_id, &target, &profile).expect("worker");
-    let mut oversized = good.clone();
-    let containers = oversized.properties.template.containers.as_mut().expect("containers");
-    containers[0].resources.cpu = 1.0;
-    let mismatch = worker_from_job(&oversized, workflow_id, job_id, &target, &profile);
+    let mut wrong_profile = good.clone();
+    wrong_profile.properties.workload_profile_name = "Dedicated".to_string();
+    let mismatch = worker_from_job(&wrong_profile, workflow_id, job_id, &target, &profile);
     assert_eq!(mismatch, Err(AzureError::ResourceIdentityMismatch));
     let mut wrong = good.clone();
     let containers = wrong.properties.template.containers.as_mut().expect("containers");
     let duplicate = containers[0].env[1].clone();
     containers[0].env.push(duplicate);
     let transport = FakeTransport::default();
-    transport.0.lock().expect("state").job = Some(wrong);
-    let mut edited_profile = profile.clone();
-    edited_profile.cpu_millicores = 750;
-    let client = AzureClient::with_transport(edited_profile, transport.clone());
-    let cleanup = client.cleanup_creation_failure::<()>(&worker.name, Some(&worker), AzureError::InvalidTarget);
-    assert!(matches!(cleanup, Err(AzureError::CleanupFailed { .. })));
+    transport.0.lock().expect("state").create_response = Some(wrong);
+    transport.0.lock().expect("state").create_is_new = true;
+    let client = AzureClient::with_transport(profile, transport.clone());
+    let failed = client.ensure_worker(workflow_id, job_id, &target);
+    assert!(matches!(failed, Err(AzureError::CleanupFailed { .. })));
+    assert_eq!(transport.0.lock().expect("state").starts, 0);
     assert!(transport.0.lock().expect("state").job.is_some());
     transport.0.lock().expect("state").job = Some(good);
     assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::Deleted));

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -1,0 +1,159 @@
+use super::*;
+use std::sync::{Arc, Mutex};
+#[derive(Clone, Default)]
+struct FakeTransport(Arc<Mutex<FakeState>>);
+#[derive(Default)]
+struct FakeState {
+    job: Option<ApiJob>,
+    create_response: Option<ApiJob>,
+    requests: Vec<CreateJobRequest>,
+    executions: Vec<ApiExecution>,
+    start_response: Option<ApiExecution>,
+    starts: usize,
+}
+impl Transport for FakeTransport {
+    fn get(&self, _name: &str) -> Result<Option<ApiJob>, AzureError> {
+        Ok(self.0.lock().expect("state").job.clone())
+    }
+    fn create(&self, _name: &str, request: &CreateJobRequest) -> Result<ApiJob, AzureError> {
+        let mut state = self.0.lock().expect("state");
+        state.requests.push(request.clone());
+        let job = state.create_response.clone().expect("create response");
+        state.job = Some(job.clone());
+        Ok(job)
+    }
+    fn executions(&self, _name: &str) -> Result<Vec<ApiExecution>, AzureError> {
+        Ok(self.0.lock().expect("state").executions.clone())
+    }
+    fn start(&self, _name: &str) -> Result<Option<ApiExecution>, AzureError> {
+        let mut state = self.0.lock().expect("state");
+        state.starts += 1;
+        let execution = state.start_response.clone();
+        state.executions.extend(execution.clone());
+        Ok(execution)
+    }
+    fn delete(&self, _name: &str) -> Result<AzureCleanup, AzureError> {
+        let mut state = self.0.lock().expect("state");
+        if state.job.take().is_none() {
+            return Ok(AzureCleanup::AlreadyAbsent);
+        }
+        Ok(AzureCleanup::Deleted)
+    }
+}
+fn profile() -> AzureProfile {
+    let subscription = "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345";
+    AzureProfile {
+        name: "general-build".to_string(),
+        subscription_id: subscription.to_string(),
+        resource_group: "horizon-workers".to_string(),
+        environment_id: format!(
+            "/subscriptions/{subscription}/resourceGroups/horizon-workers/providers/Microsoft.App/managedEnvironments/shared"
+        ),
+        location: "swedencentral".to_string(),
+        cpu_millicores: 500,
+        memory_mib: 1_024,
+        ephemeral_disk_gib: 20,
+        hourly_cost_micros: 42_000,
+        registry: Some(AzureRegistry {
+            server: "registry.example".to_string(),
+            identity_id: format!(
+                "/subscriptions/{subscription}/resourceGroups/horizon-workers/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"
+            ),
+        }),
+    }
+}
+fn target() -> WorkerTarget {
+    WorkerTarget {
+        provider: CloudProvider::Azure,
+        profile: "general-build".to_string(),
+        image: "registry.example/build/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .to_string(),
+        disk_gib: 16,
+        lease_seconds: 3_600,
+        max_hourly_cost_micros: Some(100_000),
+    }
+}
+fn api_job(workflow: CloudWorkflowId, job: CloudJobId, target: &WorkerTarget, profile: &AzureProfile) -> ApiJob {
+    let mut value = create_request(workflow, job, target, profile).expect("request");
+    let name = resource_name(workflow, job);
+    value["id"] = resource_id(&profile.subscription_id, &profile.resource_group, &name).into();
+    value["name"] = name.into();
+    value["properties"]["provisioningState"] = "Succeeded".into();
+    serde_json::from_value(value).expect("API job")
+}
+fn execution(job: &ApiJob, status: &str) -> ApiExecution {
+    ApiExecution {
+        id: format!("{}/executions/{}-abcde", job.id, job.name),
+        properties: ApiExecutionProperties {
+            status: Some(status.to_string()),
+        },
+    }
+}
+#[test]
+fn creation_is_bounded_and_retries_reuse_one_execution() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let (target, profile) = (target(), profile());
+    let job = api_job(workflow_id, job_id, &target, &profile);
+    let transport = FakeTransport::default();
+    {
+        let mut state = transport.0.lock().expect("state");
+        state.create_response = Some(job.clone());
+        state.start_response = Some(execution(&job, "Processing"));
+    }
+    let client = AzureClient::with_transport(profile, transport.clone());
+    let AzureEnsure::Created(status) = client
+        .ensure_worker(workflow_id, job_id, &target)
+        .expect("created worker")
+    else {
+        panic!("new worker must be created");
+    };
+    assert_eq!(status.lifecycle, AzureLifecycle::Running);
+    assert!(status.execution_id.is_some());
+    assert!(matches!(
+        client.ensure_worker(workflow_id, job_id, &target),
+        Ok(AzureEnsure::Reused(_))
+    ));
+    let state = transport.0.lock().expect("state");
+    let request = state.requests.first().expect("request");
+    assert_eq!(request["properties"]["configuration"]["replicaTimeout"], 3_600);
+    assert_eq!(request["identity"]["type"], "UserAssigned");
+    assert_eq!(
+        request["properties"]["configuration"]["identitySettings"][0]["lifecycle"],
+        "None"
+    );
+    assert_eq!(state.starts, 1);
+}
+#[test]
+fn validation_and_cost_fail_before_creation() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let (mut target, profile) = (target(), profile());
+    target.max_hourly_cost_micros = Some(41_999);
+    let transport = FakeTransport::default();
+    let error = AzureClient::with_transport(profile.clone(), transport.clone())
+        .ensure_worker(workflow_id, job_id, &target)
+        .expect_err("cost rejected");
+    assert!(matches!(error, AzureError::HourlyCostRejected { .. }));
+    assert!(transport.0.lock().expect("state").requests.is_empty());
+    target.max_hourly_cost_micros = None;
+    target.disk_gib = 21;
+    assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
+    target.disk_gib = 16;
+    target.image = "registry.example/build/worker:latest".to_string();
+    assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
+}
+#[test]
+fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let (target, profile) = (target(), profile());
+    let good = api_job(workflow_id, job_id, &target, &profile);
+    let worker = worker_from_job(&good, workflow_id, job_id, &target, &profile).expect("worker");
+    let mut wrong = good.clone();
+    wrong.tags.insert(JOB_TAG.to_string(), CloudJobId::new().to_string());
+    let transport = FakeTransport::default();
+    transport.0.lock().expect("state").job = Some(wrong);
+    let client = AzureClient::with_transport(profile.clone(), transport.clone());
+    assert_eq!(client.delete_worker(&worker), Err(AzureError::ResourceIdentityMismatch));
+    transport.0.lock().expect("state").job = Some(good);
+    assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::Deleted));
+    assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::AlreadyAbsent));
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -9,19 +9,26 @@ struct FakeState {
     job_after_create: Option<ApiJob>,
     requests: Vec<CreateJobRequest>,
     executions: Vec<ApiExecution>,
-    start_response: Option<ApiExecution>,
     create_is_new: bool,
     starts: usize,
 }
 impl Transport for FakeTransport {
     fn get(&self, _name: &str) -> Result<Option<ApiJob>, AzureError> {
-        Ok(self.0.lock().expect("state").job.clone())
+        let mut state = self.0.lock().expect("state");
+        if state.job.is_none()
+            && !state.requests.is_empty()
+            && let Some(job) = state.job_after_create.take()
+        {
+            state.job = Some(job);
+            return Ok(None);
+        }
+        Ok(state.job.clone())
     }
     fn create(&self, _name: &str, request: &CreateJobRequest) -> Result<CreateResult, AzureError> {
         let mut state = self.0.lock().expect("state");
         state.requests.push(request.clone());
         let job = state.create_response.clone().expect("create response");
-        state.job = Some(state.job_after_create.clone().unwrap_or_else(|| job.clone()));
+        state.job = state.job_after_create.is_none().then(|| job.clone());
         Ok(CreateResult {
             job,
             created: state.create_is_new,
@@ -33,16 +40,14 @@ impl Transport for FakeTransport {
     fn start(&self, _name: &str) -> Result<Option<ApiExecution>, AzureError> {
         let mut state = self.0.lock().expect("state");
         state.starts += 1;
-        let execution = state.start_response.clone();
-        state.executions.extend(execution.clone());
-        Ok(execution)
+        Ok(None)
     }
     fn delete(&self, _name: &str) -> Result<AzureCleanup, AzureError> {
         let mut state = self.0.lock().expect("state");
-        if state.job.take().is_none() {
-            return Ok(AzureCleanup::AlreadyAbsent);
-        }
-        Ok(AzureCleanup::Deleted)
+        Ok(state
+            .job
+            .take()
+            .map_or(AzureCleanup::AlreadyAbsent, |_| AzureCleanup::Deleted))
     }
 }
 fn profile() -> AzureProfile {
@@ -64,8 +69,7 @@ fn target() -> WorkerTarget {
     WorkerTarget {
         provider: CloudProvider::Azure,
         profile: "general-build".to_string(),
-        image: "registry.example/build/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            .to_string(),
+        image: format!("registry.example/build/worker@sha256:{}", "a".repeat(64)),
         disk_gib: 2,
         lease_seconds: 3_600,
         max_hourly_cost_micros: Some(100_000),
@@ -94,19 +98,11 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
         state.create_is_new = true;
     }
     let client = AzureClient::with_transport(profile, transport.clone());
-    let AzureEnsure::Created(status) = client
-        .ensure_worker(workflow_id, job_id, &target)
-        .expect("created worker")
-    else {
-        panic!("new worker must be created");
-    };
-    assert_eq!(status.lifecycle, AzureLifecycle::Provisioning);
+    let created = client.ensure_worker(workflow_id, job_id, &target);
+    assert!(matches!(created, Ok(AzureEnsure::Created(_))));
     let reused = client.ensure_worker(workflow_id, job_id, &target);
     assert!(matches!(reused, Ok(AzureEnsure::Reused(_))));
-    let state = transport.0.lock().expect("state");
-    assert_eq!(state.requests.len(), 1);
-    assert_eq!(state.starts, 1);
-    drop(state);
+    assert_eq!(transport.0.lock().expect("state").requests.len(), 1);
     transport.0.lock().expect("state").job = None;
     transport.0.lock().expect("state").create_is_new = false;
     let raced = client.ensure_worker(workflow_id, job_id, &target);
@@ -120,10 +116,8 @@ fn validation_and_cost_fail_before_creation() {
     target.max_hourly_cost_micros = Some(41_999);
     let transport = FakeTransport::default();
     let client = AzureClient::with_transport(profile.clone(), transport.clone());
-    let error = client
-        .ensure_worker(workflow_id, job_id, &target)
-        .expect_err("cost rejected");
-    assert!(matches!(error, AzureError::HourlyCostRejected { .. }));
+    let error = client.ensure_worker(workflow_id, job_id, &target);
+    assert!(matches!(error, Err(AzureError::HourlyCostRejected { .. })));
     assert!(transport.0.lock().expect("state").requests.is_empty());
     target.max_hourly_cost_micros = None;
     assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
@@ -134,6 +128,7 @@ fn validation_and_cost_fail_before_creation() {
     for deadline in ["2020-01-01T00:00:00Z", "2999-01-01T00:00:00Z"] {
         let mut job = api_job(workflow_id, job_id, &target, &profile);
         job.tags.insert(DEADLINE_TAG.to_string(), deadline.to_string());
+        job.properties.template.containers.as_mut().expect("containers")[0].env[3].value = Some(deadline.to_string());
         transport.0.lock().expect("state").job = Some(job);
         let result = client.ensure_worker(workflow_id, job_id, &target);
         assert_eq!(result, Err(AzureError::ResourceIdentityMismatch));
@@ -149,9 +144,8 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     let good = api_job(workflow_id, job_id, &target, &profile);
     let worker = worker_from_job(&good, workflow_id, job_id, &target, &profile).expect("worker");
     let mut oversized = good.clone();
-    oversized.properties.template.containers.as_mut().expect("containers")[0]
-        .resources
-        .cpu = 1.0;
+    let containers = oversized.properties.template.containers.as_mut().expect("containers");
+    containers[0].resources.cpu = 1.0;
     let mismatch = worker_from_job(&oversized, workflow_id, job_id, &target, &profile);
     assert_eq!(mismatch, Err(AzureError::ResourceIdentityMismatch));
     let mut wrong = good.clone();
@@ -163,8 +157,12 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     let mut edited_profile = profile.clone();
     edited_profile.cpu_millicores = 750;
     let client = AzureClient::with_transport(edited_profile, transport.clone());
-    assert_eq!(client.delete_worker(&worker), Err(AzureError::ResourceIdentityMismatch));
+    let cleanup = client.cleanup_creation_failure::<()>(&worker.name, Some(&worker), AzureError::InvalidTarget);
+    assert!(matches!(cleanup, Err(AzureError::CleanupFailed { .. })));
+    assert!(transport.0.lock().expect("state").job.is_some());
     transport.0.lock().expect("state").job = Some(good);
     assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::Deleted));
     assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::AlreadyAbsent));
+    let absent = client.cleanup_creation_failure::<()>(&worker.name, Some(&worker), AzureError::InvalidTarget);
+    assert_eq!(absent, Err(AzureError::InvalidTarget));
 }

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -6,6 +6,7 @@ struct FakeTransport(Arc<Mutex<FakeState>>);
 struct FakeState {
     job: Option<ApiJob>,
     create_response: Option<ApiJob>,
+    job_after_create: Option<ApiJob>,
     requests: Vec<CreateJobRequest>,
     executions: Vec<ApiExecution>,
     start_response: Option<ApiExecution>,
@@ -20,7 +21,7 @@ impl Transport for FakeTransport {
         let mut state = self.0.lock().expect("state");
         state.requests.push(request.clone());
         let job = state.create_response.clone().expect("create response");
-        state.job = Some(job.clone());
+        state.job = Some(state.job_after_create.clone().unwrap_or_else(|| job.clone()));
         Ok(CreateResult {
             job,
             created: state.create_is_new,
@@ -83,10 +84,13 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
     let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
     let (target, profile) = (target(), profile());
     let job = api_job(workflow_id, job_id, &target, &profile);
+    let mut provisioning = job.clone();
+    provisioning.properties.provisioning_state = Some("Provisioning".to_string());
     let transport = FakeTransport::default();
     {
         let mut state = transport.0.lock().expect("state");
-        state.create_response = Some(job.clone());
+        state.create_response = Some(provisioning);
+        state.job_after_create = Some(job.clone());
         state.create_is_new = true;
     }
     let client = AzureClient::with_transport(profile, transport.clone());
@@ -97,21 +101,16 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
         panic!("new worker must be created");
     };
     assert_eq!(status.lifecycle, AzureLifecycle::Provisioning);
-    assert!(status.execution_id.is_none());
-    assert!(matches!(
-        client.ensure_worker(workflow_id, job_id, &target),
-        Ok(AzureEnsure::Reused(_))
-    ));
+    let reused = client.ensure_worker(workflow_id, job_id, &target);
+    assert!(matches!(reused, Ok(AzureEnsure::Reused(_))));
     let state = transport.0.lock().expect("state");
     assert_eq!(state.requests.len(), 1);
     assert_eq!(state.starts, 1);
     drop(state);
     transport.0.lock().expect("state").job = None;
     transport.0.lock().expect("state").create_is_new = false;
-    assert!(matches!(
-        client.ensure_worker(workflow_id, job_id, &target),
-        Ok(AzureEnsure::Reused(_))
-    ));
+    let raced = client.ensure_worker(workflow_id, job_id, &target);
+    assert!(matches!(raced, Ok(AzureEnsure::Reused(_))));
     assert_eq!(transport.0.lock().expect("state").starts, 1);
 }
 #[test]
@@ -136,10 +135,8 @@ fn validation_and_cost_fail_before_creation() {
         let mut job = api_job(workflow_id, job_id, &target, &profile);
         job.tags.insert(DEADLINE_TAG.to_string(), deadline.to_string());
         transport.0.lock().expect("state").job = Some(job);
-        assert_eq!(
-            client.ensure_worker(workflow_id, job_id, &target),
-            Err(AzureError::ResourceIdentityMismatch)
-        );
+        let result = client.ensure_worker(workflow_id, job_id, &target);
+        assert_eq!(result, Err(AzureError::ResourceIdentityMismatch));
         assert!(transport.0.lock().expect("state").job.is_none());
     }
     target.image = "registry.example/build/worker:latest".to_string();
@@ -155,15 +152,17 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     oversized.properties.template.containers.as_mut().expect("containers")[0]
         .resources
         .cpu = 1.0;
-    assert_eq!(
-        worker_from_job(&oversized, workflow_id, job_id, &target, &profile),
-        Err(AzureError::ResourceIdentityMismatch)
-    );
+    let mismatch = worker_from_job(&oversized, workflow_id, job_id, &target, &profile);
+    assert_eq!(mismatch, Err(AzureError::ResourceIdentityMismatch));
     let mut wrong = good.clone();
-    wrong.tags.insert(JOB_TAG.to_string(), CloudJobId::new().to_string());
+    let containers = wrong.properties.template.containers.as_mut().expect("containers");
+    let duplicate = containers[0].env[1].clone();
+    containers[0].env.push(duplicate);
     let transport = FakeTransport::default();
     transport.0.lock().expect("state").job = Some(wrong);
-    let client = AzureClient::with_transport(profile.clone(), transport.clone());
+    let mut edited_profile = profile.clone();
+    edited_profile.cpu_millicores = 750;
+    let client = AzureClient::with_transport(edited_profile, transport.clone());
     assert_eq!(client.delete_worker(&worker), Err(AzureError::ResourceIdentityMismatch));
     transport.0.lock().expect("state").job = Some(good);
     assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::Deleted));


### PR DESCRIPTION
## Purpose

Add a public-image Azure Container Apps Jobs lifecycle adapter for durable cloud workers, stacked on the provider-neutral protocol and RunPod adapter in #372.

## Behavior impact

- Creates or adopts one deterministic manual Container Apps Job per workflow/job.
- Makes PUT create-only with `If-None-Match: *`; a concurrent winner is fetched through a bounded visibility retry, exactly validated, and reused rather than overwritten.
- Requires digest-pinned public images, a pre-provisioned shared environment, the Consumption workload profile, exact CPU/memory/retry/parallelism bounds, CPU-derived ephemeral-disk limits, bounded leases, and an explicit hourly-cost ceiling.
- Persists the original target, Azure profile, ARM identity, ownership metadata, and deadline for recovery after Horizon closes or the current profile changes.
- Uses provider-confirmed HTTP 201 as an at-most-once start fence. The creation path waits through bounded provisioning and starts once; retries and adopted jobs only reconcile executions.
- Requires exactly one plain-text matching value for every identity-bearing worker environment variable.
- Rejects and exactly cleans recovered jobs with expired or overlong lease deadlines.
- Maps provisioning/execution state and refuses ambiguous executions, location drift, resource-shape drift, or identity drift.
- Deletes only resources that pass the same complete persisted-worker validation immediately before deletion; malformed create responses are retained and surfaced by exact resource ID.
- Preserves the original operation error when cleanup observes exact absence; otherwise reports cleanup failure with the resource ID whenever exact cleanup cannot be proven.
- Keeps ARM request/response modeling separate from lifecycle orchestration.
- Managed-identity private-registry pulls are intentionally split into serial follow-up #374.

## Test evidence

- Full pre-push matrix passed on exact head `4ec89016caa5acbb8201cffd48da0202ca264b9c`:
  - `cargo fmt --all -- --check`
  - `./scripts/check-maintainability.sh`
  - workspace tests with and without `speech`
  - blocking, strict, and advisory pedantic Clippy tiers
- Exact diff is 999 non-generated source/test lines across five files, within the repository limit.
- Unit coverage includes new-job provisioning with temporary 404, one-time start, bounded visibility recovery for a hidden race winner, delayed execution visibility, full persisted-shape recovery after current-profile edits, duplicate/secret-backed env rejection, full cleanup identity validation, already-absent error preservation, resource bounds, cost/disk/deadline rejection, and idempotent deletion.
- An earlier live Sweden Central smoke with the same ARM API and a digest-pinned public image proved create, one execution, success, deletion, and exact absence. A current-head refresh remains intentionally pending until review stabilizes and cloud execution is explicitly authorized.

This PR targets a shared pre-provisioned Container Apps environment; creating that environment per job took roughly two minutes in the disposable smoke and is not part of the worker hot path.
