### PR TITLE
feat(store): reserve remote allocation identities

### DIFF
--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -516,6 +516,8 @@ pub enum CloudStoreError {
     Database(#[from] rusqlite::Error),
     #[error("cloud workflow store schema {0} is not supported by this binary")]
     UnsupportedSchema(i64),
+    #[error("remote allocation schema does not match its versioned table and constraint definitions")]
+    InvalidAllocationSchema,
     #[error("cloud workflow {0} already exists")]
     WorkflowExists(CloudWorkflowId),
     #[error("cloud workflow {0} does not exist")]

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -11,7 +11,7 @@ use rusqlite::{Connection, OpenFlags, TransactionBehavior};
 
 use super::CloudStoreError;
 
-const STORE_SCHEMA_VERSION: i64 = 2;
+const STORE_SCHEMA_VERSION: i64 = 3;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS cloud_workflows (
@@ -49,6 +49,18 @@ CREATE INDEX remote_workspaces_session
     ON remote_workspaces(session_id, workspace_local_id);
 ";
 
+const REMOTE_ALLOCATION_SCHEMA: &str = r"
+CREATE TABLE remote_runtime_allocations (
+    workspace_local_id TEXT PRIMARY KEY NOT NULL REFERENCES remote_workspaces(workspace_local_id),
+    session_id TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    workflow_id TEXT NOT NULL REFERENCES cloud_workflows(workflow_id),
+    job_id TEXT NOT NULL
+) STRICT;
+CREATE UNIQUE INDEX remote_runtime_allocations_workflow ON remote_runtime_allocations(workflow_id);
+CREATE UNIQUE INDEX remote_runtime_allocations_job ON remote_runtime_allocations(job_id);
+";
+
 pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
     let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
         | OpenFlags::SQLITE_OPEN_CREATE
@@ -72,10 +84,19 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
     if version < 2 {
         transaction.execute_batch(REMOTE_WORKSPACE_SCHEMA)?;
     }
+    if version < 3 {
+        transaction.execute_batch(REMOTE_ALLOCATION_SCHEMA)?;
+    }
     drop(transaction.prepare(
         "SELECT workspace_local_id, session_id, revision, snapshot
          FROM remote_workspaces INDEXED BY remote_workspaces_session LIMIT 0",
     )?);
+    for index in ["remote_runtime_allocations_workflow", "remote_runtime_allocations_job"] {
+        drop(transaction.prepare(&format!(
+            "SELECT workspace_local_id, session_id, generation, workflow_id, job_id
+             FROM remote_runtime_allocations INDEXED BY {index} LIMIT 0"
+        ))?);
+    }
     transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
     transaction.commit()?;
     Ok(())
@@ -135,3 +156,6 @@ pub(super) fn prepare_private_store(path: &Path) -> Result<PathBuf, CloudStoreEr
     }
     Ok(path)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -49,17 +49,17 @@ CREATE INDEX remote_workspaces_session
     ON remote_workspaces(session_id, workspace_local_id);
 ";
 
-const REMOTE_ALLOCATION_SCHEMA: &str = r"
-CREATE TABLE remote_runtime_allocations (
+const REMOTE_ALLOCATION_SCHEMA: [&str; 3] = [
+    r"CREATE TABLE remote_runtime_allocations (
     workspace_local_id TEXT PRIMARY KEY NOT NULL REFERENCES remote_workspaces(workspace_local_id),
     session_id TEXT NOT NULL,
     generation INTEGER NOT NULL CHECK (generation > 0),
     workflow_id TEXT NOT NULL REFERENCES cloud_workflows(workflow_id),
     job_id TEXT NOT NULL
-) STRICT;
-CREATE UNIQUE INDEX remote_runtime_allocations_workflow ON remote_runtime_allocations(workflow_id);
-CREATE UNIQUE INDEX remote_runtime_allocations_job ON remote_runtime_allocations(job_id);
-";
+) STRICT",
+    "CREATE UNIQUE INDEX remote_runtime_allocations_workflow ON remote_runtime_allocations(workflow_id)",
+    "CREATE UNIQUE INDEX remote_runtime_allocations_job ON remote_runtime_allocations(job_id)",
+];
 
 pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
     let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
@@ -85,7 +85,9 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
         transaction.execute_batch(REMOTE_WORKSPACE_SCHEMA)?;
     }
     if version < 3 {
-        transaction.execute_batch(REMOTE_ALLOCATION_SCHEMA)?;
+        for definition in REMOTE_ALLOCATION_SCHEMA {
+            transaction.execute_batch(definition)?;
+        }
     }
     drop(transaction.prepare(
         "SELECT workspace_local_id, session_id, revision, snapshot
@@ -108,20 +110,14 @@ pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), Cloud
 fn validate_allocation_schema(connection: &Connection) -> Result<(), CloudStoreError> {
     // These owned CREATE definitions are versioned data; keep their normalized SQL stable.
     // Exact matching includes constraints that column/index-name probes cannot inspect.
-    for definition in REMOTE_ALLOCATION_SCHEMA
-        .split(';')
-        .map(str::trim)
-        .filter(|sql| !sql.is_empty())
-    {
-        let matches: bool = connection.query_row(
-            "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema
-             WHERE tbl_name = 'remote_runtime_allocations' AND sql = ?1)",
-            [definition],
-            |row| row.get(0),
-        )?;
-        if !matches {
-            return Err(CloudStoreError::InvalidAllocationSchema);
-        }
+    let matches: bool = connection.query_row(
+        "SELECT COUNT(*) = 3 AND COUNT(CASE WHEN sql IN (?1, ?2, ?3) THEN 1 END) = 3
+         FROM main.sqlite_schema WHERE tbl_name = 'remote_runtime_allocations' AND sql IS NOT NULL",
+        REMOTE_ALLOCATION_SCHEMA,
+        |row| row.get(0),
+    )?;
+    if !matches {
+        return Err(CloudStoreError::InvalidAllocationSchema);
     }
     Ok(())
 }

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -91,12 +91,7 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
         "SELECT workspace_local_id, session_id, revision, snapshot
          FROM remote_workspaces INDEXED BY remote_workspaces_session LIMIT 0",
     )?);
