### PR TITLE
feat(browser): summarize audit and network health in job reports

### DIFF
--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -62,7 +62,9 @@ an owner-only job directory under `~/.horizon/browser-jobs/`; MCP runtime
 profiles use a separate temporary home and are removed after each job.
 
 Every completed prompt job also writes a private redacted `trace.jsonl`, a
-validated `executed-plan.json`, and `report.json`. The plan replaces the
+validated `executed-plan.json`, and `report.json`. The report includes the
+same `observability` summary as deterministic `run` when the agent event
+stream carries MCP results. The plan replaces the
 standalone panel id with a typed reference to the recorded `browser_list`
 result. The report marks the plan non-replayable when execution depended on
 ephemeral semantic references or when selectors, scripts, text, values, URL
@@ -132,7 +134,12 @@ and never copies tool arguments into its report. Plans are limited to 1 MiB and
 256 steps.
 
 The report is JSON with top-level `job_id`, `job_dir`, `state_path`, `ok`,
-`completed_steps`, and ordered step results. Every invocation stages its
+`completed_steps`, ordered step results, and an `observability` summary of
+audit completeness and network-capture health taken from executed MCP results
+(`records_retained`, `malformed_records`, `older_records_dropped`,
+`cursor_lost`, sequence gaps, records written/dropped, truncation, file
+limits, and writer failure). Tools that were not called are reported as
+`observed: false`. Every invocation stages its
 validated plan and initial `prepared` state in an owner-only directory, flushes
 both artifacts, and atomically publishes the complete job under
 `~/.horizon/browser-jobs/`; later lifecycle updates remain atomic. The prepared

--- a/crates/horizon-browser-cli/src/job/report.rs
+++ b/crates/horizon-browser-cli/src/job/report.rs
@@ -7,7 +7,7 @@ use horizon_browser_protocol::redact_url;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
-use crate::{Plan, PlanStep};
+use crate::{Plan, PlanStep, observability::ObservabilitySummary};
 
 use super::{JobError, JobOptions, create_private, io_error, write_private};
 
@@ -29,6 +29,7 @@ struct RecordedCall {
     tool: String,
     arguments: Map<String, Value>,
     ok: bool,
+    health: Option<Value>,
 }
 
 #[derive(Serialize)]
@@ -52,6 +53,7 @@ struct JobReport<'a> {
     replayable: bool,
     trace: String,
     executed_plan: String,
