### PR TITLE
feat(cloud): add local Docker worker provider

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -100,10 +100,12 @@ disabled. Root login is public-key-only.
 
 `horizon_core::cloud_run::local_docker` implements the interactive-worker
 contract against the local Docker daemon. Its profile name must match the
-worker target, and the target image must be an immutable digest reference that
-already exists locally. Creation uses `--pull=never`, restart policy `no`, and
-an ephemeral SSH port bound only to `127.0.0.1`; registry pulls and credentials
-remain outside the provider boundary.
+worker target and its `docker_host` must explicitly name a local Unix socket or
+Windows named pipe; ambient and remote Docker contexts are rejected. The target
+image must be an immutable digest reference that already exists locally.
+Creation uses `--pull=never`, restart policy `no`, and an ephemeral SSH port
+bound only to `127.0.0.1`; registry pulls and credentials remain outside the
+provider boundary.
 
 One workflow/job pair maps to one deterministic container name. The provider
 stores the complete target, workflow and job IDs, client public key, protocol

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -115,8 +115,10 @@ the runtime environment and exact 64-character container ID before reuse,
 inspection, or deletion. A mismatched or malformed resource fails closed. A
 delete succeeds only after inspection proves that exact ID is absent.
 
-Docker CLI calls have bounded output and a 30-second process deadline. The
-provider reports `Ready` only after Docker exposes exactly one loopback SSH
+Docker CLI calls have bounded output, a conservative Windows-compatible
+argument budget, and a 30-second process deadline. A container disappearing
+during host-key discovery is reported as absent or reconciled before reuse.
+The provider reports `Ready` only after Docker exposes exactly one loopback SSH
 binding and the container's Ed25519 host key can be read and validated.
 
 ## Local security smoke

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -96,6 +96,26 @@ Password authentication, keyboard-interactive authentication, SSH agent
 forwarding, X11 forwarding, and user-controlled SSH environment files are
 disabled. Root login is public-key-only.
 
+## Local Docker provider
+
+`horizon_core::cloud_run::local_docker` implements the interactive-worker
+contract against the local Docker daemon. Its profile name must match the
+worker target, and the target image must be an immutable digest reference that
+already exists locally. Creation uses `--pull=never`, restart policy `no`, and
+an ephemeral SSH port bound only to `127.0.0.1`; registry pulls and credentials
+remain outside the provider boundary.
+
+One workflow/job pair maps to one deterministic container name. The provider
+stores the complete target, workflow and job IDs, client public key, protocol
+version, and lease deadline in labels, then verifies those values plus the
+runtime environment and exact 64-character container ID before reuse,
+inspection, or deletion. A mismatched or malformed resource fails closed. A
+delete succeeds only after inspection proves that exact ID is absent.
+
+Docker CLI calls have bounded output and a 30-second process deadline. The
+provider reports `Ready` only after Docker exposes exactly one loopback SSH
+binding and the container's Ed25519 host key can be read and validated.
+
 ## Local security smoke
 
 Run the permanent smoke harness from the repository root:

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -101,16 +101,17 @@ disabled. Root login is public-key-only.
 `horizon_core::cloud_run::local_docker` implements the interactive-worker
 contract against the local Docker daemon. Its profile name must match the
 worker target and its `docker_host` must explicitly name a local Unix socket or
-Windows named pipe; ambient and remote Docker contexts are rejected. The target
-image must be an immutable digest reference that already exists locally.
+Windows named pipe; explicit remote endpoints are rejected and ambient context
+selection is ignored. The target image must be an immutable digest reference
+that already exists locally.
 Creation uses `--pull=never`, restart policy `no`, and an ephemeral SSH port
 bound only to `127.0.0.1`; registry pulls and credentials remain outside the
 provider boundary.
 
 One workflow/job pair maps to one deterministic container name. The provider
-stores the complete target, workflow and job IDs, client public key, protocol
-version, and lease deadline in labels, then verifies those values plus the
-runtime environment and exact 64-character container ID before reuse,
+stores the complete target, workflow and job IDs, canonical client public key,
+protocol version, and lease deadline in labels, then verifies those values plus
+the runtime environment and exact 64-character container ID before reuse,
 inspection, or deletion. A mismatched or malformed resource fails closed. A
 delete succeeds only after inspection proves that exact ID is absent.
 

--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -4,6 +4,7 @@ use std::{collections::HashSet, fmt};
 use thiserror::Error;
 use uuid::Uuid;
 pub mod interactive_worker;
+pub mod local_docker;
 pub mod runpod;
 mod store;
 mod validation;
@@ -48,7 +49,7 @@ macro_rules! string_enum {
         pub enum $name { $($variant),+ }
     };
 }