-    for index in ["remote_runtime_allocations_workflow", "remote_runtime_allocations_job"] {
-        drop(transaction.prepare(&format!(
-            "SELECT workspace_local_id, session_id, generation, workflow_id, job_id
-             FROM remote_runtime_allocations INDEXED BY {index} LIMIT 0"
-        ))?);
-    }
+    validate_allocation_schema(&transaction)?;
     transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
     transaction.commit()?;
     Ok(())
@@ -106,6 +101,27 @@ pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), Cloud
     let version = connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
     if version != STORE_SCHEMA_VERSION {
         return Err(CloudStoreError::UnsupportedSchema(version));
+    }
+    validate_allocation_schema(connection)
+}
+
+fn validate_allocation_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    // These owned CREATE definitions are versioned data; keep their normalized SQL stable.
+    // Exact matching includes constraints that column/index-name probes cannot inspect.
+    for definition in REMOTE_ALLOCATION_SCHEMA
+        .split(';')
+        .map(str::trim)
+        .filter(|sql| !sql.is_empty())
+    {
+        let matches: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema
+             WHERE tbl_name = 'remote_runtime_allocations' AND sql = ?1)",
+            [definition],
+            |row| row.get(0),
+        )?;
+        if !matches {
+            return Err(CloudStoreError::InvalidAllocationSchema);
+        }
     }
     Ok(())
 }

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -170,6 +170,50 @@ fn partial_or_missing_allocation_schema_fails_without_repairing_or_losing_record
 }
 
 #[test]