+    observability: ObservabilitySummary,
 }
 
 pub(super) struct ReportArtifacts {
@@ -148,6 +150,11 @@ impl JobTrace {
             replayable,
             trace: self.trace_path.display().to_string(),
             executed_plan: plan_path.display().to_string(),
+            observability: ObservabilitySummary::from_results(
+                self.calls
+                    .iter()
+                    .filter_map(|call| call.health.as_ref().map(|health| (call.tool.as_str(), health))),
+            ),
         };
         let mut report_bytes = serde_json::to_vec_pretty(&report)
             .map_err(|error| JobError::Result(format!("could not encode job report: {error}")))?;
@@ -208,11 +215,17 @@ fn parse_tool_call(line: &str) -> Option<RecordedCall> {
     if item.get("type")?.as_str()? != "mcp_tool_call" || item.get("server")?.as_str()? != "horizon-browser" {
         return None;
     }
+    let tool = item.get("tool")?.as_str()?.to_string();
+    let result = item
+        .get("result")
+        .or_else(|| item.get("output"))
+        .or_else(|| item.get("structured_content"));
     Some(RecordedCall {
-        tool: item.get("tool")?.as_str()?.to_string(),
         arguments: item.get("arguments")?.as_object()?.clone(),
         ok: item.get("status").and_then(Value::as_str) == Some("completed")
             && item.get("error").is_none_or(Value::is_null),
+        health: result.and_then(|result| ObservabilitySummary::health_payload(&tool, result)),
+        tool,
     })
 }
 
@@ -350,6 +363,71 @@ mod tests {
         let report: Value =
             serde_json::from_slice(&std::fs::read(&artifacts.report).expect("report bytes")).expect("validated report");
         assert_eq!(report["backend"], "firefox");
+        assert_eq!(report["observability"]["audit"]["observed"], false);
+        assert_eq!(report["observability"]["network"]["observed"], false);
+    }
+
+    #[test]
+    fn audit_and_network_results_are_summarized_without_payloads() {
+        let directory = tempfile::tempdir().expect("job directory");
+        let mut trace = JobTrace::start(directory.path()).expect("trace");
+        trace
+            .record_line(&event_with_result(
+                "browser_audit",
+                &json!({"panel_id":"p1"}),
+                &json!({
+                    "records_retained": 3,
+                    "records_returned": 3,
+                    "malformed_records": 1,
+                    "older_records_dropped": 2,
+                    "cursor_lost": true,
+                    "has_more": false,
+                    "entries": [{"event_id":"secret"}]
+                }),
+            ))
+            .expect("audit event");
+        trace
+            .record_line(&event_with_result(
+                "browser_network_watch",
+                &json!({"panel_id":"p1"}),
+                &json!({
+                    "sequence_gaps": 4,
+                    "records_dropped": 1,
+                    "writer_failed": true,
+                    "records": [{"payload":"secret"}]
+                }),
+            ))
+            .expect("watch event");
+        let options = JobOptions {
+            prompt: "observe".to_string(),
+            backend: None,
+            visible: false,
+            json: true,
+        };
+        let artifacts = trace
+            .finish(
+                directory.path(),
+                &ReportInput {
+                    options: &options,
+                    backend: BackendKind::ChromiumCdp,
+                    ok: true,
+                    summary: "done",
+                    artifact: None,
+                    browser_cleanup_ok: true,
+                },
+            )
+            .expect("report artifacts");
+        let report: Value =
+            serde_json::from_slice(&std::fs::read(&artifacts.report).expect("report bytes")).expect("validated report");
+        assert_eq!(report["observability"]["audit"]["observed"], true);
+        assert_eq!(report["observability"]["audit"]["records_retained"], 3);
+        assert_eq!(report["observability"]["audit"]["older_records_dropped"], 2);
+        assert_eq!(report["observability"]["audit"]["cursor_lost"], true);
+        assert_eq!(report["observability"]["network"]["sequence_gaps"], 4);
+        assert_eq!(report["observability"]["network"]["writer_failed"], true);
+        let report_text = report.to_string();
+        assert!(!report_text.contains("secret"));
+        assert!(!report_text.contains("payload"));
     }
 
     #[test]
@@ -388,6 +466,10 @@ mod tests {
     }
 
     fn event(tool: &str, arguments: &Value) -> String {
+        event_with_result(tool, arguments, &Value::Null)
+    }
+
+    fn event_with_result(tool: &str, arguments: &Value, result: &Value) -> String {
         json!({
             "type":"item.completed",
             "item":{
@@ -396,7 +478,8 @@ mod tests {
                 "tool":tool,
                 "arguments":arguments,
                 "status":"completed",
-                "error":null
+                "error":null,
+                "result":result
             }
         })
         .to_string()

--- a/crates/horizon-browser-cli/src/job/report.rs
+++ b/crates/horizon-browser-cli/src/job/report.rs
@@ -479,7 +479,10 @@ mod tests {
                 "arguments":arguments,
                 "status":"completed",
                 "error":null,
-                "result":result
+                "result":{
+                    "content":[],
+                    "structured_content":result
+                }
             }
         })
         .to_string()

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod execution_control;
 pub mod job;
+pub mod observability;
 pub mod run_state;
 pub mod standalone;
 
@@ -25,6 +26,7 @@ use serde_json::{Map, Value};
 use thiserror::Error;
 
 use execution_control::{ExecutionControl, ExecutionStopReason};
+use observability::ObservabilitySummary;
 
 const PLAN_VERSION: u32 = 1;
 const MAX_PLAN_STEPS: usize = 256;
@@ -72,6 +74,8 @@ pub struct ExecutionReport {
     /// Explicit cancellation or deadline stop condition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<ExecutionStopReason>,
+    /// Audit completeness and network-capture health from executed MCP results.
+    pub observability: ObservabilitySummary,
 }
 
 /// Result of one MCP tool call.
@@ -330,14 +334,7 @@ async fn execute_steps(
         result_indexes.insert(step.id.clone(), steps.len() - 1);
     }
     let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
-    ExecutionReport {
-        version: PLAN_VERSION,
-        ok,
-        completed_steps: steps.len(),
-        steps,
-        error: None,
-        stop_reason: None,
-    }
+    execution_report(ok, steps, None, None)
 }
 
 async fn wait_for_browser_action<T>(
@@ -383,13 +380,28 @@ fn stopped_report(steps: Vec<StepReport>, stopped: &ActionWaitStopped) -> Execut
     } else {
         stopped.reason.message()
     };
