### PR TITLE
feat(cloud): persist complete worker targets

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -27,16 +27,7 @@ impl InteractiveWorkerRequest {
     /// Check the provider-neutral fields before invoking a concrete provider.
     #[must_use]
     pub fn is_valid_for(&self, provider: CloudProvider) -> bool {
-        self.target.provider == provider
-            && !self.target.profile.trim().is_empty()
-            && self.target.profile.trim() == self.target.profile
-            && self.target.profile.len() <= 191
-            && !self.target.profile.chars().any(char::is_control)
-            && valid_immutable_image(&self.target.image)
-            && self.target.disk_gib > 0
-            && (1..=MAX_INTERACTIVE_WORKER_LEASE_SECONDS).contains(&self.target.lease_seconds)
-            && self.target.max_hourly_cost_micros != Some(0)
-            && valid_ed25519_key(&self.ssh_public_key, true)
+        valid_worker_target(&self.target, provider) && valid_ed25519_key(&self.ssh_public_key, true)
     }
 }
 
@@ -98,8 +89,8 @@ impl InteractiveWorkerLease {
 #[serde(deny_unknown_fields)]
 pub struct InteractiveWorker {
     pub identity: InteractiveWorkerIdentity,
-    /// Exact immutable image reference used to create the resource.
-    pub image: String,
+    /// Exact provider target used to create the resource.
+    pub target: WorkerTarget,
     /// Ephemeral client public key installed in this runtime generation.
     pub ssh_public_key: String,
     pub lease: InteractiveWorkerLease,
@@ -112,7 +103,7 @@ impl InteractiveWorker {
     #[must_use]
     pub fn has_valid_shape(&self) -> bool {
         self.identity.is_valid()
-            && valid_immutable_image(&self.image)
+            && valid_worker_target(&self.target, self.identity.provider)
             && valid_ssh_public_key(&self.ssh_public_key)
             && self.lease.has_valid_shape()
     }
@@ -178,7 +169,7 @@ impl InteractiveWorkerStatus {
             && self.worker.is_valid_for(request.target.provider)
             && identity.workflow_id == request.workflow_id
             && identity.job_id == request.job_id
-            && self.worker.image == request.target.image
+            && self.worker.target == request.target
             && self.worker.ssh_public_key == request.ssh_public_key
             && self
                 .worker
@@ -256,6 +247,18 @@ pub trait InteractiveWorkerProvider: Send + Sync {
     /// the worker is malformed or belongs to another provider, or unless
     /// absence is verified.
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error>;
+}
+
+fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider) -> bool {
+    target.provider == provider
+        && !target.profile.trim().is_empty()
+        && target.profile.trim() == target.profile
+        && target.profile.len() <= 191
+        && !target.profile.chars().any(char::is_control)
+        && valid_immutable_image(&target.image)
+        && target.disk_gib > 0
+        && (1..=MAX_INTERACTIVE_WORKER_LEASE_SECONDS).contains(&target.lease_seconds)
+        && target.max_hourly_cost_micros != Some(0)
 }
 
 fn valid_immutable_image(value: &str) -> bool {
@@ -385,7 +388,14 @@ mod tests {
                     job_id: CloudJobId::new(),
                     resource_id: "pod-123".to_string(),
                 },
-                image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
+                target: WorkerTarget {
+                    provider: CloudProvider::RunPod,
+                    profile: "gpu".to_string(),
+                    image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
+                    disk_gib: 20,
+                    lease_seconds: 900,
+                    max_hourly_cost_micros: Some(500_000),
+                },
                 ssh_public_key: ed25519_key(None),
                 lease: InteractiveWorkerLease {
                     terminate_after: "2026-09-04T12:00:00Z".to_string(),
@@ -405,14 +415,7 @@ mod tests {
         InteractiveWorkerRequest {
             workflow_id: status.worker.identity.workflow_id,
             job_id: status.worker.identity.job_id,
-            target: WorkerTarget {
-                provider: status.worker.identity.provider,
-                profile: "gpu".to_string(),
-                image: status.worker.image.clone(),
-                disk_gib: 20,
-                lease_seconds: 900,
-                max_hourly_cost_micros: Some(500_000),
-            },
+            target: status.worker.target.clone(),
             ssh_public_key: status.worker.ssh_public_key.clone(),
         }
     }
@@ -496,7 +499,10 @@ mod tests {
         status.worker.identity.job_id = CloudJobId::new();
         assert!(!status.is_ready_for(&request, observed_at()));
         status = original.clone();
-        status.worker.image = format!("registry.example/horizon/worker@sha256:{}", "a".repeat(64));
+        status.worker.target.image = format!("registry.example/horizon/worker@sha256:{}", "a".repeat(64));
+        assert!(!status.is_ready_for(&request, observed_at()));
+        status = original.clone();
+        status.worker.target.disk_gib += 1;
         assert!(!status.is_ready_for(&request, observed_at()));
         status = original.clone();
         status.worker.ssh_public_key = {
@@ -516,14 +522,7 @@ mod tests {
         let mut request = InteractiveWorkerRequest {
             workflow_id: status.worker.identity.workflow_id,
             job_id: status.worker.identity.job_id,
-            target: WorkerTarget {
-                provider: CloudProvider::RunPod,
-                profile: "gpu".to_string(),
-                image: status.worker.image,
-                disk_gib: 20,
-                lease_seconds: 900,
-                max_hourly_cost_micros: None,
-            },
+            target: status.worker.target,
             ssh_public_key: ed25519_key(Some("user@example")),
         };
         assert!(request.is_valid_for(CloudProvider::RunPod));
@@ -553,7 +552,7 @@ mod tests {
         assert!(!worker.has_valid_shape());
         assert!(!worker.is_valid_for(CloudProvider::RunPod));
         worker = worker_status().worker;
-        worker.image = "registry.example/horizon/worker:latest".to_string();
+        worker.target.image = "registry.example/horizon/worker:latest".to_string();
         assert!(!worker.has_valid_shape());
         worker = worker_status().worker;
         worker.ssh_public_key = "ssh-rsa unsupported".to_string();

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -158,9 +158,11 @@ pub struct InteractiveWorkerStatus {
 }
 
 impl InteractiveWorkerStatus {
-    /// A worker is attachable only when its lifecycle, request identity, lease,
-    /// image, and SSH data agree. `observed_at` must be a freshly sampled,
-    /// trusted UTC time from immediately before attachment.
+    /// A worker is attachable only when its lifecycle, request identity,
+    /// complete target, lease, and SSH data agree. The target comparison covers
+    /// provider, profile, image, disk, requested lease, and cost limit.
+    /// `observed_at` must be a freshly sampled, trusted UTC time from
+    /// immediately before attachment.
     #[must_use]
     pub fn is_ready_for(&self, request: &InteractiveWorkerRequest, observed_at: time::OffsetDateTime) -> bool {
         let identity = &self.worker.identity;

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    CloudProvider,
+    CloudProvider, WorkerTarget,
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
         InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
@@ -48,7 +48,12 @@ impl RunPodInteractiveWorkerProvider {
         }
     }
 
-    fn adapt_status(&self, status: RunPodWorkerStatus, ssh_public_key: &str) -> InteractiveWorkerStatus {
+    fn adapt_status(
+        &self,
+        status: RunPodWorkerStatus,
+        target: &WorkerTarget,
+        ssh_public_key: &str,
+    ) -> InteractiveWorkerStatus {
         let (lifecycle, ssh) = self.adapt_connection(&status);
         InteractiveWorkerStatus {
             worker: InteractiveWorker {
@@ -58,7 +63,7 @@ impl RunPodInteractiveWorkerProvider {
                     job_id: status.worker.job_id,
                     resource_id: status.worker.pod_id,
                 },
-                image: status.worker.image,
+                target: target.clone(),
                 ssh_public_key: ssh_public_key.to_string(),
                 lease: InteractiveWorkerLease {
                     terminate_after: status.worker.terminate_after,
@@ -140,20 +145,21 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
         )?;
         Ok(match ensured {
             RunPodEnsure::Created(status) => {
-                InteractiveWorkerEnsure::Created(self.adapt_status(status, &request.ssh_public_key))
+                InteractiveWorkerEnsure::Created(self.adapt_status(status, &request.target, &request.ssh_public_key))
             }
             RunPodEnsure::Reused(status) => {
-                InteractiveWorkerEnsure::Reused(self.adapt_status(status, &request.ssh_public_key))
+                InteractiveWorkerEnsure::Reused(self.adapt_status(status, &request.target, &request.ssh_public_key))
             }
         })
     }
 
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let target = worker.target.clone();
         let ssh_public_key = worker.ssh_public_key.clone();
         let worker = runpod_worker(worker)?;
         self.client
             .inspect_interactive_worker(&worker, &ssh_public_key)
-            .map(|status| status.map(|status| self.adapt_status(status, &ssh_public_key)))
+            .map(|status| status.map(|status| self.adapt_status(status, &target, &ssh_public_key)))
     }
 
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
@@ -175,7 +181,7 @@ fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError
         job_id: worker.identity.job_id,
         pod_id: worker.identity.resource_id.clone(),
         name: resource_name(worker.identity.workflow_id, worker.identity.job_id),
-        image: worker.image.clone(),
+        image: worker.target.image.clone(),
         terminate_after: worker.lease.terminate_after.clone(),
         hourly_cost_micros: None,
     };

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -498,7 +498,7 @@ fn interactive_adapter_rejects_invalid_handles_before_transport_io() {
             job_id,
             resource_id: "pod_123456".to_string(),
         },
-        image: request.target.image,
+        target: request.target,
         ssh_public_key: request.ssh_public_key,
         lease: InteractiveWorkerLease {
             terminate_after: termination_deadline(900).expect("termination deadline"),


### PR DESCRIPTION
## Purpose

Persist the complete provider-neutral worker target in every interactive worker handle instead of retaining only its image. This is a focused prerequisite for #392 and the local-provider work tracked by #383.

## Behavior impact

- readiness now rejects drift in provider, profile, image, disk, lease, or cost limit
- persisted worker handles validate the same target contract as create requests
- the RunPod adapter carries the exact requested target through create, reuse, inspect, and cleanup conversion
- no UI, release, deployment, or live cloud resources are changed

## Test evidence

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo test --workspace --features speech`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`
