### PR TITLE
feat(remote): preserve persistent GPU workers across reconnects

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -107,7 +107,7 @@ impl InteractiveWorkerLifetime {
             .is_none_or(InteractiveWorkerLease::has_valid_shape)
     }
 
-    fn matches_policy(&self, policy: WorkerLifetime) -> bool {
+    pub(super) fn matches_policy(&self, policy: WorkerLifetime) -> bool {
         matches!(
             (self, policy),
             (Self::Persistent, WorkerLifetime::Persistent) | (Self::TimeLimited(_), WorkerLifetime::TimeLimited { .. })

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -1,6 +1,7 @@
 //! `RunPod` Secure Cloud lifecycle adapter for durable cloud workers.
 use super::{
-    CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget, interactive_worker::valid_ssh_public_key,
+    CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime, WorkerTarget,
+    interactive_worker::{InteractiveWorkerLease, InteractiveWorkerLifetime, valid_ssh_public_key},
     validation::valid_worker_image,
 };
 use serde::{Deserialize, Deserializer, de};
@@ -24,9 +25,10 @@ const JOB_ENV: &str = "HORIZON_JOB_ID";
 const PROTOCOL_ENV: &str = "HORIZON_CLOUD_PROTOCOL_VERSION";
 const SSH_PUBLIC_KEY_ENV: &str = "HORIZON_SSH_PUBLIC_KEY";
 const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
+const LIFETIME_ENV: &str = "HORIZON_WORKER_LIFETIME";
+const PERSISTENT_LIFETIME: &str = "persistent";
 const MIN_LEASE_SECONDS: u32 = 300;
 const MAX_LEASE_SECONDS: u32 = 30 * 24 * 60 * 60;
-const LEASE_CLOCK_SKEW_SECONDS: i64 = 120;
 #[derive(Clone)]
 pub struct RunPodApiKey(String);
 impl RunPodApiKey {
@@ -150,7 +152,7 @@ impl RunPodClient {
                 let request =
                     CreatePodRequest::new(workflow_id, job_id, target, profile, name.clone(), ssh_public_key)?;
                 let expected_deadline = request.terminate_after.clone();
-                (self.transport.create(&request)?, true, Some(expected_deadline))
+                (self.create_worker(&request)?, true, expected_deadline)
             }
             [pod] => (pod.clone(), false, None),
             _ => {
@@ -169,6 +171,9 @@ impl RunPodClient {
             ssh_public_key,
         ) {
             Ok(status) => status,
+            Err(_) if created && target.lifetime == WorkerLifetime::Persistent => {
+                return Err(RunPodError::PersistentCreationReconciliationRequired { name, pod_id: pod.id });
+            }
             Err(error) if created => {
                 if self.transport.delete(&pod.id).is_err() {
                     return Err(RunPodError::CreationCleanupFailed { pod_id: pod.id });
@@ -178,10 +183,10 @@ impl RunPodClient {
             Err(error) => return Err(error),
         };
         if !created
-            && !target
+            && !status
+                .worker
                 .lifetime
-                .time_limit_seconds()
-                .is_some_and(|seconds| recovered_deadline_valid(&status.worker.terminate_after, seconds))
+                .is_valid_at(target.lifetime, time::OffsetDateTime::now_utc())
         {
             let worker = Box::new(status.worker);
             return if self.delete_worker(&worker).is_ok() {
@@ -195,6 +200,20 @@ impl RunPodClient {
             RunPodEnsure::Created(status)
         } else {
             RunPodEnsure::Reused(status)
+        })
+    }
+    fn create_worker(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError> {
+        self.transport.create(request).map_err(|error| {
+            if request.terminate_after.is_none()
+                && !matches!(error, RunPodError::PersistentCreationReconciliationRequired { .. })
+            {
+                RunPodError::PersistentCreationUnresolved {
+                    name: request.name.clone(),
+                    cause: Box::new(error),
+                }
+            } else {
+                error
+            }
         })
     }
     fn reconcile_by_name(&self, name: &str) -> Result<Vec<ApiPod>, RunPodError> {
@@ -273,6 +292,13 @@ impl RunPodClient {
         };
         match worker.hourly_cost_micros {
             Some(actual) if actual <= maximum => Ok(()),
+            actual if worker.lifetime == InteractiveWorkerLifetime::Persistent => {
+                Err(RunPodError::PersistentWorkerCostRejected {
+                    worker: Box::new(worker.clone()),
+                    actual,
+                    maximum,
+                })
+            }
             actual => self.cleanup_after_cost_rejection(worker, actual, maximum),
         }
     }
@@ -349,7 +375,7 @@ fn validate_target(target: &WorkerTarget, profile: &RunPodProfile) -> Result<(),
         && target
             .lifetime
             .time_limit_seconds()
-            .is_some_and(|seconds| (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&seconds))
+            .is_none_or(|seconds| (MIN_LEASE_SECONDS..=MAX_LEASE_SECONDS).contains(&seconds))
         && target.max_hourly_cost_micros != Some(0)
         && valid_immutable_worker_image(&target.image)
         && safe_text(&profile.name)
@@ -374,12 +400,12 @@ fn status_from_pod(
     expected_deadline: Option<&str>,
     ssh_public_key: Option<&str>,
 ) -> Result<RunPodWorkerStatus, RunPodError> {
-    let terminate_after = pod
-        .env
-        .get(TERMINATE_ENV)
-        .cloned()
-        .ok_or(RunPodError::ResourceIdentityMismatch)?;
-    if expected_deadline.is_some_and(|expected| expected != terminate_after) {
+    let lifetime = observed_lifetime(pod)?;
+    if !lifetime.matches_policy(target.lifetime)
+        || expected_deadline.is_some_and(|expected| {
+            lifetime.as_time_limited().map(|lease| lease.terminate_after.as_str()) != Some(expected)
+        })
+    {
         return Err(RunPodError::ResourceIdentityMismatch);
     }
     let worker = RunPodWorker {
@@ -388,7 +414,7 @@ fn status_from_pod(
         pod_id: pod.id.clone(),
         name: resource_name(workflow_id, job_id),
         image: target.image.clone(),
-        terminate_after,
+        lifetime,
         hourly_cost_micros: pod.cost.filter(|cost| *cost > 0),
     };
     status_from_resource(pod, &worker, ssh_public_key)
@@ -406,7 +432,7 @@ fn status_from_resource(
         && pod.env.get(JOB_ENV) == Some(&worker.job_id.to_string())
         && pod.env.get(PROTOCOL_ENV) == Some(&super::CLOUD_RUN_PROTOCOL_VERSION.to_string());
     let owned = owned
-        && pod.env.get(TERMINATE_ENV) == Some(&worker.terminate_after)
+        && observed_lifetime(pod)? == worker.lifetime
         && ssh_public_key.is_none_or(|key| pod.env.get(SSH_PUBLIC_KEY_ENV).is_some_and(|value| value == key));
     if !owned {
         return Err(RunPodError::ResourceIdentityMismatch);
@@ -435,20 +461,24 @@ fn status_from_resource(
 fn resource_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {
     format!("horizon-{workflow_id}-{job_id}")
 }
+fn observed_lifetime(pod: &ApiPod) -> Result<InteractiveWorkerLifetime, RunPodError> {
+    match (
+        pod.env.get(LIFETIME_ENV).map(String::as_str),
+        pod.env.get(TERMINATE_ENV),
+    ) {
+        (Some(PERSISTENT_LIFETIME), None) => Ok(InteractiveWorkerLifetime::Persistent),
+        (None, Some(deadline)) => Ok(InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: deadline.clone(),
+        })),
+        _ => Err(RunPodError::ResourceIdentityMismatch),
+    }
+}
 fn termination_deadline(lease_seconds: u32) -> Result<String, RunPodError> {
     time::OffsetDateTime::now_utc()
         .checked_add(time::Duration::seconds(i64::from(lease_seconds)))
         .ok_or(RunPodError::InvalidTarget)?
         .format(&time::format_description::well_known::Rfc3339)
         .map_err(|_| RunPodError::InvalidTarget)
-}
-fn recovered_deadline_valid(value: &str, lease_seconds: u32) -> bool {
-    let Ok(deadline) = time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339) else {
-        return false;
-    };
-    let now = time::OffsetDateTime::now_utc();
-    deadline >= now - time::Duration::seconds(LEASE_CLOCK_SKEW_SECONDS)
-        && deadline <= now + time::Duration::seconds(i64::from(lease_seconds) + LEASE_CLOCK_SKEW_SECONDS)
 }
 fn valid_provider_id(value: &str) -> bool {
     let valid_byte = |byte: u8| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_');

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -205,7 +205,10 @@ impl RunPodClient {
     fn create_worker(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError> {
         self.transport.create(request).map_err(|error| {
             if request.terminate_after.is_none()
-                && !matches!(error, RunPodError::PersistentCreationReconciliationRequired { .. })
+                && !matches!(
+                    error,
+                    RunPodError::CapacityUnavailable | RunPodError::PersistentCreationReconciliationRequired { .. }
+                )
             {
                 RunPodError::PersistentCreationUnresolved {
                     name: request.name.clone(),

--- a/crates/horizon-core/src/cloud_run/runpod/create_request.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/create_request.rs
@@ -1,7 +1,7 @@
 use super::super::CLOUD_RUN_PROTOCOL_VERSION;
 use super::{
-    CloudJobId, CloudWorkflowId, JOB_ENV, PROTOCOL_ENV, RunPodError, RunPodProfile, SSH_PUBLIC_KEY_ENV, TERMINATE_ENV,
-    WORKFLOW_ENV, WorkerTarget, termination_deadline,
+    CloudJobId, CloudWorkflowId, JOB_ENV, LIFETIME_ENV, PERSISTENT_LIFETIME, PROTOCOL_ENV, RunPodError, RunPodProfile,
+    SSH_PUBLIC_KEY_ENV, TERMINATE_ENV, WORKFLOW_ENV, WorkerTarget, termination_deadline,
 };
 use serde::Serialize;
 
@@ -31,7 +31,8 @@ pub(super) struct CreatePodRequest {
     pub(super) ports: String,
     pub(super) start_ssh: bool,
     pub(super) support_public_ip: bool,
-    pub(super) terminate_after: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) terminate_after: Option<String>,
     pub(super) volume_in_gb: u32,
     pub(super) volume_mount_path: &'static str,
 }
@@ -49,13 +50,20 @@ impl CreatePodRequest {
         name: String,
         ssh_public_key: Option<&str>,
     ) -> Result<Self, RunPodError> {
-        let seconds = target.lifetime.time_limit_seconds().ok_or(RunPodError::InvalidTarget)?;
-        let terminate_after = termination_deadline(seconds)?;
+        let terminate_after = target
+            .lifetime
+            .time_limit_seconds()
+            .map(termination_deadline)
+            .transpose()?;
+        let lifetime_entry = match &terminate_after {
+            Some(deadline) => (TERMINATE_ENV, deadline.clone()),
+            None => (LIFETIME_ENV, PERSISTENT_LIFETIME.to_string()),
+        };
         let mut env: Vec<_> = [
             (WORKFLOW_ENV, workflow_id.to_string()),
             (JOB_ENV, job_id.to_string()),
             (PROTOCOL_ENV, CLOUD_RUN_PROTOCOL_VERSION.to_string()),
-            (TERMINATE_ENV, terminate_after.clone()),
+            lifetime_entry,
         ]
         .into_iter()
         .map(|(key, value)| CreatePodEnv {

--- a/crates/horizon-core/src/cloud_run/runpod/http.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http.rs
@@ -85,16 +85,7 @@ impl Transport for RunPodHttp {
                 }
             });
         };
-        for delay_ms in PROPAGATION_BACKOFF_MS {
-            thread::sleep(Duration::from_millis(delay_ms));
-            if let Ok(Some(pod)) = self.get(&pod_id) {
-                return Ok(pod);
-            }
-        }
-        if self.delete(&pod_id) != Ok(RunPodCleanup::Deleted) || !matches!(self.get(&pod_id), Ok(None)) {
-            return Err(RunPodError::CreationCleanupFailed { pod_id });
-        }
-        Err(RunPodError::CreationVerificationFailed { pod_id })
+        reconcile_creation(self, request, pod_id)
     }
     fn get(&self, pod_id: &str) -> Result<Option<ApiPod>, RunPodError> {
         let url = Self::pod_url(pod_id)?;
@@ -140,6 +131,30 @@ impl Transport for RunPodHttp {
             pod_id: pod_id.to_string(),
         })
     }
+}
+pub(super) fn reconcile_creation(
+    transport: &dyn Transport,
+    request: &CreatePodRequest,
+    pod_id: String,
+) -> Result<ApiPod, RunPodError> {
+    for delay_ms in PROPAGATION_BACKOFF_MS {
+        if !cfg!(test) {
+            thread::sleep(Duration::from_millis(delay_ms));
+        }
+        if let Ok(Some(pod)) = transport.get(&pod_id) {
+            return Ok(pod);
+        }
+    }
+    if request.terminate_after.is_none() {
+        return Err(RunPodError::PersistentCreationReconciliationRequired {
+            name: request.name.clone(),
+            pod_id,
+        });
+    }
+    if transport.delete(&pod_id) != Ok(RunPodCleanup::Deleted) || !matches!(transport.get(&pod_id), Ok(None)) {
+        return Err(RunPodError::CreationCleanupFailed { pod_id });
+    }
+    Err(RunPodError::CreationVerificationFailed { pod_id })
 }
 pub(super) fn capacity_unavailable(envelope: &serde_json::Value) -> bool {
     envelope

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -2,8 +2,8 @@ use super::super::{
     CloudProvider, WorkerTarget,
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
-        InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
-        InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_coordinates,
+        InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerSshEndpoint,
+        InteractiveWorkerStatus, valid_ssh_coordinates,
     },
 };
 use super::{
@@ -65,9 +65,7 @@ impl RunPodInteractiveWorkerProvider {
                 },
                 target: target.clone(),
                 ssh_public_key: ssh_public_key.to_string(),
-                lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
-                    terminate_after: status.worker.terminate_after,
-                }),
+                lifetime: status.worker.lifetime,
             },
             lifecycle,
             ssh,
@@ -176,17 +174,13 @@ fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError
     if !worker.is_valid_for(CloudProvider::RunPod) {
         return Err(RunPodError::InvalidPersistedWorker);
     }
-    let lease = worker
-        .lifetime
-        .as_time_limited()
-        .ok_or(RunPodError::InvalidPersistedWorker)?;
     let runpod_worker = RunPodWorker {
         workflow_id: worker.identity.workflow_id,
         job_id: worker.identity.job_id,
         pod_id: worker.identity.resource_id.clone(),
         name: resource_name(worker.identity.workflow_id, worker.identity.job_id),
         image: worker.target.image.clone(),
-        terminate_after: lease.terminate_after.clone(),
+        lifetime: worker.lifetime.clone(),
         hourly_cost_micros: None,
     };
     runpod_worker.validate()?;

--- a/crates/horizon-core/src/cloud_run/runpod/models.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/models.rs
@@ -1,5 +1,6 @@
+use super::super::interactive_worker::{InteractiveWorkerLease, InteractiveWorkerLifetime};
 use super::{CloudJobId, CloudWorkflowId, resource_name, valid_immutable_worker_image, valid_provider_id};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -25,15 +26,14 @@ pub struct RunPodProfile {
     pub container_registry_auth_id: Option<String>,
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(try_from = "WorkerSnapshot", into = "WorkerSnapshot")]
 pub struct RunPodWorker {
     pub workflow_id: CloudWorkflowId,
     pub job_id: CloudJobId,
     pub pod_id: String,
     pub name: String,
     pub image: String,
-    pub terminate_after: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifetime: InteractiveWorkerLifetime,
     pub hourly_cost_micros: Option<u64>,
 }
 impl RunPodWorker {
@@ -43,9 +43,83 @@ impl RunPodWorker {
         let valid = valid_provider_id(&self.pod_id)
             && self.name == resource_name(self.workflow_id, self.job_id)
             && valid_immutable_worker_image(&self.image)
-            && time::OffsetDateTime::parse(&self.terminate_after, &time::format_description::well_known::Rfc3339)
-                .is_ok();
+            && self.lifetime.has_valid_shape();
         valid.then_some(()).ok_or(RunPodError::InvalidPersistedWorker)
+    }
+}
+
+/// Keep the legacy flat timestamp representation; omission never grants persistence.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkerSnapshot {
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    pod_id: String,
+    name: String,
+    image: String,
+    #[serde(default, deserialize_with = "present_value", skip_serializing_if = "Option::is_none")]
+    terminate_after: Option<String>,
+    #[serde(default, deserialize_with = "present_value", skip_serializing_if = "Option::is_none")]
+    lifetime: Option<PersistentMarker>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    hourly_cost_micros: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PersistentMarker {
+    Persistent,
+}
+
+fn present_value<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+impl TryFrom<WorkerSnapshot> for RunPodWorker {
+    type Error = RunPodError;
+
+    fn try_from(value: WorkerSnapshot) -> Result<Self, Self::Error> {
+        let lifetime = match (value.terminate_after, value.lifetime) {
+            (Some(terminate_after), None) => {
+                InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease { terminate_after })
+            }
+            (None, Some(PersistentMarker::Persistent)) => InteractiveWorkerLifetime::Persistent,
+            _ => return Err(RunPodError::InvalidPersistedWorker),
+        };
+        let worker = Self {
+            workflow_id: value.workflow_id,
+            job_id: value.job_id,
+            pod_id: value.pod_id,
+            name: value.name,
+            image: value.image,
+            lifetime,
+            hourly_cost_micros: value.hourly_cost_micros,
+        };
+        worker.validate()?;
+        Ok(worker)
+    }
+}
+
+impl From<RunPodWorker> for WorkerSnapshot {
+    fn from(value: RunPodWorker) -> Self {
+        let (terminate_after, lifetime) = match value.lifetime {
+            InteractiveWorkerLifetime::TimeLimited(lease) => (Some(lease.terminate_after), None),
+            InteractiveWorkerLifetime::Persistent => (None, Some(PersistentMarker::Persistent)),
+        };
+        Self {
+            workflow_id: value.workflow_id,
+            job_id: value.job_id,
+            pod_id: value.pod_id,
+            name: value.name,
+            image: value.image,
+            terminate_after,
+            lifetime,
+            hourly_cost_micros: value.hourly_cost_micros,
+        }
     }
 }
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -114,6 +188,16 @@ pub enum RunPodError {
     CreationVerificationFailed { pod_id: String },
     #[error("RunPod pod {pod_id} could not be verified or deleted after creation")]
     CreationCleanupFailed { pod_id: String },
+    #[error("persistent worker {name} creation is uncertain; reconcile before any retry: {cause}")]
+    PersistentCreationUnresolved {
+        name: String,
+        #[source]
+        cause: Box<RunPodError>,
+    },
+    #[error(
+        "persistent worker {name} (pod {pod_id}) could not be verified; it was not deleted and may remain billable"
+    )]
+    PersistentCreationReconciliationRequired { name: String, pod_id: String },
     #[error("RunPod pod {pod_id} deletion could not be verified")]
     DeletionVerificationFailed { pod_id: String },
     #[error("RunPod recovered worker lease was outside the requested bound and was deleted")]
@@ -128,4 +212,10 @@ pub enum RunPodError {
     },
     #[error("RunPod hourly cost was rejected but exact-resource cleanup failed")]
     CostRejectionCleanupFailed { worker: Box<RunPodWorker> },
+    #[error("persistent worker hourly cost was rejected; it was not deleted and may remain billable")]
+    PersistentWorkerCostRejected {
+        worker: Box<RunPodWorker>,
+        actual: Option<u64>,
+        maximum: u64,
+    },
 }

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -8,6 +8,10 @@ use super::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
 
+mod persistence;
+mod reconciliation;
+mod snapshots;
+
 const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
 
 #[derive(Clone, Default)]
@@ -21,6 +25,9 @@ struct FakeState {
     deleted: Vec<String>,
     inspected: Vec<String>,
     scripted_lists: Vec<Vec<ApiPod>>,
+    scripted_gets: Vec<Result<Option<ApiPod>, RunPodError>>,
+    fail_create_after_insert: bool,
+    reconcile_creation: bool,
 }
 impl FakeTransport {
     fn with_create_response(response: ApiPod) -> Self {
@@ -51,11 +58,25 @@ impl Transport for FakeTransport {
             response.env.insert(entry.key.clone(), entry.value.clone());
         }
         state.pods.push(response.clone());
-        Ok(response)
+        if state.fail_create_after_insert {
+            return Err(RunPodError::RequestFailed {
+                operation: "pod creation",
+            });
+        }
+        let reconcile = state.reconcile_creation;
+        drop(state);
+        if reconcile {
+            http::reconcile_creation(self, request, response.id)
+        } else {
+            Ok(response)
+        }
     }
     fn get(&self, pod_id: &str) -> Result<Option<ApiPod>, RunPodError> {
         let mut state = self.0.lock().expect("state");
         state.inspected.push(pod_id.to_string());
+        if !state.scripted_gets.is_empty() {
+            return state.scripted_gets.remove(0);
+        }
         Ok(state.pods.iter().find(|pod| pod.id == pod_id).cloned())
     }
     fn delete(&self, pod_id: &str) -> Result<RunPodCleanup, RunPodError> {
@@ -233,7 +254,7 @@ fn creation_uses_secure_direct_pull_and_bandwidth_constraints() {
         request
             .env
             .iter()
-            .any(|entry| entry.key == TERMINATE_ENV && entry.value == request.terminate_after)
+            .any(|entry| entry.key == TERMINATE_ENV && Some(entry.value.as_str()) == request.terminate_after.as_deref())
     );
     let json = serde_json::to_value(request).expect("serialize request");
     assert_eq!(json["dataCenterId"], "EUR-NO-1");
@@ -480,7 +501,7 @@ fn interactive_adapter_waits_for_trusted_host_key_and_fails_closed_on_invalid_da
 }
 
 #[test]
-fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
+fn invalid_persistent_requests_and_inconsistent_handles_fail_before_provider_io() {
     let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
     let mut request = interactive_request(workflow_id, job_id);
     request.target.lifetime = WorkerLifetime::Persistent;
@@ -490,6 +511,7 @@ fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
     let provider =
         RunPodInteractiveWorkerProvider::new(RunPodClient::with_transport(transport.clone()), profile(), host_keys);
     assert!(request.is_valid_for(CloudProvider::RunPod));
+    request.target.profile = "wrong-profile".into();
     assert_eq!(provider.ensure_worker(&request), Err(RunPodError::InvalidTarget));
     let worker = InteractiveWorker {
         identity: InteractiveWorkerIdentity {
@@ -500,9 +522,11 @@ fn unsupported_persistent_requests_and_handles_fail_before_provider_io() {
         },
         target: request.target,
         ssh_public_key: request.ssh_public_key,
-        lifetime: InteractiveWorkerLifetime::Persistent,
+        lifetime: InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: termination_deadline(900).expect("temporary observation"),
+        }),
     };
-    assert!(worker.is_valid_for(CloudProvider::RunPod));
+    assert!(!worker.is_valid_for(CloudProvider::RunPod));
     assert_eq!(
         provider.inspect_worker(&worker),
         Err(RunPodError::InvalidPersistedWorker)

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -21,6 +21,7 @@ struct FakeState {
     list_calls: usize,
     pods: Vec<ApiPod>,
     create_response: Option<ApiPod>,
+    create_rejection: Option<RunPodError>,
     create_requests: Vec<CreatePodRequest>,
     deleted: Vec<String>,
     inspected: Vec<String>,
@@ -53,6 +54,9 @@ impl Transport for FakeTransport {
     fn create(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError> {
         let mut state = self.0.lock().expect("state");
         state.create_requests.push(request.clone());
+        if let Some(error) = state.create_rejection.take() {
+            return Err(error);
+        }
         let mut response = state.create_response.clone().expect("create response");
         for entry in &request.env {
             response.env.insert(entry.key.clone(), entry.value.clone());

--- a/crates/horizon-core/src/cloud_run/runpod/tests/persistence.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/persistence.rs
@@ -1,0 +1,276 @@
+use super::*;
+
+pub(super) fn persistent_request() -> InteractiveWorkerRequest {
+    let mut request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+    request.target.lifetime = WorkerLifetime::Persistent;
+    request
+}
+
+pub(super) fn persistent_pod(request: &InteractiveWorkerRequest) -> ApiPod {
+    let mut pod = running_pod(request.workflow_id, request.job_id, &target());
+    pod.env.remove(TERMINATE_ENV);
+    pod.env.insert(LIFETIME_ENV.into(), PERSISTENT_LIFETIME.into());
+    pod.env
+        .insert(SSH_PUBLIC_KEY_ENV.into(), request.ssh_public_key.clone());
+    pod
+}
+
+pub(super) fn provider(transport: FakeTransport) -> RunPodInteractiveWorkerProvider {
+    RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(transport),
+        profile(),
+        FakeHostKeySource::new(Some(ed25519_key(73))),
+    )
+}
+
+#[test]
+fn persistent_creation_survives_controller_replacement_and_explicit_cleanup_is_exact() {
+    let request = persistent_request();
+    let mut response = persistent_pod(&request);
+    response.env.clear();
+    let transport = FakeTransport::with_create_response(response);
+    let original = provider(transport.clone());
+    let InteractiveWorkerEnsure::Created(status) = original.ensure_worker(&request).expect("persistent creation")
+    else {
+        panic!("expected one creation");
+    };
+    assert_eq!(status.worker.lifetime, InteractiveWorkerLifetime::Persistent);
+    assert!(status.is_ready_for(
+        &request,
+        time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(36_500)
+    ));
+    let encoded = serde_json::to_string(&status.worker).expect("persist worker");
+    let restored = serde_json::from_str(&encoded).expect("restore worker");
+    drop(original);
+    let reopened = provider(transport.clone());
+    assert_eq!(reopened.inspect_worker(&restored), Ok(Some(status.clone())));
+    assert_eq!(
+        reopened.ensure_worker(&request),
+        Ok(InteractiveWorkerEnsure::Reused(status))
+    );
+    {
+        let state = transport.0.lock().expect("state");
+        assert_eq!(state.create_requests.len(), 1);
+        assert!(state.deleted.is_empty());
+        let payload = serde_json::to_value(&state.create_requests[0]).expect("creation payload");
+        for field in ["terminateAfter", "stopAfter"] {
+            assert!(payload.get(field).is_none());
+        }
+        let env = &state.create_requests[0].env;
+        assert!(!env.iter().any(|entry| entry.key == TERMINATE_ENV));
+        let markers: Vec<_> = env.iter().filter(|entry| entry.key == LIFETIME_ENV).collect();
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].value, PERSISTENT_LIFETIME);
+    }
+    assert_eq!(reopened.delete_worker(&restored), Ok(InteractiveWorkerCleanup::Deleted));
+    assert_eq!(
+        reopened.delete_worker(&restored),
+        Ok(InteractiveWorkerCleanup::AlreadyAbsent)
+    );
+    assert_eq!(transport.0.lock().expect("state").deleted, ["pod_123456"]);
+}
+
+#[test]
+fn stopped_unknown_and_missing_persistent_workers_are_not_restarted_or_replaced() {
+    let request = persistent_request();
+    let transport = FakeTransport::with_pods(vec![persistent_pod(&request)]);
+    let provider = provider(transport.clone());
+    let worker = provider
+        .ensure_worker(&request)
+        .expect("existing worker")
+        .into_status()
+        .worker;
+    for (state, expected) in [
+        ("EXITED", InteractiveWorkerLifecycle::Stopped),
+        ("UNRECOGNIZED", InteractiveWorkerLifecycle::Unknown),
+    ] {
+        transport.0.lock().expect("state").pods[0].status = Some(state.into());
+        let observed = provider.inspect_worker(&worker).expect("inspect").expect("retained");
+        assert_eq!(observed.worker, worker);
+        assert_eq!(observed.lifecycle, expected);
+        assert!(observed.ssh.is_none());
+        assert_eq!(
+            provider.ensure_worker(&request),
+            Ok(InteractiveWorkerEnsure::Reused(observed))
+        );
+    }
+    transport.0.lock().expect("state").pods.clear();
+    assert_eq!(provider.inspect_worker(&worker), Ok(None));
+    let state = transport.0.lock().expect("state");
+    assert!(state.create_requests.is_empty());
+    assert!(state.deleted.is_empty());
+}
+
+#[test]
+fn persistent_metadata_and_client_identity_drift_never_authorize_reuse_or_deletion() {
+    for drift in 0..9 {
+        let request = persistent_request();
+        let transport = FakeTransport::with_pods(vec![persistent_pod(&request)]);
+        let provider = provider(transport.clone());
+        let worker = provider.ensure_worker(&request).expect("original").into_status().worker;
+        {
+            let mut state = transport.0.lock().expect("state");
+            let pod = &mut state.pods[0];
+            match drift {
+                0 => {
+                    pod.env.remove(LIFETIME_ENV);
+                }
+                1 => {
+                    pod.env.insert(LIFETIME_ENV.into(), String::new());
+                }
+                2 => {
+                    pod.env.insert(LIFETIME_ENV.into(), "unknown".into());
+                }
+                3 => {
+                    pod.env.insert(TERMINATE_ENV.into(), String::new());
+                }
+                4 => {
+                    pod.env.insert(TERMINATE_ENV.into(), "2000-01-01T00:00:00Z".into());
+                }
+                5 => {
+                    pod.env.insert(SSH_PUBLIC_KEY_ENV.into(), ed25519_key(99));
+                }
+                6 => {
+                    pod.env.insert(JOB_ENV.into(), CloudJobId::new().to_string());
+                }
+                7 => {
+                    pod.env.insert(WORKFLOW_ENV.into(), CloudWorkflowId::new().to_string());
+                }
+                _ => {
+                    pod.image = format!("registry.example/other@sha256:{}", "b".repeat(64));
+                }
+            }
+        }
+        assert_eq!(
+            provider.ensure_worker(&request),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            provider.inspect_worker(&worker),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            provider.delete_worker(&worker),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        let state = transport.0.lock().expect("state");
+        assert!(state.create_requests.is_empty());
+        assert!(state.deleted.is_empty());
+        assert_eq!(state.pods.len(), 1);
+    }
+}
+
+#[test]
+fn cross_policy_recovery_and_handles_cannot_adopt_or_delete_the_other_lifetime() {
+    for persistent_first in [false, true] {
+        let mut request = persistent_request();
+        let pod = if persistent_first {
+            persistent_pod(&request)
+        } else {
+            request.target.lifetime = target().lifetime;
+            let mut pod = running_pod(request.workflow_id, request.job_id, &request.target);
+            pod.env
+                .insert(SSH_PUBLIC_KEY_ENV.into(), request.ssh_public_key.clone());
+            pod
+        };
+        let transport = FakeTransport::with_pods(vec![pod]);
+        let provider = provider(transport.clone());
+        let mut worker = provider.ensure_worker(&request).expect("original").into_status().worker;
+        request.target.lifetime = if persistent_first {
+            target().lifetime
+        } else {
+            WorkerLifetime::Persistent
+        };
+        assert_eq!(
+            provider.ensure_worker(&request),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        worker.target = request.target.clone();
+        worker.lifetime = if persistent_first {
+            InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                terminate_after: termination_deadline(3600).expect("deadline"),
+            })
+        } else {
+            InteractiveWorkerLifetime::Persistent
+        };
+        assert!(worker.is_valid_for(CloudProvider::RunPod));
+        assert_eq!(
+            provider.inspect_worker(&worker),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            provider.delete_worker(&worker),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        let state = transport.0.lock().expect("state");
+        assert!(state.create_requests.is_empty());
+        assert!(state.deleted.is_empty());
+    }
+}
+
+#[test]
+fn new_and_recovered_persistent_cost_rejections_retain_the_worker_and_report_billing() {
+    for create in [false, true] {
+        for cost in [None, Some(0), Some(750_001)] {
+            let request = persistent_request();
+            let mut pod = persistent_pod(&request);
+            pod.cost = cost;
+            let transport = if create {
+                FakeTransport::with_create_response(pod)
+            } else {
+                FakeTransport::with_pods(vec![pod])
+            };
+            let error = provider(transport.clone())
+                .ensure_worker(&request)
+                .expect_err("cost rejection");
+            assert!(error.to_string().contains("not deleted and may remain billable"));
+            let RunPodError::PersistentWorkerCostRejected {
+                worker,
+                actual,
+                maximum,
+            } = error
+            else {
+                panic!("expected retained cost error");
+            };
+            assert_eq!(worker.pod_id, "pod_123456");
+            assert_eq!(worker.lifetime, InteractiveWorkerLifetime::Persistent);
+            assert_eq!(actual, cost.filter(|value| *value > 0));
+            assert_eq!(maximum, 750_000);
+            let state = transport.0.lock().expect("state");
+            assert_eq!(state.create_requests.len(), usize::from(create));
+            assert!(state.deleted.is_empty());
+            assert_eq!(state.pods.len(), 1);
+        }
+    }
+}
+
+#[test]
+fn conflicting_new_persistent_metadata_returns_the_exact_identity_without_cleanup() {
+    for drift in 0..3 {
+        let request = persistent_request();
+        let mut pod = persistent_pod(&request);
+        match drift {
+            0 => {
+                pod.env.insert(TERMINATE_ENV.into(), "2000-01-01T00:00:00Z".into());
+            }
+            1 => {
+                pod.env.insert(TERMINATE_ENV.into(), String::new());
+            }
+            _ => {
+                pod.image = format!("registry.example/other@sha256:{}", "b".repeat(64));
+            }
+        }
+        let transport = FakeTransport::with_create_response(pod);
+        assert_eq!(
+            provider(transport.clone()).ensure_worker(&request),
+            Err(RunPodError::PersistentCreationReconciliationRequired {
+                name: resource_name(request.workflow_id, request.job_id),
+                pod_id: "pod_123456".into(),
+            })
+        );
+        let state = transport.0.lock().expect("state");
+        assert_eq!(state.create_requests.len(), 1);
+        assert!(state.deleted.is_empty());
+        assert_eq!(state.pods.len(), 1);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/runpod/tests/reconciliation.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/reconciliation.rs
@@ -1,0 +1,181 @@
+use super::persistence::{persistent_pod, persistent_request};
+use super::*;
+use crate::cloud_run::{CloudWorkflowStore, GitCommitSha, GitSource, StoredRemoteAllocation};
+use crate::remote_workspace::{RemoteWorkspaceSpec, RemoteWorkspaceState};
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    allocation: StoredRemoteAllocation,
+    request: InteractiveWorkerRequest,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("private fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+        let mut request = persistent_request();
+        let state = RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+            workspace_local_id: "remote-workspace".into(),
+            target: request.target.clone(),
+            repository: GitSource {
+                repository: "owner/project".into(),
+                commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+                branch: None,
+            },
+            working_directory: ".".into(),
+            generation: 0,
+            panels: Vec::new(),
+        })
+        .expect("workspace");
+        let original = store.create_remote_workspace(OWNER, &state).expect("dormant record");
+        let allocation = store.allocate_remote_runtime(&original, i64::MAX).expect("allocation");
+        let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");
+        request.workflow_id = runtime.workflow_id;
+        request.job_id = runtime.job_id;
+        Self {
+            _directory: directory,
+            store,
+            allocation,
+            request,
+        }
+    }
+
+    fn provider(&self, transport: FakeTransport) -> RunPodInteractiveWorkerProvider {
+        RunPodInteractiveWorkerProvider::new(
+            RunPodClient {
+                transport: Box::new(transport),
+                creation_fence: Box::new(CloudWorkflowStore::open_path(self.store.path()).expect("reopen fence")),
+            },
+            profile(),
+            FakeHostKeySource::new(Some(ed25519_key(73))),
+        )
+    }
+}
+
+#[test]
+fn uncertain_persistent_creation_reconciles_without_deletion_or_a_second_durable_grant() {
+    // The acknowledged-ID cases run the same visibility loop used by HTTP creation.
+    for outcome in 0..4 {
+        let fixture = Fixture::new();
+        let request = &fixture.request;
+        let transport = FakeTransport::with_create_response(persistent_pod(request));
+        {
+            let mut state = transport.0.lock().expect("state");
+            state.reconcile_creation = outcome != 2;
+            state.fail_create_after_insert = outcome == 2;
+            if outcome < 2 {
+                state.scripted_gets = http::PROPAGATION_BACKOFF_MS
+                    .iter()
+                    .map(|_| {
+                        if outcome == 0 {
+                            Ok(None)
+                        } else {
+                            Err(RunPodError::RequestFailed {
+                                operation: "pod inspection",
+                            })
+                        }
+                    })
+                    .collect();
+            } else if outcome == 3 {
+                let mut incomplete = persistent_pod(request);
+                incomplete.env.remove(LIFETIME_ENV);
+                state.scripted_gets.push(Ok(Some(incomplete)));
+            }
+        }
+        let first = fixture.provider(transport.clone());
+        let error = first.ensure_worker(request).expect_err("uncertain creation");
+        let name = resource_name(request.workflow_id, request.job_id);
+        if outcome == 2 {
+            assert!(
+                matches!(error, RunPodError::PersistentCreationUnresolved { name: actual, cause }
+                if actual == name && *cause == RunPodError::RequestFailed { operation: "pod creation" })
+            );
+        } else {
+            assert_eq!(
+                error,
+                RunPodError::PersistentCreationReconciliationRequired {
+                    name,
+                    pod_id: "pod_123456".into()
+                }
+            );
+        }
+        {
+            let state = transport.0.lock().expect("state");
+            assert!(state.deleted.is_empty());
+            assert_eq!(state.pods.len(), 1);
+            assert_eq!(state.create_requests.len(), 1);
+            if outcome < 2 {
+                assert_eq!(state.inspected.len(), http::PROPAGATION_BACKOFF_MS.len());
+            }
+        }
+        drop(first);
+        let reopened = fixture.provider(transport.clone());
+        let InteractiveWorkerEnsure::Reused(status) = reopened.ensure_worker(request).expect("reconcile existing")
+        else {
+            panic!("must not create again");
+        };
+        assert_eq!(status.worker.identity.resource_id, "pod_123456");
+        assert_eq!(status.worker.lifetime, InteractiveWorkerLifetime::Persistent);
+        assert_eq!(reopened.inspect_worker(&status.worker), Ok(Some(status.clone())));
+        transport.0.lock().expect("state").pods.clear();
+        assert_eq!(reopened.inspect_worker(&status.worker), Ok(None));
+        drop(reopened);
+        let reopened = fixture.provider(transport.clone());
+        assert!(matches!(
+            reopened.ensure_worker(request),
+            Err(RunPodError::CreationUnresolved { .. })
+        ));
+        assert_eq!(
+            fixture
+                .store
+                .load_remote_allocation(OWNER, "remote-workspace")
+                .expect("allocation retained"),
+            Some(fixture.allocation.clone())
+        );
+        let state = transport.0.lock().expect("state");
+        assert_eq!(state.create_requests.len(), 1);
+        assert!(state.deleted.is_empty());
+    }
+}
+
+#[test]
+fn acknowledged_timed_creation_still_cleans_up_after_visibility_exhaustion() {
+    let request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+    let transport =
+        FakeTransport::with_create_response(running_pod(request.workflow_id, request.job_id, &request.target));
+    {
+        let mut state = transport.0.lock().expect("state");
+        state.reconcile_creation = true;
+        state.scripted_gets = http::PROPAGATION_BACKOFF_MS.iter().map(|_| Ok(None)).collect();
+    }
+    assert_eq!(
+        persistence::provider(transport.clone()).ensure_worker(&request),
+        Err(RunPodError::CreationVerificationFailed {
+            pod_id: "pod_123456".into()
+        })
+    );
+    let state = transport.0.lock().expect("state");
+    assert_eq!(state.create_requests.len(), 1);
+    assert_eq!(state.deleted, ["pod_123456"]);
+    assert!(state.pods.is_empty());
+}
+
+#[test]
+fn multiple_persistent_matches_are_rejected_without_mutation() {
+    let request = persistent_request();
+    let pod = persistent_pod(&request);
+    let mut duplicate = pod.clone();
+    duplicate.id = "pod_654321".into();
+    let transport = FakeTransport::with_pods(vec![pod.clone(), duplicate]);
+    transport.0.lock().expect("state").scripted_lists = vec![vec![pod]];
+    assert!(matches!(
+        persistence::provider(transport.clone()).ensure_worker(&request),
+        Err(RunPodError::AmbiguousResource { count: 2, .. })
+    ));
+    let state = transport.0.lock().expect("state");
+    assert!(state.create_requests.is_empty());
+    assert!(state.deleted.is_empty());
+}

--- a/crates/horizon-core/src/cloud_run/runpod/tests/reconciliation.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/reconciliation.rs
@@ -142,6 +142,42 @@ fn uncertain_persistent_creation_reconciles_without_deletion_or_a_second_durable
 }
 
 #[test]
+fn capacity_and_malformed_response_classification_preserve_the_consumed_creation_fence() {
+    for capacity in [false, true] {
+        let fixture = Fixture::new();
+        let transport = FakeTransport::default();
+        transport.0.lock().expect("state").create_rejection = Some(if capacity {
+            RunPodError::CapacityUnavailable
+        } else {
+            RunPodError::InvalidResponse {
+                operation: "pod creation",
+            }
+        });
+        let original = fixture.provider(transport.clone());
+        let result = original.ensure_worker(&fixture.request);
+        if capacity {
+            assert_eq!(result, Err(RunPodError::CapacityUnavailable));
+        } else {
+            assert!(
+                matches!(result, Err(RunPodError::PersistentCreationUnresolved { name, cause })
+                if name == resource_name(fixture.request.workflow_id, fixture.request.job_id)
+                    && *cause == RunPodError::InvalidResponse { operation: "pod creation" })
+            );
+        }
+        drop(original);
+        let reopened = fixture.provider(transport.clone());
+        assert!(matches!(
+            reopened.ensure_worker(&fixture.request),
+            Err(RunPodError::CreationUnresolved { .. })
+        ));
+        let state = transport.0.lock().expect("state");
+        assert_eq!(state.create_requests.len(), 1);
+        assert!(state.pods.is_empty());
+        assert!(state.deleted.is_empty());
+    }
+}
+
+#[test]
 fn acknowledged_timed_creation_still_cleans_up_after_visibility_exhaustion() {
     let request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
     let transport =

--- a/crates/horizon-core/src/cloud_run/runpod/tests/snapshots.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/snapshots.rs
@@ -1,0 +1,63 @@
+use super::*;
+use serde_json::json;
+
+fn snapshot(lifetime_fields: &str) -> String {
+    format!(
+        "{{\"workflow_id\":\"11111111-1111-4111-8111-111111111111\",\"job_id\":\"22222222-2222-4222-8222-222222222222\",\"pod_id\":\"pod_123456\",\"name\":\"horizon-11111111-1111-4111-8111-111111111111-22222222-2222-4222-8222-222222222222\",\"image\":\"registry.example/worker@sha256:{}\",{lifetime_fields},\"hourly_cost_micros\":420000}}",
+        "d".repeat(64)
+    )
+}
+
+#[test]
+fn persistent_and_expired_legacy_snapshots_round_trip_with_exact_bytes() {
+    for fields in [
+        r#""lifetime":"persistent""#,
+        r#""terminate_after":"2000-01-01T00:00:00Z""#,
+    ] {
+        let encoded = snapshot(fields);
+        let worker: RunPodWorker = serde_json::from_str(&encoded).expect("valid snapshot");
+        assert_eq!(worker.validate(), Ok(()));
+        assert_eq!(serde_json::to_string(&worker).expect("serialize"), encoded);
+    }
+}
+
+#[test]
+fn incomplete_conflicting_null_unknown_and_duplicate_lifetime_fields_are_rejected() {
+    for fields in [
+        r#""lifetime":null"#,
+        r#""terminate_after":null"#,
+        r#""lifetime":"unknown""#,
+        r#""lifetime":true"#,
+        r#""terminate_after":"not a timestamp""#,
+        r#""lifetime":"persistent","terminate_after":"2000-01-01T00:00:00Z""#,
+        r#""lifetime":"persistent","terminate_after":null"#,
+        r#""lifetime":null,"terminate_after":"2000-01-01T00:00:00Z""#,
+        r#""lifetime":"persistent","lifetime":"persistent""#,
+        r#""terminate_after":"2000-01-01T00:00:00Z","terminate_after":"2000-01-01T00:00:00Z""#,
+        r#""lifetime":"persistent","unexpected":true"#,
+    ] {
+        assert!(
+            serde_json::from_str::<RunPodWorker>(&snapshot(fields)).is_err(),
+            "accepted {fields}"
+        );
+    }
+    let mut missing: serde_json::Value = serde_json::from_str(&snapshot(r#""lifetime":"persistent""#)).expect("object");
+    missing.as_object_mut().expect("object").remove("lifetime");
+    assert!(serde_json::from_value::<RunPodWorker>(missing).is_err());
+}
+
+#[test]
+fn temporary_creation_keeps_the_exact_legacy_payload() {
+    let (workflow, job) = (CloudWorkflowId::new(), CloudJobId::new());
+    let request = CreatePodRequest::new(workflow, job, &target(), &profile(), resource_name(workflow, job), None)
+        .expect("legacy request");
+    let deadline = request.terminate_after.as_deref().expect("explicit deadline");
+    let expected = format!(
+        "{{\"allowedCudaVersions\":[\"12.8\"],\"cloudType\":\"SECURE\",\"containerDiskInGb\":80,\"containerRegistryAuthId\":\"registry_auth-1\",\"dataCenterId\":\"EUR-NO-1\",\"env\":[{{\"key\":\"HORIZON_WORKFLOW_ID\",\"value\":\"{workflow}\"}},{{\"key\":\"HORIZON_JOB_ID\",\"value\":\"{job}\"}},{{\"key\":\"HORIZON_CLOUD_PROTOCOL_VERSION\",\"value\":\"1\"}},{{\"key\":\"HORIZON_TERMINATE_AFTER\",\"value\":{}}}],\"gpuCount\":1,\"gpuTypeIdList\":[\"NVIDIA RTX A4000\",\"NVIDIA RTX A4500\"],\"imageName\":{},\"minDisk\":200,\"minDownload\":250,\"minUpload\":100,\"name\":{},\"ports\":\"22/tcp\",\"startSsh\":true,\"supportPublicIp\":true,\"terminateAfter\":{},\"volumeInGb\":20,\"volumeMountPath\":\"/workspace\"}}",
+        json!(deadline),
+        json!(target().image),
+        json!(request.name),
+        json!(deadline),
+    );
+    assert_eq!(serde_json::to_string(&request).expect("serialize request"), expected);
+}

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -44,9 +44,25 @@ for manual inspection; metadata drift never authorizes automatic deletion.
 After an ambiguous persistent create response, a recovered worker is retained
 if inspection fails: another controller may already be using it. The returned
 exact identity permits reconciliation, not an unverified cleanup or replacement.
-The remote GPU adapter still rejects
-unsupported persistent requests/handles before I/O; product profiles and the
-remaining remote implementations still need persistent execution support.
+The remote GPU adapter uses the same explicit lifetime contract. Persistent
+creation omits the provider deadline and image watchdog environment entry and
+records `HORIZON_WORKER_LIFETIME=persistent`. Recovery requires that marker and
+no expiry entry; legacy timed workers retain their exact deadline representation.
+Missing, contradictory or mismatched lifetime metadata cannot authorize adoption
+or cleanup. Flat provider snapshots retain the legacy `terminate_after` field
+for timed workers and require an explicit `lifetime` marker for persistence.
+
+An uncertain persistent creation preserves the deterministic resource name and,
+when acknowledged, its exact provider ID for reconciliation. Exhausting the
+bounded visibility window does not delete it or renew its one-shot creation
+grant. Persistent validation or cost rejection also retains the resource; cost
+errors include the worker and observed limit and warn that billing may continue.
+This covers newly created resources too, because another client may already be
+using the worker. Reconciliation identities alone do not establish ownership.
+Only explicit, freshly identity-verified deletion removes persistent compute.
+Provider-wide manual management and the remaining remote implementations still
+need integration. Schema and synthetic-transport tests do not establish live
+provider scheduling, storage durability or PC-off acceptance.
 Neither record storage nor these contracts alone complete persistent cloud workspaces.
 
 The product policy defaults to persistent, but saved records never infer that


### PR DESCRIPTION
## Purpose

Implement the GPU provider's explicit persistent lifetime slice of #383. A client reconnect must not renew a lifetime, replace an existing worker or implicitly delete running work.

## Behavior

- Explicit persistent requests omit the provider termination deadline and image watchdog entry, and record a persistence marker. The existing GraphQL creation operation is unchanged.
- Provider handles now use the shared observed-lifetime enum. Strict snapshots preserve exact legacy timed bytes; missing, null, conflicting, duplicate and unknown lifetime fields fail closed.
- Reconnect and inspection retain the same worker and policy. Stopped, unknown and absent workers are not restarted or replaced. Pinned SSH and exact ownership checks remain required.
- Uncertain persistent creation preserves the deterministic name and acknowledged resource ID when available. Explicit capacity rejection remains a distinct typed result. Neither path consumes another creation grant or falls through to timed cleanup.
- New or recovered persistent cost rejection retains the validated worker and cost details. These errors explicitly warn that resources were not deleted and may remain billable; exact manual deletion remains separate.
- Explicitly timed requests retain their original payload, deadline and cleanup behavior.

## Validation

- Full matrix passed on final source and exact commit `b1d02c342d25066c07b46a7aebd6d0bb96ac278b`: format, maintainability, version sync, default/speech workspace tests, and blocking/strict/advisory Clippy tiers.
- All 24 provider regressions pass; all 134 cloud-workflow tests pass with eight threads. Full workspace runs use one test thread.
- The production acknowledged-ID visibility loop is exercised through fake transport reads: repeated not-found/errors, lost creation response and missing observed metadata. A real private allocation store is reopened across clients to prove one-shot creation, same-worker recovery and no replacement after disappearance.
- Coverage also includes capacity/malformed-response classification with the consumed fence preserved after reopening, persistent payload omissions, controller replacement, snapshot compatibility, key/ownership/lifetime drift, both cross-policy directions, fresh/recovered cost rejection, duplicate matches and exact explicit deletion.
- Independent exact-tree review is clear. Scope: ten source/test files, 846 changed lines, plus the lifecycle architecture note.
- Initial-head Intel macOS CI hit an unchanged two-second PTY shutdown assertion. No timeout was loosened or terminal code changed; the corrected head must pass fresh CI before merge.

## Limits and assumptions

The official creation schema was refreshed and linked in #383; its deadline inputs are optional. Synthetic tests do not certify live cloud scheduling, durable storage or PC-off behavior. No paid provider calls, credentials, image publication, running user processes or release actions were used. No UI changes need native UI smoke.

This is a provider foundation, not completion of #383. Remote supervision/checkpoints, provider-wide management, stop/delete UI, client-reference integration and live PC-off acceptance remain separate work.

Metadata: assigned to the author; ambiguous review label, milestone and project are not selected.
