### PR TITLE
refactor(cloud): isolate store database boundary

### DIFF
--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -1,14 +1,12 @@
 //! Durable local control-plane storage for cloud workflow snapshots and creation claims.
 
-use std::collections::HashMap;
-#[cfg(unix)]
-use std::fs::OpenOptions;
-#[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
-use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+mod database;
 
-use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use thiserror::Error;
 
 use super::{
@@ -16,37 +14,12 @@ use super::{
     WorkerTarget,
 };
 use crate::HorizonHome;
+use database::{ensure_current_schema, initialize_schema, prepare_private_store};
 
-const STORE_SCHEMA_VERSION: i64 = 1;
 const MAX_SNAPSHOT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_MATERIALIZED_SNAPSHOT_BYTES: i64 = 4 * 1024 * 1024 + 1;
 const MAX_RECOVERED_WORKFLOWS: usize = 512;
 const MAX_RECOVERED_SNAPSHOT_BYTES: usize = 64 * 1024 * 1024;
-const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
-const SCHEMA: &str = r"
-CREATE TABLE IF NOT EXISTS cloud_workflows (
-    workflow_id TEXT PRIMARY KEY NOT NULL,
-    revision INTEGER NOT NULL CHECK (revision > 0),
-    created_at_millis INTEGER NOT NULL,
-    updated_at_millis INTEGER NOT NULL,
-    retain_until_millis INTEGER NOT NULL,
-    snapshot BLOB NOT NULL
-) STRICT;
-CREATE INDEX IF NOT EXISTS cloud_workflows_retention
-    ON cloud_workflows(retain_until_millis, updated_at_millis);
-CREATE TABLE IF NOT EXISTS cloud_worker_creation_claims (
-    provider TEXT NOT NULL,
-    workflow_id TEXT NOT NULL,
-    job_id TEXT NOT NULL,
-    resource_name TEXT NOT NULL,
-    claimed_at_millis INTEGER NOT NULL,
-    PRIMARY KEY (provider, resource_name),
-    UNIQUE (provider, workflow_id, job_id),
-    FOREIGN KEY (workflow_id) REFERENCES cloud_workflows(workflow_id) ON DELETE CASCADE
-) STRICT;
-CREATE INDEX IF NOT EXISTS cloud_worker_creation_claims_workflow
-    ON cloud_worker_creation_claims(workflow_id, job_id, provider);
-";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StoredWorkflow {
@@ -324,15 +297,7 @@ impl CloudWorkflowStore {
     }
 
     fn connection(&self) -> Result<Connection, CloudStoreError> {
-        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
-            | OpenFlags::SQLITE_OPEN_CREATE
-            | OpenFlags::SQLITE_OPEN_NO_MUTEX
-            | OpenFlags::SQLITE_OPEN_NOFOLLOW;
-        let connection = Connection::open_with_flags(&self.path, flags)?;
-        connection.busy_timeout(BUSY_TIMEOUT)?;
-        connection.pragma_update(None, "foreign_keys", "ON")?;
-        connection.pragma_update(None, "synchronous", "FULL")?;
-        Ok(connection)
+        database::open_connection(&self.path)
     }
 }
 
@@ -354,27 +319,6 @@ impl WorkflowRow {
             snapshot: row.get(offset + 4)?,
         })
     }