+fn schema_three_definitions_match_the_frozen_storage_format() {
+    let frozen = concat!(
+        "CREATE TABLE remote_runtime_allocations (\n",
+        "    workspace_local_id TEXT PRIMARY KEY NOT NULL REFERENCES remote_workspaces(workspace_local_id),\n",
+        "    session_id TEXT NOT NULL,\n",
+        "    generation INTEGER NOT NULL CHECK (generation > 0),\n",
+        "    workflow_id TEXT NOT NULL REFERENCES cloud_workflows(workflow_id),\n",
+        "    job_id TEXT NOT NULL\n",
+        ") STRICT;\n",
+        "CREATE UNIQUE INDEX remote_runtime_allocations_workflow ON remote_runtime_allocations(workflow_id);\n",
+        "CREATE UNIQUE INDEX remote_runtime_allocations_job ON remote_runtime_allocations(job_id)",
+    );
+    assert_eq!(REMOTE_ALLOCATION_SCHEMA.join(";\n"), frozen);
+}
+
+#[test]
+fn unexpected_allocation_objects_reject_open_reads_and_writes_without_record_loss() {
+    for sql in [
+        "CREATE INDEX unexpected_index ON remote_runtime_allocations(session_id)",
+        "CREATE TRIGGER unexpected_trigger AFTER INSERT ON remote_runtime_allocations BEGIN
+         DELETE FROM cloud_workflows; END;",
+    ] {
+        let fixture = fixture();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        let before = saved_bytes(&connection);
+        connection.execute_batch(sql).expect("unexpected object");
+        assert!(matches!(
+            CloudWorkflowStore::open_path(fixture.store.path()),
+            Err(CloudStoreError::InvalidAllocationSchema)
+        ));
+        assert!(matches!(
+            fixture.store.load(fixture.workflow.workflow().id),
+            Err(CloudStoreError::InvalidAllocationSchema)
+        ));
+        let workflow = retained_workflow(CloudProvider::LocalDocker, 2000);
+        assert!(matches!(
+            fixture.store.create(&workflow),
+            Err(CloudStoreError::InvalidAllocationSchema)
+        ));
+        assert_eq!(saved_bytes(&connection), before);
+    }
+}
+
+#[test]
 fn malformed_allocation_constraints_are_rejected_without_losing_records() {
     for (original, replacement) in [
         ("TEXT PRIMARY KEY NOT NULL", "TEXT NOT NULL"),
@@ -231,8 +275,9 @@ fn malformed_allocation_constraints_are_rejected_without_losing_records() {
         let fixture = fixture();
         let connection = open_connection(fixture.store.path()).expect("raw store");
         let before = saved_bytes(&connection);
-        let malformed = REMOTE_ALLOCATION_SCHEMA.replace(original, replacement);
-        assert_ne!(malformed, REMOTE_ALLOCATION_SCHEMA);
+        let schema = REMOTE_ALLOCATION_SCHEMA.join(";\n");
+        let malformed = schema.replace(original, replacement);
+        assert_ne!(malformed, schema);
         connection
             .execute_batch("DROP TABLE remote_runtime_allocations")
             .expect("remove empty table");
@@ -243,7 +288,7 @@ fn malformed_allocation_constraints_are_rejected_without_losing_records() {
         );
         assert!(matches!(
             fixture.store.load(fixture.workflow.workflow().id),
-            Err(super::super::CloudStoreError::InvalidAllocationSchema)
+            Err(CloudStoreError::InvalidAllocationSchema)
         ));
         assert_eq!(saved_bytes(&connection), before);
     }

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -1,0 +1,236 @@
+use super::super::{CloudWorkflowStore, StoredRemoteWorkspace, StoredWorkflow, tests::retained_workflow};
+use super::*;
+use crate::cloud_run::{CloudProvider, GitCommitSha, GitSource};
+use crate::remote_workspace::{RemoteWorkspaceSpec, RemoteWorkspaceState};
+use rusqlite::params;
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    workflow: StoredWorkflow,
+    workspace: StoredRemoteWorkspace,
+}
+
+fn fixture() -> Fixture {
+    let directory = tempfile::tempdir().expect("private directory");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
+    let target = workflow.nodes[0].worker.clone().expect("target");
+    let saved_workflow = store.create(&workflow).expect("legacy workflow");
+    assert!(
+        store
+            .claim_worker_creation(workflow.id, workflow.nodes[0].id, &target, "synthetic-worker")
+            .expect("claim")
+    );
+    let state = RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: "workspace".into(),
+        target,
+        repository: GitSource {
+            repository: "owner/project".into(),
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        working_directory: ".".into(),
+        generation: 0,
+        panels: Vec::new(),
+    })
+    .expect("remote specification");
+    let workspace = store.create_remote_workspace(OWNER, &state).expect("remote record");
+    Fixture {
+        _directory: directory,
+        store,
+        workflow: saved_workflow,
+        workspace,
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct SavedRows {
+    workflow: Vec<u8>,
+    workspace: Vec<u8>,
+    claims: Vec<SavedClaim>,
+}
+
+#[derive(Debug, PartialEq)]
+struct SavedClaim {
+    provider: String,
+    workflow_id: String,
+    job_id: String,
+    resource_name: String,
+    claimed_at_millis: i64,
+}
+
+fn saved_bytes(connection: &Connection) -> SavedRows {
+    let (workflow, workspace) = connection
+        .query_row(
+            "SELECT (SELECT snapshot FROM cloud_workflows), (SELECT snapshot FROM remote_workspaces)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("preserved snapshots");
+    let mut statement = connection
+        .prepare(
+            "SELECT provider, workflow_id, job_id, resource_name, claimed_at_millis
+             FROM cloud_worker_creation_claims ORDER BY provider, resource_name",
+        )
+        .expect("claims query");
+    let claims = statement
+        .query_map([], |row| {
+            Ok(SavedClaim {
+                provider: row.get(0)?,
+                workflow_id: row.get(1)?,
+                job_id: row.get(2)?,
+                resource_name: row.get(3)?,
+                claimed_at_millis: row.get(4)?,
+            })
+        })
+        .expect("all claims")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("saved claims");
+    SavedRows {
+        workflow,
+        workspace,
+        claims,
+    }
+}
+
+fn allocation_count(connection: &Connection) -> i64 {
+    connection
+        .query_row("SELECT COUNT(*) FROM remote_runtime_allocations", [], |row| row.get(0))
+        .expect("binding count")
+}
+
+#[test]
+fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations() {
+    let fixture = fixture();
+    let connection = open_connection(fixture.store.path()).expect("raw store");
+    connection
+        .execute_batch("DROP TABLE remote_runtime_allocations; PRAGMA user_version=2;")
+        .expect("schema two fixture");
+    let before = saved_bytes(&connection);
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
+    assert_eq!(saved_bytes(&connection), before);
+    assert_eq!(
+        connection
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .expect("version"),
+        3
+    );
+    assert_eq!(allocation_count(&connection), 0);
+    let workflow = fixture.workflow.workflow();
+    assert_eq!(
+        upgraded.load(workflow.id).expect("workflow"),
+        Some(fixture.workflow.clone())
+    );
+    assert_eq!(
+        upgraded.load_remote_workspace(OWNER, "workspace").expect("workspace"),
+        Some(fixture.workspace)
+    );
+    assert!(
+        !upgraded
+            .claim_worker_creation(
+                workflow.id,
+                workflow.nodes[0].id,
+                workflow.nodes[0].worker.as_ref().expect("target"),
+                "synthetic-worker"
+            )
+            .expect("claim retained")
+    );
+    CloudWorkflowStore::open_path(fixture.store.path()).expect("idempotent reopen");
+    assert_eq!(saved_bytes(&connection), before);
+    assert_eq!(allocation_count(&connection), 0);
+}
+
+#[test]
+fn partial_or_missing_allocation_schema_fails_without_repairing_or_losing_records() {
+    for sql in [
+        "DROP TABLE remote_runtime_allocations",
+        "DROP INDEX remote_runtime_allocations_workflow",
+        "DROP INDEX remote_runtime_allocations_job",
+        "PRAGMA user_version=2",
+    ] {
+        let fixture = fixture();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        let before = saved_bytes(&connection);
+        connection.execute_batch(sql).expect("partial schema");
+        let version: i64 = connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("version");
+        assert!(CloudWorkflowStore::open_path(fixture.store.path()).is_err(), "{sql}");
+        assert_eq!(saved_bytes(&connection), before);
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("unchanged version"),
+            version
+        );
+    }
+}
+
+#[test]
+fn allocation_schema_restricts_parent_loss_and_duplicate_workflow_or_job_identity() {
+    let fixture = fixture();
+    let connection = open_connection(fixture.store.path()).expect("foreign-key enabled connection");
+    let workflow = fixture.workflow.workflow();
+    let mut other_state = fixture.workspace.state().clone();
+    other_state.spec.workspace_local_id = "second".into();
+    fixture
+        .store
+        .create_remote_workspace(OWNER, &other_state)
+        .expect("second workspace");
+    let other = retained_workflow(CloudProvider::LocalDocker, 2000);
+    fixture.store.create(&other).expect("second workflow");
+    let before = saved_bytes(&connection);
+    let insert = "INSERT INTO remote_runtime_allocations
+        (workspace_local_id, session_id, generation, workflow_id, job_id) VALUES (?1, ?2, ?3, ?4, ?5)";
+    let first_workflow = workflow.id.to_string();
+    let first_job = workflow.nodes[0].id.to_string();
+    let other_workflow = other.id.to_string();
+    let other_job = other.nodes[0].id.to_string();
+    connection
+        .execute(insert, params!["workspace", OWNER, 1, first_workflow, first_job])
+        .expect("synthetic schema binding");
+    for (workspace_id, generation, workflow_id, job_id) in [
+        ("second", 1, &first_workflow, &other_job),
+        ("second", 1, &other_workflow, &first_job),
+        ("workspace", 1, &other_workflow, &other_job),
+        ("missing", 1, &other_workflow, &other_job),
+        ("second", 0, &other_workflow, &other_job),
+        ("second", 1, &other_job, &other_job),
+    ] {
+        assert!(
+            connection
+                .execute(insert, params![workspace_id, OWNER, generation, workflow_id, job_id])
+                .is_err()
+        );
+        assert_eq!(allocation_count(&connection), 1);
+    }
+    assert!(
+        connection
+            .execute("DELETE FROM cloud_workflows WHERE workflow_id=?1", [&first_workflow])
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute("DELETE FROM remote_workspaces WHERE workspace_local_id='workspace'", [])
+            .is_err()
+    );
+    assert_eq!(saved_bytes(&connection), before);
+    assert_eq!(
+        fixture.store.load(workflow.id).expect("parent retained"),
+        Some(fixture.workflow.clone())
+    );
+    assert_eq!(
+        fixture
+            .store
+            .load_remote_workspace(OWNER, "workspace")
+            .expect("parent retained"),
+        Some(fixture.workspace.clone())
+    );
+    connection
+        .execute(insert, params!["second", OWNER, 1, other_workflow, other_job])
+        .expect("independent identity");
+    assert_eq!(allocation_count(&connection), 2);
+}

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -170,6 +170,86 @@ fn partial_or_missing_allocation_schema_fails_without_repairing_or_losing_record
 }
 
 #[test]
+fn malformed_allocation_constraints_are_rejected_without_losing_records() {
+    for (original, replacement) in [
+        ("TEXT PRIMARY KEY NOT NULL", "TEXT NOT NULL"),
+        ("session_id TEXT NOT NULL", "session_id TEXT"),
+        ("CHECK (generation > 0)", "CHECK (generation >= 0)"),
+        (" REFERENCES remote_workspaces(workspace_local_id)", ""),
+        (" REFERENCES cloud_workflows(workflow_id)", ""),
+        (
+            "REFERENCES cloud_workflows(workflow_id)",
+            "REFERENCES cloud_workflows(workflow_id) ON DELETE CASCADE",
+        ),
+        (
+            "remote_runtime_allocations_workflow ON remote_runtime_allocations(workflow_id)",
+            "remote_runtime_allocations_workflow ON remote_runtime_allocations(session_id)",
+        ),
+        ("CREATE UNIQUE INDEX", "CREATE INDEX"),
+        (
+            "remote_runtime_allocations(job_id)",
+            "remote_runtime_allocations(job_id) WHERE generation = 1",
+        ),
+        (
+            "remote_runtime_allocations(job_id)",
+            "remote_runtime_allocations(job_id, generation)",
+        ),
+        (
+            "remote_runtime_allocations(workflow_id)",
+            "remote_runtime_allocations(lower(workflow_id))",
+        ),
+        (
+            "remote_runtime_allocations(job_id)",
+            "remote_runtime_allocations(job_id COLLATE NOCASE)",
+        ),
+        (
+            "remote_runtime_allocations(job_id)",
+            "remote_runtime_allocations(job_id DESC)",
+        ),
+        (
+            "remote_runtime_allocations(workflow_id)",
+            "remote_runtime_allocations(workflow_id) WHERE generation = 1",
+        ),
+        (
+            "remote_runtime_allocations(job_id)",
+            "remote_runtime_allocations(session_id)",
+        ),
+        (
+            "CREATE UNIQUE INDEX remote_runtime_allocations_job",
+            "CREATE INDEX remote_runtime_allocations_job",
+        ),
+        (
+            "CREATE UNIQUE INDEX remote_runtime_allocations_workflow",
+            "CREATE INDEX remote_runtime_allocations_workflow",
+        ),
+        (
+            "REFERENCES remote_workspaces(workspace_local_id)",
+            "REFERENCES remote_workspaces(workspace_local_id) ON DELETE CASCADE",
+        ),
+        (" STRICT", ""),
+    ] {
+        let fixture = fixture();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        let before = saved_bytes(&connection);
+        let malformed = REMOTE_ALLOCATION_SCHEMA.replace(original, replacement);
+        assert_ne!(malformed, REMOTE_ALLOCATION_SCHEMA);
+        connection
+            .execute_batch("DROP TABLE remote_runtime_allocations")
+            .expect("remove empty table");
+        connection.execute_batch(&malformed).expect("malformed fixture");
+        assert!(
+            CloudWorkflowStore::open_path(fixture.store.path()).is_err(),
+            "{original} -> {replacement}"
+        );
+        assert!(matches!(
+            fixture.store.load(fixture.workflow.workflow().id),
+            Err(super::super::CloudStoreError::InvalidAllocationSchema)
+        ));
+        assert_eq!(saved_bytes(&connection), before);
+    }
+}
+
+#[test]
 fn allocation_schema_restricts_parent_loss_and_duplicate_workflow_or_job_identity() {
     let fixture = fixture();
     let connection = open_connection(fixture.store.path()).expect("foreign-key enabled connection");

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
@@ -11,7 +11,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
         .expect("legacy creation fence");
     let connection = Connection::open(store.path()).expect("raw store");
     connection
-        .execute_batch("DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
+        .execute_batch("DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
         .expect("restore schema-one fixture");
     let workflow_bytes: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
@@ -42,7 +42,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .expect("schema version");
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
     let after: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
         .expect("unchanged legacy bytes");
@@ -103,6 +103,6 @@ fn current_schema_with_missing_remote_table_or_index_fails_at_open() {
         let version: i64 = connection
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .expect("schema unchanged");
-        assert_eq!(version, 2);
+        assert_eq!(version, 3);
     }
 }

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
@@ -125,7 +125,7 @@ fn invalid_keys_snapshots_and_future_schema_never_replace_saved_records() {
         .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
         .expect("before");
     connection
-        .pragma_update(None, "user_version", 3)
+        .pragma_update(None, "user_version", 4)
         .expect("future schema");
     assert!(
         store

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -59,7 +59,7 @@ fn worker_target(workflow: &CloudWorkflow) -> &WorkerTarget {
 }
 
 fn assert_unsupported_schema<T>(result: &Result<T, CloudStoreError>) {
-    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(3))));
+    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(4))));
 }
 
 fn store(temp: &TempDir) -> CloudWorkflowStore {
@@ -532,7 +532,7 @@ fn runpod_fence_uses_the_durable_workflow_claim() {
     );
     let connection = Connection::open(store.path()).expect("open raw store");
     connection
-        .pragma_update(None, "user_version", 3)
+        .pragma_update(None, "user_version", 4)
         .expect("set unsupported schema");
     drop(connection);
     let failed_claim = super::super::runpod::RunPodCreationFence::claim_once(
@@ -570,7 +570,7 @@ fn invalid_snapshots_and_future_schema_fail_closed() {
     replacement.updated_at_millis += 1;
     let connection = Connection::open(&future_path).expect("future store");
     connection
-        .pragma_update(None, "user_version", 3)
+        .pragma_update(None, "user_version", 4)
         .expect("future version");
     drop(connection);
     assert_unsupported_schema(&stale_store.load(workflow.id));

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -92,6 +92,34 @@ Domain-valid in-memory state can exceed the storage limits. Callers must persist
 intent successfully before provider side effects and surface storage-capacity
 errors without discarding the last saved runtime or cleanup record.
 
+### Reserved allocation identity schema
+
+Schema 3 reserves `remote_runtime_allocations`: one primary workspace identity,
+unique workflow/job indexes, and foreign keys to the workspace and workflow
+snapshots. Migration from schema 2 preserves the existing snapshots, revisions,
+and consumed creation claims without manufacturing allocation bindings from
+legacy runtime references. The new table starts empty.
+
+Older clients reject the newer database version. Missing or partial allocation
+tables/indexes and ambiguous interrupted-version fixtures are rejected rather
+than silently repaired or adopted. The foreign keys prevent deleting a parent
+snapshot while an allocation binding still references it; there is no implicit
+ownership cascade or provider cleanup.
+
+Generation zero describes a specification that has never allocated a runtime;
+bindings require a positive generation. A future allocation increments the
+specification generation and commits that same value in the runtime and binding.
+The allocator must validate bounded metadata and all cross-record identities;
+the schema alone does not establish session ownership or job membership.
+Retention expiry cannot remove a bound workflow or its consumed creation claim.
+Any future retirement operation must explicitly retire the binding in the same
+transaction, after its separate cleanup/recovery contract permits retirement.
+
+This schema prerequisite exposes no allocation read/write API and introduces no
+new workflow node kind, worker creation, adoption, lifetime policy, or UI behavior.
+The future allocator must commit and validate both snapshots with their binding
+in one transaction before the existing creation fence can grant provider creation.
+
 ## Options considered
 
 ### Embed the whole aggregate in runtime YAML

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -102,7 +102,13 @@ legacy runtime references. The new table starts empty.
 
 Older clients reject the newer database version. Missing or partial allocation
 tables/indexes and ambiguous interrupted-version fixtures are rejected rather
-than silently repaired or adopted. The foreign keys prevent deleting a parent
+than silently repaired or adopted. Before migration commit and on every operation,
+validate the owned table and index definitions against their exact, versioned
+`sqlite_schema.sql` representation. This includes uniqueness, indexed columns,
+the primary key, positive generation, foreign keys and strict typing; equivalent
+but unexpected definitions are not adopted. Keep these CREATE definitions stable
+until an explicit schema migration replaces them.
+The foreign keys prevent deleting a parent
 snapshot while an allocation binding still references it; there is no implicit
 ownership cascade or provider cleanup.
 

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -107,10 +107,11 @@ validate the owned table and index definitions against their exact, versioned
 `sqlite_schema.sql` representation. This includes uniqueness, indexed columns,
 the primary key, positive generation, foreign keys and strict typing; equivalent
 but unexpected definitions are not adopted. Keep these CREATE definitions stable
-until an explicit schema migration replaces them.
-The foreign keys prevent deleting a parent
-snapshot while an allocation binding still references it; there is no implicit
-ownership cascade or provider cleanup.
+until an explicit schema migration replaces them, including parent-table renames.
+A frozen format fixture prevents accidental definition drift; unexpected extra
+indexes or triggers are also rejected. The foreign keys prevent deleting a
+parent snapshot while an allocation binding still references it; there is no
+implicit ownership cascade or provider cleanup.
 
 Generation zero describes a specification that has never allocated a runtime;
 bindings require a positive generation. A future allocation increments the


### PR DESCRIPTION
## Purpose

Relates to #383. Reserve the database identity boundary needed to bind one remote
workspace generation to one setup workflow in a later focused implementation.
This follows the transaction preparation prerequisite in #403.

## Behavior

- Migrate schema 2 to schema 3 inside the existing immediate transaction, adding
  an initially empty allocation table, unique workflow/job indexes and parent
  foreign keys. Do not invent bindings from legacy runtime references.
- Preserve existing snapshots, revisions and consumed creation claims. Reject
  missing or partial allocation schema without repairing or adopting it.
- Verify the complete owned table/index definitions and reject unexpected
  indexes/triggers on open and every operation. Pin schema 3's exact format in a
  frozen regression fixture so cosmetic SQL edits cannot break existing stores.
- Prevent parent deletion from discarding bound ownership or a consumed claim.
- Document generation, ownership validation and explicit retirement boundaries.

No allocation API, new workflow node kind, provider operation, UI integration,
automatic cleanup or compute-lifetime change is introduced. Closing Horizon
does not become a stop/delete action. The complete persistent-workspace feature
and Remote Environments widget remain pending in #383.

Compatibility: older binaries intentionally reject schema 3. This follows the
existing fail-closed version policy; do not downgrade a migrated database.

## Validation

Candidate: `4410a0eafc676ae5b09fa2da389c99a632926fa4`, based on merged main
`cf146434a04929c8eed005b00e39b54c92a327c2`.

The full repository matrix passed in the exact committed task worktree:

- Format, maintainability and version synchronization checks.
- Warning-denied workspace tests, both default and speech features.
- Blocking Clippy with speech/trace profiling and strict no-unwrap/no-expect tier.
- Advisory pedantic Clippy.
- All 86 cloud-workflow regressions repeated with eight test threads.

Six new SQLite regressions prove legacy snapshot/revision/claim preservation
and idempotent migration; missing/partial schema rejection without record loss;
and positive generation, unique identity, foreign-key and failed-delete rollback
behavior, frozen format compatibility, and rejection of unexpected schema objects.
Nineteen altered-definition fixtures cover missing or weakened uniqueness, primary
key, CHECK, foreign-key, STRICT, index-column and partial-index constraints.
The missing-primary-key case failed before the review fix and passes afterward;
an already-open handle also rejects altered schema without record/claim loss.
All 40 store tests pass. Existing migration/future-version fixtures are updated
consistently. Full diff and independent source review are complete; actionable
schema-validation feedback is addressed, with fresh current-head review requested.
No UI or provider smoke lane applies to this schema-only change.

Scope: six source/test files, 415 changed source/test lines, plus one focused
architecture note (seven files total). No dependencies or configuration defaults change.
