### PR TITLE
fix(store): fence legacy runtime creation

### DIFF
--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -242,6 +242,7 @@ impl CloudWorkflowStore {
             return Err(CloudStoreError::WorkflowExpired(workflow_id));
         }
         validate_claim_target(&workflow.workflow, job_id, target)?;
+        remote_workspaces::creation_fences::ensure_unreferenced(&transaction, workflow_id, job_id)?;
         let provider_name = provider_name(target.provider);
         let job_id_text = job_id.to_string();
         let existing = transaction
@@ -518,6 +519,12 @@ pub enum CloudStoreError {
     UnsupportedSchema(i64),
     #[error("remote allocation schema does not match its versioned table and constraint definitions")]
     InvalidAllocationSchema,
+    #[error("remote creation fence schema does not match its versioned definitions")]
+    InvalidCreationFenceSchema,
+    #[error("legacy remote snapshot cannot be validated for creation fencing")]
+    InvalidLegacyRuntimeSnapshot,
+    #[error("saved remote runtime identity cannot authorize a new worker creation")]
+    LegacyRuntimeCreationDenied,
     #[error("cloud workflow {0} already exists")]
     WorkflowExists(CloudWorkflowId),
     #[error("cloud workflow {0} does not exist")]

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 
 use rusqlite::{Connection, OpenFlags, TransactionBehavior};
 
-use super::CloudStoreError;
+use super::{CloudStoreError, remote_workspaces::creation_fences};
 
-const STORE_SCHEMA_VERSION: i64 = 3;
+const STORE_SCHEMA_VERSION: i64 = 4;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS cloud_workflows (
@@ -94,6 +94,10 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
          FROM remote_workspaces INDEXED BY remote_workspaces_session LIMIT 0",
     )?);
     validate_allocation_schema(&transaction)?;
+    if version < 4 {
+        creation_fences::migrate(&transaction)?;
+    }
+    creation_fences::validate_schema(&transaction)?;
     transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
     transaction.commit()?;
     Ok(())
@@ -104,7 +108,8 @@ pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), Cloud
     if version != STORE_SCHEMA_VERSION {
         return Err(CloudStoreError::UnsupportedSchema(version));
     }
-    validate_allocation_schema(connection)
+    validate_allocation_schema(connection)?;
+    creation_fences::validate_schema(connection)
 }
 
 fn validate_allocation_schema(connection: &Connection) -> Result<(), CloudStoreError> {

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -107,7 +107,9 @@ fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations
     let fixture = fixture();
     let connection = open_connection(fixture.store.path()).expect("raw store");
     connection
-        .execute_batch("DROP TABLE remote_runtime_allocations; PRAGMA user_version=2;")
+        .execute_batch(
+            "DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; PRAGMA user_version=2;",
+        )
         .expect("schema two fixture");
     let before = saved_bytes(&connection);
     let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
@@ -116,7 +118,7 @@ fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations
         connection
             .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
             .expect("version"),
-        3
+        4
     );
     assert_eq!(allocation_count(&connection), 0);
     let workflow = fixture.workflow.workflow();

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -2,6 +2,7 @@
 //! These record operations do not authorize lifecycle actions or retire cleanup intent.
 //! Operations are synchronous and must run off the render thread.
 
+pub(super) mod creation_fences;
 mod validation;
 
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences.rs
@@ -9,7 +9,7 @@ const SCHEMA: [&str; 4] = [
     workflow_id TEXT NOT NULL CHECK (length(workflow_id) = 36),
     job_id TEXT NOT NULL CHECK (length(job_id) = 36),
     PRIMARY KEY (workflow_id, job_id)
-) STRICT",
+) STRICT, WITHOUT ROWID",
     "CREATE INDEX remote_runtime_creation_fences_job ON remote_runtime_creation_fences(job_id)",
     "CREATE TRIGGER remote_runtime_creation_fences_no_update BEFORE UPDATE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",
     "CREATE TRIGGER remote_runtime_creation_fences_no_delete BEFORE DELETE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences.rs