+    execution_report(false, steps, Some(message.to_string()), Some(stopped.reason))
+}
+
+fn execution_report(
+    ok: bool,
+    steps: Vec<StepReport>,
+    error: Option<String>,
+    stop_reason: Option<ExecutionStopReason>,
+) -> ExecutionReport {
+    let observability = ObservabilitySummary::from_results(
+        steps
+            .iter()
+            .filter_map(|step| step.result.as_ref().map(|result| (step.tool.as_str(), result))),
+    );
     ExecutionReport {
         version: PLAN_VERSION,
-        ok: false,
+        ok,
         completed_steps: steps.len(),
         steps,
-        error: Some(message.to_string()),
-        stop_reason: Some(stopped.reason),
+        error,
+        stop_reason,
+        observability,
     }
 }
 

--- a/crates/horizon-browser-cli/src/observability.rs
+++ b/crates/horizon-browser-cli/src/observability.rs
@@ -1,0 +1,253 @@
+//! Capture health and audit-completeness summaries for job reports.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Loss and completeness counters collected from executed MCP results.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct ObservabilitySummary {
+    /// Last `browser_audit` page metadata, if the job observed the journal.
+    pub audit: AuditObservability,
+    /// Aggregated `browser_network` / `browser_network_watch` health.
+    pub network: NetworkObservability,
+}
+
+/// Completeness of the retained action journal as last observed.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct AuditObservability {
+    /// True when at least one `browser_audit` result was recorded.
+    pub observed: bool,
+    /// Number of successful `browser_audit` results.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub pages: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub records_retained: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub records_returned: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub malformed_records: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub older_records_dropped: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_lost: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_more: Option<bool>,
+}
+
+/// Capture-loss counters aggregated across network tools.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct NetworkObservability {
+    /// True when a network start, status, stop, or watch result was recorded.
+    pub observed: bool,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub sequence_gaps: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub records_written: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub records_dropped: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub records_enqueued: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub payloads_truncated: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub connections_truncated: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub returned_payloads_truncated: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub malformed_records: u64,
+    #[serde(flatten)]
+    pub loss: NetworkLoss,
+}
+
+/// Capture writer and file-limit flags.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct NetworkLoss {
+    #[serde(skip_serializing_if = "is_false")]
+    pub file_limit_reached: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub writer_failed: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub file_reset: bool,
+}
+
+impl ObservabilitySummary {
+    /// Build a summary from MCP structured results, ignoring unrelated tools.
+    #[must_use]
+    pub fn from_results<'a, I>(results: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a str, &'a Value)>,
+    {
+        let mut summary = Self::default();
+        for (tool, result) in results {
+            match tool {
+                "browser_audit" => summary.audit.observe(result),
+                "browser_network" | "browser_network_watch" => summary.network.observe(result),
+                _ => {}
+            }
+        }
+        summary
+    }
+
+    /// Keep only bounded health fields from a tool result. Payload arrays are dropped.
+    #[must_use]
+    pub fn health_payload(tool: &str, result: &Value) -> Option<Value> {
+        if !matches!(tool, "browser_audit" | "browser_network" | "browser_network_watch") {
+            return None;
+        }
+        let mut object = result.as_object()?.clone();
+        object.remove("entries");
+        object.remove("records");
+        object.remove("known_connections");
+        Some(Value::Object(object))
+    }
+}
+
+impl AuditObservability {
+    fn observe(&mut self, result: &Value) {
+        self.observed = true;
+        self.pages = self.pages.saturating_add(1);
+        self.records_retained = u64_field(result, "records_retained").or(self.records_retained);
+        self.records_returned = u64_field(result, "records_returned").or(self.records_returned);
+        self.malformed_records = u64_field(result, "malformed_records").or(self.malformed_records);
+        self.older_records_dropped = u64_field(result, "older_records_dropped").or(self.older_records_dropped);
+        self.cursor_lost = bool_field(result, "cursor_lost").or(self.cursor_lost);
+        self.has_more = bool_field(result, "has_more").or(self.has_more);
+    }
+}
+
+impl NetworkObservability {
+    fn observe(&mut self, result: &Value) {
+        self.observed = true;
+        self.sequence_gaps = self
+            .sequence_gaps
+            .saturating_add(u64_field(result, "sequence_gaps").unwrap_or(0));
+        self.records_written = self
+            .records_written
+            .max(u64_field(result, "records_written").unwrap_or(0));
+        self.records_dropped = self
+            .records_dropped
+            .max(u64_field(result, "records_dropped").unwrap_or(0));
+        self.records_enqueued = self
+            .records_enqueued
+            .max(u64_field(result, "records_enqueued").unwrap_or(0));
+        self.payloads_truncated = self
+            .payloads_truncated
+            .max(u64_field(result, "payloads_truncated").unwrap_or(0));
+        self.connections_truncated = self
+            .connections_truncated
+            .max(u64_field(result, "connections_truncated").unwrap_or(0));
+        self.returned_payloads_truncated = self
+            .returned_payloads_truncated
+            .saturating_add(u64_field(result, "returned_payloads_truncated").unwrap_or(0));
+        self.malformed_records = self
+            .malformed_records
+            .saturating_add(u64_field(result, "malformed_records").unwrap_or(0));
+        self.loss.file_limit_reached |= bool_field(result, "file_limit_reached").unwrap_or(false);
+        self.loss.writer_failed |= bool_field(result, "writer_failed").unwrap_or(false);
+        self.loss.file_reset |= bool_field(result, "file_reset").unwrap_or(false);
+    }
+}
+
+fn u64_field(value: &Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(Value::as_u64)
+}
+
+fn bool_field(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_zero(value: &u64) -> bool {
+    *value == 0
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn unrelated_tools_are_not_observed() {
+        let summary = ObservabilitySummary::from_results([("browser_list", &json!({"panels":[]}))]);
+        assert!(!summary.audit.observed);
+        assert!(!summary.network.observed);
+    }
+
+    #[test]
+    fn last_audit_page_is_the_completeness_snapshot() {
+        let first = json!({
+            "records_retained": 4,
+            "records_returned": 2,
+            "malformed_records": 0,
+            "older_records_dropped": 1,
+            "cursor_lost": false,
+            "has_more": true,
+            "entries": [{"event_id":"e1"}]
+        });
+        let second = json!({
+            "records_retained": 4,
+            "records_returned": 2,
+            "malformed_records": 1,
+            "older_records_dropped": 1,
+            "cursor_lost": false,
+            "has_more": false
+        });
+        let summary = ObservabilitySummary::from_results([("browser_audit", &first), ("browser_audit", &second)]);
+        assert!(summary.audit.observed);
+        assert_eq!(summary.audit.pages, 2);
+        assert_eq!(summary.audit.records_retained, Some(4));
+        assert_eq!(summary.audit.records_returned, Some(2));
+        assert_eq!(summary.audit.malformed_records, Some(1));
+        assert_eq!(summary.audit.older_records_dropped, Some(1));
+        assert_eq!(summary.audit.has_more, Some(false));
+        assert!(
+            ObservabilitySummary::health_payload("browser_audit", &first)
+                .is_some_and(|payload| payload.get("entries").is_none())
+        );
+    }
+
+    #[test]
+    fn network_watch_and_status_counters_are_merged() {
+        let status = json!({
+            "records_written": 10,
+            "records_dropped": 2,
+            "records_enqueued": 12,
+            "payloads_truncated": 1,
+            "connections_truncated": 0,
+            "file_limit_reached": false,
+            "writer_failed": false,
+            "records": [{"sequence":1}]
+        });
+        let watch = json!({
+            "sequence_gaps": 3,
+            "records_dropped": 2,
+            "payloads_truncated": 1,
+            "returned_payloads_truncated": 4,
+            "malformed_records": 1,
+            "file_limit_reached": true,
+            "writer_failed": true,
+            "file_reset": true
+        });
+        let summary =
+            ObservabilitySummary::from_results([("browser_network", &status), ("browser_network_watch", &watch)]);
+        assert!(summary.network.observed);
+        assert_eq!(summary.network.sequence_gaps, 3);
+        assert_eq!(summary.network.records_written, 10);
+        assert_eq!(summary.network.records_dropped, 2);
+        assert_eq!(summary.network.returned_payloads_truncated, 4);
+        assert_eq!(summary.network.malformed_records, 1);
+        assert!(summary.network.loss.file_limit_reached);
+        assert!(summary.network.loss.writer_failed);
+        assert!(summary.network.loss.file_reset);
+        assert!(
+            ObservabilitySummary::health_payload("browser_network", &status)
+                .is_some_and(|payload| payload.get("records").is_none())
+        );
+    }
+}

--- a/crates/horizon-browser-cli/src/observability.rs
+++ b/crates/horizon-browser-cli/src/observability.rs
@@ -1,5 +1,7 @@
 //! Capture health and audit-completeness summaries for job reports.
 
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 use serde_json::Value;
 
@@ -52,6 +54,8 @@ pub struct NetworkObservability {
     #[serde(skip_serializing_if = "is_zero")]
     pub connections_truncated: u64,
     #[serde(skip_serializing_if = "is_zero")]
+    pub connection_urls_truncated: u64,
+    #[serde(skip_serializing_if = "is_zero")]
     pub returned_payloads_truncated: u64,
     #[serde(skip_serializing_if = "is_zero")]
     pub malformed_records: u64,
@@ -78,11 +82,31 @@ impl ObservabilitySummary {
         I: IntoIterator<Item = (&'a str, &'a Value)>,
     {
         let mut summary = Self::default();
+        let mut captures = BTreeMap::<String, CaptureTotals>::new();
+        let mut anonymous = CaptureTotals::default();
+        let mut saw_network = false;
         for (tool, result) in results {
+            let result = structured_content(result);
             match tool {
                 "browser_audit" => summary.audit.observe(result),
-                "browser_network" | "browser_network_watch" => summary.network.observe(result),
+                "browser_network" | "browser_network_watch" => {
+                    saw_network = true;
+                    match result
+                        .get("capture_id")
+                        .and_then(Value::as_str)
+                        .filter(|id| !id.is_empty())
+                    {
+                        Some(capture_id) => captures.entry(capture_id.to_string()).or_default().observe(result),
+                        None => anonymous.observe(result),
+                    }
+                }
                 _ => {}
+            }
+        }
+        if saw_network {
+            summary.network.observed = true;
+            for capture in captures.values().chain(std::iter::once(&anonymous)) {
+                summary.network.absorb(capture);
             }
         }
         summary
@@ -94,7 +118,7 @@ impl ObservabilitySummary {
         if !matches!(tool, "browser_audit" | "browser_network" | "browser_network_watch") {
             return None;
         }
-        let mut object = result.as_object()?.clone();
+        let mut object = structured_content(result).as_object()?.clone();
         object.remove("entries");
         object.remove("records");
         object.remove("known_connections");
@@ -116,11 +140,44 @@ impl AuditObservability {
 }
 
 impl NetworkObservability {
+    fn absorb(&mut self, capture: &CaptureTotals) {
+        self.sequence_gaps = self.sequence_gaps.saturating_add(capture.sequence_gaps);
+        self.records_written = self.records_written.saturating_add(capture.records_written);
+        self.records_dropped = self.records_dropped.saturating_add(capture.records_dropped);
+        self.records_enqueued = self.records_enqueued.saturating_add(capture.records_enqueued);
+        self.payloads_truncated = self.payloads_truncated.saturating_add(capture.payloads_truncated);
+        self.connections_truncated = self.connections_truncated.saturating_add(capture.connections_truncated);
+        self.connection_urls_truncated = self
+            .connection_urls_truncated
+            .saturating_add(capture.connection_urls_truncated);
+        self.returned_payloads_truncated = self
+            .returned_payloads_truncated
+            .saturating_add(capture.returned_payloads_truncated);
+        self.malformed_records = self.malformed_records.saturating_add(capture.malformed_records);
+        self.loss.file_limit_reached |= capture.file_limit_reached;
+        self.loss.writer_failed |= capture.writer_failed;
+        self.loss.file_reset |= capture.file_reset;
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct CaptureTotals {
+    records_written: u64,
+    records_dropped: u64,
+    records_enqueued: u64,
+    payloads_truncated: u64,
+    connections_truncated: u64,
+    sequence_gaps: u64,
+    returned_payloads_truncated: u64,
+    malformed_records: u64,
+    connection_urls_truncated: u64,
+    file_limit_reached: bool,
+    writer_failed: bool,
+    file_reset: bool,
+}
+
+impl CaptureTotals {
     fn observe(&mut self, result: &Value) {
-        self.observed = true;
-        self.sequence_gaps = self
-            .sequence_gaps
-            .saturating_add(u64_field(result, "sequence_gaps").unwrap_or(0));
         self.records_written = self
             .records_written
             .max(u64_field(result, "records_written").unwrap_or(0));
@@ -136,16 +193,26 @@ impl NetworkObservability {
         self.connections_truncated = self
             .connections_truncated
             .max(u64_field(result, "connections_truncated").unwrap_or(0));
+        self.sequence_gaps = self
+            .sequence_gaps
+            .saturating_add(u64_field(result, "sequence_gaps").unwrap_or(0));
         self.returned_payloads_truncated = self
             .returned_payloads_truncated
             .saturating_add(u64_field(result, "returned_payloads_truncated").unwrap_or(0));
         self.malformed_records = self
             .malformed_records
             .saturating_add(u64_field(result, "malformed_records").unwrap_or(0));
-        self.loss.file_limit_reached |= bool_field(result, "file_limit_reached").unwrap_or(false);
-        self.loss.writer_failed |= bool_field(result, "writer_failed").unwrap_or(false);
-        self.loss.file_reset |= bool_field(result, "file_reset").unwrap_or(false);
+        self.connection_urls_truncated = self
+            .connection_urls_truncated
+            .saturating_add(u64_field(result, "connection_urls_truncated").unwrap_or(0));
+        self.file_limit_reached |= bool_field(result, "file_limit_reached").unwrap_or(false);
+        self.writer_failed |= bool_field(result, "writer_failed").unwrap_or(false);
+        self.file_reset |= bool_field(result, "file_reset").unwrap_or(false);
     }
+}
+
+fn structured_content(result: &Value) -> &Value {
+    result.get("structured_content").unwrap_or(result)
 }
 
 fn u64_field(value: &Value, key: &str) -> Option<u64> {
@@ -215,6 +282,7 @@ mod tests {
     #[test]
     fn network_watch_and_status_counters_are_merged() {
         let status = json!({
+            "capture_id": "cap-1",
             "records_written": 10,
             "records_dropped": 2,
             "records_enqueued": 12,
@@ -225,10 +293,12 @@ mod tests {
             "records": [{"sequence":1}]
         });
         let watch = json!({
+            "capture_id": "cap-1",
             "sequence_gaps": 3,
             "records_dropped": 2,
             "payloads_truncated": 1,
             "returned_payloads_truncated": 4,
+            "connection_urls_truncated": 5,
             "malformed_records": 1,
             "file_limit_reached": true,
             "writer_failed": true,
@@ -241,6 +311,7 @@ mod tests {
         assert_eq!(summary.network.records_written, 10);
         assert_eq!(summary.network.records_dropped, 2);
         assert_eq!(summary.network.returned_payloads_truncated, 4);
+        assert_eq!(summary.network.connection_urls_truncated, 5);
         assert_eq!(summary.network.malformed_records, 1);
         assert!(summary.network.loss.file_limit_reached);
         assert!(summary.network.loss.writer_failed);
@@ -249,5 +320,46 @@ mod tests {
             ObservabilitySummary::health_payload("browser_network", &status)
                 .is_some_and(|payload| payload.get("records").is_none())
         );
+    }
+
+    #[test]
+    fn per_capture_totals_are_summed_and_envelopes_are_unwrapped() {
+        let first = json!({
+            "capture_id": "a",
+            "records_written": 10,
+            "records_dropped": 1
+        });
+        let first_again = json!({
+            "capture_id": "a",
+            "records_written": 12,
+            "records_dropped": 1
+        });
+        let second = json!({
+            "structured_content": {
+                "capture_id": "b",
+                "records_written": 7,
+                "records_dropped": 2,
+                "connection_urls_truncated": 3
+            }
+        });
+        let summary = ObservabilitySummary::from_results([
+            ("browser_network", &first),
+            ("browser_network", &first_again),
+            ("browser_network_watch", &second),
+        ]);
+        assert_eq!(summary.network.records_written, 19);
+        assert_eq!(summary.network.records_dropped, 3);
+        assert_eq!(summary.network.connection_urls_truncated, 3);
+        let envelope = json!({
+            "content": [],
+            "structured_content": {
+                "records_retained": 8,
+                "entries": [{"event_id":"hidden"}]
+            }
+        });
+        let payload = ObservabilitySummary::health_payload("browser_audit", &envelope).expect("payload");
+        assert_eq!(payload["records_retained"], 8);
+        assert!(payload.get("entries").is_none());
+        assert!(payload.get("structured_content").is_none());
     }
 }

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -477,6 +477,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::observability::ObservabilitySummary;
     use crate::{PlanStep, StepReport};
 
     fn plan() -> Plan {
@@ -499,6 +500,7 @@ mod tests {
             steps: Vec::new(),
             error: None,
             stop_reason: None,
+            observability: ObservabilitySummary::default(),
         }
     }
 
@@ -544,6 +546,7 @@ mod tests {
             }],
             error: None,
             stop_reason: None,
+            observability: ObservabilitySummary::default(),
         };
         run.finish(&report).expect("finish durable run");
         let succeeded: RunState = serde_json::from_slice(&std::fs::read(&run.state_path).expect("terminal state"))

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -25,6 +25,8 @@ fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
     );
     let stdout_report: Value = serde_json::from_slice(&stdout.stdout).expect("stdout report");
     assert_eq!(stdout_report["ok"], true);
+    assert_eq!(stdout_report["observability"]["audit"]["observed"], false);
+    assert_eq!(stdout_report["observability"]["network"]["observed"], false);
     assert_eq!(stdout_report["steps"][0]["tool"], "browser_list");
     assert_eq!(stdout_report["steps"][0]["result"]["panels"], json!([]));
     let job_dir = std::path::PathBuf::from(stdout_report["job_dir"].as_str().expect("job directory"));


### PR DESCRIPTION
## Purpose

[#324](https://github.com/peters/horizon/issues/324) next slice after audit pagination: carry audit completeness and network-capture health into every deterministic and prompt-job final report.

## Behavior

- Reports gain a top-level `observability` object with `audit` and `network` summaries.
- `browser_audit` results contribute last-page `records_retained`, `records_returned`, `malformed_records`, `older_records_dropped`, `cursor_lost`, and `has_more`.
- `browser_network` / `browser_network_watch` results contribute sequence gaps, records written/dropped/enqueued, payload and connection truncation, malformed watch records, file-limit, writer-failure, and file-reset flags.
- Payload arrays (`entries`, `records`, `known_connections`) are stripped from the summary.
- Jobs that never called those tools report `observed: false`.
- Summaries are taken from already-executed MCP results. The browser is not queried again after shutdown.

## Test evidence

- Unit tests cover last-page audit snapshots, merged network counters, payload stripping, and prompt-job event parsing.
- CLI `browser_list` jobs include `observability.audit.observed=false` and `observability.network.observed=false`.
- Local validation in this worktree (`917aeb4f`):
  - `cargo fmt --all -- --check`
  - `./scripts/check-maintainability.sh`
  - blocking, strict, and pedantic Clippy
  - `cargo test -p horizon-browser-cli --lib`
  - focused CLI report tests
  - Isolated reruns of the pre-existing load-sensitive CLI timeout/cancel tests passed; this PR does not change timeout or cancellation behavior.

## Follow-up (still on #324)

Checkpoint/resume, standalone reconnect, runner data model, packaging, and the performance-acceptance decision remain out of scope.