### PR TITLE
feat(browser): checkpoint verified steps and resume jobs

### DIFF
--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -149,6 +149,22 @@ deadline without relying on another write. Runs that reach plan execution also
 save a final report. Legacy `running` states remain readable. Automatic
 continuation is not enabled yet.
 
+Before each MCP call the runner persists intent in `state.json`. Only a
+verified structured outcome becomes a checkpointed completion.
+An interrupt after dispatch records that step as `uncertain`. Resume is
+explicit:
+
+```bash
+horizon-browser resume job-<id>
+horizon-browser resume job-<id> --on-uncertain skip
+```
+
+`resume` refuses a live prepared lease, a successful job, and any uncertain
+in-flight mutation unless `--on-uncertain skip` is set after inspecting the
+browser audit. Skip never replays the uncertain call; it continues later
+steps. Remaining steps currently start a new MCP session; reconnecting the
+same standalone browser is a later slice.
+
 Every deterministic run gets one action deadline. The default is 1800 seconds;
 `--timeout` accepts 1 through 86400 whole seconds. The budget is selected after
 plan input and validation, before durable preparation, and covers whether MCP
@@ -174,7 +190,7 @@ and records `timed_out` in `state.json`; the state also records the configured
 `execution_timeout_seconds` and absolute `deadline_at_millis`. If durable
 preparation consumes the deadline, no MCP action starts. An already-dispatched
 browser mutation may still complete, so inspect the browser audit before
-retrying it; automatic replay remains disabled.
+retrying it; `resume` will not automatically replay an uncertain mutation.
 
 Stdout contains only the report; diagnostics use stderr. A file report is
 created with owner-only permissions on Unix. Stable exit codes are 0 for

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -141,16 +141,21 @@ audit completeness and network-capture health taken from executed MCP results
 limits, and writer failure). Tools that were not called are reported as
 `observed: false`. Every invocation stages its
 validated plan and initial `prepared` state in an owner-only directory, flushes
-both artifacts, and atomically publishes the complete job under
-`~/.horizon/browser-jobs/`; later lifecycle updates remain atomic. The prepared
+both artifacts plus an empty checkpoint-artifact directory, and atomically
+publishes the complete job under `~/.horizon/browser-jobs/`; later lifecycle
+updates remain atomic. The prepared
 state records an absolute deadline and acts as a lease: it may represent a live
 runner before the deadline, and must be treated as `timed_out` at or after the
 deadline without relying on another write. Runs that reach plan execution also
-save a final report. Legacy `running` states remain readable. Automatic
-continuation is not enabled yet.
+save a final report. Legacy lifecycle schemas remain recognizable but are not
+resumable because they lack the current checkpoint contract. Automatic
+continuation remains disabled; resume is always explicit.
 
 Before each MCP call the runner persists intent in `state.json`. Only a
-verified structured outcome becomes a checkpointed completion.
+verified structured outcome becomes a checkpointed completion. `state.json`
+stores compact completion metadata, while each structured result is written
+once to an owner-only immutable file under the job's `checkpoints/` directory;
+later checkpoint updates do not rewrite earlier results.
 An interrupt after dispatch records that step as `uncertain`. Resume is
 explicit:
 

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -162,8 +162,10 @@ horizon-browser resume job-<id> --on-uncertain skip
 `resume` refuses a live prepared lease, a successful job, and any uncertain
 in-flight mutation unless `--on-uncertain skip` is set after inspecting the
 browser audit. Skip never replays the uncertain call; it continues later
