### PR TITLE
feat(remote): support persistent worker runtimes

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -2,8 +2,11 @@
 
 This directory defines the provider-neutral image contract for one interactive
 Horizon coding worker. The image is intentionally separate from provider
-lifecycle code: a provider prepares compute, starts this image with runtime
-credentials and a lease deadline, and destroys the compute after the lease.
+lifecycle code: a provider prepares compute and starts this image with runtime
+credentials. Without an explicit expiry, the worker keeps running independently
+of SSH clients and Horizon. Stop/kill and cleanup are explicit management actions,
+not consequences of closing a panel, exiting Horizon, or powering off the
+client PC.
 
 The image contains the Rust toolchain, Horizon's Linux build dependencies,
 Git/Git LFS, GitHub CLI, rsync, tar, tmux, SSH, CA certificates, and the
@@ -48,8 +51,14 @@ Each worker requires:
 
 - `HORIZON_SSH_PUBLIC_KEY`: exactly one valid OpenSSH Ed25519 public key, with
   a 16 KiB limit.
-- `HORIZON_TERMINATE_AFTER`: a future RFC 3339 timestamp no more than 30 days
-  away.
+
+`HORIZON_TERMINATE_AFTER` is optional. Leave it **unset** for a persistent worker;
+no termination watchdog is started and no client heartbeat/renewal is required.
+For an explicitly time-limited worker, supply a future RFC 3339 timestamp no more
+than 30 days away. A supplied empty, malformed, past, or out-of-range value is a
+configuration error, not an instruction to run forever. Existing providers that
+supply deadlines retain their bounded behavior; provider API/profile support for
+persistent lifetime is a separate integration step.
 
 The optional GitHub token must be mounted as the exact read-only file
 `/run/secrets/github-token`, with `HORIZON_GITHUB_TOKEN_FILE` set to that path.
@@ -58,39 +67,51 @@ injection are rejected. The standard `GITHUB_TOKEN` and `GH_TOKEN` environment
 variables are rejected too, because container environment values and writable
 host binds violate the secret boundary.
 
-Example:
+Persistent example (stop and remove this exact container manually when finished):
 
 ```bash
-deadline=$(
-  docker run --rm --entrypoint date horizon-remote-worker:0.1.0 \
-    -u --date='+30 minutes' +%Y-%m-%dT%H:%M:%SZ
-)
-docker run --rm \
+docker run --detach --name horizon-development \
   --publish 127.0.0.1::22 \
   --env "HORIZON_SSH_PUBLIC_KEY=$(ssh-keygen -y -f /path/to/ephemeral-worker-key)" \
-  --env "HORIZON_TERMINATE_AFTER=${deadline}" \
   --mount type=bind,src=/path/to/github-token,dst=/run/secrets/github-token,readonly \
   --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token \
   horizon-remote-worker:0.1.0
 ```
 
+For a temporary worker, add `--env HORIZON_TERMINATE_AFTER=<RFC-3339-deadline>`.
+An explicit deadline is independent of whether a client is attached. It is not
+the default product lifetime or a replacement for manual management.
+
 At startup the entrypoint:
 
-1. validates the lease, public key, and optional secret file;
+1. validates any supplied expiry, the public key, and optional secret file;
 2. creates a new SSH host identity in the container's writable layer;
 3. installs only the supplied public key for root login;
 4. copies the optional token to a root-only runtime file and configures shared
    Git authentication once, before SSH accepts concurrent sessions; and
-5. starts a watchdog that terminates the worker at the lease deadline.
+5. starts a termination watchdog only when an explicit expiry was supplied.
 
-The in-container watchdog is defense in depth. The provider remains responsible
-for enforcing the same deadline and deleting the underlying compute.
+For explicitly time-limited workers, the in-container watchdog is defense in
+depth; the selected provider policy owns compute expiry and cleanup. Persistent
+workers may continue incurring cost until explicitly stopped. Local connection
+loss must not be interpreted as permission to stop or delete them.
+Retain the exact container/provider handle outside the client session until the
+management UI is available. The SSH key remains authorized while the worker is
+running; losing the client reference neither revokes access nor stops compute.
 
 `/workspace/horizon` starts empty. The controller checks out the requested
 repository and task after host-key verification. Remote commands should run
 through `horizon-agent-session`, which exposes the Rust toolchain, marks the
 session with `HORIZON=1`, and configures GitHub authentication only when the
 runtime token file exists. tmux provides reconnectable interactive sessions.
