### PR TITLE
fix(speech): skip AT-SPI tree walks after empty Collection matches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
 regex = "1.13.1"
 arboard = "3.6.1"
-atspi = { version = "0.30.0", default-features = false, features = ["connection", "proxies", "tokio"] }
+atspi = { version = "0.30.0", default-features = false, features = ["connection", "proxies", "tokio", "zbus"] }
 tokio = { version = "1.53.1", features = ["rt", "macros", "time"] }
 axuielement = { version = "0.9.1", default-features = false, features = ["async"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSRunningApplication", "libc"] }

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -269,11 +269,13 @@ mod platform {
                 .map_err(|_| InjectError::Unsupported)
         })
         .await?;
-        let focus_pid = focus_window.and_then(crate::os_focus::window_process_id);
-        match insert_into_editable_field(&connection, deadline, &text, focus_pid).await {
+        let focus_pids = focus_window
+            .and_then(crate::os_focus::window_candidate_pids)
+            .unwrap_or_default();
+        match insert_into_editable_field(&connection, deadline, &text, &focus_pids).await {
             Ok(()) => Ok(()),
             Err(error) if can_synthesize_keys(&error) => {
-                synthesize_into_focused_target(&connection, deadline, &text, focus_window, focus_pid).await
+                synthesize_into_focused_target(&connection, deadline, &text, focus_window, &focus_pids).await
             }
             Err(error) => Err(error),
         }
@@ -283,9 +285,9 @@ mod platform {
         connection: &AccessibilityConnection,
         deadline: tokio::time::Instant,
         text: &str,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<(), InjectError> {
-        let target = bounded_preflight(deadline, find_focused_target(connection, focus_pid)).await?;
+        let target = bounded_preflight(deadline, find_focused_target(connection, focus_pids)).await?;
         let accessible = bounded_preflight(deadline, async {
             target
                 .as_accessible_proxy(connection.connection())
@@ -357,9 +359,15 @@ mod platform {
 
     async fn find_focused_target(
         connection: &AccessibilityConnection,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<ObjectRefOwned, InjectError> {
-        find_unique_focus(connection, FocusSearch::EditableText, unique_candidate_index, focus_pid).await
+        find_unique_focus(
+            connection,
+            FocusSearch::EditableText,
+            unique_candidate_index,
+            focus_pids,
+        )
+        .await
     }
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -444,8 +452,11 @@ mod platform {
         }
     }
 
-    fn include_atspi_app(app_pid: Option<u32>, focus_pid: Option<u32>) -> bool {
-        matches!((app_pid, focus_pid), (Some(app), Some(focus)) if app == focus)
+    fn include_atspi_app(app_pid: Option<u32>, focus_pids: &[u32]) -> bool {
+        match app_pid {
+            Some(app) if !focus_pids.is_empty() => focus_pids.contains(&app),
+            _ => true,
+        }
     }
 
     async fn atspi_application_pid(
@@ -522,7 +533,7 @@ mod platform {
         connection: &AccessibilityConnection,
         search: FocusSearch,
         unique_index: fn(usize) -> Result<usize, InjectError>,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<ObjectRefOwned, InjectError> {
         let registry = connection
             .root_accessible_on_registry()
@@ -542,7 +553,7 @@ mod platform {
                 Some(proxy) => atspi_application_pid(proxy, &application).await,
                 None => None,
             };
-            if !include_atspi_app(app_pid, focus_pid) {
+            if !include_atspi_app(app_pid, focus_pids) {
                 continue;
             }
             let Ok(root) = application.as_accessible_proxy(connection.connection()).await else {
@@ -574,9 +585,9 @@ mod platform {
 
     async fn find_focused_object(
         connection: &AccessibilityConnection,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<ObjectRefOwned, InjectError> {
-        find_unique_focus(connection, FocusSearch::FocusedOnly, unique_focused_index, focus_pid).await
+        find_unique_focus(connection, FocusSearch::FocusedOnly, unique_focused_index, focus_pids).await
     }
 
     async fn synthesize_into_focused_target(
@@ -584,10 +595,10 @@ mod platform {
         deadline: tokio::time::Instant,
         text: &str,
         focus_window: Option<u32>,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<(), InjectError> {
-        ensure_synthesis_target_still_safe(connection, deadline, focus_pid).await?;
-        synthesize_key_string(connection, deadline, text, focus_window, focus_pid).await
+        ensure_synthesis_target_still_safe(connection, deadline, focus_pids).await?;
+        synthesize_key_string(connection, deadline, text, focus_window, focus_pids).await
     }
 
     async fn synthesize_key_string(
@@ -595,7 +606,7 @@ mod platform {
         deadline: tokio::time::Instant,
         text: &str,
         focus_window: Option<u32>,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<(), InjectError> {
         let proxy = bounded_preflight(deadline, async {
             DeviceEventControllerProxy::new(connection.connection())
@@ -607,7 +618,7 @@ mod platform {
         // Tab/click can move focus to a password or selection in the same
         // window while the device proxy is created. Re-classify immediately
         // before the mutating call; unclassified Chromium/Teams still type.
-        ensure_synthesis_target_still_safe(connection, deadline, focus_pid).await?;
+        ensure_synthesis_target_still_safe(connection, deadline, focus_pids).await?;
         ensure_focus_window_unchanged(focus_window)?;
         proxy
             .generate_keyboard_event(0, text, KeySynthType::String)
@@ -619,9 +630,9 @@ mod platform {
     async fn ensure_synthesis_target_still_safe(
         connection: &AccessibilityConnection,
         deadline: tokio::time::Instant,
-        focus_pid: Option<u32>,
+        focus_pids: &[u32],
     ) -> Result<(), InjectError> {
-        match bounded_preflight(deadline, find_focused_object(connection, focus_pid)).await {
+        match bounded_preflight(deadline, find_focused_object(connection, focus_pids)).await {
             Ok(target) => validate_classified_synthesis_target(connection, deadline, target).await,
             // No AT-SPI focused object (Chromium/Teams). Type into OS focus.
             Err(error) if is_unclassified_focus(&error) => Ok(()),
@@ -779,12 +790,14 @@ mod platform {
             const TEAMS: u32 = 54_087;
             const FIREFOX: u32 = 14_474;
             const GNOME_SHELL: u32 = 6_749;
-            assert!(include_atspi_app(Some(TEAMS), Some(TEAMS)));
-            assert!(!include_atspi_app(Some(FIREFOX), Some(TEAMS)));
-            assert!(!include_atspi_app(Some(GNOME_SHELL), Some(TEAMS)));
-            assert!(!include_atspi_app(None, Some(TEAMS)));
-            assert!(!include_atspi_app(Some(TEAMS), None));
-            assert!(!include_atspi_app(None, None));
+            const FRAME: u32 = 6_766;
+            assert!(include_atspi_app(Some(TEAMS), &[TEAMS]));
+            assert!(include_atspi_app(Some(TEAMS), &[FRAME, TEAMS]));
+            assert!(!include_atspi_app(Some(FIREFOX), &[TEAMS]));
+            assert!(!include_atspi_app(Some(GNOME_SHELL), &[TEAMS]));
+            assert!(include_atspi_app(None, &[TEAMS]));
+            assert!(include_atspi_app(Some(FIREFOX), &[]));
+            assert!(include_atspi_app(None, &[]));
         }
 
         #[test]

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -170,10 +170,10 @@ mod platform {
             if !self.states.contains(State::Visible | State::Showing) {
                 return Err(InjectError::Target("focused field is not visible"));
             }
-            // GTK read-only entries still expose Text+EditableText. Chromium
-            // Frame/DocumentWeb often report ReadOnly without those interfaces;
-            // KEY_STRING into that unclassified window must keep working.
-            if self.has_text_interfaces() && self.states.contains(State::ReadOnly) {
+            // Chromium Frame/DocumentWeb often report ReadOnly without being
+            // an editable field. A read-only Entry/text object must still
+            // refuse KEY_STRING even when it exposes only Interface::Text.
+            if self.states.contains(State::ReadOnly) && !matches!(self.role, Role::Frame | Role::DocumentWeb) {
                 return Err(InjectError::Target("focused field is not editable"));
             }
             Ok(())
@@ -938,6 +938,18 @@ mod platform {
             let mut read_only_frame = frame;
             read_only_frame.states.insert(State::ReadOnly);
             assert_eq!(read_only_frame.validate_synthesis_target(), Ok(()));
+
+            let mut read_only_document = document;
+            read_only_document.states.insert(State::ReadOnly);
+            assert_eq!(read_only_document.validate_synthesis_target(), Ok(()));
+
+            let mut read_only_text_only_entry = terminal;
+            read_only_text_only_entry.role = Role::Entry;
+            read_only_text_only_entry.states.insert(State::ReadOnly);
+            assert_eq!(
+                read_only_text_only_entry.validate_synthesis_target(),
+                Err(InjectError::Target("focused field is not editable"))
+            );
 
             let mut read_only_text = safe_target();
             read_only_text.states.insert(State::ReadOnly);

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -421,6 +421,13 @@ mod platform {
         Some(candidates)
     }
 
+    fn resolve_focus_candidates<T>(collection: Option<Vec<T>>, traversal: Option<Vec<T>>) -> Option<Vec<T>> {
+        match collection {
+            Some(candidates) => Some(candidates),
+            None => traversal,
+        }
+    }
+
     fn unique_index(candidate_count: usize, empty: &'static str, multiple: &'static str) -> Result<usize, InjectError> {
         if candidate_count == 0 {
             return Err(InjectError::Target(empty));
@@ -503,15 +510,18 @@ mod platform {
             let Ok(root) = application.as_accessible_proxy(connection.connection()).await else {
                 continue;
             };
-            let discovered = match collection_candidates(&root, search).await {
-                Some(candidates) if !candidates.is_empty() => candidates,
-                Some(_) | None => {
-                    let Some(candidates) = traversal_candidates(application, connection.connection(), search).await
-                    else {
-                        continue;
-                    };
-                    candidates
-                }
+            // Collection GetMatches is authoritative, including no hits.
+            // Treating Some([]) as "unknown" walks GNOME Shell (~4s to the
+            // 2048-object cap) and the 5s preflight deadline expires before
+            // Chromium/Teams KEY_STRING.
+            let collection = collection_candidates(&root, search).await;
+            let traversal = if collection.is_none() {
+                traversal_candidates(application, connection.connection(), search).await
+            } else {
+                None
+            };
+            let Some(discovered) = resolve_focus_candidates(collection, traversal) else {
+                continue;
             };
             for candidate in discovered {
                 if !candidates.contains(&candidate) {
@@ -662,7 +672,8 @@ mod platform {
 
         use super::{
             INSERT_LOCK, InjectError, TargetFacts, TextSnapshot, can_synthesize_keys, focus_window_still_matches,
-            is_unclassified_focus, sanitize_desktop_transcript, unique_candidate_index, unique_focused_index,
+            is_unclassified_focus, resolve_focus_candidates, sanitize_desktop_transcript, unique_candidate_index,
+            unique_focused_index,
         };
 
         fn safe_target() -> TargetFacts {
@@ -678,6 +689,17 @@ mod platform {
                 ),
                 role: Role::Entry,
             }
+        }
+
+        #[test]
+        fn empty_collection_result_does_not_walk_the_tree() {
+            assert_eq!(
+                resolve_focus_candidates(Some(Vec::<i32>::new()), Some(vec![1, 2])),
+                Some(vec![])
+            );
+            assert_eq!(resolve_focus_candidates(Some(vec![7]), Some(vec![1])), Some(vec![7]));
+            assert_eq!(resolve_focus_candidates(None, Some(vec![9])), Some(vec![9]));
+            assert_eq!(resolve_focus_candidates::<i32>(None, None), None);
         }
 
         #[test]

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -143,7 +143,10 @@ mod platform {
         }
 
         fn is_focused_text_target(self) -> bool {
-            self.states.contains(State::Focused) && self.interfaces.contains(Interface::Text | Interface::EditableText)
+            self.states.contains(State::Focused)
+                && self.states.contains(State::Editable)
+                && !self.states.contains(State::ReadOnly)
+                && self.interfaces.contains(Interface::Text | Interface::EditableText)
         }
 
         fn is_focused(self) -> bool {
@@ -266,10 +269,11 @@ mod platform {
                 .map_err(|_| InjectError::Unsupported)
         })
         .await?;
-        match insert_into_editable_field(&connection, deadline, &text).await {
+        let focus_pid = focus_window.and_then(crate::os_focus::window_process_id);
+        match insert_into_editable_field(&connection, deadline, &text, focus_pid).await {
             Ok(()) => Ok(()),
             Err(error) if can_synthesize_keys(&error) => {
-                synthesize_into_focused_target(&connection, deadline, &text, focus_window).await
+                synthesize_into_focused_target(&connection, deadline, &text, focus_window, focus_pid).await
             }
             Err(error) => Err(error),
         }
@@ -279,8 +283,9 @@ mod platform {
         connection: &AccessibilityConnection,
         deadline: tokio::time::Instant,
         text: &str,
+        focus_pid: Option<u32>,
     ) -> Result<(), InjectError> {
-        let target = bounded_preflight(deadline, find_focused_target(connection)).await?;
+        let target = bounded_preflight(deadline, find_focused_target(connection, focus_pid)).await?;
         let accessible = bounded_preflight(deadline, async {
             target
                 .as_accessible_proxy(connection.connection())
@@ -350,8 +355,11 @@ mod platform {
             .map_err(|_| InjectError::Failed("accessibility preflight timed out"))?
     }
 
-    async fn find_focused_target(connection: &AccessibilityConnection) -> Result<ObjectRefOwned, InjectError> {
-        find_unique_focus(connection, FocusSearch::EditableText, unique_candidate_index).await
+    async fn find_focused_target(
+        connection: &AccessibilityConnection,
+        focus_pid: Option<u32>,
+    ) -> Result<ObjectRefOwned, InjectError> {
+        find_unique_focus(connection, FocusSearch::EditableText, unique_candidate_index, focus_pid).await
     }
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -365,7 +373,9 @@ mod platform {
         let collection = proxies.collection().await.ok()?;
         let mut rule = ObjectMatchRule::builder().states([State::Focused], MatchType::All);
         if search == FocusSearch::EditableText {
-            rule = rule.interfaces([Interface::Text, Interface::EditableText], MatchType::All);
+            rule = rule
+                .states([State::Focused, State::Editable], MatchType::All)
+                .interfaces([Interface::Text, Interface::EditableText], MatchType::All);
         }
         collection
             .get_matches(rule.build(), SortOrder::Canonical, 2, true)
@@ -434,6 +444,19 @@ mod platform {
         }
     }
 
+    fn include_atspi_app(app_pid: Option<u32>, focus_pid: Option<u32>) -> bool {
+        matches!((app_pid, focus_pid), (Some(app), Some(focus)) if app == focus)
+    }
+
+    async fn atspi_application_pid(
+        dbus: &atspi::zbus::fdo::DBusProxy<'_>,
+        application: &ObjectRefOwned,
+    ) -> Option<u32> {
+        let name = application.name()?;
+        let bus_name = atspi::zbus::names::BusName::try_from(name.as_str()).ok()?;
+        dbus.get_connection_unix_process_id(bus_name).await.ok()
+    }
+
     fn unique_index(candidate_count: usize, empty: &'static str, multiple: &'static str) -> Result<usize, InjectError> {
         if candidate_count == 0 {
             return Err(InjectError::Target(empty));
@@ -499,6 +522,7 @@ mod platform {
         connection: &AccessibilityConnection,
         search: FocusSearch,
         unique_index: fn(usize) -> Result<usize, InjectError>,
+        focus_pid: Option<u32>,
     ) -> Result<ObjectRefOwned, InjectError> {
         let registry = connection
             .root_accessible_on_registry()
@@ -508,9 +532,17 @@ mod platform {
             .get_children()
             .await
             .map_err(|_| InjectError::Failed("failed to inspect accessible applications"))?;
+        let dbus = atspi::zbus::fdo::DBusProxy::new(connection.connection()).await.ok();
         let mut candidates = Vec::new();
         for application in applications {
             if application.is_null() {
+                continue;
+            }
+            let app_pid = match dbus.as_ref() {
+                Some(proxy) => atspi_application_pid(proxy, &application).await,
+                None => None,
+            };
+            if !include_atspi_app(app_pid, focus_pid) {
                 continue;
             }
             let Ok(root) = application.as_accessible_proxy(connection.connection()).await else {
@@ -540,8 +572,11 @@ mod platform {
         Ok(candidates.swap_remove(index))
     }
 
-    async fn find_focused_object(connection: &AccessibilityConnection) -> Result<ObjectRefOwned, InjectError> {
-        find_unique_focus(connection, FocusSearch::FocusedOnly, unique_focused_index).await
+    async fn find_focused_object(
+        connection: &AccessibilityConnection,
+        focus_pid: Option<u32>,
+    ) -> Result<ObjectRefOwned, InjectError> {
+        find_unique_focus(connection, FocusSearch::FocusedOnly, unique_focused_index, focus_pid).await
     }
 
     async fn synthesize_into_focused_target(
@@ -549,9 +584,10 @@ mod platform {
         deadline: tokio::time::Instant,
         text: &str,
         focus_window: Option<u32>,
+        focus_pid: Option<u32>,
     ) -> Result<(), InjectError> {
-        ensure_synthesis_target_still_safe(connection, deadline).await?;
-        synthesize_key_string(connection, deadline, text, focus_window).await
+        ensure_synthesis_target_still_safe(connection, deadline, focus_pid).await?;
+        synthesize_key_string(connection, deadline, text, focus_window, focus_pid).await
     }
 
     async fn synthesize_key_string(
@@ -559,6 +595,7 @@ mod platform {
         deadline: tokio::time::Instant,
         text: &str,
         focus_window: Option<u32>,
+        focus_pid: Option<u32>,
     ) -> Result<(), InjectError> {
         let proxy = bounded_preflight(deadline, async {
             DeviceEventControllerProxy::new(connection.connection())
@@ -570,7 +607,7 @@ mod platform {
         // Tab/click can move focus to a password or selection in the same
         // window while the device proxy is created. Re-classify immediately
         // before the mutating call; unclassified Chromium/Teams still type.
-        ensure_synthesis_target_still_safe(connection, deadline).await?;
+        ensure_synthesis_target_still_safe(connection, deadline, focus_pid).await?;
         ensure_focus_window_unchanged(focus_window)?;
         proxy
             .generate_keyboard_event(0, text, KeySynthType::String)
@@ -582,8 +619,9 @@ mod platform {
     async fn ensure_synthesis_target_still_safe(
         connection: &AccessibilityConnection,
         deadline: tokio::time::Instant,
+        focus_pid: Option<u32>,
     ) -> Result<(), InjectError> {
-        match bounded_preflight(deadline, find_focused_object(connection)).await {
+        match bounded_preflight(deadline, find_focused_object(connection, focus_pid)).await {
             Ok(target) => validate_classified_synthesis_target(connection, deadline, target).await,
             // No AT-SPI focused object (Chromium/Teams). Type into OS focus.
             Err(error) if is_unclassified_focus(&error) => Ok(()),
@@ -677,8 +715,8 @@ mod platform {
 
         use super::{
             INSERT_LOCK, InjectError, TargetFacts, TextSnapshot, can_synthesize_keys, focus_window_still_matches,
-            is_unclassified_focus, resolve_focus_candidates, sanitize_desktop_transcript, unique_candidate_index,
-            unique_focused_index,
+            include_atspi_app, is_unclassified_focus, resolve_focus_candidates, sanitize_desktop_transcript,
+            unique_candidate_index, unique_focused_index,
         };
 
         fn safe_target() -> TargetFacts {
@@ -734,6 +772,31 @@ mod platform {
             }));
             assert_eq!(missing, None);
             assert!(walked);
+        }
+
+        #[test]
+        fn leftover_focused_apps_do_not_claim_the_os_focus_target() {
+            const TEAMS: u32 = 54_087;
+            const FIREFOX: u32 = 14_474;
+            const GNOME_SHELL: u32 = 6_749;
+            assert!(include_atspi_app(Some(TEAMS), Some(TEAMS)));
+            assert!(!include_atspi_app(Some(FIREFOX), Some(TEAMS)));
+            assert!(!include_atspi_app(Some(GNOME_SHELL), Some(TEAMS)));
+            assert!(!include_atspi_app(None, Some(TEAMS)));
+            assert!(!include_atspi_app(Some(TEAMS), None));
+            assert!(!include_atspi_app(None, None));
+        }
+
+        #[test]
+        fn focused_text_targets_require_an_editable_state() {
+            assert!(safe_target().is_focused_text_target());
+            let mut document = safe_target();
+            document.role = Role::DocumentWeb;
+            document.states.remove(State::Editable);
+            assert!(!document.is_focused_text_target());
+            let mut read_only = safe_target();
+            read_only.states.insert(State::ReadOnly);
+            assert!(!read_only.is_focused_text_target());
         }
 
         #[test]

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -421,10 +421,16 @@ mod platform {
         Some(candidates)
     }
 
-    fn resolve_focus_candidates<T>(collection: Option<Vec<T>>, traversal: Option<Vec<T>>) -> Option<Vec<T>> {
+    async fn resolve_focus_candidates<T, Fut>(
+        collection: Option<Vec<T>>,
+        traversal: impl FnOnce() -> Fut,
+    ) -> Option<Vec<T>>
+    where
+        Fut: Future<Output = Option<Vec<T>>>,
+    {
         match collection {
             Some(candidates) => Some(candidates),
-            None => traversal,
+            None => traversal().await,
         }
     }
 
@@ -514,13 +520,11 @@ mod platform {
             // Treating Some([]) as "unknown" walks GNOME Shell (~4s to the
             // 2048-object cap) and the 5s preflight deadline expires before
             // Chromium/Teams KEY_STRING.
-            let collection = collection_candidates(&root, search).await;
-            let traversal = if collection.is_none() {
-                traversal_candidates(application, connection.connection(), search).await
-            } else {
-                None
-            };
-            let Some(discovered) = resolve_focus_candidates(collection, traversal) else {
+            let Some(discovered) = resolve_focus_candidates(collection_candidates(&root, search).await, || {
+                traversal_candidates(application, connection.connection(), search)
+            })
+            .await
+            else {
                 continue;
             };
             for candidate in discovered {
@@ -666,6 +670,7 @@ mod platform {
 
     #[cfg(test)]
     mod tests {
+        use std::future::Future;
         use std::sync::PoisonError;
 
         use atspi::{Interface, InterfaceSet, Role, State, StateSet};
@@ -691,15 +696,44 @@ mod platform {
             }
         }
 
+        fn block_on_test<T>(future: impl Future<Output = T>) -> T {
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap_or_else(|error| panic!("{error}"))
+                .block_on(future)
+        }
+
         #[test]
         fn empty_collection_result_does_not_walk_the_tree() {
-            assert_eq!(
-                resolve_focus_candidates(Some(Vec::<i32>::new()), Some(vec![1, 2])),
-                Some(vec![])
-            );
-            assert_eq!(resolve_focus_candidates(Some(vec![7]), Some(vec![1])), Some(vec![7]));
-            assert_eq!(resolve_focus_candidates(None, Some(vec![9])), Some(vec![9]));
-            assert_eq!(resolve_focus_candidates::<i32>(None, None), None);
+            let mut walked = false;
+            let empty = block_on_test(resolve_focus_candidates(Some(Vec::<i32>::new()), || {
+                walked = true;
+                async { Some(vec![1, 2]) }
+            }));
+            assert_eq!(empty, Some(vec![]));
+            assert!(!walked);
+
+            let hit = block_on_test(resolve_focus_candidates(Some(vec![7]), || {
+                walked = true;
+                async { Some(vec![1]) }
+            }));
+            assert_eq!(hit, Some(vec![7]));
+            assert!(!walked);
+
+            let from_walk = block_on_test(resolve_focus_candidates(None, || {
+                walked = true;
+                async { Some(vec![9]) }
+            }));
+            assert_eq!(from_walk, Some(vec![9]));
+            assert!(walked);
+
+            walked = false;
+            let missing = block_on_test(resolve_focus_candidates::<i32, _>(None, || {
+                walked = true;
+                async { None }
+            }));
+            assert_eq!(missing, None);
+            assert!(walked);
         }
 
         #[test]

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -390,15 +390,28 @@ mod platform {
         FocusedOnly,
     }
 
-    async fn collection_candidates(root: &AccessibleProxy<'_>, search: FocusSearch) -> Option<Vec<ObjectRefOwned>> {
-        let proxies = root.proxies().await.ok()?;
-        let collection = proxies.collection().await.ok()?;
+    fn collection_match_rule(search: FocusSearch) -> ObjectMatchRule {
         let mut rule = ObjectMatchRule::builder().states([State::Focused], MatchType::All);
         if search == FocusSearch::EditableText {
             rule = rule.interfaces([Interface::Text, Interface::EditableText], MatchType::All);
         }
+        let mut rule = rule.build();
+        // atspi-rs defaults unused match types to Invalid. GTK's Collection
+        // treats Invalid as "match nothing", so a Focused-only rule returns
+        // empty and KEY_STRING replaces a classified selection.
+        rule.attr_mt = MatchType::All;
+        rule.roles_mt = MatchType::All;
+        if search != FocusSearch::EditableText {
+            rule.ifaces_mt = MatchType::All;
+        }
+        rule
+    }
+
+    async fn collection_candidates(root: &AccessibleProxy<'_>, search: FocusSearch) -> Option<Vec<ObjectRefOwned>> {
+        let proxies = root.proxies().await.ok()?;
+        let collection = proxies.collection().await.ok()?;
         collection
-            .get_matches(rule.build(), SortOrder::Canonical, 2, true)
+            .get_matches(collection_match_rule(search), SortOrder::Canonical, 2, true)
             .await
             .ok()
     }
@@ -676,10 +689,7 @@ mod platform {
                     .text()
                     .await
                     .map_err(|_| InjectError::Target("focused field does not expose readable text state"))?;
-                let selection_count = text_proxy
-                    .get_n_selections()
-                    .await
-                    .map_err(|_| InjectError::Failed("failed to inspect focused field selection"))?;
+                let selection_count = read_visible_selection_count(&text_proxy).await?;
                 Ok(selection_count != 0)
             };
             if let Ok(true) = bounded_preflight(deadline, selected).await {
@@ -709,11 +719,30 @@ mod platform {
         Ok(TargetFacts::new(interfaces, states, role))
     }
 
-    async fn read_text_snapshot(text: &TextProxy<'_>) -> Result<TextSnapshot, InjectError> {
-        let selection_count = text
+    fn visible_selection_count(reported: i32, first_selection: Option<(i32, i32)>) -> i32 {
+        if reported != 0 {
+            reported
+        } else {
+            i32::from(first_selection.is_some_and(|(start, end)| start != end))
+        }
+    }
+
+    async fn read_visible_selection_count(text: &TextProxy<'_>) -> Result<i32, InjectError> {
+        let reported = text
             .get_n_selections()
             .await
             .map_err(|_| InjectError::Failed("failed to inspect focused field selection"))?;
+        if reported != 0 {
+            return Ok(reported);
+        }
+        // GTK can report a caret-range selection via GetSelection(0) while
+        // GetNSelections is 0. Treat a non-empty range as selected so dictation
+        // cannot replace highlighted text.
+        Ok(visible_selection_count(reported, text.get_selection(0).await.ok()))
+    }
+
+    async fn read_text_snapshot(text: &TextProxy<'_>) -> Result<TextSnapshot, InjectError> {
+        let selection_count = read_visible_selection_count(text).await?;
         let caret = text
             .caret_offset()
             .await
@@ -734,12 +763,13 @@ mod platform {
         use std::future::Future;
         use std::sync::PoisonError;
 
-        use atspi::{Interface, InterfaceSet, Role, State, StateSet};
+        use atspi::{Interface, InterfaceSet, MatchType, Role, State, StateSet};
 
         use super::{
-            INSERT_LOCK, InjectError, TargetFacts, TextSnapshot, can_synthesize_keys, focus_window_still_matches,
-            include_atspi_app, is_unclassified_focus, resolve_focus_candidates, sanitize_desktop_transcript,
-            unique_candidate_index, unique_focused_index,
+            FocusSearch, INSERT_LOCK, InjectError, TargetFacts, TextSnapshot, can_synthesize_keys,
+            collection_match_rule, focus_window_still_matches, include_atspi_app, is_unclassified_focus,
+            resolve_focus_candidates, sanitize_desktop_transcript, unique_candidate_index, unique_focused_index,
+            visible_selection_count,
         };
 
         fn safe_target() -> TargetFacts {
@@ -795,6 +825,20 @@ mod platform {
             }));
             assert_eq!(missing, None);
             assert!(walked);
+        }
+
+        #[test]
+        fn collection_rules_do_not_leave_unused_match_types_invalid() {
+            let editable = collection_match_rule(FocusSearch::EditableText);
+            assert_eq!(editable.states_mt, MatchType::All);
+            assert_eq!(editable.ifaces_mt, MatchType::All);
+            assert_eq!(editable.roles_mt, MatchType::All);
+            assert_eq!(editable.attr_mt, MatchType::All);
+            let focused = collection_match_rule(FocusSearch::FocusedOnly);
+            assert_eq!(focused.states_mt, MatchType::All);
+            assert_eq!(focused.ifaces_mt, MatchType::All);
+            assert_eq!(focused.roles_mt, MatchType::All);
+            assert_eq!(focused.attr_mt, MatchType::All);
         }
 
         #[test]
@@ -1059,6 +1103,11 @@ mod platform {
                     "selected text cannot be replaced safely by direct dictation"
                 ))
             );
+            assert_eq!(visible_selection_count(1, None), 1);
+            assert_eq!(visible_selection_count(0, Some((0, 7))), 1);
+            assert_eq!(visible_selection_count(0, Some((7, 0))), 1);
+            assert_eq!(visible_selection_count(0, Some((0, 0))), 0);
+            assert_eq!(visible_selection_count(0, None), 0);
         }
 
         #[test]

--- a/crates/horizon-cursor/src/accessibility.rs
+++ b/crates/horizon-cursor/src/accessibility.rs
@@ -142,11 +142,12 @@ mod platform {
             }
         }
 
+        fn has_text_interfaces(self) -> bool {
+            self.interfaces.contains(Interface::Text | Interface::EditableText)
+        }
+
         fn is_focused_text_target(self) -> bool {
-            self.states.contains(State::Focused)
-                && self.states.contains(State::Editable)
-                && !self.states.contains(State::ReadOnly)
-                && self.interfaces.contains(Interface::Text | Interface::EditableText)
+            self.states.contains(State::Focused) && self.has_text_interfaces()
         }
 
         fn is_focused(self) -> bool {
@@ -169,6 +170,12 @@ mod platform {
             if !self.states.contains(State::Visible | State::Showing) {
                 return Err(InjectError::Target("focused field is not visible"));
             }
+            // GTK read-only entries still expose Text+EditableText. Chromium
+            // Frame/DocumentWeb often report ReadOnly without those interfaces;
+            // KEY_STRING into that unclassified window must keep working.
+            if self.has_text_interfaces() && self.states.contains(State::ReadOnly) {
+                return Err(InjectError::Target("focused field is not editable"));
+            }
             Ok(())
         }
 
@@ -182,13 +189,20 @@ mod platform {
             if !self.states.contains(State::Focused) {
                 return Err(InjectError::Target("focused accessibility target changed"));
             }
-            if !self.interfaces.contains(Interface::Text | Interface::EditableText) {
+            if !self.has_text_interfaces() {
                 return Err(InjectError::Target(
                     "focused field does not support direct text insertion",
                 ));
             }
-            if !self.states.contains(State::Editable) || self.states.contains(State::ReadOnly) {
+            if self.states.contains(State::ReadOnly) {
                 return Err(InjectError::Target("focused field is not editable"));
+            }
+            if !self.states.contains(State::Editable) {
+                // Firefox documents expose EditableText without Editable.
+                // Keep them classified, then fall back to KEY_STRING.
+                return Err(InjectError::Target(
+                    "focused application does not expose an editable text field",
+                ));
             }
             if !self.states.contains(State::Enabled | State::Sensitive) {
                 return Err(InjectError::Target("focused field is not available for input"));
@@ -381,9 +395,7 @@ mod platform {
         let collection = proxies.collection().await.ok()?;
         let mut rule = ObjectMatchRule::builder().states([State::Focused], MatchType::All);
         if search == FocusSearch::EditableText {
-            rule = rule
-                .states([State::Focused, State::Editable], MatchType::All)
-                .interfaces([Interface::Text, Interface::EditableText], MatchType::All);
+            rule = rule.interfaces([Interface::Text, Interface::EditableText], MatchType::All);
         }
         collection
             .get_matches(rule.build(), SortOrder::Canonical, 2, true)
@@ -801,15 +813,23 @@ mod platform {
         }
 
         #[test]
-        fn focused_text_targets_require_an_editable_state() {
+        fn focused_text_targets_include_read_only_and_non_editable_text() {
             assert!(safe_target().is_focused_text_target());
             let mut document = safe_target();
             document.role = Role::DocumentWeb;
             document.states.remove(State::Editable);
-            assert!(!document.is_focused_text_target());
+            assert!(document.is_focused_text_target());
             let mut read_only = safe_target();
             read_only.states.insert(State::ReadOnly);
-            assert!(!read_only.is_focused_text_target());
+            assert!(read_only.is_focused_text_target());
+            let mut unfocused = safe_target();
+            unfocused.states.remove(State::Focused);
+            assert!(!unfocused.is_focused_text_target());
+            let missing_interface = TargetFacts {
+                interfaces: InterfaceSet::new(Interface::Text),
+                ..safe_target()
+            };
+            assert!(!missing_interface.is_focused_text_target());
         }
 
         #[test]
@@ -837,6 +857,9 @@ mod platform {
             )));
             assert!(!can_synthesize_keys(&InjectError::Target(
                 "multiple focused editable fields were reported"
+            )));
+            assert!(!can_synthesize_keys(&InjectError::Target(
+                "focused field is not editable"
             )));
         }
 
@@ -871,6 +894,18 @@ mod platform {
             let mut read_only_frame = frame;
             read_only_frame.states.insert(State::ReadOnly);
             assert_eq!(read_only_frame.validate_synthesis_target(), Ok(()));
+
+            let mut read_only_text = safe_target();
+            read_only_text.states.insert(State::ReadOnly);
+            assert_eq!(
+                read_only_text.validate_synthesis_target(),
+                Err(InjectError::Target("focused field is not editable"))
+            );
+
+            let mut firefox_document = safe_target();
+            firefox_document.role = Role::DocumentWeb;
+            firefox_document.states.remove(State::Editable);
+            assert_eq!(firefox_document.validate_synthesis_target(), Ok(()));
 
             let mut hidden = frame;
             hidden.states.remove(State::Showing);
@@ -992,6 +1027,18 @@ mod platform {
                 assert!(matches!(unsafe_target.validate(), Err(InjectError::Target(_))));
             }
             assert_eq!(safe_target().validate(), Ok(()));
+            assert_eq!(
+                not_editable.validate(),
+                Err(InjectError::Target(
+                    "focused application does not expose an editable text field"
+                ))
+            );
+            assert!(can_synthesize_keys(&not_editable.validate().unwrap_err()));
+            assert_eq!(
+                read_only.validate(),
+                Err(InjectError::Target("focused field is not editable"))
+            );
+            assert!(!can_synthesize_keys(&read_only.validate().unwrap_err()));
         }
 
         #[test]

--- a/crates/horizon-cursor/src/os_focus.rs
+++ b/crates/horizon-cursor/src/os_focus.rs
@@ -51,10 +51,14 @@ pub fn current_input_focus_window() -> Option<u32> {
     platform::current_input_focus_window()
 }
 
-/// `_NET_WM_PID` of `window`, walking parents when the focused child has none.
+/// `_NET_WM_PID` values around `window`, including parent frames and children.
+///
+/// Compositor frames can own the X11 focus window while the client PID lives
+/// on a child. A single parent-chain PID would then miss the focused app.
+#[cfg(target_os = "linux")]
 #[must_use]
-pub fn window_process_id(window: u32) -> Option<u32> {
-    platform::window_process_id(window)
+pub fn window_candidate_pids(window: u32) -> Option<Vec<u32>> {
+    platform::window_candidate_pids(window)
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -98,7 +102,8 @@ mod platform {
         })
     }
 
-    pub(super) fn window_process_id(window: Window) -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    pub(super) fn window_candidate_pids(window: Window) -> Option<Vec<u32>> {
         DISPLAY.with(|slot| {
             let mut slot = slot.borrow_mut();
             if slot.is_none() {
@@ -106,27 +111,14 @@ mod platform {
             }
             let (conn, screen_num) = slot.as_ref()?;
             let root = conn.setup().roots.get(*screen_num)?.root;
+            if !is_focus_candidate(window, root) {
+                return Some(Vec::new());
+            }
             let (_, net_pid) = net_atoms(conn)?;
-            pid_for_window_or_parent(conn, window, root, net_pid)
+            let mut pids = Vec::new();
+            collect_pids_around(conn, window, root, net_pid, &mut pids);
+            Some(pids)
         })
-    }
-
-    fn pid_for_window_or_parent(conn: &RustConnection, window: Window, root: Window, pid_atom: Atom) -> Option<u32> {
-        if !is_focus_candidate(window, root) {
-            return None;
-        }
-        let mut current = window;
-        for _ in 0..MAX_PARENT_WALKS {
-            if let Some(pid) = window_pid(conn, current, pid_atom) {
-                return Some(pid);
-            }
-            let tree = conn.query_tree(current).ok()?.reply().ok()?;
-            if tree.parent == NONE || tree.parent == root || tree.parent == current {
-                return window_pid(conn, tree.parent, pid_atom);
-            }
-            current = tree.parent;
-        }
-        None
     }
 
     fn focused_candidate_pids() -> Option<Vec<u32>> {
@@ -355,10 +347,6 @@ mod platform {
     }
 
     pub(super) const fn current_input_focus_window() -> Option<u32> {
-        None
-    }
-
-    pub(super) const fn window_process_id(_window: u32) -> Option<u32> {
         None
     }
 }

--- a/crates/horizon-cursor/src/os_focus.rs
+++ b/crates/horizon-cursor/src/os_focus.rs
@@ -51,6 +51,12 @@ pub fn current_input_focus_window() -> Option<u32> {
     platform::current_input_focus_window()
 }
 
+/// `_NET_WM_PID` of `window`, walking parents when the focused child has none.
+#[must_use]
+pub fn window_process_id(window: u32) -> Option<u32> {
+    platform::window_process_id(window)
+}
+
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 mod platform {
     use std::cell::RefCell;
@@ -90,6 +96,37 @@ mod platform {
                 .map(|reply| reply.focus)?;
             is_focus_candidate(focus, root).then_some(focus)
         })
+    }
+
+    pub(super) fn window_process_id(window: Window) -> Option<u32> {
+        DISPLAY.with(|slot| {
+            let mut slot = slot.borrow_mut();
+            if slot.is_none() {
+                *slot = x11rb::connect(None).ok();
+            }
+            let (conn, screen_num) = slot.as_ref()?;
+            let root = conn.setup().roots.get(*screen_num)?.root;
+            let (_, net_pid) = net_atoms(conn)?;
+            pid_for_window_or_parent(conn, window, root, net_pid)
+        })
+    }
+
+    fn pid_for_window_or_parent(conn: &RustConnection, window: Window, root: Window, pid_atom: Atom) -> Option<u32> {
+        if !is_focus_candidate(window, root) {
+            return None;
+        }
+        let mut current = window;
+        for _ in 0..MAX_PARENT_WALKS {
+            if let Some(pid) = window_pid(conn, current, pid_atom) {
+                return Some(pid);
+            }
+            let tree = conn.query_tree(current).ok()?.reply().ok()?;
+            if tree.parent == NONE || tree.parent == root || tree.parent == current {
+                return window_pid(conn, tree.parent, pid_atom);
+            }
+            current = tree.parent;
+        }
+        None
     }
 
     fn focused_candidate_pids() -> Option<Vec<u32>> {
@@ -318,6 +355,10 @@ mod platform {
     }
 
     pub(super) const fn current_input_focus_window() -> Option<u32> {
+        None
+    }
+
+    pub(super) const fn window_process_id(_window: u32) -> Option<u32> {
         None
     }
 }

--- a/docs/testing/2026-09-03-linux-speech-insert-smoke.md
+++ b/docs/testing/2026-09-03-linux-speech-insert-smoke.md
@@ -1,7 +1,8 @@
 # Linux Speech Insertion Smoke Test
 
 Temporary validation for desktop dictation into Horizon terminals and apps
-that do not expose an AT-SPI editable field (Microsoft Teams / Chromium PWAs).
+that do not expose an AT-SPI editable field (Microsoft Teams / Chromium PWAs,
+Firefox content).
 
 Run against the exact candidate head. Do not stop or reuse a pre-existing
 Horizon process. Use an isolated config and `--ephemeral`. Never log
@@ -36,6 +37,7 @@ cargo build --features speech
 4. Confirm the marker appears at the caret in the compose box and the chat is not sent.
 5. Confirm the clipboard is unchanged.
 6. Confirm insertion finishes without an accessibility preflight timeout toast. On GNOME, Shell's AT-SPI tree is large; an empty Collection match must not fall through to a full tree walk or Chromium never receives KEY_STRING.
+7. With Firefox (or another AT-SPI app) still open in the background, dictate into Teams/Chromium again. Insertion must not fail with `multiple focused fields were reported`; leftover focused objects in other apps must not veto KEY_STRING.
 
 ## 4. Refusals
 

--- a/docs/testing/2026-09-03-linux-speech-insert-smoke.md
+++ b/docs/testing/2026-09-03-linux-speech-insert-smoke.md
@@ -35,6 +35,7 @@ cargo build --features speech
 3. Speak a unique marker that contains no newline.
 4. Confirm the marker appears at the caret in the compose box and the chat is not sent.
 5. Confirm the clipboard is unchanged.
+6. Confirm insertion finishes without an accessibility preflight timeout toast. On GNOME, Shell's AT-SPI tree is large; an empty Collection match must not fall through to a full tree walk or Chromium never receives KEY_STRING.
 
 ## 4. Refusals
 


### PR DESCRIPTION
## Purpose

Linux desktop dictation into Chromium/Teams/Outlook PWAs failed on GNOME: insertion hit `accessibility preflight timed out` and never typed the transcript.

AT-SPI `Collection.GetMatches` for GNOME Shell returns no focused objects (a valid empty answer). The previous code treated `Some([])` as unknown and BFS-walked up to 2048 clutter nodes (~4s). That consumed the 5s preflight deadline, so KEY_STRING into the focused Chromium window never ran.

## Behavior

- Trust an empty Collection match. Only walk an application's tree when Collection is missing or errors.
- Chromium, Electron, and Microsoft Teams still get KEY_STRING when they expose no editable field.
- GTK/Qt apps that implement Collection still get direct `InsertText`.
- Classified `PasswordText` and visible selections still refuse. No clipboard, no Return.

## Test evidence

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- Advisory: `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- Live AT-SPI: focused GTK entry received `direct blå final marker zephyr` via `insert_text` in ~3.3s (previously the GNOME Shell walk could exhaust the 5s deadline before KEY_STRING).

## Smoke

Plan: `docs/testing/2026-09-03-linux-speech-insert-smoke.md`

Restart Horizon after this lands; the currently running process will not pick up the fix.