### PR TITLE
feat(cloud): add interactive worker provider contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,7 @@ version = "0.2.7"
 dependencies = [
  "alacritty_terminal",
  "atomicwrites",
+ "base64 0.23.1",
  "comrak",
  "git2",
  "horizon-browser",

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -15,6 +15,7 @@ trace-profiling = ["profiling/profile-with-tracing"]
 workspace = true
 
 [dependencies]
+base64.workspace = true
 horizon-browser.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 use std::{collections::HashSet, fmt};
 use thiserror::Error;
 use uuid::Uuid;
+pub mod interactive_worker;
 pub mod runpod;
 mod store;
 mod validation;

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -111,6 +111,13 @@ impl InteractiveWorker {
     pub fn has_valid_shape(&self) -> bool {
         self.identity.is_valid() && valid_immutable_image(&self.image) && self.lease.has_valid_shape()
     }
+
+    /// Check the durable handle before any provider-specific inspection or
+    /// deletion call.
+    #[must_use]
+    pub fn is_valid_for(&self, provider: CloudProvider) -> bool {
+        self.identity.provider == provider && self.has_valid_shape()
+    }
 }
 
 /// Provider-neutral lifecycle observed for an exact worker resource.
@@ -166,8 +173,7 @@ impl InteractiveWorkerStatus {
         let identity = &self.worker.identity;
         request.is_valid_for(request.target.provider)
             && matches!(self.lifecycle, InteractiveWorkerLifecycle::Ready)
-            && self.worker.has_valid_shape()
-            && identity.provider == request.target.provider
+            && self.worker.is_valid_for(request.target.provider)
             && identity.workflow_id == request.workflow_id
             && identity.job_id == request.job_id
             && self.worker.image == request.target.image
@@ -212,9 +218,13 @@ pub enum InteractiveWorkerCleanup {
 /// Blocking provider boundary for one disposable interactive worker.
 ///
 /// Callers must invoke provider operations away from the render thread. An
-/// implementation must validate that request targets match [`Self::provider`],
-/// make `ensure_worker` idempotent across controllers, preserve the exact
-/// returned handle for later inspection, and delete only that exact resource.
+/// implementation must reject an ensure request unless
+/// [`InteractiveWorkerRequest::is_valid_for`] accepts [`Self::provider`]. It
+/// must also reject inspect and delete operations before provider I/O unless
+/// [`InteractiveWorker::is_valid_for`] accepts [`Self::provider`]. Valid
+/// operations must make `ensure_worker` idempotent across controllers,
+/// preserve the exact returned handle for later inspection, and delete only
+/// that exact resource.
 pub trait InteractiveWorkerProvider: Send + Sync {
     type Error: Error + Send + Sync + 'static;
 
@@ -231,13 +241,17 @@ pub trait InteractiveWorkerProvider: Send + Sync {
     /// Inspect only the exact persisted worker, returning `None` when absent.
     ///
     /// # Errors
-    /// Returns a redacted, provider-specific error when state is ambiguous.
+    /// Returns a redacted, provider-specific error before provider I/O when
+    /// the worker is malformed or belongs to another provider, or when state
+    /// is ambiguous.
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error>;
 
     /// Delete only the exact persisted worker. Repeated deletion is idempotent.
     ///
     /// # Errors
-    /// Returns a redacted, provider-specific error unless absence is verified.
+    /// Returns a redacted, provider-specific error before provider I/O when
+    /// the worker is malformed or belongs to another provider, or unless
+    /// absence is verified.
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error>;
 }
 
@@ -297,7 +311,14 @@ fn valid_ed25519_key(value: &str, allow_comment: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::Infallible;
+
+    #[derive(Debug, Eq, PartialEq, thiserror::Error)]
+    enum FakeError {
+        #[error("invalid request")]
+        InvalidRequest,
+        #[error("invalid worker")]
+        InvalidWorker,
+    }
 
     #[derive(Clone)]
     struct FakeProvider {
@@ -305,21 +326,30 @@ mod tests {
     }
 
     impl InteractiveWorkerProvider for FakeProvider {
-        type Error = Infallible;
+        type Error = FakeError;
 
         fn provider(&self) -> CloudProvider {
             CloudProvider::RunPod
         }
 
-        fn ensure_worker(&self, _request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+            if !request.is_valid_for(self.provider()) {
+                return Err(FakeError::InvalidRequest);
+            }
             Ok(InteractiveWorkerEnsure::Created(self.status.clone()))
         }
 
-        fn inspect_worker(&self, _worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+            if !worker.is_valid_for(self.provider()) {
+                return Err(FakeError::InvalidWorker);
+            }
             Ok(Some(self.status.clone()))
         }
 
-        fn delete_worker(&self, _worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+            if !worker.is_valid_for(self.provider()) {
+                return Err(FakeError::InvalidWorker);
+            }
             Ok(InteractiveWorkerCleanup::Deleted)
         }
     }
@@ -384,7 +414,7 @@ mod tests {
     fn provider_trait_is_object_safe_and_preserves_exact_status() {
         let status = worker_status();
         let provider = FakeProvider { status: status.clone() };
-        let provider: &dyn InteractiveWorkerProvider<Error = Infallible> = &provider;
+        let provider: &dyn InteractiveWorkerProvider<Error = FakeError> = &provider;
         let request = worker_request(&status);
 
         assert_eq!(provider.provider(), CloudProvider::RunPod);
@@ -397,6 +427,11 @@ mod tests {
             provider.delete_worker(&status.worker),
             Ok(InteractiveWorkerCleanup::Deleted)
         );
+
+        let mut wrong_provider = status.worker;
+        wrong_provider.identity.provider = CloudProvider::Azure;
+        assert_eq!(provider.inspect_worker(&wrong_provider), Err(FakeError::InvalidWorker));
+        assert_eq!(provider.delete_worker(&wrong_provider), Err(FakeError::InvalidWorker));
     }
 
     #[test]
@@ -492,9 +527,12 @@ mod tests {
     fn persisted_handle_rejects_ambiguous_identity_and_lease() {
         let mut worker = worker_status().worker;
         assert!(worker.has_valid_shape());
+        assert!(worker.is_valid_for(CloudProvider::RunPod));
+        assert!(!worker.is_valid_for(CloudProvider::Azure));
 
         worker.identity.resource_id = "display name".to_string();
         assert!(!worker.has_valid_shape());
+        assert!(!worker.is_valid_for(CloudProvider::RunPod));
         worker = worker_status().worker;
         worker.image = "registry.example/horizon/worker:latest".to_string();
         assert!(!worker.has_valid_shape());

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -3,10 +3,11 @@
 use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
-use std::error::Error;
+use std::{error::Error, net::IpAddr};
 
 /// Maximum lease accepted by the common disposable-worker contract.
 pub const MAX_INTERACTIVE_WORKER_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
+const INTERACTIVE_WORKER_LEASE_CLOCK_SKEW_SECONDS: i64 = 120;
 const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
 
 /// Inputs shared by every interactive-worker provider.
@@ -66,9 +67,29 @@ pub struct InteractiveWorkerLease {
 }
 
 impl InteractiveWorkerLease {
+    /// Check the durable timestamp shape without treating an expired worker as
+    /// invalid for exact-resource cleanup.
     #[must_use]
-    pub fn is_valid(&self) -> bool {
+    pub fn has_valid_shape(&self) -> bool {
         time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339).is_ok()
+    }
+
+    fn is_bounded_at(&self, lease_seconds: u32, observed_at: time::OffsetDateTime) -> bool {
+        let Ok(deadline) =
+            time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339)
+        else {
+            return false;
+        };
+        let skew = time::Duration::seconds(INTERACTIVE_WORKER_LEASE_CLOCK_SKEW_SECONDS);
+        let Some(earliest) = observed_at.checked_sub(skew) else {
+            return false;
+        };
+        let Some(latest) = observed_at.checked_add(time::Duration::seconds(
+            i64::from(lease_seconds) + INTERACTIVE_WORKER_LEASE_CLOCK_SKEW_SECONDS,
+        )) else {
+            return false;
+        };
+        (earliest..=latest).contains(&deadline)
     }
 }
 
@@ -83,9 +104,12 @@ pub struct InteractiveWorker {
 }
 
 impl InteractiveWorker {
+    /// Check fields needed to safely persist, inspect, or delete this exact
+    /// resource. Attachment additionally requires request- and time-bound
+    /// validation through [`InteractiveWorkerStatus::is_ready_for`].
     #[must_use]
-    pub fn is_valid(&self) -> bool {
-        self.identity.is_valid() && valid_immutable_image(&self.image) && self.lease.is_valid()
+    pub fn has_valid_shape(&self) -> bool {
+        self.identity.is_valid() && valid_immutable_image(&self.image) && self.lease.has_valid_shape()
     }
 }
 
@@ -134,11 +158,23 @@ pub struct InteractiveWorkerStatus {
 }
 
 impl InteractiveWorkerStatus {
-    /// A worker is attachable only when its lifecycle and SSH data agree.
+    /// A worker is attachable only when its lifecycle, request identity, lease,
+    /// image, and SSH data agree. `observed_at` must be a freshly sampled,
+    /// trusted UTC time from immediately before attachment.
     #[must_use]
-    pub fn is_ready(&self) -> bool {
-        matches!(self.lifecycle, InteractiveWorkerLifecycle::Ready)
-            && self.worker.is_valid()
+    pub fn is_ready_for(&self, request: &InteractiveWorkerRequest, observed_at: time::OffsetDateTime) -> bool {
+        let identity = &self.worker.identity;
+        request.is_valid_for(request.target.provider)
+            && matches!(self.lifecycle, InteractiveWorkerLifecycle::Ready)
+            && self.worker.has_valid_shape()
+            && identity.provider == request.target.provider
+            && identity.workflow_id == request.workflow_id
+            && identity.job_id == request.job_id
+            && self.worker.image == request.target.image
+            && self
+                .worker
+                .lease
+                .is_bounded_at(request.target.lease_seconds, observed_at)
             && self.ssh.as_ref().is_some_and(InteractiveWorkerSshEndpoint::is_complete)
     }
 }
@@ -222,10 +258,17 @@ fn valid_single_token(value: &str, maximum_length: usize) -> bool {
 }
 
 fn valid_ssh_host(value: &str) -> bool {
-    valid_single_token(value, 255)
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b':' | b'[' | b']' | b'%'))
+    if !valid_single_token(value, 253) {
+        return false;
+    }
+    value.parse::<IpAddr>().is_ok() || value.split('.').all(valid_dns_label)
+}
+
+fn valid_dns_label(value: &str) -> bool {
+    (1..=63).contains(&value.len())
+        && value.as_bytes().first().is_some_and(u8::is_ascii_alphanumeric)
+        && value.as_bytes().last().is_some_and(u8::is_ascii_alphanumeric)
+        && value.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
 fn valid_ssh_username(value: &str) -> bool {
@@ -316,16 +359,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn provider_trait_is_object_safe_and_preserves_exact_status() {
-        let status = worker_status();
-        let provider = FakeProvider { status: status.clone() };
-        let provider: &dyn InteractiveWorkerProvider<Error = Infallible> = &provider;
-        let request = InteractiveWorkerRequest {
+    fn worker_request(status: &InteractiveWorkerStatus) -> InteractiveWorkerRequest {
+        InteractiveWorkerRequest {
             workflow_id: status.worker.identity.workflow_id,
             job_id: status.worker.identity.job_id,
             target: WorkerTarget {
-                provider: CloudProvider::RunPod,
+                provider: status.worker.identity.provider,
                 profile: "gpu".to_string(),
                 image: status.worker.image.clone(),
                 disk_gib: 20,
@@ -333,7 +372,20 @@ mod tests {
                 max_hourly_cost_micros: Some(500_000),
             },
             ssh_public_key: ed25519_key(None),
-        };
+        }
+    }
+
+    fn observed_at() -> time::OffsetDateTime {
+        time::OffsetDateTime::parse("2026-09-04T11:50:00Z", &time::format_description::well_known::Rfc3339)
+            .expect("observation timestamp")
+    }
+
+    #[test]
+    fn provider_trait_is_object_safe_and_preserves_exact_status() {
+        let status = worker_status();
+        let provider = FakeProvider { status: status.clone() };
+        let provider: &dyn InteractiveWorkerProvider<Error = Infallible> = &provider;
+        let request = worker_request(&status);
 
         assert_eq!(provider.provider(), CloudProvider::RunPod);
         assert!(request.is_valid_for(provider.provider()));
@@ -350,23 +402,58 @@ mod tests {
     #[test]
     fn ready_requires_complete_ssh_data() {
         let mut status = worker_status();
-        assert!(status.is_ready());
+        let request = worker_request(&status);
+        assert!(status.is_ready_for(&request, observed_at()));
 
         status.ssh = None;
-        assert!(!status.is_ready());
+        assert!(!status.is_ready_for(&request, observed_at()));
         status.lifecycle = InteractiveWorkerLifecycle::Provisioning;
         status.ssh = worker_status().ssh;
-        assert!(!status.is_ready());
+        assert!(!status.is_ready_for(&request, observed_at()));
 
         status.lifecycle = InteractiveWorkerLifecycle::Ready;
         status.ssh.as_mut().expect("SSH endpoint").port = 0;
-        assert!(!status.is_ready());
+        assert!(!status.is_ready_for(&request, observed_at()));
         status.ssh = worker_status().ssh;
         status.ssh.as_mut().expect("SSH endpoint").host_key = "ssh-rsa unsupported".to_string();
-        assert!(!status.is_ready());
+        assert!(!status.is_ready_for(&request, observed_at()));
         status.ssh = worker_status().ssh;
         status.ssh.as_mut().expect("SSH endpoint").host = "-oProxyCommand=bad".to_string();
-        assert!(!status.is_ready());
+        assert!(!status.is_ready_for(&request, observed_at()));
+
+        for host in [".", "[", ":::", "[2001:db8::1]", "bad_host"] {
+            status.ssh = worker_status().ssh;
+            status.ssh.as_mut().expect("SSH endpoint").host = host.to_string();
+            assert!(
+                !status.is_ready_for(&request, observed_at()),
+                "accepted invalid host {host}"
+            );
+        }
+        status.ssh = worker_status().ssh;
+        status.ssh.as_mut().expect("SSH endpoint").host = "2001:db8::1".to_string();
+        assert!(status.is_ready_for(&request, observed_at()));
+    }
+
+    #[test]
+    fn ready_rejects_request_drift_and_unbounded_deadlines() {
+        let original = worker_status();
+        let request = worker_request(&original);
+
+        let mut status = original.clone();
+        status.worker.identity.provider = CloudProvider::Azure;
+        assert!(!status.is_ready_for(&request, observed_at()));
+        status = original.clone();
+        status.worker.identity.workflow_id = CloudWorkflowId::new();
+        assert!(!status.is_ready_for(&request, observed_at()));
+        status = original.clone();
+        status.worker.identity.job_id = CloudJobId::new();
+        assert!(!status.is_ready_for(&request, observed_at()));
+        status = original.clone();
+        status.worker.image = format!("registry.example/horizon/worker@sha256:{}", "a".repeat(64));
+        assert!(!status.is_ready_for(&request, observed_at()));
+        status = original;
+        status.worker.lease.terminate_after = "2999-09-04T12:00:00Z".to_string();
+        assert!(!status.is_ready_for(&request, observed_at()));
     }
 
     #[test]
@@ -404,16 +491,16 @@ mod tests {
     #[test]
     fn persisted_handle_rejects_ambiguous_identity_and_lease() {
         let mut worker = worker_status().worker;
-        assert!(worker.is_valid());
+        assert!(worker.has_valid_shape());
 
         worker.identity.resource_id = "display name".to_string();
-        assert!(!worker.is_valid());
+        assert!(!worker.has_valid_shape());
         worker = worker_status().worker;
         worker.image = "registry.example/horizon/worker:latest".to_string();
-        assert!(!worker.is_valid());
+        assert!(!worker.has_valid_shape());
         worker = worker_status().worker;
         worker.lease.terminate_after = "in two hours".to_string();
-        assert!(!worker.is_valid());
+        assert!(!worker.has_valid_shape());
     }
 
     #[test]

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -1,0 +1,431 @@
+//! Provider-neutral lifecycle contract for disposable interactive workers.
+
+use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+
+/// Maximum lease accepted by the common disposable-worker contract.
+pub const MAX_INTERACTIVE_WORKER_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
+const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
+
+/// Inputs shared by every interactive-worker provider.
+///
+/// Provider-specific credentials and profile details belong to the provider
+/// implementation and must not be persisted in this request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InteractiveWorkerRequest {
+    pub workflow_id: CloudWorkflowId,
+    pub job_id: CloudJobId,
+    pub target: WorkerTarget,
+    /// Ephemeral client public key authorized by the worker image.
+    pub ssh_public_key: String,
+}
+
+impl InteractiveWorkerRequest {
+    /// Check the provider-neutral fields before invoking a concrete provider.
+    #[must_use]
+    pub fn is_valid_for(&self, provider: CloudProvider) -> bool {
+        self.target.provider == provider
+            && !self.target.profile.trim().is_empty()
+            && self.target.profile.trim() == self.target.profile
+            && self.target.profile.len() <= 191
+            && !self.target.profile.chars().any(char::is_control)
+            && valid_immutable_image(&self.target.image)
+            && self.target.disk_gib > 0
+            && (1..=MAX_INTERACTIVE_WORKER_LEASE_SECONDS).contains(&self.target.lease_seconds)
+            && self.target.max_hourly_cost_micros != Some(0)
+            && valid_ed25519_key(&self.ssh_public_key, true)
+    }
+}
+
+/// Exact, provider-qualified ownership identity for one disposable worker.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InteractiveWorkerIdentity {
+    pub provider: CloudProvider,
+    pub workflow_id: CloudWorkflowId,
+    pub job_id: CloudJobId,
+    /// Opaque provider resource ID, never a display name or list position.
+    pub resource_id: String,
+}
+
+impl InteractiveWorkerIdentity {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        valid_single_token(&self.resource_id, 2_048)
+    }
+}
+
+/// Immutable lease data returned by a provider.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InteractiveWorkerLease {
+    /// Exact RFC 3339 deadline supplied to the worker termination watchdog.
+    pub terminate_after: String,
+}
+
+impl InteractiveWorkerLease {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339).is_ok()
+    }
+}
+
+/// Durable worker handle used for inspection and exact-resource cleanup.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InteractiveWorker {
+    pub identity: InteractiveWorkerIdentity,
+    /// Exact immutable image reference used to create the resource.
+    pub image: String,
+    pub lease: InteractiveWorkerLease,
+}
+
+impl InteractiveWorker {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.identity.is_valid() && valid_immutable_image(&self.image) && self.lease.is_valid()
+    }
+}
+
+/// Provider-neutral lifecycle observed for an exact worker resource.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractiveWorkerLifecycle {
+    Provisioning,
+    Ready,
+    Stopped,
+    Failed,
+    Deleting,
+    Unknown,
+}
+
+/// SSH data that is complete enough for a pinned interactive connection.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InteractiveWorkerSshEndpoint {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    /// OpenSSH public host key (`algorithm base64`), obtained through a trusted path.
+    pub host_key: String,
+}
+
+impl InteractiveWorkerSshEndpoint {
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        valid_ssh_host(&self.host)
+            && self.port > 0
+            && valid_ssh_username(&self.username)
+            && valid_ed25519_key(&self.host_key, false)
+    }
+}
+
+/// Current state of an exact worker and its optional connection endpoint.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InteractiveWorkerStatus {
+    pub worker: InteractiveWorker,
+    pub lifecycle: InteractiveWorkerLifecycle,
+    /// Present for `Ready`; providers must not report ready without a pinned host key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh: Option<InteractiveWorkerSshEndpoint>,
+}
+
+impl InteractiveWorkerStatus {
+    /// A worker is attachable only when its lifecycle and SSH data agree.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        matches!(self.lifecycle, InteractiveWorkerLifecycle::Ready)
+            && self.worker.is_valid()
+            && self.ssh.as_ref().is_some_and(InteractiveWorkerSshEndpoint::is_complete)
+    }
+}
+
+/// Whether an idempotent ensure call created or recovered the worker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InteractiveWorkerEnsure {
+    Created(InteractiveWorkerStatus),
+    Reused(InteractiveWorkerStatus),
+}
+
+impl InteractiveWorkerEnsure {
+    #[must_use]
+    pub const fn status(&self) -> &InteractiveWorkerStatus {
+        match self {
+            Self::Created(status) | Self::Reused(status) => status,
+        }
+    }
+
+    #[must_use]
+    pub fn into_status(self) -> InteractiveWorkerStatus {
+        match self {
+            Self::Created(status) | Self::Reused(status) => status,
+        }
+    }
+}
+
+/// Idempotent cleanup result for one exact worker resource.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InteractiveWorkerCleanup {
+    Deleted,
+    AlreadyAbsent,
+}
+
+/// Blocking provider boundary for one disposable interactive worker.
+///
+/// Callers must invoke provider operations away from the render thread. An
+/// implementation must validate that request targets match [`Self::provider`],
+/// make `ensure_worker` idempotent across controllers, preserve the exact
+/// returned handle for later inspection, and delete only that exact resource.
+pub trait InteractiveWorkerProvider: Send + Sync {
+    type Error: Error + Send + Sync + 'static;
+
+    #[must_use]
+    fn provider(&self) -> CloudProvider;
+
+    /// Create once or recover the single exact worker for this request.
+    ///
+    /// # Errors
+    /// Returns a redacted, provider-specific error when the operation cannot
+    /// safely produce an exact worker identity.
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error>;
+
+    /// Inspect only the exact persisted worker, returning `None` when absent.
+    ///
+    /// # Errors
+    /// Returns a redacted, provider-specific error when state is ambiguous.
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error>;
+
+    /// Delete only the exact persisted worker. Repeated deletion is idempotent.
+    ///
+    /// # Errors
+    /// Returns a redacted, provider-specific error unless absence is verified.
+    fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error>;
+}
+
+fn valid_immutable_image(value: &str) -> bool {
+    super::validation::valid_worker_image(value)
+        && value
+            .rsplit_once("@sha256:")
+            .is_some_and(|(_, digest)| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}
+
+fn valid_single_token(value: &str, maximum_length: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= maximum_length
+        && !value.starts_with('-')
+        && !value
+            .chars()
+            .any(|character| character.is_control() || character.is_whitespace())
+}
+
+fn valid_ssh_host(value: &str) -> bool {
+    valid_single_token(value, 255)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b':' | b'[' | b']' | b'%'))
+}
+
+fn valid_ssh_username(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && !value.starts_with('-')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn valid_ed25519_key(value: &str, allow_comment: bool) -> bool {
+    if value.is_empty() || value.len() > 16 * 1_024 || value.trim() != value || value.chars().any(char::is_control) {
+        return false;
+    }
+    let mut fields = value.split_ascii_whitespace();
+    let (Some("ssh-ed25519"), Some(encoded)) = (fields.next(), fields.next()) else {
+        return false;
+    };
+    let valid_payload = STANDARD.decode(encoded).is_ok_and(|decoded| {
+        decoded.len() == ED25519_BLOB_PREFIX.len() + 32 && decoded.starts_with(ED25519_BLOB_PREFIX)
+    });
+    valid_payload && (allow_comment || fields.next().is_none())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    #[derive(Clone)]
+    struct FakeProvider {
+        status: InteractiveWorkerStatus,
+    }
+
+    impl InteractiveWorkerProvider for FakeProvider {
+        type Error = Infallible;
+
+        fn provider(&self) -> CloudProvider {
+            CloudProvider::RunPod
+        }
+
+        fn ensure_worker(&self, _request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+            Ok(InteractiveWorkerEnsure::Created(self.status.clone()))
+        }
+
+        fn inspect_worker(&self, _worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+            Ok(Some(self.status.clone()))
+        }
+
+        fn delete_worker(&self, _worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+            Ok(InteractiveWorkerCleanup::Deleted)
+        }
+    }
+
+    fn ed25519_key(comment: Option<&str>) -> String {
+        let mut blob = ED25519_BLOB_PREFIX.to_vec();
+        blob.extend([42; 32]);
+        let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
+        if let Some(comment) = comment {
+            format!("{key} {comment}")
+        } else {
+            key
+        }
+    }
+
+    fn worker_status() -> InteractiveWorkerStatus {
+        InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::RunPod,
+                    workflow_id: CloudWorkflowId::new(),
+                    job_id: CloudJobId::new(),
+                    resource_id: "pod-123".to_string(),
+                },
+                image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
+                lease: InteractiveWorkerLease {
+                    terminate_after: "2026-09-04T12:00:00Z".to_string(),
+                },
+            },
+            lifecycle: InteractiveWorkerLifecycle::Ready,
+            ssh: Some(InteractiveWorkerSshEndpoint {
+                host: "worker.example".to_string(),
+                port: 22,
+                username: "root".to_string(),
+                host_key: ed25519_key(None),
+            }),
+        }
+    }
+
+    #[test]
+    fn provider_trait_is_object_safe_and_preserves_exact_status() {
+        let status = worker_status();
+        let provider = FakeProvider { status: status.clone() };
+        let provider: &dyn InteractiveWorkerProvider<Error = Infallible> = &provider;
+        let request = InteractiveWorkerRequest {
+            workflow_id: status.worker.identity.workflow_id,
+            job_id: status.worker.identity.job_id,
+            target: WorkerTarget {
+                provider: CloudProvider::RunPod,
+                profile: "gpu".to_string(),
+                image: status.worker.image.clone(),
+                disk_gib: 20,
+                lease_seconds: 900,
+                max_hourly_cost_micros: Some(500_000),
+            },
+            ssh_public_key: ed25519_key(None),
+        };
+
+        assert_eq!(provider.provider(), CloudProvider::RunPod);
+        assert!(request.is_valid_for(provider.provider()));
+        let ensured = provider.ensure_worker(&request).expect("fake ensure");
+        assert_eq!(ensured.status(), &status);
+        assert_eq!(ensured.into_status(), status);
+        assert_eq!(provider.inspect_worker(&status.worker), Ok(Some(status.clone())));
+        assert_eq!(
+            provider.delete_worker(&status.worker),
+            Ok(InteractiveWorkerCleanup::Deleted)
+        );
+    }
+
+    #[test]
+    fn ready_requires_complete_ssh_data() {
+        let mut status = worker_status();
+        assert!(status.is_ready());
+
+        status.ssh = None;
+        assert!(!status.is_ready());
+        status.lifecycle = InteractiveWorkerLifecycle::Provisioning;
+        status.ssh = worker_status().ssh;
+        assert!(!status.is_ready());
+
+        status.lifecycle = InteractiveWorkerLifecycle::Ready;
+        status.ssh.as_mut().expect("SSH endpoint").port = 0;
+        assert!(!status.is_ready());
+        status.ssh = worker_status().ssh;
+        status.ssh.as_mut().expect("SSH endpoint").host_key = "ssh-rsa unsupported".to_string();
+        assert!(!status.is_ready());
+        status.ssh = worker_status().ssh;
+        status.ssh.as_mut().expect("SSH endpoint").host = "-oProxyCommand=bad".to_string();
+        assert!(!status.is_ready());
+    }
+
+    #[test]
+    fn request_preflight_rejects_provider_drift_and_mutable_images() {
+        let status = worker_status();
+        let mut request = InteractiveWorkerRequest {
+            workflow_id: status.worker.identity.workflow_id,
+            job_id: status.worker.identity.job_id,
+            target: WorkerTarget {
+                provider: CloudProvider::RunPod,
+                profile: "gpu".to_string(),
+                image: status.worker.image,
+                disk_gib: 20,
+                lease_seconds: 900,
+                max_hourly_cost_micros: None,
+            },
+            ssh_public_key: ed25519_key(Some("user@example")),
+        };
+        assert!(request.is_valid_for(CloudProvider::RunPod));
+        assert!(!request.is_valid_for(CloudProvider::Azure));
+
+        request.target.image = "registry.example/horizon/worker:latest".to_string();
+        assert!(!request.is_valid_for(CloudProvider::RunPod));
+        request.target.image = format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64));
+        request.ssh_public_key = "ssh-rsa unsupported".to_string();
+        assert!(!request.is_valid_for(CloudProvider::RunPod));
+        request.ssh_public_key = ed25519_key(None);
+        request.target.lease_seconds = MAX_INTERACTIVE_WORKER_LEASE_SECONDS + 1;
+        assert!(!request.is_valid_for(CloudProvider::RunPod));
+        request.target.lease_seconds = 900;
+        request.target.max_hourly_cost_micros = Some(0);
+        assert!(!request.is_valid_for(CloudProvider::RunPod));
+    }
+
+    #[test]
+    fn persisted_handle_rejects_ambiguous_identity_and_lease() {
+        let mut worker = worker_status().worker;
+        assert!(worker.is_valid());
+
+        worker.identity.resource_id = "display name".to_string();
+        assert!(!worker.is_valid());
+        worker = worker_status().worker;
+        worker.image = "registry.example/horizon/worker:latest".to_string();
+        assert!(!worker.is_valid());
+        worker = worker_status().worker;
+        worker.lease.terminate_after = "in two hours".to_string();
+        assert!(!worker.is_valid());
+    }
+
+    #[test]
+    fn durable_worker_status_round_trips_with_stable_wire_values() {
+        let status = worker_status();
+        let encoded = serde_json::to_string(&status).expect("serialize status");
+        assert!(encoded.contains("\"lifecycle\":\"ready\""));
+        assert!(encoded.contains("\"host_key\":\"ssh-ed25519"));
+        let decoded = serde_json::from_str::<InteractiveWorkerStatus>(&encoded).expect("deserialize status");
+        assert_eq!(decoded, status);
+
+        let unknown = encoded.replacen("\"resource_id\"", "\"unexpected\":true,\"resource_id\"", 1);
+        assert!(serde_json::from_str::<InteractiveWorkerStatus>(&unknown).is_err());
+    }
+}


### PR DESCRIPTION
## Purpose

Add the small provider-neutral lifecycle boundary required by #383 before concrete interactive-worker adapters are wired.

## Behavior impact

- defines an object-safe blocking provider trait for create-or-recover, exact inspection, and idempotent deletion
- preserves provider-qualified resource identity, workflow/job ownership, immutable image, and exact lease deadline
- carries a ready SSH endpoint only with a safe host, nonzero port, username, and decoded Ed25519 host key
- rejects provider drift, mutable images, malformed keys, ambiguous resource IDs, invalid leases, and zero cost ceilings before attachment
- keeps provider calls explicitly off the render thread

This PR does not implement a provider adapter, change UI or configuration behavior, provision resources, publish an image, or create a release.

## Test evidence

- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- ./scripts/check-version-sync.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- RUSTFLAGS="-D warnings" cargo test --workspace --features speech
- cargo clippy --all-targets --features speech,trace-profiling -- -D warnings
- cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic