### PR TITLE
refactor(store): prepare writes for shared transactions

### DIFF
--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -2,8 +2,10 @@
 
 mod database;
 mod remote_workspaces;
+mod workflow_writes;
 
 pub use remote_workspaces::{RemoteWorkspaceStoreError, StoredRemoteWorkspace};
+use workflow_writes::PreparedWorkflowInsert;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -90,11 +92,11 @@ impl CloudWorkflowStore {
     /// Rejects invalid snapshots, duplicate workflow identities, and storage
     /// failures.
     pub fn create(&self, workflow: &CloudWorkflow) -> Result<StoredWorkflow, CloudStoreError> {
-        let snapshot = encode_workflow(workflow)?;
+        let prepared = PreparedWorkflowInsert::new(workflow)?;
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         ensure_current_schema(&transaction)?;
-        let stored = insert_workflow(&transaction, workflow, &snapshot)?;
+        let stored = prepared.persist(&transaction)?;
         transaction.commit()?;
         Ok(stored)
     }
@@ -293,34 +295,6 @@ struct WorkflowRow {
     updated_at_millis: i64,
     retain_until_millis: i64,
     snapshot: Vec<u8>,
-}
-
-// The caller must validate the schema before composing writes in this transaction.
-fn insert_workflow(
-    transaction: &rusqlite::Transaction<'_>,
-    workflow: &CloudWorkflow,
-    snapshot: &[u8],
-) -> Result<StoredWorkflow, CloudStoreError> {
-    let id = workflow.id.to_string();
-    if workflow_row(transaction, &id)?.is_some() {
-        return Err(CloudStoreError::WorkflowExists(workflow.id));
-    }
-    transaction.execute(
-        "INSERT INTO cloud_workflows (
-            workflow_id, revision, created_at_millis, updated_at_millis, retain_until_millis, snapshot
-         ) VALUES (?1, 1, ?2, ?3, ?4, ?5)",
-        params![
-            id,
-            workflow.created_at_millis,
-            workflow.updated_at_millis,
-            workflow.retain_until_millis,
-            snapshot
-        ],
-    )?;
-    Ok(StoredWorkflow {
-        workflow: workflow.clone(),
-        revision: 1,
-    })
 }
 
 impl WorkflowRow {

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -94,27 +94,9 @@ impl CloudWorkflowStore {
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         ensure_current_schema(&transaction)?;
-        let id = workflow.id.to_string();
-        if workflow_row(&transaction, &id)?.is_some() {
-            return Err(CloudStoreError::WorkflowExists(workflow.id));
-        }
-        transaction.execute(
-            "INSERT INTO cloud_workflows (
-                workflow_id, revision, created_at_millis, updated_at_millis, retain_until_millis, snapshot
-             ) VALUES (?1, 1, ?2, ?3, ?4, ?5)",
-            params![
-                id,
-                workflow.created_at_millis,
-                workflow.updated_at_millis,
-                workflow.retain_until_millis,
-                snapshot
-            ],
-        )?;
+        let stored = insert_workflow(&transaction, workflow, &snapshot)?;
         transaction.commit()?;
-        Ok(StoredWorkflow {
-            workflow: workflow.clone(),
-            revision: 1,
-        })
+        Ok(stored)
     }
 
     /// Load and revalidate one workflow snapshot.
