### PR TITLE
fix(terminal): keep agent OSC titles until cleared

### DIFF
--- a/assets/plugins/claude-code/skills/horizon-notify/SKILL.md
+++ b/assets/plugins/claude-code/skills/horizon-notify/SKILL.md
@@ -28,4 +28,7 @@ Related OSC API for terminal titles:
 - Clear title:
   `printf '\033]0;HORIZON_TITLE:clear\007' > "/dev/$(ps -o tty= -p $PPID | tr -d ' ')"`
 
+A set title stays on the panel titlebar until you clear it. Later OSC 0 titles
+from the TUI (cwd, spinner, status) do not overwrite it.
+
 Keep titles under 80 chars and avoid newlines.

--- a/assets/plugins/codex/skills/horizon-notify/SKILL.md
+++ b/assets/plugins/codex/skills/horizon-notify/SKILL.md
@@ -27,4 +27,7 @@ Related OSC API for terminal titles:
 - Clear title:
   `printf '\033]0;HORIZON_TITLE:clear\007' > "/dev/$(ps -o tty= -p $PPID | tr -d ' ')"`
 
+A set title stays on the panel titlebar until you clear it. Later OSC 0 titles
+from the TUI (cwd, spinner, status) do not overwrite it.
+
 Keep titles under 80 chars and avoid newlines.

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -56,7 +56,7 @@ pub use git_changes::DiffViewer;
 pub use git_status::{DiffHunk, DiffLine, DiffLineKind, FileChange, FileDiff, FileStatus, GitStatus};
 pub use git_watcher::GitWatcher;
 pub use horizon_home::{HorizonHome, browser_mcp_executable};
