### PR TITLE
feat(browser): paginate audit journals with a stable cursor

### DIFF
--- a/assets/plugins/claude-code/skills/horizon-browser/SKILL.md
+++ b/assets/plugins/claude-code/skills/horizon-browser/SKILL.md
@@ -94,4 +94,8 @@ Do not describe Firefox WebSocket instrumentation as undetectable.
 When the user must steer, call `browser_handoff` with a concise reason and stop
 issuing actions. Poll `browser_list` until `handoff_pending` becomes false,
 then take a fresh snapshot before continuing. Use `browser_audit` to review the
-redacted ordered action history or to verify a specific action id.
+redacted ordered action history or to verify a specific action id. The default
+page is the newest matching records (`limit` 1-500, default 100). To iterate
+every retained record, call with `from_start: true` and reuse `next_event_id`
+as `after_event_id` until `has_more` is false. Treat `cursor_lost`,
+`malformed_records`, and `older_records_dropped` as explicit loss.

--- a/assets/plugins/codex/skills/horizon-browser/SKILL.md
+++ b/assets/plugins/codex/skills/horizon-browser/SKILL.md
@@ -94,4 +94,8 @@ Do not describe Firefox WebSocket instrumentation as undetectable.
 When the user must steer, call `browser_handoff` with a concise reason and stop
 issuing actions. Poll `browser_list` until `handoff_pending` becomes false,
 then take a fresh snapshot before continuing. Use `browser_audit` to review the
-redacted ordered action history or to verify a specific action id.
+redacted ordered action history or to verify a specific action id. The default
+page is the newest matching records (`limit` 1-500, default 100). To iterate
+every retained record, call with `from_start: true` and reuse `next_event_id`
+as `after_event_id` until `has_more` is false. Treat `cursor_lost`,
+`malformed_records`, and `older_records_dropped` as explicit loss.

--- a/crates/horizon-browser-mcp/README.md
+++ b/crates/horizon-browser-mcp/README.md
@@ -97,7 +97,13 @@ shell commands, files, or other MCP servers.
   sequence gaps and capture health explicitly, and wakes on a matching record,
   capture stop, capture replacement, or timeout.
 - `browser_handoff` pauses automation so the user can steer.
-- `browser_audit` returns redacted ordered action records.
+- `browser_audit` returns a bounded page of redacted ordered action records.
+  The default page is the newest matching entries (`limit` 1-500, default 100).
+  Set `from_start` to iterate from the oldest retained match, then reuse
+  `next_event_id` as `after_event_id` until `has_more` is false. The response
+  reports `records_returned`, `records_retained`, `malformed_records`,
+  `older_records_dropped`, and `cursor_lost` when the resume cursor is no
+  longer retained.
 
 The server automatically claims and heartbeats a panel using
 `HORIZON_BROWSER_ACTOR`. Horizon injects that identity, together with the

--- a/crates/horizon-browser-mcp/src/controller.rs
+++ b/crates/horizon-browser-mcp/src/controller.rs
@@ -476,11 +476,16 @@ impl BrowserController {
             .map_err(|source| self.denied(panel_id, "could not request browser handoff", source))
     }
 
