### PR TITLE
feat(cloud): add Azure registry identity pulls

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -46,6 +46,12 @@ impl fmt::Debug for AzureAccessToken {
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct AzureRegistry {
+    pub server: String,
+    pub identity_id: String,
+}
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AzureProfile {
     pub name: String,
     pub subscription_id: String,
@@ -55,6 +61,8 @@ pub struct AzureProfile {
     pub cpu_millicores: u32,
     pub memory_mib: u32,
     pub hourly_cost_micros: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry: Option<AzureRegistry>,
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -328,17 +336,27 @@ fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
         && (250..=4_000).contains(&profile.cpu_millicores)
         && profile.cpu_millicores.is_multiple_of(250)
         && profile.memory_mib == profile.cpu_millicores / 250 * 512
-        && profile.hourly_cost_micros > 0;
+        && profile.hourly_cost_micros > 0
+        && profile.registry.as_ref().is_none_or(|registry| {
+            valid_registry_server(&registry.server) && valid_user_assigned_identity_id(&registry.identity_id)
+        });
     valid.then_some(()).ok_or(AzureError::InvalidProfile)
 }
 fn validate_target(target: &WorkerTarget, profile: &AzureProfile) -> Result<(), AzureError> {
     validate_profile(profile)?;
+    let registry_matches = profile.registry.as_ref().is_none_or(|registry| {
+        target
+            .image
+            .split_once('/')
+            .is_some_and(|(server, _)| server.eq_ignore_ascii_case(&registry.server))
+    });
     let valid = target.provider == CloudProvider::Azure
         && target.profile == profile.name
         && (1..=ephemeral_disk_limit(profile.cpu_millicores)).contains(&target.disk_gib)
         && (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&target.lease_seconds)
         && target.max_hourly_cost_micros.is_some_and(|maximum| maximum > 0)
-        && valid_immutable_image(&target.image);
+        && valid_immutable_image(&target.image)
+        && registry_matches;
     valid.then_some(()).ok_or(AzureError::InvalidTarget)
 }
 fn enforce_cost(target: &WorkerTarget, actual: u64) -> Result<(), AzureError> {
@@ -391,11 +409,51 @@ fn valid_resource_group(value: &str) -> bool {
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || b"._-()".contains(&byte))
 }
+fn valid_registry_server(value: &str) -> bool {
+    valid_text(value, 253) && value.contains('.') && value.split('.').all(valid_dns_label)
+}
+fn valid_dns_label(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    (1..=63).contains(&bytes.len())
+        && bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes.iter().all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+}
 fn valid_arm_id(value: &str) -> bool {
     value.starts_with("/subscriptions/")
         && valid_text(value, 2_048)
         && !value.contains(['?', '#'])
         && value.bytes().all(|byte| !byte.is_ascii_whitespace())
+}
+fn valid_user_assigned_identity_id(value: &str) -> bool {
+    let segments: Vec<_> = value.split('/').collect();
+    let [
+        "",
+        subscriptions,
+        subscription,
+        resource_groups,
+        group,
+        providers,
+        namespace,
+        identities,
+        name,
+    ] = segments.as_slice()
+    else {
+        return false;
+    };
+    valid_arm_id(value)
+        && subscriptions.eq_ignore_ascii_case("subscriptions")
+        && uuid::Uuid::parse_str(subscription).is_ok()
+        && resource_groups.eq_ignore_ascii_case("resourceGroups")
+        && valid_resource_group(group)
+        && providers.eq_ignore_ascii_case("providers")
+        && namespace.eq_ignore_ascii_case("Microsoft.ManagedIdentity")
+        && identities.eq_ignore_ascii_case("userAssignedIdentities")
+        && (3..=128).contains(&name.len())
+        && name.as_bytes()[0].is_ascii_alphanumeric()
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 fn valid_text(value: &str, maximum: usize) -> bool {
     !value.is_empty()

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -420,7 +420,10 @@ fn valid_dns_label(value: &str) -> bool {
         && bytes.iter().all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
 }
 fn valid_arm_id(value: &str) -> bool {
-    value.starts_with("/subscriptions/")
+    let prefix = "/subscriptions/";
+    value
+        .get(..prefix.len())
+        .is_some_and(|value| value.eq_ignore_ascii_case(prefix))
         && valid_text(value, 2_048)
         && !value.contains(['?', '#'])
         && value.bytes().all(|byte| !byte.is_ascii_whitespace())

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -324,7 +324,7 @@ trait Transport: Send + Sync {
 fn validate_profile(profile: &AzureProfile) -> Result<(), AzureError> {
     let prefix = format!("/subscriptions/{}/", profile.subscription_id);
     let valid = valid_text(&profile.name, 191)
-        && uuid::Uuid::parse_str(&profile.subscription_id).is_ok()
+        && valid_subscription_id(&profile.subscription_id)
         && valid_resource_group(&profile.resource_group)
         && valid_arm_id(&profile.environment_id)
         && profile
@@ -428,6 +428,9 @@ fn valid_arm_id(value: &str) -> bool {
         && !value.contains(['?', '#'])
         && value.bytes().all(|byte| !byte.is_ascii_whitespace())
 }
+fn valid_subscription_id(value: &str) -> bool {
+    uuid::Uuid::parse_str(value).is_ok_and(|id| id.hyphenated().to_string().eq_ignore_ascii_case(value))
+}
 fn valid_user_assigned_identity_id(value: &str) -> bool {
     let segments: Vec<_> = value.split('/').collect();
     let [
@@ -446,7 +449,7 @@ fn valid_user_assigned_identity_id(value: &str) -> bool {
     };
     valid_arm_id(value)
         && subscriptions.eq_ignore_ascii_case("subscriptions")
-        && uuid::Uuid::parse_str(subscription).is_ok()
+        && valid_subscription_id(subscription)
         && resource_groups.eq_ignore_ascii_case("resourceGroups")
         && valid_resource_group(group)
         && providers.eq_ignore_ascii_case("providers")

--- a/crates/horizon-core/src/cloud_run/azure/model.rs
+++ b/crates/horizon-core/src/cloud_run/azure/model.rs
@@ -4,9 +4,23 @@ use super::{
     DEADLINE_TAG, DISK_TAG, JOB_ENV, JOB_TAG, OWNER_TAG, PROFILE_TAG, PROTOCOL_ENV, PROTOCOL_TAG, TERMINATE_ENV,
     WORKFLOW_ENV, WORKFLOW_TAG, resource_id, resource_name, valid_deadline,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 pub(super) type CreateJobRequest = serde_json::Value;
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct Registry {
+    pub(super) server: String,
+    pub(super) identity: String,
+    pub(super) username: Option<String>,
+    pub(super) password_secret_ref: Option<String>,
+}
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct IdentitySetting {
+    pub(super) identity: String,
+    pub(super) lifecycle: String,
+}
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(super) struct ApiJob {
     pub(super) id: String,
@@ -47,7 +61,8 @@ pub(super) struct ApiConfiguration {
     pub(super) replica_retry_limit: u32,
     pub(super) trigger_type: String,
     pub(super) manual_trigger_config: ApiManualTriggerConfig,
-    pub(super) registries: Option<Vec<serde_json::Value>>,
+    pub(super) registries: Option<Vec<Registry>>,
+    pub(super) identity_settings: Option<Vec<IdentitySetting>>,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -105,12 +120,24 @@ pub(super) fn create_request(
         {"name": PROTOCOL_ENV, "value": super::super::CLOUD_RUN_PROTOCOL_VERSION.to_string()},
         {"name": TERMINATE_ENV, "value": deadline}
     ]);
+    let (identity, registries, identity_settings) = profile.registry.as_ref().map_or_else(
+        || (serde_json::json!({"type": "None"}), Vec::new(), Vec::new()),
+        |registry| {
+            (
+                serde_json::json!({
+                    "type": "UserAssigned", "userAssignedIdentities": {&registry.identity_id: {}}
+                }),
+                vec![serde_json::json!({"server": registry.server, "identity": registry.identity_id})],
+                vec![serde_json::json!({"identity": registry.identity_id, "lifecycle": "None"})],
+            )
+        },
+    );
     let properties = serde_json::json!({
         "environmentId": profile.environment_id, "workloadProfileName": CONSUMPTION_PROFILE,
         "configuration": {
             "triggerType": "Manual", "replicaTimeout": target.lease_seconds, "replicaRetryLimit": 0,
             "manualTriggerConfig": {"parallelism": 1, "replicaCompletionCount": 1},
-            "registries": [], "identitySettings": []
+            "registries": registries, "identitySettings": identity_settings
         },
         "template": {"containers": [{
             "name": "worker", "image": target.image, "env": env,
@@ -119,7 +146,7 @@ pub(super) fn create_request(
         }]}
     });
     Ok(serde_json::json!({
-        "location": profile.location, "tags": tags, "identity": {"type": "None"}, "properties": properties
+        "location": profile.location, "tags": tags, "identity": identity, "properties": properties
     }))
 }
 pub(super) fn worker_from_job(
@@ -230,11 +257,37 @@ fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, prof
     let config = &job.properties.configuration;
     let workload_profile = &job.properties.workload_profile_name;
     let containers = job.properties.template.containers.as_deref().unwrap_or_default();
-    let public_image = config.registries.as_deref().unwrap_or_default().is_empty()
-        && job.identity.as_ref().is_none_or(|identity| {
-            identity.user_assigned_identities.is_empty()
-                && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
-        });
+    let registry_matches = profile.registry.as_ref().map_or_else(
+        || {
+            config.registries.as_deref().unwrap_or_default().is_empty()
+                && config.identity_settings.as_deref().unwrap_or_default().is_empty()
+                && job.identity.as_ref().is_none_or(|identity| {
+                    identity.user_assigned_identities.is_empty()
+                        && (identity.kind.is_empty() || identity.kind.eq_ignore_ascii_case("None"))
+                })
+        },
+        |registry| {
+            matches!(
+                config.registries.as_deref(),
+                Some([actual])
+                    if actual.server.eq_ignore_ascii_case(&registry.server)
+                        && actual.identity.eq_ignore_ascii_case(&registry.identity_id)
+                        && actual.username.is_none()
+                        && actual.password_secret_ref.is_none()
+            ) && job.identity.as_ref().is_some_and(|identity| {
+                identity.kind.eq_ignore_ascii_case("UserAssigned")
+                    && identity.user_assigned_identities.len() == 1
+                    && identity
+                        .user_assigned_identities
+                        .keys()
+                        .any(|id| id.eq_ignore_ascii_case(&registry.identity_id))
+            }) && config.identity_settings.as_deref().is_some_and(|settings| {
+                settings.len() == 1
+                    && settings[0].identity.eq_ignore_ascii_case(&registry.identity_id)
+                    && settings[0].lifecycle.eq_ignore_ascii_case("None")
+            })
+        },
+    );
     config.trigger_type.eq_ignore_ascii_case("Manual")
         && workload_profile.eq_ignore_ascii_case(CONSUMPTION_PROFILE)
         && config.replica_timeout == lease_seconds
@@ -246,7 +299,7 @@ fn job_configuration_matches(job: &ApiJob, image: &str, lease_seconds: u32, prof
         && containers[0].image == image
         && (containers[0].resources.cpu - f64::from(profile.cpu_millicores) / 1_000.0).abs() < f64::EPSILON
         && memory_matches(&containers[0].resources.memory, profile.memory_mib)
-        && public_image
+        && registry_matches
 }
 fn memory_matches(value: &str, expected_mib: u32) -> bool {
     value

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -132,6 +132,9 @@ fn validation_and_cost_fail_before_creation() {
     target.max_hourly_cost_micros = Some(41_999);
     let transport = FakeTransport::default();
     let client = AzureClient::with_transport(profile.clone(), transport.clone());
+    let identity_id = &mut profile.registry.as_mut().expect("registry").identity_id;
+    *identity_id = identity_id.replacen("/subscriptions/", "/Subscriptions/", 1);
+    assert_eq!(validate_profile(&profile), Ok(()));
     let mut public_profile = profile.clone();
     public_profile.registry = None;
     let public_request = create_request(workflow_id, job_id, &target, &public_profile).expect("public request");

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -1,3 +1,4 @@
+use super::model::{ApiIdentity, IdentitySetting, Registry};
 use super::*;
 use AzureCleanup::{AlreadyAbsent, Deleted};
 use std::sync::{Arc, Mutex};
@@ -61,6 +62,12 @@ fn profile() -> AzureProfile {
         cpu_millicores: 500,
         memory_mib: 1_024,
         hourly_cost_micros: 42_000,
+        registry: Some(AzureRegistry {
+            server: "registry.example".to_string(),
+            identity_id: format!(
+                "/subscriptions/{subscription}/resourceGroups/horizon-workers/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"
+            ),
+        }),
     }
 }
 fn target() -> WorkerTarget {
@@ -88,7 +95,10 @@ fn assert_mismatch<T>(result: Result<T, AzureError>) {
 fn creation_is_bounded_and_retries_reuse_one_execution() {
     let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
     let (target, profile) = (target(), profile());
-    let job = api_job(workflow_id, job_id, &target, &profile);
+    let mut job = api_job(workflow_id, job_id, &target, &profile);
+    job.properties.configuration.registries.as_mut().expect("registry")[0]
+        .identity
+        .make_ascii_uppercase();
     let mut provisioning = job.clone();
     provisioning.properties.provisioning_state = Some("Provisioning".to_string());
     let transport = FakeTransport::default();
@@ -105,6 +115,11 @@ fn creation_is_bounded_and_retries_reuse_one_execution() {
     assert!(matches!(reused, Ok(AzureEnsure::Reused(_))));
     let state = transport.0.lock().expect("state");
     assert_eq!((state.requests.len(), state.starts), (1, 1));
+    assert_eq!(state.requests[0]["identity"]["type"], "UserAssigned");
+    assert_eq!(
+        state.requests[0]["properties"]["configuration"]["registries"][0]["server"],
+        "registry.example"
+    );
     drop(state);
     let mut visibility = [None, Some(job.clone())].into_iter();
     let adopted = await_job(|| Ok(visibility.next().flatten()), |_| Ok(true), "job creation").expect("adopt winner");
@@ -117,12 +132,45 @@ fn validation_and_cost_fail_before_creation() {
     target.max_hourly_cost_micros = Some(41_999);
     let transport = FakeTransport::default();
     let client = AzureClient::with_transport(profile.clone(), transport.clone());
+    let mut public_profile = profile.clone();
+    public_profile.registry = None;
+    let public_request = create_request(workflow_id, job_id, &target, &public_profile).expect("public request");
+    assert_eq!(public_request["identity"]["type"], "None");
+    let mut invalid_profile = profile.clone();
+    invalid_profile.registry.as_mut().expect("registry").identity_id = "/subscriptions/incomplete".to_string();
+    assert_eq!(validate_profile(&invalid_profile), Err(AzureError::InvalidProfile));
+    invalid_profile.registry.as_mut().expect("registry").identity_id = format!(
+        "/subscriptions/{}/resourceGroups/horizon-workers/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ab",
+        profile.subscription_id
+    );
+    assert_eq!(validate_profile(&invalid_profile), Err(AzureError::InvalidProfile));
+    for server in [
+        ".",
+        "registry..example",
+        "-registry.example",
+        "registry-.example",
+        "registry.example-",
+    ] {
+        let mut invalid_profile = profile.clone();
+        invalid_profile.registry.as_mut().expect("registry").server = server.to_string();
+        assert_eq!(validate_profile(&invalid_profile), Err(AzureError::InvalidProfile));
+    }
+    let mut invalid_profile = profile.clone();
+    invalid_profile.registry.as_mut().expect("registry").server = format!("{}.example", "a".repeat(64));
+    assert_eq!(validate_profile(&invalid_profile), Err(AzureError::InvalidProfile));
     let error = client.ensure_worker(workflow_id, job_id, &target);
     assert!(matches!(error, Err(AzureError::HourlyCostRejected { .. })));
     assert!(transport.0.lock().expect("state").requests.is_empty());
     target.max_hourly_cost_micros = None;
     assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
     target.max_hourly_cost_micros = Some(100_000);
+    target.image = format!("other.example/build/worker@sha256:{}", "a".repeat(64));
+    assert!(matches!(
+        client.ensure_worker(workflow_id, job_id, &target),
+        Err(AzureError::InvalidTarget)
+    ));
+    assert!(transport.0.lock().expect("state").requests.is_empty());
+    target.image = format!("registry.example/build/worker@sha256:{}", "a".repeat(64));
     target.disk_gib = 3;
     assert_eq!(validate_target(&target, &profile), Err(AzureError::InvalidTarget));
     target.disk_gib = 2;
@@ -151,6 +199,24 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     wrong_profile.properties.workload_profile_name = CONSUMPTION_PROFILE.to_string();
     wrong_profile.location = "eastus".to_string();
     assert_mismatch(status_from_resource(&wrong_profile, &worker, None));
+    let mut exposed = good.clone();
+    exposed
+        .properties
+        .configuration
+        .identity_settings
+        .as_mut()
+        .expect("settings")[0]
+        .lifecycle = "All".to_string();
+    assert_mismatch(worker_from_job(&exposed, workflow_id, job_id, &target, &profile));
+    let mut credentialed = good.clone();
+    credentialed
+        .properties
+        .configuration
+        .registries
+        .as_mut()
+        .expect("registry")[0]
+        .password_secret_ref = Some("legacy-password".to_string());
+    assert_mismatch(worker_from_job(&credentialed, workflow_id, job_id, &target, &profile));
     let mut wrong = good.clone();
     wrong.properties.template.containers.as_mut().expect("containers")[0].env[1].secret_ref =
         Some("job-override".to_string());
@@ -172,4 +238,45 @@ fn exact_cleanup_rejects_identity_drift_and_is_idempotent() {
     assert_eq!(client.delete_worker(&worker), Ok(AzureCleanup::AlreadyAbsent));
     let absent = client.cleanup_creation_failure::<()>(&worker.name, Some(&worker), AzureError::InvalidTarget);
     assert_eq!(absent, Err(AzureError::InvalidTarget));
+}
+#[test]
+fn public_adoption_accepts_clean_identity_and_rejects_drift() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let (target, mut profile) = (target(), profile());
+    profile.registry = None;
+    let good = api_job(workflow_id, job_id, &target, &profile);
+    let worker = worker_from_job(&good, workflow_id, job_id, &target, &profile).expect("worker");
+    let transport = FakeTransport::default();
+    transport.0.lock().expect("state").job = Some(good.clone());
+    let client = AzureClient::with_transport(profile, transport.clone());
+    assert!(matches!(
+        client.ensure_worker(workflow_id, job_id, &target),
+        Ok(AzureEnsure::Reused(_))
+    ));
+    assert!(client.inspect_worker(&worker).expect("inspection").is_some());
+    let reject = |job| {
+        transport.0.lock().expect("state").job = Some(job);
+        assert_eq!(
+            client.inspect_worker(&worker),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+    };
+    let mut drift = good.clone();
+    drift.identity = Some(ApiIdentity {
+        kind: "UserAssigned".to_string(),
+        ..ApiIdentity::default()
+    });
+    reject(drift);
+    let mut drift = good.clone();
+    drift.properties.configuration.registries = Some(vec![Registry {
+        server: "registry.example".to_string(),
+        ..Registry::default()
+    }]);
+    reject(drift);
+    let mut drift = good;
+    drift.properties.configuration.identity_settings = Some(vec![IdentitySetting {
+        identity: "drift".to_string(),
+        lifecycle: "None".to_string(),
+    }]);
+    reject(drift);
 }

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -132,6 +132,8 @@ fn validation_and_cost_fail_before_creation() {
     target.max_hourly_cost_micros = Some(41_999);
     let transport = FakeTransport::default();
     let client = AzureClient::with_transport(profile.clone(), transport.clone());
+    assert!(!valid_subscription_id(&profile.subscription_id.replace('-', "")));
+    assert!(!valid_subscription_id(&format!("{{{}}}", profile.subscription_id)));
     let identity_id = &mut profile.registry.as_mut().expect("registry").identity_id;
     *identity_id = identity_id.replacen("/subscriptions/", "/Subscriptions/", 1);
     assert_eq!(validate_profile(&profile), Ok(()));


### PR DESCRIPTION
## Purpose

Add optional private-registry pulls to the Azure Container Apps worker adapter using a user-assigned managed identity, as a focused follow-up to #373.

## Behavior impact

- Adds an optional registry profile containing the exact login server and managed-identity ARM ID.
- Requires a digest-pinned worker image from that exact server when private registry mode is enabled.
- Sends registry and identity configuration without passwords, tokens, or persisted credentials.
- Requires a full user-assigned managed-identity ARM resource ID, including the provider's three-character minimum name, and exactly one matching `identitySettings` entry with lifecycle `None`.
- Requires canonical hyphenated subscription UUIDs in both the Azure profile and identity ARM path, while accepting valid UUID hex casing.
- Validates the registry login server label by label according to DNS length and edge-character rules.
- Verifies one exact registry and identity before adoption, compares every ARM resource-ID segment case-insensitively, and rejects any returned registry username or password-secret reference.
- Keeps the public-image path from #373 unchanged when no registry is configured.
- Fits the registry wire model into #373's dedicated ARM model module without weakening its lifecycle recovery or cleanup invariants.

## Stack

This PR targets `feature/azure-container-job-worker` and will be restacked after #373's current review fixes are published.

## Test evidence

- Full pre-push matrix passed on exact head `b498566f41e4c6636076286da1609d16be627723`:
  - `cargo fmt --all -- --check`
  - `./scripts/check-maintainability.sh`
  - workspace tests with and without `speech`
  - blocking, strict, and advisory pedantic Clippy tiers
- Exact follow-up diff is 244 additions and 15 deletions across three files.
- Azure unit coverage verifies private identity request shape, full public-profile adoption/inspection, canonical and case-varied ARM UUID handling, lifecycle isolation, identity/registry/credential drift rejection, DNS login-server validation, image-to-registry rejection, case-normalized identity adoption, and all inherited worker lifecycle safeguards.

No provider resources are created by this PR.
