### PR TITLE
feat(workspace): add durable remote workspace domain

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -251,7 +251,7 @@ pub trait InteractiveWorkerProvider: Send + Sync {
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error>;
 }
 
-fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider) -> bool {
+pub(crate) fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider) -> bool {
     target.provider == provider
         && !target.profile.trim().is_empty()
         && target.profile.trim() == target.profile

--- a/crates/horizon-core/src/cloud_run/validation.rs
+++ b/crates/horizon-core/src/cloud_run/validation.rs
@@ -296,6 +296,14 @@ pub(super) fn valid_worker_image(value: &str) -> bool {
     let registry = !explicit || Url::parse(&format!("https://{value}")).is_ok_and(usable);
     OCI_REF.as_ref().is_some_and(|pattern| pattern.is_match(value)) && digest && registry
 }
+impl GitSource {
+    /// Validate the credential-free repository identity and optional branch.
+    /// # Errors
+    /// Rejects invalid repository slugs and Git branch names.
+    pub fn validate(&self) -> Result<(), Error> {
+        validate_git_source(self)
+    }
+}
 fn validate_git_source(source: &GitSource) -> Result<(), Error> {
     ensure(valid_repository(&source.repository), Error::InvalidRepository)?;
     let branch_is_valid = source.branch.as_deref().is_none_or(valid_branch);

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -20,6 +20,7 @@ mod managed_install;
 mod opencode_paths;
 mod panel;
 mod remote_hosts;
+pub mod remote_workspace;
 mod runtime_state;
 pub mod search;
 mod session_store;

--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -1,0 +1,211 @@
+//! Durable remote workspace data, independent of providers, persistence I/O, and UI.
+//! Snapshot validation is not permission to attach: fresh provider observation and lease checks remain required.
+
+#[cfg(test)]
+mod tests;
+mod validation;
+
+use crate::{
+    PanelKind,
+    cloud_run::{
+        ArtifactDigest, CloudJobId, CloudWorkflowId, GitCommitSha, GitSource, WorkerTarget,
+        interactive_worker::{InteractiveWorker, InteractiveWorkerSshEndpoint},
+    },
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub const REMOTE_WORKSPACE_STATE_VERSION: u32 = 1;
+
+/// One durable workspace owns at most one runtime; panels never own workers.
+///
+/// Deserialization validates the complete aggregate. Call [`Self::validate`]
+/// after editing public fields and before persistence or lifecycle actions.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "WorkspaceSnapshot")]
+pub struct RemoteWorkspaceState {
+    pub version: u32,
+    pub spec: RemoteWorkspaceSpec,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RemoteRuntimeGeneration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<RepositoryCheckpoint>,
+}
+
+impl RemoteWorkspaceState {
+    /// Create a dormant workspace with a validated specification.
+    /// # Errors
+    /// Rejects invalid identities, targets, repositories, directories, or panels.
+    pub fn new(spec: RemoteWorkspaceSpec) -> Result<Self, RemoteWorkspaceError> {
+        let state = Self {
+            version: REMOTE_WORKSPACE_STATE_VERSION,
+            spec,
+            runtime: None,
+            checkpoint: None,
+        };
+        state.validate()?;
+        Ok(state)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkspaceSnapshot {
+    version: u32,
+    spec: RemoteWorkspaceSpec,
+    #[serde(default)]
+    runtime: Option<RemoteRuntimeGeneration>,
+    #[serde(default)]
+    checkpoint: Option<RepositoryCheckpoint>,
+}
+
+impl TryFrom<WorkspaceSnapshot> for RemoteWorkspaceState {
+    type Error = RemoteWorkspaceError;
+
+    fn try_from(value: WorkspaceSnapshot) -> Result<Self, Self::Error> {
+        let state = Self {
+            version: value.version,
+            spec: value.spec,
+            runtime: value.runtime,
+            checkpoint: value.checkpoint,
+        };
+        state.validate()?;
+        Ok(state)
+    }
+}
+
+/// Desired workspace state survives deletion of its disposable worker.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteWorkspaceSpec {
+    pub workspace_local_id: String,
+    pub target: WorkerTarget,
+    /// Uses the existing owner/repository identity, never a credential-bearing URL.
+    pub repository: GitSource,
+    /// Normalized repository-relative POSIX path; `.` means the repository root.
+    pub working_directory: String,
+    /// Last allocated runtime generation. Zero means no runtime has been allocated.
+    pub generation: u64,
+    pub panels: Vec<RemotePanelBinding>,
+}
+
+/// A panel's durable launch intent and optional agent-native resume identity.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemotePanelBinding {
+    pub panel_local_id: String,
+    pub kind: PanelKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<RemotePanelCommand>,
+    /// Overrides the workspace directory, still relative to the repository root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    /// User task context, never a credential transport.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_handoff: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<String>,
+}
+
+impl RemotePanelBinding {
+    /// Stable tmux identity derived from the panel, with no caller-supplied alias.
+    /// # Errors
+    /// Rejects an invalid panel identity before it can enter a tmux command.
+    pub fn tmux_session_name(&self) -> Result<String, RemoteWorkspaceError> {
+        if !validation::valid_local_id(&self.panel_local_id) {
+            return Err(RemoteWorkspaceError::InvalidPanel("local_id"));
+        }
+        Ok(format!("horizon-panel-{}", self.panel_local_id))
+    }
+}
+
+/// Argument boundaries are preserved; later execution must not join these into a shell command.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemotePanelCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+/// One allocation attempt, persisted before provider creation starts.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteRuntimeGeneration {
+    pub workspace_local_id: String,
+    pub generation: u64,
+    pub workflow_id: CloudWorkflowId,
+    pub job_id: CloudJobId,
+    pub phase: RemoteRuntimePhase,
+    /// Missing until an exact provider identity has been discovered and verified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker: Option<InteractiveWorker>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh: Option<InteractiveWorkerSshEndpoint>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup: Option<RemoteCleanupIntent>,
+}
+
+/// Dormant is represented by an absent runtime, never by a retained worker.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteRuntimePhase {
+    Provisioning,
+    Reconciling,
+    Materializing,
+    Ready,
+    Checkpointing,
+    Cancelling,
+    Deleting,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteCleanupIntent {
+    pub reason: RemoteCleanupReason,
+    pub requested_at_millis: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteCleanupReason {
+    LastPanelClosed,
+    WorkspaceRemoved,
+    ApplicationExit,
+    Cancelled,
+    Failed,
+    LeaseExpired,
+}
+
+/// A verified repository watermark may outlive the runtime that produced it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryCheckpoint {
+    pub workspace_local_id: String,
+    pub base_commit: GitCommitSha,
+    pub manifest_digest: ArtifactDigest,
+    pub runtime_generation: u64,
+    /// Monotonically increasing checkpoint watermark, independent of runtime generation.
+    pub generation: u64,
+    pub captured_at_millis: i64,
+    /// Content-addressed recovery bundle, resolved by the checkpoint store.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_artifact: Option<ArtifactDigest>,
+}
+
+/// Errors identify the invariant without echoing task text or command arguments.
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum RemoteWorkspaceError {
+    #[error("unsupported remote workspace state version {0}")]
+    UnsupportedVersion(u32),
+    #[error("invalid remote workspace specification: {0}")]
+    InvalidSpec(&'static str),
+    #[error("duplicate remote panel identity")]
+    DuplicatePanel,
+    #[error("invalid remote panel: {0}")]
+    InvalidPanel(&'static str),
+    #[error("invalid remote runtime: {0}")]
+    InvalidRuntime(&'static str),
+    #[error("invalid repository checkpoint: {0}")]
+    InvalidCheckpoint(&'static str),
+}

--- a/crates/horizon-core/src/remote_workspace/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/tests.rs
@@ -1,0 +1,229 @@
+use super::*;
+use crate::cloud_run::{
+    CloudProvider,
+    interactive_worker::{InteractiveWorkerIdentity, InteractiveWorkerLease},
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde_json::json;
+
+fn panel(local_id: &str) -> RemotePanelBinding {
+    RemotePanelBinding {
+        panel_local_id: local_id.into(),
+        kind: PanelKind::Shell,
+        command: None,
+        working_directory: None,
+        task_handoff: None,
+        agent_session_id: None,
+    }
+}
+
+fn spec() -> RemoteWorkspaceSpec {
+    RemoteWorkspaceSpec {
+        workspace_local_id: "workspace-one".into(),
+        target: WorkerTarget {
+            provider: CloudProvider::RunPod,
+            profile: "gpu-development".into(),
+            image: format!("registry.example/worker@sha256:{}", "a".repeat(64)),
+            disk_gib: 20,
+            lease_seconds: 900,
+            max_hourly_cost_micros: Some(100_000),
+        },
+        repository: GitSource {
+            repository: "owner/project".into(),
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        working_directory: "crates/core".into(),
+        generation: 2,
+        panels: vec![panel("panel-one"), panel("panel-two")],
+    }
+}
+
+fn key() -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([7; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
+fn active() -> RemoteWorkspaceState {
+    let spec = spec();
+    let workflow_id = CloudWorkflowId::new();
+    let job_id = CloudJobId::new();
+    let worker = InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: spec.target.provider,
+            workflow_id,
+            job_id,
+            resource_id: "exact-resource".into(),
+        },
+        target: spec.target.clone(),
+        ssh_public_key: key(),
+        lease: InteractiveWorkerLease {
+            terminate_after: "2020-01-01T00:00:00Z".into(),
+        },
+    };
+    RemoteWorkspaceState {
+        version: REMOTE_WORKSPACE_STATE_VERSION,
+        runtime: Some(RemoteRuntimeGeneration {
+            workspace_local_id: spec.workspace_local_id.clone(),
+            generation: spec.generation,
+            workflow_id,
+            job_id,
+            phase: RemoteRuntimePhase::Ready,
+            worker: Some(worker),
+            ssh: Some(InteractiveWorkerSshEndpoint {
+                host: "127.0.0.1".into(),
+                port: 2222,
+                username: "root".into(),
+                host_key: key(),
+            }),
+            cleanup: None,
+        }),
+        checkpoint: Some(RepositoryCheckpoint {
+            workspace_local_id: spec.workspace_local_id.clone(),
+            base_commit: spec.repository.commit.clone(),
+            manifest_digest: ArtifactDigest::parse_sha256("c".repeat(64)).expect("digest"),
+            runtime_generation: 1,
+            generation: 12,
+            captured_at_millis: 1_000,
+            recovery_artifact: Some(ArtifactDigest::parse_sha256("d".repeat(64)).expect("recovery digest")),
+        }),
+        spec,
+    }
+}
+
+#[test]
+fn round_trip_preserves_durable_work_after_runtime_disposal() {
+    let mut state = active();
+    state.spec.panels[0].kind = PanelKind::Claude;
+    state.spec.panels[0].agent_session_id = Some("session-one".into());
+    state.spec.panels[0].task_handoff = Some("Continue the saved task\nwith its final checkpoint".into());
+    for runtime_present in [true, false] {
+        if !runtime_present {
+            state.runtime = None;
+        }
+        let encoded = serde_json::to_string(&state).expect("encode");
+        assert_eq!(
+            serde_json::from_str::<RemoteWorkspaceState>(&encoded).expect("decode"),
+            state
+        );
+        assert_eq!(state.checkpoint.as_ref().expect("checkpoint").generation, 12);
+    }
+    let dormant = RemoteWorkspaceState::new(spec()).expect("dormant specification");
+    assert!(dormant.runtime.is_none());
+}
+
+#[test]
+fn decoding_rejects_schema_ownership_and_generation_drift() {
+    let valid = serde_json::to_value(active()).expect("snapshot");
+    for (pointer, replacement) in [
+        ("/version", json!(2)),
+        ("/runtime/workspace_local_id", json!("another-workspace")),
+        ("/runtime/generation", json!(3)),
+        ("/runtime/worker/identity/workflow_id", json!(CloudWorkflowId::new())),
+        ("/runtime/worker/identity/job_id", json!(CloudJobId::new())),
+        ("/runtime/worker/target/disk_gib", json!(200)),
+        ("/runtime/ssh/host_key", json!("unverified-key")),
+        ("/checkpoint/workspace_local_id", json!("another-workspace")),
+        ("/checkpoint/runtime_generation", json!(3)),
+        ("/checkpoint/generation", json!(0)),
+        ("/checkpoint/base_commit", json!("e".repeat(40))),
+        ("/checkpoint/captured_at_millis", json!(-1)),
+    ] {
+        let mut altered = valid.clone();
+        *altered.pointer_mut(pointer).expect("field") = replacement;
+        assert!(
+            serde_json::from_value::<RemoteWorkspaceState>(altered).is_err(),
+            "{pointer}"
+        );
+    }
+    let mut unknown = valid;
+    unknown["credentials"] = json!("test-token");
+    assert!(serde_json::from_value::<RemoteWorkspaceState>(unknown).is_err());
+}
+
+#[test]
+fn panel_identities_cannot_alias_tmux_sessions_or_use_non_terminal_kinds() {
+    let mut spec = spec();
+    let names: Vec<_> = spec
+        .panels
+        .iter()
+        .map(|panel| panel.tmux_session_name().expect("name"))
+        .collect();
+    assert_ne!(names[0], names[1]);
+    assert_eq!(names[0], "horizon-panel-panel-one");
+    spec.panels[1].panel_local_id = spec.panels[0].panel_local_id.clone();
+    assert_eq!(spec.validate(), Err(RemoteWorkspaceError::DuplicatePanel));
+    for bad_id in ["", "panel:0", "panel.0", "panel/one", "panel;two", "panel\nthree"] {
+        assert!(panel(bad_id).tmux_session_name().is_err());
+    }
+    for kind in [
+        PanelKind::Ssh,
+        PanelKind::Browser,
+        PanelKind::Editor,
+        PanelKind::GitChanges,
+        PanelKind::Usage,
+    ] {
+        let mut panel = panel("valid");
+        panel.kind = kind;
+        assert_eq!(panel.validate(), Err(RemoteWorkspaceError::InvalidPanel("kind")));
+    }
+}
+
+#[test]
+fn source_paths_and_launch_data_are_validated_without_echoing_payloads() {
+    for path in [
+        "/absolute",
+        "../escape",
+        "nested/../escape",
+        "nested//dir",
+        "./nested",
+        "C:/repo",
+        "nested\\dir",
+        "nested\0dir",
+    ] {
+        let mut spec = spec();
+        spec.working_directory = path.into();
+        assert!(spec.validate().is_err(), "{path:?}");
+    }
+    let mut spec = spec();
+    spec.repository.repository = "https://user:test-token@example.invalid/repo".into();
+    assert_eq!(spec.validate(), Err(RemoteWorkspaceError::InvalidSpec("repository")));
+    let mut panel = panel("command");
+    panel.kind = PanelKind::Command;
+    assert!(panel.validate().is_err());
+    panel.command = Some(RemotePanelCommand {
+        program: "printf".into(),
+        args: vec!["literal ; $(text)".into(), "line one\nline two".into()],
+    });
+    assert_eq!(panel.validate(), Ok(()));
+    panel.agent_session_id = Some("session".into());
+    assert_eq!(
+        panel.validate(),
+        Err(RemoteWorkspaceError::InvalidPanel("agent session"))
+    );
+    panel.agent_session_id = None;
+    panel.command.as_mut().expect("command").args = vec!["x".repeat(40_000); 2];
+    assert_eq!(panel.validate(), Err(RemoteWorkspaceError::InvalidPanel("command")));
+}
+
+#[test]
+fn partial_creation_and_expired_handles_remain_recoverable_with_explicit_cleanup() {
+    let mut state = active();
+    assert_eq!(state.validate(), Ok(()), "expired handles remain loadable for cleanup");
+    let runtime = state.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Deleting;
+    assert!(runtime.validate_for(&state.spec).is_err());
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::ApplicationExit,
+        requested_at_millis: 2_000,
+    });
+    assert_eq!(runtime.validate_for(&state.spec), Ok(()));
+    runtime.worker = None;
+    runtime.ssh = None;
+    assert!(runtime.validate_for(&state.spec).is_err());
+    runtime.phase = RemoteRuntimePhase::Reconciling;
+    assert_eq!(runtime.validate_for(&state.spec), Ok(()));
+    runtime.phase = RemoteRuntimePhase::Ready;
+    assert!(runtime.validate_for(&state.spec).is_err());
+}

--- a/crates/horizon-core/src/remote_workspace/validation.rs
+++ b/crates/horizon-core/src/remote_workspace/validation.rs
@@ -1,0 +1,222 @@
+use super::{
+    REMOTE_WORKSPACE_STATE_VERSION, RemotePanelBinding, RemoteRuntimeGeneration, RemoteRuntimePhase,
+    RemoteWorkspaceError as Error, RemoteWorkspaceSpec, RemoteWorkspaceState, RepositoryCheckpoint,
+};
+use crate::{PanelKind, cloud_run::interactive_worker::valid_worker_target};
+use std::collections::HashSet;
+
+const MAX_PANELS: usize = 256;
+const MAX_TEXT_BYTES: usize = 64 * 1024;
+const MAX_PATH_BYTES: usize = 4096;
+
+impl RemoteWorkspaceState {
+    /// Validate identities, single-runtime ownership, panel isolation, and checkpoint provenance.
+    /// # Errors
+    /// Rejects invalid or incompatible persisted domain data without performing I/O.
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.version != REMOTE_WORKSPACE_STATE_VERSION {
+            return Err(Error::UnsupportedVersion(self.version));
+        }
+        self.spec.validate()?;
+        if let Some(runtime) = &self.runtime {
+            runtime.validate_for(&self.spec)?;
+        }
+        if let Some(checkpoint) = &self.checkpoint {
+            checkpoint.validate_for(&self.spec)?;
+        }
+        Ok(())
+    }
+}
+
+impl RemoteWorkspaceSpec {
+    /// Validate the desired workspace without creating or inspecting resources.
+    /// # Errors
+    /// Rejects unsupported launch kinds, malformed identities, and invalid source or target data.
+    pub fn validate(&self) -> Result<(), Error> {
+        if !valid_local_id(&self.workspace_local_id) {
+            return Err(Error::InvalidSpec("local_id"));
+        }
+        if self.target.image.len() > MAX_PATH_BYTES || !valid_worker_target(&self.target, self.target.provider) {
+            return Err(Error::InvalidSpec("worker target"));
+        }
+        if self.repository.repository.len() > MAX_PATH_BYTES
+            || self
+                .repository
+                .branch
+                .as_ref()
+                .is_some_and(|branch| branch.len() > MAX_PATH_BYTES)
+            || self.repository.validate().is_err()
+        {
+            return Err(Error::InvalidSpec("repository"));
+        }
+        if !valid_relative_directory(&self.working_directory) {
+            return Err(Error::InvalidSpec("working directory"));
+        }
+        if self.panels.len() > MAX_PANELS {
+            return Err(Error::InvalidSpec("panel count"));
+        }
+        let mut ids = HashSet::new();
+        for panel in &self.panels {
+            panel.validate()?;
+            if !ids.insert(&panel.panel_local_id) {
+                return Err(Error::DuplicatePanel);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl RemotePanelBinding {
+    /// Validate a panel launch and its optional supported native session binding.
+    /// # Errors
+    /// Rejects malformed identities, non-terminal panel kinds, and invalid launch data.
+    pub fn validate(&self) -> Result<(), Error> {
+        if !valid_local_id(&self.panel_local_id) {
+            return Err(Error::InvalidPanel("local_id"));
+        }
+        if !matches!(self.kind, PanelKind::Shell | PanelKind::Command) && !self.kind.is_agent() {
+            return Err(Error::InvalidPanel("kind"));
+        }
+        if self
+            .working_directory
+            .as_deref()
+            .is_some_and(|path| !valid_relative_directory(path))
+        {
+            return Err(Error::InvalidPanel("working directory"));
+        }
+        if let Some(command) = &self.command {
+            if !valid_token(&command.program, MAX_PATH_BYTES)
+                || command.args.len() > 256
+                || command
+                    .args
+                    .iter()
+                    .any(|arg| arg.len() > MAX_TEXT_BYTES || arg.contains('\0'))
+                || command.args.iter().map(String::len).sum::<usize>() > MAX_TEXT_BYTES
+            {
+                return Err(Error::InvalidPanel("command"));
+            }
+        } else if self.kind == PanelKind::Command {
+            return Err(Error::InvalidPanel("missing command"));
+        }
+        if self
+            .task_handoff
+            .as_ref()
+            .is_some_and(|task| task.len() > MAX_TEXT_BYTES || task.contains('\0'))
+        {
+            return Err(Error::InvalidPanel("task handoff"));
+        }
+        if self
+            .agent_session_id
+            .as_deref()
+            .is_some_and(|id| !self.kind.supports_session_binding() || !valid_token(id, MAX_PATH_BYTES))
+        {
+            return Err(Error::InvalidPanel("agent session"));
+        }
+        Ok(())
+    }
+}
+
+impl RemoteRuntimeGeneration {
+    /// Validate this allocation's binding to one workspace specification.
+    /// Expired lease timestamps remain valid for exact-resource cleanup.
+    /// # Errors
+    /// Rejects generation, provider, workflow, target, connection, and cleanup drift.
+    pub fn validate_for(&self, spec: &RemoteWorkspaceSpec) -> Result<(), Error> {
+        if self.workspace_local_id != spec.workspace_local_id {
+            return Err(Error::InvalidRuntime("workspace identity"));
+        }
+        if self.generation == 0 || self.generation != spec.generation {
+            return Err(Error::InvalidRuntime("generation"));
+        }
+        if let Some(worker) = &self.worker {
+            if !worker.has_valid_shape()
+                || worker.target != spec.target
+                || worker.identity.workflow_id != self.workflow_id
+                || worker.identity.job_id != self.job_id
+            {
+                return Err(Error::InvalidRuntime("worker identity"));
+            }
+        } else if matches!(
+            self.phase,
+            RemoteRuntimePhase::Materializing
+                | RemoteRuntimePhase::Ready
+                | RemoteRuntimePhase::Checkpointing
+                | RemoteRuntimePhase::Deleting
+        ) {
+            return Err(Error::InvalidRuntime("missing worker"));
+        }
+        if self
+            .ssh
+            .as_ref()
+            .is_some_and(|ssh| self.worker.is_none() || !ssh.is_complete())
+        {
+            return Err(Error::InvalidRuntime("SSH endpoint"));
+        }
+        if matches!(
+            self.phase,
+            RemoteRuntimePhase::Materializing | RemoteRuntimePhase::Ready | RemoteRuntimePhase::Checkpointing
+        ) && self.ssh.is_none()
+        {
+            return Err(Error::InvalidRuntime("missing SSH endpoint"));
+        }
+        if self
+            .cleanup
+            .as_ref()
+            .is_some_and(|cleanup| cleanup.requested_at_millis < 0)
+            || (matches!(
+                self.phase,
+                RemoteRuntimePhase::Cancelling | RemoteRuntimePhase::Deleting
+            ) && self.cleanup.is_none())
+        {
+            return Err(Error::InvalidRuntime("cleanup intent"));
+        }
+        Ok(())
+    }
+}
+
+impl RepositoryCheckpoint {
+    /// Check a watermark's relationship to the desired repository and allocated generations.
+    /// # Errors
+    /// Rejects a different base, future/unallocated runtime, zero watermark, or invalid timestamp.
+    pub fn validate_for(&self, spec: &RemoteWorkspaceSpec) -> Result<(), Error> {
+        if self.workspace_local_id != spec.workspace_local_id {
+            return Err(Error::InvalidCheckpoint("workspace identity"));
+        }
+        if self.base_commit != spec.repository.commit {
+            return Err(Error::InvalidCheckpoint("base commit"));
+        }
+        if self.runtime_generation == 0 || self.runtime_generation > spec.generation || self.generation == 0 {
+            return Err(Error::InvalidCheckpoint("generation"));
+        }
+        if self.captured_at_millis < 0 {
+            return Err(Error::InvalidCheckpoint("timestamp"));
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn valid_local_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+fn valid_token(value: &str, maximum: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= maximum
+        && !value.starts_with('-')
+        && !value
+            .chars()
+            .any(|character| character.is_control() || character.is_whitespace())
+}
+
+fn valid_relative_directory(value: &str) -> bool {
+    value == "."
+        || (!value.is_empty()
+            && value.len() <= MAX_PATH_BYTES
+            && !value.contains(['\\', ':'])
+            && !value.chars().any(char::is_control)
+            && value.split('/').all(|part| !matches!(part, "" | "." | "..")))
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -69,6 +69,10 @@ back into large multi-purpose modules.
   belongs in focused leaves such as `runtime_state/agent_sessions/codex.rs`.
 - `local_store.rs` centralizes agent-store environment paths and read-only
   SQLite opening so discovery, validation, and usage reporting agree.
+- `remote_workspace/` owns the versioned remote-workspace aggregate, desired
+  panels, disposable runtime generation, and repository checkpoint metadata.
+  Its validation is pure: provider I/O, runtime-state migration, coordination,
+  repository transfer, and UI integration belong in later focused modules.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a


### PR DESCRIPTION
## Purpose

Adds the durable remote-workspace domain foundation for #383. A versioned aggregate retains the workspace specification, desired panels, one optional disposable runtime generation, and the latest repository checkpoint after the runtime is removed.

## Behavior

- Validate the aggregate during deserialization and expose validation for later mutations.
- Bind runtime and checkpoint records to the workspace identity and allocated generation; retain expired worker handles for cleanup.
- Derive one stable tmux name from each unique panel identity and preserve command argument boundaries, task handoff, and supported native session IDs.
- Reject unsupported panel kinds, traversal paths, credential-bearing repository URLs, incomplete ready-state connections, and invalid cleanup or checkpoint metadata.
- Reuse the existing worker-target and Git-source validation rules.

This slice adds pure data and validation. Runtime-state migration, provider coordination, repository transfer, and UI wiring remain separate roadmap items.

## Validation

- Five focused domain regressions cover JSON round trips after runtime disposal, schema/ownership/generation drift, sibling tmux isolation, source and launch validation, and recovery of partial or expired allocations.
- Full Horizon matrix: formatting, maintainability, version sync, default and speech workspace suites, blocking Clippy, strict panic-path Clippy, and advisory pedantic Clippy.
- No UI or provider operations are introduced; validation uses synthetic local data and no live credentials.

Scope: six source/test files and 673 changed source/test lines, plus the module-boundary documentation.
