### PR TITLE
feat(store): atomically allocate remote runtimes

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -10,7 +10,8 @@ mod store;
 mod validation;
 mod worker_lifetime;
 pub use store::{
-    CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteWorkspace, StoredWorkflow,
+    CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
+    StoredWorkflow,
 };
 pub use worker_lifetime::WorkerLifetime;
 pub const CLOUD_RUN_PROTOCOL_VERSION: u32 = 1;
@@ -168,7 +169,7 @@ impl CloudProgress {
 }
 string_enum!(CloudJobState: Queued, Provisioning, PullingImage, Cloning, Running, Checkpointing, WaitingForApproval, Completed, Failed, Cancelled, Cleaning, Cleaned);
 string_enum!(CloudJobOutcome: Succeeded, Failed, Cancelled);
-string_enum!(WorkflowNodeKind: Build, Test, Artifact, Approval, Merge, Publish, Deploy, Verify, Cleanup);
+string_enum!(WorkflowNodeKind: Build, Test, Artifact, Approval, Merge, Publish, Deploy, Verify, Cleanup, RemoteWorkspace);
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RetryPolicy {
@@ -335,6 +336,8 @@ pub enum CloudProtocolError {
     EmptyNodeIdentity(CloudJobId),
     #[error("node {0} has an invalid worker target")]
     InvalidWorkerTarget(CloudJobId),
+    #[error("remote workspace node {0} must be the workflow's only node with a source, worker, and single attempt")]
+    InvalidRemoteWorkspaceNode(CloudJobId),
     #[error("worker target requires exactly one valid explicit lifetime policy")]
     InvalidWorkerLifetime,
     #[error("node {0} has an invalid weight")]

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -1,9 +1,11 @@
 //! Durable local control-plane storage for cloud workflow snapshots and creation claims.
 
 mod database;
+mod remote_allocations;
 mod remote_workspaces;
 mod workflow_writes;
 
+pub use remote_allocations::StoredRemoteAllocation;
 pub use remote_workspaces::{RemoteWorkspaceStoreError, StoredRemoteWorkspace};
 use workflow_writes::PreparedWorkflowInsert;
 
@@ -92,6 +94,7 @@ impl CloudWorkflowStore {
     /// Rejects invalid snapshots, duplicate workflow identities, and storage
     /// failures.
     pub fn create(&self, workflow: &CloudWorkflow) -> Result<StoredWorkflow, CloudStoreError> {
+        remote_allocations::ensure_unbound_workflow(workflow)?;
         let prepared = PreparedWorkflowInsert::new(workflow)?;
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -188,6 +191,7 @@ impl CloudWorkflowStore {
         if current.workflow != expected.workflow {
             return Err(CloudStoreError::SnapshotConflict(expected.workflow.id));
         }
+        remote_allocations::validate_workflow_replacement(&transaction, &current.workflow, next)?;
         ensure_claimed_targets_unchanged(&transaction, &id, &current.workflow, next)?;
         let revision = expected
             .revision
@@ -242,6 +246,7 @@ impl CloudWorkflowStore {
             return Err(CloudStoreError::WorkflowExpired(workflow_id));
         }
         validate_claim_target(&workflow.workflow, job_id, target)?;
+        remote_allocations::validate_creation_claim(&transaction, &workflow.workflow, job_id)?;
         let provider_name = provider_name(target.provider);
         let job_id_text = job_id.to_string();
         let existing = transaction
@@ -559,6 +564,10 @@ pub enum CloudStoreError {
     ClaimIdentityConflict,
     #[error("cloud workflow timestamp is invalid")]
     InvalidTimestamp,
+    #[error("remote workflow requires an intact session-owned runtime allocation")]
+    InvalidRemoteAllocation,
+    #[error("remote workspace workflows must be created through the runtime allocator")]
+    RemoteAllocationRequired,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -1,0 +1,218 @@
+//! Atomic allocation of one session-owned runtime and one single-worker workflow.
+//! No provider calls or creation grants occur here. Run these synchronous operations
+//! off the render thread; only the durable creation fence may grant provider creation.
+
+mod binding;
+mod guards;
+
+pub(super) use guards::{
+    ensure_unbound_workflow, validate_creation_claim, validate_workflow_replacement, validate_workspace_write,
+};
+
+use super::{
+    CloudStoreError, CloudWorkflowStore, MAX_RECOVERED_WORKFLOWS, PreparedWorkflowInsert,
+    RemoteWorkspaceStoreError as Error, StoredRemoteWorkspace, StoredWorkflow, check_recovery_budget,
+    current_unix_millis,
+    database::ensure_current_schema,
+    remote_workspaces::{WorkspaceReplacement, load_owned, validate_key},
+};
+use crate::cloud_run::{
+    CLOUD_RUN_PROTOCOL_VERSION, CloudJobId, CloudJobState, CloudProgress, CloudWorkflow, CloudWorkflowId, RetryPolicy,
+    WorkflowNode, WorkflowNodeKind,
+};
+use crate::remote_workspace::{RemoteRuntimeGeneration, RemoteRuntimePhase, RemoteWorkspaceState};
+use rusqlite::{TransactionBehavior, params};
+
+/// A recovered relationship, not permission to create or attach a provider worker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StoredRemoteAllocation {
+    workspace: StoredRemoteWorkspace,
+    workflow: StoredWorkflow,
+}
+
+impl StoredRemoteAllocation {
+    #[must_use]
+    pub fn workspace(&self) -> &StoredRemoteWorkspace {
+        &self.workspace
+    }
+
+    #[must_use]
+    pub fn workflow(&self) -> &StoredWorkflow {
+        &self.workflow
+    }
+}
+
+impl CloudWorkflowStore {
+    /// Allocate a fresh generation, workflow, and ownership binding in one transaction.
+    /// A competing/stale caller must reload; this never adopts an unbound active snapshot.
+    /// No worker is created and no one-shot creation grant is consumed by allocation.
+    /// Workflow retention bounds setup authorization, not worker execution. It must
+    /// end after the store's current clock; expiry preserves non-creating recovery.
+    /// Panel intent count never owns the runtime lifetime or permission to allocate.
+    /// No retirement/rebinding API is exposed here. Re-claims are only meaningful
+    /// while still provisioning; later observations require non-creating reconciliation.
+    /// # Errors
+    /// Rejects active workspaces, invalid retention, stale state, capacity limits,
+    /// exhausted counters, incompatible schemas, broken bindings, or storage failures.
+    pub fn allocate_remote_runtime(
+        &self,
+        expected: &StoredRemoteWorkspace,
+        retain_until_millis: i64,
+    ) -> Result<StoredRemoteAllocation, Error> {
+        let now_millis = current_unix_millis()?;
+        let PreparedAllocation { next, workflow } =
+            prepare_allocation(expected.state(), now_millis, retain_until_millis)?;
+        let replacement = WorkspaceReplacement::new(expected, &next)?;
+        let prepared_workflow = PreparedWorkflowInsert::new(&workflow)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        ensure_current_schema(&transaction)?;
+        let workspace = replacement.persist(&transaction)?;
+        ensure_workflow_budget(&transaction, prepared_workflow.snapshot_len(), now_millis)?;
+        let stored_workflow = prepared_workflow.persist(&transaction)?;
+        let runtime = next.runtime.as_ref().ok_or(CloudStoreError::InvalidRemoteAllocation)?;
+        let generation = i64::try_from(runtime.generation).map_err(|_| Error::GenerationExhausted)?;
+        transaction.execute(
+            "INSERT INTO remote_runtime_allocations (workspace_local_id, session_id, generation, workflow_id, job_id)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                next.spec.workspace_local_id,
+                expected.session_id(),
+                generation,
+                workflow.id.to_string(),
+                runtime.job_id.to_string()
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: stored_workflow,
+        })
+    }
+
+    /// Recover both sides of a committed allocation from one consistent read snapshot.
+    /// Unbound active records fail closed and remain available through the record-store API.
+    /// Expired setup workflows remain recoverable without granting new creation.
+    /// Recovery does not stop/delete workers, clear intent, or change runtime identity.
+    /// # Errors
+    /// Rejects invalid ownership, unbound active snapshots, corrupt relationships, or storage errors.
+    pub fn load_remote_allocation(
+        &self,
+        session_id: &str,
+        workspace_local_id: &str,
+    ) -> Result<Option<StoredRemoteAllocation>, Error> {
+        validate_key(session_id, workspace_local_id)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        let workspace = load_owned(&transaction, session_id, workspace_local_id)?;
+        let row = binding::load_workspace(&transaction, workspace_local_id)?;
+        match (workspace, row) {
+            (Some(workspace), Some(row)) => {
+                let allocation = binding::recover(&transaction, &row)?;
+                if allocation.workspace != workspace {
+                    return Err(CloudStoreError::InvalidRemoteAllocation.into());
+                }
+                Ok(Some(allocation))
+            }
+            (Some(workspace), None) if workspace.state().runtime.is_some() => Err(Error::UnboundRuntime),
+            (_, Some(_)) => Err(CloudStoreError::InvalidRemoteAllocation.into()),
+            (_, None) => Ok(None),
+        }
+    }
+}
+
+struct PreparedAllocation {
+    next: RemoteWorkspaceState,
+    workflow: CloudWorkflow,
+}
+
+fn ensure_workflow_budget(
+    connection: &rusqlite::Connection,
+    next_bytes: usize,
+    now_millis: i64,
+) -> Result<(), CloudStoreError> {
+    let limit = i64::try_from(MAX_RECOVERED_WORKFLOWS + 1).map_err(|_| CloudStoreError::RecoveryLimitExceeded)?;
+    let mut statement = connection.prepare(
+        "SELECT length(snapshot) FROM cloud_workflows INDEXED BY cloud_workflows_retention
+         WHERE retain_until_millis >= ?1 LIMIT ?2",
+    )?;
+    let sizes = statement.query_map(params![now_millis, limit], |row| row.get::<_, i64>(0))?;
+    let mut count = 1;
+    let mut bytes = next_bytes;
+    check_recovery_budget(count, bytes)?;
+    for size in sizes {
+        let size = usize::try_from(size?).map_err(|_| CloudStoreError::RecoveryLimitExceeded)?;
+        bytes = bytes.checked_add(size).ok_or(CloudStoreError::RecoveryLimitExceeded)?;
+        count += 1;
+        check_recovery_budget(count, bytes)?;
+    }
+    Ok(())
+}
+
+fn prepare_allocation(
+    state: &RemoteWorkspaceState,
+    now_millis: i64,
+    retain_until_millis: i64,
+) -> Result<PreparedAllocation, Error> {
+    state.validate()?;
+    if state.runtime.is_some() {
+        return Err(Error::RuntimeAlreadyActive);
+    }
+    if now_millis < 0 || retain_until_millis <= now_millis {
+        return Err(Error::InvalidAllocationRetention);
+    }
+    let generation = state
+        .spec
+        .generation
+        .checked_add(1)
+        .filter(|generation| i64::try_from(*generation).is_ok())
+        .ok_or(Error::GenerationExhausted)?;
+    let workflow_id = CloudWorkflowId::new();
+    let job_id = CloudJobId::new();
+    let mut next = state.clone();
+    next.spec.generation = generation;
+    next.runtime = Some(RemoteRuntimeGeneration {
+        workspace_local_id: state.spec.workspace_local_id.clone(),
+        generation,
+        workflow_id,
+        job_id,
+        phase: RemoteRuntimePhase::Provisioning,
+        worker: None,
+        ssh: None,
+        cleanup: None,
+    });
+    let workflow = CloudWorkflow {
+        protocol_version: CLOUD_RUN_PROTOCOL_VERSION,
+        id: workflow_id,
+        title: "Remote workspace".into(),
+        created_at_millis: now_millis,
+        updated_at_millis: now_millis,
+        retain_until_millis,
+        nodes: vec![WorkflowNode {
+            id: job_id,
+            logical_key: "workspace-worker".into(),
+            label: "Workspace worker".into(),
+            kind: WorkflowNodeKind::RemoteWorkspace,
+            state: CloudJobState::Queued,
+            outcome: None,
+            progress: CloudProgress::Pending,
+            weight: 1,
+            attempt: 1,
+            retry: RetryPolicy::default(),
+            supersedes: None,
+            depends_on: Vec::new(),
+            source: Some(state.spec.repository.clone()),
+            worker: Some(state.spec.target.clone()),
+            input_artifact_ids: Vec::new(),
+            outputs: Vec::new(),
+            approval: None,
+            release: None,
+            environment_lease: None,
+        }],
+    };
+    Ok(PreparedAllocation { next, workflow })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/binding.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/binding.rs
@@ -1,0 +1,106 @@
+//! Bounded allocation lookup and cross-record identity validation.
+
+use super::super::{decode_workflow_row, parse_workflow_id, workflow_row};
+use super::{CloudStoreError, CloudWorkflow, Error, StoredRemoteAllocation, WorkflowNodeKind, load_owned};
+use crate::remote_workspace::RemoteWorkspaceState;
+use rusqlite::{Connection, OptionalExtension};
+
+pub(super) struct AllocationRow {
+    workspace_local_id: String,
+    session_id: String,
+    generation: i64,
+    workflow_id: String,
+    job_id: String,
+}
+
+pub(super) fn load_workspace(connection: &Connection, id: &str) -> rusqlite::Result<Option<AllocationRow>> {
+    load_row(
+        connection,
+        "SELECT substr(workspace_local_id, 1, 129), substr(session_id, 1, 37), generation,
+                substr(workflow_id, 1, 37), substr(job_id, 1, 37)
+         FROM remote_runtime_allocations WHERE workspace_local_id = ?1",
+        id,
+    )
+}
+
+pub(super) fn load_workflow(connection: &Connection, id: &str) -> rusqlite::Result<Option<AllocationRow>> {
+    load_row(
+        connection,
+        "SELECT substr(workspace_local_id, 1, 129), substr(session_id, 1, 37), generation,
+                substr(workflow_id, 1, 37), substr(job_id, 1, 37)
+         FROM remote_runtime_allocations INDEXED BY remote_runtime_allocations_workflow WHERE workflow_id = ?1",
+        id,
+    )
+}
+
+fn load_row(connection: &Connection, query: &str, id: &str) -> rusqlite::Result<Option<AllocationRow>> {
+    connection
+        .query_row(query, [id], |row| {
+            Ok(AllocationRow {
+                workspace_local_id: row.get(0)?,
+                session_id: row.get(1)?,
+                generation: row.get(2)?,
+                workflow_id: row.get(3)?,
+                job_id: row.get(4)?,
+            })
+        })
+        .optional()
+}
+
+pub(super) fn recover(connection: &Connection, row: &AllocationRow) -> Result<StoredRemoteAllocation, CloudStoreError> {
+    super::validate_key(&row.session_id, &row.workspace_local_id).map_err(storage_error)?;
+    let workspace = load_owned(connection, &row.session_id, &row.workspace_local_id)
+        .map_err(storage_error)?
+        .ok_or(CloudStoreError::InvalidRemoteAllocation)?;
+    row.validate_workspace(workspace.session_id(), workspace.state())?;
+    let workflow_id = parse_workflow_id(&row.workflow_id)?;
+    let workflow = workflow_row(connection, &row.workflow_id)?
+        .ok_or(CloudStoreError::InvalidRemoteAllocation)
+        .and_then(|snapshot| decode_workflow_row(workflow_id, &snapshot))?;
+    row.validate_workflow(workspace.state(), workflow.workflow())?;
+    Ok(StoredRemoteAllocation { workspace, workflow })
+}
+
+impl AllocationRow {
+    pub(super) fn validate_workspace(&self, owner: &str, state: &RemoteWorkspaceState) -> Result<(), CloudStoreError> {
+        let runtime = state.runtime.as_ref().ok_or(CloudStoreError::InvalidRemoteAllocation)?;
+        if self.session_id != owner
+            || self.workspace_local_id != state.spec.workspace_local_id
+            || self.generation <= 0
+            || u64::try_from(self.generation).ok() != Some(runtime.generation)
+            || self.workflow_id != runtime.workflow_id.to_string()
+            || self.job_id != runtime.job_id.to_string()
+        {
+            return Err(CloudStoreError::InvalidRemoteAllocation);
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_workflow(
+        &self,
+        state: &RemoteWorkspaceState,
+        workflow: &CloudWorkflow,
+    ) -> Result<(), CloudStoreError> {
+        let [node] = workflow.nodes.as_slice() else {
+            return Err(CloudStoreError::InvalidRemoteAllocation);
+        };
+        if self.workflow_id != workflow.id.to_string()
+            || self.job_id != node.id.to_string()
+            || node.kind != WorkflowNodeKind::RemoteWorkspace
+            || node.source.as_ref() != Some(&state.spec.repository)
+            || node.worker.as_ref() != Some(&state.spec.target)
+        {
+            return Err(CloudStoreError::InvalidRemoteAllocation);
+        }
+        Ok(())
+    }
+}
+
+// Preserve retryable database errors without creating a recursive public error type.
+pub(super) fn storage_error(error: Error) -> CloudStoreError {
+    match error {
+        Error::Storage(error) => error,
+        Error::Database(error) => CloudStoreError::Database(error),
+        _ => CloudStoreError::InvalidRemoteAllocation,
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/guards.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/guards.rs
@@ -1,6 +1,6 @@
 //! Keep generic workflow/record APIs from bypassing committed runtime ownership.
 
-use super::super::{decode_workflow_row, workflow_row};
+use super::super::{decode_workflow_row, validate_claim_target, workflow_row};
 use super::{CloudJobId, CloudStoreError, CloudWorkflow, RemoteRuntimePhase, WorkflowNodeKind, binding};
 use crate::remote_workspace::RemoteWorkspaceState;
 use rusqlite::{Connection, params};
@@ -23,10 +23,15 @@ pub(in crate::cloud_run::store) fn validate_workflow_replacement(
 ) -> Result<(), CloudStoreError> {
     if let Some(row) = binding::load_workflow(connection, &previous.id.to_string())? {
         let allocation = binding::recover(connection, &row)?;
-        if next.retain_until_millis != previous.retain_until_millis {
+        let state = allocation.workspace.state();
+        let runtime = state.runtime.as_ref().ok_or(CloudStoreError::InvalidRemoteAllocation)?;
+        if next.retain_until_millis != previous.retain_until_millis
+            || (validate_claim_target(previous, runtime.job_id, &state.spec.target).is_err()
+                && validate_claim_target(next, runtime.job_id, &state.spec.target).is_ok())
+        {
             return Err(CloudStoreError::InvalidRemoteAllocation);
         }
-        row.validate_workflow(allocation.workspace.state(), next)
+        row.validate_workflow(state, next)
     } else {
         validate_unbound_snapshot(previous)?;
         ensure_unbound_workflow(next)

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/guards.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/guards.rs
@@ -1,0 +1,95 @@
+//! Keep generic workflow/record APIs from bypassing committed runtime ownership.
+
+use super::super::{decode_workflow_row, workflow_row};
+use super::{CloudJobId, CloudStoreError, CloudWorkflow, RemoteRuntimePhase, WorkflowNodeKind, binding};
+use crate::remote_workspace::RemoteWorkspaceState;
+use rusqlite::{Connection, params};
+
+pub(in crate::cloud_run::store) fn ensure_unbound_workflow(workflow: &CloudWorkflow) -> Result<(), CloudStoreError> {
+    if workflow
+        .nodes
+        .iter()
+        .any(|node| node.kind == WorkflowNodeKind::RemoteWorkspace)
+    {
+        return Err(CloudStoreError::RemoteAllocationRequired);
+    }
+    Ok(())
+}
+
+pub(in crate::cloud_run::store) fn validate_workflow_replacement(
+    connection: &Connection,
+    previous: &CloudWorkflow,
+    next: &CloudWorkflow,
+) -> Result<(), CloudStoreError> {
+    if let Some(row) = binding::load_workflow(connection, &previous.id.to_string())? {
+        let allocation = binding::recover(connection, &row)?;
+        if next.retain_until_millis != previous.retain_until_millis {
+            return Err(CloudStoreError::InvalidRemoteAllocation);
+        }
+        row.validate_workflow(allocation.workspace.state(), next)
+    } else {
+        validate_unbound_snapshot(previous)?;
+        ensure_unbound_workflow(next)
+    }
+}
+
+pub(in crate::cloud_run::store) fn validate_workspace_write(
+    connection: &Connection,
+    owner: &str,
+    previous: Option<&RemoteWorkspaceState>,
+    next: &RemoteWorkspaceState,
+) -> Result<(), CloudStoreError> {
+    if let Some(row) = binding::load_workspace(connection, &next.spec.workspace_local_id)? {
+        let allocation = binding::recover(connection, &row)?;
+        row.validate_workspace(owner, next)?;
+        row.validate_workflow(next, allocation.workflow.workflow())?;
+    } else if let Some(runtime) = previous
+        .and_then(|state| state.runtime.as_ref())
+        .or(next.runtime.as_ref())
+        && let Some(snapshot) = workflow_row(connection, &runtime.workflow_id.to_string())?
+    {
+        // Losing the binding cannot turn a committed remote workflow into a legacy unbound record.
+        let workflow = decode_workflow_row(runtime.workflow_id, &snapshot)?;
+        validate_unbound_snapshot(workflow.workflow())?;
+    }
+    if let Some(runtime) = &next.runtime {
+        let claimed_elsewhere: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM remote_runtime_allocations
+             WHERE workspace_local_id != ?1 AND (workflow_id = ?2 OR job_id = ?3))",
+            params![
+                next.spec.workspace_local_id,
+                runtime.workflow_id.to_string(),
+                runtime.job_id.to_string()
+            ],
+            |row| row.get(0),
+        )?;
+        if claimed_elsewhere {
+            return Err(CloudStoreError::InvalidRemoteAllocation);
+        }
+    }
+    Ok(())
+}
+
+pub(in crate::cloud_run::store) fn validate_creation_claim(
+    connection: &Connection,
+    workflow: &CloudWorkflow,
+    job_id: CloudJobId,
+) -> Result<(), CloudStoreError> {
+    let Some(row) = binding::load_workflow(connection, &workflow.id.to_string())? else {
+        return validate_unbound_snapshot(workflow);
+    };
+    let allocation = binding::recover(connection, &row)?;
+    let state = allocation.workspace.state();
+    let runtime = state.runtime.as_ref().ok_or(CloudStoreError::InvalidRemoteAllocation)?;
+    if allocation.workflow.workflow() != workflow || runtime.job_id != job_id {
+        return Err(CloudStoreError::InvalidRemoteAllocation);
+    }
+    if runtime.phase != RemoteRuntimePhase::Provisioning || runtime.worker.is_some() || runtime.cleanup.is_some() {
+        return Err(CloudStoreError::ClaimTargetNotReady(job_id));
+    }
+    Ok(())
+}
+
+fn validate_unbound_snapshot(workflow: &CloudWorkflow) -> Result<(), CloudStoreError> {
+    ensure_unbound_workflow(workflow).map_err(|_| CloudStoreError::InvalidRemoteAllocation)
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
@@ -1,0 +1,495 @@
+use super::super::{encode_workflow, tests::retained_workflow};
+use super::*;
+use crate::PanelKind;
+use crate::cloud_run::interactive_worker::{
+    InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLifetime, InteractiveWorkerSshEndpoint,
+};
+use crate::cloud_run::{ArtifactDigest, CloudProvider, GitCommitSha, GitSource, WorkerLifetime};
+use crate::remote_workspace::{
+    RemoteCleanupIntent, RemoteCleanupReason, RemotePanelBinding, RemoteWorkspaceSpec, RepositoryCheckpoint,
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use rusqlite::Connection;
+use std::sync::{Arc, Barrier};
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+const OTHER_OWNER: &str = "22222222-2222-4222-8222-222222222222";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    original: StoredRemoteWorkspace,
+}
+
+fn fixture() -> Fixture {
+    let directory = tempfile::tempdir().expect("private directory");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
+    let mut target = workflow.nodes[0].worker.clone().expect("target");
+    target.lifetime = WorkerLifetime::Persistent;
+    let state = RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: "workspace".into(),
+        target,
+        repository: GitSource {
+            repository: "owner/project".into(),
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        working_directory: ".".into(),
+        generation: 0,
+        panels: vec![RemotePanelBinding {
+            panel_local_id: "panel".into(),
+            kind: PanelKind::Shell,
+            command: None,
+            working_directory: None,
+            task_handoff: None,
+            agent_session_id: None,
+        }],
+    })
+    .expect("workspace specification");
+    let original = store.create_remote_workspace(OWNER, &state).expect("dormant");
+    Fixture {
+        _directory: directory,
+        store,
+        original,
+    }
+}
+
+impl Fixture {
+    fn allocate(&self) -> StoredRemoteAllocation {
+        self.store
+            .allocate_remote_runtime(&self.original, i64::MAX)
+            .expect("allocate")
+    }
+
+    fn recover(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("recovery")
+            .expect("allocation")
+    }
+
+    fn counts(&self) -> [i64; 3] {
+        Connection::open(self.store.path())
+            .expect("raw store")
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM cloud_workflows),
+             (SELECT COUNT(*) FROM remote_runtime_allocations),
+             (SELECT COUNT(*) FROM cloud_worker_creation_claims)",
+                [],
+                |row| Ok([row.get(0)?, row.get(1)?, row.get(2)?]),
+            )
+            .expect("record counts")
+    }
+}
+
+fn claim(store: &CloudWorkflowStore, saved: &StoredRemoteAllocation) -> Result<bool, CloudStoreError> {
+    let workflow = saved.workflow().workflow();
+    store.claim_worker_creation(
+        workflow.id,
+        workflow.nodes[0].id,
+        &saved.workspace().state().spec.target,
+        "synthetic-worker",
+    )
+}
+
+fn observed_worker(state: &RemoteWorkspaceState) -> InteractiveWorker {
+    let runtime = state.runtime.as_ref().expect("runtime");
+    let mut key = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    key.extend([7; 32]);
+    InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: state.spec.target.provider,
+            workflow_id: runtime.workflow_id,
+            job_id: runtime.job_id,
+            resource_id: "synthetic-worker".into(),
+        },
+        target: state.spec.target.clone(),
+        ssh_public_key: format!("ssh-ed25519 {}", STANDARD.encode(key)),
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    }
+}
+
+#[test]
+fn allocation_reopens_one_exact_identity_without_consuming_creation_or_reallocating() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let saved = fixture.allocate();
+    let state = saved.workspace().state();
+    let runtime = state.runtime.as_ref().expect("runtime");
+    let workflow = saved.workflow().workflow();
+    assert_eq!((saved.workspace().revision(), state.spec.generation), (2, 1));
+    assert_eq!(runtime.workflow_id, workflow.id);
+    assert_eq!(workflow.nodes.len(), 1);
+    assert_eq!(runtime.job_id, workflow.nodes[0].id);
+    assert_eq!(workflow.nodes[0].kind, WorkflowNodeKind::RemoteWorkspace);
+    assert_eq!(workflow.nodes[0].worker.as_ref(), Some(&state.spec.target));
+    assert_eq!(workflow.nodes[0].source.as_ref(), Some(&state.spec.repository));
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_allocation(OWNER, "workspace").expect("recover"),
+        Some(saved.clone())
+    );
+    assert!(matches!(
+        reopened.allocate_remote_runtime(&fixture.original, i64::MAX),
+        Err(Error::RevisionConflict { .. })
+    ));
+    assert!(matches!(
+        reopened.allocate_remote_runtime(saved.workspace(), i64::MAX),
+        Err(Error::RuntimeAlreadyActive)
+    ));
+    assert!(matches!(
+        reopened.load_remote_allocation(OTHER_OWNER, "workspace"),
+        Err(Error::OwnershipMismatch)
+    ));
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn concurrent_allocators_commit_exactly_one_complete_relationship() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let barrier = Arc::new(Barrier::new(3));
+    let writers: Vec<_> = (0..2)
+        .map(|_| {
+            let store = store.clone();
+            let original = fixture.original.clone();
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.allocate_remote_runtime(&original, i64::MAX)
+            })
+        })
+        .collect();
+    barrier.wait();
+    let results: Vec<_> = writers
+        .into_iter()
+        .map(|writer| writer.join().expect("writer"))
+        .collect();
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Err(Error::RevisionConflict { expected: 1, actual: 2 })))
+            .count(),
+        1
+    );
+    assert_eq!(
+        fixture.recover(),
+        results.into_iter().find_map(Result::ok).expect("winner")
+    );
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn workflow_capacity_failure_rolls_back_the_pending_generation() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let mut connection = Connection::open(store.path()).expect("raw store");
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .expect("fixture transaction");
+    ensure_current_schema(&transaction).expect("current fixture schema");
+    for _ in 0..MAX_RECOVERED_WORKFLOWS {
+        let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
+        PreparedWorkflowInsert::new(&workflow)
+            .expect("prepare fixture")
+            .persist(&transaction)
+            .expect("retained workflow");
+    }
+    transaction.commit().expect("full retained set");
+    assert_eq!(
+        store.list_retained(1000).expect("recoverable budget").len(),
+        MAX_RECOVERED_WORKFLOWS
+    );
+    assert!(matches!(
+        store.allocate_remote_runtime(&fixture.original, i64::MAX),
+        Err(Error::Storage(CloudStoreError::RecoveryLimitExceeded))
+    ));
+    assert_eq!(
+        fixture.counts(),
+        [i64::try_from(MAX_RECOVERED_WORKFLOWS).expect("bounded count"), 0, 0]
+    );
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("unchanged"),
+        Some(fixture.original.clone())
+    );
+    connection
+        .execute(
+            "DELETE FROM cloud_workflows WHERE workflow_id IN (SELECT workflow_id FROM cloud_workflows LIMIT 1)",
+            [],
+        )
+        .expect("free one fixture slot");
+    assert_eq!(fixture.allocate().workspace().state().spec.generation, 1);
+}
+
+#[test]
+fn invalid_setup_retention_and_exhausted_generation_never_allocate() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    for until in [-1, 0, 1000, current_unix_millis().expect("now")] {
+        assert!(matches!(
+            store.allocate_remote_runtime(&fixture.original, until),
+            Err(Error::InvalidAllocationRetention)
+        ));
+    }
+    let mut state = fixture.original.state().clone();
+    state.spec.workspace_local_id = "exhausted".into();
+    state.spec.generation = u64::MAX;
+    let exhausted = store.create_remote_workspace(OWNER, &state).expect("counter record");
+    assert!(matches!(
+        store.allocate_remote_runtime(&exhausted, i64::MAX),
+        Err(Error::GenerationExhausted)
+    ));
+    assert_eq!(fixture.counts(), [0, 0, 0]);
+}
+
+#[test]
+fn generic_writes_cannot_clear_copy_or_reclassify_even_when_the_binding_is_lost() {
+    for lost_binding in [false, true] {
+        let fixture = fixture();
+        let store = &fixture.store;
+        let saved = fixture.allocate();
+        if lost_binding {
+            Connection::open(store.path())
+                .expect("raw store")
+                .execute("DELETE FROM remote_runtime_allocations", [])
+                .expect("lost binding");
+        }
+        let mut cleared = saved.workspace().state().clone();
+        cleared.runtime = None;
+        assert!(matches!(
+            store.replace_remote_workspace(saved.workspace(), &cleared),
+            Err(Error::Storage(CloudStoreError::InvalidRemoteAllocation))
+        ));
+        let mut copy = saved.workspace().state().clone();
+        copy.spec.workspace_local_id = "copy".into();
+        copy.runtime.as_mut().expect("runtime").workspace_local_id = "copy".into();
+        assert!(matches!(
+            store.create_remote_workspace(OTHER_OWNER, &copy),
+            Err(Error::Storage(CloudStoreError::InvalidRemoteAllocation))
+        ));
+        let mut next = saved.workflow().workflow().clone();
+        next.updated_at_millis += 1;
+        next.nodes[0].kind = WorkflowNodeKind::Build;
+        assert!(matches!(
+            store.replace(saved.workflow(), &next),
+            Err(CloudStoreError::InvalidRemoteAllocation)
+        ));
+        if lost_binding {
+            assert!(matches!(
+                claim(store, &saved),
+                Err(CloudStoreError::InvalidRemoteAllocation)
+            ));
+        }
+        assert_eq!(
+            store.load_remote_workspace(OWNER, "workspace").expect("retained"),
+            Some(saved.workspace().clone())
+        );
+        assert_eq!(fixture.counts(), [1, i64::from(!lost_binding), 0]);
+    }
+}
+
+#[test]
+fn workflow_identity_and_single_node_shape_are_enforced_but_progress_can_update() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let saved = fixture.allocate();
+    let workflow = saved.workflow().workflow();
+    let mut copy = workflow.clone();
+    copy.id = CloudWorkflowId::new();
+    assert!(matches!(
+        store.create(&copy),
+        Err(CloudStoreError::RemoteAllocationRequired)
+    ));
+    for change in [0, 1, 2, 3] {
+        let mut next = workflow.clone();
+        next.updated_at_millis += 1;
+        match change {
+            0 => next.nodes[0].worker.as_mut().expect("target").disk_gib += 1,
+            1 => next.nodes[0].source.as_mut().expect("source").repository = "other/project".into(),
+            2 => next.nodes[0].kind = WorkflowNodeKind::Build,
+            _ => next.nodes[0].worker.as_mut().expect("target").lifetime = WorkerLifetime::TimeLimited { seconds: 900 },
+        }
+        assert!(matches!(
+            store.replace(saved.workflow(), &next),
+            Err(CloudStoreError::InvalidRemoteAllocation)
+        ));
+    }
+    let mut progress = workflow.clone();
+    progress.updated_at_millis += 1;
+    progress.nodes[0].state = CloudJobState::Provisioning;
+    let updated = store.replace(saved.workflow(), &progress).expect("progress");
+    assert_eq!(fixture.recover().workflow(), &updated);
+    for change in [0, 1, 2, 3] {
+        let mut next = saved.workflow().workflow().clone();
+        match change {
+            0 => next.nodes[0].source = None,
+            1 => next.nodes[0].worker = None,
+            2 => next.nodes[0].retry.max_attempts = 2,
+            _ => {
+                let mut extra = next.nodes[0].clone();
+                extra.id = CloudJobId::new();
+                extra.logical_key = "other".into();
+                next.nodes.push(extra);
+            }
+        }
+        assert!(next.validate().is_err());
+    }
+}
+
+#[test]
+fn zero_panels_and_detached_intents_do_not_control_lifetime_or_renew_creation() {
+    for lifetime in [WorkerLifetime::Persistent, WorkerLifetime::TimeLimited { seconds: 900 }] {
+        let fixture = fixture();
+        let store = &fixture.store;
+        let mut state = fixture.original.state().clone();
+        state.spec.target.lifetime = lifetime;
+        state.spec.panels.clear();
+        let empty = store
+            .replace_remote_workspace(&fixture.original, &state)
+            .expect("empty intent");
+        let saved = store
+            .allocate_remote_runtime(&empty, i64::MAX)
+            .expect("allocate without panels");
+        assert_eq!(saved.workspace().state().spec.target.lifetime, lifetime);
+        let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+        assert!(runtime.cleanup.is_none());
+        assert!(claim(store, &saved).expect("first grant"));
+        let mut attached = saved.workspace().state().clone();
+        attached.spec.panels.clone_from(&fixture.original.state().spec.panels);
+        let with_panel = store
+            .replace_remote_workspace(saved.workspace(), &attached)
+            .expect("attach intent");
+        attached.spec.panels.clear();
+        let detached = store
+            .replace_remote_workspace(&with_panel, &attached)
+            .expect("detach intent");
+        assert_eq!(detached.state().runtime, saved.workspace().state().runtime);
+        let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+        assert!(!claim(&reopened, &saved).expect("no second grant"));
+        assert!(matches!(
+            reopened.allocate_remote_runtime(&detached, i64::MAX),
+            Err(Error::RuntimeAlreadyActive)
+        ));
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+    }
+}
+
+#[test]
+fn expired_setup_keeps_worker_ssh_and_checkpoints_without_renewal_or_new_generation() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let saved = fixture.allocate();
+    let mut expired = saved.workflow().workflow().clone();
+    expired.created_at_millis = 1000;
+    expired.updated_at_millis = 1000;
+    expired.retain_until_millis = 2000;
+    Connection::open(store.path())
+        .expect("raw store")
+        .execute(
+            "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000,
+         retain_until_millis=2000, snapshot=?1 WHERE workflow_id=?2",
+            params![
+                encode_workflow(&expired).expect("expired snapshot"),
+                expired.id.to_string()
+            ],
+        )
+        .expect("elapsed setup fixture");
+    let saved = fixture.recover();
+    let mut state = saved.workspace().state().clone();
+    let worker = observed_worker(&state);
+    let runtime = state.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Ready;
+    runtime.ssh = Some(InteractiveWorkerSshEndpoint {
+        host: "127.0.0.1".into(),
+        port: 2222,
+        username: "horizon".into(),
+        host_key: worker.ssh_public_key.clone(),
+    });
+    runtime.worker = Some(worker);
+    let running = store
+        .replace_remote_workspace(saved.workspace(), &state)
+        .expect("running fixture");
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert!(
+        reopened
+            .list_retained(current_unix_millis().expect("now"))
+            .expect("retained setup")
+            .is_empty()
+    );
+    assert_eq!(fixture.recover().workspace(), &running);
+    assert!(matches!(
+        claim(&reopened, &saved),
+        Err(CloudStoreError::WorkflowExpired(_))
+    ));
+    let mut extended = saved.workflow().workflow().clone();
+    extended.updated_at_millis += 1;
+    extended.retain_until_millis = i64::MAX;
+    assert!(matches!(
+        reopened.replace(saved.workflow(), &extended),
+        Err(CloudStoreError::InvalidRemoteAllocation)
+    ));
+    state.checkpoint = Some(RepositoryCheckpoint {
+        workspace_local_id: "workspace".into(),
+        base_commit: state.spec.repository.commit.clone(),
+        manifest_digest: ArtifactDigest::parse_sha256("c".repeat(64)).expect("digest"),
+        runtime_generation: 1,
+        generation: 1,
+        captured_at_millis: 3000,
+        recovery_artifact: None,
+    });
+    let checkpointed = reopened
+        .replace_remote_workspace(&running, &state)
+        .expect("checkpoint after setup expiry");
+    assert_eq!(checkpointed.state().runtime, running.state().runtime);
+    assert_eq!(fixture.recover().workspace(), &checkpointed);
+    assert!(matches!(
+        reopened.allocate_remote_runtime(&checkpointed, i64::MAX),
+        Err(Error::RuntimeAlreadyActive)
+    ));
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn cleanup_reconciling_and_observed_records_remain_recoverable_without_new_grants() {
+    enum Observation {
+        Cleanup(RemoteCleanupReason),
+        Reconciling,
+        Worker,
+    }
+    for observation in [
+        Observation::Cleanup(RemoteCleanupReason::LastPanelClosed),
+        Observation::Cleanup(RemoteCleanupReason::WorkspaceRemoved),
+        Observation::Cleanup(RemoteCleanupReason::ApplicationExit),
+        Observation::Cleanup(RemoteCleanupReason::Cancelled),
+        Observation::Reconciling,
+        Observation::Worker,
+    ] {
+        let fixture = fixture();
+        let store = &fixture.store;
+        let saved = fixture.allocate();
+        let mut state = saved.workspace().state().clone();
+        let worker = observed_worker(&state);
+        let runtime = state.runtime.as_mut().expect("runtime");
+        match observation {
+            Observation::Cleanup(reason) => {
+                runtime.cleanup = Some(RemoteCleanupIntent {
+                    reason,
+                    requested_at_millis: 2000,
+                });
+            }
+            Observation::Reconciling => runtime.phase = RemoteRuntimePhase::Reconciling,
+            Observation::Worker => runtime.worker = Some(worker),
+        }
+        let retained = store
+            .replace_remote_workspace(saved.workspace(), &state)
+            .expect("observation");
+        assert_eq!(fixture.recover().workspace(), &retained);
+        assert!(matches!(
+            claim(store, &saved),
+            Err(CloudStoreError::ClaimTargetNotReady(_))
+        ));
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
@@ -114,10 +114,15 @@ fn observed_worker(state: &RemoteWorkspaceState) -> InteractiveWorker {
 fn allocation_reopens_one_exact_identity_without_consuming_creation_or_reallocating() {
     let fixture = fixture();
     let store = &fixture.store;
+    assert_eq!(store.load_remote_allocation(OWNER, "workspace").expect("dormant"), None);
+    let started = current_unix_millis().expect("clock");
     let saved = fixture.allocate();
     let state = saved.workspace().state();
     let runtime = state.runtime.as_ref().expect("runtime");
     let workflow = saved.workflow().workflow();
+    assert!((started..=current_unix_millis().expect("clock")).contains(&workflow.created_at_millis));
+    assert_eq!(workflow.updated_at_millis, workflow.created_at_millis);
+    assert_eq!(workflow.retain_until_millis, i64::MAX);
     assert_eq!((saved.workspace().revision(), state.spec.generation), (2, 1));
     assert_eq!(runtime.workflow_id, workflow.id);
     assert_eq!(workflow.nodes.len(), 1);
@@ -277,6 +282,10 @@ fn generic_writes_cannot_clear_copy_or_reclassify_even_when_the_binding_is_lost(
             Err(CloudStoreError::InvalidRemoteAllocation)
         ));
         if lost_binding {
+            assert!(matches!(
+                store.load_remote_allocation(OWNER, "workspace"),
+                Err(Error::UnboundRuntime)
+            ));
             assert!(matches!(
                 claim(store, &saved),
                 Err(CloudStoreError::InvalidRemoteAllocation)

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::cloud_run::interactive_worker::{
     InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLifetime, InteractiveWorkerSshEndpoint,
 };
-use crate::cloud_run::{ArtifactDigest, CloudProvider, GitCommitSha, GitSource, WorkerLifetime};
+use crate::cloud_run::{ArtifactDigest, CloudJobOutcome, CloudProvider, GitCommitSha, GitSource, WorkerLifetime};
 use crate::remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteWorkspaceSpec, RepositoryCheckpoint};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use rusqlite::Connection;
@@ -225,27 +225,6 @@ fn workflow_capacity_failure_rolls_back_the_pending_generation() {
 }
 
 #[test]
-fn invalid_setup_retention_and_exhausted_generation_never_allocate() {
-    let fixture = fixture();
-    let store = &fixture.store;
-    for until in [-1, 0, 1000, current_unix_millis().expect("now")] {
-        assert!(matches!(
-            store.allocate_remote_runtime(&fixture.original, until),
-            Err(Error::InvalidAllocationRetention)
-        ));
-    }
-    let mut state = fixture.original.state().clone();
-    state.spec.workspace_local_id = "exhausted".into();
-    state.spec.generation = u64::MAX;
-    let exhausted = store.create_remote_workspace(OWNER, &state).expect("counter record");
-    assert!(matches!(
-        store.allocate_remote_runtime(&exhausted, i64::MAX),
-        Err(Error::GenerationExhausted)
-    ));
-    assert_eq!(fixture.counts(), [0, 0, 0]);
-}
-
-#[test]
 fn generic_writes_cannot_clear_copy_or_reclassify_even_when_the_binding_is_lost() {
     for lost_binding in [false, true] {
         let fixture = fixture();
@@ -326,6 +305,32 @@ fn workflow_identity_and_single_node_shape_are_enforced_but_progress_can_update(
     progress.nodes[0].state = CloudJobState::Provisioning;
     let updated = store.replace(saved.workflow(), &progress).expect("progress");
     assert_eq!(fixture.recover().workflow(), &updated);
+    let mut observed = updated;
+    for (phase, outcome) in [
+        (CloudJobState::Running, None),
+        (CloudJobState::Failed, Some(CloudJobOutcome::Failed)),
+    ] {
+        let mut next = observed.workflow().clone();
+        next.updated_at_millis += 1;
+        next.nodes[0].state = phase;
+        next.nodes[0].outcome = outcome;
+        observed = store.replace(&observed, &next).expect("non-creating progress");
+        for eligible in [CloudJobState::Queued, CloudJobState::Provisioning] {
+            next.updated_at_millis += 1;
+            next.nodes[0].state = eligible;
+            next.nodes[0].outcome = None;
+            assert!(matches!(
+                store.replace(&observed, &next),
+                Err(CloudStoreError::InvalidRemoteAllocation)
+            ));
+        }
+        assert_eq!(fixture.recover().workflow(), &observed);
+        assert!(matches!(
+            claim(store, &saved),
+            Err(CloudStoreError::ClaimTargetNotReady(_))
+        ));
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+    }
     for change in [0, 1, 2, 3] {
         let mut next = saved.workflow().workflow().clone();
         match change {

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -13,7 +13,8 @@ use super::{
     MAX_SNAPSHOT_BYTES, database::ensure_current_schema,
 };
 use crate::remote_workspace::{RemoteWorkspaceError, RemoteWorkspaceState};
-use validation::{validate_key, validate_replacement, validate_session_id};
+pub(super) use validation::validate_key;
+use validation::{validate_replacement, validate_session_id};
 
 const MAX_RECOVERED_WORKSPACES: usize = 512;
 const RECOVERY_QUERY: &str = "SELECT substr(workspace_local_id, 1, 129), substr(session_id, 1, 37), revision,
@@ -68,6 +69,7 @@ impl CloudWorkflowStore {
         if exists {
             return Err(RemoteWorkspaceStoreError::AlreadyExists);
         }
+        super::remote_allocations::validate_workspace_write(&transaction, session_id, None, state)?;
         ensure_session_budget(&transaction, session_id, &state.spec.workspace_local_id, snapshot.len())?;
         transaction.execute(
             "INSERT INTO remote_workspaces (workspace_local_id, session_id, revision, snapshot)
@@ -130,7 +132,8 @@ impl CloudWorkflowStore {
 
     /// Replace exactly the observed revision and snapshot, never another session's record.
     /// The coordinator remains responsible for lifecycle legality and verified cleanup
-    /// before clearing a runtime. This operation does not allocate a workflow or worker.
+    /// before clearing an unbound runtime. Bound allocations cannot be cleared here.
+    /// This operation does not allocate a workflow or worker.
     /// # Errors
     /// Rejects stale writers, identity/generation drift, checkpoint loss, invalid snapshots,
     /// revision exhaustion, corruption, or storage failures.
@@ -192,6 +195,12 @@ impl<'a> WorkspaceReplacement<'a> {
         if current != *expected {
             return Err(RemoteWorkspaceStoreError::SnapshotConflict);
         }
+        super::remote_allocations::validate_workspace_write(
+            transaction,
+            &expected.session_id,
+            Some(&expected.state),
+            next,
+        )?;
         ensure_session_budget(
             transaction,
             &expected.session_id,
@@ -267,7 +276,7 @@ impl WorkspaceRow {
     }
 }
 
-fn load_owned(
+pub(super) fn load_owned(
     connection: &Connection,
     session_id: &str,
     workspace_local_id: &str,
@@ -407,6 +416,14 @@ pub enum RemoteWorkspaceStoreError {
     ReplacementIdentityMismatch,
     #[error("replacement loses or rewinds a remote generation, cleanup intent, or repository checkpoint")]
     NonMonotonicReplacement,
+    #[error("remote workspace already has a runtime to reconcile")]
+    RuntimeAlreadyActive,
+    #[error("remote workspace exhausted its allocation generation range")]
+    GenerationExhausted,
+    #[error("remote allocation setup retention must end after its valid creation timestamp")]
+    InvalidAllocationRetention,
+    #[error("active remote snapshot has no verified workflow allocation; reconciliation is required")]
+    UnboundRuntime,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -9,7 +9,7 @@ pub(super) fn validate_session_id(session_id: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub(super) fn validate_key(session_id: &str, workspace_local_id: &str) -> Result<(), Error> {
+pub(in crate::cloud_run::store) fn validate_key(session_id: &str, workspace_local_id: &str) -> Result<(), Error> {
     validate_session_id(session_id)?;
     if !valid_local_id(workspace_local_id) {
         return Err(Error::InvalidWorkspaceId);

--- a/crates/horizon-core/src/cloud_run/store/workflow_writes.rs
+++ b/crates/horizon-core/src/cloud_run/store/workflow_writes.rs
@@ -16,6 +16,10 @@ impl<'a> PreparedWorkflowInsert<'a> {
         })
     }
 
+    pub(super) fn snapshot_len(&self) -> usize {
+        self.snapshot.len()
+    }
+
     /// The caller must check the current schema in an immediate write transaction.
     /// The returned value is provisional until that caller commits.
     pub(super) fn persist(&self, transaction: &Transaction<'_>) -> Result<StoredWorkflow, CloudStoreError> {

--- a/crates/horizon-core/src/cloud_run/validation.rs
+++ b/crates/horizon-core/src/cloud_run/validation.rs
@@ -1,7 +1,7 @@
 use super::{
     ApprovalDecision, ApprovalGate, ArtifactDigest, ArtifactRef, CLOUD_RUN_PROTOCOL_VERSION, CloudJobId,
     CloudJobOutcome, CloudJobState, CloudProgress, CloudProtocolError as Error, CloudWorkflow, GitSource,
-    ProvenanceRecord, WorkflowNode, WorkflowNodeKind,
+    ProvenanceRecord, RetryPolicy, WorkflowNode, WorkflowNodeKind,
 };
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
@@ -92,6 +92,7 @@ fn validate_node(
     node: &WorkflowNode,
     nodes: &HashMap<CloudJobId, &WorkflowNode>,
 ) -> Result<(), Error> {
+    validate_remote_workspace_node(workflow, node)?;
     if node.logical_key.trim().is_empty() || node.label.trim().is_empty() {
         return Err(Error::EmptyNodeIdentity(node.id));
     }
@@ -150,6 +151,24 @@ fn validate_node(
     }
     Ok(())
 }
+fn validate_remote_workspace_node(workflow: &CloudWorkflow, node: &WorkflowNode) -> Result<(), Error> {
+    if node.kind == WorkflowNodeKind::RemoteWorkspace
+        && (workflow.nodes.len() != 1
+            || node.worker.is_none()
+            || node.source.is_none()
+            || node.attempt != 1
+            || node.retry != RetryPolicy::default()
+            || node.supersedes.is_some()
+            || !node.depends_on.is_empty()
+            || node.approval.is_some()
+            || node.release.is_some()
+            || node.environment_lease.is_some())
+    {
+        return Err(Error::InvalidRemoteWorkspaceNode(node.id));
+    }
+    Ok(())
+}
+
 fn validate_retry(node: &WorkflowNode, nodes: &HashMap<CloudJobId, &WorkflowNode>) -> Result<(), Error> {
     let Some(previous_id) = node.supersedes else {
         return ensure(node.attempt == 1, Error::InvalidSupersededAttempt(node.id));

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -95,6 +95,13 @@ back into large multi-purpose modules.
   encoded snapshot before staging insertion, separately from transaction commit;
   provider/workflow coordination and runtime-state references remain separate
   integration responsibilities.
+- `cloud_run/store/remote_allocations.rs` atomically binds a runtime generation,
+  its single-worker setup workflow and their ownership record. Its `binding.rs`
+  leaf performs bounded cross-record recovery; `guards.rs` prevents generic
+  record/workflow writes and creation claims from bypassing that binding.
+  Recovery preserves expired setup identities without granting new creation.
+  These store operations run off the render thread and neither own remote
+  execution lifetime nor perform provider actions.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -165,6 +165,8 @@ binding cannot reclassify its saved remote workflow as a legacy unbound record.
 Creation grants require the intact allocation to remain provisioning without
 an observed worker or cleanup intent. A later observation or uncertain claim
 outcome requires non-creating reconciliation, not a retry interpreted as a grant.
+The bound workflow also cannot return to a creation-eligible queued/provisioning
+state after leaving it, even if the runtime snapshot is still provisioning.
 Historical close/exit cleanup records remain recoverable and non-creating; they
 are not authority for provider deletion under the corrected product contract.
 

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -1,6 +1,6 @@
 # ADR-383: Session-owned remote records in the control-plane database
 
-Status: Accepted record-storage boundary; persistent-lifetime integration pending.
+Status: Accepted record/allocation storage boundary; product integration pending.
 Date: 2026-09-05 (Europe/Oslo; 2026-09-04 UTC)
 Deciders: Repository maintainer through the issue and reviewed implementation PRs.
 
@@ -70,8 +70,8 @@ they do not copy live provider handles.
 
 The initial storage PR adds schema migration, validated record operations,
 bounded session recovery, and ownership/revision regressions. It performs no
-provider calls and adds no UI consumer. Generation/workflow allocation will be
-one transaction in a subsequent coordinator slice using this same database.
+provider calls and adds no UI consumer. Generation/workflow allocation now shares
+one transaction in this database; provider coordination remains a separate slice.
 The record store is not permission to create, attach, or delete a worker.
 
 Each snapshot is limited to 4 MiB, with session recovery capped at 512 records
@@ -122,10 +122,40 @@ Retention expiry cannot remove a bound workflow or its consumed creation claim.
 Any future retirement operation must explicitly retire the binding in the same
 transaction, after its separate cleanup/recovery contract permits retirement.
 
-This schema prerequisite exposes no allocation read/write API and introduces no
-new workflow node kind, worker creation, adoption, lifetime policy, or UI behavior.
-The future allocator must commit and validate both snapshots with their binding
-in one transaction before the existing creation fence can grant provider creation.
+The schema-only prerequisite introduced no allocation API, new workflow node
+kind, provider call or UI. The atomic allocation API below builds on this boundary.
+
+### Atomic runtime and setup-workflow allocation
+
+Allocate one new generation, one strict single-worker `RemoteWorkspace` workflow,
+and their binding in one immediate transaction. Compare the exact observed
+workspace revision and snapshot; enforce session and retained-workflow recovery
+budgets before committing. Concurrent or stale callers must reload the winner.
+Allocation itself never calls a provider or consumes a creation grant.
+
+Setup authorization has an explicit deadline independent of execution lifetime.
+The store samples its own current clock for the creation timestamp and admission
+budget, rejecting already-expired requests without creating a bound record.
+Neither zero panel intents nor detaching the final local view cancels setup or
+changes worker lifetime. Once allocated, the setup deadline cannot be extended
+through a generic workflow update. Its expiry still permits exact allocation,
+worker, pinned SSH and checkpoint recovery; it does not stop or replace compute.
+
+Generic workflow/record writes cannot create remote nodes independently, change
+bound source/target identity, clear the runtime or copy its ownership. Losing a
+binding cannot reclassify its saved remote workflow as a legacy unbound record.
+Creation grants require the intact allocation to remain provisioning without
+an observed worker or cleanup intent. A later observation or uncertain claim
+outcome requires non-creating reconciliation, not a retry interpreted as a grant.
+Historical close/exit cleanup records remain recoverable and non-creating; they
+are not authority for provider deletion under the corrected product contract.
+
+This slice exposes no allocation retirement/rebinding API. Bound identity stays
+until a later explicit cleanup/recovery transaction can safely retire it.
+Legacy active unbound records remain available for reconciliation, never adopted
+as an allocation or used as permission for a new generation. Runtime references,
+remote supervision/checkpoint execution, providers and the overview widget remain
+separate integration work; these APIs alone do not prove PC-off development.
 
 ## Options considered
 


### PR DESCRIPTION
## Purpose

Relates to #383. Atomically bind one remote-workspace generation to one
single-worker setup workflow, building on #403, #404, #406, #407 and #408.

## Behavior

- Commit the workspace revision, workflow snapshot and unique ownership binding
  in one immediate transaction. Concurrent/stale callers reload the winner;
  failed admission rolls back the pending generation.
- Allocate through the dedicated API only. Generic workflow/record writes cannot
  create remote nodes independently, change bound source/target identity, clear
  the runtime, copy ownership or reclassify a workflow after its binding is lost.
- Sample the store's clock only after acquiring the immediate write transaction.
  Reject setup deadlines that expire during lock contention; keep authorization immutable.
- Preserve expired allocations, worker identity, pinned SSH and checkpoints for
  non-creating recovery. Zero panels or final-view detachment never owns compute
  lifetime or renews the durable one-shot creation claim.
- Require an intact provisioning allocation without an observed worker or cleanup
  intent before a creation grant. Later/uncertain observations require non-creating
  reconciliation and cannot rewind to provisioning; legacy close/exit records do
  not authorize provider deletion.
- Once a bound workflow leaves queued/provisioning, generic updates cannot
  return it to that creation-eligible set, even if its runtime still says provisioning.
- Publish immutable workflow/job denials with the runtime snapshot in the allocation
  transaction. A missing binding cannot authorize legacy or copied runtime identities;
  complete positive bound eligibility still permits the original one-shot grant.

These synchronous store APIs run off the render thread. Allocation itself makes
no provider call and consumes no creation grant. There is no retirement/rebinding
API, provider integration, remote task/checkpoint executor, UI, automatic stop or
delete, release, or cloud-resource operation in this slice. The Remote Environments
widget and actual PC-off development proof remain pending in #383.

## Validation

Exact candidate: `b41fb14652fbd1903c3ab8de340437babb41c099`, based on merged main
`8ad28db4e9d89bab8ed8a9b3cc959871a98a2c07`.

The complete mandatory local matrix passed in that exact committed worktree:

- Format, maintainability and version sync.
- Warning-denied full workspace tests, default and speech features.
- Blocking Clippy, strict no-unwrap/no-expect Clippy and advisory pedantic Clippy.
- All 111 cloud-workflow tests repeated with eight threads.

Eight focused allocation tests cover exact identity/reopen across schema-three-to-four migration, dormant/unbound
recovery, authoritative clock/deadline under contention, concurrent writers, real capacity-failure
rollback and retry, generic-write safeguards, strict node shape, durable claims
after reopen with zero panel intents, expired worker/SSH/checkpoint recovery without renewal,
and irreversible non-creating runtime/workflow observations. The workflow regression
holds the runtime in provisioning, rejects all four running/failed to queued/provisioning
rewinds, preserves the saved workflow and records no creation claim. In the rollback lane, the
workspace is staged before workflow admission fails; its saved revision/state
remain unchanged and retry succeeds after one fixture slot is freed.

The inherited twelve creation-fence regressions also cover legacy unclaimed
runtime denial, copied workflow/job identities, immutable metadata, migration
preservation and transactional denial rollback/publication.

Independent local review approved the complete integrated diff and exact final
commit with no remaining findings. The follow-up fixes received full local
self-review and reproduce-before/pass-after regressions; the required independent
PR review is refreshed on the updated head. No UI/native
provider smoke applies to this store-only slice; the real SQLite API/fence paths
are exercised directly. Additional deadline/generation boundary, lifetime/attach-detach policy, direct-record
corruption and byte/session capacity coverage is preserved for the next separate test-only hardening PR;
no production guard or known correctness fix is deferred.

Scope: ten source/test files, 1,000 changed source/test lines, plus two architecture
notes (twelve files total). No dependencies or configuration defaults change.