-pub use local_store::user_home_dir;
+pub use local_store::{codex_home_dir, grok_home_dir, user_home_dir};
 pub use managed_install::ManagedInstall;
 pub use panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind, PanelLayout, PanelOptions, PanelResume, browser_actor};
 pub use remote_hosts::{

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -56,6 +56,7 @@ pub use git_changes::DiffViewer;
 pub use git_status::{DiffHunk, DiffLine, DiffLineKind, FileChange, FileDiff, FileStatus, GitStatus};
 pub use git_watcher::GitWatcher;
 pub use horizon_home::{HorizonHome, browser_mcp_executable};
+pub use local_store::user_home_dir;
 pub use managed_install::ManagedInstall;
 pub use panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind, PanelLayout, PanelOptions, PanelResume, browser_actor};
 pub use remote_hosts::{

--- a/crates/horizon-core/src/local_store.rs
+++ b/crates/horizon-core/src/local_store.rs
@@ -15,11 +15,13 @@ pub fn user_home_dir() -> Option<PathBuf> {
     user_home_dir_from_env(env_path("HOME"), env_path("USERPROFILE"))
 }
 
-pub(crate) fn codex_home_dir() -> Option<PathBuf> {
+#[must_use]
+pub fn codex_home_dir() -> Option<PathBuf> {
     codex_home_dir_from_env(env_path("CODEX_HOME"), user_home_dir())
 }
 
-pub(crate) fn grok_home_dir() -> Option<PathBuf> {
+#[must_use]
+pub fn grok_home_dir() -> Option<PathBuf> {
     grok_home_dir_from_env(env_path("GROK_HOME"), user_home_dir())
 }
 

--- a/crates/horizon-core/src/local_store.rs
+++ b/crates/horizon-core/src/local_store.rs
@@ -10,7 +10,8 @@ pub(crate) fn env_path(name: &str) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-pub(crate) fn user_home_dir() -> Option<PathBuf> {
+#[must_use]
+pub fn user_home_dir() -> Option<PathBuf> {
     user_home_dir_from_env(env_path("HOME"), env_path("USERPROFILE"))
 }
 

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -382,7 +382,10 @@ impl Panel {
             return PanelProcessOutput::default();
         };
         let had_output = terminal.process_events();
-        let terminal_title = had_output.then(|| terminal.title().to_string());
+        let title_changed = self.terminal_title != terminal.title();
+        if title_changed {
+            self.terminal_title = terminal.title().to_string();
+        }
         let current_cwd = if had_output && should_track_live_cwd {
             terminal.current_cwd()
         } else {
@@ -391,10 +394,6 @@ impl Panel {
         self.had_recent_output = had_output;
         if had_output {
             self.last_output_at_millis = Some(current_unix_millis());
-        }
-
-        if let Some(title) = terminal_title {
-            self.terminal_title = title;
         }
         if self.kind == PanelKind::Ssh {
             if terminal.child_exited() {
@@ -407,7 +406,7 @@ impl Panel {
         let cwd_changed = self.update_tracked_cwd(current_cwd);
         PanelProcessOutput {
             activity: PanelProcessActivity {
-                terminal: had_output,
+                terminal: had_output || title_changed,
                 browser: false,
             },
             cwd_changed,

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -920,6 +920,11 @@ mod tests {
             kitty_keyboard: true,
         })
         .expect("terminal should spawn");
+        assert!(
+            terminal.shutdown_with_timeout(Duration::from_secs(2)),
+            "test terminal should shut down before title injection"
+        );
+        let _ = terminal.process_events();
         terminal.handle_event(Event::Title(
             "HORIZON_TITLE:set:PR comments: Docker lifecycle".to_string(),
         ));
@@ -938,14 +943,7 @@ mod tests {
         assert_eq!(panel.display_title(), "Codex — PR comments: Docker lifecycle");
         assert!(
             !output.activity.terminal,
-            "title copy after events were already drained must not count as grid output"
-        );
-
-        assert!(
-            panel
-                .terminal_mut()
-                .is_some_and(|terminal| terminal.shutdown_with_timeout(Duration::from_secs(2))),
-            "test terminal should shut down"
+            "title copy after the PTY has exited must not count as grid output"
         );
     }
 

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -406,7 +406,7 @@ impl Panel {
         let cwd_changed = self.update_tracked_cwd(current_cwd);
         PanelProcessOutput {
             activity: PanelProcessActivity {
-                terminal: had_output || title_changed,
+                terminal: had_output,
                 browser: false,
             },
             cwd_changed,
@@ -894,6 +894,59 @@ mod tests {
         let panel = test_panel("Backend", "Backend", true);
 
         assert_eq!(panel.display_title(), "Backend");
+    }
+
+    #[test]
+    fn process_output_copies_pinned_horizon_title_into_the_titlebar() {
+        use std::collections::HashMap;
+        use std::time::Duration;
+
+        use alacritty_terminal::event::Event;
+
+        use crate::terminal::{Terminal, TerminalSpawnOptions};
+
+        let mut terminal = Terminal::spawn(TerminalSpawnOptions {
+            program: std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()),
+            args: vec!["-c".to_string(), "exit".to_string()],
+            cwd: None,
+            rows: 24,
+            cols: 80,
+            cell_width: 8,
+            cell_height: 16,
+            scrollback_limit: 256,
+            window_id: 42,
+            replay_bytes: Vec::new(),
+            env: HashMap::new(),
+            kitty_keyboard: true,
+        })
+        .expect("terminal should spawn");
+        terminal.handle_event(Event::Title(
+            "HORIZON_TITLE:set:PR comments: Docker lifecycle".to_string(),
+        ));
+        terminal.handle_event(Event::Title(": horizon".to_string()));
+        terminal.handle_event(Event::ResetTitle);
+
+        let mut panel = Panel::from_content(
+            PanelId(1),
+            WorkspaceId(1),
+            PanelKind::Codex,
+            PanelContent::Terminal(terminal),
+        );
+        assert!(panel.rename("Codex"));
+
+        let output = panel.process_output();
+        assert_eq!(panel.display_title(), "Codex — PR comments: Docker lifecycle");
+        assert!(
+            !output.activity.terminal,
+            "title copy after events were already drained must not count as grid output"
+        );
+
+        assert!(
+            panel
+                .terminal_mut()
+                .is_some_and(|terminal| terminal.shutdown_with_timeout(Duration::from_secs(2))),
+            "test terminal should shut down"
+        );
     }
 
     #[test]

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -74,6 +74,57 @@ enum HorizonOscTitle {
     Ignore,
 }
 
+/// Live OSC title, pinned by `HORIZON_TITLE:set` until `HORIZON_TITLE:clear`.
+///
+/// Agent TUIs keep writing ordinary OSC 0 titles for cwd/spinner status; those
+/// must not clobber an explicit agent-set title.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RuntimeTitle {
+    Open(String),
+    Pinned(String),
+}
+
+impl Default for RuntimeTitle {
+    fn default() -> Self {
+        Self::Open(String::new())
+    }
+}
+
+impl RuntimeTitle {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Open(title) | Self::Pinned(title) => title,
+        }
+    }
+
+    fn apply_incoming(&mut self, incoming: &str) -> Option<AgentNotification> {
+        match Terminal::parse_horizon_title(incoming) {
+            Some(HorizonOscTitle::Notification(notification)) => Some(notification),
+            Some(HorizonOscTitle::SetTitle(next_title)) => {
+                *self = Self::Pinned(next_title);
+                None
+            }
+            Some(HorizonOscTitle::ClearTitle) => {
+                *self = Self::Open(String::new());
+                None
+            }
+            Some(HorizonOscTitle::Ignore) => None,
+            None => {
+                if let Self::Open(title) = self {
+                    incoming.clone_into(title);
+                }
+                None
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        if let Self::Open(title) = self {
+            title.clear();
+        }
+    }
+}
+
 #[derive(Clone)]
 struct TerminalEventProxy {
     event_tx: mpsc::Sender<Event>,
@@ -125,7 +176,7 @@ pub struct Terminal {
     cell_width: u16,
     cell_height: u16,
     scrollback_limit: usize,
-    title: String,
+    title: RuntimeTitle,
     clipboard_contents: String,
     selection_contents: String,
     pending_pty_resize: Option<std::time::Instant>,
@@ -145,9 +196,9 @@ mod tests {
     #[cfg(target_os = "linux")]
     use super::current_cwd_for_pid;
     use super::{
-        AgentNotification, HorizonOscTitle, Terminal, TerminalDimensions, TerminalEventProxy, TerminalSpawnOptions,
-        default_terminal_rgb, find_file_path_at_column, find_url_at_column, queue_debounced_pty_resize,
-        replay_terminal_bytes, should_debounce_pty_resize,
+        AgentNotification, HorizonOscTitle, RuntimeTitle, Terminal, TerminalDimensions, TerminalEventProxy,
+        TerminalSpawnOptions, default_terminal_rgb, find_file_path_at_column, find_url_at_column,
+        queue_debounced_pty_resize, replay_terminal_bytes, should_debounce_pty_resize,
     };
     use alacritty_terminal::event::Event;
     use alacritty_terminal::grid::Dimensions;
@@ -289,11 +340,30 @@ mod tests {
     #[test]
     fn horizon_notify_event_sets_notification_without_overwriting_title() {
         let mut terminal = spawn_test_terminal();
-        terminal.title = "Existing title".to_string();
+        terminal.title = RuntimeTitle::Open("Existing title".to_string());
 
         terminal.handle_event(Event::Title("HORIZON_NOTIFY:info:Saved".to_string()));
 
         assert_eq!(terminal.title(), "Existing title");
+        assert_eq!(
+            terminal.take_notification(),
+            Some(AgentNotification {
+                severity: "info".to_string(),
+                message: "Saved".to_string(),
+            })
+        );
+        assert!(terminal.shutdown_with_timeout(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn horizon_notify_does_not_unlock_horizon_title() {
+        let mut terminal = spawn_test_terminal();
+
+        terminal.handle_event(Event::Title("HORIZON_TITLE:set:Build running".to_string()));
+        terminal.handle_event(Event::Title("HORIZON_NOTIFY:info:Saved".to_string()));
+        terminal.handle_event(Event::Title(": horizon".to_string()));
+
+        assert_eq!(terminal.title(), "Build running");
         assert_eq!(
             terminal.take_notification(),
             Some(AgentNotification {
@@ -318,7 +388,7 @@ mod tests {
     #[test]
     fn horizon_title_clear_event_clears_existing_title() {
         let mut terminal = spawn_test_terminal();
-        terminal.title = "Build running".to_string();
+        terminal.title = RuntimeTitle::Open("Build running".to_string());
 
         terminal.handle_event(Event::Title("HORIZON_TITLE:clear".to_string()));
 
@@ -330,7 +400,7 @@ mod tests {
     #[test]
     fn invalid_horizon_title_event_does_not_clobber_existing_title() {
         let mut terminal = spawn_test_terminal();
-        terminal.title = "Build running".to_string();
+        terminal.title = RuntimeTitle::Open("Build running".to_string());
 
         terminal.handle_event(Event::Title("HORIZON_TITLE:rename:other".to_string()));
 
@@ -342,7 +412,7 @@ mod tests {
     #[test]
     fn malformed_horizon_notify_event_does_not_leak_into_visible_title() {
         let mut terminal = spawn_test_terminal();
-        terminal.title = "Existing title".to_string();
+        terminal.title = RuntimeTitle::Open("Existing title".to_string());
 
         terminal.handle_event(Event::Title("HORIZON_NOTIFY:attention".to_string()));
 
@@ -352,10 +422,39 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_terminal_title_replaces_horizon_title() {
+    fn later_horizon_title_set_replaces_pinned_title() {
+        let mut terminal = spawn_test_terminal();
+
+        terminal.handle_event(Event::Title("HORIZON_TITLE:set:First task".to_string()));
+        terminal.handle_event(Event::Title(
+            "HORIZON_TITLE:set:PR comments: Docker lifecycle".to_string(),
+        ));
+
+        assert_eq!(terminal.title(), "PR comments: Docker lifecycle");
+        assert!(terminal.shutdown_with_timeout(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn ordinary_terminal_title_does_not_replace_horizon_title() {
+        let mut terminal = spawn_test_terminal();
+
+        terminal.handle_event(Event::Title(
+            "HORIZON_TITLE:set:PR comments: Docker lifecycle".to_string(),
+        ));
+        terminal.handle_event(Event::Title(": horizon".to_string()));
+        terminal.handle_event(Event::ResetTitle);
+
+        assert_eq!(terminal.title(), "PR comments: Docker lifecycle");
+        assert_eq!(terminal.take_notification(), None);
+        assert!(terminal.shutdown_with_timeout(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn clearing_horizon_title_allows_ordinary_titles_again() {
         let mut terminal = spawn_test_terminal();
 
         terminal.handle_event(Event::Title("HORIZON_TITLE:set:Build running".to_string()));
+        terminal.handle_event(Event::Title("HORIZON_TITLE:clear".to_string()));
         terminal.handle_event(Event::Title("cargo test".to_string()));
 
         assert_eq!(terminal.title(), "cargo test");

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -388,8 +388,8 @@ mod tests {
     #[test]
     fn horizon_title_clear_event_clears_existing_title() {
         let mut terminal = spawn_test_terminal();
-        terminal.title = RuntimeTitle::Open("Build running".to_string());
 
+        terminal.handle_event(Event::Title("HORIZON_TITLE:set:Build running".to_string()));
         terminal.handle_event(Event::Title("HORIZON_TITLE:clear".to_string()));
 
         assert!(terminal.title().is_empty());

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -123,6 +123,14 @@ impl RuntimeTitle {
             title.clear();
         }
     }
+
+    /// Keep the visible title after transcript replay, but drop the pin so a
+    /// restored session can accept ordinary OSC 0 titles again.
+    fn release_pin(&mut self) {
+        if let Self::Pinned(title) = self {
+            *self = Self::Open(std::mem::take(title));
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/horizon-core/src/terminal/events.rs
+++ b/crates/horizon-core/src/terminal/events.rs
@@ -51,7 +51,7 @@ impl Terminal {
 
     #[must_use]
     pub fn title(&self) -> &str {
-        &self.title
+        self.title.as_str()
     }
 
     #[must_use]
@@ -78,24 +78,12 @@ impl Terminal {
 
     pub(super) fn handle_event(&mut self, event: Event) {
         match event {
-            Event::Title(title) => match Self::parse_horizon_title(&title) {
-                Some(HorizonOscTitle::Notification(notification)) => {
+            Event::Title(title) => {
+                if let Some(notification) = self.title.apply_incoming(&title) {
                     self.pending_notification = Some(notification);
                 }
-                Some(HorizonOscTitle::SetTitle(next_title)) => {
-                    self.title = next_title;
-                }
-                Some(HorizonOscTitle::ClearTitle) => {
-                    self.title.clear();
-                }
-                Some(HorizonOscTitle::Ignore) => {}
-                None => {
-                    self.title = title;
-                }
-            },
-            Event::ResetTitle => {
-                self.title.clear();
             }
+            Event::ResetTitle => self.title.reset(),
             Event::ClipboardStore(clipboard, contents) => match clipboard {
                 term::ClipboardType::Clipboard => self.clipboard_contents = contents,
                 term::ClipboardType::Selection => self.selection_contents = contents,

--- a/crates/horizon-core/src/terminal/events.rs
+++ b/crates/horizon-core/src/terminal/events.rs
@@ -76,7 +76,7 @@ impl Terminal {
         }
     }
 
-    pub(super) fn handle_event(&mut self, event: Event) {
+    pub(crate) fn handle_event(&mut self, event: Event) {
         match event {
             Event::Title(title) => {
                 if let Some(notification) = self.title.apply_incoming(&title) {

--- a/crates/horizon-core/src/terminal/replay.rs
+++ b/crates/horizon-core/src/terminal/replay.rs
@@ -32,6 +32,10 @@ pub(super) fn drain_replay_events(event_rx: &mpsc::Receiver<Event>) -> ReplayRes
         }
     }
 
+    // Pinning is a live-session contract. Replay still prefers an in-stream
+    // HORIZON_TITLE over later ordinary OSC 0 / ResetTitle, then releases the
+    // pin so a restored panel does not ignore post-restart title updates.
+    state.title.release_pin();
     state
 }
 
@@ -96,7 +100,7 @@ mod tests {
 
         let state = drain_replay_events(&rx);
 
-        assert_eq!(state.title, super::RuntimeTitle::Pinned("PR comments".to_string()));
+        assert_eq!(state.title, super::RuntimeTitle::Open("PR comments".to_string()));
         assert!(rx.try_recv().is_err());
     }
 
@@ -113,7 +117,7 @@ mod tests {
 
         assert_eq!(
             state.title,
-            super::RuntimeTitle::Pinned("PR comments: Docker lifecycle".to_string())
+            super::RuntimeTitle::Open("PR comments: Docker lifecycle".to_string())
         );
     }
 

--- a/crates/horizon-core/src/terminal/replay.rs
+++ b/crates/horizon-core/src/terminal/replay.rs
@@ -2,11 +2,11 @@ use std::sync::mpsc;
 
 use alacritty_terminal::event::Event;
 
-use super::{HorizonOscTitle, Terminal};
+use super::RuntimeTitle;
 
 #[derive(Default)]
 pub(super) struct ReplayRestoreState {
-    pub(super) title: String,
+    pub(super) title: RuntimeTitle,
 }
 
 pub(super) fn drain_replay_events(event_rx: &mpsc::Receiver<Event>) -> ReplayRestoreState {
@@ -14,15 +14,10 @@ pub(super) fn drain_replay_events(event_rx: &mpsc::Receiver<Event>) -> ReplayRes
 
     while let Ok(event) = event_rx.try_recv() {
         match event {
-            Event::Title(title) => match Terminal::parse_horizon_title(&title) {
-                Some(HorizonOscTitle::SetTitle(next_title)) => state.title = next_title,
-                Some(HorizonOscTitle::ClearTitle) => state.title.clear(),
-                Some(HorizonOscTitle::Notification(_) | HorizonOscTitle::Ignore) => {}
-                None => state.title = title,
-            },
-            Event::ResetTitle => {
-                state.title.clear();
+            Event::Title(title) => {
+                let _ = state.title.apply_incoming(&title);
             }
+            Event::ResetTitle => state.title.reset(),
             Event::ClipboardStore(_, _)
             | Event::ClipboardLoad(_, _)
             | Event::ColorRequest(_, _)
@@ -85,7 +80,23 @@ mod tests {
 
         let state = drain_replay_events(&rx);
 
-        assert_eq!(state.title, "restored title");
+        assert_eq!(state.title, super::RuntimeTitle::Open("restored title".to_string()));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn drain_replay_events_keeps_horizon_title_over_later_ordinary_titles() {
+        let (tx, rx) = mpsc::channel();
+
+        tx.send(Event::Title("HORIZON_TITLE:set:PR comments".to_string()))
+            .expect("horizon title event");
+        tx.send(Event::Title(": horizon".to_string()))
+            .expect("ordinary title event");
+        tx.send(Event::ResetTitle).expect("reset title event");
+
+        let state = drain_replay_events(&rx);
+
+        assert_eq!(state.title, super::RuntimeTitle::Pinned("PR comments".to_string()));
         assert!(rx.try_recv().is_err());
     }
 

--- a/crates/horizon-core/src/terminal/replay.rs
+++ b/crates/horizon-core/src/terminal/replay.rs
@@ -100,6 +100,23 @@ mod tests {
         assert!(rx.try_recv().is_err());
     }
 
+    #[test]
+    fn replaying_osc_bytes_pins_horizon_title_over_later_ordinary_titles() {
+        let (term, event_rx) = replay_test_term();
+
+        replay_terminal_bytes(
+            &term,
+            b"\x1b]0;HORIZON_TITLE:set:PR comments: Docker lifecycle\x07\x1b]0;: horizon\x07",
+        );
+
+        let state = drain_replay_events(&event_rx);
+
+        assert_eq!(
+            state.title,
+            super::RuntimeTitle::Pinned("PR comments: Docker lifecycle".to_string())
+        );
+    }
+
     fn replay_test_term() -> (Arc<FairMutex<Term<TerminalEventProxy>>>, mpsc::Receiver<Event>) {
         let (event_tx, event_rx) = mpsc::channel();
         let dimensions = TerminalDimensions::new(24, 80);

--- a/crates/horizon-ui/src/plugin_install.rs
+++ b/crates/horizon-ui/src/plugin_install.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use horizon_core::browser::manifest;
-use horizon_core::{HorizonHome, browser_mcp_executable};
+use horizon_core::{HorizonHome, browser_mcp_executable, user_home_dir};
 
 struct EmbeddedFile {
     relative_path: &'static str,
@@ -125,7 +125,7 @@ impl Drop for AgentPluginHostLease {
 }
 
 pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) -> Option<AgentPluginHostLease> {
-    let user_home = std::env::var_os("HOME").map(PathBuf::from);
+    let user_home = user_home_dir();
     let mcp_command = browser_mcp_executable().unwrap_or_else(|| PathBuf::from("horizon"));
     let host_dir = horizon_home.agent_plugin_host_dir(manifest::host_instance());
     let claude_plugin_dir = horizon_home.claude_plugin_dir_for_host(manifest::host_instance());

--- a/crates/horizon-ui/src/plugin_install.rs
+++ b/crates/horizon-ui/src/plugin_install.rs
@@ -50,6 +50,21 @@ const BROWSER_SKILL_FILES: &[EmbeddedFile] = &[EmbeddedFile {
     )),
 }];
 
+/// `$HOME`-relative skill roots for every built-in agent that discovers
+/// `SKILL.md` directories. Claude also receives the same files through the
+/// host plugin tree; these user paths cover sessions that do not load that
+/// plugin.
+const USER_AGENT_SKILL_ROOTS: &[&[&str]] = &[
+    &[".agents", "skills"],
+    &[".codex", "skills"],
+    &[".claude", "skills"],
+    &[".grok", "skills"],
+    &[".config", "opencode", "skills"],
+    &[".gemini", "skills"],
+    &[".kilocode", "skills"],
+    &[".pi", "agent", "skills"],
+];
+
 pub(crate) struct AgentPluginHostLease {
     host_dir: PathBuf,
     lock_path: PathBuf,
@@ -229,16 +244,22 @@ fn install_agent_plugins_impl(
             ("horizon-notify", NOTIFY_SKILL_FILES),
             ("horizon-browser", BROWSER_SKILL_FILES),
         ] {
-            let codex_home_skill_dir = home.join(".codex").join("skills").join(skill_name);
-            updated_files += sync_plugin_files(&codex_home_skill_dir, files)?;
-            let codex_export_dir = home.join(".agents").join("skills").join(skill_name);
-            updated_files += sync_plugin_files(&codex_export_dir, files)?;
-            let kilo_export_dir = home.join(".kilocode").join("skills").join(skill_name);
-            updated_files += sync_plugin_files(&kilo_export_dir, files)?;
+            for skill_root in USER_AGENT_SKILL_ROOTS {
+                updated_files += sync_plugin_files(&user_skill_dir(home, skill_root, skill_name), files)?;
+            }
         }
     }
 
     Ok(updated_files)
+}
+
+fn user_skill_dir(home: &Path, skill_root: &[&str], skill_name: &str) -> PathBuf {
+    let mut dir = home.to_path_buf();
+    for part in skill_root {
+        dir.push(part);
+    }
+    dir.push(skill_name);
+    dir
 }
 
 fn claude_mcp_config(command: &Path) -> std::io::Result<String> {
@@ -292,9 +313,9 @@ mod tests {
     use horizon_core::HorizonHome;
 
     use super::{
-        AgentPluginHostLease, BROWSER_SKILL_FILES, EmbeddedFile, NOTIFY_SKILL_FILES, agent_plugin_host_lock_path,
-        install_agent_plugins_impl, open_lock_file, prune_stale_agent_plugin_hosts, sync_file_if_changed,
-        sync_plugin_files,
+        AgentPluginHostLease, BROWSER_SKILL_FILES, CLAUDE_PLUGIN_FILES, EmbeddedFile, NOTIFY_SKILL_FILES,
+        USER_AGENT_SKILL_ROOTS, agent_plugin_host_lock_path, install_agent_plugins_impl, open_lock_file,
+        prune_stale_agent_plugin_hosts, sync_file_if_changed, sync_plugin_files, user_skill_dir,
     };
 
     #[test]
@@ -341,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn install_agent_plugins_syncs_codex_skill_into_current_codex_home() {
+    fn install_agent_plugins_syncs_notify_skill_into_every_agent_home() {
         let temp = tempfile::tempdir().expect("temp dir");
         let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
         let user_home = temp.path().join("user-home");
@@ -356,30 +377,33 @@ mod tests {
         .expect("install plugins");
 
         assert!(updated > 0);
-        assert_eq!(
-            std::fs::read_to_string(user_home.join(".codex/skills/horizon-notify/SKILL.md"))
-                .expect("codex skill should be exported"),
-            NOTIFY_SKILL_FILES[0].content,
-        );
-        assert_eq!(
-            std::fs::read_to_string(user_home.join(".agents/skills/horizon-notify/SKILL.md"))
-                .expect("legacy codex skill export should still exist"),
-            NOTIFY_SKILL_FILES[0].content,
-        );
-        assert_eq!(
-            std::fs::read_to_string(user_home.join(".kilocode/skills/horizon-notify/SKILL.md"))
-                .expect("kilo skill should be exported"),
-            NOTIFY_SKILL_FILES[0].content,
-        );
+        for skill_root in USER_AGENT_SKILL_ROOTS {
+            let notify_path = user_skill_dir(&user_home, skill_root, "horizon-notify").join("SKILL.md");
+            assert_eq!(
+                std::fs::read_to_string(&notify_path)
+                    .unwrap_or_else(|_| panic!("notify skill missing at {}", notify_path.display())),
+                NOTIFY_SKILL_FILES[0].content,
+            );
+            let browser_path = user_skill_dir(&user_home, skill_root, "horizon-browser").join("SKILL.md");
+            assert_eq!(
+                std::fs::read_to_string(&browser_path)
+                    .unwrap_or_else(|_| panic!("browser skill missing at {}", browser_path.display())),
+                BROWSER_SKILL_FILES[0].content,
+            );
+        }
         assert_eq!(
             std::fs::read_to_string(horizon_home.codex_skill_dir().join("SKILL.md"))
                 .expect("horizon codex integration should be synced"),
             NOTIFY_SKILL_FILES[0].content,
         );
         assert_eq!(
-            std::fs::read_to_string(user_home.join(".codex/skills/horizon-browser/SKILL.md"))
-                .expect("browser skill should be exported"),
-            BROWSER_SKILL_FILES[0].content,
+            std::fs::read_to_string(claude_plugin_dir.join("skills/horizon-notify/SKILL.md"))
+                .expect("claude plugin notify skill should be installed"),
+            CLAUDE_PLUGIN_FILES
+                .iter()
+                .find(|file| file.relative_path == "skills/horizon-notify/SKILL.md")
+                .expect("claude notify file")
+                .content,
         );
         assert!(BROWSER_SKILL_FILES[0].content.contains("browser_visibility"));
         assert!(BROWSER_SKILL_FILES[0].content.contains("browser_network_watch"));

--- a/crates/horizon-ui/src/plugin_install.rs
+++ b/crates/horizon-ui/src/plugin_install.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use horizon_core::browser::manifest;
-use horizon_core::{HorizonHome, browser_mcp_executable, user_home_dir};
+use horizon_core::{HorizonHome, browser_mcp_executable, codex_home_dir, grok_home_dir, user_home_dir};
 
 struct EmbeddedFile {
     relative_path: &'static str,
@@ -55,9 +55,7 @@ const BROWSER_SKILL_FILES: &[EmbeddedFile] = &[EmbeddedFile {
 /// the host plugin tree.
 const NOTIFY_SKILL_ROOTS: &[&[&str]] = &[
     &[".agents", "skills"],
-    &[".codex", "skills"],
     &[".claude", "skills"],
-    &[".grok", "skills"],
     &[".config", "opencode", "skills"],
     &[".gemini", "skills"],
     &[".kilocode", "skills"],
@@ -66,7 +64,7 @@ const NOTIFY_SKILL_ROOTS: &[&[&str]] = &[
 
 /// Browser MCP skill stays on the agents that already had Horizon browser
 /// integration. Expanding it to Grok/Gemini/Pi/OpenCode is separate work.
-const BROWSER_SKILL_ROOTS: &[&[&str]] = &[&[".agents", "skills"], &[".codex", "skills"], &[".kilocode", "skills"]];
+const BROWSER_SKILL_ROOTS: &[&[&str]] = &[&[".agents", "skills"], &[".kilocode", "skills"]];
 
 pub(crate) struct AgentPluginHostLease {
     host_dir: PathBuf,
@@ -126,6 +124,8 @@ impl Drop for AgentPluginHostLease {
 
 pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) -> Option<AgentPluginHostLease> {
     let user_home = user_home_dir();
+    let grok_home = grok_home_dir();
+    let codex_home = codex_home_dir();
     let mcp_command = browser_mcp_executable().unwrap_or_else(|| PathBuf::from("horizon"));
     let host_dir = horizon_home.agent_plugin_host_dir(manifest::host_instance());
     let claude_plugin_dir = horizon_home.claude_plugin_dir_for_host(manifest::host_instance());
@@ -137,7 +137,14 @@ pub(crate) fn install_agent_plugins(horizon_home: &HorizonHome) -> Option<AgentP
         }
     };
 
-    match install_agent_plugins_impl(horizon_home, &claude_plugin_dir, user_home.as_deref(), &mcp_command) {
+    match install_agent_plugins_impl(
+        horizon_home,
+        &claude_plugin_dir,
+        user_home.as_deref(),
+        grok_home.as_deref(),
+        codex_home.as_deref(),
+        &mcp_command,
+    ) {
         Ok(updated_files) if updated_files > 0 => {
             tracing::info!(updated_files, "synced embedded Horizon agent plugins");
         }
@@ -230,6 +237,8 @@ fn install_agent_plugins_impl(
     horizon_home: &HorizonHome,
     claude_plugin_dir: &Path,
     user_home: Option<&Path>,
+    grok_home: Option<&Path>,
+    codex_home: Option<&Path>,
     mcp_command: &Path,
 ) -> std::io::Result<usize> {
     let mut updated_files = 0usize;
@@ -255,7 +264,21 @@ fn install_agent_plugins_impl(
         }
     }
 
+    if let Some(grok_root) = provider_home(grok_home, user_home, ".grok") {
+        updated_files += sync_plugin_files(&grok_root.join("skills").join("horizon-notify"), NOTIFY_SKILL_FILES)?;
+    }
+    if let Some(codex_root) = provider_home(codex_home, user_home, ".codex") {
+        updated_files += sync_plugin_files(&codex_root.join("skills").join("horizon-notify"), NOTIFY_SKILL_FILES)?;
+        updated_files += sync_plugin_files(&codex_root.join("skills").join("horizon-browser"), BROWSER_SKILL_FILES)?;
+    }
+
     Ok(updated_files)
+}
+
+fn provider_home(override_home: Option<&Path>, user_home: Option<&Path>, default_dir: &str) -> Option<PathBuf> {
+    override_home
+        .map(Path::to_path_buf)
+        .or_else(|| user_home.map(|home| home.join(default_dir)))
 }
 
 fn user_skill_dir(home: &Path, skill_root: &[&str], skill_name: &str) -> PathBuf {
@@ -377,6 +400,8 @@ mod tests {
             &horizon_home,
             &claude_plugin_dir,
             Some(&user_home),
+            None,
+            None,
             Path::new("/opt/horizon"),
         )
         .expect("install plugins");
@@ -398,6 +423,21 @@ mod tests {
                 BROWSER_SKILL_FILES[0].content,
             );
         }
+        assert_eq!(
+            std::fs::read_to_string(user_home.join(".grok/skills/horizon-notify/SKILL.md"))
+                .expect("grok skill should fall back to ~/.grok"),
+            NOTIFY_SKILL_FILES[0].content,
+        );
+        assert_eq!(
+            std::fs::read_to_string(user_home.join(".codex/skills/horizon-notify/SKILL.md"))
+                .expect("codex skill should fall back to ~/.codex"),
+            NOTIFY_SKILL_FILES[0].content,
+        );
+        assert_eq!(
+            std::fs::read_to_string(user_home.join(".codex/skills/horizon-browser/SKILL.md"))
+                .expect("codex browser skill should fall back to ~/.codex"),
+            BROWSER_SKILL_FILES[0].content,
+        );
         assert!(
             !user_home.join(".grok/skills/horizon-browser/SKILL.md").exists(),
             "browser MCP skill must not be exported to agents without Horizon MCP injection"
@@ -425,16 +465,59 @@ mod tests {
     }
 
     #[test]
+    fn install_agent_plugins_honors_grok_home_override() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
+        let user_home = temp.path().join("user-home");
+        let grok_home = temp.path().join("custom-grok");
+        let claude_plugin_dir = horizon_home.claude_plugin_dir_for_host("host-a");
+
+        install_agent_plugins_impl(
+            &horizon_home,
+            &claude_plugin_dir,
+            Some(&user_home),
+            Some(&grok_home),
+            None,
+            Path::new("/opt/horizon"),
+        )
+        .expect("install plugins");
+
+        assert_eq!(
+            std::fs::read_to_string(grok_home.join("skills/horizon-notify/SKILL.md"))
+                .expect("notify skill should be installed under GROK_HOME"),
+            NOTIFY_SKILL_FILES[0].content,
+        );
+        assert!(
+            !user_home.join(".grok/skills/horizon-notify/SKILL.md").exists(),
+            "GROK_HOME must replace ~/.grok rather than writing both"
+        );
+    }
+
+    #[test]
     fn install_agent_plugins_keeps_mcp_commands_isolated_per_horizon_host() {
         let temp = tempfile::tempdir().expect("temp dir");
         let horizon_home = HorizonHome::from_root(temp.path().join(".horizon"));
         let first_plugin_dir = horizon_home.claude_plugin_dir_for_host("host-a");
         let second_plugin_dir = horizon_home.claude_plugin_dir_for_host("host-b");
 
-        install_agent_plugins_impl(&horizon_home, &first_plugin_dir, None, Path::new("/opt/horizon-a"))
-            .expect("install first host plugin");
-        install_agent_plugins_impl(&horizon_home, &second_plugin_dir, None, Path::new("/opt/horizon-b"))
-            .expect("install second host plugin");
+        install_agent_plugins_impl(
+            &horizon_home,
+            &first_plugin_dir,
+            None,
+            None,
+            None,
+            Path::new("/opt/horizon-a"),
+        )
+        .expect("install first host plugin");
+        install_agent_plugins_impl(
+            &horizon_home,
+            &second_plugin_dir,
+            None,
+            None,
+            None,
+            Path::new("/opt/horizon-b"),
+        )
+        .expect("install second host plugin");
 
         let first_config = std::fs::read_to_string(first_plugin_dir.join(".mcp.json")).expect("first host config");
         let second_config = std::fs::read_to_string(second_plugin_dir.join(".mcp.json")).expect("second host config");

--- a/crates/horizon-ui/src/plugin_install.rs
+++ b/crates/horizon-ui/src/plugin_install.rs
@@ -50,11 +50,10 @@ const BROWSER_SKILL_FILES: &[EmbeddedFile] = &[EmbeddedFile {
     )),
 }];
 
-/// `$HOME`-relative skill roots for every built-in agent that discovers
-/// `SKILL.md` directories. Claude also receives the same files through the
-/// host plugin tree; these user paths cover sessions that do not load that
-/// plugin.
-const USER_AGENT_SKILL_ROOTS: &[&[&str]] = &[
+/// `$HOME`-relative skill roots that receive `horizon-notify`. This is the
+/// title/notify skill every built-in agent needs. Claude also gets it through
+/// the host plugin tree.
+const NOTIFY_SKILL_ROOTS: &[&[&str]] = &[
     &[".agents", "skills"],
     &[".codex", "skills"],
     &[".claude", "skills"],
@@ -64,6 +63,10 @@ const USER_AGENT_SKILL_ROOTS: &[&[&str]] = &[
     &[".kilocode", "skills"],
     &[".pi", "agent", "skills"],
 ];
+
+/// Browser MCP skill stays on the agents that already had Horizon browser
+/// integration. Expanding it to Grok/Gemini/Pi/OpenCode is separate work.
+const BROWSER_SKILL_ROOTS: &[&[&str]] = &[&[".agents", "skills"], &[".codex", "skills"], &[".kilocode", "skills"]];
 
 pub(crate) struct AgentPluginHostLease {
     host_dir: PathBuf,
@@ -240,13 +243,15 @@ fn install_agent_plugins_impl(
     updated_files += sync_plugin_files(&horizon_home.codex_browser_skill_dir(), BROWSER_SKILL_FILES)?;
 
     if let Some(home) = user_home {
-        for (skill_name, files) in [
-            ("horizon-notify", NOTIFY_SKILL_FILES),
-            ("horizon-browser", BROWSER_SKILL_FILES),
-        ] {
-            for skill_root in USER_AGENT_SKILL_ROOTS {
-                updated_files += sync_plugin_files(&user_skill_dir(home, skill_root, skill_name), files)?;
-            }
+        for skill_root in NOTIFY_SKILL_ROOTS {
+            updated_files +=
+                sync_plugin_files(&user_skill_dir(home, skill_root, "horizon-notify"), NOTIFY_SKILL_FILES)?;
+        }
+        for skill_root in BROWSER_SKILL_ROOTS {
+            updated_files += sync_plugin_files(
+                &user_skill_dir(home, skill_root, "horizon-browser"),
+                BROWSER_SKILL_FILES,
+            )?;
         }
     }
 
@@ -313,9 +318,9 @@ mod tests {
     use horizon_core::HorizonHome;
 
     use super::{
-        AgentPluginHostLease, BROWSER_SKILL_FILES, CLAUDE_PLUGIN_FILES, EmbeddedFile, NOTIFY_SKILL_FILES,
-        USER_AGENT_SKILL_ROOTS, agent_plugin_host_lock_path, install_agent_plugins_impl, open_lock_file,
-        prune_stale_agent_plugin_hosts, sync_file_if_changed, sync_plugin_files, user_skill_dir,
+        AgentPluginHostLease, BROWSER_SKILL_FILES, BROWSER_SKILL_ROOTS, CLAUDE_PLUGIN_FILES, EmbeddedFile,
+        NOTIFY_SKILL_FILES, NOTIFY_SKILL_ROOTS, agent_plugin_host_lock_path, install_agent_plugins_impl,
+        open_lock_file, prune_stale_agent_plugin_hosts, sync_file_if_changed, sync_plugin_files, user_skill_dir,
     };
 
     #[test]
@@ -377,13 +382,15 @@ mod tests {
         .expect("install plugins");
 
         assert!(updated > 0);
-        for skill_root in USER_AGENT_SKILL_ROOTS {
+        for skill_root in NOTIFY_SKILL_ROOTS {
             let notify_path = user_skill_dir(&user_home, skill_root, "horizon-notify").join("SKILL.md");
             assert_eq!(
                 std::fs::read_to_string(&notify_path)
                     .unwrap_or_else(|_| panic!("notify skill missing at {}", notify_path.display())),
                 NOTIFY_SKILL_FILES[0].content,
             );
+        }
+        for skill_root in BROWSER_SKILL_ROOTS {
             let browser_path = user_skill_dir(&user_home, skill_root, "horizon-browser").join("SKILL.md");
             assert_eq!(
                 std::fs::read_to_string(&browser_path)
@@ -391,6 +398,10 @@ mod tests {
                 BROWSER_SKILL_FILES[0].content,
             );
         }
+        assert!(
+            !user_home.join(".grok/skills/horizon-browser/SKILL.md").exists(),
+            "browser MCP skill must not be exported to agents without Horizon MCP injection"
+        );
         assert_eq!(
             std::fs::read_to_string(horizon_home.codex_skill_dir().join("SKILL.md"))
                 .expect("horizon codex integration should be synced"),

--- a/docs/testing/2026-09-04-agent-titlebar-osc-smoke.md
+++ b/docs/testing/2026-09-04-agent-titlebar-osc-smoke.md
@@ -7,9 +7,9 @@ Temporary plan for `fix/sticky-agent-terminal-title`. Delete after the UI pass.
 1. Launch the candidate from this worktree with an isolated config (`--config` + `--ephemeral`).
 2. After launch, confirm Horizon wrote `horizon-notify/SKILL.md` into every built-in agent home (use `%USERPROFILE%` on Windows if `HOME` is unset):
    - `~/.agents/skills/horizon-notify/SKILL.md`
-   - `~/.codex/skills/horizon-notify/SKILL.md`
    - `~/.claude/skills/horizon-notify/SKILL.md`
-   - `~/.grok/skills/horizon-notify/SKILL.md`
+   - `$GROK_HOME/skills/horizon-notify/SKILL.md` when `GROK_HOME` is set, otherwise `~/.grok/skills/horizon-notify/SKILL.md`
+   - `$CODEX_HOME/skills/horizon-notify/SKILL.md` when `CODEX_HOME` is set, otherwise `~/.codex/skills/horizon-notify/SKILL.md`
    - `~/.config/opencode/skills/horizon-notify/SKILL.md`
    - `~/.gemini/skills/horizon-notify/SKILL.md`
    - `~/.kilocode/skills/horizon-notify/SKILL.md`

--- a/docs/testing/2026-09-04-agent-titlebar-osc-smoke.md
+++ b/docs/testing/2026-09-04-agent-titlebar-osc-smoke.md
@@ -1,0 +1,46 @@
+# Smoke: agent-set panel titles
+
+Temporary plan for `fix/sticky-agent-terminal-title`. Delete after the UI pass.
+
+## Setup
+
+1. Launch the candidate from this worktree with an isolated config (`--config` + `--ephemeral`).
+2. Open a Codex (or Claude) panel from the default preset. Confirm `HORIZON=1` in that panel (`echo "$HORIZON"`).
+
+## Lanes
+
+### 1. Ordinary TUI titles still appear
+
+- Before the agent sets a Horizon title, the panel titlebar may show the TUI OSC 0 title (often project name, sometimes a spinner prefix).
+- Pass: the titlebar is not stuck on the preset name alone if the TUI is emitting OSC 0.
+
+### 2. Agent `HORIZON_TITLE:set` wins
+
+In the agent panel (or a nested tool), run:
+
+```sh
+printf '\033]0;HORIZON_TITLE:set:PR comments: Docker lifecycle fixes\007' > "/dev/$(ps -o tty= -p $$ | tr -d ' ')"
+```
+
+- Pass: titlebar becomes `Codex — PR comments: Docker lifecycle fixes` (or the custom panel name plus that suffix).
+- Pass: it stays that way while the agent TUI keeps redrawing (cwd/spinner OSC 0 must not revert it to `: horizon` or similar).
+
+### 3. Clear restores ordinary titles
+
+```sh
+printf '\033]0;HORIZON_TITLE:clear\007' > "/dev/$(ps -o tty= -p $$ | tr -d ' ')"
+```
+
+- Pass: the pinned title disappears.
+- Pass: a later ordinary OSC 0 title from the TUI can show again.
+
+### 4. Skill path
+
+If the `gh-address-comments` (or equivalent) `set_terminal_title.py` skill is available, have the agent set a title for the current task.
+
+- Pass: the panel titlebar shows that title within a second and keeps it while the agent is working.
+
+## Out of scope
+
+- OS window title
+- Persisting the pinned title across Horizon restarts

--- a/docs/testing/2026-09-04-agent-titlebar-osc-smoke.md
+++ b/docs/testing/2026-09-04-agent-titlebar-osc-smoke.md
@@ -5,11 +5,22 @@ Temporary plan for `fix/sticky-agent-terminal-title`. Delete after the UI pass.
 ## Setup
 
 1. Launch the candidate from this worktree with an isolated config (`--config` + `--ephemeral`).
-2. Open a Codex (or Claude) panel from the default preset. Confirm `HORIZON=1` in that panel (`echo "$HORIZON"`).
+2. After launch, confirm Horizon wrote `horizon-notify/SKILL.md` into every built-in agent home (use `%USERPROFILE%` on Windows if `HOME` is unset):
+   - `~/.agents/skills/horizon-notify/SKILL.md`
+   - `~/.codex/skills/horizon-notify/SKILL.md`
+   - `~/.claude/skills/horizon-notify/SKILL.md`
+   - `~/.grok/skills/horizon-notify/SKILL.md`
+   - `~/.config/opencode/skills/horizon-notify/SKILL.md`
+   - `~/.gemini/skills/horizon-notify/SKILL.md`
+   - `~/.kilocode/skills/horizon-notify/SKILL.md`
+   - `~/.pi/agent/skills/horizon-notify/SKILL.md`
+3. Pass: each file exists and contains `HORIZON_TITLE:set`.
 
 ## Lanes
 
 ### 1. Ordinary TUI titles still appear
+
+Open any built-in agent panel. Codex is enough for this lane.
 
 - Before the agent sets a Horizon title, the panel titlebar may show the TUI OSC 0 title (often project name, sometimes a spinner prefix).
 - Pass: the titlebar is not stuck on the preset name alone if the TUI is emitting OSC 0.
@@ -34,7 +45,18 @@ printf '\033]0;HORIZON_TITLE:clear\007' > "/dev/$(ps -o tty= -p $$ | tr -d ' ')"
 - Pass: the pinned title disappears.
 - Pass: a later ordinary OSC 0 title from the TUI can show again.
 
-### 4. Skill path
+### 4. Each built-in agent can pin the titlebar
+
+For each preset **Codex**, **Claude**, **Grok**, **OpenCode**, **Gemini**, **Pi**, and **Kilo**:
+
+1. Open a panel from that preset.
+2. Confirm `HORIZON=1`.
+3. Run the `HORIZON_TITLE:set` command from lane 2.
+
+- Pass: the titlebar shows that panel's name plus `PR comments: Docker lifecycle fixes`.
+- Pass: later TUI OSC 0 cwd/spinner titles do not revert it.
+
+### 5. Skill path
 
 If the `gh-address-comments` (or equivalent) `set_terminal_title.py` skill is available, have the agent set a title for the current task.
 


### PR DESCRIPTION
## Purpose

When an agent sets the panel title (`HORIZON_TITLE:set`, including `set_terminal_title.py`), Horizon's titlebar should keep that title while the agent TUI is running. Codex and Claude keep emitting ordinary OSC 0 titles (cwd / spinner), so last-writer-wins left the bar stuck on values like `: horizon` instead of the task title.

Horizon now also installs the `horizon-notify` skill (title + notify OSC) into every built-in agent's user skill directory so Grok, Claude, Codex, OpenCode, Gemini, Pi, and Kilo can set those titles.

## Behavior impact

- `HORIZON_TITLE:set` pins the runtime title until `HORIZON_TITLE:clear`
- ordinary OSC 0 and `ResetTitle` from the TUI no longer overwrite a pinned title
- a later `HORIZON_TITLE:set` still replaces the pinned title
- after clear, ordinary TUI titles apply again
- restore keeps the last title text but does not keep it pinned
- panel chrome refreshes when the title changes even if the grid did not
- `horizon-notify` is synced into each built-in agent's skill home on launch
- the browser MCP skill is unchanged: Codex, Kilo, and the shared `.agents` export only

## Test evidence

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `cargo test -p horizon-core --lib`
- `cargo test -p horizon-ui install_agent_plugins`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic`

Smoke plan: `docs/testing/2026-09-04-agent-titlebar-osc-smoke.md`