### PR TITLE
fix(state): reject unsupported runtime snapshots

### DIFF
--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -2,6 +2,7 @@ mod agent_sessions;
 mod binding_bootstrap;
 mod claude_live_sessions;
 mod models;
+mod versioning;
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -39,6 +40,7 @@ const PI_SESSION_TAIL_BYTES: u64 = 64 * 1024;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RuntimeState {
+    #[serde(with = "versioning")]
     pub version: u32,
     pub window: Option<WindowConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -89,7 +91,9 @@ impl RuntimeState {
     ///
     /// # Errors
     ///
-    /// Returns an error if the state file exists but cannot be read or parsed.
+    /// Returns an error if the state file exists but cannot be read or parsed,
+    /// or its version is newer than this binary supports. Loading never rewrites
+    /// the source file, including when migration fails.
     pub fn load(path: &Path) -> Result<Option<Self>> {
         if !path.exists() {
             return Ok(None);
@@ -107,7 +111,7 @@ impl RuntimeState {
     ///
     /// # Errors
     ///
-    /// Returns an error if serialization fails.
+    /// Returns an error if serialization fails or the state version is unsupported.
     pub fn to_yaml(&self) -> Result<String> {
         serde_yaml::to_string(self).map_err(|error| Error::State(error.to_string()))
     }

--- a/crates/horizon-core/src/runtime_state/tests/mod.rs
+++ b/crates/horizon-core/src/runtime_state/tests/mod.rs
@@ -1,4 +1,5 @@
 mod panels;
+mod versioning;
 mod workspaces;
 
 use crate::board::WorkspaceLayout;

--- a/crates/horizon-core/src/runtime_state/tests/versioning.rs
+++ b/crates/horizon-core/src/runtime_state/tests/versioning.rs
@@ -1,0 +1,191 @@
+use super::*;
+use crate::{HorizonHome, SessionStore, ssh::SshConnection};
+use serde_json::{Value, json};
+
+#[test]
+fn supported_versions_preserve_local_ssh_and_agent_snapshots_during_migration() {
+    let original = mixed_runtime_state();
+    let expected = serde_json::to_value(&original).expect("snapshot value");
+    let base_yaml = original.to_yaml().expect("tagged YAML snapshot");
+    let version_header = format!("version: {RUNTIME_STATE_VERSION}\n");
+    assert!(base_yaml.starts_with(&version_header));
+    let directory = tempfile::tempdir().expect("isolated runtime directory");
+    let path = directory.path().join("runtime.yaml");
+
+    for version in std::iter::once(None).chain((0..=RUNTIME_STATE_VERSION).map(Some)) {
+        let header = version.map_or_else(String::new, |version| format!("version: {version}\n"));
+        let yaml = base_yaml.replacen(&version_header, &header, 1);
+        std::fs::write(&path, &yaml).expect("write fixture");
+
+        let loaded = RuntimeState::load(&path).expect("supported version").expect("state");
+
+        assert_eq!(serde_json::to_value(&loaded).expect("migrated value"), expected);
+        assert_eq!(std::fs::read_to_string(&path).expect("unchanged fixture"), yaml);
+    }
+}
+
+#[test]
+fn future_versions_are_rejected_by_read_and_write_serializers() {
+    for version in [RUNTIME_STATE_VERSION + 1, u32::MAX] {
+        let value = future_snapshot(version);
+        let yaml = serde_yaml::to_string(&value).expect("future fixture");
+        let error = serde_yaml::from_str::<RuntimeState>(&yaml).expect_err("newer YAML version");
+        assert!(error.to_string().contains("unsupported runtime state version"));
+        assert!(serde_json::from_value::<RuntimeState>(value).is_err());
+
+        let state = RuntimeState {
+            version,
+            ..RuntimeState::default()
+        };
+        assert!(state.to_yaml().is_err());
+        assert!(serde_yaml::to_string(&state).is_err());
+        assert!(serde_json::to_vec(&state).is_err());
+    }
+}
+
+#[test]
+fn malformed_or_duplicate_versions_cannot_fall_back_to_current() {
+    for yaml in [
+        "version: -1\n",
+        "version: null\n",
+        "version: future\n",
+        "version: 1.5\n",
+        "version: 4294967296\n",
+        "version: 2\nversion: 3\n",
+        "version: 3\nversion: 2\n",
+    ] {
+        assert!(serde_yaml::from_str::<RuntimeState>(yaml).is_err(), "{yaml}");
+    }
+}
+
+#[test]
+fn rejecting_a_future_session_preserves_runtime_metadata_index_and_transcripts() {
+    let directory = tempfile::tempdir().expect("isolated session directory");
+    let home = HorizonHome::from_root(directory.path().to_path_buf());
+    let store = SessionStore::new(home.clone(), home.config_path());
+    let session = store.create_new_session(&Config::default()).expect("create fixture");
+    let yaml = serde_yaml::to_string(&future_snapshot(RUNTIME_STATE_VERSION + 1)).expect("future fixture");
+    std::fs::write(&session.runtime_state_path, yaml).expect("write future runtime");
+    let transcript = session.transcript_root.join("saved-panel.bin");
+    std::fs::write(&transcript, b"retained terminal history").expect("write transcript");
+    let paths = [
+        session.runtime_state_path.clone(),
+        home.session_meta_path(&session.session_id),
+        home.session_index_path(),
+        transcript,
+    ];
+    let original_bytes = paths.map(|path| {
+        let bytes = std::fs::read(&path).expect("fixture bytes");
+        (path, bytes)
+    });
+
+    assert!(RuntimeState::load(&session.runtime_state_path).is_err());
+    assert!(store.prepare_startup(&Config::default()).is_err());
+    assert!(store.resume_session(&session.session_id).is_err());
+    assert!(store.take_over_session(&session.session_id).is_err());
+    assert!(store.duplicate_session(&session.session_id).is_err());
+    assert!(store.delete_session(&session.session_id).is_err());
+
+    for (path, bytes) in original_bytes {
+        assert_eq!(std::fs::read(path).expect("retained fixture"), bytes);
+    }
+    assert_eq!(store.list_profile_sessions().expect("unchanged index").len(), 1);
+}
+
+#[test]
+fn saving_an_unsupported_snapshot_preserves_the_existing_session() {
+    let directory = tempfile::tempdir().expect("isolated session directory");
+    let home = HorizonHome::from_root(directory.path().to_path_buf());
+    let store = SessionStore::new(home.clone(), home.config_path());
+    let session = store.create_new_session(&Config::default()).expect("create fixture");
+    let paths = [
+        session.runtime_state_path.clone(),
+        home.session_meta_path(&session.session_id),
+        home.session_index_path(),
+    ];
+    let original_bytes = paths.map(|path| {
+        let bytes = std::fs::read(&path).expect("fixture bytes");
+        (path, bytes)
+    });
+    let invalid = RuntimeState {
+        version: RUNTIME_STATE_VERSION + 1,
+        ..session.runtime_state
+    };
+
+    assert!(store.save_runtime_state(&session.session_id, &invalid).is_err());
+
+    for (path, bytes) in original_bytes {
+        assert_eq!(std::fs::read(path).expect("retained fixture"), bytes);
+    }
+}
+
+fn future_snapshot(version: u32) -> Value {
+    json!({
+        "version": version,
+        "workspaces": [],
+        "future_remote_state": {"workspace": "saved-remote", "checkpoint": "retained-work"},
+    })
+}
+
+fn mixed_runtime_state() -> RuntimeState {
+    RuntimeState {
+        window: Some(WindowConfig {
+            width: 1440.0,
+            height: 900.0,
+            x: Some(50.0),
+            y: Some(75.0),
+        }),
+        canvas_view: Some(CanvasViewState::new([24.0, -12.0], 1.5)),
+        active_workspace_local_id: Some("workspace".to_string()),
+        focused_panel_local_id: Some("ssh-panel".to_string()),
+        detached_workspaces: vec![DetachedWorkspaceState {
+            workspace_local_id: "workspace".to_string(),
+            window: WindowConfig::default(),
+        }],
+        workspaces: vec![WorkspaceState {
+            local_id: "workspace".to_string(),
+            name: "Retained work".to_string(),
+            cwd: Some("/synthetic/repository".to_string()),
+            position: Some([10.0, 20.0]),
+            layout: Some(WorkspaceLayout::Grid),
+            panels: vec![
+                PanelState {
+                    local_id: "local-panel".to_string(),
+                    command: Some("synthetic-shell".to_string()),
+                    args: vec!["--isolated".to_string()],
+                    cwd: Some("/synthetic/repository/nested".to_string()),
+                    ..PanelState::default()
+                },
+                PanelState {
+                    local_id: "ssh-panel".to_string(),
+                    kind: PanelKind::Ssh,
+                    ssh_connection: Some(SshConnection {
+                        host: "worker.example.invalid".to_string(),
+                        user: Some("developer".to_string()),
+                        port: Some(2222),
+                        remote_command: Some("tmux attach -t saved".to_string()),
+                        ..SshConnection::default()
+                    }),
+                    ..PanelState::default()
+                },
+                PanelState {
+                    local_id: "agent-panel".to_string(),
+                    kind: PanelKind::Pi,
+                    resume: PanelResume::Session {
+                        session_id: "saved-session".to_string(),
+                    },
+                    session_binding: Some(AgentSessionBinding::new(
+                        PanelKind::Pi,
+                        "saved-session".to_string(),
+                        Some("/synthetic/repository".to_string()),
+                        Some("Continue saved task".to_string()),
+                        Some(42),
+                    )),
+                    ..PanelState::default()
+                },
+            ],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    }
+}

--- a/crates/horizon-core/src/runtime_state/versioning.rs
+++ b/crates/horizon-core/src/runtime_state/versioning.rs
@@ -1,0 +1,41 @@
+use std::borrow::Borrow;
+
+use serde::{Deserialize, Deserializer, Serializer, de, ser};
+use thiserror::Error;
+
+use super::RUNTIME_STATE_VERSION;
+
+pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let version = u32::deserialize(deserializer)?;
+    validate(version).map_err(de::Error::custom)?;
+    Ok(version)
+}
+
+pub(super) fn serialize<S>(version: impl Borrow<u32>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let version = *version.borrow();
+    validate(version).map_err(ser::Error::custom)?;
+    serializer.serialize_u32(version)
+}
+
+fn validate(version: u32) -> Result<(), UnsupportedVersion> {
+    if version > RUNTIME_STATE_VERSION {
+        return Err(UnsupportedVersion {
+            found: version,
+            supported: RUNTIME_STATE_VERSION,
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+#[error("unsupported runtime state version {found}; maximum supported version is {supported}")]
+struct UnsupportedVersion {
+    found: u32,
+    supported: u32,
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -65,8 +65,10 @@ back into large multi-purpose modules.
 - `runtime_state.rs` should stay focused on persisted board/window orchestration.
   Persisted workspace, panel, template, and session-binding models live in
   `runtime_state/models.rs`, with board/workspace and panel persistence tests in
-  `runtime_state/tests/`. Agent binding orchestration, discovery, and
-  external-store parsing belong in `runtime_state/` helper modules.
+  `runtime_state/tests/`. `runtime_state/versioning.rs` guards schema compatibility
+  on read and write serialization boundaries; supported legacy snapshots still
+  migrate in memory. Agent binding orchestration, discovery, and external-store
+  parsing belong in `runtime_state/` helper modules.
   Binding validation and assignment live in
   `runtime_state/binding_bootstrap.rs`; provider-specific session-store parsing
   belongs in focused leaves such as `runtime_state/agent_sessions/codex.rs`.


### PR DESCRIPTION
## Purpose

Protect saved runtime state from silent schema downgrades before remote-workspace metadata is introduced for #383.

## Reproduction and behavior

On a binary that supports runtime schema version 2, loading a synthetic snapshot with `version: 3` and an unknown future field previously discarded the unknown data and relabeled the snapshot as version 2.

- Reject future schema versions during both YAML/JSON deserialization and serialization.
- Keep missing-version and legacy version 0/1/2 snapshots compatible with existing in-memory migration.
- Preserve local and SSH panel definitions, native session bindings, window/view state, focus, and detached workspace metadata.
- Fail startup, resume, takeover, duplicate, and delete operations on a newer-version session without rewriting its files.
- Reject attempts to save an in-memory unsupported snapshot before replacing the existing session files.

The schema stays at version 2. This is a serialization compatibility guard, not remote metadata storage, cross-process locking, or protection against an independent writer replacing a file after it was loaded. No provider operations, UI behavior, or configuration defaults are added.

## Validation

- Five regressions cover supported-version migration, newer-version read/write rejection, malformed/duplicate headers, file preservation across failed session operations, and failed saves.
- All fixtures use temporary directories and synthetic data; no user sessions or processes are touched.
- Full Horizon matrix: formatting, maintainability, version sync, default and speech workspace tests, blocking Clippy, strict panic-path Clippy, and advisory pedantic Clippy.

Scope: four source/test files and 241 changed source/test lines, plus the architecture boundary note.