@@ -311,6 +293,34 @@ struct WorkflowRow {
     updated_at_millis: i64,
     retain_until_millis: i64,
     snapshot: Vec<u8>,
+}
+
+// The caller must validate the schema before composing writes in this transaction.
+fn insert_workflow(
+    transaction: &rusqlite::Transaction<'_>,
+    workflow: &CloudWorkflow,
+    snapshot: &[u8],
+) -> Result<StoredWorkflow, CloudStoreError> {
+    let id = workflow.id.to_string();
+    if workflow_row(transaction, &id)?.is_some() {
+        return Err(CloudStoreError::WorkflowExists(workflow.id));
+    }
+    transaction.execute(
+        "INSERT INTO cloud_workflows (
+            workflow_id, revision, created_at_millis, updated_at_millis, retain_until_millis, snapshot
+         ) VALUES (?1, 1, ?2, ?3, ?4, ?5)",
+        params![
+            id,
+            workflow.created_at_millis,
+            workflow.updated_at_millis,
+            workflow.retain_until_millis,
+            snapshot
+        ],
+    )?;
+    Ok(StoredWorkflow {
+        workflow: workflow.clone(),
+        revision: 1,
+    })
 }
 
 impl WorkflowRow {

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -139,14 +139,45 @@ impl CloudWorkflowStore {
         expected: &StoredRemoteWorkspace,
         next: &RemoteWorkspaceState,
     ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
-        validate_key(&expected.session_id, &expected.state.spec.workspace_local_id)?;
-        validate_replacement(&expected.state, next)?;
-        let snapshot = encode(&expected.session_id, next)?;
+        let replacement = WorkspaceReplacement::new(expected, next)?;
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         ensure_current_schema(&transaction)?;
+        let stored = replacement.persist(&transaction)?;
+        transaction.commit()?;
+        Ok(stored)
+    }
+}
+
+pub(super) struct WorkspaceReplacement<'a> {
+    expected: &'a StoredRemoteWorkspace,
+    next: &'a RemoteWorkspaceState,
+    snapshot: Vec<u8>,
+}
+
+impl<'a> WorkspaceReplacement<'a> {
+    pub(super) fn new(
+        expected: &'a StoredRemoteWorkspace,
+        next: &'a RemoteWorkspaceState,
+    ) -> Result<Self, RemoteWorkspaceStoreError> {
+        validate_key(&expected.session_id, &expected.state.spec.workspace_local_id)?;
+        validate_replacement(&expected.state, next)?;
+        Ok(Self {
+            expected,
+            next,
+            snapshot: encode(&expected.session_id, next)?,
+        })
+    }
+
+    /// The caller must validate the schema before composing writes in this transaction.
+    pub(super) fn persist(
+        &self,
+        transaction: &rusqlite::Transaction<'_>,
+    ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
+        let expected = self.expected;
+        let next = self.next;
         let current = load_owned(
-            &transaction,
+            transaction,
             &expected.session_id,
             &expected.state.spec.workspace_local_id,
         )?
@@ -161,10 +192,10 @@ impl CloudWorkflowStore {
             return Err(RemoteWorkspaceStoreError::SnapshotConflict);
         }
         ensure_session_budget(
-            &transaction,
+            transaction,
             &expected.session_id,
             &expected.state.spec.workspace_local_id,
-            snapshot.len(),
+            self.snapshot.len(),
         )?;
         let revision = expected
             .revision
@@ -177,14 +208,13 @@ impl CloudWorkflowStore {
             params![
                 expected.state.spec.workspace_local_id,
                 revision,
-                snapshot,
+                self.snapshot,
                 expected.session_id
             ],
         )?;
         if changed != 1 {
             return Err(RemoteWorkspaceStoreError::SnapshotConflict);
         }
-        transaction.commit()?;
         Ok(StoredRemoteWorkspace {
             session_id: expected.session_id.clone(),
             state: next.clone(),

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -169,7 +169,8 @@ impl<'a> WorkspaceReplacement<'a> {
         })
     }
 
-    /// The caller must validate the schema before composing writes in this transaction.
+    /// The caller must check the current schema in an immediate write transaction.
+    /// The returned value is provisional until that caller commits.
     pub(super) fn persist(
         &self,
         transaction: &rusqlite::Transaction<'_>,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -1,4 +1,4 @@
-use super::super::super::{encode_workflow, insert_workflow, tests::retained_workflow, workflow_row};
+use super::super::super::{PreparedWorkflowInsert, decode_workflow_row, tests::retained_workflow, workflow_row};
 use super::*;
 
 #[test]
@@ -10,7 +10,7 @@ fn prepared_writes_share_the_callers_transaction_without_committing() {
     let next = provisioning(original.state().clone());
     let replacement = WorkspaceReplacement::new(&original, &next).expect("prepare");
     let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
-    let snapshot = encode_workflow(&workflow).expect("workflow snapshot");
+    let prepared_workflow = PreparedWorkflowInsert::new(&workflow).expect("prepare workflow");
     let mut connection = store.connection().expect("connection");
     {
         let transaction = connection
@@ -18,12 +18,16 @@ fn prepared_writes_share_the_callers_transaction_without_committing() {
             .expect("transaction");
         ensure_current_schema(&transaction).expect("schema");
         let pending = replacement.persist(&transaction).expect("replace within transaction");
-        let pending_workflow = insert_workflow(&transaction, &workflow, &snapshot).expect("insert within transaction");
+        let pending_workflow = prepared_workflow
+            .persist(&transaction)
+            .expect("insert within transaction");
         assert_eq!(pending_workflow.workflow(), &workflow);
-        assert!(
-            workflow_row(&transaction, &workflow.id.to_string())
-                .expect("pending workflow")
-                .is_some()
+        let row = workflow_row(&transaction, &workflow.id.to_string())
+            .expect("pending workflow")
+            .expect("row");
+        assert_eq!(
+            decode_workflow_row(workflow.id, &row).expect("metadata matches snapshot"),
+            pending_workflow
         );
         assert_eq!(pending.revision(), original.revision() + 1);
         assert_eq!(

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -1,4 +1,55 @@
+use super::super::super::{encode_workflow, insert_workflow, tests::retained_workflow, workflow_row};
 use super::*;
+
+#[test]
+fn prepared_writes_share_the_callers_transaction_without_committing() {
+    let (_directory, store) = store();
+    let original = store
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("record");
+    let next = provisioning(original.state().clone());
+    let replacement = WorkspaceReplacement::new(&original, &next).expect("prepare");
+    let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
+    let snapshot = encode_workflow(&workflow).expect("workflow snapshot");
+    let mut connection = store.connection().expect("connection");
+    {
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .expect("transaction");
+        ensure_current_schema(&transaction).expect("schema");
+        let pending = replacement.persist(&transaction).expect("replace within transaction");
+        let pending_workflow = insert_workflow(&transaction, &workflow, &snapshot).expect("insert within transaction");
+        assert_eq!(pending_workflow.workflow(), &workflow);
+        assert!(
+            workflow_row(&transaction, &workflow.id.to_string())
+                .expect("pending workflow")
+                .is_some()
+        );
+        assert_eq!(pending.revision(), original.revision() + 1);
+        assert_eq!(
+            load_owned(&transaction, OWNER, "workspace").expect("pending read"),
+            Some(pending)
+        );
+    }
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("rolled back"),
+        Some(original.clone())
+    );
+    assert!(store.load(workflow.id).expect("workflow rolled back").is_none());
+    let committed = store
+        .replace_remote_workspace(&original, &next)
+        .expect("normal replacement");
+    assert_eq!(committed.revision(), original.revision() + 1);
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("committed read"),
+        Some(committed)
+    );
+    let stored_workflow = store.create(&workflow).expect("normal workflow creation");
+    assert_eq!(
+        store.load(workflow.id).expect("workflow committed"),
+        Some(stored_workflow)
+    );
+}
 
 #[test]
 fn records_survive_reopen_and_cannot_be_read_or_adopted_by_another_session() {

--- a/crates/horizon-core/src/cloud_run/store/workflow_writes.rs
+++ b/crates/horizon-core/src/cloud_run/store/workflow_writes.rs
@@ -1,0 +1,44 @@
+//! Validated workflow data prepared before entering a shared write transaction.
+
+use super::{CloudStoreError, CloudWorkflow, StoredWorkflow, encode_workflow, workflow_row};
+use rusqlite::{Transaction, params};
+
+pub(super) struct PreparedWorkflowInsert<'a> {
+    workflow: &'a CloudWorkflow,
+    snapshot: Vec<u8>,
+}
+
+impl<'a> PreparedWorkflowInsert<'a> {
+    pub(super) fn new(workflow: &'a CloudWorkflow) -> Result<Self, CloudStoreError> {
+        Ok(Self {
+            workflow,
+            snapshot: encode_workflow(workflow)?,
+        })
+    }
+
+    /// The caller must check the current schema in an immediate write transaction.
+    /// The returned value is provisional until that caller commits.
+    pub(super) fn persist(&self, transaction: &Transaction<'_>) -> Result<StoredWorkflow, CloudStoreError> {
+        let workflow = self.workflow;
+        let id = workflow.id.to_string();
+        if workflow_row(transaction, &id)?.is_some() {
+            return Err(CloudStoreError::WorkflowExists(workflow.id));
+        }
+        transaction.execute(
+            "INSERT INTO cloud_workflows (
+                workflow_id, revision, created_at_millis, updated_at_millis, retain_until_millis, snapshot
+             ) VALUES (?1, 1, ?2, ?3, ?4, ?5)",
+            params![
+                id,
+                workflow.created_at_millis,
+                workflow.updated_at_millis,
+                workflow.retain_until_millis,
+                self.snapshot
+            ],
+        )?;
+        Ok(StoredWorkflow {
+            workflow: workflow.clone(),
+            revision: 1,
+        })
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -89,8 +89,11 @@ back into large multi-purpose modules.
 - `cloud_run/store/remote_workspaces.rs` owns validated, session-owned remote
   snapshot storage with exact revisions and bounded recovery. Replacement
   invariants live in its `validation.rs` leaf. These records are independent of
-  board snapshots and session-file deletion; provider/workflow coordination and
-  runtime-state references remain separate integration responsibilities.
+  board snapshots and session-file deletion. Its prepared replacement can
+  participate in a caller-owned store transaction without committing it. The
+  workflow store likewise keeps insertion separate from transaction commit;
+  provider/workflow coordination and runtime-state references remain separate
+  integration responsibilities.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -91,7 +91,8 @@ back into large multi-purpose modules.
   invariants live in its `validation.rs` leaf. These records are independent of
   board snapshots and session-file deletion. Its prepared replacement can
   participate in a caller-owned store transaction without committing it. The
-  workflow store likewise keeps insertion separate from transaction commit;
+  workflow store's `workflow_writes.rs` binds validated workflow metadata to its
+  encoded snapshot before staging insertion, separately from transaction commit;
   provider/workflow coordination and runtime-state references remain separate
   integration responsibilities.
 - Shared domain helpers belong here when both core and UI need them.


### PR DESCRIPTION
## Purpose

Small transaction-boundary prerequisite for #383. Separate prepared writes from commit so the later atomic allocator can compose workspace and workflow records in one transaction.

## Behavior and scope

- Preserve the public workflow-create and workspace-replace APIs, validation/error ordering, identity/revision guards, recovery budgets, schema and lifecycle behavior.
- Require a borrowed transaction for both internal prepared-write helpers; ordinary auto-commit connections cannot call them.
- Bind workflow identity/timestamps and its encoded snapshot in one private-field prepared value, so callers cannot pair unrelated metadata and bytes.
- Keep schema validation and commit with the caller. The current public entry points still use immediate transactions and return only after successful commit.
- Four source/test files, 172 changed source/test lines, plus one architecture note. This is a genuine small prerequisite, not the larger preserved allocation candidate.

No allocation API, schema migration, provider action, UI behavior, cloud resource, release or publication is introduced. #383 remains open.

## Validation

Exact candidate: `613b3706794fd4f96595531c4c2035426f70136c`, based on main `1ace953330f481249fcee963e697ddf4bee38143`.

- Combined SQLite regression decodes the pending workflow through the ordinary metadata/snapshot consistency checks, observes both prepared writes in one transaction, proves both roll back when it is dropped, and verifies both normal public APIs still commit.
- Full exact-commit matrix: formatting, maintainability, version sync, warnings-denied default and speech workspace tests, blocking Clippy, strict panic-lint Clippy, and advisory pedantic Clippy.
- All 80 cloud-workflow tests pass with eight test threads, including the new transaction regression.
- Full diff review and refreshed independent local review completed with no in-scope blockers.

Only synthetic, task-owned test databases were used. There is no new desktop or provider behavior requiring a UI/cloud smoke lane in this refactor. The shared primary checkout and both preserved allocation candidates remain untouched.
