### PR TITLE
fix(store): persist runtime identity denials

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -227,6 +227,9 @@ impl<'a> WorkspaceReplacement<'a> {
         if changed != 1 {
             return Err(RemoteWorkspaceStoreError::SnapshotConflict);
         }
+        if let Some(runtime) = &next.runtime {
+            creation_fences::record_identity(transaction, runtime.workflow_id, runtime.job_id)?;
+        }
         Ok(StoredRemoteWorkspace {
             session_id: expected.session_id.clone(),
             state: next.clone(),

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences.rs
@@ -1,4 +1,4 @@
-//! Migration-only, append-only denials: saved runtime identities never grant creation.
+//! Append-only denials: saved runtime identities never grant creation by themselves.
 
 use super::super::{CloudJobId, CloudWorkflowId};
 use super::{CloudStoreError, MAX_MATERIALIZED_SNAPSHOT_BYTES, WorkspaceRow, decode, validation};
@@ -41,12 +41,22 @@ pub(in crate::cloud_run::store) fn migrate(transaction: &Transaction<'_>) -> Res
         let saved =
             decode(&owner, &workspace_local_id, row).map_err(|_| CloudStoreError::InvalidLegacyRuntimeSnapshot)?;
         if let Some(runtime) = saved.state.runtime {
-            transaction.execute(
-                "INSERT OR IGNORE INTO remote_runtime_creation_fences (workflow_id, job_id) VALUES (?1, ?2)",
-                params![runtime.workflow_id.to_string(), runtime.job_id.to_string()],
-            )?;
+            record_identity(transaction, runtime.workflow_id, runtime.job_id)?;
         }
     }
+    Ok(())
+}
+
+/// Publish the denial in the same transaction as its validated runtime snapshot.
+pub(super) fn record_identity(
+    transaction: &Transaction<'_>,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+) -> Result<(), CloudStoreError> {
+    transaction.execute(
+        "INSERT OR IGNORE INTO remote_runtime_creation_fences (workflow_id, job_id) VALUES (?1, ?2)",
+        params![workflow_id.to_string(), job_id.to_string()],
+    )?;
     Ok(())
 }
 

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
@@ -1,3 +1,5 @@
+mod writes;
+
 use super::super::super::tests::retained_workflow;
 use super::*;
 use crate::cloud_run::{CloudProvider, CloudWorkflow, CloudWorkflowStore, GitCommitSha, GitSource};

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests/writes.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests/writes.rs
@@ -1,0 +1,166 @@
+use super::super::super::super::database::ensure_current_schema;
+use super::super::super::{StoredRemoteWorkspace, WorkspaceReplacement};
+use super::{OWNER, assert_denied, fence_count, retained_workflow};
+use crate::cloud_run::{
+    CloudJobId, CloudProvider, CloudWorkflow, CloudWorkflowId, CloudWorkflowStore, GitCommitSha, GitSource,
+    WorkerLifetime,
+};
+use crate::remote_workspace::{RemoteRuntimeGeneration, RemoteRuntimePhase, RemoteWorkspaceSpec, RemoteWorkspaceState};
+use rusqlite::{Connection, Transaction, TransactionBehavior};
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    workflow: CloudWorkflow,
+    dormant: StoredRemoteWorkspace,
+    active: RemoteWorkspaceState,
+}
+
+fn fixture() -> Fixture {
+    let directory = tempfile::tempdir().expect("private directory");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let mut workflow = retained_workflow(CloudProvider::LocalDocker, 1000);
+    workflow.nodes[0].source = Some(GitSource {
+        repository: "owner/project".into(),
+        commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+        branch: None,
+    });
+    let target = workflow.nodes[0].worker.as_mut().expect("target");
+    target.lifetime = WorkerLifetime::Persistent;
+    let state = RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: "workspace".into(),
+        target: target.clone(),
+        repository: workflow.nodes[0].source.clone().expect("source"),
+        working_directory: ".".into(),
+        generation: 0,
+        panels: Vec::new(),
+    })
+    .expect("dormant specification");
+    store.create(&workflow).expect("ordinary workflow");
+    let dormant = store.create_remote_workspace(OWNER, &state).expect("dormant record");
+    let mut active = state;
+    active.spec.generation = 1;
+    active.runtime = Some(RemoteRuntimeGeneration {
+        workspace_local_id: "workspace".into(),
+        generation: 1,
+        workflow_id: workflow.id,
+        job_id: workflow.nodes[0].id,
+        phase: RemoteRuntimePhase::Provisioning,
+        worker: None,
+        ssh: None,
+        cleanup: None,
+    });
+    Fixture {
+        _directory: directory,
+        store,
+        workflow,
+        dormant,
+        active,
+    }
+}
+
+impl Fixture {
+    fn stage(&self, transaction: &Transaction<'_>) -> StoredRemoteWorkspace {
+        ensure_current_schema(transaction).expect("current schema");
+        WorkspaceReplacement::new(&self.dormant, &self.active)
+            .expect("prepare runtime snapshot")
+            .persist(transaction)
+            .expect("stage runtime snapshot")
+    }
+}
+
+#[test]
+fn runtime_snapshot_and_creation_denial_commit_or_rollback_together() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let mut connection = Connection::open(store.path()).expect("raw store");
+    assert_eq!(fence_count(&connection), 0);
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .expect("write transaction");
+    let pending = fixture.stage(&transaction);
+    assert_eq!(pending.state(), &fixture.active);
+    assert_eq!(fence_count(&transaction), 1);
+    transaction.rollback().expect("roll back staged runtime");
+    assert_eq!(fence_count(&connection), 0);
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "workspace").expect("unchanged"),
+        Some(fixture.dormant.clone())
+    );
+
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .expect("commit transaction");
+    let saved = fixture.stage(&transaction);
+    transaction.commit().expect("commit runtime with denial");
+    assert_eq!(saved, pending);
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
+    assert_eq!(
+        reopened.load_remote_workspace(OWNER, "workspace").expect("retained"),
+        Some(saved.clone())
+    );
+    assert_denied(&reopened, &fixture.workflow);
+    let mut next = saved.state().clone();
+    next.spec.working_directory = "nested".into();
+    reopened
+        .replace_remote_workspace(&saved, &next)
+        .expect("repeat runtime write");
+    assert_eq!(fence_count(&connection), 1);
+}
+
+#[test]
+fn newly_persisted_runtime_ids_cannot_be_reused_after_retirement() {
+    let fixture = fixture();
+    let store = &fixture.store;
+    let mut connection = Connection::open(store.path()).expect("raw store");
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .expect("runtime transaction");
+    let saved = fixture.stage(&transaction);
+    transaction.commit().expect("commit runtime");
+
+    let mut copied = fixture.workflow.clone();
+    copied.id = CloudWorkflowId::new();
+    store.create(&copied).expect("ordinary workflow with copied job");
+    assert_denied(store, &copied);
+    let original = store
+        .load(fixture.workflow.id)
+        .expect("load")
+        .expect("original workflow");
+    let mut changed_job = original.workflow().clone();
+    changed_job.nodes[0].id = CloudJobId::new();
+    changed_job.updated_at_millis += 1;
+    store
+        .replace(&original, &changed_job)
+        .expect("ordinary workflow with new job");
+    assert_denied(store, &changed_job);
+
+    let mut retired = saved.state().clone();
+    retired.runtime = None;
+    store
+        .replace_remote_workspace(&saved, &retired)
+        .expect("retire unbound runtime");
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen retired runtime");
+    assert_denied(&reopened, &copied);
+    assert_denied(&reopened, &changed_job);
+    assert_eq!(fence_count(&connection), 1);
+    assert_eq!(
+        connection
+            .query_row("SELECT COUNT(*) FROM cloud_worker_creation_claims", [], |row| row
+                .get::<_, i64>(0))
+            .expect("no claims"),
+        0
+    );
+    let ordinary = retained_workflow(CloudProvider::LocalDocker, 1000);
+    reopened.create(&ordinary).expect("unrelated ordinary workflow");
+    assert!(
+        reopened
+            .claim_worker_creation(
+                ordinary.id,
+                ordinary.nodes[0].id,
+                ordinary.nodes[0].worker.as_ref().expect("target"),
+                "unrelated-worker"
+            )
+            .expect("unrelated grant")
+    );
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -97,8 +97,10 @@ back into large multi-purpose modules.
   integration responsibilities.
 - The remote record store's `creation_fences.rs` leaf owns the schema-four
   migration of legacy runtime identities into append-only creation denials,
-  exact schema validation, and indexed claim checks. Migration reuses the
-  aggregate decoder and does not confer allocation ownership or provider authority.
+  transactional publication alongside every prepared runtime write, exact schema
+  validation, and indexed claim checks. Migration reuses the aggregate decoder;
+  no denial confers allocation ownership or provider authority. Migration and
+  runtime-write regressions live separately under its colocated test tree.
 - Shared domain helpers belong here when both core and UI need them.
 - If a UI feature needs to reconstruct runtime state, sync template-backed
   workspace metadata, or format panel/workspace domain labels, prefer adding a

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -144,7 +144,7 @@ new workflow node kind, worker creation, adoption, lifetime policy, or UI behavi
 The future allocator must commit and validate both snapshots with their binding
 in one transaction before the existing creation fence can grant provider creation.
 
-### Legacy runtime creation denials
+### Durable runtime creation denials
 
 Schema 4 adds `remote_runtime_creation_fences`. During the immediate migration
 transaction, stream every existing remote snapshot across all sessions, bounded
@@ -159,16 +159,22 @@ Each saved runtime contributes an append-only creation denial, including when
 its ordinary workflow is missing, expired, or has never consumed a claim. The
 denial is not an allocation binding, consumed claim, or ownership grant. Preserve
 all existing snapshot bytes, revisions, and creation claims. Generic record APIs
-cannot introduce another runtime or change an active runtime's identity, so no
-ordinary record write can omit a newly introduced legacy identity from this set.
+cannot introduce another runtime or change an active runtime's identity.
+The private prepared replacement also records the canonical workflow/job denial
+in the same transaction as every nonempty runtime snapshot. Future allocation
+therefore publishes the denial before committing its runtime/workflow/binding;
+a later failure rolls back the snapshot and denial together. Repeated writes
+preserve the same append-only identity. No public runtime-import path is added.
 Neither runtime retirement nor workflow deletion removes these denials; future
 allocations must use fresh identity. No provider resource is touched.
 
 Generic worker creation checks both workflow and job denials inside its existing
 immediate transaction using two bounded indexed existence queries. Unrelated
 ordinary workflows remain usable. A future atomic allocator may bypass this
-negative legacy fence only through its separately verified, complete current
+negative fence only through its separately verified, complete current
 allocation binding; absence of a binding can never be sufficient authority.
+Copying a saved job ID into another ordinary workflow cannot obtain another
+grant, even after losing the original binding or retiring its runtime snapshot.
 Reopening a store or recreating an ordinary workflow with a saved runtime's IDs
 cannot mint a replacement worker. The two identity columns are the physical row
 key, with no implicit rowid that could redirect a replacement. Update/delete


### PR DESCRIPTION
## Purpose

Publish immutable workflow/job creation denials in the same transaction as every prepared runtime snapshot. This is a focused storage prerequisite for #405 and the persistent remote-workspace work in #383; it does not complete either feature.

## Behavior

- The existing private prepared replacement records canonical runtime identity before its transaction can commit. A later failure rolls back both the snapshot and denial; repeated writes are idempotent.
- Migration shares the same transaction-only insertion helper. The schema-four table, immutable triggers, schema validation and indexed claim queries remain unchanged.
- Copying a saved job ID into another ordinary workflow cannot obtain a creation grant, including after runtime retirement or loss of a binding. A future allocator must still use its full positive bound-identity proof for the original grant.
- No public runtime-import API, allocation API, provider call, lifecycle policy, UI, configuration or dependency change is added. Closing Horizon and PC-independent lifetime behavior are unchanged by this storage-only slice.

## Reproduction and validation

Before the fix, staging a new runtime left zero creation denials and the copied-job workflow failed the expected denial assertion. Both new regressions fail on the prior implementation and pass with this change.

Candidate: `e1edcb528b633a8de742936fe820a38778775089`.

- All 12 creation-fence regressions pass, including staged rollback/commit, repeated writes, copied workflow/job identity, retirement/reopen and unrelated ordinary creation.
- All 103 cloud tests pass with eight test threads.
- Full local matrix passed: format, maintainability, version sync, warning-denied default and speech workspace tests, blocking Clippy, strict panic-path Clippy and pedantic audit.
- Independent local review approved the complete candidate tree and exact commit. This synchronous storage change has no UI or live-provider smoke lane; it does not claim real cloud or PC-off proof.

Scope: four source/test files, 191 changed source/test lines, plus two architecture notes. No mechanical movement of existing tests. Assignee is set; no configured review label, open milestone or unambiguous project was available.

Related: #383, #405. Keep #383 open; allocator integration and product acceptance remain separate work.
