### PR TITLE
feat(remote): support persistent local workers

### DIFF
--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -1,7 +1,7 @@
-//! Local Docker implementation of the disposable interactive-worker contract.
+//! Local Docker implementation of persistent and time-limited interactive workers.
 
 use super::{
-    CLOUD_RUN_PROTOCOL_VERSION, CloudProvider, WorkerTarget,
+    CLOUD_RUN_PROTOCOL_VERSION, CloudProvider, WorkerLifetime, WorkerTarget,
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
         InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
@@ -45,7 +45,7 @@ pub struct LocalDockerProfile {
     pub docker_host: String,
 }
 
-/// Disposable worker provider backed by the local Docker daemon.
+/// Interactive worker provider backed by an explicitly selected local Docker daemon.
 pub struct LocalDockerInteractiveWorkerProvider {
     transport: Box<dyn DockerTransport>,
     profile: LocalDockerProfile,
@@ -129,7 +129,7 @@ impl LocalDockerInteractiveWorkerProvider {
                     .lifetime
                     .as_time_limited()
                     .map(|lease| lease.terminate_after.as_str())
-                    != Some(create.terminate_after.as_str())
+                    != create.terminate_after.as_deref()
                 {
                     return self.cleanup_invalid_creation(
                         &container,
@@ -165,6 +165,9 @@ impl LocalDockerInteractiveWorkerProvider {
                 match self.ensure_existing(request, &container) {
                     Ok(status) => return Ok(InteractiveWorkerEnsure::Reused(status)),
                     Err(LocalDockerError::ResourceAbsent) => {}
+                    Err(error) if create.terminate_after.is_none() => {
+                        return Err(persistent_reconciliation_error(&container, create, error));
+                    }
                     Err(error) => return self.cleanup_invalid_creation(&container, create, error),
                 }
             }
@@ -181,6 +184,12 @@ impl LocalDockerInteractiveWorkerProvider {
     ) -> DockerResult<InteractiveWorkerEnsure> {
         let resource_id = container.id.clone();
         if !created_container_matches(container, create) {
+            if create.terminate_after.is_none()
+                && created_container_identity_matches(container, create)
+                && !lifetime_matches(container, None)
+            {
+                return Err(LocalDockerError::PersistentLifetimeMetadataConflict { resource_id });
+            }
             return Err(original);
         }
         if self.transport.delete(&resource_id).is_err() || !matches!(self.transport.inspect(&resource_id), Ok(None)) {
@@ -290,6 +299,10 @@ pub enum LocalDockerError {
     ResourceIdentityMismatch,
     #[error("local Docker worker {resource_id} could not be verified or deleted after creation")]
     CreationCleanupFailed { resource_id: String },
+    #[error("created local Docker worker {resource_id} has unexpected expiry metadata and requires manual inspection")]
+    PersistentLifetimeMetadataConflict { resource_id: String },
+    #[error("persistent local Docker worker {resource_id} requires reconciliation after an uncertain create response")]
+    PersistentCreationReconciliationRequired { resource_id: String },
     #[error("local Docker worker {resource_id} had an out-of-bounds lease and was deleted")]
     LeaseDeadlineRejected { resource_id: String },
     #[error("local Docker worker {resource_id} had an out-of-bounds lease but cleanup failed")]
@@ -333,27 +346,23 @@ struct DockerCreateRequest {
     image: String,
     labels: BTreeMap<String, String>,
     ssh_public_key: String,
-    terminate_after: String,
+    terminate_after: Option<String>,
 }
 
 impl DockerCreateRequest {
     fn new(request: &InteractiveWorkerRequest, name: &str) -> DockerResult<Self> {
-        let now = time::OffsetDateTime::now_utc();
-        let seconds = request
+        let terminate_after = request
             .target
             .lifetime
             .time_limit_seconds()
-            .ok_or(LocalDockerError::InvalidTarget)?;
-        let deadline = now
-            .checked_add(time::Duration::seconds(i64::from(seconds)))
-            .ok_or(LocalDockerError::InvalidTarget)?;
-        let terminate_after = deadline
-            .format(&time::format_description::well_known::Rfc3339)
-            .map_err(|_| LocalDockerError::InvalidTarget)?;
+            .map(termination_deadline)
+            .transpose()?;
         let ssh_public_key = canonical_ed25519_key(&request.ssh_public_key).ok_or(LocalDockerError::InvalidTarget)?;
         let mut labels = request_labels(request)?;
         labels.insert(SSH_KEY_LABEL.to_string(), ssh_public_key.clone());
-        labels.insert(TERMINATE_LABEL.to_string(), terminate_after.clone());
+        if let Some(deadline) = &terminate_after {
+            labels.insert(TERMINATE_LABEL.to_string(), deadline.clone());
+        }
         Ok(Self {
             name: name.to_string(),
             image: request.target.image.clone(),
@@ -363,12 +372,17 @@ impl DockerCreateRequest {
         })
     }
 }
+fn termination_deadline(seconds: u32) -> DockerResult<String> {
+    time::OffsetDateTime::now_utc()
+        .checked_add(time::Duration::seconds(i64::from(seconds)))
+        .ok_or(LocalDockerError::InvalidTarget)?
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(|_| LocalDockerError::InvalidTarget)
+}
 fn validate_request(request: &InteractiveWorkerRequest, profile: &LocalDockerProfile) -> DockerResult<()> {
-    (request.target.profile == profile.name
-        && request.is_valid_for(CloudProvider::LocalDocker)
-        && request.target.lifetime.time_limit_seconds().is_some())
-    .then_some(())
-    .ok_or(LocalDockerError::InvalidTarget)
+    (request.target.profile == profile.name && request.is_valid_for(CloudProvider::LocalDocker))
+        .then_some(())
+        .ok_or(LocalDockerError::InvalidTarget)
 }
 fn valid_local_docker_host(value: &str) -> bool {
     let safe = |path: &str| !path.is_empty() && !path.chars().any(char::is_control);
@@ -378,17 +392,20 @@ fn valid_local_docker_host(value: &str) -> bool {
         || value.strip_prefix("npipe:////./pipe/").is_some_and(safe)
 }
 fn validate_worker(worker: &InteractiveWorker) -> DockerResult<()> {
-    (worker.is_valid_for(CloudProvider::LocalDocker)
-        && worker.lifetime.as_time_limited().is_some()
-        && valid_container_id(&worker.identity.resource_id))
-    .then_some(())
-    .ok_or(LocalDockerError::InvalidPersistedWorker)
+    (worker.is_valid_for(CloudProvider::LocalDocker) && valid_container_id(&worker.identity.resource_id))
+        .then_some(())
+        .ok_or(LocalDockerError::InvalidPersistedWorker)
 }
 fn worker_for_request(
     container: &DockerContainer,
     request: &InteractiveWorkerRequest,
 ) -> DockerResult<InteractiveWorker> {
-    let terminate_after = required_environment(container, TERMINATE_ENV)?;
+    let lifetime = match request.target.lifetime {
+        WorkerLifetime::Persistent => InteractiveWorkerLifetime::Persistent,
+        WorkerLifetime::TimeLimited { .. } => InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: required_environment(container, TERMINATE_ENV)?.to_string(),
+        }),
+    };
     let worker = InteractiveWorker {
         identity: InteractiveWorkerIdentity {
             provider: CloudProvider::LocalDocker,
@@ -398,19 +415,17 @@ fn worker_for_request(
         },
         target: request.target.clone(),
         ssh_public_key: request.ssh_public_key.clone(),
-        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
-            terminate_after: terminate_after.to_string(),
-        }),
+        lifetime,
     };
     verify_container_for_worker(container, &worker)?;
     Ok(worker)
 }
 fn verify_container_for_worker(container: &DockerContainer, worker: &InteractiveWorker) -> DockerResult<()> {
     validate_worker(worker)?;
-    let lease = worker
+    let terminate_after = worker
         .lifetime
         .as_time_limited()
-        .ok_or(LocalDockerError::InvalidPersistedWorker)?;
+        .map(|lease| lease.terminate_after.as_str());
     let ssh_public_key =
         canonical_ed25519_key(&worker.ssh_public_key).ok_or(LocalDockerError::InvalidPersistedWorker)?;
     let expected_name = container_name(worker.identity.workflow_id, worker.identity.job_id);
@@ -421,7 +436,6 @@ fn verify_container_for_worker(container: &DockerContainer, worker: &Interactive
         (WORKFLOW_LABEL, worker.identity.workflow_id.to_string()),
         (JOB_LABEL, worker.identity.job_id.to_string()),
         (SSH_KEY_LABEL, ssh_public_key.clone()),
-        (TERMINATE_LABEL, lease.terminate_after.clone()),
     ];
     let valid = container.id == worker.identity.resource_id
         && container.name == expected_name
@@ -431,7 +445,7 @@ fn verify_container_for_worker(container: &DockerContainer, worker: &Interactive
             .iter()
             .all(|(key, value)| container.labels.get(*key) == Some(value))
         && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(ssh_public_key.as_str())
-        && required_environment(container, TERMINATE_ENV) == Ok(lease.terminate_after.as_str())
+        && lifetime_matches(container, terminate_after)
         && valid_target_label(&container.labels, worker);
     valid.then_some(()).ok_or(LocalDockerError::ResourceIdentityMismatch)
 }
@@ -454,17 +468,54 @@ fn request_labels(request: &InteractiveWorkerRequest) -> DockerResult<BTreeMap<S
 }
 fn required_environment<'a>(container: &'a DockerContainer, key: &str) -> DockerResult<&'a str> {
     let prefix = format!("{key}=");
-    let mut values = container
+    let mut entries = container
         .environment
         .iter()
-        .filter_map(|entry| entry.strip_prefix(&prefix));
-    let value = values.next().ok_or(LocalDockerError::ResourceIdentityMismatch)?;
-    if values.next().is_some() {
+        .filter(|entry| environment_key_matches(entry, key));
+    let value = entries
+        .next()
+        .and_then(|entry| entry.strip_prefix(&prefix))
+        .ok_or(LocalDockerError::ResourceIdentityMismatch)?;
+    if entries.next().is_some() {
         return Err(LocalDockerError::ResourceIdentityMismatch);
     }
     Ok(value)
 }
+fn environment_key_matches(entry: &str, key: &str) -> bool {
+    entry
+        .strip_prefix(key)
+        .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('='))
+}
+fn lifetime_matches(container: &DockerContainer, terminate_after: Option<&str>) -> bool {
+    container.labels.get(TERMINATE_LABEL).map(String::as_str) == terminate_after
+        && match terminate_after {
+            Some(deadline) => required_environment(container, TERMINATE_ENV) == Ok(deadline),
+            None => !container
+                .environment
+                .iter()
+                .any(|entry| environment_key_matches(entry, TERMINATE_ENV)),
+        }
+}
 fn created_container_matches(container: &DockerContainer, create: &DockerCreateRequest) -> bool {
+    created_container_identity_matches(container, create)
+        && lifetime_matches(container, create.terminate_after.as_deref())
+}
+fn persistent_reconciliation_error(
+    container: &DockerContainer,
+    create: &DockerCreateRequest,
+    original: LocalDockerError,
+) -> LocalDockerError {
+    if !created_container_identity_matches(container, create) {
+        return original;
+    }
+    let resource_id = container.id.clone();
+    if lifetime_matches(container, None) {
+        LocalDockerError::PersistentCreationReconciliationRequired { resource_id }
+    } else {
+        LocalDockerError::PersistentLifetimeMetadataConflict { resource_id }
+    }
+}
+fn created_container_identity_matches(container: &DockerContainer, create: &DockerCreateRequest) -> bool {
     valid_container_id(&container.id)
         && container.name == create.name
         && container.image == create.image
@@ -474,7 +525,6 @@ fn created_container_matches(container: &DockerContainer, create: &DockerCreateR
             .iter()
             .all(|(key, value)| container.labels.get(key) == Some(value))
         && required_environment(container, SSH_PUBLIC_KEY_ENV) == Ok(create.ssh_public_key.as_str())
-        && required_environment(container, TERMINATE_ENV) == Ok(create.terminate_after.as_str())
 }
 fn canonical_ed25519_key(value: &str) -> Option<String> {
     if !valid_ssh_public_key(value) {

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -84,12 +84,14 @@ impl DockerTransport for DockerCli {
             "127.0.0.1::22",
             "--env",
             &format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key),
-            "--env",
-            &format!("{TERMINATE_ENV}={}", request.terminate_after),
         ]
         .into_iter()
         .map(OsString::from)
         .collect();
+        if let Some(deadline) = &request.terminate_after {
+            args.push(OsString::from("--env"));
+            args.push(OsString::from(format!("{TERMINATE_ENV}={deadline}")));
+        }
         for (key, value) in &request.labels {
             args.push(OsString::from("--label"));
             args.push(OsString::from(format!("{key}={value}")));

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -1,9 +1,10 @@
-use super::super::WorkerLifetime;
 use super::*;
 use InteractiveWorkerCleanup::{AlreadyAbsent, Deleted};
 use LocalDockerError::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
+
+mod lifetime;
 
 #[derive(Clone, Default)]
 struct FakeDocker(Arc<Mutex<FakeState>>);
@@ -15,11 +16,13 @@ struct FakeState {
     create_calls: usize,
     delete_calls: usize,
     fail_create_after_insert: bool,
+    reject_create: bool,
     create_response_id: Option<String>,
     failed_inspections_after_create: usize,
     hidden_inspections_after_create: usize,
     binding_host: Option<String>,
     disappear_during_key_read: bool,
+    image_environment: Vec<String>,
 }
 impl FakeDocker {
     fn state(&self) -> std::sync::MutexGuard<'_, FakeState> {
@@ -49,16 +52,23 @@ impl DockerTransport for FakeDocker {
     fn create(&self, request: &DockerCreateRequest) -> Result<String, LocalDockerError> {
         let mut state = self.state();
         state.create_calls += 1;
+        if state.reject_create {
+            return Err(CommandFailed {
+                operation: "container creation",
+            });
+        }
         let id = "a".repeat(64);
+        let mut environment = vec![format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key)];
+        if let Some(deadline) = &request.terminate_after {
+            environment.push(format!("{TERMINATE_ENV}={deadline}"));
+        }
+        environment.extend(state.image_environment.iter().cloned());
         state.container = Some(DockerContainer {
             id: id.clone(),
             name: request.name.clone(),
             image: request.image.clone(),
             labels: request.labels.clone(),
-            environment: vec![
-                format!("{SSH_PUBLIC_KEY_ENV}={}", request.ssh_public_key),
-                format!("{TERMINATE_ENV}={}", request.terminate_after),
-            ],
+            environment,
             restart_policy: "no".to_string(),
             running: true,
             state: "running".to_string(),
@@ -142,13 +152,15 @@ fn provider(name: &str, fake: FakeDocker) -> LocalDockerInteractiveWorkerProvide
 }
 
 #[test]
-fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
+fn malformed_lifetime_handles_fail_before_provider_io() {
     let fake = FakeDocker::default();
     let provider = provider("local", fake.clone());
     let mut request = request();
     request.target.lifetime = WorkerLifetime::Persistent;
     assert!(request.is_valid_for(CloudProvider::LocalDocker));
-    assert_eq!(provider.ensure_worker(&request), Err(InvalidTarget));
+    let mut invalid_request = request.clone();
+    invalid_request.target.lifetime = WorkerLifetime::TimeLimited { seconds: 0 };
+    assert_eq!(provider.ensure_worker(&invalid_request), Err(InvalidTarget));
     let worker = InteractiveWorker {
         identity: InteractiveWorkerIdentity {
             provider: CloudProvider::LocalDocker,
@@ -158,11 +170,19 @@ fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
         },
         target: request.target,
         ssh_public_key: request.ssh_public_key,
-        lifetime: InteractiveWorkerLifetime::Persistent,
+        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: termination_deadline(900).expect("bounded observation"),
+        }),
     };
-    assert!(worker.is_valid_for(CloudProvider::LocalDocker));
+    assert!(!worker.is_valid_for(CloudProvider::LocalDocker));
     assert_eq!(provider.inspect_worker(&worker), Err(InvalidPersistedWorker));
     assert_eq!(provider.delete_worker(&worker), Err(InvalidPersistedWorker));
+    let mut reverse = worker;
+    reverse.target.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
+    reverse.lifetime = InteractiveWorkerLifetime::Persistent;
+    assert!(!reverse.is_valid_for(CloudProvider::LocalDocker));
+    assert_eq!(provider.inspect_worker(&reverse), Err(InvalidPersistedWorker));
+    assert_eq!(provider.delete_worker(&reverse), Err(InvalidPersistedWorker));
     let state = fake.state();
     assert_eq!(
         (

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
@@ -1,0 +1,227 @@
+use super::*;
+
+fn persistent_request() -> InteractiveWorkerRequest {
+    let mut request = request();
+    request.target.lifetime = WorkerLifetime::Persistent;
+    request
+}
+
+#[test]
+fn persistent_worker_is_reused_after_controller_drop_without_an_expiry() {
+    let request = persistent_request();
+    let fake = FakeDocker::default();
+    let original = provider("local", fake.clone());
+    let created = original.ensure_worker(&request).expect("create persistent worker");
+    assert!(matches!(created, InteractiveWorkerEnsure::Created(_)));
+    let status = created.into_status();
+    assert_eq!(status.worker.lifetime, InteractiveWorkerLifetime::Persistent);
+    assert!(status.is_ready_for(&request, time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(3_650)));
+    {
+        let state = fake.state();
+        let container = state.container.as_ref().expect("running container");
+        assert!(!container.labels.contains_key(TERMINATE_LABEL));
+        assert!(lifetime_matches(container, None));
+    }
+    let encoded = serde_json::to_string(&status.worker).expect("persist handle");
+    let worker: InteractiveWorker = serde_json::from_str(&encoded).expect("restore handle");
+    drop(original);
+    let reopened = provider("local", fake.clone());
+    assert_eq!(reopened.inspect_worker(&worker), Ok(Some(status.clone())));
+    assert_eq!(
+        reopened.ensure_worker(&request),
+        Ok(InteractiveWorkerEnsure::Reused(status))
+    );
+    {
+        let state = fake.state();
+        assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+    }
+    assert_eq!(reopened.delete_worker(&worker), Ok(Deleted));
+    assert_eq!(reopened.delete_worker(&worker), Ok(AlreadyAbsent));
+}
+
+#[test]
+fn a_stopped_or_missing_persistent_worker_is_not_recreated_by_inspection() {
+    let request = persistent_request();
+    let fake = FakeDocker::default();
+    let provider = provider("local", fake.clone());
+    let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
+    {
+        let mut state = fake.state();
+        let container = state.container.as_mut().expect("container");
+        container.running = false;
+        container.state = "exited".into();
+    }
+    let stopped = provider
+        .inspect_worker(&worker)
+        .expect("inspect stopped")
+        .expect("retained");
+    assert_eq!(stopped.lifecycle, InteractiveWorkerLifecycle::Stopped);
+    assert!(stopped.ssh.is_none());
+    assert_eq!(stopped.worker, worker);
+    assert_eq!(
+        provider.ensure_worker(&request),
+        Ok(InteractiveWorkerEnsure::Reused(stopped))
+    );
+    fake.state().container = None;
+    assert_eq!(provider.inspect_worker(&worker), Ok(None));
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+}
+
+#[test]
+fn persistent_metadata_drift_never_authorizes_reuse_or_deletion() {
+    for drift in 0..6 {
+        let request = persistent_request();
+        let fake = FakeDocker::default();
+        let provider = provider("local", fake.clone());
+        let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
+        {
+            let mut state = fake.state();
+            let container = state.container.as_mut().expect("container");
+            match drift {
+                0 => container.environment.push(format!("{TERMINATE_ENV}=")),
+                1 => container
+                    .environment
+                    .push(format!("{TERMINATE_ENV}=2020-01-01T00:00:00Z")),
+                2 => container.environment.push(TERMINATE_ENV.into()),
+                3 => {
+                    container.labels.insert(TERMINATE_LABEL.into(), String::new());
+                }
+                4 => {
+                    container
+                        .labels
+                        .insert(TERMINATE_LABEL.into(), "2020-01-01T00:00:00Z".into());
+                }
+                _ => {
+                    container.labels.insert(
+                        TARGET_LABEL.into(),
+                        serde_json::to_string(&super::request().target).expect("time-limited target"),
+                    );
+                }
+            }
+        }
+        assert_eq!(provider.ensure_worker(&request), Err(ResourceIdentityMismatch));
+        assert_eq!(provider.inspect_worker(&worker), Err(ResourceIdentityMismatch));
+        assert_eq!(provider.delete_worker(&worker), Err(ResourceIdentityMismatch));
+        let state = fake.state();
+        assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+        assert!(state.container.is_some());
+    }
+}
+
+#[test]
+fn a_timed_worker_is_never_adopted_as_persistent_or_vice_versa() {
+    for initial in [request(), persistent_request()] {
+        let fake = FakeDocker::default();
+        let provider = provider("local", fake.clone());
+        provider.ensure_worker(&initial).expect("create original policy");
+        let mut changed = initial;
+        changed.target.lifetime = match changed.target.lifetime {
+            WorkerLifetime::Persistent => WorkerLifetime::TimeLimited { seconds: 900 },
+            WorkerLifetime::TimeLimited { .. } => WorkerLifetime::Persistent,
+        };
+        assert_eq!(provider.ensure_worker(&changed), Err(ResourceIdentityMismatch));
+        let state = fake.state();
+        assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+    }
+}
+
+#[test]
+fn persistent_lost_create_response_recovers_the_same_exact_worker() {
+    let fake = FakeDocker::default();
+    fake.state().fail_create_after_insert = true;
+    let provider = provider("local", fake.clone());
+    let result = provider
+        .ensure_worker(&persistent_request())
+        .expect("reconcile creation");
+    assert!(matches!(result, InteractiveWorkerEnsure::Reused(_)));
+    assert_eq!(result.status().worker.lifetime, InteractiveWorkerLifetime::Persistent);
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+}
+
+#[test]
+fn unexpected_image_expiry_retains_the_created_identity_for_manual_inspection() {
+    for entry in [
+        TERMINATE_ENV.to_string(),
+        format!("{TERMINATE_ENV}="),
+        format!("{TERMINATE_ENV}=2020-01-01T00:00:00Z"),
+    ] {
+        let fake = FakeDocker::default();
+        fake.state().image_environment.push(entry);
+        let result = provider("local", fake.clone()).ensure_worker(&persistent_request());
+        assert_eq!(
+            result,
+            Err(PersistentLifetimeMetadataConflict {
+                resource_id: "a".repeat(64)
+            })
+        );
+        let state = fake.state();
+        assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+        assert_eq!(
+            state.container.as_ref().expect("retained for manual inspection").id,
+            "a".repeat(64)
+        );
+    }
+}
+
+#[test]
+fn timed_lifetime_rejects_bare_or_duplicate_expiry_without_deletion() {
+    for bare in [true, false] {
+        let fake = FakeDocker::default();
+        let provider = provider("local", fake.clone());
+        let request = request();
+        let worker = provider
+            .ensure_worker(&request)
+            .expect("create timed worker")
+            .into_status()
+            .worker;
+        {
+            let mut state = fake.state();
+            let container = state.container.as_mut().expect("container");
+            let extra = if bare {
+                TERMINATE_ENV.to_string()
+            } else {
+                format!(
+                    "{TERMINATE_ENV}={}",
+                    required_environment(container, TERMINATE_ENV).expect("original expiry")
+                )
+            };
+            container.environment.push(extra);
+        }
+        assert_eq!(provider.ensure_worker(&request), Err(ResourceIdentityMismatch));
+        assert_eq!(provider.inspect_worker(&worker), Err(ResourceIdentityMismatch));
+        assert_eq!(provider.delete_worker(&worker), Err(ResourceIdentityMismatch));
+        assert_eq!(fake.state().delete_calls, 0);
+    }
+}
+
+#[test]
+fn a_persistent_create_race_never_deletes_the_recovered_peers_worker() {
+    let request = persistent_request();
+    let fake = FakeDocker::default();
+    let provider = provider("local", fake.clone());
+    let worker = provider
+        .ensure_worker(&request)
+        .expect("peer creates worker")
+        .into_status()
+        .worker;
+    {
+        let mut state = fake.state();
+        state.hidden_inspections_after_create = 1;
+        state.reject_create = true;
+        state.container.as_mut().expect("peer worker").ssh_bindings[0].host = "0.0.0.0".into();
+    }
+    assert_eq!(
+        provider.ensure_worker(&request),
+        Err(PersistentCreationReconciliationRequired {
+            resource_id: worker.identity.resource_id.clone()
+        })
+    );
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (2, 0));
+    assert_eq!(
+        state.container.as_ref().expect("peer worker retained").id,
+        worker.identity.resource_id
+    );
+}

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -35,8 +35,18 @@ The image permits an unset expiry for persistent execution and retains a bounded
 watchdog only for explicitly time-limited jobs. Provider-neutral targets and
 worker handles distinguish persistent execution from explicit time limits; a
 worker observation must match its target's lifetime policy before attachment.
-Provider implementations and profiles still need persistent execution support:
-the existing adapters reject unsupported persistent requests/handles before I/O.
+The local container adapter supports both explicit policies, rejects expiry
+metadata on a persistent worker, and preserves the same worker across controller
+drop/reopen. Inspection never creates a missing worker, and finding a stopped
+worker does not restart or replace it. If a newly created persistent worker
+has conflicting image-supplied expiry metadata, its exact identity is returned
+for manual inspection; metadata drift never authorizes automatic deletion.
+After an ambiguous persistent create response, a recovered worker is retained
+if inspection fails: another controller may already be using it. The returned
+exact identity permits reconciliation, not an unverified cleanup or replacement.
+The remote GPU adapter still rejects
+unsupported persistent requests/handles before I/O; product profiles and the
+remaining remote implementations still need persistent execution support.
 Neither record storage nor these contracts alone complete persistent cloud workspaces.
 
 The product policy defaults to persistent, but saved records never infer that


### PR DESCRIPTION
## Purpose

Advances #383 by supporting persistent execution through the local worker provider while preserving explicitly timed workers.

- Omit expiry environment and label metadata for a persistent request; require their verified absence before reuse or deletion.
- Preserve the same worker across client drop/reopen and serialized-handle recovery. Inspection never creates a missing worker, and a stopped worker is not restarted or replaced.
- Reject lifetime-policy drift, bare/duplicate expiry entries, and malformed handles without unsafe provider operations.
- Retain the exact identity for manual reconciliation when a persistent create has conflicting metadata or an ambiguous response. A competing client cannot trigger cleanup of a recovered persistent worker merely because inspection fails.

## Validation

Candidate: `1a08f08cd4101b1e7add9047cb052a3772f33209`.

- Formatting, maintainability, version sync, full default/speech workspace tests, blocking and strict Clippy, and the advisory pedantic tier.
- Full suites use `RUST_TEST_THREADS=1` with unchanged assertions/test selection; all 79 cloud-workflow tests also passed in an eight-thread repeat.
- All 16 focused local-provider tests pass, including explicit-timed compatibility, both lifetime-mismatch directions, dropped clients, stopped/absent inspection, ambiguous creation, conflicting metadata, and the competing-client cleanup regression.
- Full diff self-review and independent source-only local reviews completed with no remaining in-scope blockers.
- Real native-provider smoke on a pinned image: explicit local endpoint despite hostile ambient settings; no persistent expiry field/label or watchdog; pinned SSH; nine seconds of detached task progress before reconnect; unchanged worker, host key, tmux session and process across separate clients.
- Manually stopped only the test container, verified retained data, and confirmed native inspection/reuse left it stopped. Exact native deletion, repeat deletion and verified absence passed. A second native timed worker retained its explicit 900-second deadline and was explicitly deleted.
- Both test containers, image and generated key/input files were removed; all 14 pre-existing containers were preserved.

Smoke image: `sha256:a7b6b86731e3c3975ec8588e8ce5105f1aaadc615de6837cdcbc431c9f97612e`.

## Scope and limits

One provider outcome: four source/test files, 397 changed source/test lines, and one architecture document. No dependencies, default configuration, UI, cloud resources, image publication, release, or existing app process changes.

This is local native-provider and disconnected-client proof, not a real cloud or physical-PC-off interval. It does not add stop/start product actions, remote durable storage, provider inventory, or the Remote Environments widget. The remote GPU adapter remains guarded against unsupported persistent execution. Those acceptance gates remain open in #383.