-    pub(crate) fn read_audit(&self, panel_id: &str) -> Result<Vec<horizon_browser::BrowserAuditEntry>, ControlError> {
+    pub(crate) fn read_audit_page(
+        &self,
+        panel_id: &str,
+        request: &manifest::AuditPageRequest,
+    ) -> Result<manifest::AuditPage, ControlError> {
         self.authorized_manifest(panel_id)?;
         tracing::debug!(actor = %self.actor, panel_id, "reading browser action audit");
-        manifest::read_audit_for(panel_id, self.identity())
-            .map_err(|source| self.denied(panel_id, "could not read browser audit", source))
+        let journal = manifest::read_audit_journal_for(panel_id, self.identity())
+            .map_err(|source| self.denied(panel_id, "could not read browser audit", source))?;
+        Ok(manifest::page_audit(&journal, request))
     }
 
     fn ensure_claim(&self, panel_id: &str) -> Result<(), ControlError> {

--- a/crates/horizon-browser-mcp/src/model.rs
+++ b/crates/horizon-browser-mcp/src/model.rs
@@ -530,10 +530,15 @@ pub(crate) struct HandoffInput {
 pub(crate) struct AuditInput {
     /// Stable panel id returned by `browser_list`.
     pub(crate) panel_id: String,
-    /// Optional action id filter.
+    /// Optional action id filter applied before paging.
     pub(crate) action_id: Option<String>,
-    /// Maximum newest entries to return (1-500, default 100).
+    /// Maximum matching entries to return (1-500, default 100).
     pub(crate) limit: Option<usize>,
+    /// Exclusive resume cursor from a previous `next_event_id`.
+    pub(crate) after_event_id: Option<String>,
+    /// When true and `after_event_id` is omitted, start at the oldest retained match.
+    /// Default false returns the newest matching page.
+    pub(crate) from_start: Option<bool>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -677,6 +682,13 @@ pub(crate) struct HandoffOutput {
 pub(crate) struct AuditOutput {
     pub(crate) panel_id: String,
     pub(crate) entries: Vec<serde_json::Value>,
+    pub(crate) next_event_id: Option<String>,
+    pub(crate) has_more: bool,
+    pub(crate) records_returned: u64,
+    pub(crate) records_retained: u64,
+    pub(crate) malformed_records: u64,
+    pub(crate) older_records_dropped: u64,
+    pub(crate) cursor_lost: bool,
 }
 
 fn backend_name(backend: BackendKind) -> &'static str {

--- a/crates/horizon-browser-mcp/src/server.rs
+++ b/crates/horizon-browser-mcp/src/server.rs
@@ -1,4 +1,5 @@
 use horizon_browser::{BrowserControlAction, BrowserControlValue};
+use horizon_core::browser::manifest::AuditPageRequest;
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::{
@@ -304,27 +305,37 @@ impl HorizonBrowserMcp {
 
     #[tool(
         name = "browser_audit",
-        description = "Read the newest redacted audit entries for a browser panel, optionally filtered by action id."
+        description = "Read a bounded page of redacted audit entries for a browser panel. The default page is the newest matching records (limit 1-500, default 100). Set from_start=true to iterate from the oldest retained match; reuse next_event_id as after_event_id until has_more is false. Optional action_id filter. The response includes pagination and loss metadata: records_returned, records_retained, malformed_records, older_records_dropped, and cursor_lost when after_event_id is no longer retained."
     )]
     fn browser_audit(&self, Parameters(input): Parameters<AuditInput>) -> Result<Json<AuditOutput>, String> {
-        let limit = input.limit.unwrap_or(100).clamp(1, 500);
-        let mut entries = self
+        let page = self
             .controller
-            .read_audit(&input.panel_id)
+            .read_audit_page(
+                &input.panel_id,
+                &AuditPageRequest::new(
+                    input.after_event_id,
+                    input.from_start.unwrap_or(false),
+                    input.action_id,
+                    input.limit,
+                ),
+            )
             .map_err(|error| error.to_string())?;
-        if let Some(action_id) = input.action_id.as_deref() {
-            entries.retain(|entry| entry.action_id == action_id);
-        }
-        let start = entries.len().saturating_sub(limit);
-        let entries = entries
+        let entries = page
+            .entries
             .into_iter()
-            .skip(start)
             .map(serde_json::to_value)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|error| format!("could not encode browser audit: {error}"))?;
         Ok(Json(AuditOutput {
             panel_id: input.panel_id,
             entries,
+            next_event_id: page.next_event_id,
+            has_more: page.has_more,
+            records_returned: page.records_returned,
+            records_retained: page.records_retained,
+            malformed_records: page.malformed_records,
+            older_records_dropped: page.older_records_dropped,
+            cursor_lost: page.cursor_lost,
         }))
     }
 
@@ -474,6 +485,11 @@ mod tests {
         );
         let schemas = serde_json::to_string(&server.tool_router.list_all()).unwrap_or_default();
         assert!(schemas.contains("browser_unavailable"));
+        assert!(schemas.contains("after_event_id"));
+        assert!(schemas.contains("from_start"));
+        assert!(schemas.contains("next_event_id"));
+        assert!(schemas.contains("older_records_dropped"));
+        assert!(schemas.contains("cursor_lost"));
         assert!(!schemas.contains("browser_ws"));
         assert!(!schemas.contains("manifest_path"));
         assert!(!schemas.contains("cdp_endpoint"));

--- a/crates/horizon-browser-mcp/tests/stdio_protocol.rs
+++ b/crates/horizon-browser-mcp/tests/stdio_protocol.rs
@@ -108,57 +108,7 @@ fn exercise_protocol(protocol_version: &str) {
         "method": "tools/list",
         "params": {}
     }));
-    let encoded_tools = tools.to_string();
-    assert_eq!(tools["result"]["tools"].as_array().map(Vec::len), Some(14));
-    let create = tools["result"]["tools"]
-        .as_array()
-        .and_then(|tools| tools.iter().find(|tool| tool["name"] == "browser_create"))
-        .expect("browser_create tool");
-    assert!(
-        create["description"]
-            .as_str()
-            .is_some_and(|description| description.contains("browser_list is empty")
-                && description.contains("never create a helper panel")
-                && description.contains("allow_additional=true"))
-    );
-    assert!(create["inputSchema"].to_string().contains("allow_additional"));
-    let network = tools["result"]["tools"]
-        .as_array()
-        .and_then(|tools| tools.iter().find(|tool| tool["name"] == "browser_network"))
-        .expect("browser_network tool");
-    assert!(
-        network["description"]
-            .as_str()
-            .is_some_and(|description| description.contains("tail -f"))
-    );
-    assert!(network["inputSchema"].to_string().contains("Start only"));
-    let watch = tools["result"]["tools"]
-        .as_array()
-        .and_then(|tools| tools.iter().find(|tool| tool["name"] == "browser_network_watch"))
-        .expect("browser_network_watch tool");
-    assert!(watch["description"].as_str().is_some_and(|description| {
-        description.contains("next_sequence") && description.contains("no capture path")
-    }));
-    let visibility = tools["result"]["tools"]
-        .as_array()
-        .and_then(|tools| tools.iter().find(|tool| tool["name"] == "browser_visibility"))
-        .expect("browser_visibility tool");
-    assert!(
-        visibility["description"]
-            .as_str()
-            .is_some_and(|description| description.contains("without stopping"))
-    );
-    let wait = tools["result"]["tools"]
-        .as_array()
-        .and_then(|tools| tools.iter().find(|tool| tool["name"] == "browser_wait"))
-        .expect("browser_wait tool");
-    assert!(
-        wait["description"]
-            .as_str()
-            .is_some_and(|description| description.contains("browser_unavailable"))
-    );
-    assert!(!encoded_tools.contains("browser_ws"));
-    assert!(!encoded_tools.contains("manifest_path"));
+    assert_listed_tools_keep_the_browser_contract(&tools);
 
     let list = process.send(&json!({
         "jsonrpc": "2.0",
@@ -171,4 +121,57 @@ fn exercise_protocol(protocol_version: &str) {
     assert!(!list.to_string().contains("browser_ws"));
 
     process.close();
+}
+
+fn listed_tool<'a>(tools: &'a Value, name: &str) -> &'a Value {
+    tools["result"]["tools"]
+        .as_array()
+        .and_then(|tools| tools.iter().find(|tool| tool["name"] == name))
+        .unwrap_or_else(|| panic!("{name} tool"))
+}
+
+fn assert_listed_tools_keep_the_browser_contract(tools: &Value) {
+    let encoded_tools = tools.to_string();
+    assert_eq!(tools["result"]["tools"].as_array().map(Vec::len), Some(14));
+    let create = listed_tool(tools, "browser_create");
+    assert!(
+        create["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("browser_list is empty")
+                && description.contains("never create a helper panel")
+                && description.contains("allow_additional=true"))
+    );
+    assert!(create["inputSchema"].to_string().contains("allow_additional"));
+    let network = listed_tool(tools, "browser_network");
+    assert!(
+        network["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("tail -f"))
+    );
+    assert!(network["inputSchema"].to_string().contains("Start only"));
+    let watch = listed_tool(tools, "browser_network_watch");
+    assert!(watch["description"].as_str().is_some_and(|description| {
+        description.contains("next_sequence") && description.contains("no capture path")
+    }));
+    let visibility = listed_tool(tools, "browser_visibility");
+    assert!(
+        visibility["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("without stopping"))
+    );
+    let wait = listed_tool(tools, "browser_wait");
+    assert!(
+        wait["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("browser_unavailable"))
+    );
+    let audit = listed_tool(tools, "browser_audit");
+    assert!(audit["description"].as_str().is_some_and(|description| {
+        description.contains("next_event_id")
+            && description.contains("from_start")
+            && description.contains("older_records_dropped")
+    }));
+    assert!(audit["inputSchema"].to_string().contains("after_event_id"));
+    assert!(!encoded_tools.contains("browser_ws"));
+    assert!(!encoded_tools.contains("manifest_path"));
 }

--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -51,7 +51,10 @@ mod visibility;
 mod workspace;
 
 pub use agent::{claim, enqueue_action, heartbeat, release, request_handoff};
-pub use audit::{audit_path_for_root, default_audit_path, read_audit};
+pub use audit::{
+    AuditJournal, AuditPage, AuditPageRequest, DEFAULT_AUDIT_PAGE_LIMIT, MAX_AUDIT_PAGE_LIMIT, audit_path_for_root,
+    default_audit_path, page_audit, read_audit, read_audit_journal,
+};
 pub use create::{
     BrowserCreateAuditStatus, BrowserCreateOutcome, BrowserCreateRequest, BrowserCreateResult, CreateNavigation,
     claim_create_request, complete_create_request, enqueue_create, list_create_requests, record_create_status,
@@ -65,8 +68,8 @@ pub use visibility::{
 };
 pub use workspace::{
     AgentIdentity, HOST_INSTANCE_ENV, HostStampOutcome, ManifestWorkspace, OUTSIDE_WORKSPACE_MESSAGE,
-    actor_is_workspace_scoped, host_instance, publish_requested_panel, read_audit_for, sync_host_state,
-    sync_host_state_in, valid_host_instance,
+    actor_is_workspace_scoped, host_instance, publish_requested_panel, read_audit_for, read_audit_journal_for,
+    sync_host_state, sync_host_state_in, valid_host_instance,
 };
 
 /// How long an agent owner heartbeat stays fresh.

--- a/crates/horizon-core/src/browser/manifest/audit.rs
+++ b/crates/horizon-core/src/browser/manifest/audit.rs
@@ -8,11 +8,136 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use horizon_browser::BrowserAuditEntry;
+use serde::{Deserialize, Serialize};
 
 use super::ManifestLock;
 use crate::horizon_home::{HorizonHome, safe_local_id};
 
 const MAX_AUDIT_SEGMENT_BYTES: u64 = 8 * 1024 * 1024;
+/// Default `browser_audit` page size when the caller omits `limit`.
+pub const DEFAULT_AUDIT_PAGE_LIMIT: usize = 100;
+/// Maximum `browser_audit` page size. Larger journals are read with a cursor.
+pub const MAX_AUDIT_PAGE_LIMIT: usize = 500;
+
+/// Retained audit records plus loss counters for one panel journal.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AuditJournal {
+    /// Ordered retained entries, oldest first, across the live and rotated segments.
+    pub entries: Vec<BrowserAuditEntry>,
+    /// JSONL lines that could not be decoded and were skipped.
+    pub malformed_records: u64,
+    /// Valid records overwritten out of the rotated segment and no longer retained.
+    pub older_records_dropped: u64,
+}
+
+/// Bounded read of a retained audit journal.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AuditPageRequest {
+    /// Exclusive resume cursor. When set, `from_start` is ignored.
+    pub after_event_id: Option<String>,
+    /// When true and `after_event_id` is absent, start at the oldest retained match.
+    pub from_start: bool,
+    /// Optional action-id filter applied before paging.
+    pub action_id: Option<String>,
+    /// Page size after clamping to `1..=MAX_AUDIT_PAGE_LIMIT`.
+    pub limit: usize,
+}
+
+/// One bounded page of retained audit records plus pagination and loss metadata.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AuditPage {
+    /// Matching records in this page, oldest first.
+    pub entries: Vec<BrowserAuditEntry>,
+    /// `event_id` of the last returned record; reuse as `after_event_id`.
+    pub next_event_id: Option<String>,
+    /// True when newer matching retained records exist after this page.
+    pub has_more: bool,
+    /// Number of records in `entries`.
+    pub records_returned: u64,
+    /// Matching retained records across every kept segment.
+    pub records_retained: u64,
+    /// Journal-level malformed JSONL lines.
+    pub malformed_records: u64,
+    /// Journal-level records rotated out of retention.
+    pub older_records_dropped: u64,
+    /// True when `after_event_id` was not found in the retained matching records.
+    pub cursor_lost: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct AuditDropMeta {
+    older_records_dropped: u64,
+}
+
+impl AuditPageRequest {
+    /// Build a page request, dropping empty identifiers and clamping `limit`.
+    #[must_use]
+    pub fn new(
+        after_event_id: Option<String>,
+        from_start: bool,
+        action_id: Option<String>,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            after_event_id: nonempty(after_event_id),
+            from_start,
+            action_id: nonempty(action_id),
+            limit: limit.unwrap_or(DEFAULT_AUDIT_PAGE_LIMIT).clamp(1, MAX_AUDIT_PAGE_LIMIT),
+        }
+    }
+}
+
+/// Select one bounded page from a retained journal.
+#[must_use]
+pub fn page_audit(journal: &AuditJournal, request: &AuditPageRequest) -> AuditPage {
+    let limit = request.limit.clamp(1, MAX_AUDIT_PAGE_LIMIT);
+    let matching: Vec<&BrowserAuditEntry> = journal
+        .entries
+        .iter()
+        .filter(|entry| {
+            request
+                .action_id
+                .as_ref()
+                .is_none_or(|action_id| entry.action_id == *action_id)
+        })
+        .collect();
+    let records_retained = count(matching.len());
+    let (start, cursor_lost) = page_start(&matching, request, limit);
+    let has_more = start.saturating_add(limit) < matching.len();
+    let entries: Vec<BrowserAuditEntry> = matching.into_iter().skip(start).take(limit).cloned().collect();
+    AuditPage {
+        next_event_id: entries.last().map(|entry| entry.event_id.clone()),
+        has_more,
+        records_returned: count(entries.len()),
+        records_retained,
+        malformed_records: journal.malformed_records,
+        older_records_dropped: journal.older_records_dropped,
+        cursor_lost,
+        entries,
+    }
+}
+
+fn page_start(matching: &[&BrowserAuditEntry], request: &AuditPageRequest, limit: usize) -> (usize, bool) {
+    if let Some(after) = request.after_event_id.as_deref() {
+        return match matching.iter().position(|entry| entry.event_id == after) {
+            Some(index) => (index.saturating_add(1), false),
+            None => (0, true),
+        };
+    }
+    if request.from_start {
+        (0, false)
+    } else {
+        (matching.len().saturating_sub(limit), false)
+    }
+}
+
+fn nonempty(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
+fn count(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
 
 #[must_use]
 pub fn audit_path_for_root(root: &Path, panel_local_id: &str) -> PathBuf {
@@ -111,10 +236,76 @@ fn write_entry(
     let encoded_len = u64::try_from(encoded.len()).unwrap_or(u64::MAX);
     let current_len = file.metadata()?.len();
     if current_len > 0 && current_len.saturating_add(encoded_len) > max_segment_bytes {
+        record_rotated_out(path)?;
         copy_private(path, &rotated_path(path))?;
         file.set_len(0)?;
     }
     file.write_all(&encoded)
+}
+
+fn record_rotated_out(path: &Path) -> std::io::Result<()> {
+    let rotated = rotated_path(path);
+    if !rotated.exists() {
+        return Ok(());
+    }
+    let dropped = count_records(&rotated)?;
+    if dropped == 0 {
+        return Ok(());
+    }
+    let meta_path = drop_meta_path(path);
+    let meta = AuditDropMeta {
+        older_records_dropped: read_drop_meta(&meta_path)?.saturating_add(dropped),
+    };
+    write_drop_meta(&meta_path, &meta)
+}
+
+fn count_records(path: &Path) -> std::io::Result<u64> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let mut records = 0_u64;
+    for line in std::io::BufReader::new(file).lines() {
+        if !line?.trim().is_empty() {
+            records = records.saturating_add(1);
+        }
+    }
+    Ok(records)
+}
+
+fn drop_meta_path(path: &Path) -> PathBuf {
+    let mut meta = path.as_os_str().to_os_string();
+    meta.push(".meta");
+    PathBuf::from(meta)
+}
+
+fn read_drop_meta(path: &Path) -> std::io::Result<u64> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    if bytes.is_empty() {
+        return Ok(0);
+    }
+    let meta: AuditDropMeta =
+        serde_json::from_slice(&bytes).map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    Ok(meta.older_records_dropped)
+}
+
+fn write_drop_meta(path: &Path, meta: &AuditDropMeta) -> std::io::Result<()> {
+    let mut encoded = serde_json::to_vec(meta).map_err(std::io::Error::other)?;
+    encoded.push(b'\n');
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options.open(path)?;
+    #[cfg(unix)]
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    file.write_all(&encoded)?;
+    file.flush()
 }
 
 fn copy_private(source_path: &Path, destination_path: &Path) -> std::io::Result<()> {
@@ -138,29 +329,49 @@ fn rotated_path(path: &Path) -> PathBuf {
 
 /// Read the ordered action journal for one panel identity.
 ///
+/// Malformed JSONL lines are skipped; use [`read_audit_journal`] when loss
+/// counters are required.
+///
 /// # Errors
-/// Returns an I/O or invalid-data error when a persisted journal cannot be
-/// read as complete JSONL records.
+/// Returns an I/O or invalid-data error when a persisted journal or its drop
+/// metadata cannot be read.
 pub fn read_audit(panel_local_id: &str) -> std::io::Result<Vec<BrowserAuditEntry>> {
     read_at(&default_audit_path(panel_local_id))
 }
 
+/// Read retained audit records and loss counters for one panel identity.
+///
+/// # Errors
+/// Returns an I/O or invalid-data error when a persisted journal or its drop
+/// metadata cannot be read.
+pub fn read_audit_journal(panel_local_id: &str) -> std::io::Result<AuditJournal> {
+    read_journal_at(&default_audit_path(panel_local_id))
+}
+
 pub(super) fn read_at(path: &Path) -> std::io::Result<Vec<BrowserAuditEntry>> {
+    Ok(read_journal_at(path)?.entries)
+}
+
+pub(super) fn read_journal_at(path: &Path) -> std::io::Result<AuditJournal> {
     // Writers serialize one complete JSONL record while holding this same
     // inter-process lock. Taking it for the read prevents a live auditor from
     // mistaking an in-progress final append for journal corruption.
     let rotated = rotated_path(path);
-    if !path.exists() && !rotated.exists() {
-        return Ok(Vec::new());
+    let meta_path = drop_meta_path(path);
+    if !path.exists() && !rotated.exists() && !meta_path.exists() {
+        return Ok(AuditJournal::default());
     }
     let _lock = ManifestLock::acquire(path)?;
-    let mut entries = Vec::new();
-    read_segment(&rotated, &mut entries)?;
-    read_segment(path, &mut entries)?;
-    Ok(entries)
+    let mut journal = AuditJournal {
+        older_records_dropped: read_drop_meta(&meta_path)?,
+        ..AuditJournal::default()
+    };
+    read_segment(&rotated, &mut journal)?;
+    read_segment(path, &mut journal)?;
+    Ok(journal)
 }
 
-fn read_segment(path: &Path, entries: &mut Vec<BrowserAuditEntry>) -> std::io::Result<()> {
+fn read_segment(path: &Path, journal: &mut AuditJournal) -> std::io::Result<()> {
     let file = match std::fs::File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -171,9 +382,10 @@ fn read_segment(path: &Path, entries: &mut Vec<BrowserAuditEntry>) -> std::io::R
         if line.trim().is_empty() {
             continue;
         }
-        entries.push(
-            serde_json::from_str(&line).map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
-        );
+        match serde_json::from_str(&line) {
+            Ok(entry) => journal.entries.push(entry),
+            Err(_) => journal.malformed_records = journal.malformed_records.saturating_add(1),
+        }
     }
     Ok(())
 }
@@ -184,6 +396,25 @@ mod tests {
     use horizon_browser::{
         BrowserAuditAction, BrowserAuditActor, BrowserAuditEntry, BrowserAuditStatus, new_action_id,
     };
+
+    fn entry(event_id: &str, action_id: &str) -> BrowserAuditEntry {
+        BrowserAuditEntry {
+            schema_version: 1,
+            event_id: event_id.to_string(),
+            action_id: action_id.to_string(),
+            at_millis: 0,
+            actor: BrowserAuditActor::User,
+            status: BrowserAuditStatus::Dispatched,
+            action: BrowserAuditAction::Reload,
+        }
+    }
+
+    fn journal(entries: Vec<BrowserAuditEntry>) -> AuditJournal {
+        AuditJournal {
+            entries,
+            ..AuditJournal::default()
+        }
+    }
 
     #[test]
     fn audit_is_append_only_private_jsonl() {
@@ -237,9 +468,155 @@ mod tests {
             append_at_with_limit(&path, entry, 1).unwrap();
         }
 
-        assert_eq!(read_at(&path).unwrap(), entries[1..]);
+        let retained = read_journal_at(&path).unwrap();
+        assert_eq!(retained.entries, entries[1..]);
+        assert_eq!(retained.older_records_dropped, 1);
+        assert_eq!(retained.malformed_records, 0);
         assert!(std::fs::metadata(&path).unwrap().len() > 0);
         assert!(std::fs::metadata(rotated_path(&path)).unwrap().len() > 0);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn journal_skips_malformed_lines_and_counts_them() {
+        let root = tempfile::tempdir().unwrap();
+        let path = audit_path_for_root(root.path(), "panel");
+        let valid = entry("event-2", "action-a");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!("{{not json}}\n{}\n\n", serde_json::to_string(&valid).unwrap()),
+        )
+        .unwrap();
+
+        let journal = read_journal_at(&path).unwrap();
+        assert_eq!(journal.entries, [valid]);
+        assert_eq!(journal.malformed_records, 1);
+    }
+
+    #[test]
+    fn page_returns_newest_matching_window_by_default() {
+        let journal = journal(vec![
+            entry("e1", "a"),
+            entry("e2", "a"),
+            entry("e3", "b"),
+            entry("e4", "a"),
+        ]);
+        let page = page_audit(&journal, &AuditPageRequest::new(None, false, None, Some(2)));
+        assert_eq!(
+            page.entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e3", "e4"]
+        );
+        assert_eq!(page.next_event_id.as_deref(), Some("e4"));
+        assert!(!page.has_more);
+        assert_eq!(page.records_returned, 2);
+        assert_eq!(page.records_retained, 4);
+        assert!(!page.cursor_lost);
+    }
+
+    #[test]
+    fn page_from_start_walks_every_retained_record_with_the_cursor() {
+        let journal = journal((1..=5).map(|index| entry(&format!("e{index}"), "a")).collect());
+        let first = page_audit(&journal, &AuditPageRequest::new(None, true, None, Some(2)));
+        assert_eq!(
+            first
+                .entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e1", "e2"]
+        );
+        assert!(first.has_more);
+        assert_eq!(first.next_event_id.as_deref(), Some("e2"));
+
+        let second = page_audit(
+            &journal,
+            &AuditPageRequest::new(first.next_event_id.clone(), false, None, Some(2)),
+        );
+        assert_eq!(
+            second
+                .entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e3", "e4"]
+        );
+        assert!(second.has_more);
+
+        let third = page_audit(
+            &journal,
+            &AuditPageRequest::new(second.next_event_id.clone(), true, None, Some(2)),
+        );
+        assert_eq!(
+            third
+                .entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e5"]
+        );
+        assert!(!third.has_more);
+        assert!(!third.cursor_lost);
+        assert_eq!(third.records_retained, 5);
+    }
+
+    #[test]
+    fn page_filters_by_action_id_before_paging() {
+        let journal = journal(vec![
+            entry("e1", "keep"),
+            entry("e2", "drop"),
+            entry("e3", "keep"),
+            entry("e4", "keep"),
+        ]);
+        let page = page_audit(
+            &journal,
+            &AuditPageRequest::new(None, true, Some("keep".to_string()), Some(2)),
+        );
+        assert_eq!(
+            page.entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e1", "e3"]
+        );
+        assert!(page.has_more);
+        assert_eq!(page.records_retained, 3);
+    }
+
+    #[test]
+    fn page_reports_cursor_lost_and_continues_from_retained_records() {
+        let journal = AuditJournal {
+            entries: vec![entry("e3", "a"), entry("e4", "a")],
+            older_records_dropped: 2,
+            malformed_records: 1,
+        };
+        let page = page_audit(
+            &journal,
+            &AuditPageRequest::new(Some("e1".to_string()), false, None, Some(10)),
+        );
+        assert!(page.cursor_lost);
+        assert_eq!(
+            page.entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e3", "e4"]
+        );
+        assert!(!page.has_more);
+        assert_eq!(page.older_records_dropped, 2);
+        assert_eq!(page.malformed_records, 1);
+    }
+
+    #[test]
+    fn page_request_clamps_limit_and_ignores_empty_identifiers() {
+        let request = AuditPageRequest::new(Some(String::new()), true, Some(String::new()), Some(0));
+        assert_eq!(request.after_event_id, None);
+        assert_eq!(request.action_id, None);
+        assert_eq!(request.limit, 1);
+        let wide = AuditPageRequest::new(None, false, None, Some(10_000));
+        assert_eq!(wide.limit, MAX_AUDIT_PAGE_LIMIT);
     }
 }

--- a/crates/horizon-core/src/browser/manifest/audit.rs
+++ b/crates/horizon-core/src/browser/manifest/audit.rs
@@ -256,8 +256,9 @@ fn write_entry(
     let mut encoded = serde_json::to_vec(entry).map_err(std::io::Error::other)?;
     encoded.push(b'\n');
     let encoded_len = u64::try_from(encoded.len()).unwrap_or(u64::MAX);
-    let current_len = file.metadata()?.len();
     settle_pending_drop(path)?;
+    complete_interrupted_rotation(Some(file), path)?;
+    let current_len = file.metadata()?.len();
     if current_len > 0 && current_len.saturating_add(encoded_len) > max_segment_bytes {
         stage_drop_for_rotated_segment(path)?;
         copy_private(path, &rotated_path(path))?;
@@ -287,6 +288,25 @@ fn stage_drop_for_rotated_segment(path: &Path) -> std::io::Result<()> {
         fingerprint: fingerprint(&rotated)?,
     };
     request_queue::write_private_json(&pending_path, &pending)
+}
+
+fn complete_interrupted_rotation(file: Option<&mut std::fs::File>, path: &Path) -> std::io::Result<()> {
+    if !live_segment_duplicates_rotated(path)? {
+        return Ok(());
+    }
+    match file {
+        Some(file) => file.set_len(0)?,
+        None => OpenOptions::new().write(true).open(path)?.set_len(0)?,
+    }
+    Ok(())
+}
+
+fn live_segment_duplicates_rotated(path: &Path) -> std::io::Result<bool> {
+    let rotated = rotated_path(path);
+    if !path.exists() || !rotated.exists() {
+        return Ok(false);
+    }
+    Ok(fingerprint(path)? == fingerprint(&rotated)?)
 }
 
 fn settle_pending_drop(path: &Path) -> std::io::Result<u64> {
@@ -462,6 +482,7 @@ pub(super) fn read_journal_at(path: &Path) -> std::io::Result<AuditJournal> {
         older_records_dropped: settle_pending_drop(path)?,
         ..AuditJournal::default()
     };
+    complete_interrupted_rotation(None, path)?;
     read_segment(&rotated, &mut journal)?;
     read_segment(path, &mut journal)?;
     Ok(journal)
@@ -765,5 +786,36 @@ mod tests {
         assert_eq!(read_journal_at(&path).unwrap().older_records_dropped, 9);
         append_at_with_limit(&path, &entry("e4", "a"), 1).unwrap();
         assert_eq!(read_journal_at(&path).unwrap().older_records_dropped, 10);
+    }
+
+    #[test]
+    fn interrupted_copy_does_not_duplicate_event_ids_or_loop_pages() {
+        let root = tempfile::tempdir().unwrap();
+        let path = audit_path_for_root(root.path(), "panel");
+        let first = entry("e1", "a");
+        let second = entry("e2", "a");
+        append_at_with_limit(&path, &first, 1).unwrap();
+        append_at_with_limit(&path, &second, 1).unwrap();
+        copy_private(&path, &rotated_path(&path)).unwrap();
+
+        let journal = read_journal_at(&path).unwrap();
+        assert_eq!(
+            journal
+                .entries
+                .iter()
+                .map(|entry| entry.event_id.as_str())
+                .collect::<Vec<_>>(),
+            ["e2"]
+        );
+
+        let first_page = page_audit(&journal, &AuditPageRequest::new(None, true, None, Some(1)));
+        assert_eq!(first_page.next_event_id.as_deref(), Some("e2"));
+        assert!(!first_page.has_more);
+        let second_page = page_audit(
+            &journal,
+            &AuditPageRequest::new(first_page.next_event_id.clone(), false, None, Some(1)),
+        );
+        assert!(second_page.entries.is_empty());
+        assert!(!second_page.has_more);
     }
 }

--- a/crates/horizon-core/src/browser/manifest/audit.rs
+++ b/crates/horizon-core/src/browser/manifest/audit.rs
@@ -27,7 +27,8 @@ pub struct AuditJournal {
     pub entries: Vec<BrowserAuditEntry>,
     /// JSONL lines that could not be decoded and were skipped.
     pub malformed_records: u64,
-    /// Valid records overwritten out of the rotated segment and no longer retained.
+    /// Non-empty JSONL records overwritten out of the rotated segment.
+    /// Malformed lines are included; this is not a decoded-entry count.
     pub older_records_dropped: u64,
 }
 
@@ -257,12 +258,14 @@ fn write_entry(
     encoded.push(b'\n');
     let encoded_len = u64::try_from(encoded.len()).unwrap_or(u64::MAX);
     settle_pending_drop(path)?;
-    complete_interrupted_rotation(Some(file), path)?;
+    recover_interrupted_rotation(Some(file), path)?;
     let current_len = file.metadata()?.len();
     if current_len > 0 && current_len.saturating_add(encoded_len) > max_segment_bytes {
         stage_drop_for_rotated_segment(path)?;
-        copy_private(path, &rotated_path(path))?;
+        write_rotation_marker(path)?;
+        replace_file_atomically(path, &rotated_path(path))?;
         file.set_len(0)?;
+        clear_rotation_marker(path)?;
         settle_pending_drop(path)?;
     }
     file.write_all(&encoded)
@@ -290,15 +293,22 @@ fn stage_drop_for_rotated_segment(path: &Path) -> std::io::Result<()> {
     request_queue::write_private_json(&pending_path, &pending)
 }
 
-fn complete_interrupted_rotation(file: Option<&mut std::fs::File>, path: &Path) -> std::io::Result<()> {
-    if !live_segment_duplicates_rotated(path)? {
+fn recover_interrupted_rotation(file: Option<&mut std::fs::File>, path: &Path) -> std::io::Result<()> {
+    if !rotation_marker_path(path).exists() {
         return Ok(());
     }
-    match file {
-        Some(file) => file.set_len(0)?,
-        None => OpenOptions::new().write(true).open(path)?.set_len(0)?,
+    match std::fs::remove_file(rotated_tmp_path(path)) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
     }
-    Ok(())
+    if live_segment_duplicates_rotated(path)? {
+        match file {
+            Some(file) => file.set_len(0)?,
+            None => OpenOptions::new().write(true).open(path)?.set_len(0)?,
+        }
+    }
+    clear_rotation_marker(path)
 }
 
 fn live_segment_duplicates_rotated(path: &Path) -> std::io::Result<bool> {
@@ -412,6 +422,46 @@ fn pending_drop_path(path: &Path) -> PathBuf {
     PathBuf::from(pending)
 }
 
+fn rotation_marker_path(path: &Path) -> PathBuf {
+    let mut marker = path.as_os_str().to_os_string();
+    marker.push(".rotating");
+    PathBuf::from(marker)
+}
+
+fn rotated_tmp_path(path: &Path) -> PathBuf {
+    let mut tmp = rotated_path(path).into_os_string();
+    tmp.push(".tmp");
+    PathBuf::from(tmp)
+}
+
+fn write_rotation_marker(path: &Path) -> std::io::Result<()> {
+    request_queue::write_private_json(&rotation_marker_path(path), &true)
+}
+
+fn clear_rotation_marker(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(rotation_marker_path(path)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn replace_file_atomically(source: &Path, dest: &Path) -> std::io::Result<()> {
+    let tmp = {
+        let mut tmp = dest.as_os_str().to_os_string();
+        tmp.push(".tmp");
+        PathBuf::from(tmp)
+    };
+    copy_private(source, &tmp)?;
+    match std::fs::rename(&tmp, dest) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(error)
+        }
+    }
+}
+
 fn read_drop_meta(path: &Path) -> std::io::Result<AuditDropMeta> {
     match request_queue::read_json(&drop_meta_path(path))? {
         Some(meta) => Ok(meta),
@@ -474,7 +524,8 @@ pub(super) fn read_journal_at(path: &Path) -> std::io::Result<AuditJournal> {
     let rotated = rotated_path(path);
     let meta_path = drop_meta_path(path);
     let pending_path = pending_drop_path(path);
-    if !path.exists() && !rotated.exists() && !meta_path.exists() && !pending_path.exists() {
+    let marker_path = rotation_marker_path(path);
+    if !path.exists() && !rotated.exists() && !meta_path.exists() && !pending_path.exists() && !marker_path.exists() {
         return Ok(AuditJournal::default());
     }
     let _lock = ManifestLock::acquire(path)?;
@@ -482,7 +533,7 @@ pub(super) fn read_journal_at(path: &Path) -> std::io::Result<AuditJournal> {
         older_records_dropped: settle_pending_drop(path)?,
         ..AuditJournal::default()
     };
-    complete_interrupted_rotation(None, path)?;
+    recover_interrupted_rotation(None, path)?;
     read_segment(&rotated, &mut journal)?;
     read_segment(path, &mut journal)?;
     Ok(journal)
@@ -796,6 +847,7 @@ mod tests {
         let second = entry("e2", "a");
         append_at_with_limit(&path, &first, 1).unwrap();
         append_at_with_limit(&path, &second, 1).unwrap();
+        write_rotation_marker(&path).unwrap();
         copy_private(&path, &rotated_path(&path)).unwrap();
 
         let journal = read_journal_at(&path).unwrap();

--- a/crates/horizon-core/src/browser/manifest/audit.rs
+++ b/crates/horizon-core/src/browser/manifest/audit.rs
@@ -32,7 +32,7 @@ pub struct AuditJournal {
 }
 
 /// Bounded read of a retained audit journal.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuditPageRequest {
     /// Exclusive resume cursor. When set, `from_start` is ignored.
     pub after_event_id: Option<String>,
@@ -83,6 +83,12 @@ struct PendingDrop {
 struct SegmentFingerprint {
     len: u64,
     checksum: u64,
+}
+
+impl Default for AuditPageRequest {
+    fn default() -> Self {
+        Self::new(None, false, None, None)
+    }
 }
 
 impl AuditPageRequest {
@@ -699,6 +705,8 @@ mod tests {
         assert_eq!(request.limit, 1);
         let wide = AuditPageRequest::new(None, false, None, Some(10_000));
         assert_eq!(wide.limit, MAX_AUDIT_PAGE_LIMIT);
+        assert_eq!(AuditPageRequest::default().limit, DEFAULT_AUDIT_PAGE_LIMIT);
+        assert!(!AuditPageRequest::default().from_start);
     }
 
     #[test]

--- a/crates/horizon-core/src/browser/manifest/audit.rs
+++ b/crates/horizon-core/src/browser/manifest/audit.rs
@@ -11,6 +11,7 @@ use horizon_browser::BrowserAuditEntry;
 use serde::{Deserialize, Serialize};
 
 use super::ManifestLock;
+use super::request_queue;
 use crate::horizon_home::{HorizonHome, safe_local_id};
 
 const MAX_AUDIT_SEGMENT_BYTES: u64 = 8 * 1024 * 1024;
@@ -67,6 +68,21 @@ pub struct AuditPage {
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct AuditDropMeta {
     older_records_dropped: u64,
+    #[serde(default)]
+    applied_generation: u64,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct PendingDrop {
+    records: u64,
+    generation: u64,
+    fingerprint: SegmentFingerprint,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct SegmentFingerprint {
+    len: u64,
+    checksum: u64,
 }
 
 impl AuditPageRequest {
@@ -235,43 +251,127 @@ fn write_entry(
     encoded.push(b'\n');
     let encoded_len = u64::try_from(encoded.len()).unwrap_or(u64::MAX);
     let current_len = file.metadata()?.len();
+    settle_pending_drop(path)?;
     if current_len > 0 && current_len.saturating_add(encoded_len) > max_segment_bytes {
-        record_rotated_out(path)?;
+        stage_drop_for_rotated_segment(path)?;
         copy_private(path, &rotated_path(path))?;
         file.set_len(0)?;
+        settle_pending_drop(path)?;
     }
     file.write_all(&encoded)
 }
 
-fn record_rotated_out(path: &Path) -> std::io::Result<()> {
+fn stage_drop_for_rotated_segment(path: &Path) -> std::io::Result<()> {
     let rotated = rotated_path(path);
     if !rotated.exists() {
         return Ok(());
     }
-    let dropped = count_records(&rotated)?;
-    if dropped == 0 {
+    let pending_path = pending_drop_path(path);
+    if pending_path.exists() {
         return Ok(());
     }
-    let meta_path = drop_meta_path(path);
-    let meta = AuditDropMeta {
-        older_records_dropped: read_drop_meta(&meta_path)?.saturating_add(dropped),
+    let records = count_records(&rotated)?;
+    if records == 0 {
+        return Ok(());
+    }
+    let meta = read_drop_meta(path)?;
+    let pending = PendingDrop {
+        records,
+        generation: meta.applied_generation.saturating_add(1),
+        fingerprint: fingerprint(&rotated)?,
     };
-    write_drop_meta(&meta_path, &meta)
+    request_queue::write_private_json(&pending_path, &pending)
+}
+
+fn settle_pending_drop(path: &Path) -> std::io::Result<u64> {
+    let meta_path = drop_meta_path(path);
+    let pending_path = pending_drop_path(path);
+    let mut meta = read_drop_meta(path)?;
+    let Some(pending) = read_pending(&pending_path)? else {
+        return Ok(meta.older_records_dropped);
+    };
+    if rotated_segment_matches(path, &pending.fingerprint)? {
+        return Ok(meta.older_records_dropped);
+    }
+    if pending.generation > meta.applied_generation {
+        meta.older_records_dropped = meta.older_records_dropped.saturating_add(pending.records);
+        meta.applied_generation = pending.generation;
+        request_queue::write_private_json(&meta_path, &meta)?;
+    }
+    match std::fs::remove_file(&pending_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    Ok(meta.older_records_dropped)
+}
+
+fn rotated_segment_matches(path: &Path, expected: &SegmentFingerprint) -> std::io::Result<bool> {
+    match fingerprint(&rotated_path(path)) {
+        Ok(actual) => Ok(actual == *expected),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 fn count_records(path: &Path) -> std::io::Result<u64> {
+    let mut records = 0_u64;
+    for_each_nonempty_record(path, |_| {
+        records = records.saturating_add(1);
+        Ok(())
+    })?;
+    Ok(records)
+}
+
+fn for_each_nonempty_record(path: &Path, mut visit: impl FnMut(&[u8]) -> std::io::Result<()>) -> std::io::Result<()> {
     let file = match std::fs::File::open(path) {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
     };
-    let mut records = 0_u64;
-    for line in std::io::BufReader::new(file).lines() {
-        if !line?.trim().is_empty() {
-            records = records.saturating_add(1);
+    let mut reader = std::io::BufReader::new(file);
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let read = reader.read_until(b'\n', &mut line)?;
+        if read == 0 {
+            return Ok(());
+        }
+        let record = trim_ascii(&line);
+        if !record.is_empty() {
+            visit(record)?;
         }
     }
-    Ok(records)
+}
+
+fn trim_ascii(bytes: &[u8]) -> &[u8] {
+    let is_whitespace = |byte: u8| matches!(byte, b' ' | b'\t' | b'\n' | b'\r');
+    let start = bytes
+        .iter()
+        .position(|byte| !is_whitespace(*byte))
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|byte| !is_whitespace(*byte))
+        .map_or(start, |index| index.saturating_add(1));
+    bytes.get(start..end).unwrap_or(&[])
+}
+
+fn fingerprint(path: &Path) -> std::io::Result<SegmentFingerprint> {
+    let bytes = std::fs::read(path)?;
+    Ok(SegmentFingerprint {
+        len: u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+        checksum: fnv1a64(&bytes),
+    })
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
 }
 
 fn drop_meta_path(path: &Path) -> PathBuf {
@@ -280,32 +380,21 @@ fn drop_meta_path(path: &Path) -> PathBuf {
     PathBuf::from(meta)
 }
 
-fn read_drop_meta(path: &Path) -> std::io::Result<u64> {
-    let bytes = match std::fs::read(path) {
-        Ok(bytes) => bytes,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(error) => return Err(error),
-    };
-    if bytes.is_empty() {
-        return Ok(0);
-    }
-    let meta: AuditDropMeta =
-        serde_json::from_slice(&bytes).map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-    Ok(meta.older_records_dropped)
+fn pending_drop_path(path: &Path) -> PathBuf {
+    let mut pending = path.as_os_str().to_os_string();
+    pending.push(".dropping");
+    PathBuf::from(pending)
 }
 
-fn write_drop_meta(path: &Path, meta: &AuditDropMeta) -> std::io::Result<()> {
-    let mut encoded = serde_json::to_vec(meta).map_err(std::io::Error::other)?;
-    encoded.push(b'\n');
-    let mut options = OpenOptions::new();
-    options.create(true).write(true).truncate(true);
-    #[cfg(unix)]
-    options.mode(0o600);
-    let mut file = options.open(path)?;
-    #[cfg(unix)]
-    file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
-    file.write_all(&encoded)?;
-    file.flush()
+fn read_drop_meta(path: &Path) -> std::io::Result<AuditDropMeta> {
+    match request_queue::read_json(&drop_meta_path(path))? {
+        Some(meta) => Ok(meta),
+        None => Ok(AuditDropMeta::default()),
+    }
+}
+
+fn read_pending(path: &Path) -> std::io::Result<Option<PendingDrop>> {
+    request_queue::read_json(path)
 }
 
 fn copy_private(source_path: &Path, destination_path: &Path) -> std::io::Result<()> {
@@ -358,12 +447,13 @@ pub(super) fn read_journal_at(path: &Path) -> std::io::Result<AuditJournal> {
     // mistaking an in-progress final append for journal corruption.
     let rotated = rotated_path(path);
     let meta_path = drop_meta_path(path);
-    if !path.exists() && !rotated.exists() && !meta_path.exists() {
+    let pending_path = pending_drop_path(path);
+    if !path.exists() && !rotated.exists() && !meta_path.exists() && !pending_path.exists() {
         return Ok(AuditJournal::default());
     }
     let _lock = ManifestLock::acquire(path)?;
     let mut journal = AuditJournal {
-        older_records_dropped: read_drop_meta(&meta_path)?,
+        older_records_dropped: settle_pending_drop(path)?,
         ..AuditJournal::default()
     };
     read_segment(&rotated, &mut journal)?;
@@ -372,22 +462,13 @@ pub(super) fn read_journal_at(path: &Path) -> std::io::Result<AuditJournal> {
 }
 
 fn read_segment(path: &Path, journal: &mut AuditJournal) -> std::io::Result<()> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error),
-    };
-    for line in std::io::BufReader::new(file).lines() {
-        let line = line?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        match serde_json::from_str(&line) {
+    for_each_nonempty_record(path, |record| {
+        match serde_json::from_slice(record) {
             Ok(entry) => journal.entries.push(entry),
             Err(_) => journal.malformed_records = journal.malformed_records.saturating_add(1),
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -618,5 +699,63 @@ mod tests {
         assert_eq!(request.limit, 1);
         let wide = AuditPageRequest::new(None, false, None, Some(10_000));
         assert_eq!(wide.limit, MAX_AUDIT_PAGE_LIMIT);
+    }
+
+    #[test]
+    fn journal_counts_invalid_utf8_lines_as_malformed() {
+        let root = tempfile::tempdir().unwrap();
+        let path = audit_path_for_root(root.path(), "panel");
+        let valid = entry("event-2", "action-a");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut bytes = b"\xff\xfe not utf8\n".to_vec();
+        bytes.extend(serde_json::to_vec(&valid).unwrap());
+        bytes.push(b'\n');
+        std::fs::write(&path, bytes).unwrap();
+
+        let journal = read_journal_at(&path).unwrap();
+        assert_eq!(journal.entries, [valid]);
+        assert_eq!(journal.malformed_records, 1);
+    }
+
+    #[test]
+    fn rotation_counts_invalid_utf8_records_without_aborting() {
+        let root = tempfile::tempdir().unwrap();
+        let path = audit_path_for_root(root.path(), "panel");
+        let first = entry("e1", "a");
+        let second = entry("e2", "a");
+        append_at_with_limit(&path, &first, 1).unwrap();
+        append_at_with_limit(&path, &second, 1).unwrap();
+        std::fs::write(rotated_path(&path), b"\xff\n").unwrap();
+        let third = entry("e3", "a");
+        append_at_with_limit(&path, &third, 1).unwrap();
+
+        let journal = read_journal_at(&path).unwrap();
+        assert_eq!(journal.entries, [second, third]);
+        assert_eq!(journal.older_records_dropped, 1);
+    }
+
+    #[test]
+    fn pending_drop_is_held_until_the_rotated_segment_is_replaced() {
+        let root = tempfile::tempdir().unwrap();
+        let path = audit_path_for_root(root.path(), "panel");
+        let first = entry("e1", "a");
+        let second = entry("e2", "a");
+        append_at_with_limit(&path, &first, 1).unwrap();
+        append_at_with_limit(&path, &second, 1).unwrap();
+        request_queue::write_private_json(
+            &pending_drop_path(&path),
+            &PendingDrop {
+                records: 9,
+                generation: 1,
+                fingerprint: fingerprint(&rotated_path(&path)).unwrap(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(read_journal_at(&path).unwrap().older_records_dropped, 0);
+        append_at_with_limit(&path, &entry("e3", "a"), 1).unwrap();
+        assert_eq!(read_journal_at(&path).unwrap().older_records_dropped, 9);
+        append_at_with_limit(&path, &entry("e4", "a"), 1).unwrap();
+        assert_eq!(read_journal_at(&path).unwrap().older_records_dropped, 10);
     }
 }

--- a/crates/horizon-core/src/browser/manifest/workspace.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace.rs
@@ -129,20 +129,33 @@ pub(super) fn permit(manifest: &BrowserManifest, identity: AgentIdentity<'_>) ->
 /// Returns `NotFound` for a panel that is not live, `PermissionDenied` for an
 /// identity outside its workspace, or an audit storage failure.
 pub fn read_audit_for(panel_local_id: &str, identity: AgentIdentity<'_>) -> std::io::Result<Vec<BrowserAuditEntry>> {
-    read_audit_for_at(HorizonHome::resolve().root(), panel_local_id, identity)
+    Ok(read_audit_journal_for(panel_local_id, identity)?.entries)
 }
 
-fn read_audit_for_at(
+/// Read retained audit records and loss counters when `identity` may control
+/// the panel, checking membership and reading under the manifest lock.
+///
+/// # Errors
+/// Returns `NotFound` for a panel that is not live, `PermissionDenied` for an
+/// identity outside its workspace, or an audit storage failure.
+pub fn read_audit_journal_for(
+    panel_local_id: &str,
+    identity: AgentIdentity<'_>,
+) -> std::io::Result<audit::AuditJournal> {
+    read_audit_journal_for_at(HorizonHome::resolve().root(), panel_local_id, identity)
+}
+
+fn read_audit_journal_for_at(
     root: &Path,
     panel_local_id: &str,
     identity: AgentIdentity<'_>,
-) -> std::io::Result<Vec<BrowserAuditEntry>> {
+) -> std::io::Result<audit::AuditJournal> {
     let manifest_path = manifest_path_for_root(root, panel_local_id);
     let _lock = ManifestLock::acquire(&manifest_path)?;
     let manifest = read_at(&manifest_path)
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "browser panel is not live"))?;
     permit(&manifest, identity)?;
-    audit::read_at(&audit::audit_path_for_root(root, panel_local_id))
+    audit::read_journal_at(&audit::audit_path_for_root(root, panel_local_id))
 }
 
 impl ManifestWorkspace {

--- a/crates/horizon-core/src/browser/manifest/workspace/tests.rs
+++ b/crates/horizon-core/src/browser/manifest/workspace/tests.rs
@@ -81,7 +81,9 @@ fn audit_reads_are_gated_by_workspace_membership_under_the_manifest_lock() {
     )
     .expect("append audit");
 
-    let entries = read_audit_for_at(root.path(), panel, member()).expect("member reads audit");
+    let entries = read_audit_journal_for_at(root.path(), panel, member())
+        .expect("member reads audit")
+        .entries;
     assert_eq!(entries.len(), 1);
     for outsider in [
         AgentIdentity::new("horizon:agent-b", Some(HOST_A)),
@@ -89,20 +91,21 @@ fn audit_reads_are_gated_by_workspace_membership_under_the_manifest_lock() {
         AgentIdentity::new("horizon:agent-a", None),
     ] {
         assert_eq!(
-            read_audit_for_at(root.path(), panel, outsider)
+            read_audit_journal_for_at(root.path(), panel, outsider)
                 .expect_err("non-member is refused")
                 .kind(),
             std::io::ErrorKind::PermissionDenied
         );
     }
     assert_eq!(
-        read_audit_for_at(root.path(), panel, AgentIdentity::new("browser-cli-test", None))
+        read_audit_journal_for_at(root.path(), panel, AgentIdentity::new("browser-cli-test", None))
             .expect("unscoped identity reads audit")
+            .entries
             .len(),
         1
     );
     assert_eq!(
-        read_audit_for_at(root.path(), "missing", member())
+        read_audit_journal_for_at(root.path(), "missing", member())
             .expect_err("missing panel")
             .kind(),
         std::io::ErrorKind::NotFound


### PR DESCRIPTION
## Purpose

[#324](https://github.com/peters/horizon/issues/324) next slice: replace `browser_audit`'s newest-only `1..=500` window with bounded pages, a stable cursor, and loss metadata so retained journals can be iterated exhaustively.

## Behavior

- Default call still returns the newest matching page (`limit` 1–500, default 100), in chronological order within the page.
- `from_start: true` starts at the oldest retained match. Reuse `next_event_id` as `after_event_id` until `has_more` is false.
- Optional `action_id` filter is applied before paging.
- Each response includes `records_returned`, `records_retained`, `malformed_records`, `older_records_dropped`, and `cursor_lost`.
- Malformed JSONL lines are skipped and counted instead of failing the whole read.
- Overwriting the rotated `.1` segment records how many older lines left retention.
- If `after_event_id` is no longer retained, `cursor_lost` is true and the page continues from the oldest remaining match.

Workspace authorization is unchanged: the journal is still read under the manifest lock after membership is checked.

## Test evidence

- Unit tests cover newest default, `from_start` + cursor walk, action-id filtering, clamp/empty identifiers, cursor-lost continuation, malformed-line counting, and rotation drop accounting.
- MCP schema/description coverage in `server` unit tests and `stdio_protocol`.
- Local validation in this worktree (`9bd598a2`):
  - `cargo fmt --all -- --check`
  - `./scripts/check-maintainability.sh`
  - `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
  - `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
  - `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
  - Focused `horizon-core` manifest/audit tests, `horizon-browser-mcp` tests, and `horizon-browser-cli` CLI tests all passed.
  - Full `RUSTFLAGS="-D warnings" cargo test --workspace` (and `--features speech`) hit a pre-existing load flake in `run_timeout_starts_after_stdin_plan_validation` (`job deadline exceeded` after a 1s post-validation budget). Isolated reruns of that CLI file passed; this PR does not change CLI timeout behavior.

This is MCP/journal contract work, not a UI change, so there is no temporary UI smoke plan.

## Follow-up (still on #324)

Final-report observability, checkpoint/resume, standalone reconnect, runner data model, packaging, and the performance-acceptance decision are unchanged and out of scope here.