@@ -1,0 +1,84 @@
+//! Migration-only, append-only denials: saved runtime identities never grant creation.
+
+use super::super::{CloudJobId, CloudWorkflowId};
+use super::{CloudStoreError, MAX_MATERIALIZED_SNAPSHOT_BYTES, WorkspaceRow, decode, validation};
+use rusqlite::{Connection, Transaction, params};
+
+const SCHEMA: [&str; 4] = [
+    r"CREATE TABLE remote_runtime_creation_fences (
+    workflow_id TEXT NOT NULL CHECK (length(workflow_id) = 36),
+    job_id TEXT NOT NULL CHECK (length(job_id) = 36),
+    PRIMARY KEY (workflow_id, job_id)
+) STRICT",
+    "CREATE INDEX remote_runtime_creation_fences_job ON remote_runtime_creation_fences(job_id)",
+    "CREATE TRIGGER remote_runtime_creation_fences_no_update BEFORE UPDATE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",
+    "CREATE TRIGGER remote_runtime_creation_fences_no_delete BEFORE DELETE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",
+];
+
+const CLAIM_QUERY: &str = "SELECT
+    EXISTS(SELECT 1 FROM remote_runtime_creation_fences WHERE workflow_id = ?1)
+    OR EXISTS(SELECT 1 FROM remote_runtime_creation_fences
+              INDEXED BY remote_runtime_creation_fences_job WHERE job_id = ?2)";
+
+/// The schema upgrade owns the immediate transaction; any bad snapshot rolls it all back.
+/// Stream every session once, materializing at most one size-bounded snapshot at a time.
+pub(in crate::cloud_run::store) fn migrate(transaction: &Transaction<'_>) -> Result<(), CloudStoreError> {
+    for definition in SCHEMA {
+        transaction.execute_batch(definition)?;
+    }
+    let mut statement = transaction.prepare(
+        "SELECT substr(workspace_local_id, 1, 129), substr(session_id, 1, 37), revision,
+                substr(snapshot, 1, ?1) FROM remote_workspaces",
+    )?;
+    let rows = statement.query_map([MAX_MATERIALIZED_SNAPSHOT_BYTES], |row| {
+        Ok((row.get::<_, String>(0)?, WorkspaceRow::from_row(row, 1)?))
+    })?;
+    for row in rows {
+        let (workspace_local_id, row) = row?;
+        validation::validate_key(&row.session_id, &workspace_local_id)
+            .map_err(|_| CloudStoreError::InvalidLegacyRuntimeSnapshot)?;
+        let owner = row.session_id.clone();
+        let saved =
+            decode(&owner, &workspace_local_id, row).map_err(|_| CloudStoreError::InvalidLegacyRuntimeSnapshot)?;
+        if let Some(runtime) = saved.state.runtime {
+            transaction.execute(
+                "INSERT OR IGNORE INTO remote_runtime_creation_fences (workflow_id, job_id) VALUES (?1, ?2)",
+                params![runtime.workflow_id.to_string(), runtime.job_id.to_string()],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub(in crate::cloud_run::store) fn validate_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    let matches: bool = connection.query_row(
+        "SELECT COUNT(*) = 4 AND COUNT(CASE WHEN sql IN (?1, ?2, ?3, ?4) THEN 1 END) = 4
+         FROM main.sqlite_schema WHERE tbl_name = 'remote_runtime_creation_fences' AND sql IS NOT NULL",
+        SCHEMA,
+        |row| row.get(0),
+    )?;
+    if !matches {
+        return Err(CloudStoreError::InvalidCreationFenceSchema);
+    }
+    Ok(())
+}
+
+/// Check inside the claim transaction. These denials confer no ownership or provider authority.
+pub(in crate::cloud_run::store) fn ensure_unreferenced(
+    connection: &Connection,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+) -> Result<(), CloudStoreError> {
+    let fenced: bool = connection.query_row(
+        CLAIM_QUERY,
+        params![workflow_id.to_string(), job_id.to_string()],
+        |row| row.get(0),
+    )?;
+    if fenced {
+        return Err(CloudStoreError::LegacyRuntimeCreationDenied);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
@@ -1,0 +1,438 @@
+use super::super::super::tests::retained_workflow;
+use super::*;
+use crate::cloud_run::{CloudProvider, CloudWorkflow, CloudWorkflowStore, GitCommitSha, GitSource};
+use crate::remote_workspace::{RemoteRuntimeGeneration, RemoteRuntimePhase, RemoteWorkspaceSpec, RemoteWorkspaceState};
+use rusqlite::{Connection, params};
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    workflow: CloudWorkflow,
+    state: RemoteWorkspaceState,
+}
+
+fn fixture(version: i64) -> Fixture {
+    let directory = tempfile::tempdir().expect("private directory");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
+    store.create(&workflow).expect("ordinary unclaimed workflow");
+    let mut state = RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: "legacy".into(),
+        target: workflow.nodes[0].worker.clone().expect("target"),
+        repository: GitSource {
+            repository: "owner/project".into(),
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        working_directory: ".".into(),
+        generation: 1,
+        panels: Vec::new(),
+    })
+    .expect("specification");
+    state.runtime = Some(RemoteRuntimeGeneration {
+        workspace_local_id: "legacy".into(),
+        generation: 1,
+        workflow_id: workflow.id,
+        job_id: workflow.nodes[0].id,
+        phase: RemoteRuntimePhase::Reconciling,
+        worker: None,
+        ssh: None,
+        cleanup: None,
+    });
+    state.validate().expect("valid legacy runtime");
+    let snapshot = serde_json::to_vec(&serde_json::json!({"session_id": OWNER, "state": state})).expect("snapshot");
+    let connection = Connection::open(store.path()).expect("raw fixture");
+    connection
+        .execute(
+            "INSERT INTO remote_workspaces VALUES (?1, ?2, 1, ?3)",
+            params!["legacy", OWNER, snapshot],
+        )
+        .expect("legacy record");
+    connection
+        .execute_batch("DROP TABLE remote_runtime_creation_fences;")
+        .expect("legacy fence schema");
+    if version == 2 {
+        connection
+            .execute_batch("DROP TABLE remote_runtime_allocations;")
+            .expect("legacy allocation schema");
+    }
+    connection
+        .pragma_update(None, "user_version", version)
+        .expect("legacy version");
+    Fixture {
+        _directory: directory,
+        store,
+        workflow,
+        state,
+    }
+}
+
+#[test]
+fn schema_two_unclaimed_active_runtime_never_gets_creation_authority() {
+    let fixture = fixture(2);
+    let connection = Connection::open(fixture.store.path()).expect("raw store");
+    let before = snapshots(&connection);
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
+    let saved = upgraded
+        .load_remote_workspace(OWNER, "legacy")
+        .expect("recover")
+        .expect("saved runtime");
+    assert_eq!(saved.state(), &fixture.state);
+    assert_eq!(saved.revision(), 1);
+    assert_denied(&upgraded, &fixture.workflow);
+    let reopened = CloudWorkflowStore::open_path(upgraded.path()).expect("reopen");
+    assert_denied(&reopened, &fixture.workflow);
+    assert_eq!(snapshots(&connection), before);
+    let counts: (i64, i64) = connection
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM cloud_worker_creation_claims),
+                    (SELECT COUNT(*) FROM remote_runtime_allocations)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("claim and binding counts");
+    assert_eq!(counts, (0, 0));
+    assert_eq!(fence_count(&connection), 1);
+}
+
+fn snapshots(connection: &Connection) -> (Vec<u8>, Vec<u8>) {
+    connection
+        .query_row(
+            "SELECT (SELECT snapshot FROM cloud_workflows), (SELECT snapshot FROM remote_workspaces)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("unchanged snapshots")
+}
+
+fn fence_count(connection: &Connection) -> i64 {
+    connection
+        .query_row("SELECT COUNT(*) FROM remote_runtime_creation_fences", [], |row| {
+            row.get(0)
+        })
+        .expect("fences")
+}
+
+fn assert_denied(store: &CloudWorkflowStore, workflow: &CloudWorkflow) {
+    assert!(matches!(
+        store.claim_worker_creation(
+            workflow.id,
+            workflow.nodes[0].id,
+            workflow.nodes[0].worker.as_ref().expect("target"),
+            "synthetic-worker"
+        ),
+        Err(CloudStoreError::LegacyRuntimeCreationDenied)
+    ));
+}
+
+#[test]
+fn schema_three_missing_workflows_and_reused_ids_remain_non_creating() {
+    let fixture = fixture(3);
+    let connection = Connection::open(fixture.store.path()).expect("raw store");
+    connection
+        .execute("DELETE FROM cloud_workflows", [])
+        .expect("missing legacy workflow");
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade missing workflow");
+    upgraded.create(&fixture.workflow).expect("recreated ordinary workflow");
+    assert_denied(&upgraded, &fixture.workflow);
+    let mut other = fixture.workflow.clone();
+    other.id = CloudWorkflowId::new();
+    upgraded.create(&other).expect("different workflow, referenced job");
+    assert_denied(&upgraded, &other);
+    let mut new_job = fixture.workflow.clone();
+    new_job.nodes[0].id = CloudJobId::new();
+    new_job.updated_at_millis += 1;
+    let saved = upgraded.load(new_job.id).expect("load").expect("workflow");
+    upgraded
+        .replace(&saved, &new_job)
+        .expect("referenced workflow, different job");
+    assert_denied(&upgraded, &new_job);
+    let ordinary = retained_workflow(CloudProvider::LocalDocker, 1000);
+    upgraded.create(&ordinary).expect("unrelated ordinary workflow");
+    assert!(
+        upgraded
+            .claim_worker_creation(
+                ordinary.id,
+                ordinary.nodes[0].id,
+                ordinary.nodes[0].worker.as_ref().expect("target"),
+                "unrelated-worker"
+            )
+            .expect("unrelated creation remains allowed")
+    );
+    assert_eq!(fence_count(&connection), 1);
+}
+
+#[test]
+fn retiring_legacy_runtime_does_not_erase_its_creation_denial() {
+    let fixture = fixture(3);
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
+    let saved = upgraded
+        .load_remote_workspace(OWNER, "legacy")
+        .expect("load")
+        .expect("runtime");
+    let mut retired = saved.state().clone();
+    retired.runtime = None;
+    upgraded
+        .replace_remote_workspace(&saved, &retired)
+        .expect("retire legacy identity");
+    assert_denied(&upgraded, &fixture.workflow);
+    let reopened = CloudWorkflowStore::open_path(upgraded.path()).expect("reopen retired record");
+    assert_eq!(
+        reopened
+            .load_remote_workspace(OWNER, "legacy")
+            .expect("load")
+            .expect("record")
+            .state(),
+        &retired
+    );
+    assert_denied(&reopened, &fixture.workflow);
+    let connection = Connection::open(reopened.path()).expect("raw store");
+    assert_eq!(fence_count(&connection), 1);
+}
+
+#[test]
+fn migration_canonicalizes_uuid_denials_without_rewriting_legacy_bytes() {
+    for compact in [false, true] {
+        let fixture = fixture(3);
+        let connection = Connection::open(fixture.store.path()).expect("raw store");
+        let mut snapshot: serde_json::Value = serde_json::from_slice(&snapshots(&connection).1).expect("snapshot");
+        for key in ["workflow_id", "job_id"] {
+            let original = snapshot["state"]["runtime"][key]
+                .as_str()
+                .expect("UUID")
+                .to_ascii_uppercase();
+            snapshot["state"]["runtime"][key] =
+                serde_json::json!(if compact { original.replace('-', "") } else { original });
+        }
+        connection
+            .execute(
+                "UPDATE remote_workspaces SET snapshot = ?1",
+                [serde_json::to_vec(&snapshot).expect("variant bytes")],
+            )
+            .expect("legacy UUID spelling");
+        let before = snapshots(&connection);
+        let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade accepted UUID variant");
+        assert_denied(&upgraded, &fixture.workflow);
+        assert_eq!(snapshots(&connection), before);
+        assert_eq!(fence_count(&connection), 1);
+    }
+}
+
+#[test]
+fn invalid_legacy_records_roll_back_schema_and_leave_snapshots_untouched() {
+    for corrupt in [
+        "UPDATE remote_workspaces SET snapshot = x'00'",
+        "UPDATE remote_workspaces SET snapshot = zeroblob(4194305)",
+        "UPDATE remote_workspaces SET session_id = 'invalid-owner'",
+        "UPDATE remote_workspaces SET workspace_local_id = printf('%4096s', 'x')",
+    ] {
+        let fixture = fixture(3);
+        let connection = Connection::open(fixture.store.path()).expect("raw store");
+        connection.execute_batch(corrupt).expect("corrupt legacy fixture");
+        let before = snapshots(&connection);
+        assert!(matches!(
+            CloudWorkflowStore::open_path(fixture.store.path()),
+            Err(CloudStoreError::InvalidLegacyRuntimeSnapshot)
+        ));
+        assert_eq!(snapshots(&connection), before);
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("version"),
+            3
+        );
+        let objects: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_schema WHERE tbl_name = 'remote_runtime_creation_fences'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("rolled back fence objects");
+        assert_eq!(objects, 0);
+    }
+}
+
+#[test]
+fn fence_schema_drift_blocks_open_and_existing_handle_operations() {
+    for corrupt in [
+        "DROP TABLE remote_runtime_creation_fences",
+        "DROP INDEX remote_runtime_creation_fences_job",
+        "DROP TRIGGER remote_runtime_creation_fences_no_update",
+        "DROP TRIGGER remote_runtime_creation_fences_no_delete",
+        "CREATE INDEX unexpected_fence_index ON remote_runtime_creation_fences(workflow_id)",
+        "DROP TRIGGER remote_runtime_creation_fences_no_delete; CREATE TRIGGER remote_runtime_creation_fences_no_delete BEFORE DELETE ON remote_runtime_creation_fences BEGIN SELECT 1; END",
+    ] {
+        let fixture = fixture(3);
+        let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
+        let connection = Connection::open(fixture.store.path()).expect("raw store");
+        let before = snapshots(&connection);
+        connection.execute_batch(corrupt).expect("schema corruption");
+        assert!(matches!(
+            CloudWorkflowStore::open_path(fixture.store.path()),
+            Err(CloudStoreError::InvalidCreationFenceSchema)
+        ));
+        assert!(matches!(
+            upgraded.load(fixture.workflow.id),
+            Err(CloudStoreError::InvalidCreationFenceSchema)
+        ));
+        assert!(matches!(
+            upgraded.claim_worker_creation(
+                fixture.workflow.id,
+                fixture.workflow.nodes[0].id,
+                &fixture.state.spec.target,
+                "synthetic-worker"
+            ),
+            Err(CloudStoreError::InvalidCreationFenceSchema)
+        ));
+        assert_eq!(snapshots(&connection), before);
+        let claims: i64 = connection
+            .query_row("SELECT COUNT(*) FROM cloud_worker_creation_claims", [], |row| {
+                row.get(0)
+            })
+            .expect("claims");
+        assert_eq!(claims, 0);
+    }
+}
+
+#[test]
+fn creation_denials_are_immutable_and_lookup_uses_both_identity_indexes() {
+    let fixture = fixture(3);
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
+    let connection = Connection::open(upgraded.path()).expect("raw store");
+    assert!(
+        connection
+            .execute("DELETE FROM remote_runtime_creation_fences", [])
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute("UPDATE remote_runtime_creation_fences SET job_id = workflow_id", [])
+            .is_err()
+    );
+    assert_eq!(fence_count(&connection), 1);
+    assert_denied(&upgraded, &fixture.workflow);
+    let mut statement = connection
+        .prepare(&format!("EXPLAIN QUERY PLAN {CLAIM_QUERY}"))
+        .expect("query plan");
+    let plan: Vec<String> = statement
+        .query_map(
+            params![
+                fixture.workflow.id.to_string(),
+                fixture.workflow.nodes[0].id.to_string()
+            ],
+            |row| row.get(3),
+        )
+        .expect("plan rows")
+        .collect::<rusqlite::Result<_>>()
+        .expect("plan");
+    assert_eq!(
+        plan.iter()
+            .filter(|detail| detail.contains("SEARCH remote_runtime_creation_fences"))
+            .count(),
+        2,
+        "{plan:?}"
+    );
+    assert!(
+        plan.iter()
+            .any(|detail| detail.contains("sqlite_autoindex_remote_runtime_creation_fences_1")),
+        "{plan:?}"
+    );
+    assert!(
+        plan.iter()
+            .any(|detail| detail.contains("remote_runtime_creation_fences_job")),
+        "{plan:?}"
+    );
+    assert!(
+        !plan
+            .iter()
+            .any(|detail| detail.contains("SCAN remote_runtime_creation_fences")),
+        "{plan:?}"
+    );
+}
+
+#[test]
+fn migration_covers_other_sessions_and_deduplicates_shared_legacy_references() {
+    let fixture = fixture(3);
+    let connection = Connection::open(fixture.store.path()).expect("raw store");
+    let other_owner = "22222222-2222-4222-8222-222222222222";
+    let mut state = fixture.state.clone();
+    state.spec.workspace_local_id = "other-workspace".into();
+    state
+        .runtime
+        .as_mut()
+        .expect("runtime")
+        .workspace_local_id
+        .clone_from(&state.spec.workspace_local_id);
+    let snapshot = serde_json::to_vec(&serde_json::json!({"session_id": other_owner, "state": state}))
+        .expect("copied legacy snapshot");
+    connection
+        .execute(
+            "INSERT INTO remote_workspaces VALUES (?1, ?2, 1, ?3)",
+            params![state.spec.workspace_local_id, other_owner, snapshot],
+        )
+        .expect("other session legacy record");
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade all sessions");
+    assert_eq!(
+        upgraded.list_remote_workspaces(OWNER).expect("original session").len(),
+        1
+    );
+    assert_eq!(
+        upgraded
+            .list_remote_workspaces(other_owner)
+            .expect("other session")
+            .len(),
+        1
+    );
+    assert_eq!(fence_count(&connection), 1);
+    assert_denied(&upgraded, &fixture.workflow);
+}
+
+#[test]
+fn migration_preserves_consumed_claims_and_active_snapshot_bytes() {
+    let fixture = fixture(3);
+    let connection = Connection::open(fixture.store.path()).expect("raw store");
+    connection
+        .execute(
+            "INSERT INTO cloud_worker_creation_claims VALUES ('local_docker', ?1, ?2, 'synthetic-worker', 1234)",
+            params![
+                fixture.workflow.id.to_string(),
+                fixture.workflow.nodes[0].id.to_string()
+            ],
+        )
+        .expect("legacy consumed claim");
+    let before = snapshots(&connection);
+    let read_claim = || {
+        connection.query_row(
+        "SELECT provider, workflow_id, job_id, resource_name, claimed_at_millis FROM cloud_worker_creation_claims",
+        [],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?, row.get::<_, String>(3)?, row.get::<_, i64>(4)?)),
+    ).expect("claim")
+    };
+    let claim_before = read_claim();
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade consumed legacy runtime");
+    assert_eq!(snapshots(&connection), before);
+    assert_denied(&upgraded, &fixture.workflow);
+    assert_eq!(read_claim(), claim_before);
+    assert_eq!(fence_count(&connection), 1);
+}
+
+#[test]
+fn schema_four_definitions_match_the_frozen_storage_format() {
+    assert_eq!(
+        SCHEMA,
+        [
+            concat!(
+                "CREATE TABLE remote_runtime_creation_fences (\n",
+                "    workflow_id TEXT NOT NULL CHECK (length(workflow_id) = 36),\n",
+                "    job_id TEXT NOT NULL CHECK (length(job_id) = 36),\n",
+                "    PRIMARY KEY (workflow_id, job_id)\n",
+                ") STRICT",
+            ),
+            "CREATE INDEX remote_runtime_creation_fences_job ON remote_runtime_creation_fences(job_id)",
+            "CREATE TRIGGER remote_runtime_creation_fences_no_update BEFORE UPDATE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",
+            "CREATE TRIGGER remote_runtime_creation_fences_no_delete BEFORE DELETE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",
+        ]
+    );
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
@@ -311,6 +311,18 @@ fn creation_denials_are_immutable_and_lookup_uses_both_identity_indexes() {
             .execute("UPDATE remote_runtime_creation_fences SET job_id = workflow_id", [])
             .is_err()
     );
+    connection
+        .pragma_update(None, "recursive_triggers", false)
+        .expect("non-recursive triggers");
+    assert!(
+        connection
+            .execute(
+                "INSERT OR REPLACE INTO remote_runtime_creation_fences (rowid, workflow_id, job_id) VALUES (1, ?1, ?2)",
+                params![CloudWorkflowId::new().to_string(), CloudJobId::new().to_string()],
+            )
+            .is_err(),
+        "an implicit row identity must not allow replacing a creation denial"
+    );
     assert_eq!(fence_count(&connection), 1);
     assert_denied(&upgraded, &fixture.workflow);
     let mut statement = connection
@@ -335,8 +347,7 @@ fn creation_denials_are_immutable_and_lookup_uses_both_identity_indexes() {
         "{plan:?}"
     );
     assert!(
-        plan.iter()
-            .any(|detail| detail.contains("sqlite_autoindex_remote_runtime_creation_fences_1")),
+        plan.iter().any(|detail| detail.contains("USING PRIMARY KEY")),
         "{plan:?}"
     );
     assert!(
@@ -428,7 +439,7 @@ fn schema_four_definitions_match_the_frozen_storage_format() {
                 "    workflow_id TEXT NOT NULL CHECK (length(workflow_id) = 36),\n",
                 "    job_id TEXT NOT NULL CHECK (length(job_id) = 36),\n",
                 "    PRIMARY KEY (workflow_id, job_id)\n",
-                ") STRICT",
+                ") STRICT, WITHOUT ROWID",
             ),
             "CREATE INDEX remote_runtime_creation_fences_job ON remote_runtime_creation_fences(job_id)",
             "CREATE TRIGGER remote_runtime_creation_fences_no_update BEFORE UPDATE ON remote_runtime_creation_fences BEGIN SELECT RAISE(ABORT, 'remote creation fences are immutable'); END",

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
@@ -11,7 +11,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
         .expect("legacy creation fence");
     let connection = Connection::open(store.path()).expect("raw store");
     connection
-        .execute_batch("DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
+        .execute_batch("DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
         .expect("restore schema-one fixture");
     let workflow_bytes: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
@@ -42,7 +42,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .expect("schema version");
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
     let after: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
         .expect("unchanged legacy bytes");
@@ -103,6 +103,6 @@ fn current_schema_with_missing_remote_table_or_index_fails_at_open() {
         let version: i64 = connection
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .expect("schema unchanged");
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
     }
 }

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
@@ -125,7 +125,7 @@ fn invalid_keys_snapshots_and_future_schema_never_replace_saved_records() {
         .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
         .expect("before");
     connection
-        .pragma_update(None, "user_version", 4)
+        .pragma_update(None, "user_version", 5)
         .expect("future schema");
     assert!(
         store

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -59,7 +59,7 @@ fn worker_target(workflow: &CloudWorkflow) -> &WorkerTarget {
 }
 
 fn assert_unsupported_schema<T>(result: &Result<T, CloudStoreError>) {
-    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(4))));
+    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(5))));
 }
 
 fn store(temp: &TempDir) -> CloudWorkflowStore {
@@ -532,7 +532,7 @@ fn runpod_fence_uses_the_durable_workflow_claim() {
     );
     let connection = Connection::open(store.path()).expect("open raw store");
     connection
-        .pragma_update(None, "user_version", 4)
+        .pragma_update(None, "user_version", 5)
         .expect("set unsupported schema");
     drop(connection);
     let failed_claim = super::super::runpod::RunPodCreationFence::claim_once(
@@ -570,7 +570,7 @@ fn invalid_snapshots_and_future_schema_fail_closed() {
     replacement.updated_at_millis += 1;
     let connection = Connection::open(&future_path).expect("future store");
     connection
-        .pragma_update(None, "user_version", 4)
+        .pragma_update(None, "user_version", 5)
         .expect("future version");
     drop(connection);
     assert_unsupported_schema(&stale_store.load(workflow.id));

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -95,6 +95,10 @@ back into large multi-purpose modules.
   encoded snapshot before staging insertion, separately from transaction commit;
   provider/workflow coordination and runtime-state references remain separate
   integration responsibilities.
+- The remote record store's `creation_fences.rs` leaf owns the schema-four
+  migration of legacy runtime identities into append-only creation denials,
+  exact schema validation, and indexed claim checks. Migration reuses the
+  aggregate decoder and does not confer allocation ownership or provider authority.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -170,9 +170,11 @@ ordinary workflows remain usable. A future atomic allocator may bypass this
 negative legacy fence only through its separately verified, complete current
 allocation binding; absence of a binding can never be sufficient authority.
 Reopening a store or recreating an ordinary workflow with a saved runtime's IDs
-cannot mint a replacement worker. Update/delete triggers protect the append-only
-rows, and exact versioned table/index/trigger validation runs on open and every
-operation. Missing or altered metadata is rejected, not repaired or adopted.
+cannot mint a replacement worker. The two identity columns are the physical row
+key, with no implicit rowid that could redirect a replacement. Update/delete
+triggers protect the append-only rows, and exact versioned table/index/trigger
+validation runs on open and every operation. Missing or altered metadata is
+rejected, not repaired or adopted.
 
 ## Options considered
 

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -144,6 +144,36 @@ new workflow node kind, worker creation, adoption, lifetime policy, or UI behavi
 The future allocator must commit and validate both snapshots with their binding
 in one transaction before the existing creation fence can grant provider creation.
 
+### Legacy runtime creation denials
+
+Schema 4 adds `remote_runtime_creation_fences`. During the immediate migration
+transaction, stream every existing remote snapshot across all sessions, bounded
+to one 4 MiB snapshot at a time. Reuse the validated aggregate decoder to obtain
+canonical workflow/job UUIDs; do not extract identity using unvalidated JSON or
+infer ownership from old runtime references. Invalid or oversized snapshots roll
+back the entire upgrade, including its new schema objects and version change.
+The one-time migration is linear in the stored records and must run off the
+render thread; it does not impose a new global session/record recovery limit.
+
+Each saved runtime contributes an append-only creation denial, including when
+its ordinary workflow is missing, expired, or has never consumed a claim. The
+denial is not an allocation binding, consumed claim, or ownership grant. Preserve
+all existing snapshot bytes, revisions, and creation claims. Generic record APIs
+cannot introduce another runtime or change an active runtime's identity, so no
+ordinary record write can omit a newly introduced legacy identity from this set.
+Neither runtime retirement nor workflow deletion removes these denials; future
+allocations must use fresh identity. No provider resource is touched.
+
+Generic worker creation checks both workflow and job denials inside its existing
+immediate transaction using two bounded indexed existence queries. Unrelated
+ordinary workflows remain usable. A future atomic allocator may bypass this
+negative legacy fence only through its separately verified, complete current
+allocation binding; absence of a binding can never be sufficient authority.
+Reopening a store or recreating an ordinary workflow with a saved runtime's IDs
+cannot mint a replacement worker. Update/delete triggers protect the append-only
+rows, and exact versioned table/index/trigger validation runs on open and every
+operation. Missing or altered metadata is rejected, not repaired or adopted.
+
 ## Options considered
 
 ### Embed the whole aggregate in runtime YAML


### PR DESCRIPTION
## Purpose

Prevent recovered legacy remote runtimes from authorizing another worker creation.
This is a focused storage prerequisite for the remaining safety finding in #405.
Refs #383; it does not complete the remote-workspace product or close that issue.

## Behavior

- Upgrade valid legacy runtime references into canonical, append-only workflow/job creation denials, without adopting ownership or manufacturing allocation bindings or consumed claims.
- Preserve existing snapshot bytes, revisions and claims; retain denials when ordinary workflows are missing/recreated or a legacy runtime is retired.
- Check both identity indexes inside the existing creation-claim transaction. Unrelated ordinary workflows remain usable.
- Reject corrupt/oversized migration records transactionally and verify exact table/index/trigger definitions on open and every operation. The physical primary key has no implicit row identity.
- Keep migration off the render thread, streaming one bounded snapshot at a time. No provider, UI, configuration, dependency or release changes.

## Reproduction and validation

Synthetic schema-2/3 fixtures contain an active unbound runtime and an ordinary queued workflow with no consumed claim. Before the fix, the migrated workflow could receive a creation grant. After the fix, it is denied while the runtime and workflow remain recoverable and no binding or claim is inserted.

Ten focused tests cover migration/reopen, workflow/job identity reuse, unrelated positive creation, runtime retirement, canonical UUID handling, corruption rollback, schema drift, immutable denial rows, indexed query plans, cross-session references and consumed-claim preservation.

Candidate `c3990c8d1690bd3f97cc692344f9f69f0cfb9986` passed the full exact-commit local matrix: format, maintainability, version sync, warning-denying default/speech workspace tests, blocking/strict/pedantic Clippy, and all 101 cloud tests with eight threads. Both default and speech runs include all ten new tests. Independent local source review covered the complete final candidate and found no remaining actionable findings.

Scope is nine source/test files, 572 changed source/test lines, plus two architecture notes. This PR adds no allocation API, remote worker, disconnect lifetime behavior, environment widget or cloud PC-off proof; those remain tracked in #383.
