### PR TITLE
feat(cloud): connect RunPod to workflow store

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -117,14 +117,40 @@ pub enum RunPodCleanup {
 pub trait RunPodCreationFence: Send + Sync {
     /// # Errors
     /// Returns an error when the durable claim cannot be read or recorded.
-    fn claim_once(&self, resource_name: &str) -> Result<bool, RunPodError>;
+    fn claim_once(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        resource_name: &str,
+    ) -> Result<bool, RunPodError>;
 }
 impl<F> RunPodCreationFence for F
 where
-    F: Fn(&str) -> Result<bool, RunPodError> + Send + Sync,
+    F: Fn(CloudWorkflowId, CloudJobId, &WorkerTarget, &str) -> Result<bool, RunPodError> + Send + Sync,
 {
-    fn claim_once(&self, resource_name: &str) -> Result<bool, RunPodError> {
-        self(resource_name)
+    fn claim_once(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        resource_name: &str,
+    ) -> Result<bool, RunPodError> {
+        self(workflow_id, job_id, target, resource_name)
+    }
+}
+impl RunPodCreationFence for super::CloudWorkflowStore {
+    fn claim_once(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        resource_name: &str,
+    ) -> Result<bool, RunPodError> {
+        self.claim_worker_creation(workflow_id, job_id, target, resource_name)
+            .map_err(|error| RunPodError::CreationFenceFailed {
+                reason: error.to_string(),
+            })
     }
 }
 pub struct RunPodClient {
@@ -151,7 +177,7 @@ impl RunPodClient {
         validate_target(target, profile)?;
         let name = resource_name(workflow_id, job_id);
         let matches = self.reconcile_by_name(&name)?;
-        let may_create = !matches.is_empty() || self.creation_fence.claim_once(&name)?;
+        let may_create = !matches.is_empty() || self.creation_fence.claim_once(workflow_id, job_id, target, &name)?;
         let (pod, created, expected_deadline) = match matches.as_slice() {
             [] if !may_create => return Err(RunPodError::CreationUnresolved { name }),
             [] => {
@@ -260,7 +286,7 @@ impl RunPodClient {
     fn with_transport(transport: impl Transport + 'static) -> Self {
         Self {
             transport: Box::new(transport),
-            creation_fence: Box::new(|_: &str| Ok(true)),
+            creation_fence: Box::new(|_, _, _: &WorkerTarget, _: &str| Ok(true)),
         }
     }
 }
@@ -280,6 +306,8 @@ pub enum RunPodError {
     AmbiguousResource { name: String, count: usize },
     #[error("RunPod creation for {name} was already claimed but no pod became visible")]
     CreationUnresolved { name: String },
+    #[error("RunPod durable creation fence failed: {reason}")]
+    CreationFenceFailed { reason: String },
     #[error("RunPod request failed during {operation}")]
     RequestFailed { operation: &'static str },
     #[error("RunPod returned HTTP {status} during {operation}")]

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -196,9 +196,18 @@ fn retries_reuse_one_exact_worker_and_reject_ambiguity() {
     ));
     let transport = FakeTransport::with_create_response(api_pod(workflow_id, job_id, &target, Some(420_000)));
     let observer = transport.clone();
+    let expected_target = target.clone();
     let client = RunPodClient {
         transport: Box::new(transport),
-        creation_fence: Box::new(|_: &str| Ok(false)),
+        creation_fence: Box::new(
+            move |actual_workflow, actual_job, actual_target: &WorkerTarget, name: &str| {
+                assert_eq!(actual_workflow, workflow_id);
+                assert_eq!(actual_job, job_id);
+                assert_eq!(actual_target, &expected_target);
+                assert_eq!(name, resource_name(workflow_id, job_id));
+                Ok(false)
+            },
+        ),
     };
     assert!(matches!(
         client.ensure_worker(workflow_id, job_id, &target, &profile()),

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -502,6 +502,53 @@ fn expired_terminal_and_dependency_blocked_jobs_cannot_claim_creation() {
 }
 
 #[test]
+fn runpod_fence_uses_the_durable_workflow_claim() {
+    let temp = TempDir::new().expect("temp dir");
+    let store = store(&temp);
+    let workflow = retained_workflow(CloudProvider::RunPod, 30_000);
+    let job_id = workflow.nodes[0].id;
+    let target = worker_target(&workflow);
+    store.create(&workflow).expect("create workflow");
+
+    assert!(
+        super::super::runpod::RunPodCreationFence::claim_once(
+            &store,
+            workflow.id,
+            job_id,
+            target,
+            "horizon-worker-trait",
+        )
+        .expect("first claim")
+    );
+    assert!(
+        !super::super::runpod::RunPodCreationFence::claim_once(
+            &store,
+            workflow.id,
+            job_id,
+            target,
+            "horizon-worker-trait",
+        )
+        .expect("repeated claim")
+    );
+    let connection = Connection::open(store.path()).expect("open raw store");
+    connection
+        .pragma_update(None, "user_version", 2)
+        .expect("set unsupported schema");
+    drop(connection);
+    let failed_claim = super::super::runpod::RunPodCreationFence::claim_once(
+        &store,
+        workflow.id,
+        job_id,
+        target,
+        "horizon-worker-trait",
+    );
+    assert!(matches!(
+        failed_claim,
+        Err(super::super::runpod::RunPodError::CreationFenceFailed { .. })
+    ));
+}
+
+#[test]
 fn invalid_snapshots_and_future_schema_fail_closed() {
     let temp = TempDir::new().expect("temp dir");
     let store = store(&temp);


### PR DESCRIPTION
## Purpose

- connect the RunPod lifecycle adapter to the durable cloud workflow store
- carry workflow, job, complete worker-target identity, and deterministic resource identity through the creation fence
- keep provider creation fail-closed when the durable claim cannot be established

## Behavior impact

- a RunPod create request can proceed only after `CloudWorkflowStore` atomically records the matching persisted job, exact `WorkerTarget`, and resource name
- repeated controller attempts reuse the durable claim and cannot create a second resource
- store failures become a typed `CreationFenceFailed` provider error before any create request
- existing-resource reconciliation still runs before claim consumption, preserving interrupted-create adoption

No UI behavior changes are included. No cloud resources were provisioned.

## Stack

Restacked directly on #378 squash commit `d17d3d48367def96521cafac44ac0d1f39a6dde8` and targeting `main`. This PR contains only the adapter wiring intentionally split from the durable-store PR.

## Test evidence

Validated on exact head `7d074a42992f3a62d799a85b3a74ab4f52504f7f`:

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- independent full-diff review found no actionable security, correctness, performance, or maintainability issue

Both complete default and speech-feature workspace suites passed on the exact head. Focused coverage includes first and repeated durable claims, complete identity forwarding, no create after a rejected claim, and unsupported-store-schema mapping to `CreationFenceFailed`.

Exact scope: three files, 91 additions, 7 deletions. The rebased patch ID remains `7b674897d5b408f0c4e9949967b003dbc1f7519c`.