+
+This image change does not supply durable volumes, remote backup/checkpointing,
+provider restart recovery, or the Remote Environments overview. A stopped local
+container retains its writable layer until removed, but the example does not
+promise data survival after container deletion or provider loss. The full remote
+workspace must use the separately validated durable-storage design. A container
+on the client PC also cannot keep running when that same PC powers off: local
+Docker smoke demonstrates disconnection semantics, not the real cloud PC-off gate.
 
 Password authentication, keyboard-interactive authentication, SSH agent
 forwarding, X11 forwarding, and user-controlled SSH environment files are
@@ -129,10 +150,10 @@ Run the permanent smoke harness from the repository root:
 ./scripts/run-remote-worker-smoke.sh
 ```
 
-It builds a uniquely tagged local image, starts two isolated workers, and
-proves:
+It builds a uniquely tagged local image, starts isolated leased and persistent
+workers, and proves:
 
-- missing or malformed runtime inputs fail closed;
+- missing keys and explicitly supplied invalid expiry values fail closed;
 - source, build credentials, host keys, and user authentication state are not
   baked into the image;
 - both workers accept only the supplied client key;
@@ -140,9 +161,19 @@ proves:
 - concurrent token-backed sessions do not race or mutate shared Git state;
 - the optional token is copied with mode `0600` without entering image history
   or container environment values, and writable or incorrectly located mounts
-  fail closed; and
-- a short lease terminates its worker and emits the watchdog marker.
+  fail closed;
+- an explicit short lease terminates its worker and emits the watchdog marker;
+- a no-expiry worker's task progresses with all its SSH clients disconnected,
+  then reconnects with the same container, tmux session, process, and pinned
+  host key;
+- manually stopping that exact persistent test worker stops execution without
+  removing the container or its last observed workspace progress.
 
 Use `--image <reference>` to test an existing image. By default, an image built
 by the script and all task-owned containers and temporary files are removed on
 exit; `--keep-image` preserves only the locally built image.
+Interrupt, termination, and hangup signals use the same exact-resource cleanup.
+SIGKILL or host loss can bypass cleanup and leave the no-expiry test worker
+running. Retain the printed task-owned name prefix, inspect the
+exact container IDs from that run, and manually remove only those verified test
+resources. The harness does not sweep shared smoke labels or other runs.

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -14,30 +14,34 @@ fail_usage() {
 
 umask 077
 
-terminate_after=${HORIZON_TERMINATE_AFTER:-}
-if [ -z "${terminate_after}" ]; then
-    fail_usage "HORIZON_TERMINATE_AFTER must contain a future RFC 3339 timestamp"
-fi
-case "${terminate_after}" in
-    *'
+deadline_epoch=
+lease_seconds=
+if [ "${HORIZON_TERMINATE_AFTER+x}" = x ]; then
+    terminate_after=${HORIZON_TERMINATE_AFTER}
+    if [ -z "${terminate_after}" ]; then
+        fail_usage "HORIZON_TERMINATE_AFTER must contain a future RFC 3339 timestamp when supplied"
+    fi
+    case "${terminate_after}" in
+        *'
 '*)
-        fail_usage "HORIZON_TERMINATE_AFTER must contain exactly one timestamp"
-        ;;
-esac
-if ! printf '%s\n' "${terminate_after}" |
-    grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$'; then
-    fail_usage "HORIZON_TERMINATE_AFTER must contain a valid RFC 3339 timestamp"
-fi
-if ! deadline_epoch=$(date --date="${terminate_after}" +%s 2>/dev/null); then
-    fail_usage "HORIZON_TERMINATE_AFTER must contain a valid RFC 3339 timestamp"
-fi
-now_epoch=$(date +%s)
-lease_seconds=$((deadline_epoch - now_epoch))
-if [ "${lease_seconds}" -le 0 ]; then
-    fail_usage "HORIZON_TERMINATE_AFTER must be in the future"
-fi
-if [ "${lease_seconds}" -gt "${MAX_LEASE_SECONDS}" ]; then
-    fail_usage "HORIZON_TERMINATE_AFTER may be at most 30 days in the future"
+            fail_usage "HORIZON_TERMINATE_AFTER must contain exactly one timestamp"
+            ;;
+    esac
+    if ! printf '%s\n' "${terminate_after}" |
+        grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$'; then
+        fail_usage "HORIZON_TERMINATE_AFTER must contain a valid RFC 3339 timestamp"
+    fi
+    if ! deadline_epoch=$(date --date="${terminate_after}" +%s 2>/dev/null); then
+        fail_usage "HORIZON_TERMINATE_AFTER must contain a valid RFC 3339 timestamp"
+    fi
+    now_epoch=$(date +%s)
+    lease_seconds=$((deadline_epoch - now_epoch))
+    if [ "${lease_seconds}" -le 0 ]; then
+        fail_usage "HORIZON_TERMINATE_AFTER must be in the future"
+    fi
+    if [ "${lease_seconds}" -gt "${MAX_LEASE_SECONDS}" ]; then
+        fail_usage "HORIZON_TERMINATE_AFTER may be at most 30 days in the future"
+    fi
 fi
 
 ssh_public_key=${HORIZON_SSH_PUBLIC_KEY:-}
@@ -120,11 +124,13 @@ if [ ! -s /etc/ssh/ssh_host_ed25519_key ]; then
     exit 1
 fi
 
-now_epoch=$(date +%s)
-lease_seconds=$((deadline_epoch - now_epoch))
-if [ "${lease_seconds}" -le 0 ]; then
-    printf '%s\n' "horizon-worker: lease deadline reached; terminating worker" >&2
-    exit 0
+if [ -n "${deadline_epoch}" ]; then
+    now_epoch=$(date +%s)
+    lease_seconds=$((deadline_epoch - now_epoch))
+    if [ "${lease_seconds}" -le 0 ]; then
+        printf '%s\n' "horizon-worker: lease deadline reached; terminating worker" >&2
+        exit 0
+    fi
 fi
 
 unset \
@@ -144,14 +150,18 @@ unset \
     terminate_after \
     token_bytes
 
-entrypoint_pid=$$
-(
-    sleep "${lease_seconds}"
-    printf '%s\n' "horizon-worker: lease deadline reached; terminating worker" >&2
-    kill -TERM "${entrypoint_pid}" 2>/dev/null || exit 0
-    sleep 10
-    kill -KILL "${entrypoint_pid}" 2>/dev/null || true
-) &
+if [ -n "${lease_seconds}" ]; then
+    entrypoint_pid=$$
+    (
+        sleep "${lease_seconds}"
+        printf '%s\n' "horizon-worker: lease deadline reached; terminating worker" >&2
+        kill -TERM "${entrypoint_pid}" 2>/dev/null || exit 0
+        sleep 10
+        kill -KILL "${entrypoint_pid}" 2>/dev/null || true
+    ) &
+else
+    printf '%s\n' "horizon-worker: no expiry supplied; persistent worker" >&2
+fi
 unset entrypoint_pid lease_seconds
 
 exec /usr/sbin/sshd -D -e

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -1,6 +1,6 @@
 # ADR-383: Session-owned remote records in the control-plane database
 
-Status: Proposed implementation boundary for issue #383.
+Status: Accepted record-storage boundary; persistent-lifetime integration pending.
 Date: 2026-09-05 (Europe/Oslo; 2026-09-04 UTC)
 Deciders: Repository maintainer through the issue and reviewed implementation PRs.
 
@@ -13,6 +13,30 @@ ownership. Remote cleanup records must also survive removal of a workspace or
 session until exact provider cleanup completes.
 
 ## Decision
+
+### Client references are not worker lifetime
+
+The corrected product contract in [issue #383](https://github.com/peters/horizon/issues/383)
+requires remote development to keep running while Horizon is closed or the PC is
+off. Closing the final local panel, removing a local session/reference, or losing
+a client connection must not create stop/delete intent. Reopening reconnects to
+the existing worker and sessions; it does not allocate a new generation merely
+because the client restarted.
+This is the required integration contract, not behavior implemented by the
+record-storage API alone.
+
+The owning local session below scopes client records and prevents accidental
+copy/adoption. It is not a compute lifetime lease. Remote task supervision,
+repository durability, and checkpointing must not rely on that PC's database or
+event loop remaining available. A dedicated Remote Environments overview will
+expose reconnect and explicit stop/kill or manual cleanup/delete actions.
+
+The image permits an unset expiry for persistent execution and retains a bounded
+watchdog only for explicitly time-limited jobs. Existing provider deadline types,
+profiles, and integration still require the corresponding lifetime correction;
+neither record storage nor the image alone completes persistent cloud workspaces.
+
+### Durable local identity records
 
 Persist the complete validated remote aggregate in the existing private SQLite
 control-plane database. Use a globally unique logical workspace identity and an

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -53,6 +53,7 @@ done
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 smoke_id="horizon-worker-smoke-$(date -u +%Y%m%d%H%M%S)-$$"
+printf 'Task-owned container name prefix: %s\n' "${smoke_id}"
 temp_dir=$(mktemp -d /tmp/horizon-remote-worker-smoke.XXXXXX)
 case "${temp_dir}" in
   /tmp/horizon-remote-worker-smoke.*) ;;
@@ -84,6 +85,9 @@ cleanup() {
   return "${exit_code}"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 deadline_after() {
   docker run --rm --entrypoint /bin/date "${image}" \
@@ -162,6 +166,24 @@ ssh_worker() {
     "${remote_command}"
 }
 
+has_no_ssh_clients() {
+  local processes
+  processes=$(docker exec "$1" ps -eo pid=,stat=,comm=) || fail "could not inspect worker SSH processes"
+  awk '$1 != 1 && $3 ~ /^sshd(-|$)/ && $2 !~ /^Z/ { found = 1 }
+       END { exit found ? 1 : 0 }' <<<"${processes}"
+}
+
+wait_for_ssh_disconnect() {
+  local attempt
+  for attempt in {1..15}; do
+    if has_no_ssh_clients "$1"; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "an SSH client remained attached to the persistent test worker"
+}
+
 if [[ -z "${image}" ]]; then
   image="${smoke_id}:local"
   worker_image_version="smoke-$(date -u +%Y%m%d%H%M%S)"
@@ -224,11 +246,12 @@ docker run --rm --entrypoint /bin/sh "${image}" -eu -c '
   test ! -e /root/.npmrc
   test -s /etc/ssl/certs/ca-certificates.crt
   for tool in \
-    cargo rustc git git-lfs gh rsync tar tmux ssh sshd \
+    cargo rustc git git-lfs gh rsync tar tmux ssh sshd ps \
     codex claude gemini opencode kilo pi grok
   do
     command -v "${tool}" >/dev/null
   done
+  ps -eo pid=,stat=,comm= >/dev/null
 '
 
 ssh-keygen -q -t ed25519 -N '' -f "${temp_dir}/client"
@@ -256,7 +279,20 @@ expect_usage_failure \
   --env "HORIZON_SSH_PUBLIC_KEY=${unsupported_public_key}" \
   --env "HORIZON_TERMINATE_AFTER=${normal_deadline}"
 expect_usage_failure \
-  missing-lease \
+  empty-lease \
+  --env HORIZON_TERMINATE_AFTER= \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}"
+expect_usage_failure \
+  malformed-lease \
+  --env HORIZON_TERMINATE_AFTER=not-a-timestamp \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}"
+expect_usage_failure \
+  past-lease \
+  --env HORIZON_TERMINATE_AFTER=2000-01-01T00:00:00Z \
+  --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}"
+expect_usage_failure \
+  multiline-lease \
+  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}"$'\n'"${normal_deadline}" \
   --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}"
 expect_usage_failure \
   oversized-lease \
@@ -347,11 +383,19 @@ docker run --detach \
   --label horizon.remote-worker-smoke=true \
   --publish 127.0.0.1::22 \
   --env "HORIZON_SSH_PUBLIC_KEY=${client_public_key}" \
-  --env "HORIZON_TERMINATE_AFTER=${normal_deadline}" \
   "${image}" >/dev/null
 
 worker_a_port=$(wait_for_host_key "${worker_a}" "${temp_dir}/worker-a-known-hosts")
 worker_b_port=$(wait_for_host_key "${worker_b}" "${temp_dir}/worker-b-known-hosts")
+# Before any task starts, PID 1 may have only SSH children, never a watchdog shell.
+persistent_startup_processes=$(docker exec "${worker_b}" ps -eo ppid=,comm=) ||
+  fail "could not inspect persistent worker startup processes"
+awk '$1 == 1 && $2 !~ /^sshd(-|$)/ { found = 1 }
+     END { exit found ? 1 : 0 }' <<<"${persistent_startup_processes}" ||
+  fail "worker without an expiry started a background watchdog"
+worker_b_logs=$(docker logs "${worker_b}" 2>&1)
+grep -qF 'horizon-worker: no expiry supplied; persistent worker' <<<"${worker_b_logs}" ||
+  fail "worker did not report persistent execution mode"
 worker_a_fingerprint=$(
   ssh-keygen -lf "${temp_dir}/worker-a-known-hosts" | awk '{print $2}'
 )
@@ -362,12 +406,40 @@ worker_b_fingerprint=$(
   fail "the two workers reused the same runtime SSH host key"
 
 ssh_worker \
+  "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
+  'sleep 5' &
+persistent_client_control_pid=$!
+persistent_client_observed=false
+for _ in {1..15}; do
+  if ! has_no_ssh_clients "${worker_b}"; then
+    persistent_client_observed=true
+    break
+  fi
+  sleep 1
+done
+wait "${persistent_client_control_pid}" || fail "positive-control SSH session failed"
+[[ "${persistent_client_observed}" == true ]] || fail "SSH-client detector missed an attached client"
+
+ssh_worker \
   "${temp_dir}/client" \
   "${temp_dir}/worker-b-known-hosts" \
   "${worker_b_port}" \
   'horizon-agent-session env' |
   grep -qx 'HORIZON=1' ||
   fail "horizon-agent-session did not mark the remote environment"
+
+persistent_worker_id=$(docker inspect --format '{{.Id}}' "${worker_b}")
+persistent_session_id=$(ssh_worker \
+  "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
+  'tmux new-session -d -s horizon-smoke-persistent "while :; do date +%s > /workspace/horizon/smoke-progress.next; mv /workspace/horizon/smoke-progress.next /workspace/horizon/smoke-progress; sleep 1; done";
+   for attempt in 1 2 3 4 5; do test -s /workspace/horizon/smoke-progress && break; sleep 1; done;
+   tmux display-message -p -t horizon-smoke-persistent "#{session_id}:#{pane_pid}"') ||
+  fail "could not start the persistent remote session"
+[[ "${persistent_session_id}" =~ ^\$[0-9]+:[0-9]+$ ]] || fail "persistent session identity is invalid"
+wait_for_ssh_disconnect "${worker_b}"
+persistent_progress_before=$(docker exec "${worker_b}" cat /workspace/horizon/smoke-progress) ||
+  fail "could not observe the disconnected task baseline"
+[[ "${persistent_progress_before}" =~ ^[0-9]+$ ]] || fail "persistent task did not start"
 
 git_config_before=$(docker exec "${worker_a}" sha256sum /root/.gitconfig | awk '{print $1}')
 ssh_worker \
@@ -481,8 +553,52 @@ grep -qF 'horizon-worker: lease deadline reached; terminating worker' \
   <<<"${lease_logs}" ||
   fail "lease watchdog marker was not written"
 
+[[ "$(docker inspect --format '{{.State.Running}}' "${worker_b}")" == true ]] ||
+  fail "worker without an expiry stopped while its clients were disconnected"
+[[ "$(docker inspect --format '{{.Id}}' "${worker_b}")" == "${persistent_worker_id}" ]] ||
+  fail "reconnecting replaced the persistent worker"
+for _ in {1..15}; do
+  has_no_ssh_clients "${worker_b}" || fail "an SSH client was attached during the disconnected window"
+  persistent_progress_disconnected=$(docker exec "${worker_b}" cat /workspace/horizon/smoke-progress) ||
+    fail "could not observe disconnected task progress"
+  [[ "${persistent_progress_disconnected}" =~ ^[0-9]+$ ]] || fail "disconnected task lost its progress"
+  if ((persistent_progress_disconnected > persistent_progress_before)); then
+    break
+  fi
+  sleep 1
+done
+((persistent_progress_disconnected > persistent_progress_before)) ||
+  fail "remote task did not progress before any SSH client reconnected"
+persistent_session_after=$(ssh_worker \
+  "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
+  'tmux display-message -p -t horizon-smoke-persistent "#{session_id}:#{pane_pid}"') ||
+  fail "could not reconnect to the persistent remote session"
+[[ "${persistent_session_after}" == "${persistent_session_id}" ]] ||
+  fail "reconnecting replaced the running remote session or process"
+persistent_progress_after=$(ssh_worker \
+  "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
+  'cat /workspace/horizon/smoke-progress') || fail "could not observe progress after reconnect"
+[[ "${persistent_progress_after}" =~ ^[0-9]+$ ]] || fail "persistent task lost its progress"
+((persistent_progress_after >= persistent_progress_disconnected)) || fail "reconnect lost the last observed progress"
+worker_b_logs=$(docker logs "${worker_b}" 2>&1)
+if grep -qF 'lease deadline reached' <<<"${worker_b_logs}"; then
+  fail "worker without an expiry reported a lease termination"
+fi
+docker stop --time 10 "${worker_b}" >/dev/null
+[[ "$(docker inspect --format '{{.State.Running}}' "${worker_b}")" == false ]] ||
+  fail "explicit stop did not stop the selected persistent worker"
+[[ "$(docker inspect --format '{{.Id}}' "${worker_b}")" == "${persistent_worker_id}" ]] ||
+  fail "explicit stop deleted the persistent worker"
+docker cp "${worker_b}:/workspace/horizon/smoke-progress" "${temp_dir}/stopped-progress"
+stopped_progress=$(<"${temp_dir}/stopped-progress")
+[[ "${stopped_progress}" =~ ^[0-9]+$ ]] || fail "explicit stop lost workspace data"
+((stopped_progress >= persistent_progress_after)) || fail "explicit stop lost the last observed progress"
+
 image_id=$(docker image inspect --format '{{.Id}}' "${image}")
 printf 'Remote-worker smoke passed.\n'
+printf 'Persistent task progressed with no SSH clients; same worker/session reconnected; explicit stop retained data.\n'
+printf 'Disconnected progress window: %s seconds (local Docker proof).\n' \
+  "$((persistent_progress_disconnected - persistent_progress_before))"
 printf 'Image: %s (%s)\n' "${image_id}" "${actual_image_version}"
 printf 'Worker A host key: %s\n' "${worker_a_fingerprint}"
 printf 'Worker B host key: %s\n' "${worker_b_fingerprint}"


### PR DESCRIPTION
## Purpose

Addresses the corrected persistent-development contract in #383. The worker
image previously rejected startup without a termination deadline. It now keeps
running when that variable is unset, independently of client connections.

## Behavior

- An unset `HORIZON_TERMINATE_AFTER` starts a persistent worker with no watchdog.
- An explicitly supplied empty, malformed, past, or excessive expiry still
  fails closed. Valid temporary-worker deadlines retain their watchdog.
- Startup reports persistent mode without exposing authentication material.
  Existing provider callers still send deadlines and retain their behavior.
- Documentation separates client references from execution lifetime, explains
  ongoing cost/access and manual exact-resource cleanup, and marks remaining
  provider, storage, recovery, and overview integration as unfinished.

## Validation

Candidate: `fdd9bb6389032d4f3674a5351d7d8343cba36206`.

- Shell syntax, formatting, maintainability, version consistency, default and
  speech workspace tests, and blocking/strict/advisory lint tiers.
- Independent local full-diff review and focused regression fixes.
- Exact-head local container smoke: verified no watchdog and no attached SSH
  clients; observed eight seconds of remote task progress before reconnect;
  retained the same container, tmux session, process, and pinned host key.
- Explicitly stopped the selected test worker and verified retained container
  identity and workspace progress. Temporary test resources were removed; all
  14 pre-existing local containers were preserved.
- Existing authentication, secret-mount, malformed-expiry, startup-expiry, and
  explicit lease-termination smoke lanes passed.

The local suite uses `RUST_TEST_THREADS=1`; assertions and test selection are
unchanged. An earlier concurrent local run hit the unchanged one-second browser
CLI startup deadline; three isolated repetitions passed without changes. The
final full matrix and smoke both passed after rebasing onto the updated main.

This proves local disconnected-client semantics, not a real cloud PC-off
interval. It does not yet enable persistent provider profiles, durable remote
storage/checkpointing, stop/resume recovery, or the Remote Environments widget.
No UI, cloud resources, image publication, release, or existing app process was
changed. This is a focused prerequisite, not completion of #383.