-steps. Remaining steps currently start a new MCP session; reconnecting the
-same standalone browser is a later slice.
+steps. A skipped step is not a successful completion, so the job cannot
+report `ok` until every plan step has a verified result. Remaining steps
+currently start a new MCP session; reconnecting the same standalone browser
+is a later slice.
 
 Every deterministic run gets one action deadline. The default is 1800 seconds;
 `--timeout` accepts 1 through 86400 whole seconds. The budget is selected after

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -161,6 +161,8 @@ pub fn select_resume(
     let checkpoint = checkpoint.cloned().unwrap_or_default();
     let reports = reports_by_id(&checkpoint.completed)?;
     let skipped_ids = checkpoint.skipped.iter().cloned().collect::<BTreeSet<_>>();
+    let mut unused_reports = reports.keys().copied().collect::<BTreeSet<_>>();
+    let mut unused_skips = skipped_ids.clone();
     let mut completed = Vec::new();
     let mut start_index = 0;
     let mut skip_intent = None;
@@ -169,11 +171,12 @@ pub fn select_resume(
             if report.tool != step.tool {
                 return Err(ResumeError::PrefixMismatch);
             }
+            unused_reports.remove(step.id.as_str());
             completed.push((*report).clone());
             start_index = index.saturating_add(1);
             continue;
         }
-        if skipped_ids.contains(&step.id) {
+        if unused_skips.remove(&step.id) {
             start_index = index.saturating_add(1);
             continue;
         }
@@ -195,6 +198,9 @@ pub fn select_resume(
             }
         }
         break;
+    }
+    if !unused_reports.is_empty() || !unused_skips.is_empty() {
+        return Err(ResumeError::PrefixMismatch);
     }
     Ok(ResumeSelection {
         completed,
@@ -337,6 +343,17 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["list", "title"]
         );
+    }
+
+    #[test]
+    fn unconsumed_completion_is_a_prefix_mismatch() {
+        let checkpoint = RunCheckpoint {
+            completed: vec![completed("title", "browser_evaluate")],
+            intent: None,
+            skipped: Vec::new(),
+        };
+        let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("gap");
+        assert!(matches!(error, ResumeError::PrefixMismatch));
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -1,0 +1,310 @@
+//! Explicit resume policy for interrupted deterministic plan runs.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{Plan, PlanStep, StepReport};
+
+/// Verified completions and the optional in-flight step for one job.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunCheckpoint {
+    /// Tool results persisted only after MCP returned a structured outcome.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completed: Vec<StepReport>,
+    /// Step whose mutation may have been dispatched but is not yet verified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<CheckpointIntent>,
+    /// Uncertain steps the operator chose not to replay.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped: Vec<String>,
+}
+
+impl RunCheckpoint {
+    /// True when no completions, intent, or skips have been recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.completed.is_empty() && self.intent.is_none() && self.skipped.is_empty()
+    }
+}
+
+/// Intent recorded before an MCP tool future is polled.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointIntent {
+    /// Plan step that is about to run, or that was interrupted in flight.
+    pub step_id: String,
+    /// MCP tool name for diagnostics.
+    pub tool: String,
+    /// Whether the runner observed a dispatch or only a crash-safe intent.
+    pub status: IntentStatus,
+}
+
+/// Lifecycle of a persisted intent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IntentStatus {
+    /// Intent is durable; the MCP call may not have been polled yet.
+    Dispatched,
+    /// The call was interrupted after dispatch, so replay is unsafe by default.
+    Uncertain,
+}
+
+/// How `resume` treats an uncertain in-flight mutation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum UncertainPolicy {
+    /// Refuse to resume until the operator inspects the browser audit.
+    #[default]
+    Fail,
+    /// Leave the uncertain step unreplayed and continue with later steps.
+    Skip,
+}
+
+/// Prefix to reuse and the next plan index to execute.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResumeSelection {
+    /// Verified step reports reused for `$ref` resolution.
+    pub completed: Vec<StepReport>,
+    /// First plan index that is still eligible to run.
+    pub start_index: usize,
+    /// Uncertain step skipped by explicit policy, if any.
+    pub skipped: Option<String>,
+}
+
+/// Durable persistence of intent and verified completions.
+pub trait CheckpointStore {
+    /// Persist intent before the MCP tool future is polled.
+    ///
+    /// # Errors
+    /// Returns when the durable checkpoint cannot be written.
+    fn record_intent(&mut self, step: &PlanStep) -> Result<(), String>;
+    /// Persist a verified success or fail-fast tool outcome.
+    ///
+    /// # Errors
+    /// Returns when the durable checkpoint cannot be written.
+    fn record_completion(&mut self, report: &StepReport) -> Result<(), String>;
+    /// Mark the in-flight step uncertain after a dispatched interrupt.
+    ///
+    /// # Errors
+    /// Returns when the durable checkpoint cannot be written.
+    fn record_uncertain(&mut self, step: &PlanStep) -> Result<(), String>;
+    /// Drop a not-yet-polled intent so resume can retry that step.
+    ///
+    /// # Errors
+    /// Returns when the durable checkpoint cannot be written.
+    fn clear_intent(&mut self) -> Result<(), String>;
+}
+
+/// Failure to choose a safe resume point.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum ResumeError {
+    /// The job id is not a published `job-` identifier.
+    #[error("invalid job id `{0}`")]
+    InvalidJobId(String),
+    /// No published job directory exists for this id.
+    #[error("durable job `{0}` was not found")]
+    NotFound(String),
+    /// The saved plan or state could not be decoded.
+    #[error("{0}")]
+    Decode(String),
+    /// Prepared state has not expired, so another runner may still own the job.
+    #[error("durable job `{0}` may still be running; automatic continuation is disabled")]
+    StillRunning(String),
+    /// The job already reached a successful terminal report.
+    #[error("durable job `{0}` already succeeded")]
+    AlreadySucceeded(String),
+    /// Every plan step is already verified or skipped.
+    #[error("durable job `{0}` has no remaining steps to resume")]
+    NothingToResume(String),
+    /// An interrupted mutation must not be replayed without an explicit skip.
+    #[error(
+        "durable job has uncertain step `{step}` (`{tool}`); pass --on-uncertain skip after inspecting the browser audit"
+    )]
+    Uncertain { step: String, tool: String },
+    /// Saved completions do not match the saved plan prefix.
+    #[error("durable checkpoint does not match the saved plan prefix")]
+    PrefixMismatch,
+}
+
+impl UncertainPolicy {
+    /// Parse the `--on-uncertain` CLI value.
+    ///
+    /// # Errors
+    /// Returns when the value is not `fail` or `skip`.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "fail" => Ok(Self::Fail),
+            "skip" => Ok(Self::Skip),
+            _ => Err("--on-uncertain requires fail or skip".to_string()),
+        }
+    }
+}
+
+/// Choose the next runnable index without replaying verified or uncertain work.
+///
+/// # Errors
+/// Returns when the checkpoint does not match the plan or an uncertain step
+/// would be replayed under the fail policy.
+pub fn select_resume(
+    plan: &Plan,
+    checkpoint: Option<&RunCheckpoint>,
+    policy: UncertainPolicy,
+) -> Result<ResumeSelection, ResumeError> {
+    let checkpoint = checkpoint.cloned().unwrap_or_default();
+    if !prefix_matches(plan, &checkpoint.completed) {
+        return Err(ResumeError::PrefixMismatch);
+    }
+    let mut start_index = checkpoint.completed.len();
+    start_index += skipped_count_at(plan, &checkpoint.skipped, start_index);
+    let mut skipped = None;
+    if let Some(intent) = checkpoint.intent.as_ref() {
+        let expected = plan.steps.get(start_index).map(|step| step.id.as_str());
+        if expected != Some(intent.step_id.as_str()) {
+            return Err(ResumeError::PrefixMismatch);
+        }
+        match policy {
+            UncertainPolicy::Fail => {
+                return Err(ResumeError::Uncertain {
+                    step: intent.step_id.clone(),
+                    tool: intent.tool.clone(),
+                });
+            }
+            UncertainPolicy::Skip => {
+                skipped = Some(intent.step_id.clone());
+                start_index = start_index.saturating_add(1);
+            }
+        }
+    }
+    Ok(ResumeSelection {
+        completed: checkpoint.completed,
+        start_index,
+        skipped,
+    })
+}
+
+fn prefix_matches(plan: &Plan, completed: &[StepReport]) -> bool {
+    completed.len() <= plan.steps.len()
+        && completed
+            .iter()
+            .zip(&plan.steps)
+            .all(|(report, step)| report.id == step.id && report.tool == step.tool)
+}
+
+fn skipped_count_at(plan: &Plan, skipped: &[String], start_index: usize) -> usize {
+    skipped
+        .iter()
+        .take_while(|step_id| plan.steps.get(start_index).is_some_and(|step| step.id == **step_id))
+        .count()
+}
+
+/// True when `job-` is followed by a UUID and no path separators.
+#[must_use]
+pub fn valid_job_id(job_id: &str) -> bool {
+    let Some(suffix) = job_id.strip_prefix("job-") else {
+        return false;
+    };
+    uuid::Uuid::parse_str(suffix).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::PlanStep;
+
+    fn plan() -> Plan {
+        Plan {
+            version: 1,
+            steps: vec![
+                step("list", "browser_list"),
+                step("navigate", "browser_navigate"),
+                step("title", "browser_evaluate"),
+            ],
+        }
+    }
+
+    fn step(id: &str, tool: &str) -> PlanStep {
+        PlanStep {
+            id: id.to_string(),
+            tool: tool.to_string(),
+            arguments: serde_json::Map::new(),
+        }
+    }
+
+    fn completed(id: &str, tool: &str) -> StepReport {
+        StepReport {
+            id: id.to_string(),
+            tool: tool.to_string(),
+            ok: true,
+            result: Some(json!({"ok": true})),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn resume_continues_after_verified_completions() {
+        let checkpoint = RunCheckpoint {
+            completed: vec![completed("list", "browser_list")],
+            intent: None,
+            skipped: Vec::new(),
+        };
+        let selection = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect("resume");
+        assert_eq!(selection.start_index, 1);
+        assert_eq!(selection.completed.len(), 1);
+        assert!(selection.skipped.is_none());
+    }
+
+    #[test]
+    fn uncertain_intent_is_not_replayed_by_default() {
+        let checkpoint = RunCheckpoint {
+            completed: vec![completed("list", "browser_list")],
+            intent: Some(CheckpointIntent {
+                step_id: "navigate".to_string(),
+                tool: "browser_navigate".to_string(),
+                status: IntentStatus::Uncertain,
+            }),
+            skipped: Vec::new(),
+        };
+        let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("uncertain");
+        assert!(matches!(error, ResumeError::Uncertain { step, .. } if step == "navigate"));
+    }
+
+    #[test]
+    fn skip_policy_advances_past_the_uncertain_step() {
+        let checkpoint = RunCheckpoint {
+            completed: vec![completed("list", "browser_list")],
+            intent: Some(CheckpointIntent {
+                step_id: "navigate".to_string(),
+                tool: "browser_navigate".to_string(),
+                status: IntentStatus::Dispatched,
+            }),
+            skipped: Vec::new(),
+        };
+        let selection = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Skip).expect("skip");
+        assert_eq!(selection.start_index, 2);
+        assert_eq!(selection.skipped.as_deref(), Some("navigate"));
+    }
+
+    #[test]
+    fn leftover_dispatched_intent_is_uncertain_on_resume() {
+        let checkpoint = RunCheckpoint {
+            completed: Vec::new(),
+            intent: Some(CheckpointIntent {
+                step_id: "list".to_string(),
+                tool: "browser_list".to_string(),
+                status: IntentStatus::Dispatched,
+            }),
+            skipped: Vec::new(),
+        };
+        let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("dispatched");
+        assert!(matches!(error, ResumeError::Uncertain { step, .. } if step == "list"));
+    }
+
+    #[test]
+    fn job_ids_reject_path_traversal() {
+        assert!(valid_job_id("job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4"));
+        assert!(!valid_job_id("../job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4"));
+        assert!(!valid_job_id("job-not-a-uuid"));
+    }
+}

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -1,5 +1,7 @@
 //! Explicit resume policy for interrupted deterministic plan runs.
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -124,6 +126,12 @@ pub enum ResumeError {
     /// Saved completions do not match the saved plan prefix.
     #[error("durable checkpoint does not match the saved plan prefix")]
     PrefixMismatch,
+    /// The job was recorded before checkpoints existed.
+    #[error("durable job `{0}` was recorded before checkpoints; resume would replay completed mutations")]
+    LegacyState(String),
+    /// Another resume already holds this job.
+    #[error("durable job `{0}` is already being resumed")]
+    Locked(String),
 }
 
 impl UncertainPolicy {
@@ -151,50 +159,58 @@ pub fn select_resume(
     policy: UncertainPolicy,
 ) -> Result<ResumeSelection, ResumeError> {
     let checkpoint = checkpoint.cloned().unwrap_or_default();
-    if !prefix_matches(plan, &checkpoint.completed) {
-        return Err(ResumeError::PrefixMismatch);
-    }
-    let mut start_index = checkpoint.completed.len();
-    start_index += skipped_count_at(plan, &checkpoint.skipped, start_index);
-    let mut skipped = None;
-    if let Some(intent) = checkpoint.intent.as_ref() {
-        let expected = plan.steps.get(start_index).map(|step| step.id.as_str());
-        if expected != Some(intent.step_id.as_str()) {
-            return Err(ResumeError::PrefixMismatch);
-        }
-        match policy {
-            UncertainPolicy::Fail => {
-                return Err(ResumeError::Uncertain {
-                    step: intent.step_id.clone(),
-                    tool: intent.tool.clone(),
-                });
+    let reports = reports_by_id(&checkpoint.completed)?;
+    let skipped_ids = checkpoint.skipped.iter().cloned().collect::<BTreeSet<_>>();
+    let mut completed = Vec::new();
+    let mut start_index = 0;
+    let mut skip_intent = None;
+    for (index, step) in plan.steps.iter().enumerate() {
+        if let Some(report) = reports.get(step.id.as_str()) {
+            if report.tool != step.tool {
+                return Err(ResumeError::PrefixMismatch);
             }
-            UncertainPolicy::Skip => {
-                skipped = Some(intent.step_id.clone());
-                start_index = start_index.saturating_add(1);
+            completed.push((*report).clone());
+            start_index = index.saturating_add(1);
+            continue;
+        }
+        if skipped_ids.contains(&step.id) {
+            start_index = index.saturating_add(1);
+            continue;
+        }
+        if let Some(intent) = checkpoint.intent.as_ref() {
+            if intent.step_id != step.id {
+                return Err(ResumeError::PrefixMismatch);
+            }
+            match policy {
+                UncertainPolicy::Fail => {
+                    return Err(ResumeError::Uncertain {
+                        step: intent.step_id.clone(),
+                        tool: intent.tool.clone(),
+                    });
+                }
+                UncertainPolicy::Skip => {
+                    skip_intent = Some(intent.step_id.clone());
+                    start_index = index.saturating_add(1);
+                }
             }
         }
+        break;
     }
     Ok(ResumeSelection {
-        completed: checkpoint.completed,
+        completed,
         start_index,
-        skipped,
+        skipped: skip_intent,
     })
 }
 
-fn prefix_matches(plan: &Plan, completed: &[StepReport]) -> bool {
-    completed.len() <= plan.steps.len()
-        && completed
-            .iter()
-            .zip(&plan.steps)
-            .all(|(report, step)| report.id == step.id && report.tool == step.tool)
-}
-
-fn skipped_count_at(plan: &Plan, skipped: &[String], start_index: usize) -> usize {
-    skipped
-        .iter()
-        .take_while(|step_id| plan.steps.get(start_index).is_some_and(|step| step.id == **step_id))
-        .count()
+fn reports_by_id(completed: &[StepReport]) -> Result<BTreeMap<&str, &StepReport>, ResumeError> {
+    let mut reports = BTreeMap::new();
+    for report in completed {
+        if reports.insert(report.id.as_str(), report).is_some() {
+            return Err(ResumeError::PrefixMismatch);
+        }
+    }
+    Ok(reports)
 }
 
 /// True when `job-` is followed by a UUID and no path separators.
@@ -299,6 +315,28 @@ mod tests {
         };
         let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("dispatched");
         assert!(matches!(error, ResumeError::Uncertain { step, .. } if step == "list"));
+    }
+
+    #[test]
+    fn skipped_steps_are_merged_in_plan_order() {
+        let checkpoint = RunCheckpoint {
+            completed: vec![
+                completed("list", "browser_list"),
+                completed("title", "browser_evaluate"),
+            ],
+            intent: None,
+            skipped: vec!["navigate".to_string()],
+        };
+        let selection = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect("merge");
+        assert_eq!(selection.start_index, 3);
+        assert_eq!(
+            selection
+                .completed
+                .iter()
+                .map(|step| step.id.as_str())
+                .collect::<Vec<_>>(),
+            ["list", "title"]
+        );
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -11,15 +11,27 @@ use crate::{Plan, PlanStep, StepReport};
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RunCheckpoint {
-    /// Tool results persisted only after MCP returned a structured outcome.
+    /// Compact references to results persisted after MCP returned a structured outcome.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub completed: Vec<StepReport>,
+    pub completed: Vec<CheckpointCompletion>,
     /// Step whose mutation may have been dispatched but is not yet verified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intent: Option<CheckpointIntent>,
     /// Uncertain steps the operator chose not to replay.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skipped: Vec<String>,
+}
+
+/// Compact durable reference to one verified step-result artifact.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointCompletion {
+    /// Plan step identifier.
+    pub id: String,
+    /// Exact MCP tool that produced the result.
+    pub tool: String,
+    /// Job-directory-relative immutable result artifact.
+    pub report_file: String,
 }
 
 impl RunCheckpoint {
@@ -165,10 +177,12 @@ impl UncertainPolicy {
 pub fn select_resume(
     plan: &Plan,
     checkpoint: Option<&RunCheckpoint>,
+    completed_reports: &[StepReport],
     policy: UncertainPolicy,
 ) -> Result<ResumeSelection, ResumeError> {
     let checkpoint = checkpoint.cloned().unwrap_or_default();
-    let reports = reports_by_id(&checkpoint.completed)?;
+    validate_completion_metadata(&checkpoint.completed, completed_reports)?;
+    let reports = reports_by_id(completed_reports)?;
     let skipped_ids = checkpoint.skipped.iter().cloned().collect::<BTreeSet<_>>();
     let mut unused_reports = reports.keys().copied().collect::<BTreeSet<_>>();
     let mut unused_skips = skipped_ids.clone();
@@ -218,6 +232,18 @@ pub fn select_resume(
     })
 }
 
+fn validate_completion_metadata(completed: &[CheckpointCompletion], reports: &[StepReport]) -> Result<(), ResumeError> {
+    if completed.len() != reports.len()
+        || completed
+            .iter()
+            .zip(reports)
+            .any(|(metadata, report)| metadata.id != report.id || metadata.tool != report.tool)
+    {
+        return Err(ResumeError::PrefixMismatch);
+    }
+    Ok(())
+}
+
 fn reports_by_id(completed: &[StepReport]) -> Result<BTreeMap<&str, &StepReport>, ResumeError> {
     let mut reports = BTreeMap::new();
     for report in completed {
@@ -263,24 +289,32 @@ mod tests {
         }
     }
 
-    fn completed(id: &str, tool: &str) -> StepReport {
-        StepReport {
-            id: id.to_string(),
-            tool: tool.to_string(),
-            ok: true,
-            result: Some(json!({"ok": true})),
-            error: None,
-        }
+    fn completed(id: &str, tool: &str) -> (CheckpointCompletion, StepReport) {
+        (
+            CheckpointCompletion {
+                id: id.to_string(),
+                tool: tool.to_string(),
+                report_file: format!("checkpoints/{id}.json"),
+            },
+            StepReport {
+                id: id.to_string(),
+                tool: tool.to_string(),
+                ok: true,
+                result: Some(json!({"ok": true})),
+                error: None,
+            },
+        )
     }
 
     #[test]
     fn resume_continues_after_verified_completions() {
+        let (metadata, report) = completed("list", "browser_list");
         let checkpoint = RunCheckpoint {
-            completed: vec![completed("list", "browser_list")],
+            completed: vec![metadata],
             intent: None,
             skipped: Vec::new(),
         };
-        let selection = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect("resume");
+        let selection = select_resume(&plan(), Some(&checkpoint), &[report], UncertainPolicy::Fail).expect("resume");
         assert_eq!(selection.start_index, 1);
         assert_eq!(selection.completed.len(), 1);
         assert!(selection.skipped.is_none());
@@ -288,8 +322,9 @@ mod tests {
 
     #[test]
     fn uncertain_intent_is_not_replayed_by_default() {
+        let (metadata, report) = completed("list", "browser_list");
         let checkpoint = RunCheckpoint {
-            completed: vec![completed("list", "browser_list")],
+            completed: vec![metadata],
             intent: Some(CheckpointIntent {
                 step_id: "navigate".to_string(),
                 tool: "browser_navigate".to_string(),
@@ -297,14 +332,15 @@ mod tests {
             }),
             skipped: Vec::new(),
         };
-        let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("uncertain");
+        let error = select_resume(&plan(), Some(&checkpoint), &[report], UncertainPolicy::Fail).expect_err("uncertain");
         assert!(matches!(error, ResumeError::Uncertain { step, .. } if step == "navigate"));
     }
 
     #[test]
     fn skip_policy_advances_past_the_uncertain_step() {
+        let (metadata, report) = completed("list", "browser_list");
         let checkpoint = RunCheckpoint {
-            completed: vec![completed("list", "browser_list")],
+            completed: vec![metadata],
             intent: Some(CheckpointIntent {
                 step_id: "navigate".to_string(),
                 tool: "browser_navigate".to_string(),
@@ -312,7 +348,7 @@ mod tests {
             }),
             skipped: Vec::new(),
         };
-        let selection = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Skip).expect("skip");
+        let selection = select_resume(&plan(), Some(&checkpoint), &[report], UncertainPolicy::Skip).expect("skip");
         assert_eq!(selection.start_index, 2);
         assert_eq!(selection.skipped.as_deref(), Some("navigate"));
     }
@@ -328,21 +364,26 @@ mod tests {
             }),
             skipped: Vec::new(),
         };
-        let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("dispatched");
+        let error = select_resume(&plan(), Some(&checkpoint), &[], UncertainPolicy::Fail).expect_err("dispatched");
         assert!(matches!(error, ResumeError::Uncertain { step, .. } if step == "list"));
     }
 
     #[test]
     fn skipped_steps_are_merged_in_plan_order() {
+        let (first_metadata, first_report) = completed("list", "browser_list");
+        let (last_metadata, last_report) = completed("title", "browser_evaluate");
         let checkpoint = RunCheckpoint {
-            completed: vec![
-                completed("list", "browser_list"),
-                completed("title", "browser_evaluate"),
-            ],
+            completed: vec![first_metadata, last_metadata],
             intent: None,
             skipped: vec!["navigate".to_string()],
         };
-        let selection = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect("merge");
+        let selection = select_resume(
+            &plan(),
+            Some(&checkpoint),
+            &[first_report, last_report],
+            UncertainPolicy::Fail,
+        )
+        .expect("merge");
         assert_eq!(selection.start_index, 3);
         assert_eq!(
             selection
@@ -356,12 +397,28 @@ mod tests {
 
     #[test]
     fn unconsumed_completion_is_a_prefix_mismatch() {
+        let (metadata, report) = completed("title", "browser_evaluate");
         let checkpoint = RunCheckpoint {
-            completed: vec![completed("title", "browser_evaluate")],
+            completed: vec![metadata],
             intent: None,
             skipped: Vec::new(),
         };
-        let error = select_resume(&plan(), Some(&checkpoint), UncertainPolicy::Fail).expect_err("gap");
+        let error = select_resume(&plan(), Some(&checkpoint), &[report], UncertainPolicy::Fail).expect_err("gap");
+        assert!(matches!(error, ResumeError::PrefixMismatch));
+    }
+
+    #[test]
+    fn completion_metadata_must_match_loaded_reports() {
+        let (metadata, mut report) = completed("list", "browser_list");
+        report.tool = "browser_snapshot".to_string();
+        let checkpoint = RunCheckpoint {
+            completed: vec![metadata],
+            intent: None,
+            skipped: Vec::new(),
+        };
+
+        let error = select_resume(&plan(), Some(&checkpoint), &[report], UncertainPolicy::Fail).expect_err("mismatch");
+
         assert!(matches!(error, ResumeError::PrefixMismatch));
     }
 

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -129,8 +129,8 @@ pub enum ResumeError {
     /// The job was recorded before checkpoints existed.
     #[error("durable job `{0}` was recorded before checkpoints; resume would replay completed mutations")]
     LegacyState(String),
-    /// Another resume already holds this job.
-    #[error("durable job `{0}` is already being resumed")]
+    /// The original run or another resume already holds this job.
+    #[error("durable job `{0}` is already running or being resumed")]
     Locked(String),
 }
 
@@ -344,5 +344,9 @@ mod tests {
         assert!(valid_job_id("job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4"));
         assert!(!valid_job_id("../job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4"));
         assert!(!valid_job_id("job-not-a-uuid"));
+        assert_eq!(
+            ResumeError::Locked("job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4".to_string()).to_string(),
+            "durable job `job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4` is already running or being resumed"
+        );
     }
 }

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -129,6 +129,15 @@ pub enum ResumeError {
     /// The job was recorded before checkpoints existed.
     #[error("durable job `{0}` was recorded before checkpoints; resume would replay completed mutations")]
     LegacyState(String),
+    /// The job was written by a newer state schema than this binary supports.
+    #[error(
+        "durable job `{job_id}` uses unsupported state version {version}; this binary supports version {supported}"
+    )]
+    UnsupportedStateVersion {
+        job_id: String,
+        version: u32,
+        supported: u32,
+    },
     /// The original run or another resume already holds this job.
     #[error("durable job `{0}` is already running or being resumed")]
     Locked(String),

--- a/crates/horizon-browser-cli/src/execution_control.rs
+++ b/crates/horizon-browser-cli/src/execution_control.rs
@@ -199,7 +199,58 @@ impl ExecutionControl {
             output = future => Ok(output),
         }
     }
+
+    /// Run blocking I/O on an owned thread while still observing stop signals.
+    ///
+    /// When `honor_deadline` is false, a ready deadline does not skip the work;
+    /// cancellation still aborts the wait after a bounded drain.
+    ///
+    /// # Errors
+    /// Returns when cancellation or, if honored, the deadline wins before the
+    /// worker reports a result.
+    pub async fn wait_owned_blocking<T: Send + 'static>(
+        &mut self,
+        worker_name: &'static str,
+        honor_deadline: bool,
+        operation: impl FnOnce() -> T + Send + 'static,
+    ) -> Result<T, ExecutionStopReason> {
+        if honor_deadline {
+            self.check()?;
+        } else if *self.cancellation.borrow() {
+            return Err(ExecutionStopReason::Cancelled);
+        }
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        std::thread::Builder::new()
+            .name(worker_name.to_string())
+            .spawn(move || {
+                let _ = sender.send(operation());
+            })
+            .map_err(|error| {
+                tracing::warn!(%error, "could not start {worker_name}");
+                ExecutionStopReason::Cancelled
+            })?;
+        let mut completion = Box::pin(async move { receiver.await.ok() });
+        let waited = if honor_deadline {
+            self.wait(completion.as_mut()).await
+        } else {
+            tokio::select! {
+                biased;
+                () = cancellation_requested(&mut self.cancellation) => Err(ExecutionStopReason::Cancelled),
+                output = completion.as_mut() => Ok(output),
+            }
+        };
+        match waited {
+            Ok(Some(value)) => Ok(value),
+            Ok(None) => Err(ExecutionStopReason::Cancelled),
+            Err(reason) => match tokio::time::timeout(BLOCKING_IO_DRAIN, completion.as_mut()).await {
+                Ok(Some(value)) => Ok(value),
+                Ok(None) | Err(_) => Err(reason),
+            },
+        }
+    }
 }
+
+const BLOCKING_IO_DRAIN: Duration = Duration::from_secs(1);
 
 async fn cancellation_requested(receiver: &mut watch::Receiver<bool>) {
     loop {
@@ -241,5 +292,28 @@ mod tests {
         let deadline = control.start_timeout(Duration::from_secs(1));
 
         assert_eq!(control.deadline_at_millis(), Some(deadline.unix_millis()));
+    }
+
+    #[tokio::test]
+    async fn owned_blocking_work_observes_a_ready_deadline() {
+        let mut control = ExecutionControl::with_timeout(Duration::ZERO);
+        let error = control
+            .wait_owned_blocking("horizon-browser-test-deadline", true, || {
+                std::thread::sleep(Duration::from_secs(5));
+                1
+            })
+            .await
+            .expect_err("deadline must win");
+        assert_eq!(error, ExecutionStopReason::DeadlineExceeded);
+    }
+
+    #[tokio::test]
+    async fn owned_blocking_work_can_ignore_a_ready_deadline() {
+        let mut control = ExecutionControl::with_timeout(Duration::ZERO);
+        let value = control
+            .wait_owned_blocking("horizon-browser-test-ignore-deadline", false, || 7)
+            .await
+            .expect("deadline-ignored I/O");
+        assert_eq!(value, 7);
     }
 }

--- a/crates/horizon-browser-cli/src/execution_control.rs
+++ b/crates/horizon-browser-cli/src/execution_control.rs
@@ -207,24 +207,22 @@ impl ExecutionControl {
     /// always runs and joins the writer, even when already cancelled.
     ///
     /// # Errors
-    /// Returns when a bound wait observes cancellation or the deadline. The
-    /// worker is still joined before this returns.
+    /// Returns a stop reason when a bound wait observes cancellation or the
+    /// deadline, or an infrastructure failure when the worker cannot start or
+    /// panics. The worker is still joined before this returns.
     pub async fn wait_owned_blocking<T: Send + 'static>(
         &mut self,
         worker_name: &'static str,
         mode: BlockingIoMode,
         operation: impl FnOnce() -> T + Send + 'static,
-    ) -> Result<T, ExecutionStopReason> {
+    ) -> Result<T, BlockingIoError> {
         if mode == BlockingIoMode::Bound {
-            self.check()?;
+            self.check().map_err(BlockingIoError::Stopped)?;
         }
         let handle = std::thread::Builder::new()
             .name(worker_name.to_string())
             .spawn(operation)
-            .map_err(|error| {
-                tracing::warn!(%error, "could not start {worker_name}");
-                ExecutionStopReason::Cancelled
-            })?;
+            .map_err(|error| BlockingIoError::Failed(format!("could not start {worker_name}: {error}")))?;
         let stopped = match mode {
             BlockingIoMode::Required => Ok(()),
             BlockingIoMode::Bound => {
@@ -237,13 +235,24 @@ impl ExecutionControl {
             }
         };
         let Ok(Ok(value)) = tokio::task::spawn_blocking(move || handle.join()).await else {
-            return Err(ExecutionStopReason::Cancelled);
+            return Err(BlockingIoError::Failed(format!(
+                "{worker_name} stopped without a result"
+            )));
         };
         match (mode, stopped) {
             (_, Ok(())) | (BlockingIoMode::Required, _) => Ok(value),
-            (BlockingIoMode::Bound, Err(reason)) => Err(reason),
+            (BlockingIoMode::Bound, Err(reason)) => Err(BlockingIoError::Stopped(reason)),
         }
     }
+}
+
+/// Failure from owned blocking I/O.
+#[derive(Debug)]
+pub enum BlockingIoError {
+    /// Cancellation or deadline won a bound wait.
+    Stopped(ExecutionStopReason),
+    /// The worker could not start or panicked.
+    Failed(String),
 }
 
 /// How owned blocking I/O cooperates with job control.
@@ -307,7 +316,10 @@ mod tests {
             })
             .await
             .expect_err("deadline must win");
-        assert_eq!(error, ExecutionStopReason::DeadlineExceeded);
+        assert!(matches!(
+            error,
+            BlockingIoError::Stopped(ExecutionStopReason::DeadlineExceeded)
+        ));
     }
 
     #[tokio::test]

--- a/crates/horizon-browser-cli/src/execution_control.rs
+++ b/crates/horizon-browser-cli/src/execution_control.rs
@@ -202,14 +202,15 @@ impl ExecutionControl {
 
     /// Run blocking I/O on an owned thread while still observing stop signals.
     ///
-    /// [`BlockingIoMode::Bound`] observes the deadline and cancellation, then
-    /// joins the writer so it cannot race a later finalizer. [`BlockingIoMode::Required`]
-    /// always runs and joins the writer, even when already cancelled.
+    /// [`BlockingIoMode::Bound`] observes the deadline and cancellation. After a
+    /// stop, the writer is joined for one second; a stalled join exits 124/130
+    /// instead of racing a later finalizer. [`BlockingIoMode::Required`] still
+    /// runs after Ctrl-C, with the same bounded drain.
     ///
     /// # Errors
-    /// Returns a stop reason when a bound wait observes cancellation or the
-    /// deadline, or an infrastructure failure when the worker cannot start or
-    /// panics. The worker is still joined before this returns.
+    /// Returns when the worker cannot start or panics. A completed worker
+    /// result is returned even if a stop was observed, so callers can persist
+    /// that outcome and then apply `check()`.
     pub async fn wait_owned_blocking<T: Send + 'static>(
         &mut self,
         worker_name: &'static str,
@@ -223,26 +224,53 @@ impl ExecutionControl {
             .name(worker_name.to_string())
             .spawn(operation)
             .map_err(|error| BlockingIoError::Failed(format!("could not start {worker_name}: {error}")))?;
-        let stopped = match mode {
-            BlockingIoMode::Required => Ok(()),
-            BlockingIoMode::Bound => {
-                self.wait(async {
-                    while !handle.is_finished() {
-                        tokio::time::sleep(Duration::from_millis(5)).await;
-                    }
-                })
-                .await
+        let finished = async {
+            while !handle.is_finished() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
             }
         };
-        let Ok(Ok(value)) = tokio::task::spawn_blocking(move || handle.join()).await else {
-            return Err(BlockingIoError::Failed(format!(
-                "{worker_name} stopped without a result"
-            )));
+        let stopped = match mode {
+            BlockingIoMode::Required => {
+                tokio::select! {
+                    biased;
+                    () = cancellation_requested(&mut self.cancellation) => Err(ExecutionStopReason::Cancelled),
+                    () = finished => Ok(()),
+                }
+            }
+            BlockingIoMode::Bound => self.wait(finished).await,
         };
-        match (mode, stopped) {
-            (_, Ok(())) | (BlockingIoMode::Required, _) => Ok(value),
-            (BlockingIoMode::Bound, Err(reason)) => Err(BlockingIoError::Stopped(reason)),
+        match stopped {
+            Ok(()) => join_worker(handle, worker_name, None).await,
+            Err(reason) => join_worker(handle, worker_name, Some(reason)).await,
         }
+    }
+}
+
+const BLOCKING_IO_DRAIN: Duration = Duration::from_secs(1);
+
+async fn join_worker<T: Send + 'static>(
+    handle: std::thread::JoinHandle<T>,
+    worker_name: &'static str,
+    stop: Option<ExecutionStopReason>,
+) -> Result<T, BlockingIoError> {
+    let join = tokio::task::spawn_blocking(move || handle.join());
+    if stop.is_none() {
+        return match join.await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(_)) | Err(_) => Err(BlockingIoError::Failed(format!(
+                "{worker_name} stopped without a result"
+            ))),
+        };
+    }
+    match tokio::time::timeout(BLOCKING_IO_DRAIN, join).await {
+        Ok(Ok(Ok(value))) => Ok(value),
+        Ok(_) => Err(BlockingIoError::Failed(format!(
+            "{worker_name} stopped without a result"
+        ))),
+        Err(_) => std::process::exit(match stop {
+            Some(ExecutionStopReason::DeadlineExceeded) => 124,
+            Some(ExecutionStopReason::Cancelled) | None => 130,
+        }),
     }
 }
 

--- a/crates/horizon-browser-cli/src/execution_control.rs
+++ b/crates/horizon-browser-cli/src/execution_control.rs
@@ -204,8 +204,9 @@ impl ExecutionControl {
     ///
     /// [`BlockingIoMode::Bound`] observes the deadline and cancellation. After a
     /// stop, the writer is joined for one second; a stalled join exits 124/130
-    /// instead of racing a later finalizer. [`BlockingIoMode::Required`] still
-    /// runs after Ctrl-C, with the same bounded drain.
+    /// instead of racing a later finalizer. [`BlockingIoMode::Required`] starts
+    /// even when a stop is already pending, then observes the same deadline,
+    /// cancellation, and bounded drain.
     ///
     /// # Errors
     /// Returns when the worker cannot start or panics. A completed worker
@@ -229,16 +230,7 @@ impl ExecutionControl {
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
         };
-        let stopped = match mode {
-            BlockingIoMode::Required => {
-                tokio::select! {
-                    biased;
-                    () = cancellation_requested(&mut self.cancellation) => Err(ExecutionStopReason::Cancelled),
-                    () = finished => Ok(()),
-                }
-            }
-            BlockingIoMode::Bound => self.wait(finished).await,
-        };
+        let stopped = self.wait(finished).await;
         match stopped {
             Ok(()) => join_worker(handle, worker_name, None).await,
             Err(reason) => join_worker(handle, worker_name, Some(reason)).await,
@@ -288,7 +280,7 @@ pub enum BlockingIoError {
 pub enum BlockingIoMode {
     /// Observe deadline and cancellation, then join the writer.
     Bound,
-    /// Run and join even if the job already stopped.
+    /// Start even if the job already stopped, then observe the bounded drain.
     Required,
 }
 

--- a/crates/horizon-browser-cli/src/execution_control.rs
+++ b/crates/horizon-browser-cli/src/execution_control.rs
@@ -202,55 +202,58 @@ impl ExecutionControl {
 
     /// Run blocking I/O on an owned thread while still observing stop signals.
     ///
-    /// When `honor_deadline` is false, a ready deadline does not skip the work;
-    /// cancellation still aborts the wait after a bounded drain.
+    /// [`BlockingIoMode::Bound`] observes the deadline and cancellation, then
+    /// joins the writer so it cannot race a later finalizer. [`BlockingIoMode::Required`]
+    /// always runs and joins the writer, even when already cancelled.
     ///
     /// # Errors
-    /// Returns when cancellation or, if honored, the deadline wins before the
-    /// worker reports a result.
+    /// Returns when a bound wait observes cancellation or the deadline. The
+    /// worker is still joined before this returns.
     pub async fn wait_owned_blocking<T: Send + 'static>(
         &mut self,
         worker_name: &'static str,
-        honor_deadline: bool,
+        mode: BlockingIoMode,
         operation: impl FnOnce() -> T + Send + 'static,
     ) -> Result<T, ExecutionStopReason> {
-        if honor_deadline {
+        if mode == BlockingIoMode::Bound {
             self.check()?;
-        } else if *self.cancellation.borrow() {
-            return Err(ExecutionStopReason::Cancelled);
         }
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        std::thread::Builder::new()
+        let handle = std::thread::Builder::new()
             .name(worker_name.to_string())
-            .spawn(move || {
-                let _ = sender.send(operation());
-            })
+            .spawn(operation)
             .map_err(|error| {
                 tracing::warn!(%error, "could not start {worker_name}");
                 ExecutionStopReason::Cancelled
             })?;
-        let mut completion = Box::pin(async move { receiver.await.ok() });
-        let waited = if honor_deadline {
-            self.wait(completion.as_mut()).await
-        } else {
-            tokio::select! {
-                biased;
-                () = cancellation_requested(&mut self.cancellation) => Err(ExecutionStopReason::Cancelled),
-                output = completion.as_mut() => Ok(output),
+        let stopped = match mode {
+            BlockingIoMode::Required => Ok(()),
+            BlockingIoMode::Bound => {
+                self.wait(async {
+                    while !handle.is_finished() {
+                        tokio::time::sleep(Duration::from_millis(5)).await;
+                    }
+                })
+                .await
             }
         };
-        match waited {
-            Ok(Some(value)) => Ok(value),
-            Ok(None) => Err(ExecutionStopReason::Cancelled),
-            Err(reason) => match tokio::time::timeout(BLOCKING_IO_DRAIN, completion.as_mut()).await {
-                Ok(Some(value)) => Ok(value),
-                Ok(None) | Err(_) => Err(reason),
-            },
+        let Ok(Ok(value)) = tokio::task::spawn_blocking(move || handle.join()).await else {
+            return Err(ExecutionStopReason::Cancelled);
+        };
+        match (mode, stopped) {
+            (_, Ok(())) | (BlockingIoMode::Required, _) => Ok(value),
+            (BlockingIoMode::Bound, Err(reason)) => Err(reason),
         }
     }
 }
 
-const BLOCKING_IO_DRAIN: Duration = Duration::from_secs(1);
+/// How owned blocking I/O cooperates with job control.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlockingIoMode {
+    /// Observe deadline and cancellation, then join the writer.
+    Bound,
+    /// Run and join even if the job already stopped.
+    Required,
+}
 
 async fn cancellation_requested(receiver: &mut watch::Receiver<bool>) {
     loop {
@@ -298,7 +301,7 @@ mod tests {
     async fn owned_blocking_work_observes_a_ready_deadline() {
         let mut control = ExecutionControl::with_timeout(Duration::ZERO);
         let error = control
-            .wait_owned_blocking("horizon-browser-test-deadline", true, || {
+            .wait_owned_blocking("horizon-browser-test-deadline", BlockingIoMode::Bound, || {
                 std::thread::sleep(Duration::from_secs(5));
                 1
             })
@@ -308,12 +311,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn owned_blocking_work_can_ignore_a_ready_deadline() {
+    async fn required_blocking_work_runs_after_a_ready_deadline() {
         let mut control = ExecutionControl::with_timeout(Duration::ZERO);
         let value = control
-            .wait_owned_blocking("horizon-browser-test-ignore-deadline", false, || 7)
+            .wait_owned_blocking("horizon-browser-test-required", BlockingIoMode::Required, || 7)
             .await
-            .expect("deadline-ignored I/O");
+            .expect("required I/O");
         assert_eq!(value, 7);
     }
 }

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -227,6 +227,9 @@ pub async fn execute_plan_with_resume(
 ) -> Result<ExecutionReport, RunError> {
     validate_plan(plan)?;
     control.check().map_err(RunError::Stopped)?;
+    if resume.start_index >= plan.steps.len() {
+        return Ok(completed_execution_report(plan, resume.completed, resume.start_index));
+    }
     let (server_transport, client_transport) = tokio::io::duplex(MCP_BUFFER_BYTES);
     let mut server_task = tokio::spawn(async move {
         let service = horizon_browser_mcp::HorizonBrowserMcp::from_environment()
@@ -374,14 +377,20 @@ async fn execute_steps(
             }
         }
     }
+    completed_execution_report(plan, steps, start_index)
+}
+
+fn completed_execution_report(plan: &Plan, steps: Vec<StepReport>, start_index: usize) -> ExecutionReport {
     let all_reports_succeeded = steps.iter().all(|step| step.ok);
-    let skipped_ids = plan
-        .steps
-        .iter()
-        .take(start_index)
-        .filter(|step| !result_indexes.contains_key(&step.id))
-        .map(|step| step.id.as_str())
-        .collect::<Vec<_>>();
+    let skipped_ids = {
+        let reported_ids = steps.iter().map(|step| step.id.as_str()).collect::<BTreeSet<_>>();
+        plan.steps
+            .iter()
+            .take(start_index)
+            .filter(|step| !reported_ids.contains(step.id.as_str()))
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>()
+    };
     let ok = skipped_ids.is_empty() && steps.len() == plan.steps.len() && all_reports_succeeded;
     let error = if all_reports_succeeded && !skipped_ids.is_empty() {
         Some(format!(

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -265,7 +265,7 @@ pub async fn execute_plan_with_resume(
     .into_iter()
     .map(|tool| tool.name.into_owned())
     .collect::<BTreeSet<_>>();
-    for step in &plan.steps {
+    for step in plan.steps.iter().skip(resume.start_index) {
         if !tools.contains(&step.tool) {
             drop(client);
             server_task.abort();
@@ -374,10 +374,24 @@ async fn execute_steps(
             }
         }
     }
-    // Skipped plan indexes are absent from `steps`, so success still requires
-    // one successful report for every plan step.
-    let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
-    execution_report(ok, steps, None, None)
+    let all_reports_succeeded = steps.iter().all(|step| step.ok);
+    let skipped_ids = plan
+        .steps
+        .iter()
+        .take(start_index)
+        .filter(|step| !result_indexes.contains_key(&step.id))
+        .map(|step| step.id.as_str())
+        .collect::<Vec<_>>();
+    let ok = skipped_ids.is_empty() && steps.len() == plan.steps.len() && all_reports_succeeded;
+    let error = if all_reports_succeeded && !skipped_ids.is_empty() {
+        Some(format!(
+            "plan remains incomplete because resume explicitly skipped uncertain steps: {}",
+            skipped_ids.join(", ")
+        ))
+    } else {
+        None
+    };
+    execution_report(ok, steps, error, None)
 }
 
 fn stop_execution(steps: Vec<StepReport>, reason: ExecutionStopReason, request_started: bool) -> ExecutionReport {
@@ -900,6 +914,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resume_does_not_require_tools_from_the_verified_prefix() {
+        let plan = plan(
+            br#"{"version":1,"steps":[{"id":"retired","tool":"browser_retired"},{"id":"remaining","tool":"browser_list"}]}"#,
+        );
+        let report = execute_plan_with_resume(
+            &plan,
+            &mut ExecutionControl::unbounded(),
+            PlanResume {
+                completed: vec![StepReport {
+                    id: "retired".to_string(),
+                    tool: "browser_retired".to_string(),
+                    ok: true,
+                    result: Some(json!({"verified": true})),
+                    error: None,
+                }],
+                start_index: 1,
+                checkpoint: None,
+            },
+        )
+        .await
+        .expect("resume supported suffix");
+
+        assert!(report.ok);
+        assert_eq!(
+            report.steps.iter().map(|step| step.id.as_str()).collect::<Vec<_>>(),
+            ["retired", "remaining"]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_does_not_require_tools_from_the_skipped_prefix() {
+        let plan = plan(
+            br#"{"version":1,"steps":[{"id":"retired","tool":"browser_retired"},{"id":"remaining","tool":"browser_list"}]}"#,
+        );
+        let report = execute_plan_with_resume(
+            &plan,
+            &mut ExecutionControl::unbounded(),
+            PlanResume {
+                completed: Vec::new(),
+                start_index: 1,
+                checkpoint: None,
+            },
+        )
+        .await
+        .expect("resume supported suffix");
+
+        assert!(!report.ok);
+        assert_eq!(report.steps.len(), 1);
+        assert_eq!(report.steps[0].id, "remaining");
+        assert_eq!(
+            report.error.as_deref(),
+            Some("plan remains incomplete because resume explicitly skipped uncertain steps: retired")
+        );
+    }
+
+    #[tokio::test]
     async fn resume_after_a_skipped_gap_does_not_report_success() {
         let plan = plan(
             br#"{"version":1,"steps":[{"id":"first","tool":"browser_list"},{"id":"skipped","tool":"browser_list"},{"id":"third","tool":"browser_list"}]}"#,
@@ -920,6 +990,10 @@ mod tests {
         assert_eq!(
             report.steps.iter().map(|step| step.id.as_str()).collect::<Vec<_>>(),
             ["first", "third"]
+        );
+        assert_eq!(
+            report.error.as_deref(),
+            Some("plan remains incomplete because resume explicitly skipped uncertain steps: skipped")
         );
     }
 

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -228,7 +228,12 @@ pub async fn execute_plan_with_resume(
     validate_plan(plan)?;
     control.check().map_err(RunError::Stopped)?;
     if resume.start_index >= plan.steps.len() {
-        return Ok(completed_execution_report(plan, resume.completed, resume.start_index));
+        return Ok(completed_execution_report(
+            plan,
+            resume.completed,
+            resume.start_index,
+            None,
+        ));
     }
     let (server_transport, client_transport) = tokio::io::duplex(MCP_BUFFER_BYTES);
     let mut server_task = tokio::spawn(async move {
@@ -315,7 +320,7 @@ pub async fn execute_plan_with_resume(
 
 enum PersistOutcome {
     Continue,
-    Break,
+    Break(Option<String>),
     Stop(Box<ExecutionReport>),
 }
 
@@ -341,6 +346,7 @@ async fn execute_steps(
         result_indexes.insert(step.id.clone(), index);
     }
     let mut steps = completed;
+    let mut persistence_error = None;
     for step in plan.steps.iter().skip(start_index) {
         let arguments = match resolve_arguments(step, &steps, &result_indexes) {
             Ok(arguments) => arguments,
@@ -351,7 +357,10 @@ async fn execute_steps(
         };
         match persist_intent(checkpoint.as_deref_mut(), control, step, &mut steps).await {
             PersistOutcome::Continue => {}
-            PersistOutcome::Break => break,
+            PersistOutcome::Break(error) => {
+                persistence_error = error;
+                break;
+            }
             PersistOutcome::Stop(report) => return *report,
         }
         if let Err(reason) = control.check() {
@@ -367,9 +376,12 @@ async fn execute_steps(
                 break;
             }
             DispatchOutcome::Next(outcome) => {
-                match persist_completion(checkpoint.as_deref_mut(), control, step, &outcome, &mut steps).await {
+                match persist_completion(checkpoint.as_deref_mut(), control, &outcome, &mut steps).await {
                     PersistOutcome::Continue => {}
-                    PersistOutcome::Break => break,
+                    PersistOutcome::Break(error) => {
+                        persistence_error = error;
+                        break;
+                    }
                     PersistOutcome::Stop(report) => return *report,
                 }
                 result_indexes.insert(step.id.clone(), steps.len());
@@ -377,10 +389,15 @@ async fn execute_steps(
             }
         }
     }
-    completed_execution_report(plan, steps, start_index)
+    completed_execution_report(plan, steps, start_index, persistence_error)
 }
 
-fn completed_execution_report(plan: &Plan, steps: Vec<StepReport>, start_index: usize) -> ExecutionReport {
+fn completed_execution_report(
+    plan: &Plan,
+    steps: Vec<StepReport>,
+    start_index: usize,
+    persistence_error: Option<String>,
+) -> ExecutionReport {
     let all_reports_succeeded = steps.iter().all(|step| step.ok);
     let skipped_ids = {
         let reported_ids = steps.iter().map(|step| step.id.as_str()).collect::<BTreeSet<_>>();
@@ -392,7 +409,11 @@ fn completed_execution_report(plan: &Plan, steps: Vec<StepReport>, start_index: 
             .collect::<Vec<_>>()
     };
     let ok = skipped_ids.is_empty() && steps.len() == plan.steps.len() && all_reports_succeeded;
-    let error = if all_reports_succeeded && !skipped_ids.is_empty() {
+    let error = if ok {
+        None
+    } else if let Some(error) = persistence_error {
+        Some(error)
+    } else if all_reports_succeeded && !skipped_ids.is_empty() {
         Some(format!(
             "plan remains incomplete because resume explicitly skipped uncertain steps: {}",
             skipped_ids.join(", ")
@@ -426,7 +447,7 @@ async fn persist_intent(
         Ok(()) => PersistOutcome::Continue,
         Err(CheckpointPersistError::Io(error)) => {
             steps.push(failed_step(step, format!("could not persist step intent: {error}")));
-            PersistOutcome::Break
+            PersistOutcome::Break(None)
         }
         Err(CheckpointPersistError::Stopped(reason)) => {
             PersistOutcome::Stop(Box::new(stop_execution(std::mem::take(steps), reason, false)))
@@ -437,7 +458,6 @@ async fn persist_intent(
 async fn persist_completion(
     checkpoint: Option<&mut DurableRun>,
     control: &mut ExecutionControl,
-    step: &PlanStep,
     outcome: &StepReport,
     steps: &mut Vec<StepReport>,
 ) -> PersistOutcome {
@@ -447,11 +467,13 @@ async fn persist_completion(
     match store.record_completion_controlled(outcome, control).await {
         Ok(()) => PersistOutcome::Continue,
         Err(CheckpointPersistError::Io(error)) => {
-            steps.push(failed_step(step, format!("could not persist step completion: {error}")));
-            PersistOutcome::Break
+            steps.push(outcome.clone());
+            PersistOutcome::Break(Some(format!("could not persist step completion: {error}")))
         }
         Err(CheckpointPersistError::Stopped(reason)) => {
-            PersistOutcome::Stop(Box::new(stop_execution(std::mem::take(steps), reason, true)))
+            let mut completed = std::mem::take(steps);
+            completed.push(outcome.clone());
+            PersistOutcome::Stop(Box::new(stop_execution(completed, reason, true)))
         }
     }
 }
@@ -1004,6 +1026,39 @@ mod tests {
             report.error.as_deref(),
             Some("plan remains incomplete because resume explicitly skipped uncertain steps: skipped")
         );
+    }
+
+    #[test]
+    fn incomplete_checkpoint_persistence_keeps_the_verified_result_and_error() {
+        let plan = plan(
+            br#"{"version":1,"steps":[{"id":"first","tool":"browser_list"},{"id":"second","tool":"browser_list"}]}"#,
+        );
+        let report = completed_execution_report(
+            &plan,
+            vec![successful_step("first", json!({"panels": []}))],
+            0,
+            Some("checkpoint storage unavailable".to_string()),
+        );
+
+        assert!(!report.ok);
+        assert_eq!(report.completed_steps, 1);
+        assert!(report.steps[0].ok);
+        assert_eq!(report.error.as_deref(), Some("checkpoint storage unavailable"));
+    }
+
+    #[test]
+    fn terminal_persistence_can_heal_the_final_checkpoint_write() {
+        let plan = plan(br#"{"version":1,"steps":[{"id":"only","tool":"browser_list"}]}"#);
+        let report = completed_execution_report(
+            &plan,
+            vec![successful_step("only", json!({"panels": []}))],
+            0,
+            Some("transient checkpoint error".to_string()),
+        );
+
+        assert!(report.ok);
+        assert_eq!(report.completed_steps, 1);
+        assert_eq!(report.error, None);
     }
 
     fn successful_step(id: &str, result: Value) -> StepReport {

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -341,9 +341,14 @@ async fn execute_steps(
             break;
         }
         let params = CallToolRequestParams::new(step.tool.clone()).with_arguments(arguments);
-        let outcome = match wait_for_browser_action(control, client.call_tool(params)).await {
-            Ok(Ok(result)) => step_outcome(step, result),
-            Ok(Err(error)) => failed_step(step, format!("MCP call failed: {error}")),
+        let result = match wait_for_browser_action(control, client.call_tool(params)).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                if let Some(store) = checkpoint.as_mut() {
+                    let _ = store.record_uncertain(step);
+                }
+                return execution_report(false, steps, Some(format!("MCP call failed: {error}")), None);
+            }
             Err(stopped) => {
                 if let Some(store) = checkpoint.as_mut() {
                     let _ = if stopped.request_started {
@@ -355,22 +360,41 @@ async fn execute_steps(
                 return stopped_report(steps, &stopped);
             }
         };
-        if outcome.ok {
-            if let Some(store) = checkpoint.as_mut()
-                && let Err(error) = store.record_completion(&outcome)
-            {
-                steps.push(failed_step(step, format!("could not persist step completion: {error}")));
-                break;
+        if result.is_error.unwrap_or(false) {
+            let outcome = step_outcome(step, result);
+            if let Some(store) = checkpoint.as_mut() {
+                let _ = store.clear_intent();
             }
-        } else if let Some(store) = checkpoint.as_mut() {
-            let _ = store.clear_intent();
-        }
-        let ok = outcome.ok;
-        result_indexes.insert(step.id.clone(), steps.len());
-        steps.push(outcome);
-        if !ok {
+            result_indexes.insert(step.id.clone(), steps.len());
+            steps.push(outcome);
             break;
         }
+        let Some(structured) = result.structured_content else {
+            if let Some(store) = checkpoint.as_mut() {
+                let _ = store.record_uncertain(step);
+            }
+            return execution_report(
+                false,
+                steps,
+                Some("MCP tool returned no structured content".to_string()),
+                None,
+            );
+        };
+        let outcome = StepReport {
+            id: step.id.clone(),
+            tool: step.tool.clone(),
+            ok: true,
+            result: Some(structured),
+            error: None,
+        };
+        if let Some(store) = checkpoint.as_mut()
+            && let Err(error) = store.record_completion(&outcome)
+        {
+            steps.push(failed_step(step, format!("could not persist step completion: {error}")));
+            break;
+        }
+        result_indexes.insert(step.id.clone(), steps.len());
+        steps.push(outcome);
     }
     let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
     execution_report(ok, steps, None, None)

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -355,11 +355,15 @@ async fn execute_steps(
                 return stopped_report(steps, &stopped);
             }
         };
-        if let Some(store) = checkpoint.as_mut()
-            && let Err(error) = store.record_completion(&outcome)
-        {
-            steps.push(failed_step(step, format!("could not persist step completion: {error}")));
-            break;
+        if outcome.ok {
+            if let Some(store) = checkpoint.as_mut()
+                && let Err(error) = store.record_completion(&outcome)
+            {
+                steps.push(failed_step(step, format!("could not persist step completion: {error}")));
+                break;
+            }
+        } else if let Some(store) = checkpoint.as_mut() {
+            let _ = store.clear_intent();
         }
         let ok = outcome.ok;
         result_indexes.insert(step.id.clone(), steps.len());

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -6,6 +6,7 @@
 //! add a second browser action API: it connects an MCP client to the same
 //! [`horizon_browser_mcp::HorizonBrowserMcp`] service used by agents.
 
+pub mod checkpoint;
 pub mod execution_control;
 pub mod job;
 pub mod observability;
@@ -25,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
+use checkpoint::CheckpointStore;
 use execution_control::{ExecutionControl, ExecutionStopReason};
 use observability::ObservabilitySummary;
 
@@ -78,8 +80,19 @@ pub struct ExecutionReport {
     pub observability: ObservabilitySummary,
 }
 
+/// Prefix reused by an explicit resume and optional durable checkpoint sink.
+#[derive(Default)]
+pub struct PlanResume<'a> {
+    /// Verified reports from earlier attempts, used for `$ref` resolution.
+    pub completed: Vec<StepReport>,
+    /// First plan index that is still eligible to run.
+    pub start_index: usize,
+    /// Durable intent/completion sink; omitted for in-memory tests.
+    pub checkpoint: Option<&'a mut dyn CheckpointStore>,
+}
+
 /// Result of one MCP tool call.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StepReport {
     /// Plan step identifier.
     pub id: String,
@@ -199,6 +212,19 @@ pub async fn execute_plan_with_control(
     plan: &Plan,
     control: &mut ExecutionControl,
 ) -> Result<ExecutionReport, RunError> {
+    execute_plan_with_resume(plan, control, PlanResume::default()).await
+}
+
+/// Execute remaining plan steps after an explicit resume selection.
+///
+/// # Errors
+/// Returns for plan validation, MCP initialization, unavailable tools, or a
+/// stop before step execution begins.
+pub async fn execute_plan_with_resume(
+    plan: &Plan,
+    control: &mut ExecutionControl,
+    resume: PlanResume<'_>,
+) -> Result<ExecutionReport, RunError> {
     validate_plan(plan)?;
     control.check().map_err(RunError::Stopped)?;
     let (server_transport, client_transport) = tokio::io::duplex(MCP_BUFFER_BYTES);
@@ -250,7 +276,7 @@ pub async fn execute_plan_with_control(
         }
     }
 
-    let mut report = execute_steps(plan, &client, control).await;
+    let mut report = execute_steps(plan, &client, control, resume).await;
     if report.stop_reason.is_some() {
         drop(client);
         server_task.abort();
@@ -288,10 +314,19 @@ async fn execute_steps(
     plan: &Plan,
     client: &rmcp::service::RunningService<rmcp::RoleClient, PlanClient>,
     control: &mut ExecutionControl,
+    resume: PlanResume<'_>,
 ) -> ExecutionReport {
+    let PlanResume {
+        completed,
+        start_index,
+        mut checkpoint,
+    } = resume;
     let mut result_indexes = BTreeMap::new();
-    let mut steps = Vec::with_capacity(plan.steps.len());
-    for step in &plan.steps {
+    for (index, step) in completed.iter().enumerate() {
+        result_indexes.insert(step.id.clone(), index);
+    }
+    let mut steps = completed;
+    for step in plan.steps.iter().skip(start_index) {
         let arguments = match resolve_arguments(step, &steps, &result_indexes) {
             Ok(arguments) => arguments,
             Err(error) => {
@@ -299,42 +334,64 @@ async fn execute_steps(
                 break;
             }
         };
-        let params = CallToolRequestParams::new(step.tool.clone()).with_arguments(arguments);
-        let result = match wait_for_browser_action(control, client.call_tool(params)).await {
-            Ok(Ok(result)) => result,
-            Ok(Err(error)) => {
-                steps.push(failed_step(step, format!("MCP call failed: {error}")));
-                break;
-            }
-            Err(stopped) => return stopped_report(steps, &stopped),
-        };
-        let structured = result.structured_content;
-        if result.is_error.unwrap_or(false) {
-            let error = tool_error_text(&result.content);
-            steps.push(StepReport {
-                id: step.id.clone(),
-                tool: step.tool.clone(),
-                ok: false,
-                result: structured,
-                error: Some(error),
-            });
+        if let Some(store) = checkpoint.as_mut()
+            && let Err(error) = store.record_intent(step)
+        {
+            steps.push(failed_step(step, format!("could not persist step intent: {error}")));
             break;
         }
-        let Some(structured) = structured else {
-            steps.push(failed_step(step, "MCP tool returned no structured content".to_string()));
-            break;
+        let params = CallToolRequestParams::new(step.tool.clone()).with_arguments(arguments);
+        let outcome = match wait_for_browser_action(control, client.call_tool(params)).await {
+            Ok(Ok(result)) => step_outcome(step, result),
+            Ok(Err(error)) => failed_step(step, format!("MCP call failed: {error}")),
+            Err(stopped) => {
+                if let Some(store) = checkpoint.as_mut() {
+                    let _ = if stopped.request_started {
+                        store.record_uncertain(step)
+                    } else {
+                        store.clear_intent()
+                    };
+                }
+                return stopped_report(steps, &stopped);
+            }
         };
-        steps.push(StepReport {
+        if let Some(store) = checkpoint.as_mut()
+            && let Err(error) = store.record_completion(&outcome)
+        {
+            steps.push(failed_step(step, format!("could not persist step completion: {error}")));
+            break;
+        }
+        let ok = outcome.ok;
+        result_indexes.insert(step.id.clone(), steps.len());
+        steps.push(outcome);
+        if !ok {
+            break;
+        }
+    }
+    let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
+    execution_report(ok, steps, None, None)
+}
+
+fn step_outcome(step: &PlanStep, result: rmcp::model::CallToolResult) -> StepReport {
+    if result.is_error.unwrap_or(false) {
+        return StepReport {
+            id: step.id.clone(),
+            tool: step.tool.clone(),
+            ok: false,
+            result: result.structured_content,
+            error: Some(tool_error_text(&result.content)),
+        };
+    }
+    match result.structured_content {
+        Some(structured) => StepReport {
             id: step.id.clone(),
             tool: step.tool.clone(),
             ok: true,
             result: Some(structured),
             error: None,
-        });
-        result_indexes.insert(step.id.clone(), steps.len() - 1);
+        },
+        None => failed_step(step, "MCP tool returned no structured content".to_string()),
     }
-    let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
-    execution_report(ok, steps, None, None)
 }
 
 async fn wait_for_browser_action<T>(
@@ -669,6 +726,32 @@ mod tests {
             Some(ExecutionStopReason::DeadlineExceeded.message())
         );
         assert_eq!(report.stop_reason, Some(ExecutionStopReason::DeadlineExceeded));
+    }
+
+    #[tokio::test]
+    async fn resume_reuses_verified_prefix_without_replaying_it() {
+        let plan = plan(
+            br#"{"version":1,"steps":[{"id":"first","tool":"browser_list"},{"id":"second","tool":"browser_list"}]}"#,
+        );
+        let report = execute_plan_with_resume(
+            &plan,
+            &mut ExecutionControl::unbounded(),
+            PlanResume {
+                completed: vec![successful_step("first", json!({"panels":[{"panel_id":"kept"}]}))],
+                start_index: 1,
+                checkpoint: None,
+            },
+        )
+        .await
+        .expect("resume remaining list");
+        assert!(report.ok);
+        assert_eq!(report.steps.len(), 2);
+        assert_eq!(report.steps[0].id, "first");
+        assert_eq!(
+            report.steps[0].result.as_ref().expect("prefix result")["panels"][0]["panel_id"],
+            "kept"
+        );
+        assert_eq!(report.steps[1].id, "second");
     }
 
     fn successful_step(id: &str, result: Value) -> StepReport {

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -325,7 +325,6 @@ async fn execute_steps(
     for (index, step) in completed.iter().enumerate() {
         result_indexes.insert(step.id.clone(), index);
     }
-    let prefix_len = completed.len();
     let mut steps = completed;
     for step in plan.steps.iter().skip(start_index) {
         let arguments = match resolve_arguments(step, &steps, &result_indexes) {
@@ -365,7 +364,14 @@ async fn execute_steps(
             if let Some(store) = checkpoint.as_mut() {
                 let _ = store.record_uncertain(step);
             }
-            return execution_report(false, steps, Some(tool_error_text(&result.content)), None);
+            steps.push(StepReport {
+                id: step.id.clone(),
+                tool: step.tool.clone(),
+                ok: false,
+                result: result.structured_content,
+                error: Some(tool_error_text(&result.content)),
+            });
+            break;
         }
         let Some(structured) = result.structured_content else {
             if let Some(store) = checkpoint.as_mut() {
@@ -394,8 +400,9 @@ async fn execute_steps(
         result_indexes.insert(step.id.clone(), steps.len());
         steps.push(outcome);
     }
-    let ran = steps.len().saturating_sub(prefix_len);
-    let ok = steps.iter().all(|step| step.ok) && start_index.saturating_add(ran) == plan.steps.len();
+    // Skipped plan indexes are absent from `steps`, so success still requires
+    // one successful report for every plan step.
+    let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
     execution_report(ok, steps, None, None)
 }
 
@@ -757,6 +764,30 @@ mod tests {
             "kept"
         );
         assert_eq!(report.steps[1].id, "second");
+    }
+
+    #[tokio::test]
+    async fn resume_after_a_skipped_gap_does_not_report_success() {
+        let plan = plan(
+            br#"{"version":1,"steps":[{"id":"first","tool":"browser_list"},{"id":"skipped","tool":"browser_list"},{"id":"third","tool":"browser_list"}]}"#,
+        );
+        let report = execute_plan_with_resume(
+            &plan,
+            &mut ExecutionControl::unbounded(),
+            PlanResume {
+                completed: vec![successful_step("first", json!({"panels":[]}))],
+                start_index: 2,
+                checkpoint: None,
+            },
+        )
+        .await
+        .expect("resume after skip");
+        assert!(!report.ok);
+        assert_eq!(report.completed_steps, 2);
+        assert_eq!(
+            report.steps.iter().map(|step| step.id.as_str()).collect::<Vec<_>>(),
+            ["first", "third"]
+        );
     }
 
     fn successful_step(id: &str, result: Value) -> StepReport {

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -351,6 +351,12 @@ async fn execute_steps(
             PersistOutcome::Break => break,
             PersistOutcome::Stop(report) => return *report,
         }
+        if let Err(reason) = control.check() {
+            if let Err(stop) = persist_post_dispatch(checkpoint.as_deref_mut(), control, step, false).await {
+                return stop_execution(std::mem::take(&mut steps), stop, false);
+            }
+            return stop_execution(std::mem::take(&mut steps), reason, false);
+        }
         match dispatch_step(client, control, checkpoint.as_deref_mut(), step, arguments, &steps).await {
             DispatchOutcome::Stop(report) => return *report,
             DispatchOutcome::FailFast(report) => {

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -26,9 +26,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
-use checkpoint::CheckpointStore;
 use execution_control::{ExecutionControl, ExecutionStopReason};
 use observability::ObservabilitySummary;
+use run_state::{CheckpointPersistError, DurableRun};
 
 const PLAN_VERSION: u32 = 1;
 const MAX_PLAN_STEPS: usize = 256;
@@ -88,7 +88,7 @@ pub struct PlanResume<'a> {
     /// First plan index that is still eligible to run.
     pub start_index: usize,
     /// Durable intent/completion sink; omitted for in-memory tests.
-    pub checkpoint: Option<&'a mut dyn CheckpointStore>,
+    pub checkpoint: Option<&'a mut DurableRun>,
 }
 
 /// Result of one MCP tool call.
@@ -310,6 +310,18 @@ pub async fn execute_plan_with_resume(
     Ok(report)
 }
 
+enum PersistOutcome {
+    Continue,
+    Break,
+    Stop(Box<ExecutionReport>),
+}
+
+enum DispatchOutcome {
+    Next(StepReport),
+    FailFast(StepReport),
+    Stop(Box<ExecutionReport>),
+}
+
 async fn execute_steps(
     plan: &Plan,
     client: &rmcp::service::RunningService<rmcp::RoleClient, PlanClient>,
@@ -334,76 +346,191 @@ async fn execute_steps(
                 break;
             }
         };
-        if let Some(store) = checkpoint.as_mut()
-            && let Err(error) = store.record_intent(step)
-        {
-            steps.push(failed_step(step, format!("could not persist step intent: {error}")));
-            break;
+        match persist_intent(checkpoint.as_deref_mut(), control, step, &mut steps).await {
+            PersistOutcome::Continue => {}
+            PersistOutcome::Break => break,
+            PersistOutcome::Stop(report) => return *report,
         }
-        let params = CallToolRequestParams::new(step.tool.clone()).with_arguments(arguments);
-        let result = match wait_for_browser_action(control, client.call_tool(params)).await {
-            Ok(Ok(result)) => result,
-            Ok(Err(error)) => {
-                if let Some(store) = checkpoint.as_mut() {
-                    let _ = store.record_uncertain(step);
+        match dispatch_step(client, control, checkpoint.as_deref_mut(), step, arguments, &steps).await {
+            DispatchOutcome::Stop(report) => return *report,
+            DispatchOutcome::FailFast(report) => {
+                steps.push(report);
+                break;
+            }
+            DispatchOutcome::Next(outcome) => {
+                match persist_completion(checkpoint.as_deref_mut(), control, step, &outcome, &mut steps).await {
+                    PersistOutcome::Continue => {}
+                    PersistOutcome::Break => break,
+                    PersistOutcome::Stop(report) => return *report,
                 }
-                return execution_report(false, steps, Some(format!("MCP call failed: {error}")), None);
+                result_indexes.insert(step.id.clone(), steps.len());
+                steps.push(outcome);
             }
-            Err(stopped) => {
-                if let Some(store) = checkpoint.as_mut() {
-                    let _ = if stopped.request_started {
-                        store.record_uncertain(step)
-                    } else {
-                        store.clear_intent()
-                    };
-                }
-                return stopped_report(steps, &stopped);
-            }
-        };
-        if result.is_error.unwrap_or(false) {
-            if let Some(store) = checkpoint.as_mut() {
-                let _ = store.record_uncertain(step);
-            }
-            steps.push(StepReport {
-                id: step.id.clone(),
-                tool: step.tool.clone(),
-                ok: false,
-                result: result.structured_content,
-                error: Some(tool_error_text(&result.content)),
-            });
-            break;
         }
-        let Some(structured) = result.structured_content else {
-            if let Some(store) = checkpoint.as_mut() {
-                let _ = store.record_uncertain(step);
-            }
-            return execution_report(
-                false,
-                steps,
-                Some("MCP tool returned no structured content".to_string()),
-                None,
-            );
-        };
-        let outcome = StepReport {
-            id: step.id.clone(),
-            tool: step.tool.clone(),
-            ok: true,
-            result: Some(structured),
-            error: None,
-        };
-        if let Some(store) = checkpoint.as_mut()
-            && let Err(error) = store.record_completion(&outcome)
-        {
-            steps.push(failed_step(step, format!("could not persist step completion: {error}")));
-            break;
-        }
-        result_indexes.insert(step.id.clone(), steps.len());
-        steps.push(outcome);
     }
     // Skipped plan indexes are absent from `steps`, so success still requires
     // one successful report for every plan step.
     let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
     execution_report(ok, steps, None, None)
+}
+
+fn stop_execution(steps: Vec<StepReport>, reason: ExecutionStopReason, request_started: bool) -> ExecutionReport {
+    stopped_report(
+        steps,
+        &ActionWaitStopped {
+            reason,
+            request_started,
+        },
+    )
+}
+
+async fn persist_intent(
+    checkpoint: Option<&mut DurableRun>,
+    control: &mut ExecutionControl,
+    step: &PlanStep,
+    steps: &mut Vec<StepReport>,
+) -> PersistOutcome {
+    let Some(store) = checkpoint else {
+        return PersistOutcome::Continue;
+    };
+    match store.record_intent_controlled(step, control).await {
+        Ok(()) => PersistOutcome::Continue,
+        Err(CheckpointPersistError::Io(error)) => {
+            steps.push(failed_step(step, format!("could not persist step intent: {error}")));
+            PersistOutcome::Break
+        }
+        Err(CheckpointPersistError::Stopped(reason)) => {
+            PersistOutcome::Stop(Box::new(stop_execution(std::mem::take(steps), reason, false)))
+        }
+    }
+}
+
+async fn persist_completion(
+    checkpoint: Option<&mut DurableRun>,
+    control: &mut ExecutionControl,
+    step: &PlanStep,
+    outcome: &StepReport,
+    steps: &mut Vec<StepReport>,
+) -> PersistOutcome {
+    let Some(store) = checkpoint else {
+        return PersistOutcome::Continue;
+    };
+    match store.record_completion_controlled(outcome, control).await {
+        Ok(()) => PersistOutcome::Continue,
+        Err(CheckpointPersistError::Io(error)) => {
+            steps.push(failed_step(step, format!("could not persist step completion: {error}")));
+            PersistOutcome::Break
+        }
+        Err(CheckpointPersistError::Stopped(reason)) => {
+            PersistOutcome::Stop(Box::new(stop_execution(std::mem::take(steps), reason, true)))
+        }
+    }
+}
+
+async fn dispatch_step(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, PlanClient>,
+    control: &mut ExecutionControl,
+    checkpoint: Option<&mut DurableRun>,
+    step: &PlanStep,
+    arguments: Map<String, Value>,
+    steps: &[StepReport],
+) -> DispatchOutcome {
+    let params = CallToolRequestParams::new(step.tool.clone()).with_arguments(arguments);
+    let result = match wait_for_browser_action(control, client.call_tool(params)).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => {
+            return finish_after_dispatch(
+                checkpoint,
+                control,
+                step,
+                true,
+                steps,
+                execution_report(false, steps.to_vec(), Some(format!("MCP call failed: {error}")), None),
+            )
+            .await;
+        }
+        Err(stopped) => {
+            return finish_after_dispatch(
+                checkpoint,
+                control,
+                step,
+                stopped.request_started,
+                steps,
+                stopped_report(steps.to_vec(), &stopped),
+            )
+            .await;
+        }
+    };
+    if result.is_error.unwrap_or(false) {
+        if let Err(reason) = persist_post_dispatch(checkpoint, control, step, true).await {
+            return DispatchOutcome::Stop(Box::new(stop_execution(steps.to_vec(), reason, true)));
+        }
+        return DispatchOutcome::FailFast(StepReport {
+            id: step.id.clone(),
+            tool: step.tool.clone(),
+            ok: false,
+            result: result.structured_content,
+            error: Some(tool_error_text(&result.content)),
+        });
+    }
+    let Some(structured) = result.structured_content else {
+        return finish_after_dispatch(
+            checkpoint,
+            control,
+            step,
+            true,
+            steps,
+            execution_report(
+                false,
+                steps.to_vec(),
+                Some("MCP tool returned no structured content".to_string()),
+                None,
+            ),
+        )
+        .await;
+    };
+    DispatchOutcome::Next(StepReport {
+        id: step.id.clone(),
+        tool: step.tool.clone(),
+        ok: true,
+        result: Some(structured),
+        error: None,
+    })
+}
+
+async fn finish_after_dispatch(
+    checkpoint: Option<&mut DurableRun>,
+    control: &mut ExecutionControl,
+    step: &PlanStep,
+    request_started: bool,
+    steps: &[StepReport],
+    report: ExecutionReport,
+) -> DispatchOutcome {
+    if let Err(reason) = persist_post_dispatch(checkpoint, control, step, request_started).await {
+        DispatchOutcome::Stop(Box::new(stop_execution(steps.to_vec(), reason, request_started)))
+    } else {
+        DispatchOutcome::Stop(Box::new(report))
+    }
+}
+
+async fn persist_post_dispatch(
+    checkpoint: Option<&mut DurableRun>,
+    control: &mut ExecutionControl,
+    step: &PlanStep,
+    request_started: bool,
+) -> Result<(), ExecutionStopReason> {
+    let Some(store) = checkpoint else {
+        return Ok(());
+    };
+    let result = if request_started {
+        store.record_uncertain_controlled(step, control).await
+    } else {
+        store.clear_intent_controlled(control).await
+    };
+    match result {
+        Err(CheckpointPersistError::Stopped(reason)) => Err(reason),
+        Err(CheckpointPersistError::Io(_)) | Ok(()) => Ok(()),
+    }
 }
 
 async fn wait_for_browser_action<T>(

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -325,6 +325,7 @@ async fn execute_steps(
     for (index, step) in completed.iter().enumerate() {
         result_indexes.insert(step.id.clone(), index);
     }
+    let prefix_len = completed.len();
     let mut steps = completed;
     for step in plan.steps.iter().skip(start_index) {
         let arguments = match resolve_arguments(step, &steps, &result_indexes) {
@@ -361,13 +362,10 @@ async fn execute_steps(
             }
         };
         if result.is_error.unwrap_or(false) {
-            let outcome = step_outcome(step, result);
             if let Some(store) = checkpoint.as_mut() {
-                let _ = store.clear_intent();
+                let _ = store.record_uncertain(step);
             }
-            result_indexes.insert(step.id.clone(), steps.len());
-            steps.push(outcome);
-            break;
+            return execution_report(false, steps, Some(tool_error_text(&result.content)), None);
         }
         let Some(structured) = result.structured_content else {
             if let Some(store) = checkpoint.as_mut() {
@@ -396,30 +394,9 @@ async fn execute_steps(
         result_indexes.insert(step.id.clone(), steps.len());
         steps.push(outcome);
     }
-    let ok = steps.len() == plan.steps.len() && steps.iter().all(|step| step.ok);
+    let ran = steps.len().saturating_sub(prefix_len);
+    let ok = steps.iter().all(|step| step.ok) && start_index.saturating_add(ran) == plan.steps.len();
     execution_report(ok, steps, None, None)
-}
-
-fn step_outcome(step: &PlanStep, result: rmcp::model::CallToolResult) -> StepReport {
-    if result.is_error.unwrap_or(false) {
-        return StepReport {
-            id: step.id.clone(),
-            tool: step.tool.clone(),
-            ok: false,
-            result: result.structured_content,
-            error: Some(tool_error_text(&result.content)),
-        };
-    }
-    match result.structured_content {
-        Some(structured) => StepReport {
-            id: step.id.clone(),
-            tool: step.tool.clone(),
-            ok: true,
-            result: Some(structured),
-            error: None,
-        },
-        None => failed_step(step, "MCP tool returned no structured content".to_string()),
-    }
 }
 
 async fn wait_for_browser_action<T>(

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use horizon_browser::BackendKind;
 use horizon_browser_cli::{
     Plan, PlanResume,
-    checkpoint::{UncertainPolicy, valid_job_id},
+    checkpoint::{ResumeError, ResumeSelection, UncertainPolicy, valid_job_id},
     execute_plan_with_resume,
     execution_control::{
         BlockingIoError, BlockingIoMode, CancellationHandle, CancellationProbe, ExecutionControl, ExecutionStopReason,
@@ -156,6 +156,18 @@ struct PreparedRun {
     plan: Plan,
     durable: DurableRun,
     control: ExecutionControl,
+}
+
+struct PreparedResume {
+    durable: DurableRun,
+    plan: Plan,
+    selection: ResumeSelection,
+}
+
+enum ResumePreparation {
+    Completed(Box<PreparedResume>),
+    Rejected(ResumeError),
+    RearmFailed { durable: Box<DurableRun>, error: String },
 }
 
 enum BlockingCompletion<T> {
@@ -341,21 +353,40 @@ async fn resume_controlled(
     let deadline_millis = deadline.unix_millis();
     let prepared = match control
         .wait_owned_blocking("horizon-browser-resume-prepare", BlockingIoMode::Bound, move || {
-            let (mut durable, plan, selection) = DurableRun::prepare_resume(&job_id, policy)?;
-            durable
-                .rearm(timeout_secs, deadline_millis, selection.skipped.clone())
-                .map_err(|error| horizon_browser_cli::checkpoint::ResumeError::Decode(error.to_string()))?;
-            Ok((durable, plan, selection))
+            let (durable, plan, selection) = match DurableRun::prepare_resume(&job_id, policy) {
+                Ok(prepared) => prepared,
+                Err(error) => return ResumePreparation::Rejected(error),
+            };
+            match durable.rearm(timeout_secs, deadline_millis, selection.skipped.clone()) {
+                Ok(durable) => ResumePreparation::Completed(Box::new(PreparedResume {
+                    durable,
+                    plan,
+                    selection,
+                })),
+                Err(error) => {
+                    let (durable, source) = error.into_parts();
+                    ResumePreparation::RearmFailed {
+                        durable: Box::new(durable),
+                        error: source.to_string(),
+                    }
+                }
+            }
         })
         .await
     {
-        Ok(Ok(parts)) => parts,
-        Ok(Err(error)) => {
+        Ok(ResumePreparation::Completed(prepared)) => *prepared,
+        Ok(ResumePreparation::Rejected(error)) => {
             if let Some(reason) = pending_stop_reason(&control) {
                 return stop_exit_code(reason);
             }
             eprintln!("error: {error}");
             return resume_error_exit(&error);
+        }
+        Ok(ResumePreparation::RearmFailed { durable, error }) => {
+            if let Some(reason) = pending_stop_reason(&control) {
+                return persist_stopped(&durable, reason, &mut finalization_cancellation).await;
+            }
+            return persist_failed(&durable, error, &mut finalization_cancellation).await;
         }
         Err(BlockingIoError::Stopped(reason)) => return stop_exit_code(reason),
         Err(BlockingIoError::Failed(error)) => {
@@ -366,7 +397,11 @@ async fn resume_controlled(
             return ExitCode::FAILURE;
         }
     };
-    let (mut durable, plan, selection) = prepared;
+    let PreparedResume {
+        mut durable,
+        plan,
+        selection,
+    } = prepared;
     if let Err(reason) = control.check() {
         return persist_stopped(&durable, reason, &mut finalization_cancellation).await;
     }
@@ -412,10 +447,9 @@ async fn resume_controlled(
     }
 }
 
-fn resume_error_exit(error: &horizon_browser_cli::checkpoint::ResumeError) -> ExitCode {
+fn resume_error_exit(error: &ResumeError) -> ExitCode {
     match error {
-        horizon_browser_cli::checkpoint::ResumeError::InvalidJobId(_)
-        | horizon_browser_cli::checkpoint::ResumeError::Uncertain { .. } => ExitCode::from(2),
+        ResumeError::InvalidJobId(_) | ResumeError::Uncertain { .. } => ExitCode::from(2),
         _ => ExitCode::FAILURE,
     }
 }

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -17,7 +17,7 @@ use horizon_browser_cli::{
     Plan, PlanResume,
     checkpoint::{UncertainPolicy, valid_job_id},
     execute_plan_with_resume,
-    execution_control::{CancellationHandle, CancellationProbe, ExecutionControl, ExecutionStopReason},
+    execution_control::{BlockingIoMode, CancellationHandle, CancellationProbe, ExecutionControl, ExecutionStopReason},
     job::JobOptions,
     run_state::{DurableExecutionReport, DurablePreparationError, DurableRun},
     standalone::StandaloneOptions,
@@ -334,14 +334,21 @@ async fn resume_controlled(
     mut control: ExecutionControl,
     mut finalization_cancellation: CancellationProbe,
 ) -> ExitCode {
-    let (mut durable, plan, selection) = match DurableRun::prepare_resume(&job_id, policy) {
-        Ok(parts) => parts,
-        Err(error) => {
+    let deadline = control.start_timeout(timeout);
+    let prepared = match control
+        .wait_owned_blocking("horizon-browser-resume-prepare", BlockingIoMode::Bound, move || {
+            DurableRun::prepare_resume(&job_id, policy)
+        })
+        .await
+    {
+        Ok(Ok(parts)) => parts,
+        Ok(Err(error)) => {
             eprintln!("error: {error}");
             return resume_error_exit(&error);
         }
+        Err(reason) => return stop_exit_code(reason),
     };
-    let deadline = control.start_timeout(timeout);
+    let (mut durable, plan, selection) = prepared;
     if let Err(error) = durable.rearm(timeout.as_secs(), deadline.unix_millis(), selection.skipped.clone()) {
         eprintln!("error: {error}");
         return ExitCode::FAILURE;

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -14,7 +14,9 @@ use std::time::Duration;
 
 use horizon_browser::BackendKind;
 use horizon_browser_cli::{
-    Plan,
+    Plan, PlanResume,
+    checkpoint::{UncertainPolicy, valid_job_id},
+    execute_plan_with_resume,
     execution_control::{CancellationHandle, CancellationProbe, ExecutionControl, ExecutionStopReason},
     job::JobOptions,
     run_state::{DurableExecutionReport, DurablePreparationError, DurableRun},
@@ -34,6 +36,7 @@ USAGE:
     horizon-browser "<GOAL>" [--backend <auto|chromium|firefox|safari>] [--visible] [--json]
     horizon-browser do "<GOAL>" [OPTIONS]
     horizon-browser run <PLAN.json|-> [--output <REPORT.json|->] [--timeout <SECONDS>]
+    horizon-browser resume <JOB-ID> [--output <REPORT.json|->] [--timeout <SECONDS>] [--on-uncertain fail|skip]
     horizon-browser mcp [--standalone|--connect] [--backend <BACKEND>] [--visible]
 
 COMMANDS:
@@ -42,6 +45,9 @@ COMMANDS:
     run    Execute a fail-fast JSON plan through the existing MCP tools.
            Saves durable job state; reads stdin when PLAN is '-' and writes
            JSON to stdout by default. Ctrl-C preserves progress and exits 130.
+    resume Continue a cancelled, timed-out, or failed job from verified
+           checkpoints. Uncertain in-flight mutations are not replayed unless
+           --on-uncertain skip is set after inspecting the browser audit.
     mcp    Serve the browser MCP contract over stdio. Outside Horizon it owns
            a standalone browser; --connect uses existing Horizon panels only.
 
@@ -51,6 +57,7 @@ OPTIONS:
     --json                Emit stable JSONL job progress and completion events.
     -o, --output <PATH>    Write the JSON report to PATH; '-' means stdout.
     --timeout <SECONDS>    Bound durable preparation and MCP work (default 1800, max 86400).
+    --on-uncertain <MODE>  resume: fail (default) or skip an in-flight mutation.
     -h, --help             Print this help.
     -V, --version          Print the version.
 "#;
@@ -60,6 +67,12 @@ enum Command {
         plan: PathBuf,
         output: Option<PathBuf>,
         timeout: Duration,
+    },
+    Resume {
+        job_id: String,
+        output: Option<PathBuf>,
+        timeout: Duration,
+        on_uncertain: UncertainPolicy,
     },
     Do(JobOptions),
     Mcp {
@@ -85,6 +98,12 @@ async fn main() -> ExitCode {
         Ok(Command::Do(options)) => run_job(&options),
         Ok(Command::Mcp { standalone, options }) => serve_mcp(standalone, options).await,
         Ok(Command::Run { plan, output, timeout }) => run(plan, output.as_deref(), timeout).await,
+        Ok(Command::Resume {
+            job_id,
+            output,
+            timeout,
+            on_uncertain,
+        }) => resume(job_id, output.as_deref(), timeout, on_uncertain).await,
         Err(error) => {
             eprintln!("error: {error}\n\n{HELP}");
             ExitCode::from(2)
@@ -213,7 +232,7 @@ async fn prepare_run(
     )
     .await
     {
-        Ok(PreparationCompletion::Completed(prepared)) => prepared,
+        Ok(PreparationCompletion::Completed(prepared)) => prepared.map(|run| *run),
         Ok(PreparationCompletion::InfrastructureFailed(error)) => {
             eprintln!("error: {error}");
             return Err(ExitCode::FAILURE);
@@ -244,13 +263,23 @@ async fn run_controlled(
 ) -> ExitCode {
     let PreparedRun {
         plan,
-        durable,
+        mut durable,
         mut control,
     } = match prepare_run(plan_path, timeout, control, &mut preparation_cancellation).await {
         Ok(prepared) => prepared,
         Err(exit) => return exit,
     };
-    let report = match horizon_browser_cli::execute_plan_with_control(&plan, &mut control).await {
+    let report = match execute_plan_with_resume(
+        &plan,
+        &mut control,
+        PlanResume {
+            completed: Vec::new(),
+            start_index: 0,
+            checkpoint: Some(&mut durable),
+        },
+    )
+    .await
+    {
         Ok(report) => report,
         Err(horizon_browser_cli::RunError::Stopped(reason)) => {
             return persist_stopped(&durable, reason, &mut finalization_cancellation).await;
@@ -279,6 +308,93 @@ async fn run_controlled(
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE
+    }
+}
+
+async fn resume(job_id: String, output_path: Option<&Path>, timeout: Duration, policy: UncertainPolicy) -> ExitCode {
+    let (control, cancellation) = ExecutionControl::cancellable();
+    let finalization_cancellation = cancellation.probe();
+    let execution = resume_controlled(job_id, output_path, timeout, policy, control, finalization_cancellation);
+    let interrupts = forward_interrupts(cancellation);
+    tokio::pin!(execution);
+    tokio::pin!(interrupts);
+    tokio::select! {
+        biased;
+        never = &mut interrupts => match never {},
+        result = &mut execution => result,
+    }
+}
+
+async fn resume_controlled(
+    job_id: String,
+    output_path: Option<&Path>,
+    timeout: Duration,
+    policy: UncertainPolicy,
+    mut control: ExecutionControl,
+    mut finalization_cancellation: CancellationProbe,
+) -> ExitCode {
+    let (mut durable, plan, selection) = match DurableRun::prepare_resume(&job_id, policy) {
+        Ok(parts) => parts,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return resume_error_exit(&error);
+        }
+    };
+    let deadline = control.start_timeout(timeout);
+    if let Err(error) = durable.rearm(timeout.as_secs(), deadline.unix_millis(), selection.skipped.clone()) {
+        eprintln!("error: {error}");
+        return ExitCode::FAILURE;
+    }
+    if let Err(reason) = control.check() {
+        return persist_stopped(&durable, reason, &mut finalization_cancellation).await;
+    }
+    let report = match execute_plan_with_resume(
+        &plan,
+        &mut control,
+        PlanResume {
+            completed: selection.completed,
+            start_index: selection.start_index,
+            checkpoint: Some(&mut durable),
+        },
+    )
+    .await
+    {
+        Ok(report) => report,
+        Err(horizon_browser_cli::RunError::Stopped(reason)) => {
+            return persist_stopped(&durable, reason, &mut finalization_cancellation).await;
+        }
+        Err(error) => {
+            return persist_failed(&durable, error.to_string(), &mut finalization_cancellation).await;
+        }
+    };
+    let post_process_error_exit = report.stop_reason.map_or(ExitCode::FAILURE, stop_exit_code);
+    let finalization =
+        run_finalization::finalize_report(&durable, &report, output_path, &mut finalization_cancellation).await;
+    if let Err(error) = finalization.result {
+        eprintln!("error: {error}");
+        return if finalization.interrupted {
+            ExitCode::from(EXIT_CANCELLED)
+        } else {
+            post_process_error_exit
+        };
+    }
+    if finalization.interrupted {
+        return ExitCode::from(EXIT_CANCELLED);
+    }
+    if let Some(reason) = report.stop_reason {
+        stop_exit_code(reason)
+    } else if report.ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn resume_error_exit(error: &horizon_browser_cli::checkpoint::ResumeError) -> ExitCode {
+    match error {
+        horizon_browser_cli::checkpoint::ResumeError::InvalidJobId(_)
+        | horizon_browser_cli::checkpoint::ResumeError::Uncertain { .. } => ExitCode::from(2),
+        _ => ExitCode::FAILURE,
     }
 }
 
@@ -406,6 +522,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<Command, Strin
         Some("mcp") => parse_mcp(args),
         Some("do") => parse_do(args),
         Some("run") => parse_run(args),
+        Some("resume") => parse_resume(args),
         Some(prompt) if !prompt.starts_with('-') => parse_job(prompt.to_string(), args),
         Some(command) => Err(format!("unknown command or option `{command}`")),
         None => Err("command is not valid UTF-8".to_string()),
@@ -531,6 +648,54 @@ fn parse_run(mut args: impl Iterator<Item = OsString>) -> Result<Command, String
     Ok(Command::Run { plan, output, timeout })
 }
 
+fn parse_resume(mut args: impl Iterator<Item = OsString>) -> Result<Command, String> {
+    let job_id = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .ok_or_else(|| "resume requires a job id".to_string())?;
+    if !valid_job_id(&job_id) {
+        return Err(format!("invalid job id `{job_id}`"));
+    }
+    let mut output = None;
+    let mut timeout = Duration::from_secs(DEFAULT_RUN_TIMEOUT_SECONDS);
+    let mut timeout_seen = false;
+    let mut on_uncertain = UncertainPolicy::Fail;
+    let mut on_uncertain_seen = false;
+    while let Some(argument) = args.next() {
+        match argument.to_str() {
+            Some("-o" | "--output") if output.is_none() => {
+                output = Some(PathBuf::from(
+                    args.next()
+                        .ok_or_else(|| "--output requires a path or '-'".to_string())?,
+                ));
+            }
+            Some("-o" | "--output") => return Err("--output may be specified only once".to_string()),
+            Some("--timeout") if !timeout_seen => {
+                timeout_seen = true;
+                timeout = parse_run_timeout(args.next().as_ref())?;
+            }
+            Some("--timeout") => return Err("--timeout may be specified only once".to_string()),
+            Some("--on-uncertain") if !on_uncertain_seen => {
+                on_uncertain_seen = true;
+                let value = args
+                    .next()
+                    .and_then(|value| value.into_string().ok())
+                    .ok_or_else(|| "--on-uncertain requires fail or skip".to_string())?;
+                on_uncertain = UncertainPolicy::parse(&value)?;
+            }
+            Some("--on-uncertain") => return Err("--on-uncertain may be specified only once".to_string()),
+            Some(argument) => return Err(format!("unexpected resume argument `{argument}`")),
+            None => return Err("resume argument is not valid UTF-8".to_string()),
+        }
+    }
+    Ok(Command::Resume {
+        job_id,
+        output,
+        timeout,
+        on_uncertain,
+    })
+}
+
 fn parse_run_timeout(value: Option<&OsString>) -> Result<Duration, String> {
     let seconds = value
         .and_then(|value| value.to_str())
@@ -631,6 +796,36 @@ mod tests {
         assert!(parse_args(["run", "plan.json", "--timeout", "86401"].map(OsString::from)).is_err());
         assert!(parse_args(["run", "plan.json", "--timeout", "1", "--timeout", "2"].map(OsString::from)).is_err());
         assert!(parse_args(["run", "plan.json", "--actor", "spoof"].map(OsString::from)).is_err());
+        let Command::Resume {
+            job_id, on_uncertain, ..
+        } = parse_args(
+            [
+                "resume",
+                "job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4",
+                "--on-uncertain",
+                "skip",
+            ]
+            .map(OsString::from),
+        )
+        .expect("valid resume command")
+        else {
+            panic!("expected resume command");
+        };
+        assert_eq!(job_id, "job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4");
+        assert_eq!(on_uncertain, UncertainPolicy::Skip);
+        assert!(parse_args(["resume", "../job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4"].map(OsString::from)).is_err());
+        assert!(
+            parse_args(
+                [
+                    "resume",
+                    "job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4",
+                    "--on-uncertain",
+                    "retry"
+                ]
+                .map(OsString::from)
+            )
+            .is_err()
+        );
         assert!(parse_args(["mcp", "extra"].map(OsString::from)).is_err());
 
         let Command::Mcp { standalone, options } =

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -17,7 +17,9 @@ use horizon_browser_cli::{
     Plan, PlanResume,
     checkpoint::{UncertainPolicy, valid_job_id},
     execute_plan_with_resume,
-    execution_control::{BlockingIoMode, CancellationHandle, CancellationProbe, ExecutionControl, ExecutionStopReason},
+    execution_control::{
+        BlockingIoError, BlockingIoMode, CancellationHandle, CancellationProbe, ExecutionControl, ExecutionStopReason,
+    },
     job::JobOptions,
     run_state::{DurableExecutionReport, DurablePreparationError, DurableRun},
     standalone::StandaloneOptions,
@@ -335,9 +337,15 @@ async fn resume_controlled(
     mut finalization_cancellation: CancellationProbe,
 ) -> ExitCode {
     let deadline = control.start_timeout(timeout);
+    let timeout_secs = timeout.as_secs();
+    let deadline_millis = deadline.unix_millis();
     let prepared = match control
         .wait_owned_blocking("horizon-browser-resume-prepare", BlockingIoMode::Bound, move || {
-            DurableRun::prepare_resume(&job_id, policy)
+            let (mut durable, plan, selection) = DurableRun::prepare_resume(&job_id, policy)?;
+            durable
+                .rearm(timeout_secs, deadline_millis, selection.skipped.clone())
+                .map_err(|error| horizon_browser_cli::checkpoint::ResumeError::Decode(error.to_string()))?;
+            Ok((durable, plan, selection))
         })
         .await
     {
@@ -346,13 +354,13 @@ async fn resume_controlled(
             eprintln!("error: {error}");
             return resume_error_exit(&error);
         }
-        Err(reason) => return stop_exit_code(reason),
+        Err(BlockingIoError::Stopped(reason)) => return stop_exit_code(reason),
+        Err(BlockingIoError::Failed(error)) => {
+            eprintln!("error: {error}");
+            return ExitCode::FAILURE;
+        }
     };
     let (mut durable, plan, selection) = prepared;
-    if let Err(error) = durable.rearm(timeout.as_secs(), deadline.unix_millis(), selection.skipped.clone()) {
-        eprintln!("error: {error}");
-        return ExitCode::FAILURE;
-    }
     if let Err(reason) = control.check() {
         return persist_stopped(&durable, reason, &mut finalization_cancellation).await;
     }

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -46,8 +46,8 @@ COMMANDS:
            Saves durable job state; reads stdin when PLAN is '-' and writes
            JSON to stdout by default. Ctrl-C preserves progress and exits 130.
     resume Continue a cancelled, timed-out, or failed job from verified
-           checkpoints. Uncertain in-flight mutations are not replayed unless
-           --on-uncertain skip is set after inspecting the browser audit.
+           checkpoints. Uncertain in-flight calls are never replayed.
+           --on-uncertain skip continues later steps after audit inspection.
     mcp    Serve the browser MCP contract over stdio. Outside Horizon it owns
            a standalone browser; --connect uses existing Horizon panels only.
 
@@ -57,7 +57,8 @@ OPTIONS:
     --json                Emit stable JSONL job progress and completion events.
     -o, --output <PATH>    Write the JSON report to PATH; '-' means stdout.
     --timeout <SECONDS>    Bound durable preparation and MCP work (default 1800, max 86400).
-    --on-uncertain <MODE>  resume: fail (default) or skip an in-flight mutation.
+    --on-uncertain <MODE>  resume: fail (default) or continue after the
+                           uncertain step without replaying it.
     -h, --help             Print this help.
     -V, --version          Print the version.
 "#;

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -351,11 +351,17 @@ async fn resume_controlled(
     {
         Ok(Ok(parts)) => parts,
         Ok(Err(error)) => {
+            if let Some(reason) = pending_stop_reason(&control) {
+                return stop_exit_code(reason);
+            }
             eprintln!("error: {error}");
             return resume_error_exit(&error);
         }
         Err(BlockingIoError::Stopped(reason)) => return stop_exit_code(reason),
         Err(BlockingIoError::Failed(error)) => {
+            if let Some(reason) = pending_stop_reason(&control) {
+                return stop_exit_code(reason);
+            }
             eprintln!("error: {error}");
             return ExitCode::FAILURE;
         }
@@ -412,6 +418,10 @@ fn resume_error_exit(error: &horizon_browser_cli::checkpoint::ResumeError) -> Ex
         | horizon_browser_cli::checkpoint::ResumeError::Uncertain { .. } => ExitCode::from(2),
         _ => ExitCode::FAILURE,
     }
+}
+
+fn pending_stop_reason(control: &ExecutionControl) -> Option<ExecutionStopReason> {
+    control.check().err()
 }
 
 async fn run(plan_path: PathBuf, output_path: Option<&Path>, timeout: Duration) -> ExitCode {
@@ -854,6 +864,19 @@ mod tests {
         assert_eq!(options.backend, Some(BackendKind::FirefoxBidi));
         assert!(options.visible);
         assert!(parse_args(["mcp", "--connect", "--visible"].map(OsString::from)).is_err());
+    }
+
+    #[test]
+    fn pending_stop_reason_wins_over_a_late_resume_preparation_error() {
+        let (cancelled, cancellation) = ExecutionControl::cancellable();
+        cancellation.cancel();
+        assert_eq!(pending_stop_reason(&cancelled), Some(ExecutionStopReason::Cancelled));
+
+        let expired = ExecutionControl::with_timeout(Duration::ZERO);
+        assert_eq!(
+            pending_stop_reason(&expired),
+            Some(ExecutionStopReason::DeadlineExceeded)
+        );
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/run_preparation.rs
+++ b/crates/horizon-browser-cli/src/run_preparation.rs
@@ -9,7 +9,7 @@ use horizon_browser_cli::{
 use super::{CANCELLATION_FLUSH_GRACE, EXIT_CANCELLED};
 
 pub(super) enum PreparationCompletion {
-    Completed(Result<DurableRun, DurablePreparationError>),
+    Completed(Result<Box<DurableRun>, DurablePreparationError>),
     InfrastructureFailed(String),
 }
 
@@ -30,13 +30,13 @@ pub(super) async fn prepare_durable(
     deadline_at_millis: u64,
 ) -> Result<PreparationCompletion, ExecutionStopReason> {
     match await_worker(control, cancellation, "horizon-browser-state-prepare", move || {
-        DurableRun::prepare_cancellable(&plan, timeout_seconds, deadline_at_millis)
+        DurableRun::prepare_cancellable(&plan, timeout_seconds, deadline_at_millis).map(Box::new)
     })
     .await?
     {
         WorkerCompletion::Completed(outcome) => Ok(PreparationCompletion::Completed(outcome)),
         WorkerCompletion::Cancelled { result, flush_deadline } => {
-            persist_cancelled_preparation(result, flush_deadline).await;
+            persist_cancelled_preparation(result.map(|run| *run), flush_deadline).await;
             Err(ExecutionStopReason::Cancelled)
         }
         WorkerCompletion::InfrastructureFailed(error) => Ok(PreparationCompletion::InfrastructureFailed(error)),

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -276,7 +276,7 @@ impl DurableRun {
             .map_err(DurablePreparationError::unpublished)?;
         sync_directory(staging.path()).map_err(DurablePreparationError::unpublished)?;
         publish_job_directory(staging, &directory).map_err(DurablePreparationError::unpublished)?;
-        let run = Self {
+        let mut run = Self {
             state_path: directory.join(STATE_FILE),
             directory,
             state,
@@ -284,6 +284,15 @@ impl DurableRun {
         };
         if let Err(source) = sync_directory(root) {
             return Err(DurablePreparationError::published(run, source));
+        }
+        if let Err(error) = run.acquire_resume_lock() {
+            return Err(DurablePreparationError::published(
+                run,
+                io_error(
+                    error.to_string(),
+                    std::io::Error::from(std::io::ErrorKind::AlreadyExists),
+                ),
+            ));
         }
         Ok(run)
     }
@@ -456,6 +465,17 @@ impl DurableRun {
         self.persist_state().map_err(|error| error.to_string())
     }
 
+    fn persist_checkpoint_or_restore(&mut self, previous: RunCheckpoint) -> Result<(), String> {
+        match self.persist_checkpoint() {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.state.checkpoint = previous;
+                self.state.completed_steps = self.state.checkpoint.completed.len();
+                Err(error)
+            }
+        }
+    }
+
     fn acquire_resume_lock(&mut self) -> Result<(), ResumeError> {
         let path = self.directory.join(RESUME_LOCK_FILE);
         match OpenOptions::new().write(true).create_new(true).open(&path) {
@@ -496,32 +516,36 @@ impl Drop for DurableRun {
 
 impl CheckpointStore for DurableRun {
     fn record_intent(&mut self, step: &PlanStep) -> Result<(), String> {
+        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = Some(CheckpointIntent {
             step_id: step.id.clone(),
             tool: step.tool.clone(),
             status: IntentStatus::Dispatched,
         });
-        self.persist_checkpoint()
+        self.persist_checkpoint_or_restore(previous)
     }
 
     fn record_completion(&mut self, report: &StepReport) -> Result<(), String> {
+        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = None;
         self.state.checkpoint.completed.push(report.clone());
-        self.persist_checkpoint()
+        self.persist_checkpoint_or_restore(previous)
     }
 
     fn record_uncertain(&mut self, step: &PlanStep) -> Result<(), String> {
+        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = Some(CheckpointIntent {
             step_id: step.id.clone(),
             tool: step.tool.clone(),
             status: IntentStatus::Uncertain,
         });
-        self.persist_checkpoint()
+        self.persist_checkpoint_or_restore(previous)
     }
 
     fn clear_intent(&mut self) -> Result<(), String> {
+        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = None;
-        self.persist_checkpoint()
+        self.persist_checkpoint_or_restore(previous)
     }
 }
 
@@ -649,14 +673,18 @@ fn write_private_json(path: &Path, value: &impl Serialize, artifact: &'static st
 
 fn resume_lock_is_stale(path: &Path) -> bool {
     let Ok(bytes) = std::fs::read(path) else {
-        return true;
+        return false;
     };
     let Ok(pid) = std::str::from_utf8(&bytes) else {
-        return true;
+        return false;
     };
     let Ok(pid) = pid.trim().parse::<u32>() else {
-        return true;
+        return false;
     };
+    !process_is_alive(pid)
+}
+
+fn process_is_alive(pid: u32) -> bool {
     if pid == std::process::id() {
         return true;
     }
@@ -665,12 +693,19 @@ fn resume_lock_is_stale(path: &Path) -> bool {
         std::process::Command::new("kill")
             .args(["-0", &pid.to_string()])
             .status()
-            .is_ok_and(|status| !status.success())
+            .is_ok_and(|status| status.success())
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        std::process::Command::new("tasklist")
+            .args(["/NH", "/FI", &format!("PID eq {pid}")])
+            .output()
+            .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = pid;
-        false
+        true
     }
 }
 
@@ -689,7 +724,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::checkpoint::{CheckpointStore, IntentStatus, UncertainPolicy, select_resume};
+    use crate::checkpoint::{CheckpointStore, IntentStatus, ResumeError, UncertainPolicy, select_resume};
     use crate::observability::ObservabilitySummary;
     use crate::{PlanStep, StepReport};
 
@@ -906,6 +941,32 @@ mod tests {
         let selection = select_resume(&two_step_plan(), Some(&timed_out.checkpoint), UncertainPolicy::Skip)
             .expect("skip remaining");
         assert_eq!(selection.start_index, 2);
+    }
+
+    #[test]
+    fn failed_intent_persist_does_not_keep_in_memory_dispatch() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut run = DurableRun::prepare_in(root.path(), &two_step_plan(), Some(30), None).expect("prepare");
+        std::fs::remove_file(&run.state_path).expect("remove state file");
+        std::fs::create_dir(&run.state_path).expect("block state path with a directory");
+        run.record_intent(&two_step_plan().steps[0])
+            .expect_err("persist must fail");
+        assert!(run.state().checkpoint.intent.is_none());
+        std::fs::remove_dir(&run.state_path).expect("unblock state path");
+    }
+
+    #[test]
+    fn incomplete_resume_lock_is_not_stolen() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut run = DurableRun::prepare_in(root.path(), &two_step_plan(), Some(30), None).expect("prepare");
+        run.stop(ExecutionStopReason::Cancelled).expect("cancel");
+        let job_id = run.job_id().to_string();
+        let directory = run.state_path.parent().expect("job directory").to_path_buf();
+        drop(run);
+        std::fs::write(directory.join("resume.lock"), b"").expect("empty lock");
+        let mut opened = DurableRun::open_in(root.path(), &job_id).expect("open");
+        let error = opened.acquire_resume_lock().expect_err("empty lock is live");
+        assert!(matches!(error, ResumeError::Locked(_)));
     }
 
     fn two_step_plan() -> Plan {

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -286,25 +286,19 @@ impl DurableRun {
             .map_err(DurablePreparationError::unpublished)?;
         write_private_json(&staging.path().join(STATE_FILE), &state, "state")
             .map_err(DurablePreparationError::unpublished)?;
+        let lock_file = acquire_resume_lock_file(staging.path())
+            .map_err(|source| io_error(format!("could not lock staged durable job {}", state.job_id), source))
+            .map_err(DurablePreparationError::unpublished)?;
         sync_directory(staging.path()).map_err(DurablePreparationError::unpublished)?;
         publish_job_directory(staging, &directory).map_err(DurablePreparationError::unpublished)?;
-        let mut run = Self {
+        let run = Self {
             state_path: directory.join(STATE_FILE),
             directory,
             state,
-            lock_file: None,
+            lock_file: Some(lock_file),
         };
         if let Err(source) = sync_directory(root) {
             return Err(DurablePreparationError::published(run, source));
-        }
-        if let Err(error) = run.acquire_resume_lock() {
-            return Err(DurablePreparationError::published(
-                run,
-                io_error(
-                    error.to_string(),
-                    std::io::Error::from(std::io::ErrorKind::AlreadyExists),
-                ),
-            ));
         }
         Ok(run)
     }
@@ -380,21 +374,7 @@ impl DurableRun {
         }
         let directory = root.join(job_id);
         let state_path = directory.join(STATE_FILE);
-        let bytes = std::fs::read(&state_path).map_err(|source| {
-            if source.kind() == std::io::ErrorKind::NotFound {
-                ResumeError::NotFound(job_id.to_string())
-            } else {
-                ResumeError::Decode(format!("could not read {}: {source}", state_path.display()))
-            }
-        })?;
-        let state: RunState = serde_json::from_slice(&bytes)
-            .map_err(|source| ResumeError::Decode(format!("could not decode {}: {source}", state_path.display())))?;
-        if state.job_id != job_id {
-            return Err(ResumeError::Decode(format!(
-                "durable job `{job_id}` does not match state id `{}`",
-                state.job_id
-            )));
-        }
+        let state = read_run_state(&state_path, job_id)?;
         Ok(Self {
             directory,
             state_path,
@@ -411,6 +391,7 @@ impl DurableRun {
     pub fn prepare_resume(job_id: &str, policy: UncertainPolicy) -> Result<(Self, Plan, ResumeSelection), ResumeError> {
         let mut run = Self::open(job_id)?;
         run.acquire_resume_lock()?;
+        run.reload_state(job_id)?;
         if run.state.version < MIN_RESUME_VERSION {
             return Err(ResumeError::LegacyState(job_id.to_string()));
         }
@@ -602,23 +583,24 @@ impl DurableRun {
 
     fn acquire_resume_lock(&mut self) -> Result<(), ResumeError> {
         let path = self.directory.join(RESUME_LOCK_FILE);
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .write(true)
-            .open(&path)
-            .map_err(|source| ResumeError::Decode(format!("could not open {}: {source}", path.display())))?;
-        match file.try_lock() {
-            Ok(()) => {
+        match acquire_resume_lock_file(&self.directory) {
+            Ok(file) => {
                 self.lock_file = Some(file);
                 Ok(())
             }
-            Err(std::fs::TryLockError::WouldBlock) => Err(ResumeError::Locked(self.state.job_id.clone())),
-            Err(std::fs::TryLockError::Error(source)) => Err(ResumeError::Decode(format!(
+            Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(ResumeError::Locked(self.state.job_id.clone()))
+            }
+            Err(source) => Err(ResumeError::Decode(format!(
                 "could not lock {}: {source}",
                 path.display()
             ))),
         }
+    }
+
+    fn reload_state(&mut self, job_id: &str) -> Result<(), ResumeError> {
+        self.state = read_run_state(&self.state_path, job_id)?;
+        Ok(())
     }
 
     fn write_json(&self, name: &str, value: &impl Serialize, artifact: &'static str) -> Result<(), RunStateError> {
@@ -723,6 +705,38 @@ fn parent_for_sync(path: &Path) -> &Path {
     path.parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or(Path::new("."))
+}
+
+fn acquire_resume_lock_file(directory: &Path) -> Result<std::fs::File, std::io::Error> {
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(false).write(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let file = options.open(directory.join(RESUME_LOCK_FILE))?;
+    match file.try_lock() {
+        Ok(()) => Ok(file),
+        Err(std::fs::TryLockError::WouldBlock) => Err(std::io::Error::from(std::io::ErrorKind::WouldBlock)),
+        Err(std::fs::TryLockError::Error(source)) => Err(source),
+    }
+}
+
+fn read_run_state(state_path: &Path, job_id: &str) -> Result<RunState, ResumeError> {
+    let bytes = std::fs::read(state_path).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            ResumeError::NotFound(job_id.to_string())
+        } else {
+            ResumeError::Decode(format!("could not read {}: {source}", state_path.display()))
+        }
+    })?;
+    let state: RunState = serde_json::from_slice(&bytes)
+        .map_err(|source| ResumeError::Decode(format!("could not decode {}: {source}", state_path.display())))?;
+    if state.job_id != job_id {
+        return Err(ResumeError::Decode(format!(
+            "durable job `{job_id}` does not match state id `{}`",
+            state.job_id
+        )));
+    }
+    Ok(state)
 }
 
 fn publish_job_directory(staging: tempfile::TempDir, destination: &Path) -> Result<(), RunStateError> {
@@ -1040,6 +1054,26 @@ mod tests {
         contender.acquire_resume_lock().expect("lock released on drop");
     }
 
+    #[test]
+    fn resume_lock_refreshes_a_snapshot_read_before_the_prior_owner_finished() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut owner = DurableRun::prepare_in(root.path(), &two_step_plan(), Some(30), None).expect("prepare");
+        owner
+            .stop(ExecutionStopReason::DeadlineExceeded)
+            .expect("persist terminal state");
+        let job_id = owner.job_id().to_string();
+        let mut stale = DurableRun::open_in(root.path(), &job_id).expect("open stale snapshot");
+        assert_eq!(stale.state.status, RunStatus::TimedOut);
+
+        owner.state.status = RunStatus::Succeeded;
+        owner.persist_state().expect("persist newer terminal state");
+        drop(owner);
+
+        stale.acquire_resume_lock().expect("acquire released lock");
+        stale.reload_state(&job_id).expect("reload protected state");
+        assert_eq!(stale.state.status, RunStatus::Succeeded);
+    }
+
     fn two_step_plan() -> Plan {
         Plan {
             version: 1,
@@ -1124,6 +1158,23 @@ mod tests {
             std::fs::read(staging_path.join("sentinel")).expect("read sentinel"),
             b"keep me"
         );
+    }
+
+    #[test]
+    fn staging_lock_remains_held_across_atomic_publication() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let staging = tempfile::Builder::new()
+            .prefix(".preparing-")
+            .tempdir_in(root.path())
+            .expect("stage job");
+        let held = acquire_resume_lock_file(staging.path()).expect("lock staged job");
+        let destination = root.path().join("job-published");
+
+        publish_job_directory(staging, &destination).expect("publish locked job");
+
+        let error = acquire_resume_lock_file(&destination).expect_err("published lock remains held");
+        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+        drop(held);
     }
 
     #[cfg(unix)]

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -19,7 +19,7 @@ use crate::checkpoint::{
 };
 use crate::{
     ExecutionReport, Plan, PlanStep, StepReport,
-    execution_control::{ExecutionControl, ExecutionStopReason},
+    execution_control::{BlockingIoMode, ExecutionControl, ExecutionStopReason},
 };
 
 const STATE_VERSION: u32 = 3;
@@ -484,9 +484,15 @@ impl DurableRun {
         let state_path = self.state_path.clone();
         let directory = self.directory.clone();
         match control
-            .wait_owned_blocking("horizon-browser-checkpoint", honor_deadline, move || {
-                write_private_json(&state_path, &state, "state").and_then(|()| sync_directory(&directory))
-            })
+            .wait_owned_blocking(
+                "horizon-browser-checkpoint",
+                if honor_deadline {
+                    BlockingIoMode::Bound
+                } else {
+                    BlockingIoMode::Required
+                },
+                move || write_private_json(&state_path, &state, "state").and_then(|()| sync_directory(&directory)),
+            )
             .await
         {
             Ok(Ok(())) => Ok(()),

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -1,5 +1,7 @@
 //! Durable metadata for deterministic browser plan runs.
 
+mod checkpoint_artifacts;
+
 use std::fs::OpenOptions;
 use std::io::Write as _;
 #[cfg(unix)]
@@ -7,7 +9,7 @@ use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use atomicwrites::{AllowOverwrite, AtomicFile};
+use atomicwrites::{AllowOverwrite, AtomicFile, DisallowOverwrite, OverwriteBehavior};
 use horizon_core::HorizonHome;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -21,9 +23,10 @@ use crate::{
     ExecutionReport, Plan, PlanStep, StepReport,
     execution_control::{BlockingIoError, BlockingIoMode, ExecutionControl, ExecutionStopReason},
 };
+use checkpoint_artifacts::PendingCompletion;
 
-const STATE_VERSION: u32 = 3;
-const MIN_RESUME_VERSION: u32 = 3;
+const STATE_VERSION: u32 = 4;
+const MIN_RESUME_VERSION: u32 = 4;
 const PLAN_FILE: &str = "plan.json";
 const REPORT_FILE: &str = "report.json";
 const STATE_FILE: &str = "state.json";
@@ -64,6 +67,12 @@ pub struct RunState {
     /// Private initialization, plan-execution, or MCP shutdown error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StateHeader {
+    version: u32,
+    job_id: String,
 }
 
 /// Durable plan-run lifecycle state.
@@ -123,6 +132,8 @@ pub struct DurableRun {
     state_path: PathBuf,
     lock_path: PathBuf,
     state: RunState,
+    completed_reports: Vec<StepReport>,
+    pending_completion: Option<PendingCompletion>,
     lock_file: Option<std::fs::File>,
 }
 
@@ -262,6 +273,8 @@ impl DurableRun {
                 state_path: self.state_path.clone(),
                 lock_path: self.lock_path.clone(),
                 state: self.state.clone(),
+                completed_reports: Vec::new(),
+                pending_completion: self.pending_completion.clone(),
                 lock_file: None,
             },
         }
@@ -297,6 +310,8 @@ impl DurableRun {
             .map_err(|source| io_error(format!("could not stage {job_id}"), source))
             .map_err(DurablePreparationError::unpublished)?;
         secure_directory(staging.path()).map_err(DurablePreparationError::unpublished)?;
+        ensure_private_directory(&staging.path().join(checkpoint_artifacts::DIRECTORY))
+            .map_err(DurablePreparationError::unpublished)?;
         let created_at_millis = now_millis();
         let state = RunState {
             version: STATE_VERSION,
@@ -328,6 +343,8 @@ impl DurableRun {
             directory,
             lock_path,
             state,
+            completed_reports: Vec::new(),
+            pending_completion: None,
             lock_file: Some(lock_file),
         };
         if let Err(source) = sync_directory(root) {
@@ -423,6 +440,8 @@ impl DurableRun {
             state_path,
             lock_path: resume_lock_path(lock_root, job_id),
             state,
+            completed_reports: Vec::new(),
+            pending_completion: None,
             lock_file: None,
         })
     }
@@ -443,7 +462,8 @@ impl DurableRun {
             RunStatus::Succeeded => return Err(ResumeError::AlreadySucceeded(job_id.to_string())),
             RunStatus::Failed | RunStatus::Cancelled | RunStatus::TimedOut => {}
         }
-        let selection = select_resume(&plan, Some(&run.state.checkpoint), policy)?;
+        run.load_completed_reports()?;
+        let selection = select_resume(&plan, Some(&run.state.checkpoint), &run.completed_reports, policy)?;
         if selection.start_index >= plan.steps.len() && selection.skipped.is_none() {
             return Err(ResumeError::NothingToResume(job_id.to_string()));
         }
@@ -499,20 +519,28 @@ impl DurableRun {
         }
     }
 
-    fn persist_state(&self) -> Result<(), RunStateError> {
-        write_private_json(&self.state_path, &self.state, "state")?;
-        sync_directory(&self.directory)
+    fn persist_state(&mut self) -> Result<(), RunStateError> {
+        let result = checkpoint_artifacts::persist_snapshot(
+            &self.directory,
+            &self.state_path,
+            &self.state,
+            self.pending_completion.as_ref(),
+        );
+        if result.is_ok() {
+            self.pending_completion = None;
+        }
+        result
     }
 
     async fn persist_checkpoint_controlled(
         &mut self,
         control: &mut ExecutionControl,
         honor_deadline: bool,
-        previous: RunCheckpoint,
     ) -> Result<(), CheckpointPersistError> {
         self.state.updated_at_millis = now_millis();
         self.state.completed_steps = self.state.checkpoint.completed.len();
         let state = self.state.clone();
+        let pending = self.pending_completion.clone();
         let state_path = self.state_path.clone();
         let directory = self.directory.clone();
         match control
@@ -523,29 +551,36 @@ impl DurableRun {
                 } else {
                     BlockingIoMode::Required
                 },
-                move || write_private_json(&state_path, &state, "state").and_then(|()| sync_directory(&directory)),
+                move || checkpoint_artifacts::persist_snapshot(&directory, &state_path, &state, pending.as_ref()),
             )
             .await
         {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(error)) => {
-                self.restore_checkpoint(previous);
-                Err(CheckpointPersistError::Io(error.to_string()))
+            Ok(Ok(())) => {
+                self.pending_completion = None;
+                Ok(())
             }
-            Err(BlockingIoError::Failed(error)) => {
-                self.restore_checkpoint(previous);
-                Err(CheckpointPersistError::Io(error))
-            }
-            Err(BlockingIoError::Stopped(reason)) => {
-                self.restore_checkpoint(previous);
-                Err(CheckpointPersistError::Stopped(reason))
-            }
+            Ok(Err(error)) => Err(CheckpointPersistError::Io(error.to_string())),
+            Err(BlockingIoError::Failed(error)) => Err(CheckpointPersistError::Io(error)),
+            Err(BlockingIoError::Stopped(reason)) => Err(CheckpointPersistError::Stopped(reason)),
         }
     }
 
-    fn restore_checkpoint(&mut self, previous: RunCheckpoint) {
-        self.state.checkpoint = previous;
-        self.state.completed_steps = self.state.checkpoint.completed.len();
+    fn stage_completion(&mut self, report: &StepReport) -> Result<(), String> {
+        if self.pending_completion.is_some() {
+            return Err("a previous step completion still needs durable persistence".to_string());
+        }
+        let index = self.state.checkpoint.completed.len();
+        self.state.checkpoint.intent = None;
+        self.state
+            .checkpoint
+            .completed
+            .push(checkpoint_artifacts::metadata(index, report));
+        self.completed_reports.push(report.clone());
+        self.pending_completion = Some(PendingCompletion {
+            index,
+            report: report.clone(),
+        });
+        Ok(())
     }
 
     /// Record intent on an owned I/O worker before the MCP future is polled.
@@ -557,13 +592,17 @@ impl DurableRun {
         step: &PlanStep,
         control: &mut ExecutionControl,
     ) -> Result<(), CheckpointPersistError> {
-        let previous = self.state.checkpoint.clone();
+        let previous = self.state.checkpoint.intent.clone();
         self.state.checkpoint.intent = Some(CheckpointIntent {
             step_id: step.id.clone(),
             tool: step.tool.clone(),
             status: IntentStatus::Dispatched,
         });
-        self.persist_checkpoint_controlled(control, true, previous).await
+        let result = self.persist_checkpoint_controlled(control, true).await;
+        if result.is_err() {
+            self.state.checkpoint.intent = previous;
+        }
+        result
     }
 
     /// Record a verified completion on an owned I/O worker.
@@ -578,10 +617,8 @@ impl DurableRun {
         report: &StepReport,
         control: &mut ExecutionControl,
     ) -> Result<(), CheckpointPersistError> {
-        let previous = self.state.checkpoint.clone();
-        self.state.checkpoint.intent = None;
-        self.state.checkpoint.completed.push(report.clone());
-        self.persist_checkpoint_controlled(control, false, previous).await
+        self.stage_completion(report).map_err(CheckpointPersistError::Io)?;
+        self.persist_checkpoint_controlled(control, false).await
     }
 
     /// Mark an in-flight step uncertain without requiring a live deadline.
@@ -593,13 +630,12 @@ impl DurableRun {
         step: &PlanStep,
         control: &mut ExecutionControl,
     ) -> Result<(), CheckpointPersistError> {
-        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = Some(CheckpointIntent {
             step_id: step.id.clone(),
             tool: step.tool.clone(),
             status: IntentStatus::Uncertain,
         });
-        self.persist_checkpoint_controlled(control, false, previous).await
+        self.persist_checkpoint_controlled(control, false).await
     }
 
     /// Drop a not-yet-polled intent without requiring a live deadline.
@@ -610,26 +646,14 @@ impl DurableRun {
         &mut self,
         control: &mut ExecutionControl,
     ) -> Result<(), CheckpointPersistError> {
-        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = None;
-        self.persist_checkpoint_controlled(control, false, previous).await
+        self.persist_checkpoint_controlled(control, false).await
     }
 
     fn persist_checkpoint(&mut self) -> Result<(), String> {
         self.state.updated_at_millis = now_millis();
         self.state.completed_steps = self.state.checkpoint.completed.len();
         self.persist_state().map_err(|error| error.to_string())
-    }
-
-    fn persist_checkpoint_or_restore(&mut self, previous: RunCheckpoint) -> Result<(), String> {
-        match self.persist_checkpoint() {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                self.state.checkpoint = previous;
-                self.state.completed_steps = self.state.checkpoint.completed.len();
-                Err(error)
-            }
-        }
     }
 
     fn acquire_resume_lock(&mut self) -> Result<(), ResumeError> {
@@ -650,6 +674,13 @@ impl DurableRun {
 
     fn reload_state(&mut self, job_id: &str) -> Result<(), ResumeError> {
         self.state = read_run_state(&self.state_path, job_id)?;
+        self.completed_reports.clear();
+        self.pending_completion = None;
+        Ok(())
+    }
+
+    fn load_completed_reports(&mut self) -> Result<(), ResumeError> {
+        self.completed_reports = checkpoint_artifacts::load(&self.directory, &self.state.checkpoint.completed)?;
         Ok(())
     }
 
@@ -660,36 +691,36 @@ impl DurableRun {
 
 impl CheckpointStore for DurableRun {
     fn record_intent(&mut self, step: &PlanStep) -> Result<(), String> {
-        let previous = self.state.checkpoint.clone();
+        let previous = self.state.checkpoint.intent.clone();
         self.state.checkpoint.intent = Some(CheckpointIntent {
             step_id: step.id.clone(),
             tool: step.tool.clone(),
             status: IntentStatus::Dispatched,
         });
-        self.persist_checkpoint_or_restore(previous)
+        let result = self.persist_checkpoint();
+        if result.is_err() {
+            self.state.checkpoint.intent = previous;
+        }
+        result
     }
 
     fn record_completion(&mut self, report: &StepReport) -> Result<(), String> {
-        let previous = self.state.checkpoint.clone();
-        self.state.checkpoint.intent = None;
-        self.state.checkpoint.completed.push(report.clone());
-        self.persist_checkpoint_or_restore(previous)
+        self.stage_completion(report)?;
+        self.persist_checkpoint()
     }
 
     fn record_uncertain(&mut self, step: &PlanStep) -> Result<(), String> {
-        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = Some(CheckpointIntent {
             step_id: step.id.clone(),
             tool: step.tool.clone(),
             status: IntentStatus::Uncertain,
         });
-        self.persist_checkpoint_or_restore(previous)
+        self.persist_checkpoint()
     }
 
     fn clear_intent(&mut self) -> Result<(), String> {
-        let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = None;
-        self.persist_checkpoint_or_restore(previous)
+        self.persist_checkpoint()
     }
 }
 
@@ -784,24 +815,31 @@ fn read_run_state(state_path: &Path, job_id: &str) -> Result<RunState, ResumeErr
             ResumeError::Decode(format!("could not read {}: {source}", state_path.display()))
         }
     })?;
-    let state: RunState = serde_json::from_slice(&bytes)
+    let header: StateHeader = serde_json::from_slice(&bytes)
         .map_err(|source| ResumeError::Decode(format!("could not decode {}: {source}", state_path.display())))?;
-    if state.job_id != job_id {
+    if header.job_id != job_id {
         return Err(ResumeError::Decode(format!(
             "durable job `{job_id}` does not match state id `{}`",
-            state.job_id
+            header.job_id
         )));
     }
+    validate_resume_version_fields(&header.job_id, header.version)?;
+    let state: RunState = serde_json::from_slice(&bytes)
+        .map_err(|source| ResumeError::Decode(format!("could not decode {}: {source}", state_path.display())))?;
     Ok(state)
 }
 
 fn validate_resume_version(state: &RunState) -> Result<(), ResumeError> {
-    if state.version < MIN_RESUME_VERSION {
-        Err(ResumeError::LegacyState(state.job_id.clone()))
-    } else if state.version > STATE_VERSION {
+    validate_resume_version_fields(&state.job_id, state.version)
+}
+
+fn validate_resume_version_fields(job_id: &str, version: u32) -> Result<(), ResumeError> {
+    if version < MIN_RESUME_VERSION {
+        Err(ResumeError::LegacyState(job_id.to_string()))
+    } else if version > STATE_VERSION {
         Err(ResumeError::UnsupportedStateVersion {
-            job_id: state.job_id.clone(),
-            version: state.version,
+            job_id: job_id.to_string(),
+            version,
             supported: STATE_VERSION,
         })
     } else {
@@ -851,13 +889,26 @@ fn secure_directory(path: &Path) -> Result<(), RunStateError> {
 }
 
 fn write_private_json(path: &Path, value: &impl Serialize, artifact: &'static str) -> Result<(), RunStateError> {
+    write_private_json_with(path, value, artifact, AllowOverwrite)
+}
+
+fn write_private_json_once(path: &Path, value: &impl Serialize, artifact: &'static str) -> Result<(), RunStateError> {
+    write_private_json_with(path, value, artifact, DisallowOverwrite)
+}
+
+fn write_private_json_with(
+    path: &Path,
+    value: &impl Serialize,
+    artifact: &'static str,
+    overwrite: OverwriteBehavior,
+) -> Result<(), RunStateError> {
     let mut bytes = serde_json::to_vec_pretty(value).map_err(|source| RunStateError::Encode { artifact, source })?;
     bytes.push(b'\n');
     let mut options = OpenOptions::new();
     options.create(true).truncate(true).write(true);
     #[cfg(unix)]
     options.mode(0o600);
-    AtomicFile::new(path, AllowOverwrite)
+    AtomicFile::new(path, overwrite)
         .write_with_options(|file| file.write_all(&bytes).and_then(|()| file.sync_all()), options)
         .map_err(std::io::Error::from)
         .map_err(|source| io_error(format!("could not write {}", path.display()), source))?;
@@ -1052,16 +1103,45 @@ mod tests {
     }
 
     #[test]
+    fn legacy_embedded_results_are_rejected_as_a_schema_version() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let job_id = "job-4e212c23-d0dd-4ae2-bf69-9ec08fdad2b4";
+        let state_path = root.path().join(STATE_FILE);
+        std::fs::write(
+            &state_path,
+            serde_json::to_vec(&json!({
+                "version": STATE_VERSION - 1,
+                "job_id": job_id,
+                "checkpoint": {
+                    "completed": [{
+                        "id": "panels",
+                        "tool": "browser_list",
+                        "ok": true,
+                        "result": {"panels": []}
+                    }]
+                }
+            }))
+            .expect("encode legacy state"),
+        )
+        .expect("write legacy state");
+
+        let error = read_run_state(&state_path, job_id).expect_err("legacy state");
+
+        assert_eq!(error, ResumeError::LegacyState(job_id.to_string()));
+    }
+
+    #[test]
     fn rearm_clears_previous_attempt_metadata() {
         let root = tempfile::tempdir().expect("temporary job root");
         let mut run = DurableRun::prepare_in(root.path(), &plan(), Some(30), None).expect("prepare");
-        run.state.checkpoint.completed.push(StepReport {
+        run.record_completion(&StepReport {
             id: "panels".to_string(),
             tool: "browser_list".to_string(),
             ok: true,
             result: Some(json!({"panels": []})),
             error: None,
-        });
+        })
+        .expect("persist completion");
         run.state.report_file = Some(REPORT_FILE.to_string());
         run.state.completed_steps = 9;
         run.state.error = Some("previous failure".to_string());
@@ -1181,8 +1261,13 @@ mod tests {
 
         let opened = DurableRun::open_in(root.path(), run.job_id()).expect("open");
         assert_eq!(opened.state().checkpoint.completed.len(), 1);
-        let selection = select_resume(&two_step_plan(), Some(&timed_out.checkpoint), UncertainPolicy::Skip)
-            .expect("skip remaining");
+        let selection = select_resume(
+            &two_step_plan(),
+            Some(&timed_out.checkpoint),
+            &[report],
+            UncertainPolicy::Skip,
+        )
+        .expect("skip remaining");
         assert_eq!(selection.start_index, 2);
     }
 
@@ -1196,6 +1281,169 @@ mod tests {
             .expect_err("persist must fail");
         assert!(run.state().checkpoint.intent.is_none());
         std::fs::remove_dir(&run.state_path).expect("unblock state path");
+    }
+
+    #[tokio::test]
+    async fn failed_clear_keeps_intent_cleared_for_terminal_retry() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let plan = two_step_plan();
+        let mut run = DurableRun::prepare_in(root.path(), &plan, Some(30), None).expect("prepare");
+        run.record_intent(&plan.steps[0]).expect("intent");
+        std::fs::remove_file(&run.state_path).expect("remove state file");
+        std::fs::create_dir(&run.state_path).expect("block state path with a directory");
+
+        let error = run
+            .clear_intent_controlled(&mut ExecutionControl::unbounded())
+            .await
+            .expect_err("persist must fail");
+
+        assert!(matches!(error, CheckpointPersistError::Io(_)));
+        assert!(run.state().checkpoint.intent.is_none());
+        std::fs::remove_dir(&run.state_path).expect("unblock state path");
+        run.stop(ExecutionStopReason::DeadlineExceeded)
+            .expect("terminal persistence retries cleared intent");
+        let state: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&run.state_path).expect("terminal state")).expect("decode state");
+        assert!(state["checkpoint"].get("intent").is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_completion_artifact_is_retried_by_terminal_persistence() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let plan = two_step_plan();
+        let mut run = DurableRun::prepare_in(root.path(), &plan, Some(30), None).expect("prepare");
+        let step = &plan.steps[0];
+        let report = StepReport {
+            id: step.id.clone(),
+            tool: step.tool.clone(),
+            ok: true,
+            result: Some(json!({"panels": ["verified"]})),
+            error: None,
+        };
+        run.record_intent(step).expect("intent");
+        let checkpoint_directory = run.directory.join(checkpoint_artifacts::DIRECTORY);
+        std::fs::remove_dir(&checkpoint_directory).expect("remove empty checkpoint directory");
+        std::fs::write(&checkpoint_directory, b"block checkpoint artifacts").expect("block checkpoint directory");
+
+        let error = run
+            .record_completion_controlled(&report, &mut ExecutionControl::unbounded())
+            .await
+            .expect_err("artifact persistence must fail");
+
+        assert!(matches!(error, CheckpointPersistError::Io(_)));
+        assert!(run.state().checkpoint.intent.is_none());
+        assert_eq!(run.state().checkpoint.completed.len(), 1);
+        assert!(run.pending_completion.is_some());
+        std::fs::remove_file(&checkpoint_directory).expect("unblock checkpoint directory");
+        ensure_private_directory(&checkpoint_directory).expect("restore checkpoint directory");
+        run.stop(ExecutionStopReason::DeadlineExceeded)
+            .expect("terminal persistence retries completion");
+        run.load_completed_reports().expect("reload completion artifact");
+        assert_eq!(run.completed_reports, vec![report]);
+    }
+
+    #[tokio::test]
+    async fn orphaned_uncertain_result_does_not_block_a_later_skipped_step() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let plan = two_step_plan();
+        let mut run = DurableRun::prepare_in(root.path(), &plan, Some(30), None).expect("prepare");
+        let first = StepReport {
+            id: plan.steps[0].id.clone(),
+            tool: plan.steps[0].tool.clone(),
+            ok: true,
+            result: Some(json!({"attempt": "orphaned"})),
+            error: None,
+        };
+        run.record_intent(&plan.steps[0]).expect("first intent");
+        let state_path = run.state_path.clone();
+        run.state_path = run.directory.join("missing/state.json");
+        run.record_completion_controlled(&first, &mut ExecutionControl::unbounded())
+            .await
+            .expect_err("state persistence must fail after the artifact write");
+        let orphan = run.directory.join(&run.state.checkpoint.completed[0].report_file);
+        assert!(orphan.is_file());
+
+        run.state_path = state_path;
+        let job_id = run.job_id().to_string();
+        run.reload_state(&job_id).expect("reload state before failed write");
+        assert!(run.state.checkpoint.completed.is_empty());
+        run.state.checkpoint.skipped.push(plan.steps[0].id.clone());
+        run.state.checkpoint.intent = None;
+        let second = StepReport {
+            id: plan.steps[1].id.clone(),
+            tool: plan.steps[1].tool.clone(),
+            ok: true,
+            result: Some(json!({"attempt": "verified"})),
+            error: None,
+        };
+        run.record_intent(&plan.steps[1]).expect("second intent");
+        run.record_completion(&second).expect("later completion");
+
+        let verified = run.directory.join(&run.state.checkpoint.completed[0].report_file);
+        assert_ne!(orphan, verified);
+        assert!(orphan.is_file());
+        assert!(verified.is_file());
+        run.load_completed_reports().expect("load later result");
+        assert_eq!(run.completed_reports, vec![second]);
+    }
+
+    #[test]
+    fn large_checkpoint_results_live_in_linear_per_step_artifacts() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let plan = two_step_plan();
+        let mut run = DurableRun::prepare_in(root.path(), &plan, Some(30), None).expect("prepare");
+        let payload = "x".repeat(256 * 1024);
+        let reports = plan
+            .steps
+            .iter()
+            .map(|step| StepReport {
+                id: step.id.clone(),
+                tool: step.tool.clone(),
+                ok: true,
+                result: Some(json!({"payload": payload})),
+                error: None,
+            })
+            .collect::<Vec<_>>();
+        for (step, report) in plan.steps.iter().zip(&reports) {
+            run.record_intent(step).expect("intent");
+            run.record_completion(report).expect("completion");
+        }
+
+        let state_bytes = std::fs::read(&run.state_path).expect("compact state");
+        assert!(
+            state_bytes.len() < 4 * 1024,
+            "state grew to {} bytes",
+            state_bytes.len()
+        );
+        let state: serde_json::Value = serde_json::from_slice(&state_bytes).expect("decode compact state");
+        let completed = state["checkpoint"]["completed"]
+            .as_array()
+            .expect("completion metadata");
+        assert_eq!(completed.len(), reports.len());
+        assert!(completed.iter().all(|entry| entry.get("result").is_none()));
+        let artifact_sizes = completed
+            .iter()
+            .map(|entry| {
+                let path = run.directory.join(entry["report_file"].as_str().expect("result path"));
+                std::fs::metadata(path).expect("result artifact").len()
+            })
+            .collect::<Vec<_>>();
+        assert!(artifact_sizes.iter().all(|size| *size > 256 * 1024));
+
+        run.stop(ExecutionStopReason::DeadlineExceeded).expect("terminal state");
+        let job_id = run.job_id().to_string();
+        drop(run);
+        let mut opened = DurableRun::open_in(root.path(), &job_id).expect("open compact state");
+        opened.load_completed_reports().expect("load per-step results");
+        let selection = select_resume(
+            &plan,
+            Some(&opened.state.checkpoint),
+            &opened.completed_reports,
+            UncertainPolicy::Fail,
+        )
+        .expect("select verified prefix");
+        assert_eq!(selection.completed, reports);
+        assert_eq!(selection.start_index, plan.steps.len());
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -27,7 +27,7 @@ const MIN_RESUME_VERSION: u32 = 3;
 const PLAN_FILE: &str = "plan.json";
 const REPORT_FILE: &str = "report.json";
 const STATE_FILE: &str = "state.json";
-const RESUME_LOCK_FILE: &str = "resume.lock";
+const RESUME_LOCK_DIRECTORY: &str = "browser-job-locks";
 
 /// Persisted lifecycle state for one deterministic plan run.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -121,6 +121,7 @@ pub struct DurableExecutionReport<'a> {
 pub struct DurableRun {
     directory: PathBuf,
     state_path: PathBuf,
+    lock_path: PathBuf,
     state: RunState,
     lock_file: Option<std::fs::File>,
 }
@@ -228,8 +229,16 @@ impl DurableRun {
         execution_timeout_seconds: u64,
         deadline_at_millis: u64,
     ) -> Result<Self, DurablePreparationError> {
-        let root = HorizonHome::resolve().root().join("browser-jobs");
-        Self::prepare_cancellable_in(&root, plan, Some(execution_timeout_seconds), Some(deadline_at_millis))
+        let horizon_root = HorizonHome::resolve().root().to_path_buf();
+        let job_root = horizon_root.join("browser-jobs");
+        let lock_root = horizon_root.join(RESUME_LOCK_DIRECTORY);
+        Self::prepare_cancellable_in(
+            &job_root,
+            &lock_root,
+            plan,
+            Some(execution_timeout_seconds),
+            Some(deadline_at_millis),
+        )
     }
 
     /// Stable id of this durable run.
@@ -251,6 +260,7 @@ impl DurableRun {
             run: Self {
                 directory: self.directory.clone(),
                 state_path: self.state_path.clone(),
+                lock_path: self.lock_path.clone(),
                 state: self.state.clone(),
                 lock_file: None,
             },
@@ -264,19 +274,23 @@ impl DurableRun {
         execution_timeout_seconds: Option<u64>,
         deadline_at_millis: Option<u64>,
     ) -> Result<Self, RunStateError> {
-        Self::prepare_cancellable_in(root, plan, execution_timeout_seconds, deadline_at_millis)
+        let lock_root = root.join(".locks");
+        Self::prepare_cancellable_in(root, &lock_root, plan, execution_timeout_seconds, deadline_at_millis)
             .map_err(|error| error.into_parts().1)
     }
 
     fn prepare_cancellable_in(
         root: &Path,
+        lock_root: &Path,
         plan: &Plan,
         execution_timeout_seconds: Option<u64>,
         deadline_at_millis: Option<u64>,
     ) -> Result<Self, DurablePreparationError> {
         ensure_private_directory(root).map_err(DurablePreparationError::unpublished)?;
+        ensure_private_directory(lock_root).map_err(DurablePreparationError::unpublished)?;
         let job_id = format!("job-{}", Uuid::new_v4());
         let directory = root.join(&job_id);
+        let lock_path = resume_lock_path(lock_root, &job_id);
         let staging = tempfile::Builder::new()
             .prefix(".preparing-")
             .tempdir_in(root)
@@ -303,14 +317,16 @@ impl DurableRun {
             .map_err(DurablePreparationError::unpublished)?;
         write_private_json(&staging.path().join(STATE_FILE), &state, "state")
             .map_err(DurablePreparationError::unpublished)?;
-        let lock_file = acquire_resume_lock_file(staging.path())
+        let lock_file = acquire_resume_lock_file(&lock_path)
             .map_err(|source| io_error(format!("could not lock staged durable job {}", state.job_id), source))
             .map_err(DurablePreparationError::unpublished)?;
+        sync_directory(lock_root).map_err(DurablePreparationError::unpublished)?;
         sync_directory(staging.path()).map_err(DurablePreparationError::unpublished)?;
         publish_job_directory(staging, &directory).map_err(DurablePreparationError::unpublished)?;
         let run = Self {
             state_path: directory.join(STATE_FILE),
             directory,
+            lock_path,
             state,
             lock_file: Some(lock_file),
         };
@@ -381,20 +397,31 @@ impl DurableRun {
     /// # Errors
     /// Returns when the id is invalid, the job is missing, or state cannot be read.
     pub fn open(job_id: &str) -> Result<Self, ResumeError> {
-        let root = HorizonHome::resolve().root().join("browser-jobs");
-        Self::open_in(&root, job_id)
+        let horizon_root = HorizonHome::resolve().root().to_path_buf();
+        let job_root = horizon_root.join("browser-jobs");
+        let lock_root = horizon_root.join(RESUME_LOCK_DIRECTORY);
+        Self::open_in_with_lock_root(&job_root, &lock_root, job_id)
     }
 
-    pub(crate) fn open_in(root: &Path, job_id: &str) -> Result<Self, ResumeError> {
+    #[cfg(test)]
+    fn open_in(root: &Path, job_id: &str) -> Result<Self, ResumeError> {
+        let lock_root = root.join(".locks");
+        Self::open_in_with_lock_root(root, &lock_root, job_id)
+    }
+
+    fn open_in_with_lock_root(root: &Path, lock_root: &Path, job_id: &str) -> Result<Self, ResumeError> {
         if !valid_job_id(job_id) {
             return Err(ResumeError::InvalidJobId(job_id.to_string()));
         }
+        ensure_private_directory(lock_root)
+            .map_err(|error| ResumeError::Decode(format!("could not prepare resume locks: {error}")))?;
         let directory = root.join(job_id);
         let state_path = directory.join(STATE_FILE);
         let state = read_run_state(&state_path, job_id)?;
         Ok(Self {
             directory,
             state_path,
+            lock_path: resume_lock_path(lock_root, job_id),
             state,
             lock_file: None,
         })
@@ -606,8 +633,7 @@ impl DurableRun {
     }
 
     fn acquire_resume_lock(&mut self) -> Result<(), ResumeError> {
-        let path = self.directory.join(RESUME_LOCK_FILE);
-        match acquire_resume_lock_file(&self.directory) {
+        match acquire_resume_lock_file(&self.lock_path) {
             Ok(file) => {
                 self.lock_file = Some(file);
                 Ok(())
@@ -617,7 +643,7 @@ impl DurableRun {
             }
             Err(source) => Err(ResumeError::Decode(format!(
                 "could not lock {}: {source}",
-                path.display()
+                self.lock_path.display()
             ))),
         }
     }
@@ -731,12 +757,18 @@ fn parent_for_sync(path: &Path) -> &Path {
         .unwrap_or(Path::new("."))
 }
 
-fn acquire_resume_lock_file(directory: &Path) -> Result<std::fs::File, std::io::Error> {
+// Keep the live lease outside the staged job tree: Windows cannot rename a
+// directory while a locked descendant handle is open.
+fn resume_lock_path(lock_root: &Path, job_id: &str) -> PathBuf {
+    lock_root.join(format!("{job_id}.lock"))
+}
+
+fn acquire_resume_lock_file(path: &Path) -> Result<std::fs::File, std::io::Error> {
     let mut options = OpenOptions::new();
     options.create(true).truncate(false).write(true);
     #[cfg(unix)]
     options.mode(0o600);
-    let file = options.open(directory.join(RESUME_LOCK_FILE))?;
+    let file = options.open(path)?;
     match file.try_lock() {
         Ok(()) => Ok(file),
         Err(std::fs::TryLockError::WouldBlock) => Err(std::io::Error::from(std::io::ErrorKind::WouldBlock)),
@@ -904,6 +936,11 @@ mod tests {
         );
         let published = std::fs::read_dir(&root)
             .expect("list job root")
+            .filter(|entry| {
+                entry
+                    .as_ref()
+                    .is_ok_and(|entry| entry.file_name().to_string_lossy().starts_with("job-"))
+            })
             .collect::<Result<Vec<_>, _>>()
             .expect("read job entries");
         assert_eq!(published.len(), 1);
@@ -1292,18 +1329,21 @@ mod tests {
     }
 
     #[test]
-    fn staging_lock_remains_held_across_atomic_publication() {
+    fn external_lock_remains_held_across_atomic_publication() {
         let root = tempfile::tempdir().expect("temporary root");
+        let lock_root = root.path().join(".locks");
+        ensure_private_directory(&lock_root).expect("create lock root");
         let staging = tempfile::Builder::new()
             .prefix(".preparing-")
             .tempdir_in(root.path())
             .expect("stage job");
-        let held = acquire_resume_lock_file(staging.path()).expect("lock staged job");
         let destination = root.path().join("job-published");
+        let lock_path = resume_lock_path(&lock_root, "job-published");
+        let held = acquire_resume_lock_file(&lock_path).expect("lock staged job");
 
         publish_job_directory(staging, &destination).expect("publish locked job");
 
-        let error = acquire_resume_lock_file(&destination).expect_err("published lock remains held");
+        let error = acquire_resume_lock_file(&lock_path).expect_err("published lock remains held");
         assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
         drop(held);
     }

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -809,6 +809,8 @@ fn now_millis() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use serde_json::json;
 
     use super::*;
@@ -1051,7 +1053,7 @@ mod tests {
         let error = contender.acquire_resume_lock().expect_err("owner holds lock");
         assert!(matches!(error, ResumeError::Locked(_)));
         drop(run);
-        contender.acquire_resume_lock().expect("lock released on drop");
+        acquire_lock_after_owner_exit(&mut contender);
     }
 
     #[test]
@@ -1069,9 +1071,22 @@ mod tests {
         owner.persist_state().expect("persist newer terminal state");
         drop(owner);
 
-        stale.acquire_resume_lock().expect("acquire released lock");
+        acquire_lock_after_owner_exit(&mut stale);
         stale.reload_state(&job_id).expect("reload protected state");
         assert_eq!(stale.state.status, RunStatus::Succeeded);
+    }
+
+    fn acquire_lock_after_owner_exit(run: &mut DurableRun) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match run.acquire_resume_lock() {
+                Ok(()) => return,
+                Err(ResumeError::Locked(_)) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(error) => panic!("acquire released lock: {error}"),
+            }
+        }
     }
 
     fn two_step_plan() -> Plan {

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -13,9 +13,13 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::{ExecutionReport, Plan, execution_control::ExecutionStopReason};
+use crate::checkpoint::{
+    CheckpointIntent, CheckpointStore, IntentStatus, ResumeError, ResumeSelection, RunCheckpoint, UncertainPolicy,
+    select_resume, valid_job_id,
+};
+use crate::{ExecutionReport, Plan, PlanStep, StepReport, execution_control::ExecutionStopReason};
 
-const STATE_VERSION: u32 = 2;
+const STATE_VERSION: u32 = 3;
 const PLAN_FILE: &str = "plan.json";
 const REPORT_FILE: &str = "report.json";
 const STATE_FILE: &str = "state.json";
@@ -49,6 +53,9 @@ pub struct RunState {
     pub report_file: Option<String>,
     /// Number of step reports produced before the run stopped.
     pub completed_steps: usize,
+    /// Verified completions and any in-flight or skipped uncertain step.
+    #[serde(default, skip_serializing_if = "RunCheckpoint::is_empty")]
+    pub checkpoint: RunCheckpoint,
     /// Private initialization, plan-execution, or MCP shutdown error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -256,6 +263,7 @@ impl DurableRun {
             plan_file: PLAN_FILE.to_string(),
             report_file: None,
             completed_steps: 0,
+            checkpoint: RunCheckpoint::default(),
             error: None,
         };
         write_private_json(&staging.path().join(PLAN_FILE), plan, "plan")
@@ -331,12 +339,146 @@ impl DurableRun {
         self.persist_state()
     }
 
+    /// Open a previously published job by id.
+    ///
+    /// # Errors
+    /// Returns when the id is invalid, the job is missing, or state cannot be read.
+    pub fn open(job_id: &str) -> Result<Self, ResumeError> {
+        let root = HorizonHome::resolve().root().join("browser-jobs");
+        Self::open_in(&root, job_id)
+    }
+
+    pub(crate) fn open_in(root: &Path, job_id: &str) -> Result<Self, ResumeError> {
+        if !valid_job_id(job_id) {
+            return Err(ResumeError::InvalidJobId(job_id.to_string()));
+        }
+        let directory = root.join(job_id);
+        let state_path = directory.join(STATE_FILE);
+        let bytes = std::fs::read(&state_path).map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                ResumeError::NotFound(job_id.to_string())
+            } else {
+                ResumeError::Decode(format!("could not read {}: {source}", state_path.display()))
+            }
+        })?;
+        let state: RunState = serde_json::from_slice(&bytes)
+            .map_err(|source| ResumeError::Decode(format!("could not decode {}: {source}", state_path.display())))?;
+        if state.job_id != job_id {
+            return Err(ResumeError::Decode(format!(
+                "durable job `{job_id}` does not match state id `{}`",
+                state.job_id
+            )));
+        }
+        Ok(Self {
+            directory,
+            state_path,
+            state,
+        })
+    }
+
+    /// Load a terminal job and choose remaining work for an explicit resume.
+    ///
+    /// # Errors
+    /// Returns when the job is missing, still leased, already succeeded, or
+    /// would replay an uncertain mutation.
+    pub fn prepare_resume(job_id: &str, policy: UncertainPolicy) -> Result<(Self, Plan, ResumeSelection), ResumeError> {
+        let run = Self::open(job_id)?;
+        let plan = run.load_plan()?;
+        match run.state.effective_status_at(now_millis()) {
+            RunStatus::Prepared | RunStatus::Running => return Err(ResumeError::StillRunning(job_id.to_string())),
+            RunStatus::Succeeded => return Err(ResumeError::AlreadySucceeded(job_id.to_string())),
+            RunStatus::Failed | RunStatus::Cancelled | RunStatus::TimedOut => {}
+        }
+        let selection = select_resume(&plan, Some(&run.state.checkpoint), policy)?;
+        if selection.start_index >= plan.steps.len() {
+            return Err(ResumeError::NothingToResume(job_id.to_string()));
+        }
+        Ok((run, plan, selection))
+    }
+
+    /// Saved plan for this durable run.
+    ///
+    /// # Errors
+    /// Returns when the plan file cannot be read or validated.
+    pub fn load_plan(&self) -> Result<Plan, ResumeError> {
+        let path = self.directory.join(&self.state.plan_file);
+        let bytes = std::fs::read(&path)
+            .map_err(|source| ResumeError::Decode(format!("could not read {}: {source}", path.display())))?;
+        Plan::from_slice(&bytes).map_err(|source| ResumeError::Decode(source.to_string()))
+    }
+
+    /// Current durable snapshot.
+    #[must_use]
+    pub fn state(&self) -> &RunState {
+        &self.state
+    }
+
+    /// Re-arm a terminal job for an explicit resume without creating a new id.
+    ///
+    /// # Errors
+    /// Returns when the updated lease cannot be persisted.
+    pub fn rearm(
+        &mut self,
+        execution_timeout_seconds: u64,
+        deadline_at_millis: u64,
+        skipped: Option<String>,
+    ) -> Result<(), RunStateError> {
+        self.state.status = RunStatus::Prepared;
+        self.state.execution_timeout_seconds = Some(execution_timeout_seconds);
+        self.state.deadline_at_millis = Some(deadline_at_millis);
+        self.state.updated_at_millis = now_millis();
+        self.state.runner_pid = std::process::id();
+        self.state.error = None;
+        if let Some(step_id) = skipped {
+            self.state.checkpoint.skipped.push(step_id);
+            self.state.checkpoint.intent = None;
+        }
+        self.persist_state()
+    }
+
     fn persist_state(&self) -> Result<(), RunStateError> {
         write_private_json(&self.state_path, &self.state, "state")
     }
 
+    fn persist_checkpoint(&mut self) -> Result<(), String> {
+        self.state.updated_at_millis = now_millis();
+        self.state.completed_steps = self.state.checkpoint.completed.len();
+        self.persist_state().map_err(|error| error.to_string())
+    }
+
     fn write_json(&self, name: &str, value: &impl Serialize, artifact: &'static str) -> Result<(), RunStateError> {
         write_private_json(&self.directory.join(name), value, artifact)
+    }
+}
+
+impl CheckpointStore for DurableRun {
+    fn record_intent(&mut self, step: &PlanStep) -> Result<(), String> {
+        self.state.checkpoint.intent = Some(CheckpointIntent {
+            step_id: step.id.clone(),
+            tool: step.tool.clone(),
+            status: IntentStatus::Dispatched,
+        });
+        self.persist_checkpoint()
+    }
+
+    fn record_completion(&mut self, report: &StepReport) -> Result<(), String> {
+        self.state.checkpoint.intent = None;
+        self.state.checkpoint.completed.push(report.clone());
+        self.persist_checkpoint()
+    }
+
+    fn record_uncertain(&mut self, step: &PlanStep) -> Result<(), String> {
+        self.state.checkpoint.intent = Some(CheckpointIntent {
+            step_id: step.id.clone(),
+            tool: step.tool.clone(),
+            status: IntentStatus::Uncertain,
+        });
+        self.persist_checkpoint()
+    }
+
+    fn clear_intent(&mut self) -> Result<(), String> {
+        self.state.checkpoint.intent = None;
+        self.persist_checkpoint()
     }
 }
 
@@ -477,6 +619,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::checkpoint::{CheckpointStore, IntentStatus, UncertainPolicy, select_resume};
     use crate::observability::ObservabilitySummary;
     use crate::{PlanStep, StepReport};
 
@@ -646,6 +789,71 @@ mod tests {
             cancelled.error.as_deref(),
             Some(ExecutionStopReason::Cancelled.message())
         );
+    }
+
+    #[test]
+    fn checkpoints_record_intent_then_only_verified_completions() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut run = DurableRun::prepare_in(root.path(), &two_step_plan(), Some(30), None).expect("prepare");
+        let first = &two_step_plan().steps[0];
+        run.record_intent(first).expect("intent");
+        let dispatched: RunState =
+            serde_json::from_slice(&std::fs::read(&run.state_path).expect("state")).expect("decode dispatched");
+        assert_eq!(
+            dispatched.checkpoint.intent.as_ref().map(|intent| intent.status),
+            Some(IntentStatus::Dispatched)
+        );
+        assert!(dispatched.checkpoint.completed.is_empty());
+
+        let report = StepReport {
+            id: first.id.clone(),
+            tool: first.tool.clone(),
+            ok: true,
+            result: Some(json!({"panels": []})),
+            error: None,
+        };
+        run.record_completion(&report).expect("completion");
+        let completed: RunState =
+            serde_json::from_slice(&std::fs::read(&run.state_path).expect("state")).expect("decode completed");
+        assert!(completed.checkpoint.intent.is_none());
+        assert_eq!(completed.checkpoint.completed.len(), 1);
+        assert_eq!(completed.completed_steps, 1);
+
+        let second = &two_step_plan().steps[1];
+        run.record_intent(second).expect("second intent");
+        run.record_uncertain(second).expect("uncertain");
+        run.stop(ExecutionStopReason::DeadlineExceeded).expect("timeout");
+        let timed_out: RunState =
+            serde_json::from_slice(&std::fs::read(&run.state_path).expect("state")).expect("decode timed out");
+        assert_eq!(
+            timed_out.checkpoint.intent.as_ref().map(|intent| intent.status),
+            Some(IntentStatus::Uncertain)
+        );
+        assert_eq!(timed_out.checkpoint.completed.len(), 1);
+
+        let opened = DurableRun::open_in(root.path(), run.job_id()).expect("open");
+        assert_eq!(opened.state().checkpoint.completed.len(), 1);
+        let selection = select_resume(&two_step_plan(), Some(&timed_out.checkpoint), UncertainPolicy::Skip)
+            .expect("skip remaining");
+        assert_eq!(selection.start_index, 2);
+    }
+
+    fn two_step_plan() -> Plan {
+        Plan {
+            version: 1,
+            steps: vec![
+                PlanStep {
+                    id: "list".to_string(),
+                    tool: "browser_list".to_string(),
+                    arguments: serde_json::Map::new(),
+                },
+                PlanStep {
+                    id: "again".to_string(),
+                    tool: "browser_list".to_string(),
+                    arguments: serde_json::Map::new(),
+                },
+            ],
+        }
     }
 
     #[cfg(unix)]

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -20,9 +20,11 @@ use crate::checkpoint::{
 use crate::{ExecutionReport, Plan, PlanStep, StepReport, execution_control::ExecutionStopReason};
 
 const STATE_VERSION: u32 = 3;
+const MIN_RESUME_VERSION: u32 = 3;
 const PLAN_FILE: &str = "plan.json";
 const REPORT_FILE: &str = "report.json";
 const STATE_FILE: &str = "state.json";
+const RESUME_LOCK_FILE: &str = "resume.lock";
 
 /// Persisted lifecycle state for one deterministic plan run.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -117,6 +119,7 @@ pub struct DurableRun {
     directory: PathBuf,
     state_path: PathBuf,
     state: RunState,
+    lock_path: Option<PathBuf>,
 }
 
 /// Detached finalization view of an already published durable run.
@@ -220,6 +223,7 @@ impl DurableRun {
                 directory: self.directory.clone(),
                 state_path: self.state_path.clone(),
                 state: self.state.clone(),
+                lock_path: None,
             },
         }
     }
@@ -276,6 +280,7 @@ impl DurableRun {
             state_path: directory.join(STATE_FILE),
             directory,
             state,
+            lock_path: None,
         };
         if let Err(source) = sync_directory(root) {
             return Err(DurablePreparationError::published(run, source));
@@ -373,6 +378,7 @@ impl DurableRun {
             directory,
             state_path,
             state,
+            lock_path: None,
         })
     }
 
@@ -382,7 +388,11 @@ impl DurableRun {
     /// Returns when the job is missing, still leased, already succeeded, or
     /// would replay an uncertain mutation.
     pub fn prepare_resume(job_id: &str, policy: UncertainPolicy) -> Result<(Self, Plan, ResumeSelection), ResumeError> {
-        let run = Self::open(job_id)?;
+        let mut run = Self::open(job_id)?;
+        run.acquire_resume_lock()?;
+        if run.state.version < MIN_RESUME_VERSION {
+            return Err(ResumeError::LegacyState(job_id.to_string()));
+        }
         let plan = run.load_plan()?;
         match run.state.effective_status_at(now_millis()) {
             RunStatus::Prepared | RunStatus::Running => return Err(ResumeError::StillRunning(job_id.to_string())),
@@ -446,8 +456,41 @@ impl DurableRun {
         self.persist_state().map_err(|error| error.to_string())
     }
 
+    fn acquire_resume_lock(&mut self) -> Result<(), ResumeError> {
+        let path = self.directory.join(RESUME_LOCK_FILE);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                let pid = format!("{}\n", std::process::id());
+                file.write_all(pid.as_bytes())
+                    .and_then(|()| file.sync_all())
+                    .map_err(|source| ResumeError::Decode(format!("could not write {}: {source}", path.display())))?;
+                self.lock_path = Some(path);
+                Ok(())
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
+                if resume_lock_is_stale(&path) {
+                    let _ = std::fs::remove_file(&path);
+                    return self.acquire_resume_lock();
+                }
+                Err(ResumeError::Locked(self.state.job_id.clone()))
+            }
+            Err(source) => Err(ResumeError::Decode(format!(
+                "could not lock {}: {source}",
+                path.display()
+            ))),
+        }
+    }
+
     fn write_json(&self, name: &str, value: &impl Serialize, artifact: &'static str) -> Result<(), RunStateError> {
         write_private_json(&self.directory.join(name), value, artifact)
+    }
+}
+
+impl Drop for DurableRun {
+    fn drop(&mut self) {
+        if let Some(path) = self.lock_path.take() {
+            let _ = std::fs::remove_file(path);
+        }
     }
 }
 
@@ -602,6 +645,33 @@ fn write_private_json(path: &Path, value: &impl Serialize, artifact: &'static st
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
         .map_err(|source| io_error(format!("could not secure {}", path.display()), source))?;
     Ok(())
+}
+
+fn resume_lock_is_stale(path: &Path) -> bool {
+    let Ok(bytes) = std::fs::read(path) else {
+        return true;
+    };
+    let Ok(pid) = std::str::from_utf8(&bytes) else {
+        return true;
+    };
+    let Ok(pid) = pid.trim().parse::<u32>() else {
+        return true;
+    };
+    if pid == std::process::id() {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .is_ok_and(|status| !status.success())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
 }
 
 fn io_error(operation: String, source: std::io::Error) -> RunStateError {

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -536,8 +536,11 @@ impl DurableRun {
 
     /// Record a verified completion on an owned I/O worker.
     ///
+    /// Uses required I/O so a racing stop cannot roll back a structured MCP
+    /// outcome that already reached disk.
+    ///
     /// # Errors
-    /// Returns when the durable write fails or a stop is observed first.
+    /// Returns when the durable write fails.
     pub async fn record_completion_controlled(
         &mut self,
         report: &StepReport,
@@ -546,7 +549,7 @@ impl DurableRun {
         let previous = self.state.checkpoint.clone();
         self.state.checkpoint.intent = None;
         self.state.checkpoint.completed.push(report.clone());
-        self.persist_checkpoint_controlled(control, true, previous).await
+        self.persist_checkpoint_controlled(control, false, previous).await
     }
 
     /// Mark an in-flight step uncertain without requiring a live deadline.

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -185,6 +185,23 @@ impl DurablePreparationError {
     }
 }
 
+/// Rearm failure that retains exclusive job ownership for terminal recovery.
+#[derive(Debug, Error)]
+#[error("{source}")]
+pub struct DurableRearmError {
+    run: Box<DurableRun>,
+    #[source]
+    source: RunStateError,
+}
+
+impl DurableRearmError {
+    /// Split the still-owned run handle from the underlying persistence error.
+    #[must_use]
+    pub fn into_parts(self) -> (DurableRun, RunStateError) {
+        (*self.run, self.source)
+    }
+}
+
 impl DurableRun {
     /// Create a private job directory and persist a deadline-bound prepared
     /// state plus the validated plan before any MCP action is attempted.
@@ -392,9 +409,7 @@ impl DurableRun {
         let mut run = Self::open(job_id)?;
         run.acquire_resume_lock()?;
         run.reload_state(job_id)?;
-        if run.state.version < MIN_RESUME_VERSION {
-            return Err(ResumeError::LegacyState(job_id.to_string()));
-        }
+        validate_resume_version(&run.state)?;
         let plan = run.load_plan()?;
         match run.state.effective_status_at(now_millis()) {
             RunStatus::Prepared | RunStatus::Running => return Err(ResumeError::StillRunning(job_id.to_string())),
@@ -428,24 +443,33 @@ impl DurableRun {
     /// Re-arm a terminal job for an explicit resume without creating a new id.
     ///
     /// # Errors
-    /// Returns when the updated lease cannot be persisted.
+    /// Returns the still-owned run when the updated lease cannot be persisted,
+    /// so the caller can record a terminal state before releasing its lock.
     pub fn rearm(
-        &mut self,
+        mut self,
         execution_timeout_seconds: u64,
         deadline_at_millis: u64,
         skipped: Option<String>,
-    ) -> Result<(), RunStateError> {
+    ) -> Result<Self, DurableRearmError> {
         self.state.status = RunStatus::Prepared;
         self.state.execution_timeout_seconds = Some(execution_timeout_seconds);
         self.state.deadline_at_millis = Some(deadline_at_millis);
         self.state.updated_at_millis = now_millis();
         self.state.runner_pid = std::process::id();
+        self.state.report_file = None;
+        self.state.completed_steps = self.state.checkpoint.completed.len();
         self.state.error = None;
         if let Some(step_id) = skipped {
             self.state.checkpoint.skipped.push(step_id);
             self.state.checkpoint.intent = None;
         }
-        self.persist_state()
+        match self.persist_state() {
+            Ok(()) => Ok(self),
+            Err(source) => Err(DurableRearmError {
+                run: Box::new(self),
+                source,
+            }),
+        }
     }
 
     fn persist_state(&self) -> Result<(), RunStateError> {
@@ -739,6 +763,20 @@ fn read_run_state(state_path: &Path, job_id: &str) -> Result<RunState, ResumeErr
     Ok(state)
 }
 
+fn validate_resume_version(state: &RunState) -> Result<(), ResumeError> {
+    if state.version < MIN_RESUME_VERSION {
+        Err(ResumeError::LegacyState(state.job_id.clone()))
+    } else if state.version > STATE_VERSION {
+        Err(ResumeError::UnsupportedStateVersion {
+            job_id: state.job_id.clone(),
+            version: state.version,
+            supported: STATE_VERSION,
+        })
+    } else {
+        Ok(())
+    }
+}
+
 fn publish_job_directory(staging: tempfile::TempDir, destination: &Path) -> Result<(), RunStateError> {
     std::fs::rename(staging.path(), destination).map_err(|source| {
         io_error(
@@ -951,6 +989,84 @@ mod tests {
         }))
         .expect("decode incomplete prepared state");
         assert_eq!(prepared_without_deadline.effective_status_at(1), RunStatus::TimedOut);
+    }
+
+    #[test]
+    fn resume_version_window_rejects_legacy_and_future_schemas() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut run = DurableRun::prepare_in(root.path(), &plan(), Some(30), None).expect("prepare");
+        let job_id = run.job_id().to_string();
+
+        run.state.version = MIN_RESUME_VERSION - 1;
+        assert_eq!(
+            validate_resume_version(run.state()),
+            Err(ResumeError::LegacyState(job_id.clone()))
+        );
+
+        run.state.version = STATE_VERSION + 1;
+        assert_eq!(
+            validate_resume_version(run.state()),
+            Err(ResumeError::UnsupportedStateVersion {
+                job_id,
+                version: STATE_VERSION + 1,
+                supported: STATE_VERSION,
+            })
+        );
+    }
+
+    #[test]
+    fn rearm_clears_previous_attempt_metadata() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut run = DurableRun::prepare_in(root.path(), &plan(), Some(30), None).expect("prepare");
+        run.state.checkpoint.completed.push(StepReport {
+            id: "panels".to_string(),
+            tool: "browser_list".to_string(),
+            ok: true,
+            result: Some(json!({"panels": []})),
+            error: None,
+        });
+        run.state.report_file = Some(REPORT_FILE.to_string());
+        run.state.completed_steps = 9;
+        run.state.error = Some("previous failure".to_string());
+        run.persist_state().expect("persist previous attempt");
+
+        let run = run.rearm(45, 1_234, None).expect("rearm");
+
+        assert_eq!(run.state.status, RunStatus::Prepared);
+        assert_eq!(run.state.execution_timeout_seconds, Some(45));
+        assert_eq!(run.state.deadline_at_millis, Some(1_234));
+        assert_eq!(run.state.report_file, None);
+        assert_eq!(run.state.completed_steps, 1);
+        assert_eq!(run.state.error, None);
+    }
+
+    #[test]
+    fn rearm_failure_retains_lock_owner_for_terminal_recovery() {
+        let root = tempfile::tempdir().expect("temporary job root");
+        let mut run = DurableRun::prepare_in(root.path(), &plan(), Some(30), None).expect("prepare");
+        run.stop(ExecutionStopReason::DeadlineExceeded)
+            .expect("persist terminal state");
+        let job_id = run.job_id().to_string();
+        let directory = run.directory.clone();
+        let state_path = run.state_path.clone();
+        run.directory = root.path().join("missing-sync-directory");
+
+        let error = run.rearm(45, 1_234, None).expect_err("directory sync must fail");
+        let (mut retained, _source) = error.into_parts();
+        let partially_rearmed: RunState = serde_json::from_slice(&std::fs::read(&state_path).expect("state"))
+            .expect("decode partially rearmed state");
+        assert_eq!(partially_rearmed.status, RunStatus::Prepared);
+
+        let mut contender = DurableRun::open_in(root.path(), &job_id).expect("open contender");
+        assert!(matches!(contender.acquire_resume_lock(), Err(ResumeError::Locked(_))));
+
+        retained.directory = directory;
+        retained.fail("resume rearm failed").expect("persist terminal recovery");
+        let recovered: RunState = serde_json::from_slice(&std::fs::read(&state_path).expect("recovered state"))
+            .expect("decode recovered state");
+        assert_eq!(recovered.status, RunStatus::Failed);
+        drop(retained);
+        acquire_lock_after_owner_exit(&mut contender);
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -19,7 +19,7 @@ use crate::checkpoint::{
 };
 use crate::{
     ExecutionReport, Plan, PlanStep, StepReport,
-    execution_control::{BlockingIoMode, ExecutionControl, ExecutionStopReason},
+    execution_control::{BlockingIoError, BlockingIoMode, ExecutionControl, ExecutionStopReason},
 };
 
 const STATE_VERSION: u32 = 3;
@@ -500,7 +500,11 @@ impl DurableRun {
                 self.restore_checkpoint(previous);
                 Err(CheckpointPersistError::Io(error.to_string()))
             }
-            Err(reason) => {
+            Err(BlockingIoError::Failed(error)) => {
+                self.restore_checkpoint(previous);
+                Err(CheckpointPersistError::Io(error))
+            }
+            Err(BlockingIoError::Stopped(reason)) => {
                 self.restore_checkpoint(previous);
                 Err(CheckpointPersistError::Stopped(reason))
             }

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -119,7 +119,7 @@ pub struct DurableRun {
     directory: PathBuf,
     state_path: PathBuf,
     state: RunState,
-    lock_path: Option<PathBuf>,
+    lock_file: Option<std::fs::File>,
 }
 
 /// Detached finalization view of an already published durable run.
@@ -223,7 +223,7 @@ impl DurableRun {
                 directory: self.directory.clone(),
                 state_path: self.state_path.clone(),
                 state: self.state.clone(),
-                lock_path: None,
+                lock_file: None,
             },
         }
     }
@@ -280,7 +280,7 @@ impl DurableRun {
             state_path: directory.join(STATE_FILE),
             directory,
             state,
-            lock_path: None,
+            lock_file: None,
         };
         if let Err(source) = sync_directory(root) {
             return Err(DurablePreparationError::published(run, source));
@@ -387,7 +387,7 @@ impl DurableRun {
             directory,
             state_path,
             state,
-            lock_path: None,
+            lock_file: None,
         })
     }
 
@@ -478,23 +478,19 @@ impl DurableRun {
 
     fn acquire_resume_lock(&mut self) -> Result<(), ResumeError> {
         let path = self.directory.join(RESUME_LOCK_FILE);
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
-            Ok(mut file) => {
-                let pid = format!("{}\n", std::process::id());
-                file.write_all(pid.as_bytes())
-                    .and_then(|()| file.sync_all())
-                    .map_err(|source| ResumeError::Decode(format!("could not write {}: {source}", path.display())))?;
-                self.lock_path = Some(path);
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&path)
+            .map_err(|source| ResumeError::Decode(format!("could not open {}: {source}", path.display())))?;
+        match file.try_lock() {
+            Ok(()) => {
+                self.lock_file = Some(file);
                 Ok(())
             }
-            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
-                if resume_lock_is_stale(&path) {
-                    let _ = std::fs::remove_file(&path);
-                    return self.acquire_resume_lock();
-                }
-                Err(ResumeError::Locked(self.state.job_id.clone()))
-            }
-            Err(source) => Err(ResumeError::Decode(format!(
+            Err(std::fs::TryLockError::WouldBlock) => Err(ResumeError::Locked(self.state.job_id.clone())),
+            Err(std::fs::TryLockError::Error(source)) => Err(ResumeError::Decode(format!(
                 "could not lock {}: {source}",
                 path.display()
             ))),
@@ -503,14 +499,6 @@ impl DurableRun {
 
     fn write_json(&self, name: &str, value: &impl Serialize, artifact: &'static str) -> Result<(), RunStateError> {
         write_private_json(&self.directory.join(name), value, artifact)
-    }
-}
-
-impl Drop for DurableRun {
-    fn drop(&mut self) {
-        if let Some(path) = self.lock_path.take() {
-            let _ = std::fs::remove_file(path);
-        }
     }
 }
 
@@ -669,44 +657,6 @@ fn write_private_json(path: &Path, value: &impl Serialize, artifact: &'static st
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
         .map_err(|source| io_error(format!("could not secure {}", path.display()), source))?;
     Ok(())
-}
-
-fn resume_lock_is_stale(path: &Path) -> bool {
-    let Ok(bytes) = std::fs::read(path) else {
-        return false;
-    };
-    let Ok(pid) = std::str::from_utf8(&bytes) else {
-        return false;
-    };
-    let Ok(pid) = pid.trim().parse::<u32>() else {
-        return false;
-    };
-    !process_is_alive(pid)
-}
-
-fn process_is_alive(pid: u32) -> bool {
-    if pid == std::process::id() {
-        return true;
-    }
-    #[cfg(unix)]
-    {
-        std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .status()
-            .is_ok_and(|status| status.success())
-    }
-    #[cfg(windows)]
-    {
-        std::process::Command::new("tasklist")
-            .args(["/NH", "/FI", &format!("PID eq {pid}")])
-            .output()
-            .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = pid;
-        true
-    }
 }
 
 fn io_error(operation: String, source: std::io::Error) -> RunStateError {
@@ -956,17 +906,14 @@ mod tests {
     }
 
     #[test]
-    fn incomplete_resume_lock_is_not_stolen() {
+    fn resume_lock_is_exclusive_while_the_owner_lives() {
         let root = tempfile::tempdir().expect("temporary job root");
-        let mut run = DurableRun::prepare_in(root.path(), &two_step_plan(), Some(30), None).expect("prepare");
-        run.stop(ExecutionStopReason::Cancelled).expect("cancel");
-        let job_id = run.job_id().to_string();
-        let directory = run.state_path.parent().expect("job directory").to_path_buf();
-        drop(run);
-        std::fs::write(directory.join("resume.lock"), b"").expect("empty lock");
-        let mut opened = DurableRun::open_in(root.path(), &job_id).expect("open");
-        let error = opened.acquire_resume_lock().expect_err("empty lock is live");
+        let run = DurableRun::prepare_in(root.path(), &two_step_plan(), Some(30), None).expect("prepare");
+        let mut contender = DurableRun::open_in(root.path(), run.job_id()).expect("open");
+        let error = contender.acquire_resume_lock().expect_err("owner holds lock");
         assert!(matches!(error, ResumeError::Locked(_)));
+        drop(run);
+        contender.acquire_resume_lock().expect("lock released on drop");
     }
 
     fn two_step_plan() -> Plan {

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -444,7 +444,7 @@ impl DurableRun {
             RunStatus::Failed | RunStatus::Cancelled | RunStatus::TimedOut => {}
         }
         let selection = select_resume(&plan, Some(&run.state.checkpoint), policy)?;
-        if selection.start_index >= plan.steps.len() {
+        if selection.start_index >= plan.steps.len() && selection.skipped.is_none() {
             return Err(ResumeError::NothingToResume(job_id.to_string()));
         }
         Ok((run, plan, selection))

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -17,7 +17,10 @@ use crate::checkpoint::{
     CheckpointIntent, CheckpointStore, IntentStatus, ResumeError, ResumeSelection, RunCheckpoint, UncertainPolicy,
     select_resume, valid_job_id,
 };
-use crate::{ExecutionReport, Plan, PlanStep, StepReport, execution_control::ExecutionStopReason};
+use crate::{
+    ExecutionReport, Plan, PlanStep, StepReport,
+    execution_control::{ExecutionControl, ExecutionStopReason},
+};
 
 const STATE_VERSION: u32 = 3;
 const MIN_RESUME_VERSION: u32 = 3;
@@ -126,6 +129,15 @@ pub struct DurableRun {
 #[derive(Debug)]
 pub struct DurablePostProcessor {
     run: DurableRun,
+}
+
+/// Failure while persisting a checkpoint under execution control.
+#[derive(Debug, Error)]
+pub enum CheckpointPersistError {
+    #[error("{0}")]
+    Io(String),
+    #[error("{}", .0.message())]
+    Stopped(ExecutionStopReason),
 }
 
 /// Failure to create or atomically update durable plan-run state.
@@ -456,7 +468,106 @@ impl DurableRun {
     }
 
     fn persist_state(&self) -> Result<(), RunStateError> {
-        write_private_json(&self.state_path, &self.state, "state")
+        write_private_json(&self.state_path, &self.state, "state")?;
+        sync_directory(&self.directory)
+    }
+
+    async fn persist_checkpoint_controlled(
+        &mut self,
+        control: &mut ExecutionControl,
+        honor_deadline: bool,
+        previous: RunCheckpoint,
+    ) -> Result<(), CheckpointPersistError> {
+        self.state.updated_at_millis = now_millis();
+        self.state.completed_steps = self.state.checkpoint.completed.len();
+        let state = self.state.clone();
+        let state_path = self.state_path.clone();
+        let directory = self.directory.clone();
+        match control
+            .wait_owned_blocking("horizon-browser-checkpoint", honor_deadline, move || {
+                write_private_json(&state_path, &state, "state").and_then(|()| sync_directory(&directory))
+            })
+            .await
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => {
+                self.restore_checkpoint(previous);
+                Err(CheckpointPersistError::Io(error.to_string()))
+            }
+            Err(reason) => {
+                self.restore_checkpoint(previous);
+                Err(CheckpointPersistError::Stopped(reason))
+            }
+        }
+    }
+
+    fn restore_checkpoint(&mut self, previous: RunCheckpoint) {
+        self.state.checkpoint = previous;
+        self.state.completed_steps = self.state.checkpoint.completed.len();
+    }
+
+    /// Record intent on an owned I/O worker before the MCP future is polled.
+    ///
+    /// # Errors
+    /// Returns when the durable write fails or a stop is observed first.
+    pub async fn record_intent_controlled(
+        &mut self,
+        step: &PlanStep,
+        control: &mut ExecutionControl,
+    ) -> Result<(), CheckpointPersistError> {
+        let previous = self.state.checkpoint.clone();
+        self.state.checkpoint.intent = Some(CheckpointIntent {
+            step_id: step.id.clone(),
+            tool: step.tool.clone(),
+            status: IntentStatus::Dispatched,
+        });
+        self.persist_checkpoint_controlled(control, true, previous).await
+    }
+
+    /// Record a verified completion on an owned I/O worker.
+    ///
+    /// # Errors
+    /// Returns when the durable write fails or a stop is observed first.
+    pub async fn record_completion_controlled(
+        &mut self,
+        report: &StepReport,
+        control: &mut ExecutionControl,
+    ) -> Result<(), CheckpointPersistError> {
+        let previous = self.state.checkpoint.clone();
+        self.state.checkpoint.intent = None;
+        self.state.checkpoint.completed.push(report.clone());
+        self.persist_checkpoint_controlled(control, true, previous).await
+    }
+
+    /// Mark an in-flight step uncertain without requiring a live deadline.
+    ///
+    /// # Errors
+    /// Returns when the durable write fails or cancellation wins first.
+    pub async fn record_uncertain_controlled(
+        &mut self,
+        step: &PlanStep,
+        control: &mut ExecutionControl,
+    ) -> Result<(), CheckpointPersistError> {
+        let previous = self.state.checkpoint.clone();
+        self.state.checkpoint.intent = Some(CheckpointIntent {
+            step_id: step.id.clone(),
+            tool: step.tool.clone(),
+            status: IntentStatus::Uncertain,
+        });
+        self.persist_checkpoint_controlled(control, false, previous).await
+    }
+
+    /// Drop a not-yet-polled intent without requiring a live deadline.
+    ///
+    /// # Errors
+    /// Returns when the durable write fails or cancellation wins first.
+    pub async fn clear_intent_controlled(
+        &mut self,
+        control: &mut ExecutionControl,
+    ) -> Result<(), CheckpointPersistError> {
+        let previous = self.state.checkpoint.clone();
+        self.state.checkpoint.intent = None;
+        self.persist_checkpoint_controlled(control, false, previous).await
     }
 
     fn persist_checkpoint(&mut self) -> Result<(), String> {

--- a/crates/horizon-browser-cli/src/run_state/checkpoint_artifacts.rs
+++ b/crates/horizon-browser-cli/src/run_state/checkpoint_artifacts.rs
@@ -1,0 +1,121 @@
+//! Compact checkpoint metadata backed by immutable per-step result artifacts.
+
+use std::path::Path;
+
+use crate::{
+    StepReport,
+    checkpoint::{CheckpointCompletion, ResumeError},
+};
+
+use super::{RunState, RunStateError, io_error, sync_directory, write_private_json, write_private_json_once};
+
+pub(super) const DIRECTORY: &str = "checkpoints";
+
+#[derive(Clone, Debug)]
+pub(super) struct PendingCompletion {
+    pub(super) index: usize,
+    pub(super) report: StepReport,
+}
+
+pub(super) fn metadata(index: usize, report: &StepReport) -> CheckpointCompletion {
+    CheckpointCompletion {
+        id: report.id.clone(),
+        tool: report.tool.clone(),
+        report_file: relative_path(index, &report.id),
+    }
+}
+
+pub(super) fn persist_snapshot(
+    directory: &Path,
+    state_path: &Path,
+    state: &RunState,
+    pending: Option<&PendingCompletion>,
+) -> Result<(), RunStateError> {
+    if let Some(pending) = pending {
+        persist_completion(directory, state, pending)?;
+    }
+    write_private_json(state_path, state, "state")?;
+    sync_directory(directory)
+}
+
+pub(super) fn load(directory: &Path, completed: &[CheckpointCompletion]) -> Result<Vec<StepReport>, ResumeError> {
+    completed
+        .iter()
+        .enumerate()
+        .map(|(index, metadata)| load_completion(directory, index, metadata))
+        .collect()
+}
+
+fn persist_completion(directory: &Path, state: &RunState, pending: &PendingCompletion) -> Result<(), RunStateError> {
+    let Some(saved) = state.checkpoint.completed.get(pending.index) else {
+        return Err(invalid_checkpoint("pending completion is missing from state"));
+    };
+    let expected = metadata(pending.index, &pending.report);
+    if saved != &expected {
+        return Err(invalid_checkpoint("pending completion does not match state"));
+    }
+    let path = directory.join(&saved.report_file);
+    match write_private_json_once(&path, &pending.report, "checkpoint completion") {
+        Ok(()) => {}
+        Err(RunStateError::Io { source, .. }) if source.kind() == std::io::ErrorKind::AlreadyExists => {
+            verify_existing(&path, &pending.report)?;
+        }
+        Err(error) => return Err(error),
+    }
+    sync_directory(&directory.join(DIRECTORY))
+}
+
+fn load_completion(directory: &Path, index: usize, metadata: &CheckpointCompletion) -> Result<StepReport, ResumeError> {
+    let expected_path = relative_path(index, &metadata.id);
+    if metadata.report_file != expected_path {
+        return Err(ResumeError::Decode(format!(
+            "durable checkpoint `{}` has invalid result path `{}`",
+            metadata.id, metadata.report_file
+        )));
+    }
+    let path = directory.join(&metadata.report_file);
+    let bytes = std::fs::read(&path)
+        .map_err(|source| ResumeError::Decode(format!("could not read {}: {source}", path.display())))?;
+    let report: StepReport = serde_json::from_slice(&bytes)
+        .map_err(|source| ResumeError::Decode(format!("could not decode {}: {source}", path.display())))?;
+    if report.id != metadata.id || report.tool != metadata.tool {
+        return Err(ResumeError::Decode(format!(
+            "durable checkpoint result {} does not match state metadata",
+            path.display()
+        )));
+    }
+    Ok(report)
+}
+
+fn verify_existing(path: &Path, expected: &StepReport) -> Result<(), RunStateError> {
+    let saved = std::fs::read(path)
+        .map_err(|source| io_error(format!("could not read existing {}", path.display()), source))?;
+    let mut expected_bytes = serde_json::to_vec_pretty(expected).map_err(|source| RunStateError::Encode {
+        artifact: "checkpoint completion",
+        source,
+    })?;
+    expected_bytes.push(b'\n');
+    if saved != expected_bytes {
+        return Err(invalid_checkpoint(
+            "checkpoint artifact already contains another result",
+        ));
+    }
+    Ok(())
+}
+
+fn relative_path(index: usize, step_id: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded_id = String::with_capacity(step_id.len().saturating_mul(2));
+    for byte in step_id.bytes() {
+        encoded_id.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded_id.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    format!("{DIRECTORY}/{index:06}-{encoded_id}.json")
+}
+
+fn invalid_checkpoint(message: &str) -> RunStateError {
+    io_error(
+        message.to_string(),
+        std::io::Error::from(std::io::ErrorKind::InvalidData),
+    )
+}

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -261,6 +261,57 @@ fn resume_refuses_an_uncertain_in_flight_step() {
 }
 
 #[test]
+fn resume_skip_runs_later_steps_without_replaying_or_succeeding() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let (plan, manifest_path) = write_blocking_plan_with_followup(root.path());
+    let output = run_deadline_after_action(root.path(), &plan, &manifest_path, None);
+    assert_eq!(output.status.code(), Some(124));
+    let report: Value = serde_json::from_slice(&output.stdout).expect("deadline report");
+    let job_id = report["job_id"].as_str().expect("job id");
+    let job_dir = std::path::Path::new(report["job_dir"].as_str().expect("job directory"));
+    let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("deadline state"))
+        .expect("decode deadline state");
+    assert_eq!(state["checkpoint"]["completed"][0]["id"], "list");
+    assert_eq!(state["checkpoint"]["intent"]["status"], "uncertain");
+    assert_eq!(state["checkpoint"]["intent"]["step_id"], "snapshot");
+
+    let skipped = run_command(root.path(), ["resume", job_id, "--on-uncertain", "skip"]);
+    assert_eq!(skipped.status.code(), Some(1));
+    assert!(
+        skipped.stderr.is_empty(),
+        "stderr: {}",
+        String::from_utf8_lossy(&skipped.stderr)
+    );
+    let resume_report: Value = serde_json::from_slice(&skipped.stdout).expect("skip resume report");
+    assert_eq!(resume_report["ok"], false);
+    assert_eq!(resume_report["completed_steps"], 2);
+    assert_eq!(
+        resume_report["steps"]
+            .as_array()
+            .expect("step reports")
+            .iter()
+            .map(|step| step["id"].as_str())
+            .collect::<Vec<_>>(),
+        [Some("list"), Some("followup")]
+    );
+
+    let resumed: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("resumed state"))
+        .expect("decode resumed state");
+    assert_eq!(resumed["status"], "failed");
+    assert_eq!(resumed["checkpoint"]["skipped"], json!(["snapshot"]));
+    assert_eq!(
+        resumed["checkpoint"]["completed"]
+            .as_array()
+            .expect("completed reports")
+            .iter()
+            .map(|step| step["id"].as_str())
+            .collect::<Vec<_>>(),
+        [Some("list"), Some("followup")]
+    );
+    assert!(resumed["checkpoint"].get("intent").is_none());
+}
+
+#[test]
 fn run_timeout_starts_after_stdin_plan_validation() {
     let root = tempfile::tempdir().expect("isolated root");
     let mut child = Command::new(env!("CARGO_BIN_EXE_horizon-browser"))
@@ -572,6 +623,14 @@ fn run_deadline_after_action(
 }
 
 fn write_blocking_plan(home: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    write_blocking_plan_with(home, "")
+}
+
+fn write_blocking_plan_with_followup(home: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    write_blocking_plan_with(home, r#",{"id":"followup","tool":"browser_list"}"#)
+}
+
+fn write_blocking_plan_with(home: &std::path::Path, extra_steps: &str) -> (std::path::PathBuf, std::path::PathBuf) {
     let panel_id = "blocked-panel";
     let manifest_path = manifest::manifest_path_for_root(&home.join(".horizon"), panel_id);
     manifest::write_at(
@@ -586,7 +645,7 @@ fn write_blocking_plan(home: &std::path::Path) -> (std::path::PathBuf, std::path
     std::fs::write(
         &plan,
         format!(
-            r#"{{"version":1,"steps":[{{"id":"list","tool":"browser_list"}},{{"id":"snapshot","tool":"browser_snapshot","arguments":{{"panel_id":"{panel_id}","timeout_millis":60000}}}}]}}"#
+            r#"{{"version":1,"steps":[{{"id":"list","tool":"browser_list"}},{{"id":"snapshot","tool":"browser_snapshot","arguments":{{"panel_id":"{panel_id}","timeout_millis":60000}}}}{extra_steps}]}}"#
         ),
     )
     .expect("write blocking plan");

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -254,10 +254,33 @@ fn resume_refuses_an_uncertain_in_flight_step() {
     let skipped = run_command(root.path(), ["resume", job_id, "--on-uncertain", "skip"]);
     assert_eq!(skipped.status.code(), Some(1));
     assert!(
-        String::from_utf8_lossy(&skipped.stderr).contains("no remaining steps to resume"),
+        skipped.stderr.is_empty(),
         "stderr: {}",
         String::from_utf8_lossy(&skipped.stderr)
     );
+    let skipped_report: Value = serde_json::from_slice(&skipped.stdout).expect("skipped final-step report");
+    assert_eq!(skipped_report["ok"], false);
+    assert_eq!(skipped_report["completed_steps"], 1);
+    assert_eq!(
+        skipped_report["steps"]
+            .as_array()
+            .expect("step reports")
+            .iter()
+            .map(|step| step["id"].as_str())
+            .collect::<Vec<_>>(),
+        [Some("list")]
+    );
+    assert_eq!(
+        skipped_report["error"],
+        "plan remains incomplete because resume explicitly skipped uncertain steps: snapshot"
+    );
+    let skipped_state: Value =
+        serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("skipped final-step state"))
+            .expect("decode skipped final-step state");
+    assert_eq!(skipped_state["status"], "failed");
+    assert_eq!(skipped_state["report_file"], "report.json");
+    assert_eq!(skipped_state["checkpoint"]["skipped"], json!(["snapshot"]));
+    assert!(skipped_state["checkpoint"].get("intent").is_none());
 }
 
 #[test]

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -286,6 +286,10 @@ fn resume_skip_runs_later_steps_without_replaying_or_succeeding() {
     assert_eq!(resume_report["ok"], false);
     assert_eq!(resume_report["completed_steps"], 2);
     assert_eq!(
+        resume_report["error"],
+        "plan remains incomplete because resume explicitly skipped uncertain steps: snapshot"
+    );
+    assert_eq!(
         resume_report["steps"]
             .as_array()
             .expect("step reports")

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -144,7 +144,7 @@ fn run_publishes_a_complete_relative_job_when_home_is_unset() {
     assert!(job_dir.join("plan.json").is_file());
     let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("job state"))
         .expect("decode job state");
-    assert_eq!(state["version"], 2);
+    assert_eq!(state["version"], 3);
     assert_eq!(state["status"], "succeeded");
     assert!(state["deadline_at_millis"].as_u64().is_some());
     assert_eq!(state["report_file"], "report.json");
@@ -223,6 +223,38 @@ fn run_deadline_persists_a_partial_report_and_stable_exit_code() {
     );
     assert_eq!(failed_output.status.code(), Some(124));
     assert!(String::from_utf8_lossy(&failed_output.stderr).contains("could not open report"));
+}
+
+#[test]
+fn resume_refuses_an_uncertain_in_flight_step() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let (plan, manifest_path) = write_blocking_plan(root.path());
+    let output = run_deadline_after_action(root.path(), &plan, &manifest_path, None);
+    assert_eq!(output.status.code(), Some(124));
+    let report: Value = serde_json::from_slice(&output.stdout).expect("deadline report");
+    let job_id = report["job_id"].as_str().expect("job id");
+    let job_dir = std::path::Path::new(report["job_dir"].as_str().expect("job directory"));
+    let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("deadline state"))
+        .expect("decode deadline state");
+    assert_eq!(state["checkpoint"]["completed"].as_array().map(Vec::len), Some(1));
+    assert_eq!(state["checkpoint"]["intent"]["status"], "uncertain");
+    assert_eq!(state["checkpoint"]["intent"]["step_id"], "snapshot");
+
+    let refused = run_command(root.path(), ["resume", job_id]);
+    assert_eq!(refused.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("uncertain step `snapshot`"),
+        "stderr: {}",
+        String::from_utf8_lossy(&refused.stderr)
+    );
+
+    let skipped = run_command(root.path(), ["resume", job_id, "--on-uncertain", "skip"]);
+    assert_eq!(skipped.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&skipped.stderr).contains("no remaining steps to resume"),
+        "stderr: {}",
+        String::from_utf8_lossy(&skipped.stderr)
+    );
 }
 
 #[test]

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -39,6 +39,7 @@ fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
     assert!(state["deadline_at_millis"].as_u64().is_some());
     assert_eq!(state["completed_steps"], 1);
     assert_eq!(state["report_file"], "report.json");
+    assert_checkpoint_artifact(&job_dir, &state, &stdout_report["steps"][0]);
     assert_eq!(
         serde_json::from_slice::<Value>(&std::fs::read(job_dir.join("report.json")).expect("durable report"))
             .expect("decode durable report"),
@@ -109,6 +110,41 @@ fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
     assert!(failed_state["checkpoint"].get("completed").is_none());
 }
 
+fn assert_checkpoint_artifact(job_dir: &std::path::Path, state: &Value, expected: &Value) {
+    assert!(state["checkpoint"]["completed"][0].get("result").is_none());
+    let checkpoint_report = job_dir.join(
+        state["checkpoint"]["completed"][0]["report_file"]
+            .as_str()
+            .expect("checkpoint result path"),
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&std::fs::read(&checkpoint_report).expect("checkpoint result"))
+            .expect("decode checkpoint result"),
+        *expected
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        assert_eq!(
+            std::fs::metadata(job_dir.join("checkpoints"))
+                .expect("checkpoint directory metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(checkpoint_report)
+                .expect("checkpoint result metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+}
+
 #[test]
 fn run_publishes_a_complete_relative_job_when_home_is_unset() {
     let current_dir = tempfile::tempdir().expect("isolated working directory");
@@ -147,7 +183,7 @@ fn run_publishes_a_complete_relative_job_when_home_is_unset() {
     assert!(job_dir.join("plan.json").is_file());
     let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("job state"))
         .expect("decode job state");
-    assert_eq!(state["version"], 3);
+    assert_eq!(state["version"], 4);
     assert_eq!(state["status"], "succeeded");
     assert!(state["deadline_at_millis"].as_u64().is_some());
     assert_eq!(state["report_file"], "report.json");

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -104,6 +104,9 @@ fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
     .expect("decode failed job state");
     assert_eq!(failed_state["status"], "failed");
     assert_eq!(failed_state["completed_steps"], 1);
+    assert_eq!(failed_state["checkpoint"]["intent"]["status"], "uncertain");
+    assert_eq!(failed_state["checkpoint"]["intent"]["step_id"], "fill");
+    assert!(failed_state["checkpoint"].get("completed").is_none());
 }
 
 #[test]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -74,6 +74,15 @@ back into large multi-purpose modules.
   workspace metadata, or format panel/workspace domain labels, prefer adding a
   core API instead of rebuilding that logic in `horizon-ui`.
 
+### `horizon-browser-cli`
+
+- Owns deterministic browser plans, bounded execution control, durable job
+  lifecycle, explicit resume policy, and user-facing reports.
+- `run_state.rs` coordinates lifecycle metadata and exclusive resume leases.
+  Large verified step results live in immutable files managed by
+  `run_state/checkpoint_artifacts.rs`; `state.json` retains only compact result
+  references so intent updates never rewrite prior payloads.
+
 ### `horizon-ui`
 
 - Owns rendering, egui interaction, transient view state, and deferred UI


### PR DESCRIPTION
## Purpose

Issue #324 checkpoint-and-resume slice: persist intent before each MCP dispatch, checkpoint only verified completions, classify an interrupted in-flight mutation as uncertain, and add an explicit `resume` command.

## Behavior

- `run` writes intent to `state.json` before polling a tool, then checkpoints only a structured MCP outcome.
- State schema v4 keeps `state.json` compact: verified results are written once as private immutable per-step artifacts, and the state file stores only validated artifact metadata.
- Checkpoint artifacts are durably published before their compact metadata, use step-identity filenames to prevent orphan collisions, and are loaded and cross-checked under the same OS lease during resume.
- An interrupt after dispatch records `checkpoint.intent.status = uncertain`; an interrupt before poll clears intent so that step can retry.
- `horizon-browser resume <job-id>` continues remaining steps from verified completions. It refuses a live lease, a succeeded job, legacy and future state schemas, and any uncertain mutation unless `--on-uncertain skip` is set.
- The original runner locks the staged job before atomic publication; a resume takes the same OS lock and reloads state under that lock before selecting work.
- The OS lease lives in a private sibling lock directory, preserving pre-publication exclusion without blocking the staged-directory rename on Windows.
- Rearming clears the previous attempt's report reference and recomputes the completed-step count from verified checkpoints.
- If rearm persistence fails after writing prepared state, the caller retains the locked durable run and records failure or a pending stop before releasing ownership.
- A resumed MCP session validates tool availability only for the runnable suffix; verified or explicitly skipped prefix tools need not remain installed.
- When an explicit skip is the only remaining gap, the public report stays unsuccessful and names the skipped step instead of returning an unexplained `error: null`.
- Required checkpoint writes start even after a stop but still observe cancellation and the configured deadline, with the bounded one-second drain.
- Failed cleanup or completion persistence retains the newest in-memory safety fact for terminal retry; a never-polled step remains retryable, while a verified result is never replayed merely because its first checkpoint write failed.
- Skip never replays the uncertain call. Automatic continuation remains disabled.
- Remaining steps still start a new MCP session; standalone reconnect is the next #324 slice.

## Test evidence

Exact head `1e807ccdfdbd9f33f33e02f5b2f67a76c95d112f`:

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`

Focused regressions additionally cover lock release, failed-persistence recovery, legacy-schema rejection, orphan-artifact isolation, and exact reload of two 256 KiB results while keeping `state.json` below 4 KiB.

Refs #324
