### PR TITLE
feat(remote): add secure worker image contract

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**
+!Cargo.toml
+!Cargo.lock
+!crates/
+!crates/*/
+crates/*/**
+!crates/*/Cargo.toml
+!containers/
+!containers/remote-worker/
+containers/remote-worker/**
+!containers/remote-worker/Dockerfile
+!containers/remote-worker/entrypoint.sh
+!containers/remote-worker/rust-path.sh
+!containers/remote-worker/session.sh
+!containers/remote-worker/sshd_config

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -1,0 +1,180 @@
+ARG WORKER_BASE_IMAGE=rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1
+
+FROM node:24-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e AS node-runtime
+
+FROM ${WORKER_BASE_IMAGE}
+
+ARG WORKER_BASE_IMAGE
+ARG WORKER_IMAGE_VERSION=0.1.0
+ARG CODEX_VERSION=0.153.2
+ARG CLAUDE_VERSION=2.1.260
+ARG GEMINI_VERSION=0.58.0
+ARG OPENCODE_VERSION=1.18.27
+ARG KILO_VERSION=7.5.9
+ARG PI_VERSION=0.84.4
+ARG GROK_VERSION=1.0.18
+ARG GROK_AMD64_SHA256=42f6efb496feafea3e8807b75852cc1f792cba0bd0be8ecbd1c9f7ed5816a7f0
+ARG GROK_ARM64_SHA256=e5c96058b6f88b2e9ae7d61401e80ac6bcbcaf1be5681eae19e36a2b8aff121d
+ARG TARGETARCH
+
+LABEL org.opencontainers.image.title="Horizon remote worker" \
+      org.opencontainers.image.description="Provider-neutral interactive coding worker for Horizon" \
+      org.opencontainers.image.version="${WORKER_IMAGE_VERSION}"
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV RUSTUP_TOOLCHAIN=1.95.0
+ENV HORIZON_WORKER_IMAGE_VERSION=${WORKER_IMAGE_VERSION}
+ENV PATH="/usr/local/cargo/bin:${PATH}"
+
+RUN case "${WORKER_BASE_IMAGE}" in \
+        *@sha256:*) base_digest="${WORKER_BASE_IMAGE##*@sha256:}" ;; \
+        *) echo "WORKER_BASE_IMAGE must be pinned by sha256 digest" >&2; exit 64 ;; \
+    esac \
+    && if [ "${#base_digest}" -ne 64 ]; then \
+        echo "WORKER_BASE_IMAGE must use a 64-character sha256 digest" >&2; \
+        exit 64; \
+    fi \
+    && case "${base_digest}" in \
+        *[!0-9a-f]*) echo "WORKER_BASE_IMAGE sha256 digest must be lowercase hexadecimal" >&2; exit 64 ;; \
+    esac
+
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/include/node/ /usr/local/include/node/
+COPY --from=node-runtime /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+
+RUN ln -sfn node /usr/local/bin/nodejs \
+    && ln -sfn ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack \
+    && ln -sfn ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sfn ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        gh \
+        git \
+        git-lfs \
+        libasound2-dev \
+        libgl-dev \
+        libvulkan-dev \
+        libwayland-dev \
+        libxcb-render0-dev \
+        libxcb-shape0-dev \
+        libxcb-xfixes0-dev \
+        libxkbcommon-dev \
+        openssh-server \
+        pkg-config \
+        python3 \
+        rsync \
+        tar \
+        tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup toolchain install 1.95.0 --profile minimal \
+    && rustup component add --toolchain 1.95.0 rustfmt clippy
+
+# Keep this explicit: npm must fail if a new dependency adds an unreviewed
+# lifecycle script instead of silently skipping or running it.
+RUN npm install --global --no-audit --no-fund --strict-allow-scripts \
+        --allow-scripts="@anthropic-ai/claude-code,@kilocode/cli,opencode-ai,@github/keytar,node-pty,@google/genai,protobufjs" \
+        "@openai/codex@${CODEX_VERSION}" \
+        "@anthropic-ai/claude-code@${CLAUDE_VERSION}" \
+        "@google/gemini-cli@${GEMINI_VERSION}" \
+        "opencode-ai@${OPENCODE_VERSION}" \
+        "@kilocode/cli@${KILO_VERSION}" \
+        "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    && npm cache clean --force
+
+RUN case "${TARGETARCH}" in \
+        amd64) grok_arch=x86_64; grok_sha256="${GROK_AMD64_SHA256}" ;; \
+        arm64) grok_arch=aarch64; grok_sha256="${GROK_ARM64_SHA256}" ;; \
+        *) echo "Unsupported Grok target architecture: ${TARGETARCH}" >&2; exit 64 ;; \
+    esac \
+    && curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+        "https://x.ai/cli/grok-${GROK_VERSION}-linux-${grok_arch}" \
+        --output /usr/local/bin/grok \
+    && printf '%s  %s\n' "${grok_sha256}" /usr/local/bin/grok | sha256sum --check --strict - \
+    && chmod 0755 /usr/local/bin/grok
+
+RUN node --version \
+    && npm --version \
+    && codex --version \
+    && claude --version \
+    && gemini --version \
+    && opencode --version \
+    && kilo --version \
+    && pi --version \
+    && grok --version \
+    && rustc --version \
+    && cargo --version \
+    && git --version \
+    && git lfs version \
+    && gh --version \
+    && rsync --version \
+    && tar --version \
+    && tmux -V
+
+WORKDIR /opt/horizon-dependency-cache
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN mkdir -p \
+        crates/horizon-browser/src \
+        crates/horizon-browser-cli/src \
+        crates/horizon-browser-mcp/src \
+        crates/horizon-browser-protocol/src \
+        crates/horizon-core/src \
+        crates/horizon-cursor/src \
+        crates/horizon-ui/src \
+    && touch \
+        crates/horizon-browser/src/lib.rs \
+        crates/horizon-browser-cli/src/lib.rs \
+        crates/horizon-browser-cli/src/main.rs \
+        crates/horizon-browser-mcp/src/lib.rs \
+        crates/horizon-browser-mcp/src/main.rs \
+        crates/horizon-browser-protocol/src/lib.rs \
+        crates/horizon-core/src/lib.rs \
+        crates/horizon-cursor/src/lib.rs \
+        crates/horizon-ui/src/main.rs \
+    && cargo fetch --locked \
+    && rm -rf /opt/horizon-dependency-cache
+
+WORKDIR /workspace/horizon
+
+COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entrypoint
+COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session
+COPY containers/remote-worker/rust-path.sh /etc/profile.d/horizon-rust.sh
+COPY containers/remote-worker/sshd_config /etc/ssh/sshd_config.d/99-horizon-worker.conf
+
+RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-agent-session \
+    && chmod 0644 /etc/profile.d/horizon-rust.sh /etc/ssh/sshd_config.d/99-horizon-worker.conf \
+    && git lfs install --system \
+    && rm -f /etc/ssh/ssh_host_* \
+    && rm -rf \
+        /root/.cache \
+        /root/.cargo \
+        /root/.claude \
+        /root/.claude.json \
+        /root/.codex \
+        /root/.config \
+        /root/.docker \
+        /root/.gemini \
+        /root/.gitconfig \
+        /root/.grok \
+        /root/.kilo \
+        /root/.local \
+        /root/.netrc \
+        /root/.npm \
+        /root/.npmrc \
+        /root/.opencode \
+        /root/.pi \
+        /root/.rustup \
+        /root/.ssh \
+    && mkdir -p /run/sshd /workspace/horizon
+
+EXPOSE 22
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/horizon-worker-entrypoint"]

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -170,6 +170,9 @@ RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-a
     && mkdir -p /run/sshd /workspace/horizon
 
 ARG WORKER_IMAGE_VERSION=0.1.0
+RUN if [ -z "${WORKER_IMAGE_VERSION}" ]; then \
+        echo "WORKER_IMAGE_VERSION must not be empty" >&2; exit 64; \
+    fi
 LABEL org.opencontainers.image.title="Horizon remote worker" \
       org.opencontainers.image.description="Provider-neutral interactive coding worker for Horizon" \
       org.opencontainers.image.version="${WORKER_IMAGE_VERSION}"

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -5,7 +5,6 @@ FROM node:24-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c
 FROM ${WORKER_BASE_IMAGE}
 
 ARG WORKER_BASE_IMAGE
-ARG WORKER_IMAGE_VERSION=0.1.0
 ARG CODEX_VERSION=0.153.2
 ARG CLAUDE_VERSION=2.1.260
 ARG GEMINI_VERSION=0.58.0
@@ -17,14 +16,9 @@ ARG GROK_AMD64_SHA256=42f6efb496feafea3e8807b75852cc1f792cba0bd0be8ecbd1c9f7ed58
 ARG GROK_ARM64_SHA256=e5c96058b6f88b2e9ae7d61401e80ac6bcbcaf1be5681eae19e36a2b8aff121d
 ARG TARGETARCH
 
-LABEL org.opencontainers.image.title="Horizon remote worker" \
-      org.opencontainers.image.description="Provider-neutral interactive coding worker for Horizon" \
-      org.opencontainers.image.version="${WORKER_IMAGE_VERSION}"
-
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV RUSTUP_TOOLCHAIN=1.95.0
-ENV HORIZON_WORKER_IMAGE_VERSION=${WORKER_IMAGE_VERSION}
 ENV PATH="/usr/local/cargo/bin:${PATH}"
 
 RUN case "${WORKER_BASE_IMAGE}" in \
@@ -174,6 +168,12 @@ RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-a
         /root/.rustup \
         /root/.ssh \
     && mkdir -p /run/sshd /workspace/horizon
+
+ARG WORKER_IMAGE_VERSION=0.1.0
+LABEL org.opencontainers.image.title="Horizon remote worker" \
+      org.opencontainers.image.description="Provider-neutral interactive coding worker for Horizon" \
+      org.opencontainers.image.version="${WORKER_IMAGE_VERSION}"
+ENV HORIZON_WORKER_IMAGE_VERSION=${WORKER_IMAGE_VERSION}
 
 EXPOSE 22
 STOPSIGNAL SIGTERM

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -54,8 +54,9 @@ Each worker requires:
 The optional GitHub token must be mounted as the exact read-only file
 `/run/secrets/github-token`, with `HORIZON_GITHUB_TOKEN_FILE` set to that path.
 Writable mounts, other paths, symlinks, and direct `HORIZON_GITHUB_TOKEN`
-injection are rejected because container environment values and writable host
-binds violate the secret boundary.
+injection are rejected. The standard `GITHUB_TOKEN` and `GH_TOKEN` environment
+variables are rejected too, because container environment values and writable
+host binds violate the secret boundary.
 
 Example:
 

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -59,7 +59,10 @@ values remain inspectable.
 Example:
 
 ```bash
-deadline=$(date -u --date='+30 minutes' +%Y-%m-%dT%H:%M:%SZ)
+deadline=$(
+  docker run --rm --entrypoint date horizon-remote-worker:0.1.0 \
+    -u --date='+30 minutes' +%Y-%m-%dT%H:%M:%SZ
+)
 docker run --rm \
   --publish 127.0.0.1::22 \
   --env "HORIZON_SSH_PUBLIC_KEY=$(ssh-keygen -y -f /path/to/ephemeral-worker-key)" \
@@ -106,6 +109,7 @@ proves:
   baked into the image;
 - both workers accept only the supplied client key;
 - strict known-host verification works and the two runtime host keys differ;
+- repeated token-backed session setup remains idempotent;
 - the optional token is copied with mode `0600` without entering image history
   or container environment values; and
 - a short lease terminates its worker and emits the watchdog marker.

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -46,15 +46,16 @@ credentials are excluded from the build context and final image.
 
 Each worker requires:
 
-- `HORIZON_SSH_PUBLIC_KEY`: exactly one valid OpenSSH public key, with a
-  16 KiB limit.
+- `HORIZON_SSH_PUBLIC_KEY`: exactly one valid OpenSSH Ed25519 public key, with
+  a 16 KiB limit.
 - `HORIZON_TERMINATE_AFTER`: a future RFC 3339 timestamp no more than 30 days
   away.
 
-The optional GitHub token must be mounted as a read-only secret file. Set
-`HORIZON_GITHUB_TOKEN_FILE` to its absolute path inside the container. Direct
-`HORIZON_GITHUB_TOKEN` injection is rejected because container environment
-values remain inspectable.
+The optional GitHub token must be mounted as the exact read-only file
+`/run/secrets/github-token`, with `HORIZON_GITHUB_TOKEN_FILE` set to that path.
+Writable mounts, other paths, symlinks, and direct `HORIZON_GITHUB_TOKEN`
+injection are rejected because container environment values and writable host
+binds violate the secret boundary.
 
 Example:
 
@@ -77,7 +78,8 @@ At startup the entrypoint:
 1. validates the lease, public key, and optional secret file;
 2. creates a new SSH host identity in the container's writable layer;
 3. installs only the supplied public key for root login;
-4. copies the optional token to a root-only runtime file; and
+4. copies the optional token to a root-only runtime file and configures shared
+   Git authentication once, before SSH accepts concurrent sessions; and
 5. starts a watchdog that terminates the worker at the lease deadline.
 
 The in-container watchdog is defense in depth. The provider remains responsible
@@ -109,9 +111,10 @@ proves:
   baked into the image;
 - both workers accept only the supplied client key;
 - strict known-host verification works and the two runtime host keys differ;
-- repeated token-backed session setup remains idempotent;
+- concurrent token-backed sessions do not race or mutate shared Git state;
 - the optional token is copied with mode `0600` without entering image history
-  or container environment values; and
+  or container environment values, and writable or incorrectly located mounts
+  fail closed; and
 - a short lease terminates its worker and emits the watchdog marker.
 
 Use `--image <reference>` to test an existing image. By default, an image built

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -1,0 +1,115 @@
+# Horizon remote worker image
+
+This directory defines the provider-neutral image contract for one interactive
+Horizon coding worker. The image is intentionally separate from provider
+lifecycle code: a provider prepares compute, starts this image with runtime
+credentials and a lease deadline, and destroys the compute after the lease.
+
+The image contains the Rust toolchain, Horizon's Linux build dependencies,
+Git/Git LFS, GitHub CLI, rsync, tar, tmux, SSH, CA certificates, and the
+supported coding-agent CLIs. Their versions and both base-image digests are
+pinned in `Dockerfile`.
+
+## Build
+
+Build from the repository root:
+
+```bash
+docker build \
+  --file containers/remote-worker/Dockerfile \
+  --build-arg WORKER_IMAGE_VERSION=0.1.0 \
+  --tag horizon-remote-worker:0.1.0 \
+  .
+```
+
+The default Rust and Node base images are immutable digest references. A base
+override must also include a SHA-256 digest:
+
+```bash
+docker build \
+  --file containers/remote-worker/Dockerfile \
+  --build-arg WORKER_BASE_IMAGE=registry.example/worker-base@sha256:<64-lowercase-hex-digits> \
+  --build-arg WORKER_IMAGE_VERSION=0.1.0 \
+  --tag horizon-remote-worker:0.1.0 \
+  .
+```
+
+Version tags make development builds understandable, but provider profiles must
+use a registry digest after publication. This slice does not publish an image
+or change any provider configuration.
+
+Only workspace manifests and the lockfile enter the dependency-cache build
+stage. Horizon source, local configuration, SSH material, tokens, and registry
+credentials are excluded from the build context and final image.
+
+## Runtime contract
+
+Each worker requires:
+
+- `HORIZON_SSH_PUBLIC_KEY`: exactly one valid OpenSSH public key, with a
+  16 KiB limit.
+- `HORIZON_TERMINATE_AFTER`: a future RFC 3339 timestamp no more than 30 days
+  away.
+
+The optional GitHub token must be mounted as a read-only secret file. Set
+`HORIZON_GITHUB_TOKEN_FILE` to its absolute path inside the container. Direct
+`HORIZON_GITHUB_TOKEN` injection is rejected because container environment
+values remain inspectable.
+
+Example:
+
+```bash
+deadline=$(date -u --date='+30 minutes' +%Y-%m-%dT%H:%M:%SZ)
+docker run --rm \
+  --publish 127.0.0.1::22 \
+  --env "HORIZON_SSH_PUBLIC_KEY=$(ssh-keygen -y -f /path/to/ephemeral-worker-key)" \
+  --env "HORIZON_TERMINATE_AFTER=${deadline}" \
+  --mount type=bind,src=/path/to/github-token,dst=/run/secrets/github-token,readonly \
+  --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token \
+  horizon-remote-worker:0.1.0
+```
+
+At startup the entrypoint:
+
+1. validates the lease, public key, and optional secret file;
+2. creates a new SSH host identity in the container's writable layer;
+3. installs only the supplied public key for root login;
+4. copies the optional token to a root-only runtime file; and
+5. starts a watchdog that terminates the worker at the lease deadline.
+
+The in-container watchdog is defense in depth. The provider remains responsible
+for enforcing the same deadline and deleting the underlying compute.
+
+`/workspace/horizon` starts empty. The controller checks out the requested
+repository and task after host-key verification. Remote commands should run
+through `horizon-agent-session`, which exposes the Rust toolchain, marks the
+session with `HORIZON=1`, and configures GitHub authentication only when the
+runtime token file exists. tmux provides reconnectable interactive sessions.
+
+Password authentication, keyboard-interactive authentication, SSH agent
+forwarding, X11 forwarding, and user-controlled SSH environment files are
+disabled. Root login is public-key-only.
+
+## Local security smoke
+
+Run the permanent smoke harness from the repository root:
+
+```bash
+./scripts/run-remote-worker-smoke.sh
+```
+
+It builds a uniquely tagged local image, starts two isolated workers, and
+proves:
+
+- missing or malformed runtime inputs fail closed;
+- source, build credentials, host keys, and user authentication state are not
+  baked into the image;
+- both workers accept only the supplied client key;
+- strict known-host verification works and the two runtime host keys differ;
+- the optional token is copied with mode `0600` without entering image history
+  or container environment values; and
+- a short lease terminates its worker and emits the watchdog marker.
+
+Use `--image <reference>` to test an existing image. By default, an image built
+by the script and all task-owned containers and temporary files are removed on
+exit; `--keep-image` preserves only the locally built image.

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -60,8 +60,8 @@ case "${public_key_kind}" in
     *) fail_usage "HORIZON_SSH_PUBLIC_KEY must use an ssh-ed25519 key" ;;
 esac
 
-if [ -n "${HORIZON_GITHUB_TOKEN:-}" ]; then
-    fail_usage "HORIZON_GITHUB_TOKEN is not accepted; mount a secret file and set HORIZON_GITHUB_TOKEN_FILE"
+if [ -n "${HORIZON_GITHUB_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${GH_TOKEN:-}" ]; then
+    fail_usage "GitHub tokens are not accepted through environment variables; mount a secret file and set HORIZON_GITHUB_TOKEN_FILE"
 fi
 
 mkdir -p /run/horizon /run/sshd /root/.ssh
@@ -118,6 +118,13 @@ ssh-keygen -A >/dev/null
 if [ ! -s /etc/ssh/ssh_host_ed25519_key ]; then
     printf '%s\n' "failed to generate the runtime SSH host key" >&2
     exit 1
+fi
+
+now_epoch=$(date +%s)
+lease_seconds=$((deadline_epoch - now_epoch))
+if [ "${lease_seconds}" -le 0 ]; then
+    printf '%s\n' "horizon-worker: lease deadline reached; terminating worker" >&2
+    exit 0
 fi
 
 unset \

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 readonly EX_USAGE=64
+readonly GITHUB_TOKEN_MOUNT=/run/secrets/github-token
 readonly MAX_LEASE_SECONDS=2592000
 readonly MAX_PUBLIC_KEY_BYTES=16384
 readonly MAX_TOKEN_BYTES=16384
@@ -55,8 +56,8 @@ if [ "${public_key_bytes}" -gt "${MAX_PUBLIC_KEY_BYTES}" ]; then
 fi
 public_key_kind=${ssh_public_key%%[[:space:]]*}
 case "${public_key_kind}" in
-    ssh-* | ecdsa-* | sk-*) ;;
-    *) fail_usage "HORIZON_SSH_PUBLIC_KEY must start with an OpenSSH key type" ;;
+    ssh-ed25519) ;;
+    *) fail_usage "HORIZON_SSH_PUBLIC_KEY must use an ssh-ed25519 key" ;;
 esac
 
 if [ -n "${HORIZON_GITHUB_TOKEN:-}" ]; then
@@ -79,18 +80,38 @@ rm -f /run/horizon/github-token
 github_token_file=${HORIZON_GITHUB_TOKEN_FILE:-}
 token_bytes=0
 if [ -n "${github_token_file}" ]; then
-    case "${github_token_file}" in
-        /*) ;;
-        *) fail_usage "HORIZON_GITHUB_TOKEN_FILE must be an absolute path" ;;
-    esac
-    if [ ! -f "${github_token_file}" ] || [ ! -r "${github_token_file}" ] || [ ! -s "${github_token_file}" ]; then
+    if [ "${github_token_file}" != "${GITHUB_TOKEN_MOUNT}" ]; then
+        fail_usage "HORIZON_GITHUB_TOKEN_FILE must be ${GITHUB_TOKEN_MOUNT}"
+    fi
+    if [ -L "${github_token_file}" ] || [ ! -f "${github_token_file}" ] || [ ! -r "${github_token_file}" ] || [ ! -s "${github_token_file}" ]; then
         fail_usage "HORIZON_GITHUB_TOKEN_FILE must name a readable non-empty regular file"
+    fi
+    if ! awk -v target="${GITHUB_TOKEN_MOUNT}" '
+        $5 == target {
+            option_count = split($6, options, ",")
+            for (i = 1; i <= option_count; i++) {
+                if (options[i] == "ro") {
+                    read_only = 1
+                }
+            }
+        }
+        END { exit read_only ? 0 : 1 }
+    ' /proc/self/mountinfo; then
+        fail_usage "${GITHUB_TOKEN_MOUNT} must be mounted as a read-only file"
     fi
     token_bytes=$(wc -c < "${github_token_file}" | tr -d '[:space:]')
     if [ "${token_bytes}" -gt "${MAX_TOKEN_BYTES}" ]; then
         fail_usage "HORIZON_GITHUB_TOKEN_FILE exceeds the 16384-byte limit"
     fi
     install -m 0600 "${github_token_file}" /run/horizon/github-token
+
+    GITHUB_TOKEN=$(cat /run/horizon/github-token)
+    export GITHUB_TOKEN
+    GH_TOKEN=${GITHUB_TOKEN}
+    export GH_TOKEN
+    gh auth setup-git
+    git config --global --replace-all url.https://github.com/.insteadOf git@github.com:
+    git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
 fi
 
 ssh-keygen -A >/dev/null
@@ -103,10 +124,12 @@ unset \
     authorized_key_candidate \
     deadline_epoch \
     github_token_file \
+    GH_TOKEN \
     HORIZON_GITHUB_TOKEN \
     HORIZON_GITHUB_TOKEN_FILE \
     HORIZON_SSH_PUBLIC_KEY \
     HORIZON_TERMINATE_AFTER \
+    GITHUB_TOKEN \
     now_epoch \
     public_key_bytes \
     public_key_kind \

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+set -eu
+
+readonly EX_USAGE=64
+readonly MAX_LEASE_SECONDS=2592000
+readonly MAX_PUBLIC_KEY_BYTES=16384
+readonly MAX_TOKEN_BYTES=16384
+
+fail_usage() {
+    printf '%s\n' "$1" >&2
+    exit "${EX_USAGE}"
+}
+
+umask 077
+
+terminate_after=${HORIZON_TERMINATE_AFTER:-}
+if [ -z "${terminate_after}" ]; then
+    fail_usage "HORIZON_TERMINATE_AFTER must contain a future RFC 3339 timestamp"
+fi
+case "${terminate_after}" in
+    *'
+'*)
+        fail_usage "HORIZON_TERMINATE_AFTER must contain exactly one timestamp"
+        ;;
+esac
+if ! printf '%s\n' "${terminate_after}" |
+    grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$'; then
+    fail_usage "HORIZON_TERMINATE_AFTER must contain a valid RFC 3339 timestamp"
+fi
+if ! deadline_epoch=$(date --date="${terminate_after}" +%s 2>/dev/null); then
+    fail_usage "HORIZON_TERMINATE_AFTER must contain a valid RFC 3339 timestamp"
+fi
+now_epoch=$(date +%s)
+lease_seconds=$((deadline_epoch - now_epoch))
+if [ "${lease_seconds}" -le 0 ]; then
+    fail_usage "HORIZON_TERMINATE_AFTER must be in the future"
+fi
+if [ "${lease_seconds}" -gt "${MAX_LEASE_SECONDS}" ]; then
+    fail_usage "HORIZON_TERMINATE_AFTER may be at most 30 days in the future"
+fi
+
+ssh_public_key=${HORIZON_SSH_PUBLIC_KEY:-}
+if [ -z "${ssh_public_key}" ]; then
+    fail_usage "HORIZON_SSH_PUBLIC_KEY must contain one OpenSSH public key"
+fi
+case "${ssh_public_key}" in
+    *'
+'*)
+        fail_usage "HORIZON_SSH_PUBLIC_KEY must contain exactly one OpenSSH public key"
+        ;;
+esac
+public_key_bytes=$(printf '%s' "${ssh_public_key}" | wc -c | tr -d '[:space:]')
+if [ "${public_key_bytes}" -gt "${MAX_PUBLIC_KEY_BYTES}" ]; then
+    fail_usage "HORIZON_SSH_PUBLIC_KEY exceeds the 16384-byte limit"
+fi
+public_key_kind=${ssh_public_key%%[[:space:]]*}
+case "${public_key_kind}" in
+    ssh-* | ecdsa-* | sk-*) ;;
+    *) fail_usage "HORIZON_SSH_PUBLIC_KEY must start with an OpenSSH key type" ;;
+esac
+
+if [ -n "${HORIZON_GITHUB_TOKEN:-}" ]; then
+    fail_usage "HORIZON_GITHUB_TOKEN is not accepted; mount a secret file and set HORIZON_GITHUB_TOKEN_FILE"
+fi
+
+mkdir -p /run/horizon /run/sshd /root/.ssh
+chmod 0700 /run/horizon /root/.ssh
+
+authorized_key_candidate=/run/horizon/authorized-key.candidate
+printf '%s\n' "${ssh_public_key}" > "${authorized_key_candidate}"
+if ! ssh-keygen -l -f "${authorized_key_candidate}" >/dev/null 2>&1; then
+    rm -f "${authorized_key_candidate}"
+    fail_usage "HORIZON_SSH_PUBLIC_KEY is not a valid OpenSSH public key"
+fi
+install -m 0600 "${authorized_key_candidate}" /root/.ssh/authorized_keys
+rm -f "${authorized_key_candidate}"
+
+rm -f /run/horizon/github-token
+github_token_file=${HORIZON_GITHUB_TOKEN_FILE:-}
+token_bytes=0
+if [ -n "${github_token_file}" ]; then
+    case "${github_token_file}" in
+        /*) ;;
+        *) fail_usage "HORIZON_GITHUB_TOKEN_FILE must be an absolute path" ;;
+    esac
+    if [ ! -f "${github_token_file}" ] || [ ! -r "${github_token_file}" ] || [ ! -s "${github_token_file}" ]; then
+        fail_usage "HORIZON_GITHUB_TOKEN_FILE must name a readable non-empty regular file"
+    fi
+    token_bytes=$(wc -c < "${github_token_file}" | tr -d '[:space:]')
+    if [ "${token_bytes}" -gt "${MAX_TOKEN_BYTES}" ]; then
+        fail_usage "HORIZON_GITHUB_TOKEN_FILE exceeds the 16384-byte limit"
+    fi
+    install -m 0600 "${github_token_file}" /run/horizon/github-token
+fi
+
+ssh-keygen -A >/dev/null
+if [ ! -s /etc/ssh/ssh_host_ed25519_key ]; then
+    printf '%s\n' "failed to generate the runtime SSH host key" >&2
+    exit 1
+fi
+
+unset \
+    authorized_key_candidate \
+    deadline_epoch \
+    github_token_file \
+    HORIZON_GITHUB_TOKEN \
+    HORIZON_GITHUB_TOKEN_FILE \
+    HORIZON_SSH_PUBLIC_KEY \
+    HORIZON_TERMINATE_AFTER \
+    now_epoch \
+    public_key_bytes \
+    public_key_kind \
+    ssh_public_key \
+    terminate_after \
+    token_bytes
+
+entrypoint_pid=$$
+(
+    sleep "${lease_seconds}"
+    printf '%s\n' "horizon-worker: lease deadline reached; terminating worker" >&2
+    kill -TERM "${entrypoint_pid}" 2>/dev/null || exit 0
+    sleep 10
+    kill -KILL "${entrypoint_pid}" 2>/dev/null || true
+) &
+unset entrypoint_pid lease_seconds
+
+exec /usr/sbin/sshd -D -e

--- a/containers/remote-worker/rust-path.sh
+++ b/containers/remote-worker/rust-path.sh
@@ -1,0 +1,1 @@
+export PATH="/usr/local/cargo/bin:${PATH}"

--- a/containers/remote-worker/session.sh
+++ b/containers/remote-worker/session.sh
@@ -13,9 +13,6 @@ if [ -f /run/horizon/github-token ]; then
     export GITHUB_TOKEN
     GH_TOKEN=${GITHUB_TOKEN}
     export GH_TOKEN
-    gh auth setup-git
-    git config --global --replace-all url.https://github.com/.insteadOf git@github.com:
-    git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
 fi
 
 export HORIZON=1

--- a/containers/remote-worker/session.sh
+++ b/containers/remote-worker/session.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    printf '%s\n' "usage: horizon-agent-session <command> [argument ...]" >&2
+    exit 64
+fi
+
+export PATH="/usr/local/cargo/bin:${PATH}"
+
+if [ -f /run/horizon/github-token ]; then
+    GITHUB_TOKEN=$(cat /run/horizon/github-token)
+    export GITHUB_TOKEN
+    GH_TOKEN=${GITHUB_TOKEN}
+    export GH_TOKEN
+    gh auth setup-git
+    git config --global url.https://github.com/.insteadOf git@github.com:
+    git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
+fi
+
+export HORIZON=1
+exec "$@"

--- a/containers/remote-worker/session.sh
+++ b/containers/remote-worker/session.sh
@@ -14,7 +14,7 @@ if [ -f /run/horizon/github-token ]; then
     GH_TOKEN=${GITHUB_TOKEN}
     export GH_TOKEN
     gh auth setup-git
-    git config --global url.https://github.com/.insteadOf git@github.com:
+    git config --global --replace-all url.https://github.com/.insteadOf git@github.com:
     git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
 fi
 

--- a/containers/remote-worker/sshd_config
+++ b/containers/remote-worker/sshd_config
@@ -1,0 +1,11 @@
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PermitEmptyPasswords no
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+StrictModes yes
+AllowAgentForwarding no
+X11Forwarding no
+PermitUserEnvironment no

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -219,7 +219,9 @@ docker run --rm --entrypoint /bin/sh "${image}" -eu -c '
 
 ssh-keygen -q -t ed25519 -N '' -f "${temp_dir}/client"
 ssh-keygen -q -t ed25519 -N '' -f "${temp_dir}/wrong-client"
+ssh-keygen -q -t rsa -b 2048 -N '' -f "${temp_dir}/unsupported-client"
 client_public_key=$(<"${temp_dir}/client.pub")
+unsupported_public_key=$(<"${temp_dir}/unsupported-client.pub")
 fake_token="ghp_horizon_worker_smoke_${smoke_id}_not_real"
 printf '%s' "${fake_token}" >"${temp_dir}/github-token"
 chmod 0600 "${temp_dir}/github-token"
@@ -234,6 +236,10 @@ expect_usage_failure \
 expect_usage_failure \
   malformed-key \
   --env HORIZON_SSH_PUBLIC_KEY=not-a-public-key \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}"
+expect_usage_failure \
+  unsupported-key \
+  --env "HORIZON_SSH_PUBLIC_KEY=${unsupported_public_key}" \
   --env "HORIZON_TERMINATE_AFTER=${normal_deadline}"
 expect_usage_failure \
   missing-lease \
@@ -252,6 +258,18 @@ expect_usage_failure \
   --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
   --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
   --mount "type=bind,src=${temp_dir}/oversized-token,dst=/run/secrets/github-token,readonly" \
+  --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token
+expect_usage_failure \
+  misplaced-token \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/other-token,readonly" \
+  --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/other-token
+expect_usage_failure \
+  writable-token \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/github-token" \
   --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token
 
 worker_a="${smoke_id}-worker-a"
@@ -296,14 +314,30 @@ ssh_worker \
   grep -qx 'HORIZON=1' ||
   fail "horizon-agent-session did not mark the remote environment"
 
-for _ in 1 2; do
-  ssh_worker \
-    "${temp_dir}/client" \
-    "${temp_dir}/worker-a-known-hosts" \
-    "${worker_a_port}" \
-    'horizon-agent-session true' ||
-    fail "a repeated token-backed agent session failed"
-done
+git_config_before=$(docker exec "${worker_a}" sha256sum /root/.gitconfig | awk '{print $1}')
+ssh_worker \
+  "${temp_dir}/client" \
+  "${temp_dir}/worker-a-known-hosts" \
+  "${worker_a_port}" \
+  'horizon-agent-session sleep 2' &
+session_one_pid=$!
+ssh_worker \
+  "${temp_dir}/client" \
+  "${temp_dir}/worker-a-known-hosts" \
+  "${worker_a_port}" \
+  'horizon-agent-session sleep 2' &
+session_two_pid=$!
+set +e
+wait "${session_one_pid}"
+session_one_status=$?
+wait "${session_two_pid}"
+session_two_status=$?
+set -e
+[[ "${session_one_status}" -eq 0 && "${session_two_status}" -eq 0 ]] ||
+  fail "concurrent token-backed agent sessions failed"
+git_config_after=$(docker exec "${worker_a}" sha256sum /root/.gitconfig | awk '{print $1}')
+[[ "${git_config_after}" == "${git_config_before}" ]] ||
+  fail "token-backed agent sessions changed shared Git configuration"
 git_rewrites=$(
   docker exec "${worker_a}" \
     git config --global --get-all url.https://github.com/.insteadOf

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Run the local security smoke test for the Horizon remote-worker image.
+
+Usage:
+  run-remote-worker-smoke.sh [--image <reference>] [--keep-image]
+
+Options:
+  --image <reference>  Test an existing local image instead of building one.
+  --keep-image         Keep an image built by this script after the smoke.
+  -h, --help           Show this help.
+EOF
+}
+
+fail() {
+  printf 'remote-worker smoke failed: %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+image=
+keep_image=false
+while (($# > 0)); do
+  case "$1" in
+    --image)
+      (($# >= 2)) || fail "--image requires a value"
+      image=$2
+      shift 2
+      ;;
+    --keep-image)
+      keep_image=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+for command_name in docker ssh ssh-keygen ssh-keyscan; do
+  require_command "${command_name}"
+done
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+smoke_id="horizon-worker-smoke-$(date -u +%Y%m%d%H%M%S)-$$"
+temp_dir=$(mktemp -d /tmp/horizon-remote-worker-smoke.XXXXXX)
+case "${temp_dir}" in
+  /tmp/horizon-remote-worker-smoke.*) ;;
+  *) fail "refusing unexpected temporary directory: ${temp_dir}" ;;
+esac
+
+declare -a containers=()
+built_image=false
+
+cleanup() {
+  local exit_code=$?
+  local container_name
+  for container_name in "${containers[@]}"; do
+    docker rm --force "${container_name}" >/dev/null 2>&1 || true
+  done
+  if [[ "${built_image}" == true && "${keep_image}" != true ]]; then
+    docker image rm --force "${image}" >/dev/null 2>&1 || true
+  fi
+  case "${temp_dir}" in
+    /tmp/horizon-remote-worker-smoke.*)
+      rm -rf -- "${temp_dir}"
+      ;;
+  esac
+  return "${exit_code}"
+}
+trap cleanup EXIT
+
+deadline_after() {
+  date -u --date="+$1 seconds" +%Y-%m-%dT%H:%M:%SZ
+}
+
+record_container() {
+  containers+=("$1")
+}
+
+expect_usage_failure() {
+  local case_name=$1
+  shift
+  local container_name="${smoke_id}-${case_name}"
+  local output
+  local status
+  record_container "${container_name}"
+
+  set +e
+  output=$(docker run --name "${container_name}" "$@" "${image}" 2>&1)
+  status=$?
+  set -e
+
+  [[ "${status}" -eq 64 ]] ||
+    fail "${case_name} returned ${status}, expected configuration exit 64"
+  if [[ "${output}" == *"${fake_token}"* ]]; then
+    fail "${case_name} exposed the test token in container logs"
+  fi
+}
+
+wait_for_host_key() {
+  local container_name=$1
+  local known_hosts_path=$2
+  local port
+  local attempt
+
+  port=$(docker port "${container_name}" 22/tcp | sed -n 's/.*://p' | tail -n 1)
+  [[ "${port}" =~ ^[0-9]+$ ]] ||
+    fail "could not resolve the SSH port for ${container_name}"
+
+  for attempt in {1..30}; do
+    if ssh-keyscan -T 1 -p "${port}" -t ed25519 127.0.0.1 \
+      >"${known_hosts_path}" 2>/dev/null &&
+      [[ -s "${known_hosts_path}" ]]; then
+      printf '%s\n' "${port}"
+      return 0
+    fi
+    if [[ "$(docker inspect --format '{{.State.Running}}' "${container_name}")" != true ]]; then
+      docker logs "${container_name}" >&2 || true
+      fail "${container_name} exited before SSH became ready"
+    fi
+    sleep 1
+  done
+
+  docker logs "${container_name}" >&2 || true
+  fail "SSH did not become ready for ${container_name}"
+}
+
+ssh_worker() {
+  local identity_file=$1
+  local known_hosts_path=$2
+  local port=$3
+  local remote_command=$4
+
+  ssh \
+    -F /dev/null \
+    -i "${identity_file}" \
+    -o BatchMode=yes \
+    -o IdentitiesOnly=yes \
+    -o KbdInteractiveAuthentication=no \
+    -o PasswordAuthentication=no \
+    -o StrictHostKeyChecking=yes \
+    -o "UserKnownHostsFile=${known_hosts_path}" \
+    -p "${port}" \
+    root@127.0.0.1 \
+    "${remote_command}"
+}
+
+if [[ -z "${image}" ]]; then
+  image="${smoke_id}:local"
+  worker_image_version="smoke-$(date -u +%Y%m%d%H%M%S)"
+  printf 'Building %s\n' "${image}"
+  docker build \
+    --file "${repo_root}/containers/remote-worker/Dockerfile" \
+    --build-arg "WORKER_IMAGE_VERSION=${worker_image_version}" \
+    --tag "${image}" \
+    "${repo_root}"
+  built_image=true
+else
+  worker_image_version=$(
+    docker image inspect \
+      --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' \
+      "${image}"
+  )
+  [[ -n "${worker_image_version}" && "${worker_image_version}" != "<no value>" ]] ||
+    fail "${image} has no worker image version label"
+fi
+
+actual_image_version=$(
+  docker image inspect \
+    --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' \
+    "${image}"
+)
+[[ "${actual_image_version}" == "${worker_image_version}" ]] ||
+  fail "worker image version label does not match the requested build version"
+
+image_environment=$(docker image inspect --format '{{json .Config.Env}}' "${image}")
+if grep -Eq '"(GH_TOKEN|GITHUB_TOKEN|HORIZON_GITHUB_TOKEN|HORIZON_SSH_PUBLIC_KEY)=' \
+  <<<"${image_environment}"; then
+  fail "image configuration contains runtime authentication material"
+fi
+
+image_history=$(docker history --no-trunc --format '{{.CreatedBy}}' "${image}")
+if grep -Eq '(github_pat_|ghp_|rpa_)' <<<"${image_history}"; then
+  fail "image history resembles embedded authentication material"
+fi
+
+docker run --rm --entrypoint /bin/sh "${image}" -eu -c '
+  test -z "$(find /workspace/horizon -mindepth 1 -print -quit)"
+  test ! -e /opt/horizon-dependency-cache
+  test -z "$(find /etc/ssh -maxdepth 1 -name "ssh_host_*" -print -quit)"
+  test ! -e /root/.ssh
+  test ! -e /root/.config
+  test ! -e /root/.docker
+  test ! -e /root/.gitconfig
+  test ! -e /root/.local
+  test ! -e /root/.netrc
+  test ! -e /root/.npm
+  test ! -e /root/.npmrc
+  test -s /etc/ssl/certs/ca-certificates.crt
+  for tool in \
+    cargo rustc git git-lfs gh rsync tar tmux ssh sshd \
+    codex claude gemini opencode kilo pi grok
+  do
+    command -v "${tool}" >/dev/null
+  done
+'
+
+ssh-keygen -q -t ed25519 -N '' -f "${temp_dir}/client"
+ssh-keygen -q -t ed25519 -N '' -f "${temp_dir}/wrong-client"
+client_public_key=$(<"${temp_dir}/client.pub")
+fake_token="ghp_horizon_worker_smoke_${smoke_id}_not_real"
+printf '%s' "${fake_token}" >"${temp_dir}/github-token"
+chmod 0600 "${temp_dir}/github-token"
+head -c 16385 /dev/zero | tr '\0' x >"${temp_dir}/oversized-token"
+
+normal_deadline=$(deadline_after 600)
+oversized_deadline=$(deadline_after 2678400)
+
+expect_usage_failure \
+  missing-key \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}"
+expect_usage_failure \
+  malformed-key \
+  --env HORIZON_SSH_PUBLIC_KEY=not-a-public-key \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}"
+expect_usage_failure \
+  missing-lease \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}"
+expect_usage_failure \
+  oversized-lease \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${oversized_deadline}"
+expect_usage_failure \
+  direct-token \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --env "HORIZON_GITHUB_TOKEN=${fake_token}"
+expect_usage_failure \
+  oversized-token \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --mount "type=bind,src=${temp_dir}/oversized-token,dst=/run/secrets/github-token,readonly" \
+  --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token
+
+worker_a="${smoke_id}-worker-a"
+worker_b="${smoke_id}-worker-b"
+record_container "${worker_a}"
+record_container "${worker_b}"
+
+docker run --detach \
+  --name "${worker_a}" \
+  --label horizon.remote-worker-smoke=true \
+  --publish 127.0.0.1::22 \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/github-token,readonly" \
+  --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token \
+  "${image}" >/dev/null
+
+docker run --detach \
+  --name "${worker_b}" \
+  --label horizon.remote-worker-smoke=true \
+  --publish 127.0.0.1::22 \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  "${image}" >/dev/null
+
+worker_a_port=$(wait_for_host_key "${worker_a}" "${temp_dir}/worker-a-known-hosts")
+worker_b_port=$(wait_for_host_key "${worker_b}" "${temp_dir}/worker-b-known-hosts")
+worker_a_fingerprint=$(
+  ssh-keygen -lf "${temp_dir}/worker-a-known-hosts" | awk '{print $2}'
+)
+worker_b_fingerprint=$(
+  ssh-keygen -lf "${temp_dir}/worker-b-known-hosts" | awk '{print $2}'
+)
+[[ "${worker_a_fingerprint}" != "${worker_b_fingerprint}" ]] ||
+  fail "the two workers reused the same runtime SSH host key"
+
+ssh_worker \
+  "${temp_dir}/client" \
+  "${temp_dir}/worker-b-known-hosts" \
+  "${worker_b_port}" \
+  'horizon-agent-session env' |
+  grep -qx 'HORIZON=1' ||
+  fail "horizon-agent-session did not mark the remote environment"
+
+set +e
+ssh_worker \
+  "${temp_dir}/wrong-client" \
+  "${temp_dir}/worker-a-known-hosts" \
+  "${worker_a_port}" \
+  'true' >/dev/null 2>&1
+wrong_key_status=$?
+set -e
+[[ "${wrong_key_status}" -ne 0 ]] ||
+  fail "worker accepted an SSH identity that was not authorized"
+
+authorized_key=$(docker exec "${worker_a}" cat /root/.ssh/authorized_keys)
+[[ "${authorized_key}" == "${client_public_key}" ]] ||
+  fail "worker authorized_keys differs from the supplied public key"
+[[ "$(docker exec "${worker_a}" stat -c %a /root/.ssh/authorized_keys)" == 600 ]] ||
+  fail "worker authorized_keys is not mode 0600"
+
+copied_token=$(docker exec "${worker_a}" cat /run/horizon/github-token)
+[[ "${copied_token}" == "${fake_token}" ]] ||
+  fail "worker runtime token copy differs from the mounted secret"
+[[ "$(docker exec "${worker_a}" stat -c %a /run/horizon/github-token)" == 600 ]] ||
+  fail "worker runtime token copy is not mode 0600"
+
+worker_environment=$(docker inspect --format '{{json .Config.Env}}' "${worker_a}")
+if [[ "${worker_environment}" == *"${fake_token}"* ]]; then
+  fail "mounted token entered the worker container environment"
+fi
+pid_one_environment=$(
+  docker exec "${worker_a}" /bin/sh -c "tr '\\0' '\\n' </proc/1/environ"
+)
+if [[ "${pid_one_environment}" == *"${fake_token}"* ]] ||
+  grep -Eq '^HORIZON_(GITHUB_TOKEN|GITHUB_TOKEN_FILE|SSH_PUBLIC_KEY|TERMINATE_AFTER)=' \
+    <<<"${pid_one_environment}"; then
+  fail "runtime credentials remained in the SSH daemon environment"
+fi
+if grep -qF "${fake_token}" <<<"${image_history}"; then
+  fail "mounted token entered image history"
+fi
+
+effective_sshd_config=$(docker exec "${worker_a}" sshd -T)
+for required_setting in \
+  'authenticationmethods publickey' \
+  'passwordauthentication no' \
+  'kbdinteractiveauthentication no' \
+  'permitemptypasswords no' \
+  'allowagentforwarding no' \
+  'x11forwarding no' \
+  'permituserenvironment no'
+do
+  grep -qx "${required_setting}" <<<"${effective_sshd_config}" ||
+    fail "effective sshd configuration is missing: ${required_setting}"
+done
+grep -Eq '^permitrootlogin (prohibit-password|without-password)$' \
+  <<<"${effective_sshd_config}" ||
+  fail "root login is not restricted to public-key authentication"
+
+lease_worker="${smoke_id}-lease"
+record_container "${lease_worker}"
+docker run --detach \
+  --name "${lease_worker}" \
+  --label horizon.remote-worker-smoke=true \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=$(deadline_after 5)" \
+  "${image}" >/dev/null
+
+lease_stopped=false
+for _ in {1..20}; do
+  if [[ "$(docker inspect --format '{{.State.Running}}' "${lease_worker}")" != true ]]; then
+    lease_stopped=true
+    break
+  fi
+  sleep 1
+done
+[[ "${lease_stopped}" == true ]] ||
+  fail "lease watchdog did not stop the worker within 20 seconds"
+lease_logs=$(docker logs "${lease_worker}" 2>&1)
+grep -qF 'horizon-worker: lease deadline reached; terminating worker' \
+  <<<"${lease_logs}" ||
+  fail "lease watchdog marker was not written"
+
+image_id=$(docker image inspect --format '{{.Id}}' "${image}")
+printf 'Remote-worker smoke passed.\n'
+printf 'Image: %s (%s)\n' "${image_id}" "${actual_image_version}"
+printf 'Worker A host key: %s\n' "${worker_a_fingerprint}"
+printf 'Worker B host key: %s\n' "${worker_b_fingerprint}"

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -81,7 +81,8 @@ cleanup() {
 trap cleanup EXIT
 
 deadline_after() {
-  date -u --date="+$1 seconds" +%Y-%m-%dT%H:%M:%SZ
+  docker run --rm --entrypoint /bin/date "${image}" \
+    -u --date="+$1 seconds" +%Y-%m-%dT%H:%M:%SZ
 }
 
 record_container() {
@@ -294,6 +295,22 @@ ssh_worker \
   'horizon-agent-session env' |
   grep -qx 'HORIZON=1' ||
   fail "horizon-agent-session did not mark the remote environment"
+
+for _ in 1 2; do
+  ssh_worker \
+    "${temp_dir}/client" \
+    "${temp_dir}/worker-a-known-hosts" \
+    "${worker_a_port}" \
+    'horizon-agent-session true' ||
+    fail "a repeated token-backed agent session failed"
+done
+git_rewrites=$(
+  docker exec "${worker_a}" \
+    git config --global --get-all url.https://github.com/.insteadOf
+)
+expected_git_rewrites=$'git@github.com:\nssh://git@github.com/'
+[[ "${git_rewrites}" == "${expected_git_rewrites}" ]] ||
+  fail "repeated token-backed sessions left unexpected Git URL rewrites"
 
 set +e
 ssh_worker \

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -167,6 +167,15 @@ if [[ -z "${image}" ]]; then
     --tag "${image}" \
     "${repo_root}"
   built_image=true
+  set +e
+  empty_version_output=$(docker build \
+    --file "${repo_root}/containers/remote-worker/Dockerfile" \
+    --build-arg WORKER_IMAGE_VERSION= "${repo_root}" 2>&1)
+  empty_version_status=$?
+  set -e
+  [[ "${empty_version_status}" -ne 0 ]] || fail "worker image build accepted an empty version"
+  grep -qF 'WORKER_IMAGE_VERSION must not be empty' <<<"${empty_version_output}" ||
+    fail "empty-version build did not reach the expected validation"
 else
   worker_image_version=$(
     docker image inspect \

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -64,18 +64,23 @@ built_image=false
 
 cleanup() {
   local exit_code=$?
+  local cleanup_status=0
   local container_name
   for container_name in "${containers[@]}"; do
-    docker rm --force "${container_name}" >/dev/null 2>&1 || true
+    docker rm --force "${container_name}" >/dev/null 2>&1 || cleanup_status=1
   done
   if [[ "${built_image}" == true && "${keep_image}" != true ]]; then
-    docker image rm --force "${image}" >/dev/null 2>&1 || true
+    docker image rm --force "${image}" >/dev/null 2>&1 || cleanup_status=1
   fi
   case "${temp_dir}" in
     /tmp/horizon-remote-worker-smoke.*)
-      rm -rf -- "${temp_dir}"
+      rm -rf -- "${temp_dir}" || cleanup_status=1
       ;;
   esac
+  if ((exit_code == 0 && cleanup_status != 0)); then
+    printf '%s\n' "remote-worker smoke cleanup failed" >&2
+    exit "${cleanup_status}"
+  fi
   return "${exit_code}"
 }
 trap cleanup EXIT

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -254,6 +254,16 @@ expect_usage_failure \
   --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
   --env "HORIZON_GITHUB_TOKEN=${fake_token}"
 expect_usage_failure \
+  github-token-env \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --env "GITHUB_TOKEN=${fake_token}"
+expect_usage_failure \
+  gh-token-env \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
+  --env "GH_TOKEN=${fake_token}"
+expect_usage_failure \
   oversized-token \
   --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
   --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
@@ -271,6 +281,37 @@ expect_usage_failure \
   --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
   --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/github-token" \
   --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token
+
+printf '%s\n' '#!/bin/sh' 'sleep 7' 'exit 0' >"${temp_dir}/slow-gh"
+chmod 0755 "${temp_dir}/slow-gh"
+startup_expiry_worker="${smoke_id}-startup-expiry"
+record_container "${startup_expiry_worker}"
+docker run --detach \
+  --name "${startup_expiry_worker}" \
+  --label horizon.remote-worker-smoke=true \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
+  --env "HORIZON_TERMINATE_AFTER=$(deadline_after 5)" \
+  --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/github-token,readonly" \
+  --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token \
+  --mount "type=bind,src=${temp_dir}/slow-gh,dst=/usr/bin/gh,readonly" \
+  "${image}" >/dev/null
+startup_expired=false
+for _ in {1..20}; do
+  if [[ "$(docker inspect --format '{{.State.Running}}' "${startup_expiry_worker}")" != true ]]; then
+    startup_expired=true
+    break
+  fi
+  sleep 1
+done
+[[ "${startup_expired}" == true ]] ||
+  fail "worker did not enforce a deadline that expired during initialization"
+startup_expiry_logs=$(docker logs "${startup_expiry_worker}" 2>&1)
+grep -qF 'horizon-worker: lease deadline reached; terminating worker' \
+  <<<"${startup_expiry_logs}" ||
+  fail "startup-expiry worker did not log the watchdog marker"
+if grep -qF 'Server listening on' <<<"${startup_expiry_logs}"; then
+  fail "worker accepted SSH after its deadline expired during initialization"
+fi
 
 worker_a="${smoke_id}-worker-a"
 worker_b="${smoke_id}-worker-b"
@@ -377,7 +418,7 @@ pid_one_environment=$(
   docker exec "${worker_a}" /bin/sh -c "tr '\\0' '\\n' </proc/1/environ"
 )
 if [[ "${pid_one_environment}" == *"${fake_token}"* ]] ||
-  grep -Eq '^HORIZON_(GITHUB_TOKEN|GITHUB_TOKEN_FILE|SSH_PUBLIC_KEY|TERMINATE_AFTER)=' \
+  grep -Eq '^(GH_TOKEN|GITHUB_TOKEN|HORIZON_(GITHUB_TOKEN|GITHUB_TOKEN_FILE|SSH_PUBLIC_KEY|TERMINATE_AFTER))=' \
     <<<"${pid_one_environment}"; then
   fail "runtime credentials remained in the SSH daemon environment"
 fi


### PR DESCRIPTION
## Purpose

Establish the provider-neutral remote-worker image contract for the next independently testable slice of #383.

## Behavior impact

- builds from immutable Rust and Node base-image digests and records an explicit image version
- includes the Linux build toolchain, repository tooling, tmux, SSH, CA certificates, and pinned supported coding-agent CLIs
- sends only workspace manifests and runtime image files to the Docker builder; project source and local state remain outside the build context
- requires one runtime public key and generates per-container SSH host keys
- disables password, keyboard-interactive, agent-forwarding, X11, and user-environment SSH paths
- accepts an optional repository token only through a bounded mounted secret file
- requires a bounded termination deadline and enforces it with an in-container watchdog
- adds a repeatable two-worker security smoke with fail-closed, host-identity, key-authentication, secret, cleanup, and lease assertions

This PR does not change UI behavior, provider configuration, cloud resources, image publication, or release state.

## Test evidence

- docker build --check --file containers/remote-worker/Dockerfile .
- ./scripts/run-remote-worker-smoke.sh
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- ./scripts/check-version-sync.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- RUSTFLAGS="-D warnings" cargo test --workspace --features speech
- cargo clippy --all-targets --features speech,trace-profiling -- -D warnings
- cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic

The Docker smoke passed on Linux amd64 with distinct host fingerprints for two simultaneous workers and verified automatic termination of a short-lived third worker.