### PR TITLE
feat(cloud): adapt GPU workers to provider contract

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -100,6 +100,8 @@ pub struct InteractiveWorker {
     pub identity: InteractiveWorkerIdentity,
     /// Exact immutable image reference used to create the resource.
     pub image: String,
+    /// Ephemeral client public key installed in this runtime generation.
+    pub ssh_public_key: String,
     pub lease: InteractiveWorkerLease,
 }
 
@@ -109,7 +111,10 @@ impl InteractiveWorker {
     /// validation through [`InteractiveWorkerStatus::is_ready_for`].
     #[must_use]
     pub fn has_valid_shape(&self) -> bool {
-        self.identity.is_valid() && valid_immutable_image(&self.image) && self.lease.has_valid_shape()
+        self.identity.is_valid()
+            && valid_immutable_image(&self.image)
+            && valid_ssh_public_key(&self.ssh_public_key)
+            && self.lease.has_valid_shape()
     }
 
     /// Check the durable handle before any provider-specific inspection or
@@ -146,10 +151,7 @@ pub struct InteractiveWorkerSshEndpoint {
 impl InteractiveWorkerSshEndpoint {
     #[must_use]
     pub fn is_complete(&self) -> bool {
-        valid_ssh_host(&self.host)
-            && self.port > 0
-            && valid_ssh_username(&self.username)
-            && valid_ed25519_key(&self.host_key, false)
+        valid_ssh_coordinates(&self.host, self.port, &self.username) && valid_ed25519_key(&self.host_key, false)
     }
 }
 
@@ -177,6 +179,7 @@ impl InteractiveWorkerStatus {
             && identity.workflow_id == request.workflow_id
             && identity.job_id == request.job_id
             && self.worker.image == request.target.image
+            && self.worker.ssh_public_key == request.ssh_public_key
             && self
                 .worker
                 .lease
@@ -278,6 +281,10 @@ fn valid_ssh_host(value: &str) -> bool {
     value.parse::<IpAddr>().is_ok() || value.split('.').all(valid_dns_label)
 }
 
+pub(super) fn valid_ssh_coordinates(host: &str, port: u16, username: &str) -> bool {
+    valid_ssh_host(host) && port > 0 && valid_ssh_username(username)
+}
+
 fn valid_dns_label(value: &str) -> bool {
     (1..=63).contains(&value.len())
         && value.as_bytes().first().is_some_and(u8::is_ascii_alphanumeric)
@@ -292,6 +299,10 @@ fn valid_ssh_username(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+pub(super) fn valid_ssh_public_key(value: &str) -> bool {
+    valid_ed25519_key(value, true)
 }
 
 fn valid_ed25519_key(value: &str, allow_comment: bool) -> bool {
@@ -375,6 +386,7 @@ mod tests {
                     resource_id: "pod-123".to_string(),
                 },
                 image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
+                ssh_public_key: ed25519_key(None),
                 lease: InteractiveWorkerLease {
                     terminate_after: "2026-09-04T12:00:00Z".to_string(),
                 },
@@ -401,7 +413,7 @@ mod tests {
                 lease_seconds: 900,
                 max_hourly_cost_micros: Some(500_000),
             },
-            ssh_public_key: ed25519_key(None),
+            ssh_public_key: status.worker.ssh_public_key.clone(),
         }
     }
 
@@ -486,6 +498,13 @@ mod tests {
         status = original.clone();
         status.worker.image = format!("registry.example/horizon/worker@sha256:{}", "a".repeat(64));
         assert!(!status.is_ready_for(&request, observed_at()));
+        status = original.clone();
+        status.worker.ssh_public_key = {
+            let mut blob = ED25519_BLOB_PREFIX.to_vec();
+            blob.extend([43; 32]);
+            format!("ssh-ed25519 {}", STANDARD.encode(blob))
+        };
+        assert!(!status.is_ready_for(&request, observed_at()));
         status = original;
         status.worker.lease.terminate_after = "2999-09-04T12:00:00Z".to_string();
         assert!(!status.is_ready_for(&request, observed_at()));
@@ -537,6 +556,9 @@ mod tests {
         worker.image = "registry.example/horizon/worker:latest".to_string();
         assert!(!worker.has_valid_shape());
         worker = worker_status().worker;
+        worker.ssh_public_key = "ssh-rsa unsupported".to_string();
+        assert!(!worker.has_valid_shape());
+        worker = worker_status().worker;
         worker.lease.terminate_after = "in two hours".to_string();
         assert!(!worker.has_valid_shape());
     }
@@ -547,6 +569,7 @@ mod tests {
         let encoded = serde_json::to_string(&status).expect("serialize status");
         assert!(encoded.contains("\"lifecycle\":\"ready\""));
         assert!(encoded.contains("\"host_key\":\"ssh-ed25519"));
+        assert!(encoded.contains("\"ssh_public_key\":\"ssh-ed25519"));
         let decoded = serde_json::from_str::<InteractiveWorkerStatus>(&encoded).expect("deserialize status");
         assert_eq!(decoded, status);
 

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -79,8 +79,6 @@ pub struct RunPodWorker {
     pub image: String,
     pub terminate_after: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ssh_public_key: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hourly_cost_micros: Option<u64>,
 }
 impl RunPodWorker {
@@ -90,7 +88,6 @@ impl RunPodWorker {
         let valid = valid_provider_id(&self.pod_id)
             && self.name == resource_name(self.workflow_id, self.job_id)
             && valid_immutable_worker_image(&self.image)
-            && self.ssh_public_key.as_deref().is_none_or(valid_ssh_public_key)
             && time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339)
                 .is_ok();
         valid.then_some(()).ok_or(RunPodError::InvalidPersistedWorker)
@@ -117,7 +114,9 @@ pub struct RunPodSshEndpoint {
 pub struct RunPodWorkerStatus {
     pub worker: RunPodWorker,
     pub lifecycle: RunPodLifecycle,
-    pub ssh: Option<RunPodSshEndpoint>,
+    pub ssh_username: Option<String>,
+    pub ssh_host: Option<String>,
+    pub ssh_port: Option<u16>,
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RunPodEnsure {
@@ -294,7 +293,22 @@ impl RunPodClient {
         worker.validate()?;
         self.transport
             .get(&worker.pod_id)?
-            .map(|pod| status_from_resource(&pod, worker))
+            .map(|pod| status_from_resource(&pod, worker, None))
+            .transpose()
+    }
+
+    fn inspect_interactive_worker(
+        &self,
+        worker: &RunPodWorker,
+        ssh_public_key: &str,
+    ) -> Result<Option<RunPodWorkerStatus>, RunPodError> {
+        worker.validate()?;
+        if !valid_ssh_public_key(ssh_public_key) {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        self.transport
+            .get(&worker.pod_id)?
+            .map(|pod| status_from_resource(&pod, worker, Some(ssh_public_key)))
             .transpose()
     }
     /// Delete only the exact resource proven to belong to the persisted workflow and job.
@@ -304,7 +318,23 @@ impl RunPodClient {
         let Some(pod) = self.transport.get(&worker.pod_id)? else {
             return Ok(RunPodCleanup::AlreadyAbsent);
         };
-        status_from_resource(&pod, worker)?;
+        status_from_resource(&pod, worker, None)?;
+        self.transport.delete(&worker.pod_id)
+    }
+
+    fn delete_interactive_worker(
+        &self,
+        worker: &RunPodWorker,
+        ssh_public_key: &str,
+    ) -> Result<RunPodCleanup, RunPodError> {
+        worker.validate()?;
+        if !valid_ssh_public_key(ssh_public_key) {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        let Some(pod) = self.transport.get(&worker.pod_id)? else {
+            return Ok(RunPodCleanup::AlreadyAbsent);
+        };
+        status_from_resource(&pod, worker, Some(ssh_public_key))?;
         self.transport.delete(&worker.pod_id)
     }
     fn enforce_cost_limit(&self, worker: &RunPodWorker, maximum: Option<u64>) -> Result<(), RunPodError> {
@@ -557,12 +587,15 @@ fn status_from_pod(
         name: resource_name(workflow_id, job_id),
         image: target.image.clone(),
         terminate_after,
-        ssh_public_key: ssh_public_key.map(str::to_string),
         hourly_cost_micros: pod.cost.filter(|cost| *cost > 0),
     };
-    status_from_resource(pod, &worker)
+    status_from_resource(pod, &worker, ssh_public_key)
 }
-fn status_from_resource(pod: &ApiPod, worker: &RunPodWorker) -> Result<RunPodWorkerStatus, RunPodError> {
+fn status_from_resource(
+    pod: &ApiPod,
+    worker: &RunPodWorker,
+    ssh_public_key: Option<&str>,
+) -> Result<RunPodWorkerStatus, RunPodError> {
     worker.validate()?;
     let owned = pod.id == worker.pod_id
         && pod.name == worker.name
@@ -572,7 +605,7 @@ fn status_from_resource(pod: &ApiPod, worker: &RunPodWorker) -> Result<RunPodWor
         && pod.env.get(PROTOCOL_ENV) == Some(&super::CLOUD_RUN_PROTOCOL_VERSION.to_string());
     let owned = owned
         && pod.env.get(TERMINATE_ENV) == Some(&worker.terminate_after)
-        && pod.env.get(SSH_PUBLIC_KEY_ENV) == worker.ssh_public_key.as_ref();
+        && ssh_public_key.is_none_or(|key| pod.env.get(SSH_PUBLIC_KEY_ENV).is_some_and(|value| value == key));
     if !owned {
         return Err(RunPodError::ResourceIdentityMismatch);
     }
@@ -592,11 +625,9 @@ fn status_from_resource(pod: &ApiPod, worker: &RunPodWorker) -> Result<RunPodWor
             ..worker.clone()
         },
         lifecycle,
-        ssh: direct_ssh.map(|endpoint| RunPodSshEndpoint {
-            username: endpoint.username.clone(),
-            host: endpoint.host.clone(),
-            port: endpoint.port,
-        }),
+        ssh_username: direct_ssh.map(|endpoint| endpoint.username.clone()),
+        ssh_host: direct_ssh.map(|endpoint| endpoint.host.clone()),
+        ssh_port: direct_ssh.map(|endpoint| endpoint.port),
     })
 }
 fn resource_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -1,14 +1,22 @@
 //! `RunPod` Secure Cloud lifecycle adapter for durable cloud workers.
-use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget, validation::valid_worker_image};
+use super::{
+    CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget, interactive_worker::valid_ssh_public_key,
+    validation::valid_worker_image,
+};
 use serde::{Deserialize, Deserializer, Serialize, de};
 use std::{collections::BTreeMap, env, fmt};
 use thiserror::Error;
 mod http;
+mod interactive;
 #[cfg(test)]
 mod tests;
+
+pub use interactive::{RunPodHostKeySource, RunPodInteractiveWorkerProvider};
+
 const WORKFLOW_ENV: &str = "HORIZON_WORKFLOW_ID";
 const JOB_ENV: &str = "HORIZON_JOB_ID";
 const PROTOCOL_ENV: &str = "HORIZON_CLOUD_PROTOCOL_VERSION";
+const SSH_PUBLIC_KEY_ENV: &str = "HORIZON_SSH_PUBLIC_KEY";
 const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
 const MIN_LEASE_SECONDS: u32 = 300;
 const MAX_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
@@ -71,6 +79,8 @@ pub struct RunPodWorker {
     pub image: String,
     pub terminate_after: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_public_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hourly_cost_micros: Option<u64>,
 }
 impl RunPodWorker {
@@ -80,6 +90,7 @@ impl RunPodWorker {
         let valid = valid_provider_id(&self.pod_id)
             && self.name == resource_name(self.workflow_id, self.job_id)
             && valid_immutable_worker_image(&self.image)
+            && self.ssh_public_key.as_deref().is_none_or(valid_ssh_public_key)
             && time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339)
                 .is_ok();
         valid.then_some(()).ok_or(RunPodError::InvalidPersistedWorker)
@@ -94,13 +105,19 @@ pub enum RunPodLifecycle {
     Terminated,
     Unknown,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunPodSshEndpoint {
+    pub username: String,
+    pub host: String,
+    pub port: u16,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RunPodWorkerStatus {
     pub worker: RunPodWorker,
     pub lifecycle: RunPodLifecycle,
-    pub ssh_username: Option<String>,
-    pub ssh_host: Option<String>,
-    pub ssh_port: Option<u16>,
+    pub ssh: Option<RunPodSshEndpoint>,
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RunPodEnsure {
@@ -174,14 +191,40 @@ impl RunPodClient {
         target: &WorkerTarget,
         profile: &RunPodProfile,
     ) -> Result<RunPodEnsure, RunPodError> {
+        self.ensure_worker_with_ssh_public_key(workflow_id, job_id, target, profile, None)
+    }
+
+    fn ensure_interactive_worker(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        profile: &RunPodProfile,
+        ssh_public_key: &str,
+    ) -> Result<RunPodEnsure, RunPodError> {
+        self.ensure_worker_with_ssh_public_key(workflow_id, job_id, target, profile, Some(ssh_public_key))
+    }
+
+    fn ensure_worker_with_ssh_public_key(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        profile: &RunPodProfile,
+        ssh_public_key: Option<&str>,
+    ) -> Result<RunPodEnsure, RunPodError> {
         validate_target(target, profile)?;
+        if ssh_public_key.is_some_and(|key| !valid_ssh_public_key(key)) {
+            return Err(RunPodError::InvalidTarget);
+        }
         let name = resource_name(workflow_id, job_id);
         let matches = self.reconcile_by_name(&name)?;
         let may_create = !matches.is_empty() || self.creation_fence.claim_once(workflow_id, job_id, target, &name)?;
         let (pod, created, expected_deadline) = match matches.as_slice() {
             [] if !may_create => return Err(RunPodError::CreationUnresolved { name }),
             [] => {
-                let request = CreatePodRequest::new(workflow_id, job_id, target, profile, name.clone())?;
+                let request =
+                    CreatePodRequest::new(workflow_id, job_id, target, profile, name.clone(), ssh_public_key)?;
                 let expected_deadline = request.terminate_after.clone();
                 (self.transport.create(&request)?, true, Some(expected_deadline))
             }
@@ -193,7 +236,14 @@ impl RunPodClient {
                 });
             }
         };
-        let status = match status_from_pod(&pod, workflow_id, job_id, target, expected_deadline.as_deref()) {
+        let status = match status_from_pod(
+            &pod,
+            workflow_id,
+            job_id,
+            target,
+            expected_deadline.as_deref(),
+            ssh_public_key,
+        ) {
             Ok(status) => status,
             Err(error) if created => {
                 if self.transport.delete(&pod.id).is_err() {
@@ -383,9 +433,10 @@ impl CreatePodRequest {
         target: &WorkerTarget,
         profile: &RunPodProfile,
         name: String,
+        ssh_public_key: Option<&str>,
     ) -> Result<Self, RunPodError> {
         let terminate_after = termination_deadline(target.lease_seconds)?;
-        let env = [
+        let mut env: Vec<_> = [
             (WORKFLOW_ENV, workflow_id.to_string()),
             (JOB_ENV, job_id.to_string()),
             (PROTOCOL_ENV, super::CLOUD_RUN_PROTOCOL_VERSION.to_string()),
@@ -397,6 +448,12 @@ impl CreatePodRequest {
             value,
         })
         .collect();
+        if let Some(ssh_public_key) = ssh_public_key {
+            env.push(CreatePodEnv {
+                key: SSH_PUBLIC_KEY_ENV.to_string(),
+                value: ssh_public_key.to_string(),
+            });
+        }
         Ok(Self {
             allowed_cuda_versions: profile.allowed_cuda_versions.clone(),
             cloud_type: "SECURE",
@@ -483,6 +540,7 @@ fn status_from_pod(
     job_id: CloudJobId,
     target: &WorkerTarget,
     expected_deadline: Option<&str>,
+    ssh_public_key: Option<&str>,
 ) -> Result<RunPodWorkerStatus, RunPodError> {
     let terminate_after = pod
         .env
@@ -499,6 +557,7 @@ fn status_from_pod(
         name: resource_name(workflow_id, job_id),
         image: target.image.clone(),
         terminate_after,
+        ssh_public_key: ssh_public_key.map(str::to_string),
         hourly_cost_micros: pod.cost.filter(|cost| *cost > 0),
     };
     status_from_resource(pod, &worker)
@@ -511,7 +570,9 @@ fn status_from_resource(pod: &ApiPod, worker: &RunPodWorker) -> Result<RunPodWor
         && pod.env.get(WORKFLOW_ENV) == Some(&worker.workflow_id.to_string())
         && pod.env.get(JOB_ENV) == Some(&worker.job_id.to_string())
         && pod.env.get(PROTOCOL_ENV) == Some(&super::CLOUD_RUN_PROTOCOL_VERSION.to_string());
-    let owned = owned && pod.env.get(TERMINATE_ENV) == Some(&worker.terminate_after);
+    let owned = owned
+        && pod.env.get(TERMINATE_ENV) == Some(&worker.terminate_after)
+        && pod.env.get(SSH_PUBLIC_KEY_ENV) == worker.ssh_public_key.as_ref();
     if !owned {
         return Err(RunPodError::ResourceIdentityMismatch);
     }
@@ -531,9 +592,11 @@ fn status_from_resource(pod: &ApiPod, worker: &RunPodWorker) -> Result<RunPodWor
             ..worker.clone()
         },
         lifecycle,
-        ssh_username: direct_ssh.map(|endpoint| endpoint.username.clone()),
-        ssh_host: direct_ssh.map(|endpoint| endpoint.host.clone()),
-        ssh_port: direct_ssh.map(|endpoint| endpoint.port),
+        ssh: direct_ssh.map(|endpoint| RunPodSshEndpoint {
+            username: endpoint.username.clone(),
+            host: endpoint.host.clone(),
+            port: endpoint.port,
+        }),
     })
 }
 fn resource_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -1,0 +1,174 @@
+use super::super::{
+    CloudProvider,
+    interactive_worker::{
+        InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
+        InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_coordinates,
+    },
+};
+use super::{
+    RunPodCleanup, RunPodClient, RunPodEnsure, RunPodError, RunPodLifecycle, RunPodProfile, RunPodSshEndpoint,
+    RunPodWorker, RunPodWorkerStatus, resource_name,
+};
+
+/// Trusted source for the runtime SSH host key of one exact worker.
+///
+/// Returning `None` keeps a running worker in `Provisioning`. Implementations
+/// must authenticate that the returned key belongs to the supplied exact
+/// worker identity and endpoint. An unauthenticated network key scan is not an
+/// attestation source.
+pub trait RunPodHostKeySource: Send + Sync {
+    #[must_use]
+    fn host_key(&self, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> Option<String>;
+}
+
+impl<F> RunPodHostKeySource for F
+where
+    F: Fn(&RunPodWorker, &RunPodSshEndpoint) -> Option<String> + Send + Sync,
+{
+    fn host_key(&self, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> Option<String> {
+        self(worker, endpoint)
+    }
+}
+
+/// Adapts the exact GPU-worker lifecycle to the common interactive contract.
+pub struct RunPodInteractiveWorkerProvider {
+    client: RunPodClient,
+    profile: RunPodProfile,
+    host_keys: Box<dyn RunPodHostKeySource>,
+}
+
+impl RunPodInteractiveWorkerProvider {
+    #[must_use]
+    pub fn new(client: RunPodClient, profile: RunPodProfile, host_keys: impl RunPodHostKeySource + 'static) -> Self {
+        Self {
+            client,
+            profile,
+            host_keys: Box::new(host_keys),
+        }
+    }
+
+    fn adapt_status(&self, status: RunPodWorkerStatus) -> Result<InteractiveWorkerStatus, RunPodError> {
+        let ssh_public_key = status
+            .worker
+            .ssh_public_key
+            .clone()
+            .ok_or(RunPodError::InvalidPersistedWorker)?;
+        let (lifecycle, ssh) = self.adapt_connection(&status);
+        Ok(InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::RunPod,
+                    workflow_id: status.worker.workflow_id,
+                    job_id: status.worker.job_id,
+                    resource_id: status.worker.pod_id,
+                },
+                image: status.worker.image,
+                ssh_public_key,
+                lease: InteractiveWorkerLease {
+                    terminate_after: status.worker.terminate_after,
+                },
+            },
+            lifecycle,
+            ssh,
+        })
+    }
+
+    fn adapt_connection(
+        &self,
+        status: &RunPodWorkerStatus,
+    ) -> (InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>) {
+        match status.lifecycle {
+            RunPodLifecycle::Provisioning => (InteractiveWorkerLifecycle::Provisioning, None),
+            RunPodLifecycle::Exited | RunPodLifecycle::Terminated => (InteractiveWorkerLifecycle::Stopped, None),
+            RunPodLifecycle::Failed => (InteractiveWorkerLifecycle::Failed, None),
+            RunPodLifecycle::Unknown => (InteractiveWorkerLifecycle::Unknown, None),
+            RunPodLifecycle::Running => self.adapt_running_connection(status),
+        }
+    }
+
+    fn adapt_running_connection(
+        &self,
+        status: &RunPodWorkerStatus,
+    ) -> (InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>) {
+        let Some(endpoint) = status.ssh.as_ref() else {
+            return (InteractiveWorkerLifecycle::Provisioning, None);
+        };
+        if !valid_ssh_coordinates(&endpoint.host, endpoint.port, &endpoint.username) {
+            return (InteractiveWorkerLifecycle::Failed, None);
+        }
+        let Some(host_key) = self.host_keys.host_key(&status.worker, endpoint) else {
+            return (InteractiveWorkerLifecycle::Provisioning, None);
+        };
+        let endpoint = InteractiveWorkerSshEndpoint {
+            host: endpoint.host.clone(),
+            port: endpoint.port,
+            username: endpoint.username.clone(),
+            host_key,
+        };
+        if endpoint.is_complete() {
+            (InteractiveWorkerLifecycle::Ready, Some(endpoint))
+        } else {
+            (InteractiveWorkerLifecycle::Failed, None)
+        }
+    }
+}
+
+impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
+    type Error = RunPodError;
+
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::RunPod
+    }
+
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        if !request.is_valid_for(self.provider()) {
+            return Err(RunPodError::InvalidTarget);
+        }
+        let ensured = self.client.ensure_interactive_worker(
+            request.workflow_id,
+            request.job_id,
+            &request.target,
+            &self.profile,
+            &request.ssh_public_key,
+        )?;
+        Ok(match ensured {
+            RunPodEnsure::Created(status) => InteractiveWorkerEnsure::Created(self.adapt_status(status)?),
+            RunPodEnsure::Reused(status) => InteractiveWorkerEnsure::Reused(self.adapt_status(status)?),
+        })
+    }
+
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let worker = runpod_worker(worker)?;
+        self.client
+            .inspect_worker(&worker)?
+            .map(|status| self.adapt_status(status))
+            .transpose()
+    }
+
+    fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        let worker = runpod_worker(worker)?;
+        Ok(match self.client.delete_worker(&worker)? {
+            RunPodCleanup::Deleted => InteractiveWorkerCleanup::Deleted,
+            RunPodCleanup::AlreadyAbsent => InteractiveWorkerCleanup::AlreadyAbsent,
+        })
+    }
+}
+
+fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError> {
+    if !worker.is_valid_for(CloudProvider::RunPod) {
+        return Err(RunPodError::InvalidPersistedWorker);
+    }
+    let runpod_worker = RunPodWorker {
+        workflow_id: worker.identity.workflow_id,
+        job_id: worker.identity.job_id,
+        pod_id: worker.identity.resource_id.clone(),
+        name: resource_name(worker.identity.workflow_id, worker.identity.job_id),
+        image: worker.image.clone(),
+        terminate_after: worker.lease.terminate_after.clone(),
+        ssh_public_key: Some(worker.ssh_public_key.clone()),
+        hourly_cost_micros: None,
+    };
+    runpod_worker.validate()?;
+    Ok(runpod_worker)
+}

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -48,14 +48,9 @@ impl RunPodInteractiveWorkerProvider {
         }
     }
 
-    fn adapt_status(&self, status: RunPodWorkerStatus) -> Result<InteractiveWorkerStatus, RunPodError> {
-        let ssh_public_key = status
-            .worker
-            .ssh_public_key
-            .clone()
-            .ok_or(RunPodError::InvalidPersistedWorker)?;
+    fn adapt_status(&self, status: RunPodWorkerStatus, ssh_public_key: &str) -> InteractiveWorkerStatus {
         let (lifecycle, ssh) = self.adapt_connection(&status);
-        Ok(InteractiveWorkerStatus {
+        InteractiveWorkerStatus {
             worker: InteractiveWorker {
                 identity: InteractiveWorkerIdentity {
                     provider: CloudProvider::RunPod,
@@ -64,14 +59,14 @@ impl RunPodInteractiveWorkerProvider {
                     resource_id: status.worker.pod_id,
                 },
                 image: status.worker.image,
-                ssh_public_key,
+                ssh_public_key: ssh_public_key.to_string(),
                 lease: InteractiveWorkerLease {
                     terminate_after: status.worker.terminate_after,
                 },
             },
             lifecycle,
             ssh,
-        })
+        }
     }
 
     fn adapt_connection(
@@ -91,13 +86,24 @@ impl RunPodInteractiveWorkerProvider {
         &self,
         status: &RunPodWorkerStatus,
     ) -> (InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>) {
-        let Some(endpoint) = status.ssh.as_ref() else {
+        let Some((username, host, port)) = status
+            .ssh_username
+            .as_ref()
+            .zip(status.ssh_host.as_ref())
+            .zip(status.ssh_port)
+            .map(|((username, host), port)| (username, host, port))
+        else {
             return (InteractiveWorkerLifecycle::Provisioning, None);
+        };
+        let endpoint = RunPodSshEndpoint {
+            username: username.clone(),
+            host: host.clone(),
+            port,
         };
         if !valid_ssh_coordinates(&endpoint.host, endpoint.port, &endpoint.username) {
             return (InteractiveWorkerLifecycle::Failed, None);
         }
-        let Some(host_key) = self.host_keys.host_key(&status.worker, endpoint) else {
+        let Some(host_key) = self.host_keys.host_key(&status.worker, &endpoint) else {
             return (InteractiveWorkerLifecycle::Provisioning, None);
         };
         let endpoint = InteractiveWorkerSshEndpoint {
@@ -133,22 +139,27 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
             &request.ssh_public_key,
         )?;
         Ok(match ensured {
-            RunPodEnsure::Created(status) => InteractiveWorkerEnsure::Created(self.adapt_status(status)?),
-            RunPodEnsure::Reused(status) => InteractiveWorkerEnsure::Reused(self.adapt_status(status)?),
+            RunPodEnsure::Created(status) => {
+                InteractiveWorkerEnsure::Created(self.adapt_status(status, &request.ssh_public_key))
+            }
+            RunPodEnsure::Reused(status) => {
+                InteractiveWorkerEnsure::Reused(self.adapt_status(status, &request.ssh_public_key))
+            }
         })
     }
 
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let ssh_public_key = worker.ssh_public_key.clone();
         let worker = runpod_worker(worker)?;
         self.client
-            .inspect_worker(&worker)?
-            .map(|status| self.adapt_status(status))
-            .transpose()
+            .inspect_interactive_worker(&worker, &ssh_public_key)
+            .map(|status| status.map(|status| self.adapt_status(status, &ssh_public_key)))
     }
 
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        let ssh_public_key = worker.ssh_public_key.clone();
         let worker = runpod_worker(worker)?;
-        Ok(match self.client.delete_worker(&worker)? {
+        Ok(match self.client.delete_interactive_worker(&worker, &ssh_public_key)? {
             RunPodCleanup::Deleted => InteractiveWorkerCleanup::Deleted,
             RunPodCleanup::AlreadyAbsent => InteractiveWorkerCleanup::AlreadyAbsent,
         })
@@ -166,7 +177,6 @@ fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError
         name: resource_name(worker.identity.workflow_id, worker.identity.job_id),
         image: worker.image.clone(),
         terminate_after: worker.lease.terminate_after.clone(),
-        ssh_public_key: Some(worker.ssh_public_key.clone()),
         hourly_cost_micros: None,
     };
     runpod_worker.validate()?;

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -321,7 +321,7 @@ fn identity_mismatch_blocks_delete_and_exact_delete_is_idempotent() {
     let observer = transport.clone();
     let client = RunPodClient::with_transport(transport);
     assert!(
-        matches!(client.inspect_worker(&worker), Ok(Some(status)) if status.worker.hourly_cost_micros == Some(420_000) && status.ssh.as_ref().map(|ssh| ssh.username.as_str()) == Some("root"))
+        matches!(client.inspect_worker(&worker), Ok(Some(status)) if status.worker.hourly_cost_micros == Some(420_000) && status.ssh_username.as_deref() == Some("root"))
     );
     assert_eq!(client.delete_worker(&worker), Ok(RunPodCleanup::Deleted));
     assert_eq!(client.delete_worker(&worker), Ok(RunPodCleanup::AlreadyAbsent));

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -1,5 +1,13 @@
+use super::super::interactive_worker::{
+    InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+    InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
+};
 use super::*;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
+
+const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
+
 #[derive(Clone, Default)]
 struct FakeTransport(Arc<Mutex<FakeState>>);
 #[derive(Default)]
@@ -8,6 +16,7 @@ struct FakeState {
     create_response: Option<ApiPod>,
     create_requests: Vec<CreatePodRequest>,
     deleted: Vec<String>,
+    inspected: Vec<String>,
     scripted_lists: Vec<Vec<ApiPod>>,
 }
 impl FakeTransport {
@@ -34,14 +43,15 @@ impl Transport for FakeTransport {
         let mut state = self.0.lock().expect("state");
         state.create_requests.push(request.clone());
         let mut response = state.create_response.clone().expect("create response");
-        response
-            .env
-            .insert(TERMINATE_ENV.to_string(), request.terminate_after.clone());
+        for entry in &request.env {
+            response.env.insert(entry.key.clone(), entry.value.clone());
+        }
         state.pods.push(response.clone());
         Ok(response)
     }
     fn get(&self, pod_id: &str) -> Result<Option<ApiPod>, RunPodError> {
-        let state = self.0.lock().expect("state");
+        let mut state = self.0.lock().expect("state");
+        state.inspected.push(pod_id.to_string());
         Ok(state.pods.iter().find(|pod| pod.id == pod_id).cloned())
     }
     fn delete(&self, pod_id: &str) -> Result<RunPodCleanup, RunPodError> {
@@ -78,6 +88,13 @@ fn profile() -> RunPodProfile {
         container_registry_auth_id: Some("registry_auth-1".to_string()),
     }
 }
+
+fn ed25519_key(byte: u8) -> String {
+    let mut blob = ED25519_BLOB_PREFIX.to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
 fn api_pod(
     workflow_id: CloudWorkflowId,
     job_id: CloudJobId,
@@ -101,6 +118,53 @@ fn api_pod(
             (TERMINATE_ENV.to_string(), terminate_after),
         ]),
         cost: hourly_cost_micros,
+    }
+}
+
+fn interactive_request(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> InteractiveWorkerRequest {
+    InteractiveWorkerRequest {
+        workflow_id,
+        job_id,
+        target: target(),
+        ssh_public_key: ed25519_key(41),
+    }
+}
+
+fn running_pod(workflow_id: CloudWorkflowId, job_id: CloudJobId, target: &WorkerTarget) -> ApiPod {
+    let mut pod = api_pod(workflow_id, job_id, target, Some(420_000));
+    pod.status = Some("RUNNING".to_string());
+    pod.ssh = Some(ApiSsh {
+        direct: Some(ApiSshEndpoint {
+            username: "root".to_string(),
+            host: "worker.example".to_string(),
+            port: 22,
+        }),
+    });
+    pod
+}
+
+#[derive(Clone)]
+struct FakeHostKeySource {
+    host_key: Option<String>,
+    calls: Arc<Mutex<Vec<(String, String, u16)>>>,
+}
+
+impl FakeHostKeySource {
+    fn new(host_key: Option<String>) -> Self {
+        Self {
+            host_key,
+            calls: Arc::default(),
+        }
+    }
+}
+
+impl RunPodHostKeySource for FakeHostKeySource {
+    fn host_key(&self, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> Option<String> {
+        self.calls
+            .lock()
+            .expect("host key calls")
+            .push((worker.pod_id.clone(), endpoint.host.clone(), endpoint.port));
+        self.host_key.clone()
     }
 }
 #[test]
@@ -257,9 +321,210 @@ fn identity_mismatch_blocks_delete_and_exact_delete_is_idempotent() {
     let observer = transport.clone();
     let client = RunPodClient::with_transport(transport);
     assert!(
-        matches!(client.inspect_worker(&worker), Ok(Some(status)) if status.worker.hourly_cost_micros == Some(420_000) && status.ssh_username.as_deref() == Some("root"))
+        matches!(client.inspect_worker(&worker), Ok(Some(status)) if status.worker.hourly_cost_micros == Some(420_000) && status.ssh.as_ref().map(|ssh| ssh.username.as_str()) == Some("root"))
     );
     assert_eq!(client.delete_worker(&worker), Ok(RunPodCleanup::Deleted));
     assert_eq!(client.delete_worker(&worker), Ok(RunPodCleanup::AlreadyAbsent));
     assert_eq!(observer.0.lock().expect("state").deleted, [worker.pod_id]);
+}
+
+#[test]
+fn interactive_adapter_preserves_identity_and_reaches_attested_ready_state() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let request = interactive_request(workflow_id, job_id);
+    let transport = FakeTransport::with_create_response(running_pod(workflow_id, job_id, &request.target));
+    let observer = transport.clone();
+    let host_keys = FakeHostKeySource::new(Some(ed25519_key(73)));
+    let host_key_calls = host_keys.calls.clone();
+    let provider = RunPodInteractiveWorkerProvider::new(RunPodClient::with_transport(transport), profile(), host_keys);
+
+    assert_eq!(provider.provider(), CloudProvider::RunPod);
+    let InteractiveWorkerEnsure::Created(status) = provider.ensure_worker(&request).expect("create interactive worker")
+    else {
+        panic!("new worker must be created");
+    };
+    assert_eq!(status.worker.identity.resource_id, "pod_123456");
+    assert_eq!(status.worker.ssh_public_key, request.ssh_public_key);
+    assert!(status.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+    assert_eq!(
+        status.ssh.as_ref().map(|ssh| (ssh.host.as_str(), ssh.port)),
+        Some(("worker.example", 22))
+    );
+
+    let InteractiveWorkerEnsure::Reused(reused) = provider.ensure_worker(&request).expect("reuse interactive worker")
+    else {
+        panic!("existing worker must be reused");
+    };
+    assert_eq!(reused, status);
+
+    let inspected = provider
+        .inspect_worker(&status.worker)
+        .expect("inspect interactive worker")
+        .expect("worker present");
+    assert!(inspected.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+    assert_eq!(
+        provider.delete_worker(&status.worker),
+        Ok(InteractiveWorkerCleanup::Deleted)
+    );
+    assert_eq!(
+        provider.delete_worker(&status.worker),
+        Ok(InteractiveWorkerCleanup::AlreadyAbsent)
+    );
+
+    let state = observer.0.lock().expect("state");
+    assert_eq!(state.create_requests.len(), 1);
+    assert!(
+        state.create_requests[0]
+            .env
+            .iter()
+            .any(|entry| entry.key == SSH_PUBLIC_KEY_ENV && entry.value == request.ssh_public_key)
+    );
+    assert_eq!(state.deleted, ["pod_123456"]);
+    assert_eq!(
+        *host_key_calls.lock().expect("host key calls"),
+        [
+            ("pod_123456".to_string(), "worker.example".to_string(), 22),
+            ("pod_123456".to_string(), "worker.example".to_string(), 22),
+            ("pod_123456".to_string(), "worker.example".to_string(), 22),
+        ]
+    );
+}
+
+#[test]
+fn interactive_adapter_rejects_recovered_client_key_drift() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let request = interactive_request(workflow_id, job_id);
+    let mut pod = running_pod(workflow_id, job_id, &request.target);
+    pod.env.insert(SSH_PUBLIC_KEY_ENV.to_string(), ed25519_key(99));
+    let transport = FakeTransport::with_pods(vec![pod]);
+    let observer = transport.clone();
+    let provider = RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(transport),
+        profile(),
+        FakeHostKeySource::new(Some(ed25519_key(73))),
+    );
+
+    assert_eq!(
+        provider.ensure_worker(&request),
+        Err(RunPodError::ResourceIdentityMismatch)
+    );
+    let state = observer.0.lock().expect("state");
+    assert!(state.create_requests.is_empty());
+    assert!(state.deleted.is_empty());
+}
+
+#[test]
+fn interactive_adapter_waits_for_trusted_host_key_and_fails_closed_on_invalid_data() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let request = interactive_request(workflow_id, job_id);
+    let pending_provider = RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(FakeTransport::with_create_response(running_pod(
+            workflow_id,
+            job_id,
+            &request.target,
+        ))),
+        profile(),
+        FakeHostKeySource::new(None),
+    );
+    let pending = pending_provider
+        .ensure_worker(&request)
+        .expect("pending worker")
+        .into_status();
+    assert_eq!(pending.lifecycle, InteractiveWorkerLifecycle::Provisioning);
+    assert!(pending.ssh.is_none());
+
+    let invalid_key_provider = RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(FakeTransport::with_create_response(running_pod(
+            workflow_id,
+            job_id,
+            &request.target,
+        ))),
+        profile(),
+        FakeHostKeySource::new(Some("ssh-rsa unsupported".to_string())),
+    );
+    let invalid_key = invalid_key_provider
+        .ensure_worker(&request)
+        .expect("worker identity remains recoverable")
+        .into_status();
+    assert_eq!(invalid_key.lifecycle, InteractiveWorkerLifecycle::Failed);
+    assert!(invalid_key.ssh.is_none());
+
+    let mut invalid_endpoint = running_pod(workflow_id, job_id, &request.target);
+    invalid_endpoint
+        .ssh
+        .as_mut()
+        .expect("SSH response")
+        .direct
+        .as_mut()
+        .expect("direct SSH")
+        .host = "-oProxyCommand=bad".to_string();
+    let host_keys = FakeHostKeySource::new(Some(ed25519_key(73)));
+    let host_key_calls = host_keys.calls.clone();
+    let invalid_endpoint_provider = RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(FakeTransport::with_create_response(invalid_endpoint)),
+        profile(),
+        host_keys,
+    );
+    let invalid_endpoint = invalid_endpoint_provider
+        .ensure_worker(&request)
+        .expect("worker identity remains recoverable")
+        .into_status();
+    assert_eq!(invalid_endpoint.lifecycle, InteractiveWorkerLifecycle::Failed);
+    assert!(invalid_endpoint.ssh.is_none());
+    assert!(host_key_calls.lock().expect("host key calls").is_empty());
+}
+
+#[test]
+fn interactive_adapter_rejects_invalid_handles_before_transport_io() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let request = interactive_request(workflow_id, job_id);
+    let transport = FakeTransport::default();
+    let observer = transport.clone();
+    let provider = RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(transport),
+        profile(),
+        FakeHostKeySource::new(None),
+    );
+    let mut invalid_request = request.clone();
+    invalid_request.ssh_public_key = "ssh-rsa unsupported".to_string();
+    assert_eq!(
+        provider.ensure_worker(&invalid_request),
+        Err(RunPodError::InvalidTarget)
+    );
+    let mut worker = InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: CloudProvider::Azure,
+            workflow_id,
+            job_id,
+            resource_id: "pod_123456".to_string(),
+        },
+        image: request.target.image,
+        ssh_public_key: request.ssh_public_key,
+        lease: InteractiveWorkerLease {
+            terminate_after: termination_deadline(900).expect("termination deadline"),
+        },
+    };
+
+    assert_eq!(
+        provider.inspect_worker(&worker),
+        Err(RunPodError::InvalidPersistedWorker)
+    );
+    assert_eq!(
+        provider.delete_worker(&worker),
+        Err(RunPodError::InvalidPersistedWorker)
+    );
+    worker.identity.provider = CloudProvider::RunPod;
+    worker.identity.resource_id = "x".repeat(192);
+    assert_eq!(
+        provider.inspect_worker(&worker),
+        Err(RunPodError::InvalidPersistedWorker)
+    );
+    assert_eq!(
+        provider.delete_worker(&worker),
+        Err(RunPodError::InvalidPersistedWorker)
+    );
+
+    let state = observer.0.lock().expect("state");
+    assert!(state.inspected.is_empty());
+    assert!(state.deleted.is_empty());
 }


### PR DESCRIPTION
## Purpose

Connect the existing exact GPU-worker lifecycle to the provider-neutral interactive-worker contract from #390.

## Behavior impact

- Installs and persists the exact ephemeral Ed25519 client public key for each worker generation.
- Maps creation, reuse, inspection, lifecycle, endpoint, and idempotent deletion into the common contract.
- Keeps a running worker in provisioning until an independently authenticated host key is available for the exact resource and endpoint.
- Fails closed on malformed endpoints, host keys, key drift, and malformed or wrong-provider persisted handles.
- Preserves the existing non-interactive lifecycle API.

## Test evidence

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`

No UI or configuration behavior changed. No live cloud resource, image publication, or release action was performed.

Part of #383.