### PR TITLE
fix(session): match history across equivalent cwd paths

### DIFF
--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -684,6 +684,9 @@ fn reserve_new_local_id(reserved: &mut HashSet<String>) -> String {
     }
 }
 
+/// Lexically normalize a configured cwd so equivalent spellings match in
+/// history lookups: `~` expands, and trailing, duplicate, and `.`/`..`
+/// separator runs fold. Symlinks are intentionally not resolved.
 fn normalize_cwd(cwd: Option<&str>) -> Option<String> {
     cwd.map(Config::expand_tilde)
         .map(|path| path.components().collect::<PathBuf>())

--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -685,8 +685,8 @@ fn reserve_new_local_id(reserved: &mut HashSet<String>) -> String {
 }
 
 /// Lexically normalize a configured cwd so equivalent spellings match in
-/// history lookups: `~` expands, and trailing, duplicate, and `.`/`..`
-/// separator runs fold. Symlinks are intentionally not resolved.
+/// history lookups: `~` expands, and trailing or duplicate separators plus
+/// interior `.` components fold. Parent components and symlinks remain unresolved.
 fn normalize_cwd(cwd: Option<&str>) -> Option<String> {
     cwd.map(Config::expand_tilde)
         .map(|path| path.components().collect::<PathBuf>())

--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -685,7 +685,9 @@ fn reserve_new_local_id(reserved: &mut HashSet<String>) -> String {
 }
 
 fn normalize_cwd(cwd: Option<&str>) -> Option<String> {
-    cwd.map(Config::expand_tilde).map(|path| path.display().to_string())
+    cwd.map(Config::expand_tilde)
+        .map(|path| path.components().collect::<PathBuf>())
+        .map(|path| path.display().to_string())
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use crate::error::Error;
 
+mod cwd;
 mod grok;
 mod provider_scoping;
 

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests/cwd.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests/cwd.rs
@@ -14,13 +14,21 @@ fn catalog_for(cwd: &str) -> AgentSessionCatalog {
 }
 
 #[test]
-fn recent_sessions_match_cwd_with_trailing_separators() {
-    let cwd = std::env::temp_dir().join("horizon-session-cwd");
+fn recent_sessions_match_lexically_equivalent_cwds() {
+    let parent = std::env::temp_dir().join("horizon-session-parent");
+    let leaf = "horizon-session-cwd";
+    let cwd = parent.join(leaf);
     let cwd = cwd.display().to_string();
+    let parent = parent.display().to_string();
     let sep = std::path::MAIN_SEPARATOR;
     let catalog = catalog_for(&cwd);
 
-    for query in [format!("{cwd}{sep}"), format!("{cwd}{sep}{sep}")] {
+    for query in [
+        format!("{cwd}{sep}"),
+        format!("{cwd}{sep}{sep}"),
+        format!("{parent}{sep}{sep}{leaf}"),
+        format!("{parent}{sep}.{sep}{leaf}"),
+    ] {
         let sessions = catalog.recent_for(PanelKind::Codex, Some(&query));
 
         assert_eq!(sessions.len(), 1, "query {query} should match {cwd}");

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests/cwd.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests/cwd.rs
@@ -1,23 +1,29 @@
 use super::super::{AgentSessionCatalog, AgentSessionRecord, PanelKind, normalize_cwd};
 
-#[test]
-fn recent_sessions_match_cwd_with_a_trailing_separator() {
-    let cwd = std::env::temp_dir().join("horizon-session-cwd");
-    let cwd = cwd.display().to_string();
-    let cwd_with_separator = format!("{cwd}{}", std::path::MAIN_SEPARATOR);
-    let catalog = AgentSessionCatalog {
+fn catalog_for(cwd: &str) -> AgentSessionCatalog {
+    AgentSessionCatalog {
         sessions: vec![AgentSessionRecord {
             kind: PanelKind::Codex,
             session_id: "session-root".to_string(),
-            cwd: normalize_cwd(Some(&cwd)),
+            cwd: normalize_cwd(Some(cwd)),
             label: Some("Saved session".to_string()),
             updated_at: 42,
             interactive: true,
         }],
-    };
+    }
+}
 
-    let sessions = catalog.recent_for(PanelKind::Codex, Some(&cwd_with_separator));
+#[test]
+fn recent_sessions_match_cwd_with_trailing_separators() {
+    let cwd = std::env::temp_dir().join("horizon-session-cwd");
+    let cwd = cwd.display().to_string();
+    let sep = std::path::MAIN_SEPARATOR;
+    let catalog = catalog_for(&cwd);
 
-    assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0].session_id, "session-root");
+    for query in [format!("{cwd}{sep}"), format!("{cwd}{sep}{sep}")] {
+        let sessions = catalog.recent_for(PanelKind::Codex, Some(&query));
+
+        assert_eq!(sessions.len(), 1, "query {query} should match {cwd}");
+        assert_eq!(sessions[0].session_id, "session-root");
+    }
 }

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests/cwd.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests/cwd.rs
@@ -1,0 +1,23 @@
+use super::super::{AgentSessionCatalog, AgentSessionRecord, PanelKind, normalize_cwd};
+
+#[test]
+fn recent_sessions_match_cwd_with_a_trailing_separator() {
+    let cwd = std::env::temp_dir().join("horizon-session-cwd");
+    let cwd = cwd.display().to_string();
+    let cwd_with_separator = format!("{cwd}{}", std::path::MAIN_SEPARATOR);
+    let catalog = AgentSessionCatalog {
+        sessions: vec![AgentSessionRecord {
+            kind: PanelKind::Codex,
+            session_id: "session-root".to_string(),
+            cwd: normalize_cwd(Some(&cwd)),
+            label: Some("Saved session".to_string()),
+            updated_at: 42,
+            interactive: true,
+        }],
+    };
+
+    let sessions = catalog.recent_for(PanelKind::Codex, Some(&cwd_with_separator));
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id, "session-root");
+}


### PR DESCRIPTION
## Purpose

Saved-session discovery used exact string equality for working directories. A persisted workspace path with a trailing separator therefore failed to match the same directory in the provider history store.

## Behavior impact

- Lexically normalizes expanded working directories before catalog matching.
- Treats trailing and duplicate separators, plus interior dot components, as equivalent.
- Does not resolve parent components or symlinks.
- Adds focused regression coverage for one and two trailing separators.

## Reproduction

1. Save a workspace with cwd `/workspace/project/`.
2. Keep a recent provider session recorded at `/workspace/project`.
3. Open the session-rebind menu.
4. Before this change, no matching session appeared; after it, the saved session appears and can be rebound.

## Validation

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- Isolated Linux/X11 smoke: same-directory history discovery, unrelated-directory filtering, exact-session rebind and restart, persisted relaunch, resize, and fit all passed on the candidate head.
