### PR TITLE
fix(ui): keep panel area input inside canvas

### DIFF
--- a/crates/horizon-ui/src/app/panels.rs
+++ b/crates/horizon-ui/src/app/panels.rs
@@ -19,6 +19,7 @@ pub(super) use super::panel_chrome::{
 use super::shortcut_inventory::{global_shortcut_bindings, ssh_reconnect_shortcut_conflicts};
 use super::speech::MicState;
 use super::util::primary_shortcut_label;
+use super::view::canvas_scene_transform;
 use super::{HorizonApp, PANEL_PADDING, PANEL_TITLEBAR_HEIGHT, RESIZE_HANDLE_SIZE, RenameEditAction};
 
 mod interaction;
@@ -265,6 +266,18 @@ fn clip_screen_rect_to_canvas(raw_rect: Rect, canvas_rect: Rect) -> Option<Rect>
         && clipped.max.x.is_finite()
         && clipped.max.y.is_finite())
     .then_some(clipped)
+}
+
+trait CanvasClippedArea {
+    fn clip_to_canvas(self, canvas_layer_clip: Rect) -> Self;
+}
+
+impl CanvasClippedArea for egui::Area {
+    fn clip_to_canvas(self, canvas_layer_clip: Rect) -> Self {
+        // Keep the explicit clip for hit-testing without forcing the panel's
+        // freely positioned canvas coordinates inside that rectangle.
+        self.constrain_to(canvas_layer_clip).constrain(false)
+    }
 }
 
 impl HorizonApp {
@@ -580,13 +593,17 @@ impl HorizonApp {
         } else {
             &all_shortcut_bindings[..]
         };
+        // Area registers its parent response before the closure applies the
+        // canvas transform and clip. Give that response the same local-layer
+        // clip so an off-canvas panel cannot block fixed overlay controls.
+        let canvas_layer_clip = canvas_scene_transform(canvas_rect, self.canvas_view).inverse() * canvas_rect;
 
         // The area must stay interactable: since egui 0.36, non-interactable
         // layers are skipped by hit-testing, which makes every widget inside
         // (titlebar drag, close, resize handles) click-through.
         egui::Area::new(Id::new(("panel", panel_id.0)))
             .fixed_pos(snapshot.canvas_position)
-            .constrain(false)
+            .clip_to_canvas(canvas_layer_clip)
             .order(if snapshot.is_focused {
                 Order::Foreground
             } else {

--- a/crates/horizon-ui/src/app/panels/tests.rs
+++ b/crates/horizon-ui/src/app/panels/tests.rs
@@ -3,8 +3,8 @@ use egui::{Context, Event, Id, Key, Modifiers, PointerButton, Pos2, RawInput, Re
 use horizon_core::{AgentSessionBinding, PanelKind};
 
 use super::{
-    MicState, clip_screen_rect_to_canvas, mic_accessibility_label, mic_control_enabled, mic_control_response,
-    mic_widget_info, render_session_rebind_options,
+    CanvasClippedArea, MicState, clip_screen_rect_to_canvas, mic_accessibility_label, mic_control_enabled,
+    mic_control_response, mic_widget_info, render_session_rebind_options,
 };
 
 fn key_press(key: Key) -> Event {
@@ -80,6 +80,63 @@ fn session_binding(session_id: &str) -> AgentSessionBinding {
     )
 }
 
+fn overlay_click_frame(ctx: &Context, events: Vec<Event>, panel_clip: Rect) -> bool {
+    let input = RawInput {
+        screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(500.0, 240.0))),
+        events,
+        ..RawInput::default()
+    };
+    let mut clicked = false;
+    let _ = ctx
+        .run_ui(input, |ui| {
+            clicked = ui
+                .put(
+                    Rect::from_min_size(Pos2::new(300.0, 80.0), Vec2::new(100.0, 30.0)),
+                    egui::Button::new("YAML"),
+                )
+                .clicked();
+            egui::Area::new(Id::new("panel-overlap-test"))
+                .fixed_pos(Pos2::ZERO)
+                .clip_to_canvas(panel_clip)
+                .order(egui::Order::Foreground)
+                .show(ctx, |ui| {
+                    let _ = ui.allocate_exact_size(Vec2::new(500.0, 200.0), egui::Sense::click_and_drag());
+                });
+        })
+        .discard_textures();
+    clicked
+}
+
+fn click_overlay_through_panel_clip(panel_clip: Rect) -> bool {
+    let ctx = Context::default();
+    let target = Pos2::new(350.0, 95.0);
+    assert!(!overlay_click_frame(&ctx, Vec::new(), panel_clip));
+    assert!(!overlay_click_frame(&ctx, Vec::new(), panel_clip));
+    assert!(!overlay_click_frame(
+        &ctx,
+        vec![
+            Event::PointerMoved(target),
+            Event::PointerButton {
+                pos: target,
+                button: PointerButton::Primary,
+                pressed: true,
+                modifiers: Modifiers::NONE,
+            },
+        ],
+        panel_clip,
+    ));
+    overlay_click_frame(
+        &ctx,
+        vec![Event::PointerButton {
+            pos: target,
+            button: PointerButton::Primary,
+            pressed: false,
+            modifiers: Modifiers::NONE,
+        }],
+        panel_clip,
+    )
+}
+
 #[test]
 fn clip_screen_rect_to_canvas_intersects_with_canvas_bounds() {
     let canvas_rect = Rect::from_min_max(Pos2::new(100.0, 80.0), Pos2::new(420.0, 320.0));
@@ -97,6 +154,15 @@ fn clip_screen_rect_to_canvas_rejects_non_positive_intersections() {
     let raw_rect = Rect::from_min_size(Pos2::new(430.0, 90.0), Vec2::new(80.0, 80.0));
 
     assert_eq!(clip_screen_rect_to_canvas(raw_rect, canvas_rect), None);
+}
+
+#[test]
+fn canvas_clipped_panel_area_does_not_block_overlay_input() {
+    let full_panel_clip = Rect::from_min_size(Pos2::ZERO, Vec2::new(500.0, 240.0));
+    assert!(!click_overlay_through_panel_clip(full_panel_clip));
+
+    let canvas_clip = Rect::from_min_size(Pos2::ZERO, Vec2::new(200.0, 240.0));
+    assert!(click_overlay_through_panel_clip(canvas_clip));
 }
 
 #[test]


### PR DESCRIPTION
## Purpose

Follow up on #385 after its macOS smoke pass exposed a second overlap path: terminal selection was correctly suppressed under Settings, but a focused panel Area could still claim the same pointer region and prevent the YAML editor itself from selecting text.

## Behavior impact

Clip each panel Area to the inverse-transformed live canvas rect for hit-testing while keeping canvas positioning unconstrained. Fixed Settings controls can now receive pointer input above an intersecting panel; titlebar drag, resize, and terminal selection inside the visible canvas remain unchanged. A focused egui regression test covers the blocked-overlay case and its clipped counterpart.

## Reproduction

1. Open a wide terminal panel that extends underneath the right Settings pane.
2. Open Settings → YAML.
3. Drag across YAML rows whose screen coordinates intersect the hidden terminal.
4. Before this change, no YAML selection appeared; after this change, YAML selects and copies normally without selecting terminal cells.

## Validation

Exact head `dfe1b0afbba5eebac0f4941f068402a847d50efb`:

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- blocking, strict, and pedantic Clippy tiers from AGENTS.md
- macOS 26.6.2 arm64 / Apple M4 Max / Metal live smoke: YAML-only copy, cross-boundary drag, visible terminal selection/copy, Fit transform, panel drag, panel resize, Settings width/tab changes, paste, and relaunch

The temporary #385 smoke plan was removed after the completed pass, per repository policy.