### PR TITLE
feat(remote): persist session-owned workspace snapshots

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -8,7 +8,9 @@ pub mod local_docker;
 pub mod runpod;
 mod store;
 mod validation;
-pub use store::{CloudStoreError, CloudWorkflowStore, StoredWorkflow};
+pub use store::{
+    CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteWorkspace, StoredWorkflow,
+};
 pub const CLOUD_RUN_PROTOCOL_VERSION: u32 = 1;
 macro_rules! uuid_id {
     ($name:ident) => {

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -1,6 +1,9 @@
 //! Durable local control-plane storage for cloud workflow snapshots and creation claims.
 
 mod database;
+mod remote_workspaces;
+
+pub use remote_workspaces::{RemoteWorkspaceStoreError, StoredRemoteWorkspace};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -17,6 +20,7 @@ use crate::HorizonHome;
 use database::{ensure_current_schema, initialize_schema, prepare_private_store};
 
 const MAX_SNAPSHOT_BYTES: usize = 4 * 1024 * 1024;
+// Materialize one extra byte so an oversized stored blob is distinguishable from a valid maximum-sized snapshot.
 const MAX_MATERIALIZED_SNAPSHOT_BYTES: i64 = 4 * 1024 * 1024 + 1;
 const MAX_RECOVERED_WORKFLOWS: usize = 512;
 const MAX_RECOVERED_SNAPSHOT_BYTES: usize = 64 * 1024 * 1024;

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -11,7 +11,7 @@ use rusqlite::{Connection, OpenFlags, TransactionBehavior};
 
 use super::CloudStoreError;
 
-const STORE_SCHEMA_VERSION: i64 = 1;
+const STORE_SCHEMA_VERSION: i64 = 2;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS cloud_workflows (
@@ -38,6 +38,17 @@ CREATE INDEX IF NOT EXISTS cloud_worker_creation_claims_workflow
     ON cloud_worker_creation_claims(workflow_id, job_id, provider);
 ";
 
+const REMOTE_WORKSPACE_SCHEMA: &str = r"
+CREATE TABLE remote_workspaces (
+    workspace_local_id TEXT PRIMARY KEY NOT NULL,
+    session_id TEXT NOT NULL,
+    revision INTEGER NOT NULL CHECK (revision > 0),
+    snapshot BLOB NOT NULL
+) STRICT;
+CREATE INDEX remote_workspaces_session
+    ON remote_workspaces(session_id, workspace_local_id);
+";
+
 pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
     let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
         | OpenFlags::SQLITE_OPEN_CREATE
@@ -54,10 +65,17 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
     connection.pragma_update(None, "journal_mode", "WAL")?;
     let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
     let version = transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
-    if version != 0 && version != STORE_SCHEMA_VERSION {
+    if !(0..=STORE_SCHEMA_VERSION).contains(&version) {
         return Err(CloudStoreError::UnsupportedSchema(version));
     }
     transaction.execute_batch(SCHEMA)?;
+    if version < 2 {
+        transaction.execute_batch(REMOTE_WORKSPACE_SCHEMA)?;
+    }
+    drop(transaction.prepare(
+        "SELECT workspace_local_id, session_id, revision, snapshot
+         FROM remote_workspaces INDEXED BY remote_workspaces_session LIMIT 0",
+    )?);
     transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
     transaction.commit()?;
     Ok(())

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -1,0 +1,382 @@
+//! Session-owned remote records, independent of board saves and provider I/O.
+//! These record operations do not authorize lifecycle actions or retire cleanup intent.
+//! Operations are synchronous and must run off the render thread.
+
+mod validation;
+
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::{
+    CloudStoreError, CloudWorkflowStore, MAX_MATERIALIZED_SNAPSHOT_BYTES, MAX_RECOVERED_SNAPSHOT_BYTES,
+    MAX_SNAPSHOT_BYTES, database::ensure_current_schema,
+};
+use crate::remote_workspace::{RemoteWorkspaceError, RemoteWorkspaceState};
+use validation::{validate_key, validate_replacement, validate_session_id};
+
+const MAX_RECOVERED_WORKSPACES: usize = 512;
+const RECOVERY_QUERY: &str = "SELECT substr(workspace_local_id, 1, 129), substr(session_id, 1, 37), revision,
+                                   substr(snapshot, 1, ?3)
+    FROM remote_workspaces INDEXED BY remote_workspaces_session
+    WHERE session_id = ?1 ORDER BY workspace_local_id LIMIT ?2";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StoredRemoteWorkspace {
+    session_id: String,
+    state: RemoteWorkspaceState,
+    revision: u64,
+}
+
+impl StoredRemoteWorkspace {
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    #[must_use]
+    pub fn state(&self) -> &RemoteWorkspaceState {
+        &self.state
+    }
+
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+}
+
+impl CloudWorkflowStore {
+    /// Persist a validated remote aggregate with one immutable owning session.
+    /// A logical workspace identity cannot also belong to a copied session.
+    /// # Errors
+    /// Rejects invalid keys/snapshots, existing workspace identities, or storage failures.
+    pub fn create_remote_workspace(
+        &self,
+        session_id: &str,
+        state: &RemoteWorkspaceState,
+    ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
+        validate_key(session_id, &state.spec.workspace_local_id)?;
+        let snapshot = encode(session_id, state)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        ensure_current_schema(&transaction)?;
+        let exists: bool = transaction.query_row(
+            "SELECT EXISTS(SELECT 1 FROM remote_workspaces WHERE workspace_local_id = ?1)",
+            [&state.spec.workspace_local_id],
+            |row| row.get(0),
+        )?;
+        if exists {
+            return Err(RemoteWorkspaceStoreError::AlreadyExists);
+        }
+        ensure_session_budget(&transaction, session_id, &state.spec.workspace_local_id, snapshot.len())?;
+        transaction.execute(
+            "INSERT INTO remote_workspaces (workspace_local_id, session_id, revision, snapshot)
+             VALUES (?1, ?2, 1, ?3)",
+            params![state.spec.workspace_local_id, session_id, snapshot],
+        )?;
+        transaction.commit()?;
+        Ok(StoredRemoteWorkspace {
+            session_id: session_id.into(),
+            state: state.clone(),
+            revision: 1,
+        })
+    }
+
+    /// Load one record only for its owning session, revalidating all stored data.
+    /// # Errors
+    /// Fails closed on ownership mismatch, corruption, incompatible schema, or storage errors.
+    pub fn load_remote_workspace(
+        &self,
+        session_id: &str,
+        workspace_local_id: &str,
+    ) -> Result<Option<StoredRemoteWorkspace>, RemoteWorkspaceStoreError> {
+        validate_key(session_id, workspace_local_id)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        load_owned(&transaction, session_id, workspace_local_id)
+    }
+
+    /// Recover a bounded session-local set in stable workspace identity order.
+    /// No partial set is returned if any selected record is invalid or over budget.
+    /// # Errors
+    /// Rejects invalid sessions, corrupt/oversized records, excessive recovery sets, or storage errors.
+    pub fn list_remote_workspaces(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<StoredRemoteWorkspace>, RemoteWorkspaceStoreError> {
+        validate_session_id(session_id)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        let limit = i64::try_from(MAX_RECOVERED_WORKSPACES + 1)
+            .map_err(|_| RemoteWorkspaceStoreError::RecoveryLimitExceeded)?;
+        let mut statement = transaction.prepare(RECOVERY_QUERY)?;
+        let rows = statement.query_map(params![session_id, limit, MAX_MATERIALIZED_SNAPSHOT_BYTES], |row| {
+            Ok((row.get::<_, String>(0)?, WorkspaceRow::from_row(row, 1)?))
+        })?;
+        let mut states = Vec::new();
+        let mut snapshot_bytes = 0_usize;
+        for row in rows {
+            let (workspace_local_id, row) = row?;
+            snapshot_bytes = snapshot_bytes
+                .checked_add(row.snapshot.len())
+                .ok_or(RemoteWorkspaceStoreError::RecoveryLimitExceeded)?;
+            check_recovery_budget(states.len() + 1, snapshot_bytes)?;
+            states.push(decode(session_id, &workspace_local_id, row)?);
+        }
+        Ok(states)
+    }
+
+    /// Replace exactly the observed revision and snapshot, never another session's record.
+    /// The coordinator remains responsible for lifecycle legality and verified cleanup
+    /// before clearing a runtime. This operation does not allocate a workflow or worker.
+    /// # Errors
+    /// Rejects stale writers, identity/generation drift, checkpoint loss, invalid snapshots,
+    /// revision exhaustion, corruption, or storage failures.
+    pub fn replace_remote_workspace(
+        &self,
+        expected: &StoredRemoteWorkspace,
+        next: &RemoteWorkspaceState,
+    ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
+        validate_key(&expected.session_id, &expected.state.spec.workspace_local_id)?;
+        validate_replacement(&expected.state, next)?;
+        let snapshot = encode(&expected.session_id, next)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        ensure_current_schema(&transaction)?;
+        let current = load_owned(
+            &transaction,
+            &expected.session_id,
+            &expected.state.spec.workspace_local_id,
+        )?
+        .ok_or(RemoteWorkspaceStoreError::Missing)?;
+        if current.revision != expected.revision {
+            return Err(RemoteWorkspaceStoreError::RevisionConflict {
+                expected: expected.revision,
+                actual: current.revision,
+            });
+        }
+        if current != *expected {
+            return Err(RemoteWorkspaceStoreError::SnapshotConflict);
+        }
+        ensure_session_budget(
+            &transaction,
+            &expected.session_id,
+            &expected.state.spec.workspace_local_id,
+            snapshot.len(),
+        )?;
+        let revision = expected
+            .revision
+            .checked_add(1)
+            .and_then(|revision| i64::try_from(revision).ok())
+            .ok_or(RemoteWorkspaceStoreError::RevisionExhausted)?;
+        let changed = transaction.execute(
+            "UPDATE remote_workspaces SET revision = ?2, snapshot = ?3
+             WHERE workspace_local_id = ?1 AND session_id = ?4",
+            params![
+                expected.state.spec.workspace_local_id,
+                revision,
+                snapshot,
+                expected.session_id
+            ],
+        )?;
+        if changed != 1 {
+            return Err(RemoteWorkspaceStoreError::SnapshotConflict);
+        }
+        transaction.commit()?;
+        Ok(StoredRemoteWorkspace {
+            session_id: expected.session_id.clone(),
+            state: next.clone(),
+            revision: expected.revision + 1,
+        })
+    }
+}
+
+struct WorkspaceRow {
+    session_id: String,
+    revision: i64,
+    snapshot: Vec<u8>,
+}
+
+fn ensure_session_budget(
+    connection: &Connection,
+    session_id: &str,
+    replaced_id: &str,
+    next_bytes: usize,
+) -> Result<(), RemoteWorkspaceStoreError> {
+    let limit =
+        i64::try_from(MAX_RECOVERED_WORKSPACES + 1).map_err(|_| RemoteWorkspaceStoreError::RecoveryLimitExceeded)?;
+    let mut statement = connection.prepare(
+        "SELECT length(snapshot) FROM remote_workspaces INDEXED BY remote_workspaces_session
+         WHERE session_id = ?1 AND workspace_local_id != ?2 LIMIT ?3",
+    )?;
+    let sizes = statement.query_map(params![session_id, replaced_id, limit], |row| row.get::<_, i64>(0))?;
+    let mut count = 1;
+    let mut bytes = next_bytes;
+    check_recovery_budget(count, bytes)?;
+    for size in sizes {
+        let size = usize::try_from(size?).map_err(|_| RemoteWorkspaceStoreError::RecoveryLimitExceeded)?;
+        bytes = bytes
+            .checked_add(size)
+            .ok_or(RemoteWorkspaceStoreError::RecoveryLimitExceeded)?;
+        count += 1;
+        check_recovery_budget(count, bytes)?;
+    }
+    Ok(())
+}
+
+impl WorkspaceRow {
+    fn from_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Self> {
+        Ok(Self {
+            session_id: row.get(offset)?,
+            revision: row.get(offset + 1)?,
+            snapshot: row.get(offset + 2)?,
+        })
+    }
+}
+
+fn load_owned(
+    connection: &Connection,
+    session_id: &str,
+    workspace_local_id: &str,
+) -> Result<Option<StoredRemoteWorkspace>, RemoteWorkspaceStoreError> {
+    connection
+        .query_row(
+            "SELECT substr(session_id, 1, 37), revision, substr(snapshot, 1, ?2)
+             FROM remote_workspaces WHERE workspace_local_id = ?1",
+            params![workspace_local_id, MAX_MATERIALIZED_SNAPSHOT_BYTES],
+            |row| WorkspaceRow::from_row(row, 0),
+        )
+        .optional()?
+        .map(|row| decode(session_id, workspace_local_id, row))
+        .transpose()
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct WorkspaceSnapshot<T> {
+    session_id: String,
+    state: T,
+}
+
+fn encode(session_id: &str, state: &RemoteWorkspaceState) -> Result<Vec<u8>, RemoteWorkspaceStoreError> {
+    state.validate()?;
+    let mut buffer = SnapshotBuffer::default();
+    serde_json::to_writer(
+        &mut buffer,
+        &WorkspaceSnapshot {
+            session_id: session_id.into(),
+            state,
+        },
+    )
+    .map_err(|_| {
+        if buffer.too_large {
+            RemoteWorkspaceStoreError::SnapshotTooLarge
+        } else {
+            RemoteWorkspaceStoreError::InvalidStoredSnapshot
+        }
+    })?;
+    Ok(buffer.bytes)
+}
+
+#[derive(Default)]
+struct SnapshotBuffer {
+    bytes: Vec<u8>,
+    too_large: bool,
+}
+
+impl std::io::Write for SnapshotBuffer {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if bytes.len() > MAX_SNAPSHOT_BYTES - self.bytes.len() {
+            self.too_large = true;
+            return Err(std::io::Error::other("remote snapshot size limit"));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn decode(
+    session_id: &str,
+    workspace_local_id: &str,
+    row: WorkspaceRow,
+) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
+    if row.session_id != session_id {
+        return Err(RemoteWorkspaceStoreError::OwnershipMismatch);
+    }
+    ensure_snapshot_size(row.snapshot.len())?;
+    // The aggregate's deserializer validates its schema, identities, and all domain invariants.
+    let snapshot: WorkspaceSnapshot<RemoteWorkspaceState> =
+        serde_json::from_slice(&row.snapshot).map_err(|_| RemoteWorkspaceStoreError::InvalidStoredSnapshot)?;
+    let revision = u64::try_from(row.revision)
+        .ok()
+        .filter(|revision| *revision > 0)
+        .ok_or(RemoteWorkspaceStoreError::InvalidStoredSnapshot)?;
+    if snapshot.session_id != session_id || snapshot.state.spec.workspace_local_id != workspace_local_id {
+        return Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot);
+    }
+    Ok(StoredRemoteWorkspace {
+        session_id: row.session_id,
+        state: snapshot.state,
+        revision,
+    })
+}
+
+fn ensure_snapshot_size(size: usize) -> Result<(), RemoteWorkspaceStoreError> {
+    if size > MAX_SNAPSHOT_BYTES {
+        return Err(RemoteWorkspaceStoreError::SnapshotTooLarge);
+    }
+    Ok(())
+}
+
+fn check_recovery_budget(count: usize, bytes: usize) -> Result<(), RemoteWorkspaceStoreError> {
+    if count > MAX_RECOVERED_WORKSPACES || bytes > MAX_RECOVERED_SNAPSHOT_BYTES {
+        return Err(RemoteWorkspaceStoreError::RecoveryLimitExceeded);
+    }
+    Ok(())
+}
+
+/// Errors omit snapshot content, command arguments, task handoffs, and remote endpoint values.
+#[derive(Debug, Error)]
+pub enum RemoteWorkspaceStoreError {
+    #[error(transparent)]
+    Workspace(#[from] RemoteWorkspaceError),
+    #[error(transparent)]
+    Storage(#[from] CloudStoreError),
+    #[error("remote workspace database operation failed: {0}")]
+    Database(#[from] rusqlite::Error),
+    #[error("remote workspace owner must be a canonical session UUID")]
+    InvalidSessionId,
+    #[error("invalid remote workspace identity")]
+    InvalidWorkspaceId,
+    #[error("remote workspace identity already exists")]
+    AlreadyExists,
+    #[error("remote workspace record is missing")]
+    Missing,
+    #[error("remote workspace belongs to a different session")]
+    OwnershipMismatch,
+    #[error("remote workspace revision changed from expected {expected} to {actual}")]
+    RevisionConflict { expected: u64, actual: u64 },
+    #[error("remote workspace snapshot does not match its revision")]
+    SnapshotConflict,
+    #[error("remote workspace exhausted its revision range")]
+    RevisionExhausted,
+    #[error("stored remote workspace snapshot is invalid")]
+    InvalidStoredSnapshot,
+    #[error("remote workspace snapshot exceeds the storage size limit")]
+    SnapshotTooLarge,
+    #[error("remote workspace recovery exceeds the bounded storage budget")]
+    RecoveryLimitExceeded,
+    #[error("replacement changes remote workspace or active runtime identity")]
+    ReplacementIdentityMismatch,
+    #[error("replacement loses or rewinds a remote generation, cleanup intent, or repository checkpoint")]
+    NonMonotonicReplacement,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+#[test]
+fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims() {
+    let (_directory, store) = store();
+    let workflow = super::super::super::tests::retained_workflow(CloudProvider::RunPod, 1000);
+    let saved = store.create(&workflow).expect("save legacy workflow");
+    let target = workflow.nodes[0].worker.as_ref().expect("worker target");
+    store
+        .claim_worker_creation(workflow.id, workflow.nodes[0].id, target, "legacy-worker")
+        .expect("legacy creation fence");
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .execute_batch("DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
+        .expect("restore schema-one fixture");
+    let workflow_bytes: Vec<u8> = connection
+        .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
+        .expect("legacy snapshot bytes");
+    let claim: (String, String, String, String, i64) = connection
+        .query_row(
+            "SELECT provider, workflow_id, job_id, resource_name, claimed_at_millis FROM cloud_worker_creation_claims",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        )
+        .expect("legacy claim");
+    drop(connection);
+
+    let upgraded = CloudWorkflowStore::open_path(store.path()).expect("upgrade schema one");
+    assert_eq!(upgraded.load(workflow.id).expect("load legacy workflow"), Some(saved));
+    assert!(
+        !upgraded
+            .claim_worker_creation(workflow.id, workflow.nodes[0].id, target, "legacy-worker")
+            .expect("fence remains claimed")
+    );
+    assert!(
+        upgraded
+            .list_remote_workspaces(OWNER)
+            .expect("empty remote records")
+            .is_empty()
+    );
+    let connection = Connection::open(upgraded.path()).expect("raw upgraded store");
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .expect("schema version");
+    assert_eq!(version, 2);
+    let after: Vec<u8> = connection
+        .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
+        .expect("unchanged legacy bytes");
+    assert_eq!(workflow_bytes, after);
+    let after_claim: (String, String, String, String, i64) = connection
+        .query_row(
+            "SELECT provider, workflow_id, job_id, resource_name, claimed_at_millis FROM cloud_worker_creation_claims",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        )
+        .expect("unchanged legacy claim");
+    assert_eq!(claim, after_claim);
+    upgraded
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("new remote snapshot");
+    assert_eq!(
+        CloudWorkflowStore::open_path(upgraded.path())
+            .expect("repeat open")
+            .list_remote_workspaces(OWNER)
+            .expect("retained remote record")
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn partial_migration_fails_without_adopting_or_destroying_existing_remote_data() {
+    let (_directory, store) = store();
+    let state = workspace("workspace");
+    store.create_remote_workspace(OWNER, &state).expect("create");
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .pragma_update(None, "user_version", 1)
+        .expect("partial migration fixture");
+    assert!(CloudWorkflowStore::open_path(store.path()).is_err());
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .expect("version unchanged");
+    assert_eq!(version, 1);
+    let bytes: Vec<u8> = connection
+        .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
+        .expect("snapshot retained");
+    assert_eq!(
+        serde_json::from_slice::<WorkspaceSnapshot<RemoteWorkspaceState>>(&bytes)
+            .expect("valid record")
+            .state,
+        state
+    );
+}
+
+#[test]
+fn current_schema_with_missing_remote_table_or_index_fails_at_open() {
+    for sql in ["DROP TABLE remote_workspaces", "DROP INDEX remote_workspaces_session"] {
+        let (_directory, store) = store();
+        let connection = Connection::open(store.path()).expect("raw store");
+        connection.execute_batch(sql).expect("incomplete schema fixture");
+        assert!(CloudWorkflowStore::open_path(store.path()).is_err());
+        let version: i64 = connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("schema unchanged");
+        assert_eq!(version, 2);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
@@ -1,0 +1,89 @@
+use super::*;
+use crate::PanelKind;
+use crate::cloud_run::{
+    ArtifactDigest, CloudJobId, CloudProvider, CloudWorkflowId, GitCommitSha, GitSource, WorkerTarget,
+};
+use crate::remote_workspace::{
+    RemoteCleanupIntent, RemoteCleanupReason, RemotePanelBinding, RemoteRuntimeGeneration, RemoteRuntimePhase,
+    RemoteWorkspaceSpec, RepositoryCheckpoint,
+};
+use std::sync::{Arc, Barrier};
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+const OTHER_OWNER: &str = "22222222-2222-4222-8222-222222222222";
+
+fn workspace(id: &str) -> RemoteWorkspaceState {
+    RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: id.into(),
+        target: WorkerTarget {
+            provider: CloudProvider::LocalDocker,
+            profile: "local-development".into(),
+            image: format!("registry.example/worker@sha256:{}", "a".repeat(64)),
+            disk_gib: 20,
+            lease_seconds: 900,
+            max_hourly_cost_micros: None,
+        },
+        repository: GitSource {
+            repository: "owner/project".into(),
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        working_directory: "crates/core".into(),
+        generation: 0,
+        panels: vec![RemotePanelBinding {
+            panel_local_id: "panel-one".into(),
+            kind: PanelKind::Pi,
+            command: None,
+            working_directory: Some("crates/core/tests".into()),
+            task_handoff: Some("Continue the saved task\nwithout losing its tail marker".into()),
+            agent_session_id: Some("saved-session".into()),
+        }],
+    })
+    .expect("valid workspace")
+}
+
+fn store() -> (tempfile::TempDir, CloudWorkflowStore) {
+    let directory = tempfile::tempdir().expect("private test directory");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control-plane/workflows.sqlite3"))
+        .expect("open test store");
+    (directory, store)
+}
+
+fn provisioning(mut state: RemoteWorkspaceState) -> RemoteWorkspaceState {
+    state.spec.generation += 1;
+    state.runtime = Some(RemoteRuntimeGeneration {
+        workspace_local_id: state.spec.workspace_local_id.clone(),
+        generation: state.spec.generation,
+        workflow_id: CloudWorkflowId::new(),
+        job_id: CloudJobId::new(),
+        phase: RemoteRuntimePhase::Provisioning,
+        worker: None,
+        ssh: None,
+        cleanup: None,
+    });
+    state
+}
+
+mod migration;
+mod ownership;
+mod recovery;
+
+fn seed_workspaces(store: &CloudWorkflowStore, sizes: impl IntoIterator<Item = Option<usize>>) {
+    let mut connection = Connection::open(store.path()).expect("raw store");
+    let transaction = connection.transaction().expect("fixture transaction");
+    for (index, size) in sizes.into_iter().enumerate() {
+        let state = workspace(&format!("workspace-{index:04}"));
+        let mut snapshot = encode(OWNER, &state).expect("encode fixture");
+        if let Some(size) = size {
+            assert!(size >= snapshot.len());
+            snapshot.resize(size, b' ');
+        }
+        transaction
+            .execute(
+                "INSERT INTO remote_workspaces VALUES (?1, ?2, 1, ?3)",
+                params![state.spec.workspace_local_id, OWNER, snapshot],
+            )
+            .expect("insert fixture");
+    }
+    transaction.commit().expect("commit fixture");
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -1,0 +1,211 @@
+use super::*;
+
+#[test]
+fn records_survive_reopen_and_cannot_be_read_or_adopted_by_another_session() {
+    let (_directory, store) = store();
+    let state = workspace("workspace-one");
+    let stored = store.create_remote_workspace(OWNER, &state).expect("create");
+    assert_eq!(stored.state(), &state);
+    assert_eq!(stored.session_id(), OWNER);
+    assert_eq!(stored.revision(), 1);
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_workspace(OWNER, "workspace-one").expect("load"),
+        Some(stored.clone())
+    );
+    assert_eq!(reopened.list_remote_workspaces(OWNER).expect("list"), vec![stored]);
+    assert!(
+        reopened
+            .list_remote_workspaces(OTHER_OWNER)
+            .expect("other session")
+            .is_empty()
+    );
+    assert!(matches!(
+        reopened.load_remote_workspace(OTHER_OWNER, "workspace-one"),
+        Err(RemoteWorkspaceStoreError::OwnershipMismatch)
+    ));
+    assert!(matches!(
+        reopened.create_remote_workspace(OTHER_OWNER, &state),
+        Err(RemoteWorkspaceStoreError::AlreadyExists)
+    ));
+    assert!(
+        reopened
+            .load_remote_workspace(OWNER, "missing")
+            .expect("missing")
+            .is_none()
+    );
+}
+
+#[test]
+fn concurrent_writers_have_exactly_one_winner_and_preserve_the_winning_intent() {
+    let (_directory, store) = store();
+    let stored = store
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("create");
+    let barrier = Arc::new(Barrier::new(3));
+    let writers: Vec<_> = (0..2)
+        .map(|_| {
+            let store = store.clone();
+            let expected = stored.clone();
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                let next = provisioning(expected.state().clone());
+                barrier.wait();
+                store.replace_remote_workspace(&expected, &next)
+            })
+        })
+        .collect();
+    barrier.wait();
+    let results: Vec<_> = writers
+        .into_iter()
+        .map(|writer| writer.join().expect("writer"))
+        .collect();
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(
+                result,
+                Err(RemoteWorkspaceStoreError::RevisionConflict { expected: 1, actual: 2 })
+            ))
+            .count(),
+        1
+    );
+    let winner = results.into_iter().find_map(Result::ok).expect("winner");
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("load winner"),
+        Some(winner)
+    );
+}
+
+#[test]
+fn replacements_preserve_identity_runtime_and_checkpoint_watermarks() {
+    let (_directory, store) = store();
+    let mut state = provisioning(workspace("workspace"));
+    state.checkpoint = Some(RepositoryCheckpoint {
+        workspace_local_id: "workspace".into(),
+        base_commit: state.spec.repository.commit.clone(),
+        manifest_digest: ArtifactDigest::parse_sha256("c".repeat(64)).expect("digest"),
+        runtime_generation: 1,
+        generation: 4,
+        captured_at_millis: 1000,
+        recovery_artifact: Some(ArtifactDigest::parse_sha256("d".repeat(64)).expect("artifact")),
+    });
+    let stored = store
+        .create_remote_workspace(OWNER, &state)
+        .expect("create active snapshot");
+    let mut changed = state.clone();
+    changed.runtime.as_mut().expect("runtime").workflow_id = CloudWorkflowId::new();
+    assert!(matches!(
+        store.replace_remote_workspace(&stored, &changed),
+        Err(RemoteWorkspaceStoreError::ReplacementIdentityMismatch)
+    ));
+    changed = state.clone();
+    changed.checkpoint = None;
+    assert!(matches!(
+        store.replace_remote_workspace(&stored, &changed),
+        Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+    ));
+    changed = state.clone();
+    changed.checkpoint.as_mut().expect("checkpoint").manifest_digest =
+        ArtifactDigest::parse_sha256("e".repeat(64)).expect("digest");
+    assert!(matches!(
+        store.replace_remote_workspace(&stored, &changed),
+        Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+    ));
+    changed = state;
+    let runtime = changed.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Cancelling;
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 2000,
+    });
+    let cancelling = store
+        .replace_remote_workspace(&stored, &changed)
+        .expect("persist cleanup intent");
+    let mut lost_cleanup = changed.clone();
+    let runtime = lost_cleanup.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Provisioning;
+    runtime.cleanup = None;
+    assert!(matches!(
+        store.replace_remote_workspace(&cancelling, &lost_cleanup),
+        Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+    ));
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened
+            .load_remote_workspace(OWNER, "workspace")
+            .expect("load cleanup"),
+        Some(cancelling.clone())
+    );
+    changed.runtime = None;
+    let dormant = store
+        .replace_remote_workspace(&cancelling, &changed)
+        .expect("record already verified disposal");
+    assert_eq!(dormant.state().checkpoint, cancelling.state().checkpoint);
+    let mut reused = provisioning(changed.clone());
+    reused.spec.generation = changed.spec.generation;
+    reused.runtime.as_mut().expect("runtime").generation = changed.spec.generation;
+    assert!(matches!(
+        store.replace_remote_workspace(&dormant, &reused),
+        Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+    ));
+    store
+        .replace_remote_workspace(&dormant, &provisioning(changed))
+        .expect("next generation");
+}
+
+#[test]
+fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconciliation() {
+    use crate::cloud_run::interactive_worker::{
+        InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerSshEndpoint,
+    };
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    let (_directory, store) = store();
+    let mut state = provisioning(workspace("workspace"));
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([7; 32]);
+    let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
+    let runtime = state.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Ready;
+    runtime.worker = Some(InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: state.spec.target.provider,
+            workflow_id: runtime.workflow_id,
+            job_id: runtime.job_id,
+            resource_id: "synthetic-exact-worker".into(),
+        },
+        target: state.spec.target.clone(),
+        ssh_public_key: key.clone(),
+        lease: InteractiveWorkerLease {
+            terminate_after: "2020-01-01T00:00:00Z".into(),
+        },
+    });
+    runtime.ssh = Some(InteractiveWorkerSshEndpoint {
+        host: "127.0.0.1".into(),
+        port: 2222,
+        username: "developer".into(),
+        host_key: key,
+    });
+    let stored = store
+        .create_remote_workspace(OWNER, &state)
+        .expect("store expired handle");
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_workspace(OWNER, "workspace").expect("load"),
+        Some(stored.clone())
+    );
+    state
+        .runtime
+        .as_mut()
+        .expect("runtime")
+        .worker
+        .as_mut()
+        .expect("worker")
+        .identity
+        .resource_id = "another-worker".into();
+    assert!(matches!(
+        reopened.replace_remote_workspace(&stored, &state),
+        Err(RemoteWorkspaceStoreError::ReplacementIdentityMismatch)
+    ));
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -196,17 +196,12 @@ fn pending_cleanup_preserves_its_exact_reason_and_request_time() {
     );
 }
 
-#[test]
-fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconciliation() {
+fn expired_runtime() -> RemoteWorkspaceState {
     use crate::cloud_run::interactive_worker::{
         InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerSshEndpoint,
     };
-    use base64::{Engine as _, engine::general_purpose::STANDARD};
-    let (_directory, store) = store();
     let mut state = provisioning(workspace("workspace"));
-    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
-    blob.extend([7; 32]);
-    let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
+    let key = public_key(7);
     let runtime = state.runtime.as_mut().expect("runtime");
     runtime.phase = RemoteRuntimePhase::Ready;
     runtime.worker = Some(InteractiveWorker {
@@ -217,7 +212,7 @@ fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconcil
             resource_id: "synthetic-exact-worker".into(),
         },
         target: state.spec.target.clone(),
-        ssh_public_key: key.clone(),
+        ssh_public_key: public_key(6),
         lease: InteractiveWorkerLease {
             terminate_after: "2020-01-01T00:00:00Z".into(),
         },
@@ -228,6 +223,20 @@ fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconcil
         username: "developer".into(),
         host_key: key,
     });
+    state
+}
+
+fn public_key(byte: u8) -> String {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
+#[test]
+fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconciliation() {
+    let (_directory, store) = store();
+    let mut state = expired_runtime();
     let stored = store
         .create_remote_workspace(OWNER, &state)
         .expect("store expired handle");
@@ -249,4 +258,60 @@ fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconcil
         reopened.replace_remote_workspace(&stored, &state),
         Err(RemoteWorkspaceStoreError::ReplacementIdentityMismatch)
     ));
+}
+
+#[test]
+fn first_endpoint_can_be_pinned_but_never_replaced_within_the_same_runtime() {
+    use crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint;
+    let (_directory, store) = store();
+    let state = expired_runtime();
+    let endpoint = state.runtime.as_ref().expect("runtime").ssh.as_ref().expect("endpoint");
+    let mut unpinned = state.clone();
+    let runtime = unpinned.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Reconciling;
+    runtime.ssh = None;
+    let pending = store
+        .create_remote_workspace(OWNER, &unpinned)
+        .expect("no endpoint yet");
+    let pinned = store
+        .replace_remote_workspace(&pending, &state)
+        .expect("pin the first trusted endpoint");
+    for changed_endpoint in [
+        None,
+        Some(InteractiveWorkerSshEndpoint {
+            host: "192.0.2.44".into(),
+            ..endpoint.clone()
+        }),
+        Some(InteractiveWorkerSshEndpoint {
+            port: 2223,
+            ..endpoint.clone()
+        }),
+        Some(InteractiveWorkerSshEndpoint {
+            username: "another-user".into(),
+            ..endpoint.clone()
+        }),
+        Some(InteractiveWorkerSshEndpoint {
+            host_key: public_key(8),
+            ..endpoint.clone()
+        }),
+    ] {
+        let mut changed = state.clone();
+        let runtime = changed.runtime.as_mut().expect("runtime");
+        runtime.phase = RemoteRuntimePhase::Reconciling;
+        runtime.ssh = changed_endpoint;
+        changed.validate().expect("domain-valid observation");
+        assert!(matches!(
+            store.replace_remote_workspace(&pinned, &changed),
+            Err(RemoteWorkspaceStoreError::ReplacementIdentityMismatch)
+        ));
+    }
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_workspace(OWNER, "workspace").expect("load pin"),
+        Some(pinned.clone())
+    );
+    unpinned.runtime.as_mut().expect("runtime").ssh = Some(endpoint.clone());
+    reopened
+        .replace_remote_workspace(&pinned, &unpinned)
+        .expect("reconciliation retains the same endpoint");
 }

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -156,6 +156,47 @@ fn replacements_preserve_identity_runtime_and_checkpoint_watermarks() {
 }
 
 #[test]
