### PR TITLE
feat(remote): model explicit worker lifetimes

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -8,9 +8,11 @@ pub mod local_docker;
 pub mod runpod;
 mod store;
 mod validation;
+mod worker_lifetime;
 pub use store::{
     CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteWorkspace, StoredWorkflow,
 };
+pub use worker_lifetime::WorkerLifetime;
 pub const CLOUD_RUN_PROTOCOL_VERSION: u32 = 1;
 macro_rules! uuid_id {
     ($name:ident) => {
@@ -84,13 +86,16 @@ macro_rules! hex_value {
     };
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(
+    try_from = "worker_lifetime::WorkerTargetSnapshot",
+    into = "worker_lifetime::WorkerTargetSnapshot"
+)]
 pub struct WorkerTarget {
     pub provider: CloudProvider,
     pub profile: String,
     pub image: String,
     pub disk_gib: u32,
-    pub lease_seconds: u32,
+    pub lifetime: WorkerLifetime,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_hourly_cost_micros: Option<u64>,
 }
@@ -330,6 +335,8 @@ pub enum CloudProtocolError {
     EmptyNodeIdentity(CloudJobId),
     #[error("node {0} has an invalid worker target")]
     InvalidWorkerTarget(CloudJobId),
+    #[error("worker target requires exactly one valid explicit lifetime policy")]
+    InvalidWorkerLifetime,
     #[error("node {0} has an invalid weight")]
     InvalidWeight(CloudJobId),
     #[error("node {0} has an invalid retry attempt")]

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -1,11 +1,11 @@
-//! Provider-neutral lifecycle contract for disposable interactive workers.
+//! Provider-neutral lifecycle contract for persistent or time-limited interactive workers.
 
-use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget};
+use super::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime, WorkerTarget};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 use std::{error::Error, net::IpAddr};
 
-/// Maximum lease accepted by the common disposable-worker contract.
+/// Maximum explicitly selected time limit accepted by the common worker contract.
 pub const MAX_INTERACTIVE_WORKER_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
 const INTERACTIVE_WORKER_LEASE_CLOCK_SKEW_SECONDS: i64 = 120;
 const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
@@ -19,7 +19,7 @@ pub struct InteractiveWorkerRequest {
     pub workflow_id: CloudWorkflowId,
     pub job_id: CloudJobId,
     pub target: WorkerTarget,
-    /// Ephemeral client public key authorized by the worker image.
+    /// Client public key retained for reconnect during this runtime generation.
     pub ssh_public_key: String,
 }
 
@@ -31,7 +31,7 @@ impl InteractiveWorkerRequest {
     }
 }
 
-/// Exact, provider-qualified ownership identity for one disposable worker.
+/// Exact, provider-qualified ownership identity for one interactive worker.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InteractiveWorkerIdentity {
@@ -49,7 +49,7 @@ impl InteractiveWorkerIdentity {
     }
 }
 
-/// Immutable lease data returned by a provider.
+/// Immutable expiry returned for an explicitly time-limited worker.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InteractiveWorkerLease {
@@ -84,6 +84,80 @@ impl InteractiveWorkerLease {
     }
 }
 
