### PR TITLE
fix(store): restrict generic runtime transitions

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -58,6 +58,9 @@ impl CloudWorkflowStore {
     ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
         validate_key(session_id, &state.spec.workspace_local_id)?;
         let snapshot = encode(session_id, state)?;
+        if state.runtime.is_some() {
+            return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
+        }
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         ensure_current_schema(&transaction)?;
@@ -68,9 +71,6 @@ impl CloudWorkflowStore {
         )?;
         if exists {
             return Err(RemoteWorkspaceStoreError::AlreadyExists);
-        }
-        if state.runtime.is_some() {
-            return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
         }
         ensure_session_budget(&transaction, session_id, &state.spec.workspace_local_id, snapshot.len())?;
         transaction.execute(

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -46,8 +46,9 @@ impl StoredRemoteWorkspace {
 }
 
 impl CloudWorkflowStore {
-    /// Persist a validated remote aggregate with one immutable owning session.
+    /// Persist a validated dormant aggregate with one immutable owning session.
     /// A logical workspace identity cannot also belong to a copied session.
+    /// Existing legacy runtimes remain readable; new runtime identity requires allocation.
     /// # Errors
     /// Rejects invalid keys/snapshots, existing workspace identities, or storage failures.
     pub fn create_remote_workspace(
@@ -67,6 +68,9 @@ impl CloudWorkflowStore {
         )?;
         if exists {
             return Err(RemoteWorkspaceStoreError::AlreadyExists);
+        }
+        if state.runtime.is_some() {
+            return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
         }
         ensure_session_budget(&transaction, session_id, &state.spec.workspace_local_id, snapshot.len())?;
         transaction.execute(
@@ -130,7 +134,8 @@ impl CloudWorkflowStore {
 
     /// Replace exactly the observed revision and snapshot, never another session's record.
     /// The coordinator remains responsible for lifecycle legality and verified cleanup
-    /// before clearing a runtime. This operation does not allocate a workflow or worker.
+    /// before clearing an unbound runtime. This operation cannot introduce a runtime,
+    /// rewind a non-creating observation to provisioning, or allocate a workflow or worker.
     /// # Errors
     /// Rejects stale writers, identity/generation drift, checkpoint loss, invalid snapshots,
     /// revision exhaustion, corruption, or storage failures.
@@ -140,6 +145,9 @@ impl CloudWorkflowStore {
         next: &RemoteWorkspaceState,
     ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
         let replacement = WorkspaceReplacement::new(expected, next)?;
+        if expected.state.runtime.is_none() && next.runtime.is_some() {
+            return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
+        }
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         ensure_current_schema(&transaction)?;
@@ -170,7 +178,9 @@ impl<'a> WorkspaceReplacement<'a> {
     }
 
     /// The caller must check the current schema in an immediate write transaction.
-    /// The returned value is provisional until that caller commits.
+    /// The returned value is provisional until that caller commits. Unlike generic
+    /// record writes, the allocator may stage a new runtime here; it must commit
+    /// the matching workflow and ownership binding in that same transaction.
     pub(super) fn persist(
         &self,
         transaction: &rusqlite::Transaction<'_>,
@@ -405,8 +415,12 @@ pub enum RemoteWorkspaceStoreError {
     RecoveryLimitExceeded,
     #[error("replacement changes remote workspace or active runtime identity")]
     ReplacementIdentityMismatch,
-    #[error("replacement loses or rewinds a remote generation, cleanup intent, or repository checkpoint")]
+    #[error(
+        "replacement loses or rewinds a remote generation, observed phase, cleanup intent, or repository checkpoint"
+    )]
     NonMonotonicReplacement,
+    #[error("new remote runtime identity requires atomic allocation")]
+    RuntimeAllocationRequired,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
@@ -67,6 +67,26 @@ fn provisioning(mut state: RemoteWorkspaceState) -> RemoteWorkspaceState {
 mod migration;
 mod ownership;
 mod recovery;
+mod transitions;
+
+fn seed_legacy_workspace(store: &CloudWorkflowStore, state: &RemoteWorkspaceState) -> StoredRemoteWorkspace {
+    // Seed an already-persisted legacy snapshot; public writes must not import runtimes.
+    Connection::open(store.path())
+        .expect("raw legacy fixture")
+        .execute(
+            "INSERT INTO remote_workspaces VALUES (?1, ?2, 1, ?3)",
+            params![
+                state.spec.workspace_local_id,
+                OWNER,
+                encode(OWNER, state).expect("legacy snapshot")
+            ],
+        )
+        .expect("seed legacy record");
+    store
+        .load_remote_workspace(OWNER, &state.spec.workspace_local_id)
+        .expect("recover legacy record")
+        .expect("legacy record")
+}
 
 fn seed_workspaces(store: &CloudWorkflowStore, sizes: impl IntoIterator<Item = Option<usize>>) {
     let mut connection = Connection::open(store.path()).expect("raw store");

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -127,13 +127,13 @@ fn concurrent_writers_have_exactly_one_winner_and_preserve_the_winning_intent() 
         .expect("create");
     let barrier = Arc::new(Barrier::new(3));
     let writers: Vec<_> = (0..2)
-        .map(|_| {
+        .map(|index| {
             let store = store.clone();
             let expected = stored.clone();
             let barrier = Arc::clone(&barrier);
             std::thread::spawn(move || {
                 let mut next = expected.state().clone();
-                next.spec.working_directory = "src".into();
+                next.spec.working_directory = format!("src-{index}");
                 barrier.wait();
                 store.replace_remote_workspace(&expected, &next)
             })

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/ownership.rs
@@ -7,7 +7,8 @@ fn prepared_writes_share_the_callers_transaction_without_committing() {
     let original = store
         .create_remote_workspace(OWNER, &workspace("workspace"))
         .expect("record");
-    let next = provisioning(original.state().clone());
+    let mut next = original.state().clone();
+    next.spec.working_directory = "src".into();
     let replacement = WorkspaceReplacement::new(&original, &next).expect("prepare");
     let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
     let prepared_workflow = PreparedWorkflowInsert::new(&workflow).expect("prepare workflow");
@@ -108,7 +109,7 @@ fn persistent_runtime_round_trips_without_expiry_or_new_identity() {
     worker.target = state.spec.target.clone();
     worker.lifetime = InteractiveWorkerLifetime::Persistent;
     state.validate().expect("persistent aggregate");
-    let stored = store.create_remote_workspace(OWNER, &state).expect("persist worker");
+    let stored = seed_legacy_workspace(&store, &state);
     let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
     assert_eq!(
         reopened.load_remote_workspace(OWNER, "workspace").expect("recover"),
@@ -131,7 +132,8 @@ fn concurrent_writers_have_exactly_one_winner_and_preserve_the_winning_intent() 
             let expected = stored.clone();
             let barrier = Arc::clone(&barrier);
             std::thread::spawn(move || {
-                let next = provisioning(expected.state().clone());
+                let mut next = expected.state().clone();
+                next.spec.working_directory = "src".into();
                 barrier.wait();
                 store.replace_remote_workspace(&expected, &next)
             })
@@ -173,9 +175,7 @@ fn replacements_preserve_identity_runtime_and_checkpoint_watermarks() {
         captured_at_millis: 1000,
         recovery_artifact: Some(ArtifactDigest::parse_sha256("d".repeat(64)).expect("artifact")),
     });
-    let stored = store
-        .create_remote_workspace(OWNER, &state)
-        .expect("create active snapshot");
+    let stored = seed_legacy_workspace(&store, &state);
     let mut changed = state.clone();
     changed.runtime.as_mut().expect("runtime").workflow_id = CloudWorkflowId::new();
     assert!(matches!(
@@ -232,9 +232,10 @@ fn replacements_preserve_identity_runtime_and_checkpoint_watermarks() {
         store.replace_remote_workspace(&dormant, &reused),
         Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
     ));
-    store
-        .replace_remote_workspace(&dormant, &provisioning(changed))
-        .expect("next generation");
+    assert!(matches!(
+        store.replace_remote_workspace(&dormant, &provisioning(changed)),
+        Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired)
+    ));
 }
 
 #[test]
@@ -247,7 +248,7 @@ fn pending_cleanup_preserves_its_exact_reason_and_request_time() {
         reason: RemoteCleanupReason::Cancelled,
         requested_at_millis: 2000,
     });
-    let stored = store.create_remote_workspace(OWNER, &state).expect("pending cleanup");
+    let stored = seed_legacy_workspace(&store, &state);
     for (reason, requested_at_millis) in [
         (RemoteCleanupReason::LastPanelClosed, 2000),
         (RemoteCleanupReason::Cancelled, 1999),
@@ -278,7 +279,7 @@ fn pending_cleanup_preserves_its_exact_reason_and_request_time() {
     );
 }
 
-fn expired_runtime() -> RemoteWorkspaceState {
+pub(super) fn expired_runtime() -> RemoteWorkspaceState {
     use crate::cloud_run::interactive_worker::{
         InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLease, InteractiveWorkerLifetime,
         InteractiveWorkerSshEndpoint,
@@ -320,9 +321,7 @@ fn public_key(byte: u8) -> String {
 fn expired_exact_worker_handles_and_pinned_endpoints_remain_durable_for_reconciliation() {
     let (_directory, store) = store();
     let mut state = expired_runtime();
-    let stored = store
-        .create_remote_workspace(OWNER, &state)
-        .expect("store expired handle");
+    let stored = seed_legacy_workspace(&store, &state);
     let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
     assert_eq!(
         reopened.load_remote_workspace(OWNER, "workspace").expect("load"),
@@ -353,9 +352,7 @@ fn first_endpoint_can_be_pinned_but_never_replaced_within_the_same_runtime() {
     let runtime = unpinned.runtime.as_mut().expect("runtime");
     runtime.phase = RemoteRuntimePhase::Reconciling;
     runtime.ssh = None;
-    let pending = store
-        .create_remote_workspace(OWNER, &unpinned)
-        .expect("no endpoint yet");
+    let pending = seed_legacy_workspace(&store, &unpinned);
     let pinned = store
         .replace_remote_workspace(&pending, &state)
         .expect("pin the first trusted endpoint");

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
@@ -310,7 +310,7 @@ fn well_formed_json_cannot_bypass_aggregate_validation_during_recovery() {
     use serde_json::json;
     let (_directory, store) = store();
     let state = provisioning(workspace("workspace"));
-    store.create_remote_workspace(OWNER, &state).expect("create");
+    seed_legacy_workspace(&store, &state);
     let original = serde_json::to_value(WorkspaceSnapshot {
         session_id: OWNER.into(),
         state,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/transitions.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/transitions.rs
@@ -39,6 +39,9 @@ fn non_creating_observations_cannot_revert_to_provisioning() {
         let (_directory, store) = store();
         let mut state = provisioning(workspace("workspace"));
         let original = seed_legacy_workspace(&store, &state);
+        let original = store
+            .replace_remote_workspace(&original, &state)
+            .expect("still provisioning");
         state.runtime.as_mut().expect("runtime").phase = phase;
         let observed = store
             .replace_remote_workspace(&original, &state)

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/transitions.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/transitions.rs
@@ -1,0 +1,126 @@
+use super::*;
+
+#[test]
+fn generic_create_cannot_introduce_a_runtime() {
+    let (_directory, store) = store();
+    let state = provisioning(workspace("workspace"));
+    assert!(matches!(
+        store.create_remote_workspace(OWNER, &state),
+        Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired)
+    ));
+    assert!(
+        store
+            .list_remote_workspaces(OWNER)
+            .expect("unchanged inventory")
+            .is_empty()
+    );
+}
+
+#[test]
+fn generic_replacement_cannot_introduce_a_runtime() {
+    let (_directory, store) = store();
+    let original = store
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("dormant");
+    let next = provisioning(original.state().clone());
+    assert!(matches!(
+        store.replace_remote_workspace(&original, &next),
+        Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired)
+    ));
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("retained"),
+        Some(original)
+    );
+}
+
+#[test]
+fn non_creating_observations_cannot_revert_to_provisioning() {
+    for phase in [RemoteRuntimePhase::Reconciling, RemoteRuntimePhase::Failed] {
+        let (_directory, store) = store();
+        let mut state = provisioning(workspace("workspace"));
+        let original = seed_legacy_workspace(&store, &state);
+        state.runtime.as_mut().expect("runtime").phase = phase;
+        let observed = store
+            .replace_remote_workspace(&original, &state)
+            .expect("non-creating observation");
+        let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+        state.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Provisioning;
+        assert!(matches!(
+            reopened.replace_remote_workspace(&observed, &state),
+            Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+        ));
+        assert_eq!(
+            reopened.load_remote_workspace(OWNER, "workspace").expect("retained"),
+            Some(observed)
+        );
+    }
+}
+
+#[test]
+fn every_observed_phase_retains_legacy_identity_and_does_not_return_to_provisioning() {
+    for phase in [
+        RemoteRuntimePhase::Reconciling,
+        RemoteRuntimePhase::Materializing,
+        RemoteRuntimePhase::Ready,
+        RemoteRuntimePhase::Checkpointing,
+        RemoteRuntimePhase::Cancelling,
+        RemoteRuntimePhase::Deleting,
+        RemoteRuntimePhase::Failed,
+    ] {
+        let (_directory, store) = store();
+        let mut state = ownership::expired_runtime();
+        let runtime = state.runtime.as_mut().expect("runtime");
+        runtime.phase = phase;
+        if matches!(phase, RemoteRuntimePhase::Cancelling | RemoteRuntimePhase::Deleting) {
+            runtime.cleanup = Some(RemoteCleanupIntent {
+                reason: RemoteCleanupReason::Cancelled,
+                requested_at_millis: 2000,
+            });
+        }
+        let original = seed_legacy_workspace(&store, &state);
+        let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+        assert_eq!(
+            reopened.list_remote_workspaces(OWNER).expect("recover"),
+            vec![original.clone()]
+        );
+        state.spec.panels.clear();
+        let detached = reopened
+            .replace_remote_workspace(&original, &state)
+            .expect("remove client intent");
+        assert_eq!(detached.state().runtime, original.state().runtime);
+        state.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Provisioning;
+        assert!(matches!(
+            reopened.replace_remote_workspace(&detached, &state),
+            Err(RemoteWorkspaceStoreError::NonMonotonicReplacement)
+        ));
+        assert_eq!(
+            reopened.load_remote_workspace(OWNER, "workspace").expect("retained"),
+            Some(detached)
+        );
+    }
+}
+
+#[test]
+fn the_internal_allocation_path_can_stage_runtime_identity_but_never_commits_itself() {
+    let (_directory, store) = store();
+    let original = store
+        .create_remote_workspace(OWNER, &workspace("workspace"))
+        .expect("dormant");
+    let next = provisioning(original.state().clone());
+    let replacement = WorkspaceReplacement::new(&original, &next).expect("prepare allocation snapshot");
+    let mut connection = store.connection().expect("connection");
+    {
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .expect("transaction");
+        ensure_current_schema(&transaction).expect("schema");
+        let staged = replacement.persist(&transaction).expect("internal allocation staging");
+        assert_eq!(staged.state(), &next);
+        assert_eq!(staged.revision(), original.revision() + 1);
+        // No allocator committed a workflow and binding, so abandon the transaction.
+    }
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("rolled back"),
+        Some(original)
+    );
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -1,5 +1,5 @@
 use super::RemoteWorkspaceStoreError as Error;
-use crate::remote_workspace::{RemoteWorkspaceState, valid_local_id};
+use crate::remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState, valid_local_id};
 
 pub(super) fn validate_session_id(session_id: &str) -> Result<(), Error> {
     let id = uuid::Uuid::parse_str(session_id).map_err(|_| Error::InvalidSessionId)?;
@@ -42,8 +42,9 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
         }
     }
     if let (Some(runtime), Some(next_runtime)) = (&previous.runtime, &next.runtime)
-        && runtime.cleanup.is_some()
-        && next_runtime.cleanup != runtime.cleanup
+        && ((runtime.cleanup.is_some() && next_runtime.cleanup != runtime.cleanup)
+            || (runtime.phase != RemoteRuntimePhase::Provisioning
+                && next_runtime.phase == RemoteRuntimePhase::Provisioning))
     {
         return Err(Error::NonMonotonicReplacement);
     }

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -81,12 +81,15 @@ prepared replacement may stage identity inside the caller's immediate transactio
 the allocator must commit the matching workflow and ownership binding with it.
 There is no public import shortcut for active runtimes. Already-persisted legacy
 snapshots remain readable and updateable with their original identity.
+Generic replacements cannot advance the specification's generation; that is also
+allocator-owned, and the shared replacement validation retains its allocation path.
 
 Once an existing generation leaves provisioning, a replacement cannot move it
 back to provisioning, including from reconciling or failed with no observed
 worker. This rule also applies to legacy snapshots and survives reopening the
-store. Reconciliation and attachment may still progress between non-creating
-phases; local panel intent remains independent of the runtime's lifetime.
+store. Reconciliation and attachment may still move between non-creating phases;
+ordering among them remains coordinator policy. Local panel intent remains
+independent of the runtime's lifetime.
 
 Each snapshot is limited to 4 MiB, with session recovery capped at 512 records
 and 64 MiB of serialized snapshots. Reads are bounded before materialization;

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -74,6 +74,20 @@ provider calls and adds no UI consumer. Generation/workflow allocation will be
 one transaction in a subsequent coordinator slice using this same database.
 The record store is not permission to create, attach, or delete a worker.
 
+Generic creation accepts only dormant records, and generic replacement cannot
+introduce a runtime into a dormant record, including a previously retired legacy
+record. New runtime identity requires the dedicated atomic allocator. Its private
+prepared replacement may stage identity inside the caller's immediate transaction;
+the allocator must commit the matching workflow and ownership binding with it.
+There is no public import shortcut for active runtimes. Already-persisted legacy
+snapshots remain readable and updateable with their original identity.
+
+Once an existing generation leaves provisioning, a replacement cannot move it
+back to provisioning, including from reconciling or failed with no observed
+worker. This rule also applies to legacy snapshots and survives reopening the
+store. Reconciliation and attachment may still progress between non-creating
+phases; local panel intent remains independent of the runtime's lifetime.
+
 Each snapshot is limited to 4 MiB, with session recovery capped at 512 records
 and 64 MiB of serialized snapshots. Reads are bounded before materialization;
 creates and replacements enforce the same per-session limits in their write


### PR DESCRIPTION
## Purpose

Part of #383; a focused record-store prerequisite for #405.

Generic writes must not manufacture a remote runtime without its allocation,
or turn a durable non-creating observation back into provisioning.

## Behavior

- Generic create accepts only dormant aggregates; generic replacement cannot
  introduce a runtime, including after legacy retirement.
- Once a generation leaves provisioning, it cannot return to provisioning.
  This also covers reconciling/failed records without an observed worker.
- Already-persisted legacy records retain their identities, checkpoints,
  endpoints and cleanup intent. Local panel intent can change independently.
- The private prepared replacement remains transaction-only so the allocator
  can later commit the runtime, workflow and ownership binding together.

No provider calls, new resources, UI changes, schema migration, dependencies,
configuration changes or release actions. This does not complete #383.

## Reproduction and validation

Before the fix, three synthetic SQLite regressions reproduced active generic
creation, dormant-to-runtime replacement, and reversal from non-creating phases.
The corrected tests pass, with coverage for all observed phases, legacy reopen,
retired records, stale writers and private-transaction rollback.

The full required local validation matrix passes on the published commit:
formatting, maintainability, version sync, warning-denied default and speech
workspace tests, blocking and strict Clippy, and advisory pedantic Clippy.
All 91 cloud tests also pass with eight threads, including 24 record-store tests.
Full-diff self-review and independent local review are complete.

This storage-only slice uses real temporary SQLite databases; native UI and live
provider smoke are not applicable. No existing application or provider resource
is touched.

Scope: six source/test files, 213 changed source/test lines, plus one
architecture note. The prerequisite is independently testable on current main;
#405 remains blocked until its updated exact head passes all gates.