-}
-
-fn initialize_schema(connection: &mut Connection) -> Result<(), CloudStoreError> {
-    connection.pragma_update(None, "journal_mode", "WAL")?;
-    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-    let version = transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
-    if version != 0 && version != STORE_SCHEMA_VERSION {
-        return Err(CloudStoreError::UnsupportedSchema(version));
-    }
-    transaction.execute_batch(SCHEMA)?;
-    transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
-    transaction.commit()?;
-    Ok(())
-}
-
-fn ensure_current_schema(connection: &Connection) -> Result<(), CloudStoreError> {
-    let version = connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
-    if version != STORE_SCHEMA_VERSION {
-        return Err(CloudStoreError::UnsupportedSchema(version));
-    }
-    Ok(())
 }
 
 fn workflow_row(connection: &Connection, workflow_id: &str) -> rusqlite::Result<Option<WorkflowRow>> {
@@ -566,53 +510,6 @@ fn current_unix_millis() -> Result<i64, CloudStoreError> {
         .map_err(|_| CloudStoreError::InvalidTimestamp)?
         .as_millis();
     i64::try_from(millis).map_err(|_| CloudStoreError::InvalidTimestamp)
-}
-
-fn prepare_private_store(path: &Path) -> Result<PathBuf, CloudStoreError> {
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or(Path::new("."));
-    #[cfg(not(unix))]
-    std::fs::create_dir_all(parent)?;
-    #[cfg(unix)]
-    {
-        let mut builder = std::fs::DirBuilder::new();
-        builder.recursive(true).mode(0o700).create(parent)?;
-        if parent.metadata()?.permissions().mode() & 0o077 != 0 {
-            return Err(CloudStoreError::InsecureStoreDirectory);
-        }
-    }
-    #[cfg(unix)]
-    let path = parent
-        .canonicalize()?
-        .join(path.file_name().unwrap_or(path.as_os_str()));
-    #[cfg(not(unix))]
-    let path = path.to_path_buf();
-    #[cfg(not(unix))]
-    match std::fs::symlink_metadata(&path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => return Err(CloudStoreError::SymlinkStorePath),
-        Ok(_) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error.into()),
-    }
-    #[cfg(unix)]
-    {
-        let mut options = OpenOptions::new();
-        options
-            .create(true)
-            .read(true)
-            .write(true)
-            .mode(0o600)
-            .custom_flags(libc::O_NOFOLLOW);
-        let file = match options.open(&path) {
-            Ok(file) => file,
-            Err(error) if error.raw_os_error() == Some(libc::ELOOP) => return Err(CloudStoreError::SymlinkStorePath),
-            Err(error) => return Err(error.into()),
-        };
-        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(path)
 }
 
 #[derive(Debug, Error)]

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -1,0 +1,119 @@
+//! Private database opening and schema boundary shared by control-plane records.
+
+#[cfg(unix)]
+use std::fs::OpenOptions;
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rusqlite::{Connection, OpenFlags, TransactionBehavior};
+
+use super::CloudStoreError;
+
+const STORE_SCHEMA_VERSION: i64 = 1;
+const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+const SCHEMA: &str = r"
+CREATE TABLE IF NOT EXISTS cloud_workflows (
+    workflow_id TEXT PRIMARY KEY NOT NULL,
+    revision INTEGER NOT NULL CHECK (revision > 0),
+    created_at_millis INTEGER NOT NULL,
+    updated_at_millis INTEGER NOT NULL,
+    retain_until_millis INTEGER NOT NULL,
+    snapshot BLOB NOT NULL
+) STRICT;
+CREATE INDEX IF NOT EXISTS cloud_workflows_retention
+    ON cloud_workflows(retain_until_millis, updated_at_millis);
+CREATE TABLE IF NOT EXISTS cloud_worker_creation_claims (
+    provider TEXT NOT NULL,
+    workflow_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    resource_name TEXT NOT NULL,
+    claimed_at_millis INTEGER NOT NULL,
+    PRIMARY KEY (provider, resource_name),
+    UNIQUE (provider, workflow_id, job_id),
+    FOREIGN KEY (workflow_id) REFERENCES cloud_workflows(workflow_id) ON DELETE CASCADE
+) STRICT;
+CREATE INDEX IF NOT EXISTS cloud_worker_creation_claims_workflow
+    ON cloud_worker_creation_claims(workflow_id, job_id, provider);
+";
+
+pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_CREATE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+    let connection = Connection::open_with_flags(path, flags)?;
+    connection.busy_timeout(BUSY_TIMEOUT)?;
+    connection.pragma_update(None, "foreign_keys", "ON")?;
+    connection.pragma_update(None, "synchronous", "FULL")?;
+    Ok(connection)
+}
+
+pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), CloudStoreError> {
+    connection.pragma_update(None, "journal_mode", "WAL")?;
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let version = transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
+    if version != 0 && version != STORE_SCHEMA_VERSION {
+        return Err(CloudStoreError::UnsupportedSchema(version));
+    }
+    transaction.execute_batch(SCHEMA)?;
+    transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    let version = connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
+    if version != STORE_SCHEMA_VERSION {
+        return Err(CloudStoreError::UnsupportedSchema(version));
+    }
+    Ok(())
+}
+
+pub(super) fn prepare_private_store(path: &Path) -> Result<PathBuf, CloudStoreError> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    #[cfg(not(unix))]
+    std::fs::create_dir_all(parent)?;
+    #[cfg(unix)]
+    {
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700).create(parent)?;
+        if parent.metadata()?.permissions().mode() & 0o077 != 0 {
+            return Err(CloudStoreError::InsecureStoreDirectory);
+        }
+    }
+    #[cfg(unix)]
+    let path = parent
+        .canonicalize()?
+        .join(path.file_name().unwrap_or(path.as_os_str()));
+    #[cfg(not(unix))]
+    let path = path.to_path_buf();
+    #[cfg(not(unix))]
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => return Err(CloudStoreError::SymlinkStorePath),
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    #[cfg(unix)]
+    {
+        let mut options = OpenOptions::new();
+        options
+            .create(true)
+            .read(true)
+            .write(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW);
+        let file = match options.open(&path) {
+            Ok(file) => file,
+            Err(error) if error.raw_os_error() == Some(libc::ELOOP) => return Err(CloudStoreError::SymlinkStorePath),
+            Err(error) => return Err(error.into()),
+        };
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(path)
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -78,6 +78,10 @@ back into large multi-purpose modules.
   panels, disposable runtime generation, and repository checkpoint metadata.
   Its validation is pure: provider I/O, runtime-state migration, coordination,
   repository transfer, and UI integration belong in later focused modules.
+- `cloud_run/store.rs` owns workflow snapshots and creation-claim transactions.
+  Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
+  schema initialization, and compatibility checks. Keep database opening separate
+  from domain-specific record operations.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a


### PR DESCRIPTION
## Purpose

Extract the private SQLite opening and schema boundary before adding remote-workspace records for #383.

## Behavior impact

- Move connection options, private-path preparation, schema SQL, initialization, and compatibility checks into `cloud_run/store/database.rs`.
- Preserve every policy and SQL statement; the store's connection method delegates to a path-taking helper. Other moved bodies change only in parent-module visibility.
- Keep the public API, schema version, workflow/creation-claim behavior, paths, permissions, and all existing tests unchanged.
- Document the new module boundary. No provider calls, UI changes, dependencies, configuration changes, or release actions.

## Validation

- Mechanically compared moved bodies and schema against the base: unchanged, with only the connection receiver replaced by an explicit path parameter.
- Full local matrix passed: formatting, maintainability, version synchronization, default and speech workspace tests, blocking Clippy, strict panic-lint Clippy, and advisory pedantic Clippy.
- Repeated the full matrix on the final committed head before push.
- Local full-diff and independent static review completed; actionable in-scope findings were addressed before opening.
- UI/provider smoke is not applicable to this behavior-preserving extraction.

Related: #383. This is a prerequisite, not remote metadata persistence or completion of the MVP.