+/// Observed execution lifetime. This is not a client or ownership lease.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(from = "ObservedLifetimeSnapshot", into = "ObservedLifetimeSnapshot")]
+pub enum InteractiveWorkerLifetime {
+    Persistent,
+    TimeLimited(InteractiveWorkerLease),
+}
+
+impl InteractiveWorkerLifetime {
+    #[must_use]
+    pub const fn as_time_limited(&self) -> Option<&InteractiveWorkerLease> {
+        match self {
+            Self::Persistent => None,
+            Self::TimeLimited(lease) => Some(lease),
+        }
+    }
+
+    #[must_use]
+    pub fn has_valid_shape(&self) -> bool {
+        self.as_time_limited()
+            .is_none_or(InteractiveWorkerLease::has_valid_shape)
+    }
+
+    fn matches_policy(&self, policy: WorkerLifetime) -> bool {
+        matches!(
+            (self, policy),
+            (Self::Persistent, WorkerLifetime::Persistent) | (Self::TimeLimited(_), WorkerLifetime::TimeLimited { .. })
+        )
+    }
+
+    pub(super) fn is_valid_at(&self, policy: WorkerLifetime, observed_at: time::OffsetDateTime) -> bool {
+        match (self, policy) {
+            (Self::Persistent, WorkerLifetime::Persistent) => true,
+            (Self::TimeLimited(lease), WorkerLifetime::TimeLimited { seconds }) => {
+                lease.is_bounded_at(seconds, observed_at)
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum ObservedLifetimeSnapshot {
+    TimeLimited(InteractiveWorkerLease),
+    Persistent { lifetime: PersistentObservedMarker },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PersistentObservedMarker {
+    Persistent,
+}
+
+impl From<ObservedLifetimeSnapshot> for InteractiveWorkerLifetime {
+    fn from(value: ObservedLifetimeSnapshot) -> Self {
+        match value {
+            ObservedLifetimeSnapshot::TimeLimited(lease) => Self::TimeLimited(lease),
+            ObservedLifetimeSnapshot::Persistent { .. } => Self::Persistent,
+        }
+    }
+}
+
+impl From<InteractiveWorkerLifetime> for ObservedLifetimeSnapshot {
+    fn from(value: InteractiveWorkerLifetime) -> Self {
+        match value {
+            InteractiveWorkerLifetime::TimeLimited(lease) => Self::TimeLimited(lease),
+            InteractiveWorkerLifetime::Persistent => Self::Persistent {
+                lifetime: PersistentObservedMarker::Persistent,
+            },
+        }
+    }
+}
+
 /// Durable worker handle used for inspection and exact-resource cleanup.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -91,9 +165,11 @@ pub struct InteractiveWorker {
     pub identity: InteractiveWorkerIdentity,
     /// Exact provider target used to create the resource.
     pub target: WorkerTarget,
-    /// Ephemeral client public key installed in this runtime generation.
+    /// Client public key installed for this runtime generation's reconnects.
     pub ssh_public_key: String,
-    pub lease: InteractiveWorkerLease,
+    /// The v1 wire field name remains `lease` to preserve bounded records.
+    #[serde(rename = "lease")]
+    pub lifetime: InteractiveWorkerLifetime,
 }
 
 impl InteractiveWorker {
@@ -105,7 +181,8 @@ impl InteractiveWorker {
         self.identity.is_valid()
             && valid_worker_target(&self.target, self.identity.provider)
             && valid_ssh_public_key(&self.ssh_public_key)
-            && self.lease.has_valid_shape()
+            && self.lifetime.has_valid_shape()
+            && self.lifetime.matches_policy(self.target.lifetime)
     }
 
     /// Check the durable handle before any provider-specific inspection or
@@ -159,8 +236,8 @@ pub struct InteractiveWorkerStatus {
 
 impl InteractiveWorkerStatus {
     /// A worker is attachable only when its lifecycle, request identity,
-    /// complete target, lease, and SSH data agree. The target comparison covers
-    /// provider, profile, image, disk, requested lease, and cost limit.
+    /// complete target, lifetime, and SSH data agree. The target comparison covers
+    /// provider, profile, image, disk, explicit lifetime policy, and cost limit.
     /// `observed_at` must be a freshly sampled, trusted UTC time from
     /// immediately before attachment.
     #[must_use]
@@ -173,10 +250,7 @@ impl InteractiveWorkerStatus {
             && identity.job_id == request.job_id
             && self.worker.target == request.target
             && self.worker.ssh_public_key == request.ssh_public_key
-            && self
-                .worker
-                .lease
-                .is_bounded_at(request.target.lease_seconds, observed_at)
+            && self.worker.lifetime.is_valid_at(request.target.lifetime, observed_at)
             && self.ssh.as_ref().is_some_and(InteractiveWorkerSshEndpoint::is_complete)
     }
 }
@@ -211,7 +285,7 @@ pub enum InteractiveWorkerCleanup {
     AlreadyAbsent,
 }
 
-/// Blocking provider boundary for one disposable interactive worker.
+/// Blocking provider boundary for one interactive worker.
 ///
 /// Callers must invoke provider operations away from the render thread. An
 /// implementation must reject an ensure request unless
@@ -221,6 +295,8 @@ pub enum InteractiveWorkerCleanup {
 /// operations must make `ensure_worker` idempotent across controllers,
 /// preserve the exact returned handle for later inspection, and delete only
 /// that exact resource.
+/// Providers must reject unsupported lifetime policies before provider I/O;
+/// they must not silently convert a persistent request to a time-limited job.
 pub trait InteractiveWorkerProvider: Send + Sync {
     type Error: Error + Send + Sync + 'static;
 
@@ -259,7 +335,11 @@ pub(crate) fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider
         && !target.profile.chars().any(char::is_control)
         && valid_immutable_image(&target.image)
         && target.disk_gib > 0
-        && (1..=MAX_INTERACTIVE_WORKER_LEASE_SECONDS).contains(&target.lease_seconds)
+        && target.lifetime.is_valid()
+        && target
+            .lifetime
+            .time_limit_seconds()
+            .is_none_or(|seconds| seconds <= MAX_INTERACTIVE_WORKER_LEASE_SECONDS)
         && target.max_hourly_cost_micros != Some(0)
 }
 
@@ -325,6 +405,9 @@ fn valid_ed25519_key(value: &str, allow_comment: bool) -> bool {
 }
 
 #[cfg(test)]
+mod lifetime_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -381,7 +464,7 @@ mod tests {
         }
     }
 
-    fn worker_status() -> InteractiveWorkerStatus {
+    pub(super) fn worker_status() -> InteractiveWorkerStatus {
         InteractiveWorkerStatus {
             worker: InteractiveWorker {
                 identity: InteractiveWorkerIdentity {
@@ -395,13 +478,13 @@ mod tests {
                     profile: "gpu".to_string(),
                     image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
                     disk_gib: 20,
-                    lease_seconds: 900,
+                    lifetime: WorkerLifetime::TimeLimited { seconds: 900 },
                     max_hourly_cost_micros: Some(500_000),
                 },
                 ssh_public_key: ed25519_key(None),
-                lease: InteractiveWorkerLease {
+                lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
                     terminate_after: "2026-09-04T12:00:00Z".to_string(),
-                },
+                }),
             },
             lifecycle: InteractiveWorkerLifecycle::Ready,
             ssh: Some(InteractiveWorkerSshEndpoint {
@@ -514,7 +597,9 @@ mod tests {
         };
         assert!(!status.is_ready_for(&request, observed_at()));
         status = original;
-        status.worker.lease.terminate_after = "2999-09-04T12:00:00Z".to_string();
+        status.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: "2999-09-04T12:00:00Z".to_string(),
+        });
         assert!(!status.is_ready_for(&request, observed_at()));
     }
 
@@ -536,9 +621,11 @@ mod tests {
         request.ssh_public_key = "ssh-rsa unsupported".to_string();
         assert!(!request.is_valid_for(CloudProvider::RunPod));
         request.ssh_public_key = ed25519_key(None);
-        request.target.lease_seconds = MAX_INTERACTIVE_WORKER_LEASE_SECONDS + 1;
+        request.target.lifetime = WorkerLifetime::TimeLimited {
+            seconds: MAX_INTERACTIVE_WORKER_LEASE_SECONDS + 1,
+        };
         assert!(!request.is_valid_for(CloudProvider::RunPod));
-        request.target.lease_seconds = 900;
+        request.target.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
         request.target.max_hourly_cost_micros = Some(0);
         assert!(!request.is_valid_for(CloudProvider::RunPod));
     }
@@ -560,7 +647,9 @@ mod tests {
         worker.ssh_public_key = "ssh-rsa unsupported".to_string();
         assert!(!worker.has_valid_shape());
         worker = worker_status().worker;
-        worker.lease.terminate_after = "in two hours".to_string();
+        worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: "in two hours".to_string(),
+        });
         assert!(!worker.has_valid_shape());
     }
 

--- a/crates/horizon-core/src/cloud_run/interactive_worker/lifetime_tests.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker/lifetime_tests.rs
@@ -1,0 +1,86 @@
+use super::{tests::worker_status, *};
+use serde_json::json;
+
+fn persistent_status() -> InteractiveWorkerStatus {
+    let mut status = worker_status();
+    status.worker.target.lifetime = WorkerLifetime::Persistent;
+    status.worker.lifetime = InteractiveWorkerLifetime::Persistent;
+    status
+}
+
+fn request(status: &InteractiveWorkerStatus) -> InteractiveWorkerRequest {
+    InteractiveWorkerRequest {
+        workflow_id: status.worker.identity.workflow_id,
+        job_id: status.worker.identity.job_id,
+        target: status.worker.target.clone(),
+        ssh_public_key: status.worker.ssh_public_key.clone(),
+    }
+}
+
+#[test]
+fn persistent_attachment_has_no_default_expiry_boundary() {
+    let status = persistent_status();
+    let request = request(&status);
+    assert!(request.is_valid_for(CloudProvider::RunPod));
+    assert!(status.worker.has_valid_shape());
+    let observed_at = time::OffsetDateTime::UNIX_EPOCH;
+    for elapsed in [0, 31, 366, 3_650] {
+        assert!(status.is_ready_for(&request, observed_at + time::Duration::days(elapsed)));
+    }
+}
+
+#[test]
+fn persisted_worker_requires_matching_target_and_observed_lifetime() {
+    let mut persistent = persistent_status();
+    let persistent_request = request(&persistent);
+    persistent.worker.lifetime = worker_status().worker.lifetime;
+    assert!(!persistent.worker.has_valid_shape());
+    assert!(!persistent.is_ready_for(&persistent_request, time::OffsetDateTime::UNIX_EPOCH));
+
+    let mut temporary = worker_status();
+    let temporary_request = request(&temporary);
+    temporary.worker.lifetime = InteractiveWorkerLifetime::Persistent;
+    assert!(!temporary.worker.has_valid_shape());
+    assert!(!temporary.is_ready_for(&temporary_request, time::OffsetDateTime::UNIX_EPOCH));
+}
+
+#[test]
+fn observed_lifetime_preserves_expiry_and_requires_explicit_persistence() {
+    let legacy = r#"{"terminate_after":"2020-01-01T00:00:00Z"}"#;
+    let lifetime: InteractiveWorkerLifetime = serde_json::from_str(legacy).expect("legacy expiry");
+    assert!(lifetime.has_valid_shape());
+    assert!(lifetime.as_time_limited().is_some());
+    assert_eq!(serde_json::to_string(&lifetime).expect("serialize expiry"), legacy);
+    assert_eq!(
+        serde_json::to_value(InteractiveWorkerLifetime::Persistent).expect("serialize persistent"),
+        json!({"lifetime": "persistent"})
+    );
+    for invalid in [
+        json!({}),
+        json!(null),
+        json!("persistent"),
+        json!({"lifetime": null}),
+        json!({"lifetime": "unknown"}),
+        json!({"terminate_after": null}),
+        json!({"lifetime": "persistent", "terminate_after": "2020-01-01T00:00:00Z"}),
+        json!({"lifetime": "persistent", "terminate_after": null}),
+        json!({"lifetime": "persistent", "unexpected": true}),
+    ] {
+        assert!(
+            serde_json::from_value::<InteractiveWorkerLifetime>(invalid.clone()).is_err(),
+            "accepted {invalid}"
+        );
+    }
+}
+
+#[test]
+fn persistent_handle_round_trips_without_manufacturing_a_deadline() {
+    let status = persistent_status();
+    let encoded = serde_json::to_value(&status).expect("serialize persistent status");
+    assert_eq!(encoded["worker"]["lease"], json!({"lifetime": "persistent"}));
+    assert_eq!(encoded["worker"]["target"]["lifetime"], "persistent");
+    assert!(encoded["worker"]["target"].get("lease_seconds").is_none());
+    let restored: InteractiveWorkerStatus = serde_json::from_value(encoded).expect("restore persistent status");
+    assert_eq!(restored, status);
+    assert!(restored.worker.has_valid_shape());
+}

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -4,8 +4,8 @@ use super::{
     CLOUD_RUN_PROTOCOL_VERSION, CloudProvider, WorkerTarget,
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
-        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
-        InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_public_key,
+        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
+        InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_public_key,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -71,8 +71,8 @@ impl LocalDockerInteractiveWorkerProvider {
     ) -> DockerResult<InteractiveWorkerStatus> {
         let worker = worker_for_request(container, request)?;
         if !worker
-            .lease
-            .is_bounded_at(request.target.lease_seconds, time::OffsetDateTime::now_utc())
+            .lifetime
+            .is_valid_at(request.target.lifetime, time::OffsetDateTime::now_utc())
         {
             return self.reject_unbounded_lease(&worker, container);
         }
@@ -125,7 +125,12 @@ impl LocalDockerInteractiveWorkerProvider {
                     Ok(worker) => worker,
                     Err(error) => return self.cleanup_invalid_creation(&container, &create, error),
                 };
-                if worker.lease.terminate_after != create.terminate_after {
+                if worker
+                    .lifetime
+                    .as_time_limited()
+                    .map(|lease| lease.terminate_after.as_str())
+                    != Some(create.terminate_after.as_str())
+                {
                     return self.cleanup_invalid_creation(
                         &container,
                         &create,
@@ -334,8 +339,13 @@ struct DockerCreateRequest {
 impl DockerCreateRequest {
     fn new(request: &InteractiveWorkerRequest, name: &str) -> DockerResult<Self> {
         let now = time::OffsetDateTime::now_utc();
+        let seconds = request
+            .target
+            .lifetime
+            .time_limit_seconds()
+            .ok_or(LocalDockerError::InvalidTarget)?;
         let deadline = now
-            .checked_add(time::Duration::seconds(i64::from(request.target.lease_seconds)))
+            .checked_add(time::Duration::seconds(i64::from(seconds)))
             .ok_or(LocalDockerError::InvalidTarget)?;
         let terminate_after = deadline
             .format(&time::format_description::well_known::Rfc3339)
@@ -354,9 +364,11 @@ impl DockerCreateRequest {
     }
 }
 fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerProfile) -> DockerResult<()> {
-    (request.target.profile == profile.name && request.is_valid_for(CloudProvider::LocalDocker))
-        .then_some(())
-        .ok_or(LocalDockerError::InvalidTarget)
+    (request.target.profile == profile.name
+        && request.is_valid_for(CloudProvider::LocalDocker)
+        && request.target.lifetime.time_limit_seconds().is_some())
+    .then_some(())
+    .ok_or(LocalDockerError::InvalidTarget)
 }
 fn valid_local_docker_host(value: &str) -> bool {
     let safe = |path: &str| !path.is_empty() && !path.chars().any(char::is_control);
@@ -366,9 +378,11 @@ fn valid_local_docker_host(value: &str) -> bool {
         || value.strip_prefix("npipe:////./pipe/").is_some_and(safe)
 }
 fn validate_worker(worker: &InteractiveWorker) -> DockerResult<()> {
-    (worker.is_valid_for(CloudProvider::LocalDocker) && valid_container_id(&worker.identity.resource_id))
-        .then_some(())
-        .ok_or(LocalDockerError::InvalidPersistedWorker)
+    (worker.is_valid_for(CloudProvider::LocalDocker)
+        && worker.lifetime.as_time_limited().is_some()
+        && valid_container_id(&worker.identity.resource_id))
+    .then_some(())
+    .ok_or(LocalDockerError::InvalidPersistedWorker)
 }
 fn worker_for_request(
     container: &DockerContainer,
@@ -384,15 +398,19 @@ fn worker_for_request(
         },
         target: request.target.clone(),
         ssh_public_key: request.ssh_public_key.clone(),
-        lease: InteractiveWorkerLease {
+        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
             terminate_after: terminate_after.to_string(),
-        },
+        }),
     };
     verify_container_for_worker(container, &worker)?;
     Ok(worker)
 }
 fn verify_container_for_worker(container: &DockerContainer, worker: &InteractiveWorker) -> DockerResult<()> {
     validate_worker(worker)?;
+    let lease = worker
+        .lifetime
+        .as_time_limited()
+        .ok_or(LocalDockerError::InvalidPersistedWorker)?;
     let ssh_public_key =
         canonical_ed25519_key(&worker.ssh_public_key).ok_or(LocalDockerError::InvalidPersistedWorker)?;
     let expected_name = container_name(worker.identity.workflow_id, worker.identity.job_id);
@@ -403,7 +421,7 @@ fn verify_container_for_worker(container: &DockerContainer, worker: &Interactive
         (WORKFLOW_LABEL, worker.identity.workflow_id.to_string()),
         (JOB_LABEL, worker.identity.job_id.to_string()),
         (SSH_KEY_LABEL, ssh_public_key.clone()),
-        (TERMINATE_LABEL, worker.lease.terminate_after.clone()),
+        (TERMINATE_LABEL, lease.terminate_after.clone()),
     ];
     let valid = container.id == worker.identity.resource_id
         && container.name == expected_name
@@ -413,7 +431,7 @@ fn verify_container_for_worker(container: &DockerContainer, worker: &Interactive
             .iter()
             .all(|(key, value)| container.labels.get(*key) == Some(value))
         && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(ssh_public_key.as_str())
-        && required_environment(container, TERMINATE_ENV) == Ok(worker.lease.terminate_after.as_str())
+        && required_environment(container, TERMINATE_ENV) == Ok(lease.terminate_after.as_str())
         && valid_target_label(&container.labels, worker);
     valid.then_some(()).ok_or(LocalDockerError::ResourceIdentityMismatch)
 }

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -1,3 +1,4 @@
+use super::super::WorkerLifetime;
 use super::*;
 use InteractiveWorkerCleanup::{AlreadyAbsent, Deleted};
 use LocalDockerError::*;
@@ -9,6 +10,8 @@ struct FakeDocker(Arc<Mutex<FakeState>>);
 #[derive(Default)]
 struct FakeState {
     container: Option<DockerContainer>,
+    inspect_calls: usize,
+    host_key_calls: usize,
     create_calls: usize,
     delete_calls: usize,
     fail_create_after_insert: bool,
@@ -26,6 +29,7 @@ impl FakeDocker {
 impl DockerTransport for FakeDocker {
     fn inspect(&self, reference: &str) -> DockerResult<Option<DockerContainer>> {
         let mut state = self.state();
+        state.inspect_calls += 1;
         if state.container.is_some() && state.failed_inspections_after_create > 0 {
             state.failed_inspections_after_create -= 1;
             return Err(invalid_response("container inspection"));
@@ -73,6 +77,7 @@ impl DockerTransport for FakeDocker {
     }
     fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
         let mut state = self.state();
+        state.host_key_calls += 1;
         if std::mem::take(&mut state.disappear_during_key_read) {
             state.container = None;
             return Err(ResourceAbsent);
@@ -100,7 +105,7 @@ pub(super) fn request() -> InteractiveWorkerRequest {
             profile: "local".to_string(),
             image: format!("registry.example/horizon/worker@sha256:{}", "d".repeat(64)),
             disk_gib: 20,
-            lease_seconds: 900,
+            lifetime: WorkerLifetime::TimeLimited { seconds: 900 },
             max_hourly_cost_micros: None,
         },
         ssh_public_key: ed25519_key(3),
@@ -135,6 +140,41 @@ fn provider(name: &str, fake: FakeDocker) -> LocalDockerInteractiveWorkerProvide
         profile: profile(name, "unix:///var/run/docker.sock"),
     }
 }
+
+#[test]
+fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
+    let fake = FakeDocker::default();
+    let provider = provider("local", fake.clone());
+    let mut request = request();
+    request.target.lifetime = WorkerLifetime::Persistent;
+    assert!(request.is_valid_for(CloudProvider::LocalDocker));
+    assert_eq!(provider.ensure_worker(&request), Err(InvalidTarget));
+    let worker = InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: CloudProvider::LocalDocker,
+            workflow_id: request.workflow_id,
+            job_id: request.job_id,
+            resource_id: "a".repeat(64),
+        },
+        target: request.target,
+        ssh_public_key: request.ssh_public_key,
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    };
+    assert!(worker.is_valid_for(CloudProvider::LocalDocker));
+    assert_eq!(provider.inspect_worker(&worker), Err(InvalidPersistedWorker));
+    assert_eq!(provider.delete_worker(&worker), Err(InvalidPersistedWorker));
+    let state = fake.state();
+    assert_eq!(
+        (
+            state.inspect_calls,
+            state.create_calls,
+            state.host_key_calls,
+            state.delete_calls
+        ),
+        (0, 0, 0, 0)
+    );
+}
+
 #[test]
 fn creates_reuses_inspects_and_deletes_one_exact_worker() {
     let fake = FakeDocker::default();

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -252,7 +252,12 @@ impl RunPodClient {
             }
             Err(error) => return Err(error),
         };
-        if !created && !recovered_deadline_valid(&status.worker.terminate_after, target.lease_seconds) {
+        if !created
+            && !target
+                .lifetime
+                .time_limit_seconds()
+                .is_some_and(|seconds| recovered_deadline_valid(&status.worker.terminate_after, seconds))
+        {
             let worker = Box::new(status.worker);
             return if self.delete_worker(&worker).is_ok() {
                 Err(RunPodError::LeaseDeadlineRejected { worker })
@@ -465,7 +470,8 @@ impl CreatePodRequest {
         name: String,
         ssh_public_key: Option<&str>,
     ) -> Result<Self, RunPodError> {
-        let terminate_after = termination_deadline(target.lease_seconds)?;
+        let seconds = target.lifetime.time_limit_seconds().ok_or(RunPodError::InvalidTarget)?;
+        let terminate_after = termination_deadline(seconds)?;
         let mut env: Vec<_> = [
             (WORKFLOW_ENV, workflow_id.to_string()),
             (JOB_ENV, job_id.to_string()),
@@ -547,7 +553,10 @@ fn validate_target(target: &WorkerTarget, profile: &RunPodProfile) -> Result<(),
     let valid = target.provider == CloudProvider::RunPod
         && target.profile == profile.name
         && target.disk_gib > 0
-        && (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&target.lease_seconds)
+        && target
+            .lifetime
+            .time_limit_seconds()
+            .is_some_and(|seconds| (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&seconds))
         && target.max_hourly_cost_micros != Some(0)
         && valid_immutable_worker_image(&target.image)
         && safe_text(&profile.name)

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -2,8 +2,8 @@ use super::super::{
     CloudProvider, WorkerTarget,
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
-        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
-        InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_coordinates,
+        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
+        InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_coordinates,
     },
 };
 use super::{
@@ -65,9 +65,9 @@ impl RunPodInteractiveWorkerProvider {
                 },
                 target: target.clone(),
                 ssh_public_key: ssh_public_key.to_string(),
-                lease: InteractiveWorkerLease {
+                lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
                     terminate_after: status.worker.terminate_after,
-                },
+                }),
             },
             lifecycle,
             ssh,
@@ -176,13 +176,17 @@ fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError
     if !worker.is_valid_for(CloudProvider::RunPod) {
         return Err(RunPodError::InvalidPersistedWorker);
     }
+    let lease = worker
+        .lifetime
+        .as_time_limited()
+        .ok_or(RunPodError::InvalidPersistedWorker)?;
     let runpod_worker = RunPodWorker {
         workflow_id: worker.identity.workflow_id,
         job_id: worker.identity.job_id,
         pod_id: worker.identity.resource_id.clone(),
         name: resource_name(worker.identity.workflow_id, worker.identity.job_id),
         image: worker.target.image.clone(),
-        terminate_after: worker.lease.terminate_after.clone(),
+        terminate_after: lease.terminate_after.clone(),
         hourly_cost_micros: None,
     };
     runpod_worker.validate()?;

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -1,6 +1,8 @@
+use super::super::WorkerLifetime;
 use super::super::interactive_worker::{
     InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
-    InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest,
+    InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
+    InteractiveWorkerRequest,
 };
 use super::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
@@ -12,6 +14,7 @@ const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
 struct FakeTransport(Arc<Mutex<FakeState>>);
 #[derive(Default)]
 struct FakeState {
+    list_calls: usize,
     pods: Vec<ApiPod>,
     create_response: Option<ApiPod>,
     create_requests: Vec<CreatePodRequest>,
@@ -34,6 +37,7 @@ impl FakeTransport {
 impl Transport for FakeTransport {
     fn list_by_name(&self, _name: &str) -> Result<Vec<ApiPod>, RunPodError> {
         let mut state = self.0.lock().expect("state");
+        state.list_calls += 1;
         if !state.scripted_lists.is_empty() {
             return Ok(state.scripted_lists.remove(0));
         }
@@ -69,7 +73,7 @@ fn target() -> WorkerTarget {
             "registry.example/team/nativesdk@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
                 .to_string(),
         disk_gib: 80,
-        lease_seconds: 3_600,
+        lifetime: WorkerLifetime::TimeLimited { seconds: 3_600 },
         max_hourly_cost_micros: Some(750_000),
     }
 }
@@ -101,7 +105,8 @@ fn api_pod(
     target: &WorkerTarget,
     hourly_cost_micros: Option<u64>,
 ) -> ApiPod {
-    let terminate_after = termination_deadline(target.lease_seconds).expect("termination deadline");
+    let terminate_after = termination_deadline(target.lifetime.time_limit_seconds().expect("time-limited fixture"))
+        .expect("termination deadline");
     ApiPod {
         id: "pod_123456".to_string(),
         name: resource_name(workflow_id, job_id),
@@ -475,6 +480,46 @@ fn interactive_adapter_waits_for_trusted_host_key_and_fails_closed_on_invalid_da
 }
 
 #[test]
+fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let mut request = interactive_request(workflow_id, job_id);
+    request.target.lifetime = WorkerLifetime::Persistent;
+    let transport = FakeTransport::default();
+    let host_keys = FakeHostKeySource::new(None);
+    let host_key_calls = host_keys.calls.clone();
+    let provider =
+        RunPodInteractiveWorkerProvider::new(RunPodClient::with_transport(transport.clone()), profile(), host_keys);
+    assert!(request.is_valid_for(CloudProvider::RunPod));
+    assert_eq!(provider.ensure_worker(&request), Err(RunPodError::InvalidTarget));
+    let worker = InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: CloudProvider::RunPod,
+            workflow_id,
+            job_id,
+            resource_id: "pod_123456".to_string(),
+        },
+        target: request.target,
+        ssh_public_key: request.ssh_public_key,
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    };
+    assert!(worker.is_valid_for(CloudProvider::RunPod));
+    assert_eq!(
+        provider.inspect_worker(&worker),
+        Err(RunPodError::InvalidPersistedWorker)
+    );
+    assert_eq!(
+        provider.delete_worker(&worker),
+        Err(RunPodError::InvalidPersistedWorker)
+    );
+    let state = transport.0.lock().expect("state");
+    assert_eq!(state.list_calls, 0);
+    assert!(state.create_requests.is_empty());
+    assert!(state.inspected.is_empty());
+    assert!(state.deleted.is_empty());
+    assert!(host_key_calls.lock().expect("host key calls").is_empty());
+}
+
+#[test]
 fn interactive_adapter_rejects_invalid_handles_before_transport_io() {
     let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
     let request = interactive_request(workflow_id, job_id);
@@ -500,9 +545,9 @@ fn interactive_adapter_rejects_invalid_handles_before_transport_io() {
         },
         target: request.target,
         ssh_public_key: request.ssh_public_key,
-        lease: InteractiveWorkerLease {
+        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
             terminate_after: termination_deadline(900).expect("termination deadline"),
-        },
+        }),
     };
 
     assert_eq!(

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::PanelKind;
 use crate::cloud_run::{
-    ArtifactDigest, CloudJobId, CloudProvider, CloudWorkflowId, GitCommitSha, GitSource, WorkerTarget,
+    ArtifactDigest, CloudJobId, CloudProvider, CloudWorkflowId, GitCommitSha, GitSource, WorkerLifetime, WorkerTarget,
 };
 use crate::remote_workspace::{
     RemoteCleanupIntent, RemoteCleanupReason, RemotePanelBinding, RemoteRuntimeGeneration, RemoteRuntimePhase,
@@ -20,7 +20,7 @@ fn workspace(id: &str) -> RemoteWorkspaceState {
             profile: "local-development".into(),
             image: format!("registry.example/worker@sha256:{}", "a".repeat(64)),
             disk_gib: 20,
-            lease_seconds: 900,
+            lifetime: WorkerLifetime::TimeLimited { seconds: 900 },
             max_hourly_cost_micros: None,
         },
         repository: GitSource {

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -37,6 +37,33 @@ fn records_survive_reopen_and_cannot_be_read_or_adopted_by_another_session() {
 }
 
 #[test]
+fn persistent_runtime_round_trips_without_expiry_or_new_identity() {
+    use crate::cloud_run::interactive_worker::InteractiveWorkerLifetime;
+
+    let (_directory, store) = store();
+    let mut state = expired_runtime();
+    state.spec.target.lifetime = WorkerLifetime::Persistent;
+    let worker = state
+        .runtime
+        .as_mut()
+        .expect("runtime")
+        .worker
+        .as_mut()
+        .expect("worker");
+    worker.target = state.spec.target.clone();
+    worker.lifetime = InteractiveWorkerLifetime::Persistent;
+    state.validate().expect("persistent aggregate");
+    let stored = store.create_remote_workspace(OWNER, &state).expect("persist worker");
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_workspace(OWNER, "workspace").expect("recover"),
+        Some(stored.clone())
+    );
+    assert_eq!(reopened.list_remote_workspaces(OWNER).expect("inventory"), vec![stored]);
+    assert!(state.runtime.as_ref().expect("runtime").cleanup.is_none());
+}
+
+#[test]
 fn concurrent_writers_have_exactly_one_winner_and_preserve_the_winning_intent() {
     let (_directory, store) = store();
     let stored = store
@@ -198,7 +225,8 @@ fn pending_cleanup_preserves_its_exact_reason_and_request_time() {
 
 fn expired_runtime() -> RemoteWorkspaceState {
     use crate::cloud_run::interactive_worker::{
-        InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerSshEndpoint,
+        InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerLifetime,
+        InteractiveWorkerSshEndpoint,
     };
     let mut state = provisioning(workspace("workspace"));
     let key = public_key(7);
@@ -213,9 +241,9 @@ fn expired_runtime() -> RemoteWorkspaceState {
         },
         target: state.spec.target.clone(),
         ssh_public_key: public_key(6),
-        lease: InteractiveWorkerLease {
+        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
             terminate_after: "2020-01-01T00:00:00Z".into(),
-        },
+        }),
     });
     runtime.ssh = Some(InteractiveWorkerSshEndpoint {
         host: "127.0.0.1".into(),

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -5,8 +5,8 @@ use tempfile::TempDir;
 
 use super::*;
 use crate::cloud_run::{
-    CLOUD_RUN_PROTOCOL_VERSION, CloudJobOutcome, CloudJobState, CloudProgress, RetryPolicy, WorkerTarget, WorkflowNode,
-    WorkflowNodeKind,
+    CLOUD_RUN_PROTOCOL_VERSION, CloudJobOutcome, CloudJobState, CloudProgress, RetryPolicy, WorkerLifetime,
+    WorkerTarget, WorkflowNode, WorkflowNodeKind,
 };
 
 fn test_workflow(provider: CloudProvider, timestamp: i64) -> CloudWorkflow {
@@ -36,7 +36,7 @@ fn test_workflow(provider: CloudProvider, timestamp: i64) -> CloudWorkflow {
                 profile: "general".to_string(),
                 image: format!("registry.example/worker@sha256:{}", "a".repeat(64)),
                 disk_gib: 20,
-                lease_seconds: 3_600,
+                lifetime: WorkerLifetime::TimeLimited { seconds: 3_600 },
                 max_hourly_cost_micros: Some(500_000),
             }),
             input_artifact_ids: Vec::new(),

--- a/crates/horizon-core/src/cloud_run/validation.rs
+++ b/crates/horizon-core/src/cloud_run/validation.rs
@@ -102,7 +102,7 @@ fn validate_node(
         && (worker.profile.trim().is_empty()
             || !valid_worker_image(&worker.image)
             || worker.disk_gib == 0
-            || worker.lease_seconds == 0)
+            || !worker.lifetime.is_valid())
     {
         return Err(Error::InvalidWorkerTarget(node.id));
     }

--- a/crates/horizon-core/src/cloud_run/worker_lifetime.rs
+++ b/crates/horizon-core/src/cloud_run/worker_lifetime.rs
@@ -1,0 +1,160 @@
+//! Explicit execution lifetime, independent of controller ownership leases.
+
+use super::{CloudProtocolError, CloudProvider, WorkerTarget};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Persistent execution is the product default, never inferred from missing
+/// or malformed legacy metadata. Time limits require an explicit policy.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum WorkerLifetime {
+    #[default]
+    Persistent,
+    TimeLimited {
+        seconds: u32,
+    },
+}
+
+impl WorkerLifetime {
+    #[must_use]
+    pub const fn time_limit_seconds(self) -> Option<u32> {
+        match self {
+            Self::Persistent => None,
+            Self::TimeLimited { seconds } => Some(seconds),
+        }
+    }
+
+    pub(super) const fn is_valid(self) -> bool {
+        !matches!(self, Self::TimeLimited { seconds: 0 })
+    }
+}
+
+/// The bounded v1 representation is kept byte-for-byte. Persistent targets use
+/// a separate explicit marker; neither omission nor null selects persistence.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct WorkerTargetSnapshot {
+    provider: CloudProvider,
+    profile: String,
+    image: String,
+    disk_gib: u32,
+    #[serde(default, deserialize_with = "present_value", skip_serializing_if = "Option::is_none")]
+    lease_seconds: Option<u32>,
+    #[serde(default, deserialize_with = "present_value", skip_serializing_if = "Option::is_none")]
+    lifetime: Option<PersistentMarker>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_hourly_cost_micros: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PersistentMarker {
+    Persistent,
+}
+
+fn present_value<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+impl TryFrom<WorkerTargetSnapshot> for WorkerTarget {
+    type Error = CloudProtocolError;
+
+    fn try_from(value: WorkerTargetSnapshot) -> Result<Self, Self::Error> {
+        let lifetime = match (value.lease_seconds, value.lifetime) {
+            (Some(seconds), None) if seconds > 0 => WorkerLifetime::TimeLimited { seconds },
+            (None, Some(PersistentMarker::Persistent)) => WorkerLifetime::Persistent,
+            _ => return Err(CloudProtocolError::InvalidWorkerLifetime),
+        };
+        Ok(Self {
+            provider: value.provider,
+            profile: value.profile,
+            image: value.image,
+            disk_gib: value.disk_gib,
+            lifetime,
+            max_hourly_cost_micros: value.max_hourly_cost_micros,
+        })
+    }
+}
+
+impl From<WorkerTarget> for WorkerTargetSnapshot {
+    fn from(value: WorkerTarget) -> Self {
+        Self {
+            provider: value.provider,
+            profile: value.profile,
+            image: value.image,
+            disk_gib: value.disk_gib,
+            lease_seconds: value.lifetime.time_limit_seconds(),
+            lifetime: matches!(value.lifetime, WorkerLifetime::Persistent).then_some(PersistentMarker::Persistent),
+            max_hourly_cost_micros: value.max_hourly_cost_micros,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn target_fields() -> serde_json::Value {
+        json!({
+            "provider": "local_docker",
+            "profile": "development",
+            "image": format!("registry.example/worker@sha256:{}", "a".repeat(64)),
+            "disk_gib": 20
+        })
+    }
+
+    #[test]
+    fn persistent_default_requires_an_explicit_wire_marker() {
+        assert_eq!(WorkerLifetime::default(), WorkerLifetime::Persistent);
+        let mut fields = target_fields();
+        assert!(serde_json::from_value::<WorkerTarget>(fields.clone()).is_err());
+        fields["lifetime"] = json!("persistent");
+        let target: WorkerTarget = serde_json::from_value(fields.clone()).expect("explicit persistent target");
+        assert_eq!(target.lifetime, WorkerLifetime::Persistent);
+        assert_eq!(target.lifetime.time_limit_seconds(), None);
+        assert_eq!(serde_json::to_value(target).expect("serialize target"), fields);
+    }
+
+    #[test]
+    fn legacy_time_limit_keeps_its_exact_wire_representation() {
+        let legacy = r#"{"provider":"local_docker","profile":"development","image":"registry.example/worker","disk_gib":20,"lease_seconds":900,"max_hourly_cost_micros":500000}"#;
+        let target: WorkerTarget = serde_json::from_str(legacy).expect("legacy target");
+        assert_eq!(target.lifetime, WorkerLifetime::TimeLimited { seconds: 900 });
+        assert_eq!(target.lifetime.time_limit_seconds(), Some(900));
+        assert_eq!(serde_json::to_string(&target).expect("serialize legacy"), legacy);
+    }
+
+    #[test]
+    fn missing_conflicting_null_or_unknown_lifetime_never_means_persistent() {
+        for policy in [
+            json!({}),
+            json!({"lease_seconds": null}),
+            json!({"lifetime": null}),
+            json!({"lease_seconds": 0}),
+            json!({"lease_seconds": -1}),
+            json!({"lease_seconds": 4_294_967_296_u64}),
+            json!({"lease_seconds": "900"}),
+            json!({"lifetime": "unknown"}),
+            json!({"lifetime": true}),
+            json!({"lifetime": "persistent", "lease_seconds": 900}),
+            json!({"lifetime": "persistent", "lease_seconds": null}),
+            json!({"lifetime": null, "lease_seconds": 900}),
+            json!({"lifetime": "persistent", "unexpected": true}),
+        ] {
+            let mut fields = target_fields();
+            fields
+                .as_object_mut()
+                .expect("target object")
+                .extend(policy.as_object().expect("policy object").clone());
+            assert!(
+                serde_json::from_value::<WorkerTarget>(fields).is_err(),
+                "accepted {policy}"
+            );
+        }
+        assert!(!WorkerLifetime::TimeLimited { seconds: 0 }.is_valid());
+    }
+}

--- a/crates/horizon-core/src/remote_workspace/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cloud_run::{
-    CloudProvider,
-    interactive_worker::{InteractiveWorkerIdentity, InteractiveWorkerLease},
+    CloudProvider, WorkerLifetime,
+    interactive_worker::{InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerLifetime},
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde_json::json;
@@ -25,7 +25,7 @@ fn spec() -> RemoteWorkspaceSpec {
             profile: "gpu-development".into(),
             image: format!("registry.example/worker@sha256:{}", "a".repeat(64)),
             disk_gib: 20,
-            lease_seconds: 900,
+            lifetime: WorkerLifetime::TimeLimited { seconds: 900 },
             max_hourly_cost_micros: Some(100_000),
         },
         repository: GitSource {
@@ -58,9 +58,9 @@ fn active() -> RemoteWorkspaceState {
         },
         target: spec.target.clone(),
         ssh_public_key: key(),
-        lease: InteractiveWorkerLease {
+        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
             terminate_after: "2020-01-01T00:00:00Z".into(),
-        },
+        }),
     };
     RemoteWorkspaceState {
         version: REMOTE_WORKSPACE_STATE_VERSION,

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -75,9 +75,13 @@ back into large multi-purpose modules.
 - `local_store.rs` centralizes agent-store environment paths and read-only
   SQLite opening so discovery, validation, and usage reporting agree.
 - `remote_workspace/` owns the versioned remote-workspace aggregate, desired
-  panels, disposable runtime generation, and repository checkpoint metadata.
+  panels, exact runtime generation, and repository checkpoint metadata.
   Its validation is pure: provider I/O, runtime-state migration, coordination,
   repository transfer, and UI integration belong in later focused modules.
+- `cloud_run/worker_lifetime.rs` owns explicit execution lifetime and compatible
+  target serialization. `interactive_worker.rs` validates observed lifetime
+  against that policy; neither represents the client/creation ownership lease.
+  Missing or malformed legacy metadata never selects persistent execution.
 - `cloud_run/store.rs` owns workflow snapshots and creation-claim transactions.
   Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
   schema initialization, and compatibility checks. Keep database opening separate

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -32,9 +32,22 @@ event loop remaining available. A dedicated Remote Environments overview will
 expose reconnect and explicit stop/kill or manual cleanup/delete actions.
 
 The image permits an unset expiry for persistent execution and retains a bounded
-watchdog only for explicitly time-limited jobs. Existing provider deadline types,
-profiles, and integration still require the corresponding lifetime correction;
-neither record storage nor the image alone completes persistent cloud workspaces.
+watchdog only for explicitly time-limited jobs. Provider-neutral targets and
+worker handles distinguish persistent execution from explicit time limits; a
+worker observation must match its target's lifetime policy before attachment.
+Provider implementations and profiles still need persistent execution support:
+the existing adapters reject unsupported persistent requests/handles before I/O.
+Neither record storage nor these contracts alone complete persistent cloud workspaces.
+
+The product policy defaults to persistent, but saved records never infer that
+policy from missing or malformed data. Persistent targets contain the explicit
+`"lifetime":"persistent"` marker; legacy timed targets retain `lease_seconds`
+and their exact v1 wire representation. Observed worker lifetimes keep the v1
+`lease` field name: a timed observation contains `terminate_after`, while a
+persistent observation contains only `"lifetime":"persistent"`. Missing, null,
+conflicting, and unknown policies fail closed. Older clients reject the new
+marker instead of silently treating a persistent environment as temporary.
+Existing time-limited jobs are never converted into unbounded compute.
 
 ### Durable local identity records
 


### PR DESCRIPTION
## Purpose

Advances #383 with an explicit execution-lifetime model, independent of client attachment and ownership leases.

- Represent persistent execution separately from explicitly time-limited jobs, with no numeric sentinel or manufactured expiry.
- Preserve the exact v1 representation of legacy timed targets and worker observations.
- Require an explicit persistence marker; reject missing, null, conflicting, or unknown policy metadata.
- Validate that observed worker lifetime matches the requested policy before attachment, and preserve persistent identity through store reopen.
- Make both existing adapters reject unsupported persistent requests and handles before any provider I/O.

## Scope and limits

One model/compatibility outcome: 14 source/test files, 628 changed source/test lines, plus two architecture documents. The existing scope exception covers the required constructor and validation migrations.

This does not activate persistent provider execution, add the Remote Environments widget, implement remote storage, or prove physical-PC-off operation. Existing timed resources retain their bounded behavior. No UI, default configuration, dependency, cloud resource, image publication, or release changes are included.

## Validation

Candidate: `6ce4b690da7af7032c2f365c3a12d805ad69efec`.

- Formatting, maintainability, and version-sync checks.
- Full workspace default and speech tests with warnings denied and `RUST_TEST_THREADS=1`; assertions and test selection are unchanged.
- Blocking, strict panic-lint, and advisory pedantic Clippy tiers.
- All 71 focused cloud-workflow tests, including an eight-thread repeat.
- Explicit-marker and malformed-policy regressions, exact legacy serialization, target/observation mismatch rejection, persistent store reopen with unchanged identity, and zero-call guards for unsupported provider operations.
- Full-diff self-review and independent source-only local review before opening.

There is no changed UI to smoke. Runtime provider activation and the independent-machine persistence proof remain separate acceptance gates tracked in #383.