+fn pending_cleanup_preserves_its_exact_reason_and_request_time() {
+    let (_directory, store) = store();
+    let mut state = provisioning(workspace("workspace"));
+    let runtime = state.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Cancelling;
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 2000,
+    });
+    let stored = store.create_remote_workspace(OWNER, &state).expect("pending cleanup");
+    for (reason, requested_at_millis) in [
+        (RemoteCleanupReason::LastPanelClosed, 2000),
+        (RemoteCleanupReason::Cancelled, 1999),
+        (RemoteCleanupReason::Cancelled, 2001),
+    ] {
+        let mut changed = state.clone();
+        changed.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+            reason,
+            requested_at_millis,
+        });
+        assert!(matches!(
+            store.replace_remote_workspace(&stored, &changed),
+            Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+        ));
+    }
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_workspace(OWNER, "workspace").expect("load intent"),
+        Some(stored.clone())
+    );
+    state.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Failed;
+    let failed = reopened
+        .replace_remote_workspace(&stored, &state)
+        .expect("phase update retains the same cleanup intent");
+    assert_eq!(
+        failed.state().runtime.as_ref().expect("runtime").cleanup,
+        stored.state().runtime.as_ref().expect("runtime").cleanup
+    );
+}
+
+#[test]
 fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconciliation() {
     use crate::cloud_run::interactive_worker::{
         InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerSshEndpoint,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
@@ -1,0 +1,351 @@
+use super::*;
+
+#[test]
+fn corrupt_snapshot_metadata_and_exhausted_revisions_fail_closed_without_echoing_payloads() {
+    let (_directory, store) = store();
+    let state = workspace("workspace");
+    let stored = store.create_remote_workspace(OWNER, &state).expect("create");
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET snapshot = ?1",
+            [b"{\"sensitive-task-payload\":true}".as_slice()],
+        )
+        .expect("corrupt snapshot");
+    let error = store
+        .load_remote_workspace(OWNER, "workspace")
+        .expect_err("reject corrupt");
+    assert!(matches!(error, RemoteWorkspaceStoreError::InvalidStoredSnapshot));
+    assert!(!error.to_string().contains("sensitive-task-payload"));
+    assert!(store.list_remote_workspaces(OWNER).is_err());
+    assert!(store.replace_remote_workspace(&stored, &state).is_err());
+    let altered = workspace("another-workspace");
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET snapshot = ?1",
+            [encode(OWNER, &altered).expect("encode")],
+        )
+        .expect("identity drift");
+    assert!(matches!(
+        store.load_remote_workspace(OWNER, "workspace"),
+        Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot)
+    ));
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET revision = ?1, snapshot = ?2",
+            params![i64::MAX, encode(OWNER, &state).expect("encode")],
+        )
+        .expect("exhaust revision");
+    let exhausted = store
+        .load_remote_workspace(OWNER, "workspace")
+        .expect("load")
+        .expect("record");
+    assert!(matches!(
+        store.replace_remote_workspace(&exhausted, &state),
+        Err(RemoteWorkspaceStoreError::RevisionExhausted)
+    ));
+    connection
+        .execute("UPDATE remote_workspaces SET revision = 1", [])
+        .expect("reset revision");
+    let mut same_revision_change = state.clone();
+    same_revision_change.spec.working_directory = ".".into();
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET snapshot = ?1",
+            [encode(OWNER, &same_revision_change).expect("encode")],
+        )
+        .expect("unrevisioned write");
+    assert!(matches!(
+        store.replace_remote_workspace(&stored, &state),
+        Err(RemoteWorkspaceStoreError::SnapshotConflict)
+    ));
+}
+
+#[test]
+fn recovery_and_snapshot_materialization_are_bounded() {
+    let (_directory, store) = store();
+    store
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("create");
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET snapshot = zeroblob(?1)",
+            [MAX_MATERIALIZED_SNAPSHOT_BYTES],
+        )
+        .expect("oversize");
+    assert!(matches!(
+        store.load_remote_workspace(OWNER, "workspace"),
+        Err(RemoteWorkspaceStoreError::SnapshotTooLarge)
+    ));
+    assert!(matches!(
+        store.list_remote_workspaces(OWNER),
+        Err(RemoteWorkspaceStoreError::SnapshotTooLarge)
+    ));
+    assert!(check_recovery_budget(MAX_RECOVERED_WORKSPACES + 1, 0).is_err());
+    assert!(check_recovery_budget(1, MAX_RECOVERED_SNAPSHOT_BYTES + 1).is_err());
+    let detail: String = connection
+        .query_row(
+            &format!("EXPLAIN QUERY PLAN {RECOVERY_QUERY}"),
+            params![OWNER, 513, MAX_MATERIALIZED_SNAPSHOT_BYTES],
+            |row| row.get(3),
+        )
+        .expect("query plan");
+    assert!(detail.contains("USING INDEX remote_workspaces_session"));
+}
+
+#[test]
+fn invalid_keys_snapshots_and_future_schema_never_replace_saved_records() {
+    let (_directory, store) = store();
+    let state = workspace("workspace");
+    for invalid in [
+        "../escape",
+        "",
+        "00000000-0000-0000-0000-000000000000",
+        "11111111111141118111111111111111",
+    ] {
+        assert!(matches!(
+            store.create_remote_workspace(invalid, &state),
+            Err(RemoteWorkspaceStoreError::InvalidSessionId)
+        ));
+    }
+    let stored = store.create_remote_workspace(OWNER, &state).expect("create");
+    assert!(matches!(
+        store.load_remote_workspace(OWNER, "workspace/escape"),
+        Err(RemoteWorkspaceStoreError::InvalidWorkspaceId)
+    ));
+    let mut invalid = state.clone();
+    invalid.version += 1;
+    assert!(matches!(
+        store.replace_remote_workspace(&stored, &invalid),
+        Err(RemoteWorkspaceStoreError::Workspace(_))
+    ));
+    let connection = Connection::open(store.path()).expect("raw store");
+    let before: Vec<u8> = connection
+        .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
+        .expect("before");
+    connection
+        .pragma_update(None, "user_version", 3)
+        .expect("future schema");
+    assert!(
+        store
+            .create_remote_workspace(OWNER, &workspace("new-workspace"))
+            .is_err()
+    );
+    assert!(store.load_remote_workspace(OWNER, "workspace").is_err());
+    assert!(store.list_remote_workspaces(OWNER).is_err());
+    assert!(store.replace_remote_workspace(&stored, &state).is_err());
+    assert!(CloudWorkflowStore::open_path(store.path()).is_err());
+    let after: Vec<u8> = connection
+        .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
+        .expect("after");
+    assert_eq!(before, after);
+}
+
+#[test]
+fn indexed_owner_corruption_cannot_redirect_a_valid_snapshot() {
+    let (_directory, store) = store();
+    store
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("create");
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .execute("UPDATE remote_workspaces SET session_id = ?1", [OTHER_OWNER])
+        .expect("corrupt owner index");
+    assert!(matches!(
+        store.load_remote_workspace(OWNER, "workspace"),
+        Err(RemoteWorkspaceStoreError::OwnershipMismatch)
+    ));
+    assert!(matches!(
+        store.load_remote_workspace(OTHER_OWNER, "workspace"),
+        Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot)
+    ));
+    assert!(matches!(
+        store.list_remote_workspaces(OTHER_OWNER),
+        Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot)
+    ));
+}
+
+#[test]
+fn oversize_writes_and_excessive_recovery_sets_are_rejected_without_partial_results() {
+    let (_directory, store) = store();
+    let mut huge = workspace("huge");
+    let panel = huge.spec.panels[0].clone();
+    huge.spec.panels = (0..65)
+        .map(|index| {
+            let mut panel = panel.clone();
+            panel.panel_local_id = format!("panel-{index}");
+            panel.task_handoff = Some("x".repeat(64 * 1024));
+            panel
+        })
+        .collect();
+    assert!(matches!(
+        store.create_remote_workspace(OWNER, &huge),
+        Err(RemoteWorkspaceStoreError::SnapshotTooLarge)
+    ));
+    assert!(
+        store
+            .list_remote_workspaces(OWNER)
+            .expect("no partial write")
+            .is_empty()
+    );
+    seed_workspaces(&store, std::iter::repeat_n(None, MAX_RECOVERED_WORKSPACES));
+    let overflow = workspace("overflow");
+    assert!(matches!(
+        store.create_remote_workspace(OWNER, &overflow),
+        Err(RemoteWorkspaceStoreError::RecoveryLimitExceeded)
+    ));
+    assert_eq!(
+        store.list_remote_workspaces(OWNER).expect("still recoverable").len(),
+        MAX_RECOVERED_WORKSPACES
+    );
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .execute(
+            "INSERT INTO remote_workspaces VALUES (?1, ?2, 1, ?3)",
+            params![
+                overflow.spec.workspace_local_id,
+                OWNER,
+                encode(OWNER, &overflow).expect("encode")
+            ],
+        )
+        .expect("corrupt recovery count");
+    assert!(matches!(
+        store.list_remote_workspaces(OWNER),
+        Err(RemoteWorkspaceStoreError::RecoveryLimitExceeded)
+    ));
+    assert!(
+        store
+            .list_remote_workspaces(OTHER_OWNER)
+            .expect("independent empty session")
+            .is_empty()
+    );
+}
+
+#[test]
+fn concurrent_creates_cannot_overfill_the_last_recoverable_slot() {
+    let (_directory, store) = store();
+    seed_workspaces(&store, std::iter::repeat_n(None, MAX_RECOVERED_WORKSPACES - 1));
+    let barrier = Arc::new(Barrier::new(3));
+    let writers: Vec<_> = (0..2)
+        .map(|index| {
+            let store = store.clone();
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.create_remote_workspace(OWNER, &workspace(&format!("new-{index}")))
+            })
+        })
+        .collect();
+    barrier.wait();
+    let results: Vec<_> = writers
+        .into_iter()
+        .map(|writer| writer.join().expect("writer"))
+        .collect();
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Err(RemoteWorkspaceStoreError::RecoveryLimitExceeded)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        store.list_remote_workspaces(OWNER).expect("recoverable").len(),
+        MAX_RECOVERED_WORKSPACES
+    );
+}
+
+#[test]
+fn create_and_replace_enforce_the_serialized_session_byte_budget() {
+    let (_directory, store) = store();
+    seed_workspaces(
+        &store,
+        std::iter::repeat_n(Some(MAX_SNAPSHOT_BYTES), 15).chain([Some(MAX_SNAPSHOT_BYTES / 2); 2]),
+    );
+    assert!(matches!(
+        store.create_remote_workspace(OWNER, &workspace("overflow")),
+        Err(RemoteWorkspaceStoreError::RecoveryLimitExceeded)
+    ));
+    assert_eq!(
+        store
+            .list_remote_workspaces(OWNER)
+            .expect("exact byte budget recoverable")
+            .len(),
+        17
+    );
+    let expected = store
+        .load_remote_workspace(OWNER, "workspace-0016")
+        .expect("load")
+        .expect("record");
+    let mut grown = expected.state().clone();
+    let panel = grown.spec.panels[0].clone();
+    grown.spec.panels = (0..48)
+        .map(|index| {
+            let mut panel = panel.clone();
+            panel.panel_local_id = format!("panel-{index}");
+            panel.agent_session_id = None;
+            panel.task_handoff = Some("x".repeat(64 * 1024));
+            panel
+        })
+        .collect();
+    assert!(matches!(
+        store.replace_remote_workspace(&expected, &grown),
+        Err(RemoteWorkspaceStoreError::RecoveryLimitExceeded)
+    ));
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace-0016").expect("unchanged"),
+        Some(expected.clone())
+    );
+    store
+        .replace_remote_workspace(&expected, expected.state())
+        .expect("compacting a snapshot is allowed");
+    store
+        .create_remote_workspace(OWNER, &workspace("new-after-shrink"))
+        .expect("capacity reclaimed by compact serialization");
+}
+
+#[test]
+fn well_formed_json_cannot_bypass_aggregate_validation_during_recovery() {
+    use serde_json::json;
+    let (_directory, store) = store();
+    let state = provisioning(workspace("workspace"));
+    store.create_remote_workspace(OWNER, &state).expect("create");
+    let original = serde_json::to_value(WorkspaceSnapshot {
+        session_id: OWNER.into(),
+        state,
+    })
+    .expect("value");
+    let connection = Connection::open(store.path()).expect("raw store");
+    for (pointer, value) in [("/state/version", json!(2)), ("/state/runtime/generation", json!(42))] {
+        let mut invalid = original.clone();
+        *invalid.pointer_mut(pointer).expect("field") = value;
+        connection
+            .execute(
+                "UPDATE remote_workspaces SET snapshot = ?1",
+                [serde_json::to_vec(&invalid).expect("invalid JSON")],
+            )
+            .expect("corrupt snapshot");
+        assert!(matches!(
+            store.load_remote_workspace(OWNER, "workspace"),
+            Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot)
+        ));
+        assert!(matches!(
+            store.list_remote_workspaces(OWNER),
+            Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot)
+        ));
+    }
+    let mut invalid = original;
+    invalid["state"]["spec"]["workspace_local_id"] = json!("../escape");
+    invalid["state"]["runtime"]["workspace_local_id"] = json!("../escape");
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET workspace_local_id = '../escape', snapshot = ?1",
+            [serde_json::to_vec(&invalid).expect("invalid identity")],
+        )
+        .expect("corrupt indexed identity");
+    assert!(matches!(
+        store.list_remote_workspaces(OWNER),
+        Err(RemoteWorkspaceStoreError::InvalidStoredSnapshot)
+    ));
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -1,0 +1,70 @@
+use super::RemoteWorkspaceStoreError as Error;
+use crate::remote_workspace::{RemoteWorkspaceState, valid_local_id};
+
+pub(super) fn validate_session_id(session_id: &str) -> Result<(), Error> {
+    let id = uuid::Uuid::parse_str(session_id).map_err(|_| Error::InvalidSessionId)?;
+    if id.to_string() != session_id || id.is_nil() {
+        return Err(Error::InvalidSessionId);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_key(session_id: &str, workspace_local_id: &str) -> Result<(), Error> {
+    validate_session_id(session_id)?;
+    if !valid_local_id(workspace_local_id) {
+        return Err(Error::InvalidWorkspaceId);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &RemoteWorkspaceState) -> Result<(), Error> {
+    next.validate()?;
+    if previous.spec.workspace_local_id != next.spec.workspace_local_id {
+        return Err(Error::ReplacementIdentityMismatch);
+    }
+    if next.spec.generation != previous.spec.generation
+        && (previous.runtime.is_some()
+            || next.runtime.is_none()
+            || previous.spec.generation.checked_add(1) != Some(next.spec.generation))
+    {
+        return Err(Error::NonMonotonicReplacement);
+    }
+    if let Some(checkpoint) = &previous.checkpoint {
+        let Some(next_checkpoint) = &next.checkpoint else {
+            return Err(Error::NonMonotonicReplacement);
+        };
+        if next_checkpoint.generation < checkpoint.generation
+            || next_checkpoint.runtime_generation < checkpoint.runtime_generation
+            || next_checkpoint.captured_at_millis < checkpoint.captured_at_millis
+            || (next_checkpoint.generation == checkpoint.generation && next_checkpoint != checkpoint)
+        {
+            return Err(Error::NonMonotonicReplacement);
+        }
+    }
+    if let (Some(runtime), Some(next_runtime)) = (&previous.runtime, &next.runtime)
+        && runtime.cleanup.is_some()
+        && next_runtime.cleanup.is_none()
+    {
+        return Err(Error::NonMonotonicReplacement);
+    }
+    if let (Some(runtime), Some(next_runtime)) = (&previous.runtime, &next.runtime)
+        && (runtime.generation != next_runtime.generation
+            || runtime.workflow_id != next_runtime.workflow_id
+            || runtime.job_id != next_runtime.job_id
+            || previous.spec.target != next.spec.target
+            || previous.spec.repository != next.spec.repository
+            || runtime
+                .worker
+                .as_ref()
+                .is_some_and(|worker| next_runtime.worker.as_ref() != Some(worker)))
+    {
+        return Err(Error::ReplacementIdentityMismatch);
+    }
+    if previous.runtime.is_none()
+        && next.runtime.is_some()
+        && previous.spec.generation.checked_add(1) != Some(next.spec.generation)
+    {
+        return Err(Error::NonMonotonicReplacement);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -43,7 +43,7 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
     }
     if let (Some(runtime), Some(next_runtime)) = (&previous.runtime, &next.runtime)
         && runtime.cleanup.is_some()
-        && next_runtime.cleanup.is_none()
+        && next_runtime.cleanup != runtime.cleanup
     {
         return Err(Error::NonMonotonicReplacement);
     }

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -56,7 +56,11 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
             || runtime
                 .worker
                 .as_ref()
-                .is_some_and(|worker| next_runtime.worker.as_ref() != Some(worker)))
+                .is_some_and(|worker| next_runtime.worker.as_ref() != Some(worker))
+            || runtime
+                .ssh
+                .as_ref()
+                .is_some_and(|ssh| next_runtime.ssh.as_ref() != Some(ssh)))
     {
         return Err(Error::ReplacementIdentityMismatch);
     }

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -48,7 +48,7 @@ fn test_workflow(provider: CloudProvider, timestamp: i64) -> CloudWorkflow {
     }
 }
 
-fn retained_workflow(provider: CloudProvider, timestamp: i64) -> CloudWorkflow {
+pub(super) fn retained_workflow(provider: CloudProvider, timestamp: i64) -> CloudWorkflow {
     let mut workflow = test_workflow(provider, timestamp);
     workflow.retain_until_millis = i64::MAX;
     workflow
@@ -59,7 +59,7 @@ fn worker_target(workflow: &CloudWorkflow) -> &WorkerTarget {
 }
 
 fn assert_unsupported_schema<T>(result: &Result<T, CloudStoreError>) {
-    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(2))));
+    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(3))));
 }
 
 fn store(temp: &TempDir) -> CloudWorkflowStore {
@@ -532,7 +532,7 @@ fn runpod_fence_uses_the_durable_workflow_claim() {
     );
     let connection = Connection::open(store.path()).expect("open raw store");
     connection
-        .pragma_update(None, "user_version", 2)
+        .pragma_update(None, "user_version", 3)
         .expect("set unsupported schema");
     drop(connection);
     let failed_claim = super::super::runpod::RunPodCreationFence::claim_once(
@@ -570,7 +570,7 @@ fn invalid_snapshots_and_future_schema_fail_closed() {
     replacement.updated_at_millis += 1;
     let connection = Connection::open(&future_path).expect("future store");
     connection
-        .pragma_update(None, "user_version", 2)
+        .pragma_update(None, "user_version", 3)
         .expect("future version");
     drop(connection);
     assert_unsupported_schema(&stale_store.load(workflow.id));

--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -5,6 +5,8 @@
 mod tests;
 mod validation;
 
+pub(crate) use validation::valid_local_id;
+
 use crate::{
     PanelKind,
     cloud_run::{

--- a/crates/horizon-core/src/remote_workspace/validation.rs
+++ b/crates/horizon-core/src/remote_workspace/validation.rs
@@ -195,7 +195,7 @@ impl RepositoryCheckpoint {
     }
 }
 
-pub(super) fn valid_local_id(value: &str) -> bool {
+pub(crate) fn valid_local_id(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
         && value

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -82,6 +82,11 @@ back into large multi-purpose modules.
   Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
   schema initialization, and compatibility checks. Keep database opening separate
   from domain-specific record operations.
+- `cloud_run/store/remote_workspaces.rs` owns validated, session-owned remote
+  snapshot storage with exact revisions and bounded recovery. Replacement
+  invariants live in its `validation.rs` leaf. These records are independent of
+  board snapshots and session-file deletion; provider/workflow coordination and
+  runtime-state references remain separate integration responsibilities.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -34,6 +34,10 @@ transaction so accepted writes cannot make recovery exceed its budget.
 All record operations run synchronously off the render thread. This storage
 boundary exposes no automatic retention or record-deletion API.
 
+Once recorded, the exact cleanup reason and request timestamp remain immutable
+while that runtime exists. Later cleanup observations cannot replace the original
+intent or reset its age; only verified runtime disposal can retire it.
+
 Domain-valid in-memory state can exceed the storage limits. Callers must persist
 intent successfully before provider side effects and surface storage-capacity
 errors without discarding the last saved runtime or cleanup record.

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -37,6 +37,9 @@ boundary exposes no automatic retention or record-deletion API.
 Once recorded, the exact cleanup reason and request timestamp remain immutable
 while that runtime exists. Later cleanup observations cannot replace the original
 intent or reset its age; only verified runtime disposal can retire it.
+The first trusted SSH endpoint may be recorded once while the runtime exists. Once pinned,
+its host, port, user, and host key cannot be replaced or dropped within that
+runtime generation, even while reconnecting or reconciling.
 
 Domain-valid in-memory state can exceed the storage limits. Callers must persist
 intent successfully before provider side effects and surface storage-capacity

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -1,7 +1,7 @@
 # ADR-383: Session-owned remote records in the control-plane database
 
 Status: Proposed implementation boundary for issue #383.
-Date: 2026-09-05
+Date: 2026-09-05 (Europe/Oslo; 2026-09-04 UTC)
 Deciders: Repository maintainer through the issue and reviewed implementation PRs.
 
 ## Context
@@ -31,7 +31,7 @@ Each snapshot is limited to 4 MiB, with session recovery capped at 512 records
 and 64 MiB of serialized snapshots. Reads are bounded before materialization;
 creates and replacements enforce the same per-session limits in their write
 transaction so accepted writes cannot make recovery exceed its budget.
-all record operations run synchronously off the render thread. This storage
+All record operations run synchronously off the render thread. This storage
 boundary exposes no automatic retention or record-deletion API.
 
 Domain-valid in-memory state can exceed the storage limits. Callers must persist

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -1,0 +1,80 @@
+# ADR-383: Session-owned remote records in the control-plane database
+
+Status: Proposed implementation boundary for issue #383.
+Date: 2026-09-05
+Deciders: Repository maintainer through the issue and reviewed implementation PRs.
+
+## Context
+
+Board snapshots are rebuilt from live panels during normal saves. The local
+restore factory starts terminal commands, and session duplication retains most
+workspace identities. None of those paths currently understands remote worker
+ownership. Remote cleanup records must also survive removal of a workspace or
+session until exact provider cleanup completes.
+
+## Decision
+
+Persist the complete validated remote aggregate in the existing private SQLite
+control-plane database. Use a globally unique logical workspace identity and an
+immutable owning session identity. Every replacement compares the exact stored
+revision and snapshot. Keep remote records out of board snapshot replacement and
+session-file deletion. Later runtime snapshots reference session-owned records;
+they do not copy live provider handles.
+
+The initial storage PR adds schema migration, validated record operations,
+bounded session recovery, and ownership/revision regressions. It performs no
+provider calls and adds no UI consumer. Generation/workflow allocation will be
+one transaction in a subsequent coordinator slice using this same database.
+The record store is not permission to create, attach, or delete a worker.
+
+Each snapshot is limited to 4 MiB, with session recovery capped at 512 records
+and 64 MiB of serialized snapshots. Reads are bounded before materialization;
+creates and replacements enforce the same per-session limits in their write
+transaction so accepted writes cannot make recovery exceed its budget.
+all record operations run synchronously off the render thread. This storage
+boundary exposes no automatic retention or record-deletion API.
+
+Domain-valid in-memory state can exceed the storage limits. Callers must persist
+intent successfully before provider side effects and surface storage-capacity
+errors without discarding the last saved runtime or cleanup record.
+
+## Options considered
+
+### Embed the whole aggregate in runtime YAML
+
+Low initial complexity and no dependency cost; familiar serialization. It makes
+session-file inspection easy. However, normal board saves can drop remote data,
+copying sessions can duplicate cleanup identity, and ordinary session deletion
+can erase unresolved cleanup intent. Multi-controller creation would still need
+a separate transactional ownership store.
+
+### Use the existing SQLite control-plane store
+
+Moderate implementation complexity; no new dependencies or hosted-service cost.
+Uses existing transaction, privacy, and compatibility policy. Indexed, bounded
+recovery fits local workspace counts. Shared transactions can later bind runtime
+generations to single-worker workflows. Requires explicit UI references and
+eventual cleanup-aware record retirement.
+
+### Separate remote SQLite database
+
+Similar storage cost and familiarity, but introduces a cross-database crash
+boundary between generation ownership and the existing workflow creation fence.
+No MVP benefit justifies that extra recovery protocol.
+
+## Trade-off and consequences
+
+Choose one durable control-plane database and explicit session ownership. This
+delays UI restore until it can safely resolve references, but avoids pretending
+that YAML metadata alone makes remote startup or deletion safe. Existing local
+panels, SSH restoration, browser/session bindings, and runtime YAML stay unchanged
+in the storage-only slice. It does not solve session duplication or UI migration
+by itself; those remain explicit acceptance criteria.
+
+## Action items
+
+1. Extract database policy mechanically without changing behavior.
+2. Add session-owned aggregate records and exact-revision storage tests.
+3. Atomically bind one runtime generation to one single-worker workflow.
+4. Add copy-safe runtime references and deferred remote panel restoration.
+5. Retire records only through cleanup-aware coordinator transitions.


### PR DESCRIPTION
## Purpose

Persist session-owned remote-workspace snapshots in the existing private control-plane database for #383.

## Behavior impact

- Transactionally migrate database schema 1 to 2 without changing existing workflow snapshots, revisions, or creation claims.
- Persist the validated workspace specification, panel intents, runtime handle, cleanup intent, and checkpoint metadata under one immutable owning session.
- Reject cross-session access, duplicate logical workspace ownership, stale revisions, same-revision snapshot drift, runtime identity changes, and checkpoint/cleanup loss. A pending cleanup reason and request timestamp cannot be replaced while the runtime remains active; an existing pinned SSH endpoint cannot be replaced or dropped either.
- Bound serialization to 4 MiB. Enforce recovery limits of 512 records and 64 MiB per session in both reads and write transactions, including competing writers.
- Keep local/SSH panels, runtime YAML, board restore, session duplication/deletion, and UI behavior unchanged. This API has no provider calls, workflow allocation, automatic retention, or record-deletion path.

The coordinator still must bind each generation to one single-worker workflow atomically and verify provider absence before clearing an entire runtime. These storage operations are not lifecycle authorization.

## Validation

- Seventeen synthetic regressions cover reopen/round-trip, expired exact handles, ownership corruption, concurrent revisions and capacity claims, malformed and semantically invalid records, monotonic metadata, size/count limits, and schema migration/failure preservation. Cleanup-intent and pinned-endpoint regressions were confirmed red before their fixes and green afterward; all 17 storage tests also pass with eight parallel test threads.
- Full repository validation passed on the final committed head before push: formatting, maintainability, version synchronization, default/speech workspace tests, blocking Clippy, strict panic-lint Clippy, and advisory pedantic Clippy.
- Local test scheduling uses `RUST_TEST_THREADS=1` after intermittent short-deadline CLI failures in the full parallel suite. No assertions, timeouts, or test selections changed; explicit concurrent-writer regressions still exercise their races. GitHub CI scheduling is unchanged.
- Cleared only task-owned workspace build artifacts after baseline comparisons, then verified that all 17 new tests actually ran in both test tiers, including both new identity regressions on the final commit.
- Full-diff local and independent static reviews are complete, including the final cleanup and endpoint fixes. No actionable in-scope findings remain. All three GitHub review threads are resolved.
- Exact-head CI passed on `6e1701f94f265dbbcbd682bb2258b59690b95cab`: https://github.com/peters/horizon/actions/runs/33931323419. The latest independent GitHub review inspected all 14 files and generated zero new comments. On 2026-09-05 the maintainer explicitly waived the extra final-human-review pause for the ongoing plan, including this PR; all technical gates remained required.
- Squash-merged with the exact-head guard as `3a63e5fc9f2980a36504ec5453b924206cefabcf`. The merged tree equals the reviewed tree and the patch IDs match. Post-merge CI succeeded: https://github.com/peters/horizon/actions/runs/33939410646. The verified clean task worktree and unchanged local branch have been removed; the shared checkout is untouched.
- UI/provider smoke is not applicable: no consumer or provider side effect is introduced, and every storage regression uses a private temporary database.

## Scope

One independently testable storage outcome across 12 source/test files and 1,363 changed source/test lines, plus two architecture documents. The standing scope exception and guarded-merge approval recorded in #383 applies. New tests are split by ownership, recovery, and migration behavior.

Related: #383. Remote runtime-state references, copy-safe integration, and the single-worker coordinator remain follow-up work; this does not complete the MVP.