-string_enum!(CloudProvider: Azure, RunPod);
+string_enum!(CloudProvider: Azure, RunPod, LocalDocker);
 macro_rules! hex_value {
     ($name:ident => $parser:ident; $length:literal; $error:ident; $description:literal) => {
         #[derive(Clone, Debug, Eq, PartialEq, Serialize)]

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -65,7 +65,7 @@ impl InteractiveWorkerLease {
         time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339).is_ok()
     }
 
-    fn is_bounded_at(&self, lease_seconds: u32, observed_at: time::OffsetDateTime) -> bool {
+    pub(super) fn is_bounded_at(&self, lease_seconds: u32, observed_at: time::OffsetDateTime) -> bool {
         let Ok(deadline) =
             time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339)
         else {

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -118,7 +118,8 @@ impl LocalDockerInteractiveWorkerProvider {
                     Err(error) => return self.reconcile_uncertain_create(request, &create, error),
                 };
                 if container.id != resource_id {
-                    return Err(LocalDockerError::ResourceIdentityMismatch);
+                    let error = LocalDockerError::ResourceIdentityMismatch;
+                    return self.reconcile_uncertain_create(request, &create, error);
                 }
                 let worker = match worker_for_request(&container, request) {
                     Ok(worker) => worker,

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -35,6 +35,7 @@ const HOST_KEY_PATH: &str = "/etc/ssh/ssh_host_ed25519_key.pub";
 #[serde(deny_unknown_fields)]
 pub struct LocalDockerProfile {
     pub name: String,
+    pub docker_host: String,
 }
 
 /// Disposable worker provider backed by the local Docker daemon.
@@ -44,12 +45,17 @@ pub struct LocalDockerInteractiveWorkerProvider {
 }
 
 impl LocalDockerInteractiveWorkerProvider {
-    #[must_use]
-    pub fn new(profile: LocalDockerProfile) -> Self {
-        Self {
-            transport: Box::new(command::DockerCli::new()),
-            profile,
-        }
+    /// Build a provider pinned to an explicit local Unix socket or Windows named pipe.
+    ///
+    /// # Errors
+    /// Returns [`LocalDockerError::NonLocalDockerHost`] for ambient or remote daemon endpoints.
+    pub fn new(profile: LocalDockerProfile) -> Result<Self, LocalDockerError> {
+        valid_local_docker_host(&profile.docker_host)
+            .then(|| Self {
+                transport: Box::new(command::DockerCli::new(&profile.docker_host)),
+                profile,
+            })
+            .ok_or(LocalDockerError::NonLocalDockerHost)
     }
 
     #[cfg(test)]
@@ -256,6 +262,8 @@ pub enum LocalDockerError {
     InvalidTarget,
     #[error("persisted local Docker worker identity is invalid")]
     InvalidPersistedWorker,
+    #[error("local Docker provider requires an explicit local Unix socket or Windows named pipe")]
+    NonLocalDockerHost,
     #[error("required command 'docker' is unavailable")]
     DockerUnavailable,
     #[error("local Docker command timed out during {operation}")]
@@ -344,6 +352,14 @@ fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerPro
         .ok_or(LocalDockerError::InvalidTarget)
 }
 
+fn valid_local_docker_host(value: &str) -> bool {
+    let safe = |path: &str| !path.is_empty() && !path.chars().any(char::is_control);
+    value
+        .strip_prefix("unix://")
+        .is_some_and(|path| path.len() > 1 && path.starts_with('/') && safe(path))
+        || value.strip_prefix("npipe:////./pipe/").is_some_and(safe)
+}
+
 fn validate_worker(worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
     (worker.is_valid_for(CloudProvider::LocalDocker) && valid_container_id(&worker.identity.resource_id))
         .then_some(())
@@ -362,16 +378,13 @@ fn worker_for_request(
             job_id: request.job_id,
             resource_id: container.id.clone(),
         },
-        image: request.target.image.clone(),
+        target: request.target.clone(),
         ssh_public_key: request.ssh_public_key.clone(),
         lease: InteractiveWorkerLease {
             terminate_after: terminate_after.to_string(),
         },
     };
     verify_container_for_worker(container, &worker)?;
-    if container.labels.get(TARGET_LABEL) != request_labels(request)?.get(TARGET_LABEL) {
-        return Err(LocalDockerError::ResourceIdentityMismatch);
-    }
     Ok(worker)
 }
 
@@ -392,7 +405,7 @@ fn verify_container_for_worker(
     ];
     let valid = container.id == worker.identity.resource_id
         && container.name == expected_name
-        && container.image == worker.image
+        && container.image == worker.target.image
         && container.restart_policy == "no"
         && exact_labels
             .iter()
@@ -407,16 +420,7 @@ fn valid_target_label(labels: &BTreeMap<String, String>, worker: &InteractiveWor
     labels
         .get(TARGET_LABEL)
         .and_then(|value| serde_json::from_str::<WorkerTarget>(value).ok())
-        .is_some_and(|target| {
-            target.image == worker.image
-                && InteractiveWorkerRequest {
-                    workflow_id: worker.identity.workflow_id,
-                    job_id: worker.identity.job_id,
-                    target,
-                    ssh_public_key: worker.ssh_public_key.clone(),
-                }
-                .is_valid_for(CloudProvider::LocalDocker)
-        })
+        .is_some_and(|target| target == worker.target)
 }
 
 fn request_labels(request: &InteractiveWorkerRequest) -> Result<BTreeMap<String, String>, LocalDockerError> {

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -64,7 +64,6 @@ impl LocalDockerInteractiveWorkerProvider {
             })
             .ok_or(LocalDockerError::NonLocalDockerHost)
     }
-
     fn ensure_existing(
         &self,
         request: &InteractiveWorkerRequest,
@@ -79,14 +78,12 @@ impl LocalDockerInteractiveWorkerProvider {
         }
         self.observe(container, worker)
     }
-
     fn validate_persisted_worker(&self, worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
         validate_worker(worker)?;
         (worker.target.profile == self.profile.name)
             .then_some(())
             .ok_or(LocalDockerError::InvalidPersistedWorker)
     }
-
     fn reject_unbounded_lease(
         &self,
         worker: &InteractiveWorker,
@@ -101,7 +98,6 @@ impl LocalDockerInteractiveWorkerProvider {
         }
         Err(LocalDockerError::LeaseDeadlineRejected { resource_id })
     }
-
     fn create_worker(
         &self,
         request: &InteractiveWorkerRequest,
@@ -144,7 +140,6 @@ impl LocalDockerInteractiveWorkerProvider {
             Err(error) => self.reconcile_uncertain_create(request, &create, error),
         }
     }
-
     fn reconcile_uncertain_create(
         &self,
         request: &InteractiveWorkerRequest,
@@ -168,7 +163,6 @@ impl LocalDockerInteractiveWorkerProvider {
         }
         Err(original)
     }
-
     fn cleanup_invalid_creation(
         &self,
         container: &DockerContainer,
@@ -184,7 +178,6 @@ impl LocalDockerInteractiveWorkerProvider {
         }
         Err(original)
     }
-
     fn observe(
         &self,
         container: &DockerContainer,
@@ -200,7 +193,6 @@ impl LocalDockerInteractiveWorkerProvider {
         };
         Ok(InteractiveWorkerStatus { worker, lifecycle, ssh })
     }
-
     fn running_connection(
         &self,
         container: &DockerContainer,
@@ -214,7 +206,7 @@ impl LocalDockerInteractiveWorkerProvider {
         let Some(raw_host_key) = self.transport.read_host_key(&container.id)? else {
             return Ok((InteractiveWorkerLifecycle::Provisioning, None));
         };
-        let host_key = canonical_host_key(&raw_host_key).ok_or(LocalDockerError::InvalidHostKey)?;
+        let host_key = canonical_ed25519_key(&raw_host_key).ok_or(LocalDockerError::InvalidHostKey)?;
         let endpoint = InteractiveWorkerSshEndpoint {
             host: LOCAL_HOST.to_string(),
             port: binding.port,
@@ -227,11 +219,9 @@ impl LocalDockerInteractiveWorkerProvider {
 
 impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
     type Error = LocalDockerError;
-
     fn provider(&self) -> CloudProvider {
         CloudProvider::LocalDocker
     }
-
     fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
         validate_request(request, &self.profile)?;
         let container_name = container_name(request.workflow_id, request.job_id);
@@ -242,7 +232,6 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
         }
         self.create_worker(request, &container_name)
     }
-
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
         self.validate_persisted_worker(worker)?;
         let Some(container) = self.transport.inspect(&worker.identity.resource_id)? else {
@@ -251,7 +240,6 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
         verify_container_for_worker(&container, worker)?;
         self.observe(&container, worker.clone()).map(Some)
     }
-
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
         self.validate_persisted_worker(worker)?;
         let resource_id = &worker.identity.resource_id;
@@ -268,7 +256,6 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
         Ok(InteractiveWorkerCleanup::Deleted)
     }
 }
-
 #[derive(Debug, Error, Eq, PartialEq)]
 pub enum LocalDockerError {
     #[error("local Docker worker target or profile is invalid")]
@@ -344,14 +331,15 @@ impl DockerCreateRequest {
         let terminate_after = deadline
             .format(&time::format_description::well_known::Rfc3339)
             .map_err(|_| LocalDockerError::InvalidTarget)?;
+        let ssh_public_key = canonical_ed25519_key(&request.ssh_public_key).ok_or(LocalDockerError::InvalidTarget)?;
         let mut labels = request_labels(request)?;
-        labels.insert(SSH_KEY_LABEL.to_string(), request.ssh_public_key.clone());
+        labels.insert(SSH_KEY_LABEL.to_string(), ssh_public_key.clone());
         labels.insert(TERMINATE_LABEL.to_string(), terminate_after.clone());
         Ok(Self {
             name: name.to_string(),
             image: request.target.image.clone(),
             labels,
-            ssh_public_key: request.ssh_public_key.clone(),
+            ssh_public_key,
             terminate_after,
         })
     }
@@ -399,6 +387,8 @@ fn verify_container_for_worker(
     worker: &InteractiveWorker,
 ) -> Result<(), LocalDockerError> {
     validate_worker(worker)?;
+    let ssh_public_key =
+        canonical_ed25519_key(&worker.ssh_public_key).ok_or(LocalDockerError::InvalidPersistedWorker)?;
     let expected_name = container_name(worker.identity.workflow_id, worker.identity.job_id);
     let exact_labels = [
         (MANAGED_LABEL, "true".to_string()),
@@ -406,7 +396,7 @@ fn verify_container_for_worker(
         (PROTOCOL_LABEL, CLOUD_RUN_PROTOCOL_VERSION.to_string()),
         (WORKFLOW_LABEL, worker.identity.workflow_id.to_string()),
         (JOB_LABEL, worker.identity.job_id.to_string()),
-        (SSH_KEY_LABEL, worker.ssh_public_key.clone()),
+        (SSH_KEY_LABEL, ssh_public_key.clone()),
         (TERMINATE_LABEL, worker.lease.terminate_after.clone()),
     ];
     let valid = container.id == worker.identity.resource_id
@@ -416,7 +406,7 @@ fn verify_container_for_worker(
         && exact_labels
             .iter()
             .all(|(key, value)| container.labels.get(*key) == Some(value))
-        && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(worker.ssh_public_key.as_str())
+        && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(ssh_public_key.as_str())
         && required_environment(container, TERMINATE_ENV) == Ok(worker.lease.terminate_after.as_str())
         && valid_target_label(&container.labels, worker);
     valid.then_some(()).ok_or(LocalDockerError::ResourceIdentityMismatch)
@@ -462,7 +452,7 @@ fn created_container_matches(container: &DockerContainer, create: &DockerCreateR
         && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(create.ssh_public_key.as_str())
         && required_environment(container, TERMINATE_ENV) == Ok(create.terminate_after.as_str())
 }
-fn canonical_host_key(value: &str) -> Option<String> {
+fn canonical_ed25519_key(value: &str) -> Option<String> {
     if !valid_ssh_public_key(value) {
         return None;
     }

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -29,6 +29,8 @@ const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
 const LOCAL_HOST: &str = "127.0.0.1";
 const SSH_USERNAME: &str = "root";
 const HOST_KEY_PATH: &str = "/etc/ssh/ssh_host_ed25519_key.pub";
+const CREATE_RECONCILE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const CREATE_RECONCILE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
 /// Non-secret configuration for the local Docker daemon provider.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -148,11 +150,16 @@ impl LocalDockerInteractiveWorkerProvider {
         container_name: &str,
         original: LocalDockerError,
     ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
-        let Some(container) = self.transport.inspect(container_name)? else {
-            return Err(original);
-        };
-        self.ensure_existing(request, &container)
-            .map(InteractiveWorkerEnsure::Reused)
+        let deadline = std::time::Instant::now() + CREATE_RECONCILE_TIMEOUT;
+        while std::time::Instant::now() < deadline {
+            if let Some(container) = self.transport.inspect(container_name)? {
+                return self
+                    .ensure_existing(request, &container)
+                    .map(InteractiveWorkerEnsure::Reused);
+            }
+            std::thread::sleep(CREATE_RECONCILE_POLL_INTERVAL);
+        }
+        Err(original)
     }
 
     fn cleanup_invalid_creation(

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -152,7 +152,7 @@ impl LocalDockerInteractiveWorkerProvider {
             if remaining.is_zero() {
                 break;
             }
-            if let Some(container) = self.transport.inspect_with_timeout(&create.name, remaining)? {
+            if let Ok(Some(container)) = self.transport.inspect_with_timeout(&create.name, remaining) {
                 return match self.ensure_existing(request, &container) {
                     Ok(status) => Ok(InteractiveWorkerEnsure::Reused(status)),
                     Err(error) => self.cleanup_invalid_creation(&container, create, error),

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -1,0 +1,477 @@
+//! Local Docker implementation of the disposable interactive-worker contract.
+
+use super::{
+    CLOUD_RUN_PROTOCOL_VERSION, CloudProvider, WorkerTarget,
+    interactive_worker::{
+        InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
+        InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_public_key,
+    },
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+mod command;
+#[cfg(test)]
+mod tests;
+
+const MANAGED_LABEL: &str = "io.horizon.local-docker";
+const PROVIDER_LABEL: &str = "io.horizon.provider";
+const PROTOCOL_LABEL: &str = "io.horizon.cloud-protocol";
+const WORKFLOW_LABEL: &str = "io.horizon.workflow";
+const JOB_LABEL: &str = "io.horizon.job";
+const TARGET_LABEL: &str = "io.horizon.target";
+const SSH_KEY_LABEL: &str = "io.horizon.ssh-public-key";
+const TERMINATE_LABEL: &str = "io.horizon.terminate-after";
+const SSH_PUBLIC_KEY_ENV: &str = "HORIZON_SSH_PUBLIC_KEY";
+const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
+const LOCAL_HOST: &str = "127.0.0.1";
+const SSH_USERNAME: &str = "root";
+const HOST_KEY_PATH: &str = "/etc/ssh/ssh_host_ed25519_key.pub";
+
+/// Non-secret configuration for the local Docker daemon provider.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LocalDockerProfile {
+    pub name: String,
+}
+
+/// Disposable worker provider backed by the local Docker daemon.
+pub struct LocalDockerInteractiveWorkerProvider {
+    transport: Box<dyn DockerTransport>,
+    profile: LocalDockerProfile,
+}
+
+impl LocalDockerInteractiveWorkerProvider {
+    #[must_use]
+    pub fn new(profile: LocalDockerProfile) -> Self {
+        Self {
+            transport: Box::new(command::DockerCli::new()),
+            profile,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_transport(profile: LocalDockerProfile, transport: impl DockerTransport + 'static) -> Self {
+        Self {
+            transport: Box::new(transport),
+            profile,
+        }
+    }
+
+    fn ensure_existing(
+        &self,
+        request: &InteractiveWorkerRequest,
+        container: &DockerContainer,
+    ) -> Result<InteractiveWorkerStatus, LocalDockerError> {
+        let worker = worker_for_request(container, request)?;
+        if !worker
+            .lease
+            .is_bounded_at(request.target.lease_seconds, time::OffsetDateTime::now_utc())
+        {
+            return self.reject_unbounded_lease(&worker, container);
+        }
+        self.observe(container, worker)
+    }
+
+    fn reject_unbounded_lease(
+        &self,
+        worker: &InteractiveWorker,
+        container: &DockerContainer,
+    ) -> Result<InteractiveWorkerStatus, LocalDockerError> {
+        let resource_id = worker.identity.resource_id.clone();
+        if verify_container_for_worker(container, worker).is_err()
+            || self.transport.delete(&resource_id).is_err()
+            || !matches!(self.transport.inspect(&resource_id), Ok(None))
+        {
+            return Err(LocalDockerError::LeaseRejectionCleanupFailed { resource_id });
+        }
+        Err(LocalDockerError::LeaseDeadlineRejected { resource_id })
+    }
+
+    fn create_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+        container_name: &str,
+    ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
+        let create = DockerCreateRequest::new(request, container_name)?;
+        match self.transport.create(&create) {
+            Ok(resource_id) if valid_container_id(&resource_id) => {
+                let Some(container) = self.transport.inspect(&resource_id)? else {
+                    return self.reconcile_uncertain_create(
+                        request,
+                        container_name,
+                        LocalDockerError::InvalidResponse {
+                            operation: "container creation verification",
+                        },
+                    );
+                };
+                if container.id != resource_id {
+                    return Err(LocalDockerError::ResourceIdentityMismatch);
+                }
+                let worker = match worker_for_request(&container, request) {
+                    Ok(worker) => worker,
+                    Err(error) => return self.cleanup_invalid_creation(&container, &create, error),
+                };
+                if worker.lease.terminate_after != create.terminate_after {
+                    return self.cleanup_invalid_creation(
+                        &container,
+                        &create,
+                        LocalDockerError::ResourceIdentityMismatch,
+                    );
+                }
+                match self.observe(&container, worker) {
+                    Ok(status) => Ok(InteractiveWorkerEnsure::Created(status)),
+                    Err(error) => self.cleanup_invalid_creation(&container, &create, error),
+                }
+            }
+            Ok(_) => self.reconcile_uncertain_create(
+                request,
+                container_name,
+                LocalDockerError::InvalidResponse {
+                    operation: "container creation",
+                },
+            ),
+            Err(error) => self.reconcile_uncertain_create(request, container_name, error),
+        }
+    }
+
+    fn reconcile_uncertain_create(
+        &self,
+        request: &InteractiveWorkerRequest,
+        container_name: &str,
+        original: LocalDockerError,
+    ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
+        let Some(container) = self.transport.inspect(container_name)? else {
+            return Err(original);
+        };
+        self.ensure_existing(request, &container)
+            .map(InteractiveWorkerEnsure::Reused)
+    }
+
+    fn cleanup_invalid_creation(
+        &self,
+        container: &DockerContainer,
+        create: &DockerCreateRequest,
+        original: LocalDockerError,
+    ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
+        let resource_id = container.id.clone();
+        if !created_container_matches(container, create) {
+            return Err(original);
+        }
+        if self.transport.delete(&resource_id).is_err() || !matches!(self.transport.inspect(&resource_id), Ok(None)) {
+            return Err(LocalDockerError::CreationCleanupFailed { resource_id });
+        }
+        Err(original)
+    }
+
+    fn observe(
+        &self,
+        container: &DockerContainer,
+        worker: InteractiveWorker,
+    ) -> Result<InteractiveWorkerStatus, LocalDockerError> {
+        let (lifecycle, ssh) = match (container.state.as_str(), container.running) {
+            ("running", true) => self.running_connection(container)?,
+            ("created" | "restarting", false) => (InteractiveWorkerLifecycle::Provisioning, None),
+            ("exited" | "dead", false) if container.exit_code == 0 => (InteractiveWorkerLifecycle::Stopped, None),
+            ("exited" | "dead", false) => (InteractiveWorkerLifecycle::Failed, None),
+            ("removing", false) => (InteractiveWorkerLifecycle::Deleting, None),
+            _ => (InteractiveWorkerLifecycle::Unknown, None),
+        };
+        Ok(InteractiveWorkerStatus { worker, lifecycle, ssh })
+    }
+
+    fn running_connection(
+        &self,
+        container: &DockerContainer,
+    ) -> Result<(InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>), LocalDockerError> {
+        let Some(binding) = container.ssh_bindings.as_slice().first() else {
+            return Ok((InteractiveWorkerLifecycle::Provisioning, None));
+        };
+        if container.ssh_bindings.len() != 1 || binding.host != LOCAL_HOST || binding.port == 0 {
+            return Err(LocalDockerError::InvalidSshEndpoint);
+        }
+        let Some(raw_host_key) = self.transport.read_host_key(&container.id)? else {
+            return Ok((InteractiveWorkerLifecycle::Provisioning, None));
+        };
+        let host_key = canonical_host_key(&raw_host_key).ok_or(LocalDockerError::InvalidHostKey)?;
+        let endpoint = InteractiveWorkerSshEndpoint {
+            host: LOCAL_HOST.to_string(),
+            port: binding.port,
+            username: SSH_USERNAME.to_string(),
+            host_key,
+        };
+        Ok((InteractiveWorkerLifecycle::Ready, Some(endpoint)))
+    }
+}
+
+impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
+    type Error = LocalDockerError;
+
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::LocalDocker
+    }
+
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        validate_request(request, &self.profile)?;
+        let container_name = container_name(request.workflow_id, request.job_id);
+        if let Some(container) = self.transport.inspect(&container_name)? {
+            return self
+                .ensure_existing(request, &container)
+                .map(InteractiveWorkerEnsure::Reused);
+        }
+        self.create_worker(request, &container_name)
+    }
+
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        validate_worker(worker)?;
+        let Some(container) = self.transport.inspect(&worker.identity.resource_id)? else {
+            return Ok(None);
+        };
+        verify_container_for_worker(&container, worker)?;
+        self.observe(&container, worker.clone()).map(Some)
+    }
+
+    fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        validate_worker(worker)?;
+        let resource_id = &worker.identity.resource_id;
+        let Some(container) = self.transport.inspect(resource_id)? else {
+            return Ok(InteractiveWorkerCleanup::AlreadyAbsent);
+        };
+        verify_container_for_worker(&container, worker)?;
+        let _ = self.transport.delete(resource_id)?;
+        if self.transport.inspect(resource_id)?.is_some() {
+            return Err(LocalDockerError::DeletionVerificationFailed {
+                resource_id: resource_id.clone(),
+            });
+        }
+        Ok(InteractiveWorkerCleanup::Deleted)
+    }
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum LocalDockerError {
+    #[error("local Docker worker target or profile is invalid")]
+    InvalidTarget,
+    #[error("persisted local Docker worker identity is invalid")]
+    InvalidPersistedWorker,
+    #[error("required command 'docker' is unavailable")]
+    DockerUnavailable,
+    #[error("local Docker command timed out during {operation}")]
+    CommandTimedOut { operation: &'static str },
+    #[error("local Docker command failed during {operation}")]
+    CommandFailed { operation: &'static str },
+    #[error("local Docker returned a malformed response during {operation}")]
+    InvalidResponse { operation: &'static str },
+    #[error("local Docker returned an invalid or mismatched resource identity")]
+    ResourceIdentityMismatch,
+    #[error("local Docker worker {resource_id} could not be verified or deleted after creation")]
+    CreationCleanupFailed { resource_id: String },
+    #[error("local Docker worker {resource_id} had an out-of-bounds lease and was deleted")]
+    LeaseDeadlineRejected { resource_id: String },
+    #[error("local Docker worker {resource_id} had an out-of-bounds lease but cleanup failed")]
+    LeaseRejectionCleanupFailed { resource_id: String },
+    #[error("local Docker worker has an invalid SSH endpoint")]
+    InvalidSshEndpoint,
+    #[error("local Docker worker has an invalid SSH host key")]
+    InvalidHostKey,
+    #[error("local Docker worker {resource_id} deletion could not be verified")]
+    DeletionVerificationFailed { resource_id: String },
+}
+
+trait DockerTransport: Send + Sync {
+    fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError>;
+    fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError>;
+    fn read_host_key(&self, resource_id: &str) -> Result<Option<String>, LocalDockerError>;
+    fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError>;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DockerContainer {
+    id: String,
+    name: String,
+    image: String,
+    labels: BTreeMap<String, String>,
+    environment: Vec<String>,
+    restart_policy: String,
+    running: bool,
+    state: String,
+    exit_code: i64,
+    ssh_bindings: Vec<DockerPortBinding>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DockerPortBinding {
+    host: String,
+    port: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DockerCreateRequest {
+    name: String,
+    image: String,
+    labels: BTreeMap<String, String>,
+    ssh_public_key: String,
+    terminate_after: String,
+}
+
+impl DockerCreateRequest {
+    fn new(request: &InteractiveWorkerRequest, name: &str) -> Result<Self, LocalDockerError> {
+        let now = time::OffsetDateTime::now_utc();
+        let deadline = now
+            .checked_add(time::Duration::seconds(i64::from(request.target.lease_seconds)))
+            .ok_or(LocalDockerError::InvalidTarget)?;
+        let terminate_after = deadline
+            .format(&time::format_description::well_known::Rfc3339)
+            .map_err(|_| LocalDockerError::InvalidTarget)?;
+        let mut labels = request_labels(request)?;
+        labels.insert(SSH_KEY_LABEL.to_string(), request.ssh_public_key.clone());
+        labels.insert(TERMINATE_LABEL.to_string(), terminate_after.clone());
+        Ok(Self {
+            name: name.to_string(),
+            image: request.target.image.clone(),
+            labels,
+            ssh_public_key: request.ssh_public_key.clone(),
+            terminate_after,
+        })
+    }
+}
+
+fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerProfile) -> Result<(), LocalDockerError> {
+    (request.target.profile == profile.name && request.is_valid_for(CloudProvider::LocalDocker))
+        .then_some(())
+        .ok_or(LocalDockerError::InvalidTarget)
+}
+
+fn validate_worker(worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
+    (worker.is_valid_for(CloudProvider::LocalDocker) && valid_container_id(&worker.identity.resource_id))
+        .then_some(())
+        .ok_or(LocalDockerError::InvalidPersistedWorker)
+}
+
+fn worker_for_request(
+    container: &DockerContainer,
+    request: &InteractiveWorkerRequest,
+) -> Result<InteractiveWorker, LocalDockerError> {
+    let terminate_after = required_environment(container, TERMINATE_ENV)?;
+    let worker = InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: CloudProvider::LocalDocker,
+            workflow_id: request.workflow_id,
+            job_id: request.job_id,
+            resource_id: container.id.clone(),
+        },
+        image: request.target.image.clone(),
+        ssh_public_key: request.ssh_public_key.clone(),
+        lease: InteractiveWorkerLease {
+            terminate_after: terminate_after.to_string(),
+        },
+    };
+    verify_container_for_worker(container, &worker)?;
+    if container.labels.get(TARGET_LABEL) != request_labels(request)?.get(TARGET_LABEL) {
+        return Err(LocalDockerError::ResourceIdentityMismatch);
+    }
+    Ok(worker)
+}
+
+fn verify_container_for_worker(
+    container: &DockerContainer,
+    worker: &InteractiveWorker,
+) -> Result<(), LocalDockerError> {
+    validate_worker(worker)?;
+    let expected_name = container_name(worker.identity.workflow_id, worker.identity.job_id);
+    let exact_labels = [
+        (MANAGED_LABEL, "true".to_string()),
+        (PROVIDER_LABEL, "local_docker".to_string()),
+        (PROTOCOL_LABEL, CLOUD_RUN_PROTOCOL_VERSION.to_string()),
+        (WORKFLOW_LABEL, worker.identity.workflow_id.to_string()),
+        (JOB_LABEL, worker.identity.job_id.to_string()),
+        (SSH_KEY_LABEL, worker.ssh_public_key.clone()),
+        (TERMINATE_LABEL, worker.lease.terminate_after.clone()),
+    ];
+    let valid = container.id == worker.identity.resource_id
+        && container.name == expected_name
+        && container.image == worker.image
+        && container.restart_policy == "no"
+        && exact_labels
+            .iter()
+            .all(|(key, value)| container.labels.get(*key) == Some(value))
+        && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(worker.ssh_public_key.as_str())
+        && required_environment(container, TERMINATE_ENV) == Ok(worker.lease.terminate_after.as_str())
+        && valid_target_label(&container.labels, worker);
+    valid.then_some(()).ok_or(LocalDockerError::ResourceIdentityMismatch)
+}
+
+fn valid_target_label(labels: &BTreeMap<String, String>, worker: &InteractiveWorker) -> bool {
+    labels
+        .get(TARGET_LABEL)
+        .and_then(|value| serde_json::from_str::<WorkerTarget>(value).ok())
+        .is_some_and(|target| {
+            target.image == worker.image
+                && InteractiveWorkerRequest {
+                    workflow_id: worker.identity.workflow_id,
+                    job_id: worker.identity.job_id,
+                    target,
+                    ssh_public_key: worker.ssh_public_key.clone(),
+                }
+                .is_valid_for(CloudProvider::LocalDocker)
+        })
+}
+
+fn request_labels(request: &InteractiveWorkerRequest) -> Result<BTreeMap<String, String>, LocalDockerError> {
+    let target = serde_json::to_string(&request.target).map_err(|_| LocalDockerError::InvalidTarget)?;
+    Ok(BTreeMap::from([
+        (MANAGED_LABEL.to_string(), "true".to_string()),
+        (PROVIDER_LABEL.to_string(), "local_docker".to_string()),
+        (PROTOCOL_LABEL.to_string(), CLOUD_RUN_PROTOCOL_VERSION.to_string()),
+        (WORKFLOW_LABEL.to_string(), request.workflow_id.to_string()),
+        (JOB_LABEL.to_string(), request.job_id.to_string()),
+        (TARGET_LABEL.to_string(), target),
+    ]))
+}
+
+fn required_environment<'a>(container: &'a DockerContainer, key: &str) -> Result<&'a str, LocalDockerError> {
+    let prefix = format!("{key}=");
+    let mut values = container
+        .environment
+        .iter()
+        .filter_map(|entry| entry.strip_prefix(&prefix));
+    let value = values.next().ok_or(LocalDockerError::ResourceIdentityMismatch)?;
+    if values.next().is_some() {
+        return Err(LocalDockerError::ResourceIdentityMismatch);
+    }
+    Ok(value)
+}
+
+fn created_container_matches(container: &DockerContainer, create: &DockerCreateRequest) -> bool {
+    valid_container_id(&container.id)
+        && container.name == create.name
+        && container.image == create.image
+        && container.restart_policy == "no"
+        && create
+            .labels
+            .iter()
+            .all(|(key, value)| container.labels.get(key) == Some(value))
+        && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(create.ssh_public_key.as_str())
+        && required_environment(container, TERMINATE_ENV) == Ok(create.terminate_after.as_str())
+}
+
+fn canonical_host_key(value: &str) -> Option<String> {
+    if !valid_ssh_public_key(value) {
+        return None;
+    }
+    let mut fields = value.split_ascii_whitespace();
+    Some(format!("{} {}", fields.next()?, fields.next()?))
+}
+
+fn container_name(workflow_id: super::CloudWorkflowId, job_id: super::CloudJobId) -> String {
+    format!("horizon-local-{workflow_id}-{job_id}")
+}
+
+fn valid_container_id(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -9,7 +9,10 @@ use super::{
     },
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
 use thiserror::Error;
 
 mod command;
@@ -29,8 +32,10 @@ const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
 const LOCAL_HOST: &str = "127.0.0.1";
 const SSH_USERNAME: &str = "root";
 const HOST_KEY_PATH: &str = "/etc/ssh/ssh_host_ed25519_key.pub";
-const CREATE_RECONCILE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-const CREATE_RECONCILE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const CREATE_RECONCILE_TIMEOUT: Duration = Duration::from_secs(2);
+const CREATE_RECONCILE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+type DockerResult<T> = Result<T, LocalDockerError>;
 
 /// Non-secret configuration for the local Docker daemon provider.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -105,14 +110,16 @@ impl LocalDockerInteractiveWorkerProvider {
         let create = DockerCreateRequest::new(request, container_name)?;
         match self.transport.create(&create) {
             Ok(resource_id) if valid_container_id(&resource_id) => {
-                let Some(container) = self.transport.inspect(&resource_id)? else {
-                    return self.reconcile_uncertain_create(
-                        request,
-                        container_name,
-                        LocalDockerError::InvalidResponse {
-                            operation: "container creation verification",
-                        },
-                    );
+                let container = match self.transport.inspect(&resource_id) {
+                    Ok(Some(container)) => container,
+                    Ok(None) => {
+                        return self.reconcile_uncertain_create(
+                            request,
+                            &create,
+                            invalid_response("container creation verification"),
+                        );
+                    }
+                    Err(error) => return self.reconcile_uncertain_create(request, &create, error),
                 };
                 if container.id != resource_id {
                     return Err(LocalDockerError::ResourceIdentityMismatch);
@@ -133,31 +140,31 @@ impl LocalDockerInteractiveWorkerProvider {
                     Err(error) => self.cleanup_invalid_creation(&container, &create, error),
                 }
             }
-            Ok(_) => self.reconcile_uncertain_create(
-                request,
-                container_name,
-                LocalDockerError::InvalidResponse {
-                    operation: "container creation",
-                },
-            ),
-            Err(error) => self.reconcile_uncertain_create(request, container_name, error),
+            Ok(_) => self.reconcile_uncertain_create(request, &create, invalid_response("container creation")),
+            Err(error) => self.reconcile_uncertain_create(request, &create, error),
         }
     }
 
     fn reconcile_uncertain_create(
         &self,
         request: &InteractiveWorkerRequest,
-        container_name: &str,
+        create: &DockerCreateRequest,
         original: LocalDockerError,
     ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
-        let deadline = std::time::Instant::now() + CREATE_RECONCILE_TIMEOUT;
-        while std::time::Instant::now() < deadline {
-            if let Some(container) = self.transport.inspect(container_name)? {
-                return self
-                    .ensure_existing(request, &container)
-                    .map(InteractiveWorkerEnsure::Reused);
+        let deadline = Instant::now() + CREATE_RECONCILE_TIMEOUT;
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
             }
-            std::thread::sleep(CREATE_RECONCILE_POLL_INTERVAL);
+            if let Some(container) = self.transport.inspect_with_timeout(&create.name, remaining)? {
+                return match self.ensure_existing(request, &container) {
+                    Ok(status) => Ok(InteractiveWorkerEnsure::Reused(status)),
+                    Err(error) => self.cleanup_invalid_creation(&container, create, error),
+                };
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            std::thread::sleep(CREATE_RECONCILE_POLL_INTERVAL.min(remaining));
         }
         Err(original)
     }
@@ -295,12 +302,12 @@ pub enum LocalDockerError {
 }
 
 trait DockerTransport: Send + Sync {
-    fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError>;
-    fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError>;
-    fn read_host_key(&self, resource_id: &str) -> Result<Option<String>, LocalDockerError>;
-    fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError>;
+    fn inspect(&self, reference: &str) -> DockerResult<Option<DockerContainer>>;
+    fn inspect_with_timeout(&self, reference: &str, timeout: Duration) -> DockerResult<Option<DockerContainer>>;
+    fn create(&self, request: &DockerCreateRequest) -> DockerResult<String>;
+    fn read_host_key(&self, resource_id: &str) -> DockerResult<Option<String>>;
+    fn delete(&self, resource_id: &str) -> DockerResult<bool>;
 }
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct DockerContainer {
     id: String,
@@ -314,13 +321,11 @@ struct DockerContainer {
     exit_code: i64,
     ssh_bindings: Vec<DockerPortBinding>,
 }
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct DockerPortBinding {
     host: String,
     port: u16,
 }
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct DockerCreateRequest {
     name: String,
@@ -351,13 +356,11 @@ impl DockerCreateRequest {
         })
     }
 }
-
 fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerProfile) -> Result<(), LocalDockerError> {
     (request.target.profile == profile.name && request.is_valid_for(CloudProvider::LocalDocker))
         .then_some(())
         .ok_or(LocalDockerError::InvalidTarget)
 }
-
 fn valid_local_docker_host(value: &str) -> bool {
     let safe = |path: &str| !path.is_empty() && !path.chars().any(char::is_control);
     value
@@ -365,13 +368,11 @@ fn valid_local_docker_host(value: &str) -> bool {
         .is_some_and(|path| path.len() > 1 && path.starts_with('/') && safe(path))
         || value.strip_prefix("npipe:////./pipe/").is_some_and(safe)
 }
-
 fn validate_worker(worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
     (worker.is_valid_for(CloudProvider::LocalDocker) && valid_container_id(&worker.identity.resource_id))
         .then_some(())
         .ok_or(LocalDockerError::InvalidPersistedWorker)
 }
-
 fn worker_for_request(
     container: &DockerContainer,
     request: &InteractiveWorkerRequest,
@@ -393,7 +394,6 @@ fn worker_for_request(
     verify_container_for_worker(container, &worker)?;
     Ok(worker)
 }
-
 fn verify_container_for_worker(
     container: &DockerContainer,
     worker: &InteractiveWorker,
@@ -421,14 +421,12 @@ fn verify_container_for_worker(
         && valid_target_label(&container.labels, worker);
     valid.then_some(()).ok_or(LocalDockerError::ResourceIdentityMismatch)
 }
-
 fn valid_target_label(labels: &BTreeMap<String, String>, worker: &InteractiveWorker) -> bool {
     labels
         .get(TARGET_LABEL)
         .and_then(|value| serde_json::from_str::<WorkerTarget>(value).ok())
         .is_some_and(|target| target == worker.target)
 }
-
 fn request_labels(request: &InteractiveWorkerRequest) -> Result<BTreeMap<String, String>, LocalDockerError> {
     let target = serde_json::to_string(&request.target).map_err(|_| LocalDockerError::InvalidTarget)?;
     Ok(BTreeMap::from([
@@ -440,7 +438,6 @@ fn request_labels(request: &InteractiveWorkerRequest) -> Result<BTreeMap<String,
         (TARGET_LABEL.to_string(), target),
     ]))
 }
-
 fn required_environment<'a>(container: &'a DockerContainer, key: &str) -> Result<&'a str, LocalDockerError> {
     let prefix = format!("{key}=");
     let mut values = container
@@ -453,7 +450,6 @@ fn required_environment<'a>(container: &'a DockerContainer, key: &str) -> Result
     }
     Ok(value)
 }
-
 fn created_container_matches(container: &DockerContainer, create: &DockerCreateRequest) -> bool {
     valid_container_id(&container.id)
         && container.name == create.name
@@ -466,7 +462,6 @@ fn created_container_matches(container: &DockerContainer, create: &DockerCreateR
         && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(create.ssh_public_key.as_str())
         && required_environment(container, TERMINATE_ENV) == Ok(create.terminate_after.as_str())
 }
-
 fn canonical_host_key(value: &str) -> Option<String> {
     if !valid_ssh_public_key(value) {
         return None;
@@ -474,11 +469,12 @@ fn canonical_host_key(value: &str) -> Option<String> {
     let mut fields = value.split_ascii_whitespace();
     Some(format!("{} {}", fields.next()?, fields.next()?))
 }
-
 fn container_name(workflow_id: super::CloudWorkflowId, job_id: super::CloudJobId) -> String {
     format!("horizon-local-{workflow_id}-{job_id}")
 }
-
 fn valid_container_id(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+}
+fn invalid_response(operation: &'static str) -> LocalDockerError {
+    LocalDockerError::InvalidResponse { operation }
 }

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -58,14 +58,6 @@ impl LocalDockerInteractiveWorkerProvider {
             .ok_or(LocalDockerError::NonLocalDockerHost)
     }
 
-    #[cfg(test)]
-    fn with_transport(profile: LocalDockerProfile, transport: impl DockerTransport + 'static) -> Self {
-        Self {
-            transport: Box::new(transport),
-            profile,
-        }
-    }
-
     fn ensure_existing(
         &self,
         request: &InteractiveWorkerRequest,
@@ -79,6 +71,13 @@ impl LocalDockerInteractiveWorkerProvider {
             return self.reject_unbounded_lease(&worker, container);
         }
         self.observe(container, worker)
+    }
+
+    fn validate_persisted_worker(&self, worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
+        validate_worker(worker)?;
+        (worker.target.profile == self.profile.name)
+            .then_some(())
+            .ok_or(LocalDockerError::InvalidPersistedWorker)
     }
 
     fn reject_unbounded_lease(
@@ -231,7 +230,7 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
     }
 
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
-        validate_worker(worker)?;
+        self.validate_persisted_worker(worker)?;
         let Some(container) = self.transport.inspect(&worker.identity.resource_id)? else {
             return Ok(None);
         };
@@ -240,7 +239,7 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
     }
 
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
-        validate_worker(worker)?;
+        self.validate_persisted_worker(worker)?;
         let resource_id = &worker.identity.resource_id;
         let Some(container) = self.transport.inspect(resource_id)? else {
             return Ok(InteractiveWorkerCleanup::AlreadyAbsent);
@@ -474,8 +473,5 @@ fn container_name(workflow_id: super::CloudWorkflowId, job_id: super::CloudJobId
 }
 
 fn valid_container_id(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    value.len() == 64 && value.bytes().all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
 }

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -68,7 +68,7 @@ impl LocalDockerInteractiveWorkerProvider {
         &self,
         request: &InteractiveWorkerRequest,
         container: &DockerContainer,
-    ) -> Result<InteractiveWorkerStatus, LocalDockerError> {
+    ) -> DockerResult<InteractiveWorkerStatus> {
         let worker = worker_for_request(container, request)?;
         if !worker
             .lease
@@ -78,7 +78,7 @@ impl LocalDockerInteractiveWorkerProvider {
         }
         self.observe(container, worker)
     }
-    fn validate_persisted_worker(&self, worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
+    fn validate_persisted_worker(&self, worker: &InteractiveWorker) -> DockerResult<()> {
         validate_worker(worker)?;
         (worker.target.profile == self.profile.name)
             .then_some(())
@@ -88,7 +88,7 @@ impl LocalDockerInteractiveWorkerProvider {
         &self,
         worker: &InteractiveWorker,
         container: &DockerContainer,
-    ) -> Result<InteractiveWorkerStatus, LocalDockerError> {
+    ) -> DockerResult<InteractiveWorkerStatus> {
         let resource_id = worker.identity.resource_id.clone();
         if verify_container_for_worker(container, worker).is_err()
             || self.transport.delete(&resource_id).is_err()
@@ -102,7 +102,7 @@ impl LocalDockerInteractiveWorkerProvider {
         &self,
         request: &InteractiveWorkerRequest,
         container_name: &str,
-    ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
+    ) -> DockerResult<InteractiveWorkerEnsure> {
         let create = DockerCreateRequest::new(request, container_name)?;
         match self.transport.create(&create) {
             Ok(resource_id) if valid_container_id(&resource_id) => {
@@ -134,6 +134,9 @@ impl LocalDockerInteractiveWorkerProvider {
                 }
                 match self.observe(&container, worker) {
                     Ok(status) => Ok(InteractiveWorkerEnsure::Created(status)),
+                    Err(error @ LocalDockerError::ResourceAbsent) => {
+                        self.reconcile_uncertain_create(request, &create, error)
+                    }
                     Err(error) => self.cleanup_invalid_creation(&container, &create, error),
                 }
             }
@@ -146,7 +149,7 @@ impl LocalDockerInteractiveWorkerProvider {
         request: &InteractiveWorkerRequest,
         create: &DockerCreateRequest,
         original: LocalDockerError,
-    ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
+    ) -> DockerResult<InteractiveWorkerEnsure> {
         let deadline = Instant::now() + CREATE_RECONCILE_TIMEOUT;
         while Instant::now() < deadline {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -154,10 +157,11 @@ impl LocalDockerInteractiveWorkerProvider {
                 break;
             }
             if let Ok(Some(container)) = self.transport.inspect_with_timeout(&create.name, remaining) {
-                return match self.ensure_existing(request, &container) {
-                    Ok(status) => Ok(InteractiveWorkerEnsure::Reused(status)),
-                    Err(error) => self.cleanup_invalid_creation(&container, create, error),
-                };
+                match self.ensure_existing(request, &container) {
+                    Ok(status) => return Ok(InteractiveWorkerEnsure::Reused(status)),
+                    Err(LocalDockerError::ResourceAbsent) => {}
+                    Err(error) => return self.cleanup_invalid_creation(&container, create, error),
+                }
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
             std::thread::sleep(CREATE_RECONCILE_POLL_INTERVAL.min(remaining));
@@ -169,7 +173,7 @@ impl LocalDockerInteractiveWorkerProvider {
         container: &DockerContainer,
         create: &DockerCreateRequest,
         original: LocalDockerError,
-    ) -> Result<InteractiveWorkerEnsure, LocalDockerError> {
+    ) -> DockerResult<InteractiveWorkerEnsure> {
         let resource_id = container.id.clone();
         if !created_container_matches(container, create) {
             return Err(original);
@@ -179,11 +183,7 @@ impl LocalDockerInteractiveWorkerProvider {
         }
         Err(original)
     }
-    fn observe(
-        &self,
-        container: &DockerContainer,
-        worker: InteractiveWorker,
-    ) -> Result<InteractiveWorkerStatus, LocalDockerError> {
+    fn observe(&self, container: &DockerContainer, worker: InteractiveWorker) -> DockerResult<InteractiveWorkerStatus> {
         let (lifecycle, ssh) = match (container.state.as_str(), container.running) {
             ("running", true) => self.running_connection(container)?,
             ("created" | "restarting", false) => (InteractiveWorkerLifecycle::Provisioning, None),
@@ -197,7 +197,7 @@ impl LocalDockerInteractiveWorkerProvider {
     fn running_connection(
         &self,
         container: &DockerContainer,
-    ) -> Result<(InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>), LocalDockerError> {
+    ) -> DockerResult<(InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>)> {
         let Some(binding) = container.ssh_bindings.as_slice().first() else {
             return Ok((InteractiveWorkerLifecycle::Provisioning, None));
         };
@@ -227,9 +227,10 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
         validate_request(request, &self.profile)?;
         let container_name = container_name(request.workflow_id, request.job_id);
         if let Some(container) = self.transport.inspect(&container_name)? {
-            return self
-                .ensure_existing(request, &container)
-                .map(InteractiveWorkerEnsure::Reused);
+            match self.ensure_existing(request, &container) {
+                Err(LocalDockerError::ResourceAbsent) => {}
+                result => return result.map(InteractiveWorkerEnsure::Reused),
+            }
         }
         self.create_worker(request, &container_name)
     }
@@ -239,7 +240,10 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
             return Ok(None);
         };
         verify_container_for_worker(&container, worker)?;
-        self.observe(&container, worker.clone()).map(Some)
+        match self.observe(&container, worker.clone()) {
+            Err(LocalDockerError::ResourceAbsent) => Ok(None),
+            result => result.map(Some),
+        }
     }
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
         self.validate_persisted_worker(worker)?;
@@ -267,6 +271,10 @@ pub enum LocalDockerError {
     NonLocalDockerHost,
     #[error("required command 'docker' is unavailable")]
     DockerUnavailable,
+    #[error("local Docker command exceeds the portable argument limit during {operation}")]
+    CommandTooLong { operation: &'static str },
+    #[error("local Docker worker disappeared during inspection")]
+    ResourceAbsent,
     #[error("local Docker command timed out during {operation}")]
     CommandTimedOut { operation: &'static str },
     #[error("local Docker command failed during {operation}")]
@@ -324,7 +332,7 @@ struct DockerCreateRequest {
 }
 
 impl DockerCreateRequest {
-    fn new(request: &InteractiveWorkerRequest, name: &str) -> Result<Self, LocalDockerError> {
+    fn new(request: &InteractiveWorkerRequest, name: &str) -> DockerResult<Self> {
         let now = time::OffsetDateTime::now_utc();
         let deadline = now
             .checked_add(time::Duration::seconds(i64::from(request.target.lease_seconds)))
@@ -345,7 +353,7 @@ impl DockerCreateRequest {
         })
     }
 }
-fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerProfile) -> Result<(), LocalDockerError> {
+fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerProfile) -> DockerResult<()> {
     (request.target.profile == profile.name && request.is_valid_for(CloudProvider::LocalDocker))
         .then_some(())
         .ok_or(LocalDockerError::InvalidTarget)
@@ -357,7 +365,7 @@ fn valid_local_docker_host(value: &str) -> bool {
         .is_some_and(|path| path.len() > 1 && path.starts_with('/') && safe(path))
         || value.strip_prefix("npipe:////./pipe/").is_some_and(safe)
 }
-fn validate_worker(worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
+fn validate_worker(worker: &InteractiveWorker) -> DockerResult<()> {
     (worker.is_valid_for(CloudProvider::LocalDocker) && valid_container_id(&worker.identity.resource_id))
         .then_some(())
         .ok_or(LocalDockerError::InvalidPersistedWorker)
@@ -365,7 +373,7 @@ fn validate_worker(worker: &InteractiveWorker) -> Result<(), LocalDockerError> {
 fn worker_for_request(
     container: &DockerContainer,
     request: &InteractiveWorkerRequest,
-) -> Result<InteractiveWorker, LocalDockerError> {
+) -> DockerResult<InteractiveWorker> {
     let terminate_after = required_environment(container, TERMINATE_ENV)?;
     let worker = InteractiveWorker {
         identity: InteractiveWorkerIdentity {
@@ -383,10 +391,7 @@ fn worker_for_request(
     verify_container_for_worker(container, &worker)?;
     Ok(worker)
 }
-fn verify_container_for_worker(
-    container: &DockerContainer,
-    worker: &InteractiveWorker,
-) -> Result<(), LocalDockerError> {
+fn verify_container_for_worker(container: &DockerContainer, worker: &InteractiveWorker) -> DockerResult<()> {
     validate_worker(worker)?;
     let ssh_public_key =
         canonical_ed25519_key(&worker.ssh_public_key).ok_or(LocalDockerError::InvalidPersistedWorker)?;
@@ -418,7 +423,7 @@ fn valid_target_label(labels: &BTreeMap<String, String>, worker: &InteractiveWor
         .and_then(|value| serde_json::from_str::<WorkerTarget>(value).ok())
         .is_some_and(|target| target == worker.target)
 }
-fn request_labels(request: &InteractiveWorkerRequest) -> Result<BTreeMap<String, String>, LocalDockerError> {
+fn request_labels(request: &InteractiveWorkerRequest) -> DockerResult<BTreeMap<String, String>> {
     let target = serde_json::to_string(&request.target).map_err(|_| LocalDockerError::InvalidTarget)?;
     Ok(BTreeMap::from([
         (MANAGED_LABEL.to_string(), "true".to_string()),
@@ -429,7 +434,7 @@ fn request_labels(request: &InteractiveWorkerRequest) -> Result<BTreeMap<String,
         (TARGET_LABEL.to_string(), target),
     ]))
 }
-fn required_environment<'a>(container: &'a DockerContainer, key: &str) -> Result<&'a str, LocalDockerError> {
+fn required_environment<'a>(container: &'a DockerContainer, key: &str) -> DockerResult<&'a str> {
     let prefix = format!("{key}=");
     let mut values = container
         .environment

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -105,22 +105,15 @@ impl DockerTransport for DockerCli {
             "SSH host-key inspection",
         )?;
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
-            return if object_missing(&output.stderr)
-                || stderr.contains("no such file or directory")
-                || stderr.contains("is not running")
-            {
-                Ok(None)
-            } else {
-                Err(LocalDockerError::CommandFailed {
+            return host_key_unavailable(&output.stderr)
+                .then_some(None)
+                .ok_or(LocalDockerError::CommandFailed {
                     operation: "SSH host-key inspection",
-                })
-            };
+                });
         }
         output
             .stdout_text("SSH host-key inspection")
-            .map(str::to_string)
-            .map(Some)
+            .map(|value| Some(value.to_string()))
     }
 
     fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError> {
@@ -216,6 +209,13 @@ fn read_bounded(mut reader: impl Read) -> std::io::Result<(Vec<u8>, bool)> {
 fn object_missing(stderr: &[u8]) -> bool {
     let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
     stderr.contains("no such object") || stderr.contains("no such container")
+}
+
+fn host_key_unavailable(stderr: &[u8]) -> bool {
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    object_missing(stderr.as_bytes())
+        || stderr.contains("is not running")
+        || (stderr.contains(HOST_KEY_PATH) && stderr.contains("no such file or directory"))
 }
 
 fn parse_inspection(value: &str) -> Result<DockerContainer, LocalDockerError> {
@@ -325,5 +325,13 @@ mod tests {
         assert_eq!(parsed.ssh_bindings[0].host, "127.0.0.1");
         assert_eq!(parsed.ssh_bindings[0].port, 49_152);
         assert!(parse_inspection("[]").is_err());
+    }
+
+    #[test]
+    fn missing_host_key_does_not_hide_a_missing_daemon_socket() {
+        let missing_key = format!("cat: {HOST_KEY_PATH}: No such file or directory");
+        assert!(host_key_unavailable(missing_key.as_bytes()));
+        let missing_socket = b"dial unix /tmp/docker.sock: connect: no such file or directory";
+        assert!(!host_key_unavailable(missing_socket));
     }
 }

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -1,0 +1,332 @@
+use super::{
+    DockerContainer, DockerCreateRequest, DockerPortBinding, DockerTransport, HOST_KEY_PATH, SSH_PUBLIC_KEY_ENV,
+    TERMINATE_ENV,
+};
+use crate::cloud_run::local_docker::LocalDockerError;
+use serde::Deserialize;
+use std::{
+    collections::BTreeMap,
+    ffi::{OsStr, OsString},
+    io::Read,
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const RESPONSE_LIMIT_BYTES: usize = 1024 * 1024;
+
+pub(super) struct DockerCli {
+    executable: OsString,
+}
+
+impl DockerCli {
+    pub(super) fn new() -> Self {
+        Self {
+            executable: OsString::from("docker"),
+        }
+    }
+
+    fn output<I, S>(&self, args: I, operation: &'static str) -> Result<CapturedOutput, LocalDockerError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut child = Command::new(&self.executable)
+            .args(args)
+            .env("DOCKER_CLIENT_TIMEOUT", COMMAND_TIMEOUT.as_secs().to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    LocalDockerError::DockerUnavailable
+                } else {
+                    LocalDockerError::CommandFailed { operation }
+                }
+            })?;
+        capture_output(&mut child, operation)
+    }
+}
+
+impl DockerTransport for DockerCli {
+    fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError> {
+        let output = self.output(["container", "inspect", "--", reference], "container inspection")?;
+        if !output.status.success() {
+            return if object_missing(&output.stderr) {
+                Ok(None)
+            } else {
+                Err(LocalDockerError::CommandFailed {
+                    operation: "container inspection",
+                })
+            };
+        }
+        parse_inspection(output.stdout_text("container inspection")?).map(Some)
+    }
+
+    fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError> {
+        let mut args = vec![
+            OsString::from("run"),
+            OsString::from("--detach"),
+            OsString::from("--pull=never"),
+            OsString::from("--restart=no"),
+            OsString::from("--name"),
+            OsString::from(&request.name),
+            OsString::from("--publish"),
+            OsString::from("127.0.0.1::22"),
+            OsString::from("--env"),
+            OsString::from(format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key)),
+            OsString::from("--env"),
+            OsString::from(format!("{TERMINATE_ENV}={}", request.terminate_after)),
+        ];
+        for (key, value) in &request.labels {
+            args.push(OsString::from("--label"));
+            args.push(OsString::from(format!("{key}={value}")));
+        }
+        args.push(OsString::from(&request.image));
+        let output = self.output(args, "container creation")?;
+        if !output.status.success() {
+            return Err(LocalDockerError::CommandFailed {
+                operation: "container creation",
+            });
+        }
+        output.stdout_text("container creation").map(str::to_string)
+    }
+
+    fn read_host_key(&self, resource_id: &str) -> Result<Option<String>, LocalDockerError> {
+        let output = self.output(
+            ["exec", "--", resource_id, "cat", HOST_KEY_PATH],
+            "SSH host-key inspection",
+        )?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+            return if object_missing(&output.stderr)
+                || stderr.contains("no such file or directory")
+                || stderr.contains("is not running")
+            {
+                Ok(None)
+            } else {
+                Err(LocalDockerError::CommandFailed {
+                    operation: "SSH host-key inspection",
+                })
+            };
+        }
+        output
+            .stdout_text("SSH host-key inspection")
+            .map(str::to_string)
+            .map(Some)
+    }
+
+    fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError> {
+        let output = self.output(["container", "rm", "--force", "--", resource_id], "container deletion")?;
+        if output.status.success() {
+            return Ok(true);
+        }
+        if object_missing(&output.stderr) {
+            Ok(false)
+        } else {
+            Err(LocalDockerError::CommandFailed {
+                operation: "container deletion",
+            })
+        }
+    }
+}
+
+struct CapturedOutput {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+impl CapturedOutput {
+    fn stdout_text(&self, operation: &'static str) -> Result<&str, LocalDockerError> {
+        let value = std::str::from_utf8(&self.stdout)
+            .map_err(|_| LocalDockerError::InvalidResponse { operation })?
+            .trim();
+        if value.is_empty() {
+            Err(LocalDockerError::InvalidResponse { operation })
+        } else {
+            Ok(value)
+        }
+    }
+}
+
+fn capture_output(child: &mut Child, operation: &'static str) -> Result<CapturedOutput, LocalDockerError> {
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or(LocalDockerError::InvalidResponse { operation })?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or(LocalDockerError::InvalidResponse { operation })?;
+    let stdout_reader = thread::spawn(move || read_bounded(stdout));
+    let stderr_reader = thread::spawn(move || read_bounded(stderr));
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|_| LocalDockerError::CommandFailed { operation })?
+        {
+            break status;
+        }
+        if started.elapsed() >= COMMAND_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(LocalDockerError::CommandTimedOut { operation });
+        }
+        thread::sleep(COMMAND_POLL_INTERVAL);
+    };
+    let (stdout, stdout_oversized) = stdout_reader
+        .join()
+        .map_err(|_| LocalDockerError::InvalidResponse { operation })?
+        .map_err(|_| LocalDockerError::InvalidResponse { operation })?;
+    let (stderr, stderr_oversized) = stderr_reader
+        .join()
+        .map_err(|_| LocalDockerError::InvalidResponse { operation })?
+        .map_err(|_| LocalDockerError::InvalidResponse { operation })?;
+    if stdout_oversized || stderr_oversized {
+        return Err(LocalDockerError::InvalidResponse { operation });
+    }
+    Ok(CapturedOutput { status, stdout, stderr })
+}
+
+fn read_bounded(mut reader: impl Read) -> std::io::Result<(Vec<u8>, bool)> {
+    let mut retained = Vec::new();
+    let mut oversized = false;
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        let remaining = RESPONSE_LIMIT_BYTES.saturating_sub(retained.len());
+        retained.extend_from_slice(&buffer[..count.min(remaining)]);
+        oversized |= count > remaining;
+    }
+    Ok((retained, oversized))
+}
+
+fn object_missing(stderr: &[u8]) -> bool {
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    stderr.contains("no such object") || stderr.contains("no such container")
+}
+
+fn parse_inspection(value: &str) -> Result<DockerContainer, LocalDockerError> {
+    let mut records: Vec<Inspection> = serde_json::from_str(value).map_err(|_| invalid_inspection())?;
+    if records.len() != 1 {
+        return Err(invalid_inspection());
+    }
+    let record = records.pop().ok_or_else(invalid_inspection)?;
+    let name = record.name.strip_prefix('/').unwrap_or(&record.name).to_string();
+    let ssh_bindings = record
+        .network_settings
+        .ports
+        .and_then(|ports| ports.ssh)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|binding| {
+            let port = binding.host_port.parse::<u16>().map_err(|_| invalid_inspection())?;
+            Ok(DockerPortBinding {
+                host: binding.host_ip,
+                port,
+            })
+        })
+        .collect::<Result<Vec<_>, LocalDockerError>>()?;
+    Ok(DockerContainer {
+        id: record.id,
+        name,
+        image: record.config.image,
+        labels: record.config.labels.unwrap_or_default(),
+        environment: record.config.env.unwrap_or_default(),
+        restart_policy: record.host_config.restart_policy.name,
+        running: record.state.running,
+        state: record.state.status,
+        exit_code: record.state.exit_code,
+        ssh_bindings,
+    })
+}
+
+fn invalid_inspection() -> LocalDockerError {
+    LocalDockerError::InvalidResponse {
+        operation: "container inspection",
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Inspection {
+    id: String,
+    name: String,
+    config: InspectionConfig,
+    host_config: InspectionHostConfig,
+    state: InspectionState,
+    network_settings: InspectionNetworkSettings,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InspectionConfig {
+    image: String,
+    #[serde(default)]
+    labels: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    env: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InspectionHostConfig {
+    restart_policy: InspectionRestartPolicy,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InspectionRestartPolicy {
+    name: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InspectionState {
+    running: bool,
+    status: String,
+    exit_code: i64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InspectionNetworkSettings {
+    #[serde(default)]
+    ports: Option<InspectionPorts>,
+}
+
+#[derive(Deserialize)]
+struct InspectionPorts {
+    #[serde(rename = "22/tcp", default)]
+    ssh: Option<Vec<InspectionBinding>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InspectionBinding {
+    host_ip: String,
+    host_port: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inspection_decodes_one_loopback_binding() {
+        let value = r#"[{"Id":"id","Name":"/horizon-local-worker","Config":{"Image":"image","Labels":null,"Env":null},"HostConfig":{"RestartPolicy":{"Name":"no"}},"State":{"Running":true,"Status":"running","ExitCode":0},"NetworkSettings":{"Ports":{"22/tcp":[{"HostIp":"127.0.0.1","HostPort":"49152"}]}}}]"#;
+        let parsed = parse_inspection(value).expect("Docker inspection");
+        assert_eq!(parsed.ssh_bindings.len(), 1);
+        assert_eq!(parsed.ssh_bindings[0].host, "127.0.0.1");
+        assert_eq!(parsed.ssh_bindings[0].port, 49_152);
+        assert!(parse_inspection("[]").is_err());
+    }
+}

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -28,7 +28,6 @@ impl DockerCli {
             docker_host: OsString::from(docker_host),
         }
     }
-
     fn output<I, S>(&self, args: I, operation: &'static str, timeout: Duration) -> DockerResult<CapturedOutput>
     where
         I: IntoIterator<Item = S>,
@@ -58,7 +57,6 @@ impl DockerTransport for DockerCli {
     fn inspect(&self, reference: &str) -> DockerResult<Option<DockerContainer>> {
         self.inspect_with_timeout(reference, COMMAND_TIMEOUT)
     }
-
     fn inspect_with_timeout(&self, reference: &str, timeout: Duration) -> DockerResult<Option<DockerContainer>> {
         let args = ["container", "inspect", "--", reference];
         let output = self.output(args, "container inspection", timeout)?;
@@ -73,7 +71,6 @@ impl DockerTransport for DockerCli {
         }
         parse_inspection(output.stdout_text("container inspection")?).map(Some)
     }
-
     fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError> {
         let mut args = vec![
             OsString::from("run"),
@@ -102,7 +99,6 @@ impl DockerTransport for DockerCli {
         }
         output.stdout_text("container creation").map(str::to_string)
     }
-
     fn read_host_key(&self, resource_id: &str) -> Result<Option<String>, LocalDockerError> {
         let output = self.output(
             ["exec", "--", resource_id, "cat", HOST_KEY_PATH],
@@ -118,7 +114,6 @@ impl DockerTransport for DockerCli {
         }
         Ok(Some(output.stdout_text("SSH host-key inspection")?.to_string()))
     }
-
     fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError> {
         let args = ["container", "rm", "--force", "--", resource_id];
         let output = self.output(args, "container deletion", COMMAND_TIMEOUT)?;
@@ -153,7 +148,6 @@ impl CapturedOutput {
         }
     }
 }
-
 fn capture_output(child: &mut Child, operation: &'static str, timeout: Duration) -> DockerResult<CapturedOutput> {
     let stdout = child
         .stdout
@@ -193,7 +187,6 @@ fn capture_output(child: &mut Child, operation: &'static str, timeout: Duration)
     }
     Ok(CapturedOutput { status, stdout, stderr })
 }
-
 fn read_bounded(mut reader: impl Read) -> std::io::Result<(Vec<u8>, bool)> {
     let mut retained = Vec::new();
     let mut oversized = false;

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -1,8 +1,7 @@
 use super::{
     COMMAND_TIMEOUT, DockerContainer, DockerCreateRequest, DockerPortBinding, DockerResult, DockerTransport,
-    HOST_KEY_PATH, SSH_PUBLIC_KEY_ENV, TERMINATE_ENV, invalid_response,
+    HOST_KEY_PATH, LocalDockerError, SSH_PUBLIC_KEY_ENV, TERMINATE_ENV, invalid_response,
 };
-use crate::cloud_run::local_docker::LocalDockerError;
 use serde::Deserialize;
 use std::{
     collections::BTreeMap,
@@ -33,10 +32,12 @@ impl DockerCli {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let mut child = Command::new(&self.executable)
-            .arg("--host")
-            .arg(&self.docker_host)
-            .args(args)
+        let mut command = Command::new(&self.executable);
+        command.arg("--host").arg(&self.docker_host).args(args);
+        if !command_fits(&command) {
+            return Err(LocalDockerError::CommandTooLong { operation });
+        }
+        let mut child = command
             .env("DOCKER_CLIENT_TIMEOUT", timeout.as_secs().saturating_add(1).to_string())
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -71,21 +72,24 @@ impl DockerTransport for DockerCli {
         }
         parse_inspection(output.stdout_text("container inspection")?).map(Some)
     }
-    fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError> {
-        let mut args = vec![
-            OsString::from("run"),
-            OsString::from("--detach"),
-            OsString::from("--pull=never"),
-            OsString::from("--restart=no"),
-            OsString::from("--name"),
-            OsString::from(&request.name),
-            OsString::from("--publish"),
-            OsString::from("127.0.0.1::22"),
-            OsString::from("--env"),
-            OsString::from(format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key)),
-            OsString::from("--env"),
-            OsString::from(format!("{TERMINATE_ENV}={}", request.terminate_after)),
-        ];
+    fn create(&self, request: &DockerCreateRequest) -> DockerResult<String> {
+        let mut args: Vec<OsString> = [
+            "run",
+            "--detach",
+            "--pull=never",
+            "--restart=no",
+            "--name",
+            &request.name,
+            "--publish",
+            "127.0.0.1::22",
+            "--env",
+            &format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key),
+            "--env",
+            &format!("{TERMINATE_ENV}={}", request.terminate_after),
+        ]
+        .into_iter()
+        .map(OsString::from)
+        .collect();
         for (key, value) in &request.labels {
             args.push(OsString::from("--label"));
             args.push(OsString::from(format!("{key}={value}")));
@@ -99,13 +103,16 @@ impl DockerTransport for DockerCli {
         }
         output.stdout_text("container creation").map(str::to_string)
     }
-    fn read_host_key(&self, resource_id: &str) -> Result<Option<String>, LocalDockerError> {
+    fn read_host_key(&self, resource_id: &str) -> DockerResult<Option<String>> {
         let output = self.output(
             ["exec", "--", resource_id, "cat", HOST_KEY_PATH],
             "SSH host-key inspection",
             COMMAND_TIMEOUT,
         )?;
         if !output.status.success() {
+            if object_missing(&output.stderr) {
+                return Err(LocalDockerError::ResourceAbsent);
+            }
             return host_key_unavailable(&output.stderr)
                 .then_some(None)
                 .ok_or(LocalDockerError::CommandFailed {
@@ -114,7 +121,7 @@ impl DockerTransport for DockerCli {
         }
         Ok(Some(output.stdout_text("SSH host-key inspection")?.to_string()))
     }
-    fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError> {
+    fn delete(&self, resource_id: &str) -> DockerResult<bool> {
         let args = ["container", "rm", "--force", "--", resource_id];
         let output = self.output(args, "container deletion", COMMAND_TIMEOUT)?;
         if output.status.success() {
@@ -130,6 +137,16 @@ impl DockerTransport for DockerCli {
     }
 }
 
+fn command_fits(command: &Command) -> bool {
+    // Bound UTF-16 plus worst-case Windows quoting, separators, and the terminating NUL.
+    std::iter::once(command.get_program())
+        .chain(command.get_args())
+        .fold(1usize, |length, arg| {
+            length.saturating_add(arg.as_encoded_bytes().len().saturating_mul(2).saturating_add(3))
+        })
+        <= 32_767
+}
+
 struct CapturedOutput {
     status: ExitStatus,
     stdout: Vec<u8>,
@@ -137,7 +154,7 @@ struct CapturedOutput {
 }
 
 impl CapturedOutput {
-    fn stdout_text(&self, operation: &'static str) -> Result<&str, LocalDockerError> {
+    fn stdout_text(&self, operation: &'static str) -> DockerResult<&str> {
         let value = std::str::from_utf8(&self.stdout)
             .map_err(|_| LocalDockerError::InvalidResponse { operation })?
             .trim();
@@ -210,12 +227,10 @@ fn object_missing(stderr: &[u8]) -> bool {
 
 fn host_key_unavailable(stderr: &[u8]) -> bool {
     let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
-    object_missing(stderr.as_bytes())
-        || stderr.contains("is not running")
-        || (stderr.contains(HOST_KEY_PATH) && stderr.contains("no such file or directory"))
+    stderr.contains(HOST_KEY_PATH) && stderr.contains("no such file or directory")
 }
 
-fn parse_inspection(value: &str) -> Result<DockerContainer, LocalDockerError> {
+fn parse_inspection(value: &str) -> DockerResult<DockerContainer> {
     let [record] = serde_json::from_str::<[Inspection; 1]>(value).map_err(|_| invalid_inspection())?;
     let name = record.name.strip_prefix('/').unwrap_or(&record.name).to_string();
     let ssh_bindings = record
@@ -319,7 +334,27 @@ mod tests {
         let missing_key = format!("cat: {HOST_KEY_PATH}: No such file or directory");
         assert!(host_key_unavailable(missing_key.as_bytes()));
         assert!(!host_key_unavailable(
+            b"Error response from daemon: No such container: abc"
+        ));
+        assert!(!host_key_unavailable(
             b"dial unix /tmp/docker.sock: connect: no such file or directory"
         ));
+    }
+
+    #[test]
+    fn oversized_arguments_are_rejected_before_process_creation() {
+        let cli = DockerCli {
+            executable: "missing-test-docker".into(),
+            docker_host: "unix:///docker.sock".into(),
+        };
+        let mut request = super::super::tests::request();
+        request.target.image = format!("{}@sha256:{}", "a".repeat(16_384), "d".repeat(64));
+        let create = DockerCreateRequest::new(&request, "worker").expect("create request");
+        assert_eq!(
+            cli.create(&create),
+            Err(LocalDockerError::CommandTooLong {
+                operation: "container creation"
+            })
+        );
     }
 }

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -19,12 +19,14 @@ const RESPONSE_LIMIT_BYTES: usize = 1024 * 1024;
 
 pub(super) struct DockerCli {
     executable: OsString,
+    docker_host: OsString,
 }
 
 impl DockerCli {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(docker_host: &str) -> Self {
         Self {
             executable: OsString::from("docker"),
+            docker_host: OsString::from(docker_host),
         }
     }
 
@@ -34,6 +36,8 @@ impl DockerCli {
         S: AsRef<OsStr>,
     {
         let mut child = Command::new(&self.executable)
+            .arg("--host")
+            .arg(&self.docker_host)
             .args(args)
             .env("DOCKER_CLIENT_TIMEOUT", COMMAND_TIMEOUT.as_secs().to_string())
             .stdin(Stdio::null())
@@ -215,11 +219,7 @@ fn object_missing(stderr: &[u8]) -> bool {
 }
 
 fn parse_inspection(value: &str) -> Result<DockerContainer, LocalDockerError> {
-    let mut records: Vec<Inspection> = serde_json::from_str(value).map_err(|_| invalid_inspection())?;
-    if records.len() != 1 {
-        return Err(invalid_inspection());
-    }
-    let record = records.pop().ok_or_else(invalid_inspection)?;
+    let [record] = serde_json::from_str::<[Inspection; 1]>(value).map_err(|_| invalid_inspection())?;
     let name = record.name.strip_prefix('/').unwrap_or(&record.name).to_string();
     let ssh_bindings = record
         .network_settings
@@ -270,9 +270,7 @@ struct Inspection {
 #[serde(rename_all = "PascalCase")]
 struct InspectionConfig {
     image: String,
-    #[serde(default)]
     labels: Option<BTreeMap<String, String>>,
-    #[serde(default)]
     env: Option<Vec<String>>,
 }
 
@@ -299,7 +297,6 @@ struct InspectionState {
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionNetworkSettings {
-    #[serde(default)]
     ports: Option<InspectionPorts>,
 }
 

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -1,6 +1,6 @@
 use super::{
-    DockerContainer, DockerCreateRequest, DockerPortBinding, DockerTransport, HOST_KEY_PATH, SSH_PUBLIC_KEY_ENV,
-    TERMINATE_ENV,
+    COMMAND_TIMEOUT, DockerContainer, DockerCreateRequest, DockerPortBinding, DockerResult, DockerTransport,
+    HOST_KEY_PATH, SSH_PUBLIC_KEY_ENV, TERMINATE_ENV, invalid_response,
 };
 use crate::cloud_run::local_docker::LocalDockerError;
 use serde::Deserialize;
@@ -13,7 +13,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const RESPONSE_LIMIT_BYTES: usize = 1024 * 1024;
 
@@ -30,7 +29,7 @@ impl DockerCli {
         }
     }
 
-    fn output<I, S>(&self, args: I, operation: &'static str) -> Result<CapturedOutput, LocalDockerError>
+    fn output<I, S>(&self, args: I, operation: &'static str, timeout: Duration) -> DockerResult<CapturedOutput>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
@@ -39,7 +38,7 @@ impl DockerCli {
             .arg("--host")
             .arg(&self.docker_host)
             .args(args)
-            .env("DOCKER_CLIENT_TIMEOUT", COMMAND_TIMEOUT.as_secs().to_string())
+            .env("DOCKER_CLIENT_TIMEOUT", timeout.as_secs().saturating_add(1).to_string())
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -51,13 +50,18 @@ impl DockerCli {
                     LocalDockerError::CommandFailed { operation }
                 }
             })?;
-        capture_output(&mut child, operation)
+        capture_output(&mut child, operation, timeout)
     }
 }
 
 impl DockerTransport for DockerCli {
-    fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError> {
-        let output = self.output(["container", "inspect", "--", reference], "container inspection")?;
+    fn inspect(&self, reference: &str) -> DockerResult<Option<DockerContainer>> {
+        self.inspect_with_timeout(reference, COMMAND_TIMEOUT)
+    }
+
+    fn inspect_with_timeout(&self, reference: &str, timeout: Duration) -> DockerResult<Option<DockerContainer>> {
+        let args = ["container", "inspect", "--", reference];
+        let output = self.output(args, "container inspection", timeout)?;
         if !output.status.success() {
             return if object_missing(&output.stderr) {
                 Ok(None)
@@ -90,7 +94,7 @@ impl DockerTransport for DockerCli {
             args.push(OsString::from(format!("{key}={value}")));
         }
         args.push(OsString::from(&request.image));
-        let output = self.output(args, "container creation")?;
+        let output = self.output(args, "container creation", COMMAND_TIMEOUT)?;
         if !output.status.success() {
             return Err(LocalDockerError::CommandFailed {
                 operation: "container creation",
@@ -103,6 +107,7 @@ impl DockerTransport for DockerCli {
         let output = self.output(
             ["exec", "--", resource_id, "cat", HOST_KEY_PATH],
             "SSH host-key inspection",
+            COMMAND_TIMEOUT,
         )?;
         if !output.status.success() {
             return host_key_unavailable(&output.stderr)
@@ -115,7 +120,8 @@ impl DockerTransport for DockerCli {
     }
 
     fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError> {
-        let output = self.output(["container", "rm", "--force", "--", resource_id], "container deletion")?;
+        let args = ["container", "rm", "--force", "--", resource_id];
+        let output = self.output(args, "container deletion", COMMAND_TIMEOUT)?;
         if output.status.success() {
             return Ok(true);
         }
@@ -148,7 +154,7 @@ impl CapturedOutput {
     }
 }
 
-fn capture_output(child: &mut Child, operation: &'static str) -> Result<CapturedOutput, LocalDockerError> {
+fn capture_output(child: &mut Child, operation: &'static str, timeout: Duration) -> DockerResult<CapturedOutput> {
     let stdout = child
         .stdout
         .take()
@@ -167,12 +173,12 @@ fn capture_output(child: &mut Child, operation: &'static str) -> Result<Captured
         {
             break status;
         }
-        if started.elapsed() >= COMMAND_TIMEOUT {
+        if started.elapsed() >= timeout {
             let _ = child.kill();
             let _ = child.wait();
             return Err(LocalDockerError::CommandTimedOut { operation });
         }
-        thread::sleep(COMMAND_POLL_INTERVAL);
+        thread::sleep(COMMAND_POLL_INTERVAL.min(timeout.saturating_sub(started.elapsed())));
     };
     let (stdout, stdout_oversized) = stdout_reader
         .join()
@@ -248,11 +254,8 @@ fn parse_inspection(value: &str) -> Result<DockerContainer, LocalDockerError> {
 }
 
 fn invalid_inspection() -> LocalDockerError {
-    LocalDockerError::InvalidResponse {
-        operation: "container inspection",
-    }
+    invalid_response("container inspection")
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Inspection {
@@ -263,7 +266,6 @@ struct Inspection {
     state: InspectionState,
     network_settings: InspectionNetworkSettings,
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionConfig {
@@ -271,19 +273,16 @@ struct InspectionConfig {
     labels: Option<BTreeMap<String, String>>,
     env: Option<Vec<String>>,
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionHostConfig {
     restart_policy: InspectionRestartPolicy,
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionRestartPolicy {
     name: String,
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionState {
@@ -291,19 +290,16 @@ struct InspectionState {
     status: String,
     exit_code: i64,
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionNetworkSettings {
     ports: Option<InspectionPorts>,
 }
-
 #[derive(Deserialize)]
 struct InspectionPorts {
     #[serde(rename = "22/tcp", default)]
     ssh: Option<Vec<InspectionBinding>>,
 }
-
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InspectionBinding {

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -111,9 +111,7 @@ impl DockerTransport for DockerCli {
                     operation: "SSH host-key inspection",
                 });
         }
-        output
-            .stdout_text("SSH host-key inspection")
-            .map(|value| Some(value.to_string()))
+        Ok(Some(output.stdout_text("SSH host-key inspection")?.to_string()))
     }
 
     fn delete(&self, resource_id: &str) -> Result<bool, LocalDockerError> {
@@ -331,7 +329,8 @@ mod tests {
     fn missing_host_key_does_not_hide_a_missing_daemon_socket() {
         let missing_key = format!("cat: {HOST_KEY_PATH}: No such file or directory");
         assert!(host_key_unavailable(missing_key.as_bytes()));
-        let missing_socket = b"dial unix /tmp/docker.sock: connect: no such file or directory";
-        assert!(!host_key_unavailable(missing_socket));
+        assert!(!host_key_unavailable(
+            b"dial unix /tmp/docker.sock: connect: no such file or directory"
+        ));
     }
 }

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -12,19 +12,22 @@ struct FakeState {
     create_calls: usize,
     delete_calls: usize,
     fail_create_after_insert: bool,
+    failed_inspections_after_create: usize,
     hidden_inspections_after_create: usize,
     binding_host: Option<String>,
 }
-
 impl FakeDocker {
     fn state(&self) -> std::sync::MutexGuard<'_, FakeState> {
         self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
-
 impl DockerTransport for FakeDocker {
     fn inspect(&self, reference: &str) -> DockerResult<Option<DockerContainer>> {
         let mut state = self.state();
+        if state.container.is_some() && state.failed_inspections_after_create > 0 {
+            state.failed_inspections_after_create -= 1;
+            return Err(invalid_response("container inspection"));
+        }
         if state.container.is_some() && state.hidden_inspections_after_create > 0 {
             state.hidden_inspections_after_create -= 1;
             return Ok(None);
@@ -75,13 +78,11 @@ impl DockerTransport for FakeDocker {
         Ok(true)
     }
 }
-
 fn ed25519_key(seed: u8) -> String {
     let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
     blob.extend([seed; 32]);
     format!("ssh-ed25519 {}", STANDARD.encode(blob))
 }
-
 fn request() -> InteractiveWorkerRequest {
     InteractiveWorkerRequest {
         workflow_id: "00000000-0000-4000-8000-000000000001".parse().expect("workflow ID"),
@@ -97,21 +98,18 @@ fn request() -> InteractiveWorkerRequest {
         ssh_public_key: ed25519_key(3),
     }
 }
-
 fn profile(name: &str, docker_host: &str) -> LocalDockerProfile {
     LocalDockerProfile {
         name: name.to_string(),
         docker_host: docker_host.to_string(),
     }
 }
-
 fn provider(name: &str, fake: FakeDocker) -> LocalDockerInteractiveWorkerProvider {
     LocalDockerInteractiveWorkerProvider {
         transport: Box::new(fake),
         profile: profile(name, "unix:///var/run/docker.sock"),
     }
 }
-
 #[test]
 fn creates_reuses_inspects_and_deletes_one_exact_worker() {
     let fake = FakeDocker::default();
@@ -166,9 +164,10 @@ fn rejects_preflight_and_resource_drift_without_unsafe_io() {
 }
 
 #[test]
-fn reconciles_delayed_lost_create_response_and_cleans_invalid_new_endpoints() {
+fn reconciles_failed_and_delayed_inspection_and_cleans_invalid_endpoint() {
     let recovered = FakeDocker::default();
     recovered.state().fail_create_after_insert = true;
+    recovered.state().failed_inspections_after_create = 1;
     recovered.state().hidden_inspections_after_create = 2;
     let reconciled = provider("local", recovered.clone()).ensure_worker(&request());
     assert!(matches!(reconciled, Ok(InteractiveWorkerEnsure::Reused(_))));

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -12,6 +12,7 @@ struct FakeState {
     create_calls: usize,
     delete_calls: usize,
     fail_create_after_insert: bool,
+    create_response_id: Option<String>,
     failed_inspections_after_create: usize,
     hidden_inspections_after_create: usize,
     binding_host: Option<String>,
@@ -33,7 +34,8 @@ impl DockerTransport for FakeDocker {
             return Ok(None);
         }
         let container = state.container.clone();
-        Ok(container.filter(|container| container.id == reference || container.name == reference))
+        let alias = state.create_response_id.as_deref() == Some(reference);
+        Ok(container.filter(|container| alias || container.id == reference || container.name == reference))
     }
     fn inspect_with_timeout(&self, reference: &str, timeout: Duration) -> DockerResult<Option<DockerContainer>> {
         assert!(!timeout.is_zero() && timeout <= CREATE_RECONCILE_TIMEOUT);
@@ -66,7 +68,7 @@ impl DockerTransport for FakeDocker {
                 operation: "container creation",
             });
         }
-        Ok(id)
+        Ok(state.create_response_id.clone().unwrap_or(id))
     }
     fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
         Ok(Some(format!("{} worker@local", ed25519_key(7))))
@@ -164,7 +166,7 @@ fn rejects_preflight_and_resource_drift_without_unsafe_io() {
 }
 
 #[test]
-fn reconciles_failed_and_delayed_inspection_and_cleans_invalid_endpoint() {
+fn reconciles_uncertain_creates_and_cleans_invalid_endpoint() {
     let recovered = FakeDocker::default();
     recovered.state().fail_create_after_insert = true;
     recovered.state().failed_inspections_after_create = 1;
@@ -172,6 +174,10 @@ fn reconciles_failed_and_delayed_inspection_and_cleans_invalid_endpoint() {
     let reconciled = provider("local", recovered.clone()).ensure_worker(&request());
     assert!(matches!(reconciled, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(recovered.state().create_calls, 1);
+    let mismatched = FakeDocker::default();
+    mismatched.state().create_response_id = Some("b".repeat(64));
+    let reconciled = provider("local", mismatched).ensure_worker(&request());
+    assert!(matches!(reconciled, Ok(InteractiveWorkerEnsure::Reused(_))));
     let invalid = FakeDocker::default();
     invalid.state().fail_create_after_insert = true;
     invalid.state().binding_host = Some("0.0.0.0".to_string());

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -116,10 +116,21 @@ fn provider(name: &str, fake: FakeDocker) -> LocalDockerInteractiveWorkerProvide
 fn creates_reuses_inspects_and_deletes_one_exact_worker() {
     let fake = FakeDocker::default();
     let provider = provider("local", fake.clone());
-    let request = request();
+    let mut request = request();
+    request.ssh_public_key.push(' ');
+    request
+        .ssh_public_key
+        .push_str(&"x".repeat(16 * 1_024 - request.ssh_public_key.len()));
     let status = provider.ensure_worker(&request).expect("create").into_status();
     assert!(status.is_ready_for(&request, time::OffsetDateTime::now_utc()));
     assert_eq!(status.ssh.as_ref().expect("SSH").host_key, ed25519_key(7));
+    let stored = fake.state().container.clone().expect("container");
+    let canonical_key = ed25519_key(3);
+    assert_eq!(
+        required_environment(&stored, SSH_PUBLIC_KEY_ENV),
+        Ok(canonical_key.as_str())
+    );
+    assert_eq!(stored.labels.get(SSH_KEY_LABEL), Some(&canonical_key));
     let reused = provider.ensure_worker(&request);
     assert!(matches!(reused, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(provider.inspect_worker(&status.worker), Ok(Some(status.clone())));

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -1,0 +1,181 @@
+use super::*;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct FakeDocker(Arc<Mutex<FakeState>>);
+
+#[derive(Default)]
+struct FakeState {
+    container: Option<DockerContainer>,
+    create_calls: usize,
+    delete_calls: usize,
+    fail_create_after_insert: bool,
+    binding_host: Option<String>,
+}
+
+impl FakeDocker {
+    fn state(&self) -> std::sync::MutexGuard<'_, FakeState> {
+        self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl DockerTransport for FakeDocker {
+    fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError> {
+        let container = self.state().container.clone();
+        Ok(container.filter(|container| container.id == reference || container.name == reference))
+    }
+
+    fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError> {
+        let mut state = self.state();
+        state.create_calls += 1;
+        let id = "a".repeat(64);
+        state.container = Some(DockerContainer {
+            id: id.clone(),
+            name: request.name.clone(),
+            image: request.image.clone(),
+            labels: request.labels.clone(),
+            environment: vec![
+                format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key),
+                format!("{TERMINATE_ENV}={}", request.terminate_after),
+            ],
+            restart_policy: "no".to_string(),
+            running: true,
+            state: "running".to_string(),
+            exit_code: 0,
+            ssh_bindings: vec![DockerPortBinding {
+                host: state.binding_host.clone().unwrap_or_else(|| LOCAL_HOST.to_string()),
+                port: 49_152,
+            }],
+        });
+        if state.fail_create_after_insert {
+            return Err(LocalDockerError::CommandFailed {
+                operation: "container creation",
+            });
+        }
+        Ok(id)
+    }
+
+    fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
+        Ok(Some(ed25519_key(7, Some("worker@local"))))
+    }
+
+    fn delete(&self, _resource_id: &str) -> Result<bool, LocalDockerError> {
+        let mut state = self.state();
+        state.delete_calls += 1;
+        state.container = None;
+        Ok(true)
+    }
+}
+
+fn ed25519_key(seed: u8, comment: Option<&str>) -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([seed; 32]);
+    let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
+    comment.map_or(key.clone(), |comment| format!("{key} {comment}"))
+}
+
+fn request() -> InteractiveWorkerRequest {
+    InteractiveWorkerRequest {
+        workflow_id: "00000000-0000-4000-8000-000000000001".parse().expect("workflow ID"),
+        job_id: "00000000-0000-4000-8000-000000000002".parse().expect("job ID"),
+        target: super::super::WorkerTarget {
+            provider: CloudProvider::LocalDocker,
+            profile: "local".to_string(),
+            image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
+            disk_gib: 20,
+            lease_seconds: 900,
+            max_hourly_cost_micros: None,
+        },
+        ssh_public_key: ed25519_key(3, Some("client@local")),
+    }
+}
+
+fn provider(fake: FakeDocker) -> LocalDockerInteractiveWorkerProvider {
+    let profile = LocalDockerProfile {
+        name: "local".to_string(),
+    };
+    LocalDockerInteractiveWorkerProvider::with_transport(profile, fake)
+}
+
+#[test]
+fn creates_reuses_inspects_and_deletes_one_exact_worker() {
+    let fake = FakeDocker::default();
+    let provider = provider(fake.clone());
+    let request = request();
+    let InteractiveWorkerEnsure::Created(status) = provider.ensure_worker(&request).expect("create") else {
+        panic!("expected a created worker");
+    };
+    assert!(status.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+    assert_eq!(status.ssh.as_ref().expect("SSH").host_key, ed25519_key(7, None));
+    assert!(matches!(
+        provider.ensure_worker(&request),
+        Ok(InteractiveWorkerEnsure::Reused(_))
+    ));
+    assert_eq!(provider.inspect_worker(&status.worker), Ok(Some(status.clone())));
+    assert_eq!(
+        provider.delete_worker(&status.worker),
+        Ok(InteractiveWorkerCleanup::Deleted)
+    );
+    assert_eq!(
+        provider.delete_worker(&status.worker),
+        Ok(InteractiveWorkerCleanup::AlreadyAbsent)
+    );
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (1, 1));
+}
+
+#[test]
+fn rejects_preflight_and_resource_drift_without_unsafe_io() {
+    let fake = FakeDocker::default();
+    let provider = provider(fake.clone());
+    let mut invalid = request();
+    invalid.target.provider = CloudProvider::RunPod;
+    assert_eq!(provider.ensure_worker(&invalid), Err(LocalDockerError::InvalidTarget));
+    assert_eq!(fake.state().create_calls, 0);
+
+    let request = request();
+    let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
+    let mut drifted = request;
+    drifted.target.disk_gib += 1;
+    assert_eq!(
+        provider.ensure_worker(&drifted),
+        Err(LocalDockerError::ResourceIdentityMismatch)
+    );
+    fake.state()
+        .container
+        .as_mut()
+        .expect("container")
+        .labels
+        .insert(TARGET_LABEL.to_string(), "spoofed".to_string());
+    assert_eq!(
+        provider.inspect_worker(&worker),
+        Err(LocalDockerError::ResourceIdentityMismatch)
+    );
+    assert_eq!(
+        provider.delete_worker(&worker),
+        Err(LocalDockerError::ResourceIdentityMismatch)
+    );
+    assert_eq!(fake.state().delete_calls, 0);
+}
+
+#[test]
+fn reconciles_a_lost_create_response_and_cleans_invalid_new_endpoints() {
+    let recovered = FakeDocker::default();
+    recovered.state().fail_create_after_insert = true;
+    assert!(matches!(
+        provider(recovered.clone()).ensure_worker(&request()),
+        Ok(InteractiveWorkerEnsure::Reused(_))
+    ));
+    assert_eq!(recovered.state().create_calls, 1);
+
+    let invalid = FakeDocker::default();
+    invalid.state().binding_host = Some("0.0.0.0".to_string());
+    assert_eq!(
+        provider(invalid.clone()).ensure_worker(&request()),
+        Err(LocalDockerError::InvalidSshEndpoint)
+    );
+    let state = invalid.state();
+    assert!(state.container.is_none());
+    assert_eq!(state.delete_calls, 1);
+}

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -16,6 +16,7 @@ struct FakeState {
     failed_inspections_after_create: usize,
     hidden_inspections_after_create: usize,
     binding_host: Option<String>,
+    disappear_during_key_read: bool,
 }
 impl FakeDocker {
     fn state(&self) -> std::sync::MutexGuard<'_, FakeState> {
@@ -71,6 +72,11 @@ impl DockerTransport for FakeDocker {
         Ok(state.create_response_id.clone().unwrap_or(id))
     }
     fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
+        let mut state = self.state();
+        if std::mem::take(&mut state.disappear_during_key_read) {
+            state.container = None;
+            return Err(ResourceAbsent);
+        }
         Ok(Some(format!("{} worker@local", ed25519_key(7))))
     }
     fn delete(&self, _resource_id: &str) -> Result<bool, LocalDockerError> {
@@ -85,7 +91,7 @@ fn ed25519_key(seed: u8) -> String {
     blob.extend([seed; 32]);
     format!("ssh-ed25519 {}", STANDARD.encode(blob))
 }
-fn request() -> InteractiveWorkerRequest {
+pub(super) fn request() -> InteractiveWorkerRequest {
     InteractiveWorkerRequest {
         workflow_id: "00000000-0000-4000-8000-000000000001".parse().expect("workflow ID"),
         job_id: "00000000-0000-4000-8000-000000000002".parse().expect("job ID"),
@@ -99,6 +105,23 @@ fn request() -> InteractiveWorkerRequest {
         },
         ssh_public_key: ed25519_key(3),
     }
+}
+
+#[test]
+fn disappearance_during_key_discovery_is_absent_or_recreated() {
+    let fake = FakeDocker::default();
+    let provider = provider("local", fake.clone());
+    let request = request();
+    let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
+    fake.state().disappear_during_key_read = true;
+    assert_eq!(provider.inspect_worker(&worker), Ok(None));
+    provider.ensure_worker(&request).expect("recreate");
+    fake.state().disappear_during_key_read = true;
+    assert!(matches!(
+        provider.ensure_worker(&request),
+        Ok(InteractiveWorkerEnsure::Created(_))
+    ));
+    assert_eq!(fake.state().create_calls, 3);
 }
 fn profile(name: &str, docker_host: &str) -> LocalDockerProfile {
     LocalDockerProfile {

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Default)]
 struct FakeDocker(Arc<Mutex<FakeState>>);
-
 #[derive(Default)]
 struct FakeState {
     container: Option<DockerContainer>,
@@ -24,7 +23,7 @@ impl FakeDocker {
 }
 
 impl DockerTransport for FakeDocker {
-    fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError> {
+    fn inspect(&self, reference: &str) -> DockerResult<Option<DockerContainer>> {
         let mut state = self.state();
         if state.container.is_some() && state.hidden_inspections_after_create > 0 {
             state.hidden_inspections_after_create -= 1;
@@ -33,7 +32,10 @@ impl DockerTransport for FakeDocker {
         let container = state.container.clone();
         Ok(container.filter(|container| container.id == reference || container.name == reference))
     }
-
+    fn inspect_with_timeout(&self, reference: &str, timeout: Duration) -> DockerResult<Option<DockerContainer>> {
+        assert!(!timeout.is_zero() && timeout <= CREATE_RECONCILE_TIMEOUT);
+        self.inspect(reference)
+    }
     fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError> {
         let mut state = self.state();
         state.create_calls += 1;
@@ -63,11 +65,9 @@ impl DockerTransport for FakeDocker {
         }
         Ok(id)
     }
-
     fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
         Ok(Some(format!("{} worker@local", ed25519_key(7))))
     }
-
     fn delete(&self, _resource_id: &str) -> Result<bool, LocalDockerError> {
         let mut state = self.state();
         state.delete_calls += 1;
@@ -163,6 +163,7 @@ fn reconciles_delayed_lost_create_response_and_cleans_invalid_new_endpoints() {
     assert!(matches!(reconciled, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(recovered.state().create_calls, 1);
     let invalid = FakeDocker::default();
+    invalid.state().fail_create_after_insert = true;
     invalid.state().binding_host = Some("0.0.0.0".to_string());
     let rejected = provider("local", invalid.clone()).ensure_worker(&request());
     assert_eq!(rejected.err(), Some(InvalidSshEndpoint));

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -94,6 +94,7 @@ fn request() -> InteractiveWorkerRequest {
 fn provider(fake: FakeDocker) -> LocalDockerInteractiveWorkerProvider {
     let profile = LocalDockerProfile {
         name: "local".to_string(),
+        docker_host: "unix:///var/run/docker.sock".to_string(),
     };
     LocalDockerInteractiveWorkerProvider::with_transport(profile, fake)
 }
@@ -113,20 +114,23 @@ fn creates_reuses_inspects_and_deletes_one_exact_worker() {
         Ok(InteractiveWorkerEnsure::Reused(_))
     ));
     assert_eq!(provider.inspect_worker(&status.worker), Ok(Some(status.clone())));
-    assert_eq!(
-        provider.delete_worker(&status.worker),
-        Ok(InteractiveWorkerCleanup::Deleted)
-    );
-    assert_eq!(
-        provider.delete_worker(&status.worker),
-        Ok(InteractiveWorkerCleanup::AlreadyAbsent)
-    );
+    let deleted = provider.delete_worker(&status.worker);
+    let absent = provider.delete_worker(&status.worker);
+    assert!(matches!(deleted, Ok(InteractiveWorkerCleanup::Deleted)));
+    assert!(matches!(absent, Ok(InteractiveWorkerCleanup::AlreadyAbsent)));
     let state = fake.state();
     assert_eq!((state.create_calls, state.delete_calls), (1, 1));
 }
 
 #[test]
 fn rejects_preflight_and_resource_drift_without_unsafe_io() {
+    assert!(matches!(
+        LocalDockerInteractiveWorkerProvider::new(LocalDockerProfile {
+            name: "local".to_string(),
+            docker_host: "ssh://remote.example/run/docker.sock".to_string(),
+        }),
+        Err(LocalDockerError::NonLocalDockerHost)
+    ));
     let fake = FakeDocker::default();
     let provider = provider(fake.clone());
     let mut invalid = request();
@@ -142,12 +146,8 @@ fn rejects_preflight_and_resource_drift_without_unsafe_io() {
         provider.ensure_worker(&drifted),
         Err(LocalDockerError::ResourceIdentityMismatch)
     );
-    fake.state()
-        .container
-        .as_mut()
-        .expect("container")
-        .labels
-        .insert(TARGET_LABEL.to_string(), "spoofed".to_string());
+    let mut worker = worker;
+    worker.target.disk_gib += 1;
     assert_eq!(
         provider.inspect_worker(&worker),
         Err(LocalDockerError::ResourceIdentityMismatch)

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use InteractiveWorkerCleanup::{AlreadyAbsent, Deleted};
 use LocalDockerError::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
@@ -12,6 +13,7 @@ struct FakeState {
     create_calls: usize,
     delete_calls: usize,
     fail_create_after_insert: bool,
+    hidden_inspections_after_create: usize,
     binding_host: Option<String>,
 }
 
@@ -23,7 +25,12 @@ impl FakeDocker {
 
 impl DockerTransport for FakeDocker {
     fn inspect(&self, reference: &str) -> Result<Option<DockerContainer>, LocalDockerError> {
-        let container = self.state().container.clone();
+        let mut state = self.state();
+        if state.container.is_some() && state.hidden_inspections_after_create > 0 {
+            state.hidden_inspections_after_create -= 1;
+            return Ok(None);
+        }
+        let container = state.container.clone();
         Ok(container.filter(|container| container.id == reference || container.name == reference))
     }
 
@@ -50,7 +57,7 @@ impl DockerTransport for FakeDocker {
             }],
         });
         if state.fail_create_after_insert {
-            return Err(LocalDockerError::CommandFailed {
+            return Err(CommandFailed {
                 operation: "container creation",
             });
         }
@@ -58,7 +65,7 @@ impl DockerTransport for FakeDocker {
     }
 
     fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
-        Ok(Some(ed25519_key(7, Some("worker@local"))))
+        Ok(Some(format!("{} worker@local", ed25519_key(7))))
     }
 
     fn delete(&self, _resource_id: &str) -> Result<bool, LocalDockerError> {
@@ -69,11 +76,10 @@ impl DockerTransport for FakeDocker {
     }
 }
 
-fn ed25519_key(seed: u8, comment: Option<&str>) -> String {
+fn ed25519_key(seed: u8) -> String {
     let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
     blob.extend([seed; 32]);
-    let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
-    comment.map_or(key.clone(), |comment| format!("{key} {comment}"))
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
 }
 
 fn request() -> InteractiveWorkerRequest {
@@ -88,7 +94,7 @@ fn request() -> InteractiveWorkerRequest {
             lease_seconds: 900,
             max_hourly_cost_micros: None,
         },
-        ssh_public_key: ed25519_key(3, Some("client@local")),
+        ssh_public_key: ed25519_key(3),
     }
 }
 
@@ -111,18 +117,14 @@ fn creates_reuses_inspects_and_deletes_one_exact_worker() {
     let fake = FakeDocker::default();
     let provider = provider("local", fake.clone());
     let request = request();
-    let InteractiveWorkerEnsure::Created(status) = provider.ensure_worker(&request).expect("create") else {
-        panic!("expected a created worker");
-    };
+    let status = provider.ensure_worker(&request).expect("create").into_status();
     assert!(status.is_ready_for(&request, time::OffsetDateTime::now_utc()));
-    assert_eq!(status.ssh.as_ref().expect("SSH").host_key, ed25519_key(7, None));
+    assert_eq!(status.ssh.as_ref().expect("SSH").host_key, ed25519_key(7));
     let reused = provider.ensure_worker(&request);
     assert!(matches!(reused, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(provider.inspect_worker(&status.worker), Ok(Some(status.clone())));
-    let deleted = provider.delete_worker(&status.worker);
-    let absent = provider.delete_worker(&status.worker);
-    assert!(matches!(deleted, Ok(InteractiveWorkerCleanup::Deleted)));
-    assert!(matches!(absent, Ok(InteractiveWorkerCleanup::AlreadyAbsent)));
+    assert_eq!(provider.delete_worker(&status.worker), Ok(Deleted));
+    assert_eq!(provider.delete_worker(&status.worker), Ok(AlreadyAbsent));
     let state = fake.state();
     assert_eq!((state.create_calls, state.delete_calls), (1, 1));
 }
@@ -131,24 +133,17 @@ fn creates_reuses_inspects_and_deletes_one_exact_worker() {
 fn rejects_preflight_and_resource_drift_without_unsafe_io() {
     let remote = LocalDockerInteractiveWorkerProvider::new(profile("local", "ssh://remote.example/run/docker.sock"));
     assert_eq!(remote.err(), Some(NonLocalDockerHost));
-    let other_provider = provider("other", FakeDocker::default());
+    let other = provider("other", FakeDocker::default());
     let fake = FakeDocker::default();
     let provider = provider("local", fake.clone());
     let mut invalid = request();
     invalid.target.provider = CloudProvider::RunPod;
     assert_eq!(provider.ensure_worker(&invalid).err(), Some(InvalidTarget));
     assert_eq!(fake.state().create_calls, 0);
-
     let request = request();
     let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
-    assert_eq!(
-        other_provider.inspect_worker(&worker).err(),
-        Some(InvalidPersistedWorker)
-    );
-    assert_eq!(
-        other_provider.delete_worker(&worker).err(),
-        Some(InvalidPersistedWorker)
-    );
+    assert_eq!(other.inspect_worker(&worker).err(), Some(InvalidPersistedWorker));
+    assert_eq!(other.delete_worker(&worker).err(), Some(InvalidPersistedWorker));
     let mut drifted = request;
     drifted.target.disk_gib += 1;
     assert_eq!(provider.ensure_worker(&drifted).err(), Some(ResourceIdentityMismatch));
@@ -160,18 +155,17 @@ fn rejects_preflight_and_resource_drift_without_unsafe_io() {
 }
 
 #[test]
-fn reconciles_a_lost_create_response_and_cleans_invalid_new_endpoints() {
+fn reconciles_delayed_lost_create_response_and_cleans_invalid_new_endpoints() {
     let recovered = FakeDocker::default();
     recovered.state().fail_create_after_insert = true;
+    recovered.state().hidden_inspections_after_create = 2;
     let reconciled = provider("local", recovered.clone()).ensure_worker(&request());
     assert!(matches!(reconciled, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(recovered.state().create_calls, 1);
-
     let invalid = FakeDocker::default();
     invalid.state().binding_host = Some("0.0.0.0".to_string());
     let rejected = provider("local", invalid.clone()).ensure_worker(&request());
     assert_eq!(rejected.err(), Some(InvalidSshEndpoint));
     let state = invalid.state();
-    assert!(state.container.is_none());
-    assert_eq!(state.delete_calls, 1);
+    assert_eq!((state.container.is_none(), state.delete_calls), (true, 1));
 }

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use LocalDockerError::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
 
@@ -91,28 +92,32 @@ fn request() -> InteractiveWorkerRequest {
     }
 }
 
-fn provider(fake: FakeDocker) -> LocalDockerInteractiveWorkerProvider {
-    let profile = LocalDockerProfile {
-        name: "local".to_string(),
-        docker_host: "unix:///var/run/docker.sock".to_string(),
-    };
-    LocalDockerInteractiveWorkerProvider::with_transport(profile, fake)
+fn profile(name: &str, docker_host: &str) -> LocalDockerProfile {
+    LocalDockerProfile {
+        name: name.to_string(),
+        docker_host: docker_host.to_string(),
+    }
+}
+
+fn provider(name: &str, fake: FakeDocker) -> LocalDockerInteractiveWorkerProvider {
+    LocalDockerInteractiveWorkerProvider {
+        transport: Box::new(fake),
+        profile: profile(name, "unix:///var/run/docker.sock"),
+    }
 }
 
 #[test]
 fn creates_reuses_inspects_and_deletes_one_exact_worker() {
     let fake = FakeDocker::default();
-    let provider = provider(fake.clone());
+    let provider = provider("local", fake.clone());
     let request = request();
     let InteractiveWorkerEnsure::Created(status) = provider.ensure_worker(&request).expect("create") else {
         panic!("expected a created worker");
     };
     assert!(status.is_ready_for(&request, time::OffsetDateTime::now_utc()));
     assert_eq!(status.ssh.as_ref().expect("SSH").host_key, ed25519_key(7, None));
-    assert!(matches!(
-        provider.ensure_worker(&request),
-        Ok(InteractiveWorkerEnsure::Reused(_))
-    ));
+    let reused = provider.ensure_worker(&request);
+    assert!(matches!(reused, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(provider.inspect_worker(&status.worker), Ok(Some(status.clone())));
     let deleted = provider.delete_worker(&status.worker);
     let absent = provider.delete_worker(&status.worker);
@@ -124,38 +129,33 @@ fn creates_reuses_inspects_and_deletes_one_exact_worker() {
 
 #[test]
 fn rejects_preflight_and_resource_drift_without_unsafe_io() {
-    assert!(matches!(
-        LocalDockerInteractiveWorkerProvider::new(LocalDockerProfile {
-            name: "local".to_string(),
-            docker_host: "ssh://remote.example/run/docker.sock".to_string(),
-        }),
-        Err(LocalDockerError::NonLocalDockerHost)
-    ));
+    let remote = LocalDockerInteractiveWorkerProvider::new(profile("local", "ssh://remote.example/run/docker.sock"));
+    assert_eq!(remote.err(), Some(NonLocalDockerHost));
+    let other_provider = provider("other", FakeDocker::default());
     let fake = FakeDocker::default();
-    let provider = provider(fake.clone());
+    let provider = provider("local", fake.clone());
     let mut invalid = request();
     invalid.target.provider = CloudProvider::RunPod;
-    assert_eq!(provider.ensure_worker(&invalid), Err(LocalDockerError::InvalidTarget));
+    assert_eq!(provider.ensure_worker(&invalid).err(), Some(InvalidTarget));
     assert_eq!(fake.state().create_calls, 0);
 
     let request = request();
     let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
+    assert_eq!(
+        other_provider.inspect_worker(&worker).err(),
+        Some(InvalidPersistedWorker)
+    );
+    assert_eq!(
+        other_provider.delete_worker(&worker).err(),
+        Some(InvalidPersistedWorker)
+    );
     let mut drifted = request;
     drifted.target.disk_gib += 1;
-    assert_eq!(
-        provider.ensure_worker(&drifted),
-        Err(LocalDockerError::ResourceIdentityMismatch)
-    );
+    assert_eq!(provider.ensure_worker(&drifted).err(), Some(ResourceIdentityMismatch));
     let mut worker = worker;
     worker.target.disk_gib += 1;
-    assert_eq!(
-        provider.inspect_worker(&worker),
-        Err(LocalDockerError::ResourceIdentityMismatch)
-    );
-    assert_eq!(
-        provider.delete_worker(&worker),
-        Err(LocalDockerError::ResourceIdentityMismatch)
-    );
+    assert_eq!(provider.inspect_worker(&worker).err(), Some(ResourceIdentityMismatch));
+    assert_eq!(provider.delete_worker(&worker).err(), Some(ResourceIdentityMismatch));
     assert_eq!(fake.state().delete_calls, 0);
 }
 
@@ -163,18 +163,14 @@ fn rejects_preflight_and_resource_drift_without_unsafe_io() {
 fn reconciles_a_lost_create_response_and_cleans_invalid_new_endpoints() {
     let recovered = FakeDocker::default();
     recovered.state().fail_create_after_insert = true;
-    assert!(matches!(
-        provider(recovered.clone()).ensure_worker(&request()),
-        Ok(InteractiveWorkerEnsure::Reused(_))
-    ));
+    let reconciled = provider("local", recovered.clone()).ensure_worker(&request());
+    assert!(matches!(reconciled, Ok(InteractiveWorkerEnsure::Reused(_))));
     assert_eq!(recovered.state().create_calls, 1);
 
     let invalid = FakeDocker::default();
     invalid.state().binding_host = Some("0.0.0.0".to_string());
-    assert_eq!(
-        provider(invalid.clone()).ensure_worker(&request()),
-        Err(LocalDockerError::InvalidSshEndpoint)
-    );
+    let rejected = provider("local", invalid.clone()).ensure_worker(&request());
+    assert_eq!(rejected.err(), Some(InvalidSshEndpoint));
     let state = invalid.state();
     assert!(state.container.is_none());
     assert_eq!(state.delete_calls, 1);

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -410,7 +410,7 @@ fn ensure_claimed_targets_unchanged(
         .and_then(|limit| i64::try_from(limit).ok())
         .ok_or(CloudStoreError::InvalidStoredCreationClaim)?;
     let mut statement = connection.prepare(
-        "SELECT substr(provider, 1, 9), substr(job_id, 1, 37)
+        "SELECT substr(provider, 1, 13), substr(job_id, 1, 37)
          FROM cloud_worker_creation_claims
          WHERE workflow_id = ?1
          LIMIT ?2",

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -556,6 +556,7 @@ fn provider_name(provider: CloudProvider) -> &'static str {
     match provider {
         CloudProvider::Azure => "azure",
         CloudProvider::RunPod => "run_pod",
+        CloudProvider::LocalDocker => "local_docker",
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -218,7 +218,7 @@ fn creation_claim_lookup_has_a_covering_workflow_index() {
     let detail = connection
         .query_row(
             "EXPLAIN QUERY PLAN
-             SELECT substr(provider, 1, 9), substr(job_id, 1, 37)
+             SELECT substr(provider, 1, 13), substr(job_id, 1, 37)
              FROM cloud_worker_creation_claims
              WHERE workflow_id = ?1
              LIMIT ?2",
@@ -233,7 +233,7 @@ fn creation_claim_lookup_has_a_covering_workflow_index() {
 fn creation_claim_is_durable_atomic_and_bound_to_the_persisted_job() {
     let temp = TempDir::new().expect("temp dir");
     let store = store(&temp);
-    let workflow = retained_workflow(CloudProvider::RunPod, 1_000);
+    let workflow = retained_workflow(CloudProvider::LocalDocker, 1_000);
     let job_id = workflow.nodes[0].id;
     let stored = store.create(&workflow).expect("create workflow");
     let target = worker_target(&workflow).clone();
@@ -261,7 +261,7 @@ fn creation_claim_is_durable_atomic_and_bound_to_the_persisted_job() {
             .claim_worker_creation(workflow.id, job_id, &target, "horizon-worker-1")
             .expect("repeat claim")
     );
-    for provider in [CloudProvider::RunPod, CloudProvider::Azure, CloudProvider::LocalDocker] {
+    for provider in [CloudProvider::RunPod, CloudProvider::Azure] {
         let mut changed = workflow.clone();
         changed.updated_at_millis += 1;
         let changed_target = changed.nodes[0].worker.as_mut().expect("worker target");
@@ -288,7 +288,7 @@ fn creation_claim_is_durable_atomic_and_bound_to_the_persisted_job() {
         reopened.claim_worker_creation(workflow.id, job_id, &target, "bad/name"),
         Err(CloudStoreError::InvalidResourceName)
     ));
-    let other = retained_workflow(CloudProvider::RunPod, 3_000);
+    let other = retained_workflow(CloudProvider::LocalDocker, 3_000);
     let other_job = other.nodes[0].id;
     reopened.create(&other).expect("create other workflow");
     assert!(matches!(

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -261,7 +261,7 @@ fn creation_claim_is_durable_atomic_and_bound_to_the_persisted_job() {
             .claim_worker_creation(workflow.id, job_id, &target, "horizon-worker-1")
             .expect("repeat claim")
     );
-    for provider in [CloudProvider::RunPod, CloudProvider::Azure] {
+    for provider in [CloudProvider::RunPod, CloudProvider::Azure, CloudProvider::LocalDocker] {
         let mut changed = workflow.clone();
         changed.updated_at_millis += 1;
         let changed_target = changed.nodes[0].worker.as_mut().expect("worker target");


### PR DESCRIPTION
## Purpose

Advances #383 by completing the focused local Docker interactive-worker provider slice.

- implement the common provider contract directly against the local Docker CLI
- create or reconcile one deterministic container per workflow/job pair, including delayed daemon visibility after an uncertain create response
- bind SSH only to loopback and return a validated runtime Ed25519 host key
- verify the complete target, ownership labels, environment, restart policy, exact container ID, and provider profile before reuse or cleanup
- persist and reload `local_docker` creation claims without truncating the provider identity
- bound command duration and retained output, and verify absence after deletion
- canonicalize valid client keys in Docker arguments while retaining the caller's exact key in the durable worker handle

## Behavior impact

`CloudProvider` now includes the stable `local_docker` value. Callers can construct a `LocalDockerInteractiveWorkerProvider` with a non-secret profile name, an explicit local Unix socket or Windows named pipe, and a preloaded digest-pinned worker image. Every Docker invocation is pinned to that endpoint, so ambient context selection is ignored and explicit remote endpoints are rejected. Persisted handles are rejected before Docker I/O when their profile does not match the provider instance.

Failed, timed-out, malformed, or unverifiable creation responses enter a two-second deterministic-name discovery window. Every discovery inspection receives only the remaining deadline budget. A recovered container is reused only after full validation; an invalid recovered container is deleted only when its exact task ownership is independently proven. The provider never pulls implicitly and fails closed on identity, target, endpoint, host-key, lease, or transport drift.

Valid Ed25519 request keys may include comments up to the common 16 KiB limit. The provider passes only the canonical `algorithm base64` form through the Docker environment and ownership label, preventing duplicated comments from exhausting Windows process command-line space, while the durable worker handle keeps the exact request key used for caller identity checks.

Every invocation preflights the complete command, including the endpoint and serialized labels, against a conservative Windows-compatible argument budget before spawning Docker. A container that disappears between inspection and host-key discovery is preserved as an absent-resource result: inspection returns `None`, and an ensure operation recreates or reconciles the deterministic name instead of returning a stale worker.

This PR does not add UI or configuration wiring, publish an image, create cloud resources, or change release behavior.

## Test evidence

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
- exact committed head: `e69fafc6e01c3d5588418ccf65149a951b88963c`
- direct durable `local_docker` claim regression covers replacement, reopen, repeat claim, and cross-workflow resource-name collision
- uncertain-create regression injects a transient failed inspection, then hides the created container for two inspections after a lost create response, and requires exact validated reuse within the original two-second budget
- mismatched-create regression returns a valid-looking response ID that differs from the inspected container ID and requires deterministic-name reconciliation to exact validated reuse
- invalid-endpoint regression combines a lost create response with recovered invalid state and proves task-owned cleanup
- maximum-length-key regression supplies an exact 16 KiB valid key and verifies that the Docker environment and ownership label retain only its canonical 80-byte form
- oversized-image regression proves the complete command is rejected before the Docker process starts
- concurrent-disappearance regression proves inspection returns absence and ensure recreates instead of reusing a vanished worker
- current remote-worker image security smoke passed on task image `sha256:beb5877f1651be714b71ba8ac6c283c58fe5409bb9f2d8384a0ae5b72a790c66`
- temporary live provider smoke passed on the same digest-pinned task image with an exact 16 KiB request key: hostile ambient `DOCKER_HOST`/`DOCKER_CONTEXT`, explicit local-socket create, canonical Docker key arguments, exact durable request-key retention, runtime host-key discovery, pinned SSH command, exact-target reuse, exact delete, and verified absence; the task container, image, key, and known-hosts file were removed afterward

Scope: seven source/test files and 1,061 changed source/test lines.

