### PR TITLE
refactor(panel): isolate restart and terminal restoration

### DIFF
--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -1,3 +1,4 @@
+mod lifecycle;
 mod spawn;
 
 use std::borrow::Cow;
@@ -11,17 +12,18 @@ use crate::agents::{AGENT_WORKING_SCAN_ROWS, AgentStatus, is_agent_working_line}
 use crate::editor::{MarkdownEditor, PanelContent};
 use crate::error::Result;
 use crate::git_changes::DiffViewer;
-use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef, claude_session_transcript_exists};
+use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef};
 use crate::ssh::{SshConnection, SshConnectionStatus};
-use crate::terminal::{AgentNotification, Terminal, TerminalSpawnOptions};
+use crate::terminal::{AgentNotification, Terminal};
+#[cfg(test)]
 use crate::usage_dashboard::UsageDashboard;
 use crate::workspace::WorkspaceId;
 
+use self::spawn::spawn_panel;
 #[cfg(test)]
-use self::spawn::platform_default_shell;
 use self::spawn::{
-    AgentLaunchContext, agent_env, kitty_keyboard_for_kind, resolve_launch_command, scrollback_limit_for_kind,
-    spawn_panel,
+    AgentLaunchContext, kitty_keyboard_for_kind, platform_default_shell, resolve_launch_command,
+    scrollback_limit_for_kind,
 };
 pub use self::spawn::{browser_actor, current_unix_millis};
 
@@ -558,107 +560,6 @@ impl Panel {
 
     pub fn resize_layout(&mut self, size: [f32; 2]) {
         self.layout.size = size;
-    }
-
-    /// Restart panel content while keeping the same identity and layout.
-    /// Terminal agent panels resume their existing session. Browser panels
-    /// only schedule an asynchronous relaunch; `Ok(())` confirms that the
-    /// request was accepted, while launch failures arrive through Browser
-    /// status/events.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a terminal cannot be spawned or a file-backed
-    /// editor cannot be reopened.
-    pub fn restart(&mut self) -> Result<()> {
-        if let PanelContent::GitChanges(_) = &self.content {
-            return Ok(());
-        }
-
-        if let PanelContent::Browser(browser) = &mut self.content {
-            browser.relaunch();
-            return Ok(());
-        }
-
-        if let PanelContent::Usage(_) = &self.content {
-            self.content = PanelContent::Usage(UsageDashboard::new());
-            return Ok(());
-        }
-
-        let Some(terminal) = self.content.terminal_mut() else {
-            // Editor panels don't restart — just reload from disk if file-backed.
-            if let Some(editor) = self.content.editor_mut()
-                && let Some(path) = editor.file_path.clone()
-                && path.exists()
-            {
-                *editor = MarkdownEditor::open(path)?;
-            }
-            return Ok(());
-        };
-
-        let rows = terminal.rows();
-        let cols = terminal.cols();
-
-        // Graceful shutdown of the old terminal.
-        let _ = terminal.shutdown_with_timeout(Duration::from_secs(2));
-
-        // A pre-assigned Claude binding may not have a transcript yet (panel
-        // never received a message); resuming it would fail, so relaunch
-        // fresh under the same session id instead.
-        let should_resume = self.kind.supports_session_binding()
-            && self.session_binding.as_ref().is_some_and(|binding| {
-                self.kind != PanelKind::Claude || claude_session_transcript_exists(&binding.session_id)
-            });
-        let (program, launch_args) = resolve_launch_command(
-            self.launch_command.clone(),
-            self.launch_args.clone(),
-            self.ssh_connection.clone(),
-            self.kind,
-            AgentLaunchContext {
-                resume: &self.resume,
-                session_binding: self.session_binding.as_ref(),
-                should_resume_binding: should_resume,
-                is_restore: true,
-            },
-        );
-
-        if self.kind.is_agent() {
-            tracing::info!(
-                panel_id = self.id.0,
-                kind = ?self.kind,
-                resume = ?self.resume,
-                session_id = self.session_binding.as_ref().map(|b| b.session_id.as_str()),
-                should_resume,
-                cwd = self.launch_cwd.as_ref().map(|p| p.display().to_string()).as_deref(),
-                cmd = %format!("{program} {}", launch_args.join(" ")),
-                "restarting agent panel"
-            );
-        }
-
-        let env = agent_env(self.kind, &self.local_id);
-        self.content = PanelContent::Terminal(Terminal::spawn(TerminalSpawnOptions {
-            program,
-            args: launch_args,
-            cwd: self.launch_cwd.clone(),
-            rows,
-            cols,
-            cell_width: DEFAULT_CELL_WIDTH,
-            cell_height: DEFAULT_CELL_HEIGHT,
-            scrollback_limit: scrollback_limit_for_kind(self.kind),
-            window_id: self.id.0,
-            replay_bytes: Vec::new(),
-            env,
-            kitty_keyboard: kitty_keyboard_for_kind(self.kind),
-        })?);
-
-        self.launched_at_millis = current_unix_millis();
-        self.ssh_status = if self.kind == PanelKind::Ssh {
-            Some(SshConnectionStatus::Connecting)
-        } else {
-            None
-        };
-        tracing::info!("restarted panel '{}' (id={})", self.title, self.id.0);
-        Ok(())
     }
 
     pub fn set_session_binding(&mut self, session_binding: Option<AgentSessionBinding>) {

--- a/crates/horizon-core/src/panel/lifecycle.rs
+++ b/crates/horizon-core/src/panel/lifecycle.rs
@@ -1,0 +1,117 @@
+use std::time::Duration;
+
+use crate::editor::{MarkdownEditor, PanelContent};
+use crate::error::Result;
+use crate::runtime_state::claude_session_transcript_exists;
+use crate::ssh::SshConnectionStatus;
+use crate::terminal::{Terminal, TerminalSpawnOptions};
+use crate::usage_dashboard::UsageDashboard;
+
+use super::spawn::{
+    AgentLaunchContext, agent_env, current_unix_millis, kitty_keyboard_for_kind, resolve_launch_command,
+    scrollback_limit_for_kind,
+};
+use super::{DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, Panel, PanelKind};
+
+impl Panel {
+    /// Restart panel content while keeping the same identity and layout.
+    /// Terminal agent panels resume their existing session. Browser panels
+    /// only schedule an asynchronous relaunch; `Ok(())` confirms that the
+    /// request was accepted, while launch failures arrive through Browser
+    /// status/events.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a terminal cannot be spawned or a file-backed
+    /// editor cannot be reopened.
+    pub fn restart(&mut self) -> Result<()> {
+        if let PanelContent::GitChanges(_) = &self.content {
+            return Ok(());
+        }
+
+        if let PanelContent::Browser(browser) = &mut self.content {
+            browser.relaunch();
+            return Ok(());
+        }
+
+        if let PanelContent::Usage(_) = &self.content {
+            self.content = PanelContent::Usage(UsageDashboard::new());
+            return Ok(());
+        }
+
+        let Some(terminal) = self.content.terminal_mut() else {
+            // Editor panels don't restart — just reload from disk if file-backed.
+            if let Some(editor) = self.content.editor_mut()
+                && let Some(path) = editor.file_path.clone()
+                && path.exists()
+            {
+                *editor = MarkdownEditor::open(path)?;
+            }
+            return Ok(());
+        };
+
+        let rows = terminal.rows();
+        let cols = terminal.cols();
+
+        // Graceful shutdown of the old terminal.
+        let _ = terminal.shutdown_with_timeout(Duration::from_secs(2));
+
+        // A pre-assigned Claude binding may not have a transcript yet (panel
+        // never received a message); resuming it would fail, so relaunch
+        // fresh under the same session id instead.
+        let should_resume = self.kind.supports_session_binding()
+            && self.session_binding.as_ref().is_some_and(|binding| {
+                self.kind != PanelKind::Claude || claude_session_transcript_exists(&binding.session_id)
+            });
+        let (program, launch_args) = resolve_launch_command(
+            self.launch_command.clone(),
+            self.launch_args.clone(),
+            self.ssh_connection.clone(),
+            self.kind,
+            AgentLaunchContext {
+                resume: &self.resume,
+                session_binding: self.session_binding.as_ref(),
+                should_resume_binding: should_resume,
+                is_restore: true,
+            },
+        );
+
+        if self.kind.is_agent() {
+            tracing::info!(
+                panel_id = self.id.0,
+                kind = ?self.kind,
+                resume = ?self.resume,
+                session_id = self.session_binding.as_ref().map(|b| b.session_id.as_str()),
+                should_resume,
+                cwd = self.launch_cwd.as_ref().map(|p| p.display().to_string()).as_deref(),
+                cmd = %format!("{program} {}", launch_args.join(" ")),
+                "restarting agent panel"
+            );
+        }
+
+        let env = agent_env(self.kind, &self.local_id);
+        self.content = PanelContent::Terminal(Terminal::spawn(TerminalSpawnOptions {
+            program,
+            args: launch_args,
+            cwd: self.launch_cwd.clone(),
+            rows,
+            cols,
+            cell_width: DEFAULT_CELL_WIDTH,
+            cell_height: DEFAULT_CELL_HEIGHT,
+            scrollback_limit: scrollback_limit_for_kind(self.kind),
+            window_id: self.id.0,
+            replay_bytes: Vec::new(),
+            env,
+            kitty_keyboard: kitty_keyboard_for_kind(self.kind),
+        })?);
+
+        self.launched_at_millis = current_unix_millis();
+        self.ssh_status = if self.kind == PanelKind::Ssh {
+            Some(SshConnectionStatus::Connecting)
+        } else {
+            None
+        };
+        tracing::info!("restarted panel '{}' (id={})", self.title, self.id.0);
+        Ok(())
+    }
+}

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -1,3 +1,10 @@
+mod terminal;
+
+pub(super) use terminal::restore_failure_panel;
+use terminal::spawn_terminal;
+#[cfg(test)]
+use terminal::{disconnected_snapshot_launch_command, prepare_transcript_restore};
+
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
@@ -11,16 +18,15 @@ use crate::error::Result;
 use crate::git_changes::DiffViewer;
 use crate::horizon_home::HorizonHome;
 use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef, claude_session_transcript_exists, new_local_id};
-use crate::ssh::{SshConnection, SshConnectionStatus};
-use crate::terminal::{Terminal, TerminalSpawnOptions};
+use crate::ssh::SshConnection;
 use crate::transcript::PanelTranscript;
 use crate::usage_dashboard::UsageDashboard;
 use crate::workspace::WorkspaceId;
 use crate::{AgentIntegrationKind, AgentResumeMode, agent_definition};
 
 use super::{
-    AGENT_PANEL_SCROLLBACK_LIMIT, DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, DEFAULT_PANEL_SCROLLBACK_LIMIT,
-    DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind, PanelLayout, PanelOptions, PanelResume,
+    AGENT_PANEL_SCROLLBACK_LIMIT, DEFAULT_PANEL_SCROLLBACK_LIMIT, DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind,
+    PanelLayout, PanelOptions, PanelResume,
 };
 
 struct StaticPanelSeed {
@@ -59,24 +65,6 @@ pub(super) struct AgentLaunchContext<'a> {
     /// than launching a newly added one; continue-style agents only pass
     /// their continue flag when reconnecting.
     pub(super) is_restore: bool,
-}
-
-struct TerminalPanelBuildArgs {
-    id: PanelId,
-    local_id: String,
-    title: String,
-    kind: PanelKind,
-    resume: PanelResume,
-    position: Option<[f32; 2]>,
-    size: Option<[f32; 2]>,
-    workspace_id: WorkspaceId,
-    session_binding: Option<AgentSessionBinding>,
-    template: Option<PanelTemplateRef>,
-    has_custom_name: bool,
-    launch_command: Option<String>,
-    launch_args: Vec<String>,
-    launch_cwd: Option<PathBuf>,
-    ssh_connection: Option<SshConnection>,
 }
 
 impl StaticPanelSeed {
@@ -165,240 +153,6 @@ pub(super) fn spawn_panel(id: PanelId, workspace_id: WorkspaceId, mut opts: Pane
     }
 }
 
-pub(super) fn restore_failure_panel(
-    id: PanelId,
-    workspace_id: WorkspaceId,
-    opts: PanelOptions,
-    error_message: &str,
-) -> Result<Panel> {
-    let local_id = opts.local_id.clone().unwrap_or_else(new_local_id);
-    let PanelOptions {
-        name,
-        name_is_custom,
-        command,
-        args,
-        cwd,
-        ssh_connection,
-        rows,
-        cols,
-        kind,
-        resume,
-        position,
-        size,
-        session_binding,
-        template,
-        ..
-    } = opts;
-
-    let saved_ssh_connection = ssh_connection.clone();
-    let has_custom_name = name_is_custom.unwrap_or_else(|| name.is_some());
-    let title = name.unwrap_or_else(|| default_terminal_title(id, saved_ssh_connection.as_ref()));
-    let replay_bytes = restore_failure_replay_bytes(&title, error_message);
-    let terminal = spawn_restore_failure_snapshot_terminal(id, kind, rows, cols, replay_bytes)?;
-    let ssh_status = if kind == PanelKind::Ssh {
-        Some(SshConnectionStatus::Disconnected)
-    } else {
-        None
-    };
-
-    Ok(build_terminal_panel(
-        TerminalPanelBuildArgs {
-            id,
-            local_id,
-            title,
-            kind,
-            resume,
-            position,
-            size,
-            workspace_id,
-            session_binding,
-            template,
-            has_custom_name,
-            launch_command: command,
-            launch_args: args,
-            launch_cwd: cwd,
-            ssh_connection: saved_ssh_connection,
-        },
-        terminal,
-        ssh_status,
-    ))
-}
-
-fn spawn_terminal(id: PanelId, workspace_id: WorkspaceId, local_id: String, opts: PanelOptions) -> Result<Panel> {
-    let PanelOptions {
-        name,
-        name_is_custom,
-        command,
-        args,
-        cwd,
-        ssh_connection,
-        rows,
-        cols,
-        kind,
-        resume,
-        position,
-        size,
-        session_binding,
-        template,
-        transcript_root,
-        restore_as_disconnected_snapshot,
-        is_restore,
-        ..
-    } = opts;
-
-    let (transcript, replay_bytes, had_persisted_transcript_state) =
-        prepare_transcript_restore(id, kind, transcript_root, &local_id);
-    let saved_command = command.clone();
-    let saved_args = args.clone();
-    let saved_cwd = cwd.clone();
-    let saved_ssh_connection = ssh_connection.clone();
-    let resolved_launch = resolve_terminal_launch(
-        id,
-        kind,
-        &resume,
-        name.as_deref(),
-        command,
-        args,
-        ssh_connection,
-        session_binding,
-        saved_cwd.as_ref(),
-        transcript.as_ref(),
-        is_restore,
-    );
-    let ResolvedTerminalLaunch {
-        session_binding,
-        program,
-        launch_args,
-    } = resolved_launch;
-    let has_custom_name = name_is_custom.unwrap_or_else(|| name.is_some());
-    let title = name.unwrap_or_else(|| default_terminal_title(id, saved_ssh_connection.as_ref()));
-    let initial_ssh_status = if kind == PanelKind::Ssh {
-        Some(SshConnectionStatus::Connecting)
-    } else {
-        None
-    };
-    let env = agent_env(kind, &local_id);
-    let panel_args = TerminalPanelBuildArgs {
-        id,
-        local_id,
-        title,
-        kind,
-        resume,
-        position,
-        size,
-        workspace_id,
-        session_binding,
-        template,
-        has_custom_name,
-        launch_command: saved_command,
-        launch_args: saved_args,
-        launch_cwd: saved_cwd,
-        ssh_connection: saved_ssh_connection,
-    };
-    if restore_as_disconnected_snapshot && panel_args.kind == PanelKind::Ssh && had_persisted_transcript_state {
-        return spawn_disconnected_ssh_snapshot_panel(panel_args, rows, cols, replay_bytes);
-    }
-    let terminal = Terminal::spawn(TerminalSpawnOptions {
-        program,
-        args: launch_args,
-        cwd,
-        rows,
-        cols,
-        cell_width: DEFAULT_CELL_WIDTH,
-        cell_height: DEFAULT_CELL_HEIGHT,
-        scrollback_limit: scrollback_limit_for_kind(kind),
-        window_id: id.0,
-        replay_bytes,
-        env,
-        kitty_keyboard: kitty_keyboard_for_kind(kind),
-    })?;
-    tracing::info!("created panel '{}' (id={})", panel_args.title, panel_args.id.0);
-    Ok(build_terminal_panel(panel_args, terminal, initial_ssh_status))
-}
-
-fn spawn_restore_failure_snapshot_terminal(
-    id: PanelId,
-    kind: PanelKind,
-    rows: u16,
-    cols: u16,
-    replay_bytes: Vec<u8>,
-) -> Result<Terminal> {
-    let (program, args) = disconnected_snapshot_launch_command();
-    Terminal::spawn(TerminalSpawnOptions {
-        program,
-        args,
-        cwd: None,
-        rows,
-        cols,
-        cell_width: DEFAULT_CELL_WIDTH,
-        cell_height: DEFAULT_CELL_HEIGHT,
-        scrollback_limit: scrollback_limit_for_kind(kind),
-        window_id: id.0,
-        replay_bytes,
-        env: HashMap::new(),
-        kitty_keyboard: kitty_keyboard_for_kind(kind),
-    })
-}
-
-fn restore_failure_replay_bytes(title: &str, error_message: &str) -> Vec<u8> {
-    format!(
-        concat!(
-            "Horizon could not restore this panel.\r\n\r\n",
-            "Panel: {title}\r\n",
-            "Error: {error_message}\r\n\r\n",
-            "Fix the command or binary, then restart the panel.\r\n"
-        ),
-        title = title,
-        error_message = error_message
-    )
-    .into_bytes()
-}
-
-fn spawn_disconnected_snapshot_terminal(id: PanelId, rows: u16, cols: u16, replay_bytes: Vec<u8>) -> Result<Terminal> {
-    let (program, args) = disconnected_snapshot_launch_command();
-    Terminal::spawn(TerminalSpawnOptions {
-        program,
-        args,
-        cwd: None,
-        rows,
-        cols,
-        cell_width: DEFAULT_CELL_WIDTH,
-        cell_height: DEFAULT_CELL_HEIGHT,
-        scrollback_limit: scrollback_limit_for_kind(PanelKind::Ssh),
-        window_id: id.0,
-        replay_bytes,
-        env: HashMap::new(),
-        kitty_keyboard: kitty_keyboard_for_kind(PanelKind::Ssh),
-    })
-}
-
-fn disconnected_snapshot_launch_command() -> (String, Vec<String>) {
-    if cfg!(windows) {
-        ("cmd.exe".to_string(), vec!["/C".to_string(), "exit".to_string()])
-    } else {
-        (default_shell(), vec!["-c".to_string(), "exit".to_string()])
-    }
-}
-
-fn spawn_disconnected_ssh_snapshot_panel(
-    panel_args: TerminalPanelBuildArgs,
-    rows: u16,
-    cols: u16,
-    replay_bytes: Vec<u8>,
-) -> Result<Panel> {
-    let terminal = spawn_disconnected_snapshot_terminal(panel_args.id, rows, cols, replay_bytes)?;
-    tracing::info!(
-        "restored disconnected ssh snapshot '{}' (id={})",
-        panel_args.title,
-        panel_args.id.0
-    );
-    Ok(build_terminal_panel(
-        panel_args,
-        terminal,
-        Some(SshConnectionStatus::Disconnected),
-    ))
-}
-
 #[expect(
     clippy::too_many_arguments,
     reason = "terminal launch resolution needs the saved runtime-state metadata plus transcript context"
@@ -459,64 +213,6 @@ fn resolve_terminal_launch(
         program,
         launch_args,
     }
-}
-
-fn build_terminal_panel(
-    panel_args: TerminalPanelBuildArgs,
-    terminal: Terminal,
-    ssh_status: Option<SshConnectionStatus>,
-) -> Panel {
-    let TerminalPanelBuildArgs {
-        id,
-        local_id,
-        title,
-        kind,
-        resume,
-        position,
-        size,
-        workspace_id,
-        session_binding,
-        template,
-        has_custom_name,
-        launch_command,
-        launch_args,
-        launch_cwd,
-        ssh_connection,
-    } = panel_args;
-    Panel {
-        id,
-        local_id,
-        title,
-        kind,
-        resume,
-        layout: PanelLayout {
-            position: position.unwrap_or_default(),
-            size: size.unwrap_or(DEFAULT_PANEL_SIZE),
-        },
-        visible: true,
-        workspace_id,
-        content: PanelContent::Terminal(terminal),
-        session_binding,
-        template,
-        launched_at_millis: current_unix_millis(),
-        has_custom_name,
-        had_recent_output: false,
-        agent_status: AgentStatus::default(),
-        last_output_at_millis: None,
-        terminal_title: String::new(),
-        launch_command,
-        launch_args,
-        launch_cwd,
-        ssh_connection,
-        ssh_status,
-    }
-}
-
-fn default_terminal_title(id: PanelId, ssh_connection: Option<&SshConnection>) -> String {
-    ssh_connection.map_or_else(
-        || format!("Terminal {}", id.0),
-        |connection| format!("SSH: {}", connection.display_label()),
-    )
 }
 
 fn log_terminal_launch(id: PanelId, trace: &TerminalLaunchTrace<'_>) {
@@ -736,34 +432,6 @@ pub fn current_unix_millis() -> i64 {
         .unwrap_or_default()
         .as_millis();
     i64::try_from(now).unwrap_or(i64::MAX)
-}
-
-fn prepare_transcript_restore(
-    id: PanelId,
-    kind: PanelKind,
-    transcript_root: Option<PathBuf>,
-    local_id: &str,
-) -> (Option<PanelTranscript>, Vec<u8>, bool) {
-    let mut transcript = PanelTranscript::for_panel(kind, transcript_root, local_id);
-    let had_persisted_state = transcript.as_ref().is_some_and(PanelTranscript::has_persisted_state);
-    let replay_bytes = if let Some(active_transcript) = transcript.as_ref() {
-        match active_transcript.prepare_replay_bytes() {
-            Ok(bytes) => bytes,
-            Err(error) => {
-                tracing::warn!(
-                    panel_id = id.0,
-                    kind = ?kind,
-                    "failed to prepare persisted transcript, starting fresh shell: {error}"
-                );
-                transcript = None;
-                Vec::new()
-            }
-        }
-    } else {
-        Vec::new()
-    };
-
-    (transcript, replay_bytes, had_persisted_state)
 }
 
 fn resolve_session_binding(

--- a/crates/horizon-core/src/panel/spawn/terminal.rs
+++ b/crates/horizon-core/src/panel/spawn/terminal.rs
@@ -1,0 +1,363 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::agents::AgentStatus;
+use crate::editor::PanelContent;
+use crate::error::Result;
+use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef, new_local_id};
+use crate::ssh::{SshConnection, SshConnectionStatus};
+use crate::terminal::{Terminal, TerminalSpawnOptions};
+use crate::transcript::PanelTranscript;
+use crate::workspace::WorkspaceId;
+
+use super::super::{
+    DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, DEFAULT_PANEL_SIZE, Panel, PanelId, PanelKind, PanelLayout, PanelOptions,
+    PanelResume,
+};
+use super::{
+    ResolvedTerminalLaunch, agent_env, current_unix_millis, default_shell, kitty_keyboard_for_kind,
+    resolve_terminal_launch, scrollback_limit_for_kind,
+};
+
+struct TerminalPanelBuildArgs {
+    id: PanelId,
+    local_id: String,
+    title: String,
+    kind: PanelKind,
+    resume: PanelResume,
+    position: Option<[f32; 2]>,
+    size: Option<[f32; 2]>,
+    workspace_id: WorkspaceId,
+    session_binding: Option<AgentSessionBinding>,
+    template: Option<PanelTemplateRef>,
+    has_custom_name: bool,
+    launch_command: Option<String>,
+    launch_args: Vec<String>,
+    launch_cwd: Option<PathBuf>,
+    ssh_connection: Option<SshConnection>,
+}
+
+pub(in crate::panel) fn restore_failure_panel(
+    id: PanelId,
+    workspace_id: WorkspaceId,
+    opts: PanelOptions,
+    error_message: &str,
+) -> Result<Panel> {
+    let local_id = opts.local_id.clone().unwrap_or_else(new_local_id);
+    let PanelOptions {
+        name,
+        name_is_custom,
+        command,
+        args,
+        cwd,
+        ssh_connection,
+        rows,
+        cols,
+        kind,
+        resume,
+        position,
+        size,
+        session_binding,
+        template,
+        ..
+    } = opts;
+
+    let saved_ssh_connection = ssh_connection.clone();
+    let has_custom_name = name_is_custom.unwrap_or_else(|| name.is_some());
+    let title = name.unwrap_or_else(|| default_terminal_title(id, saved_ssh_connection.as_ref()));
+    let replay_bytes = restore_failure_replay_bytes(&title, error_message);
+    let terminal = spawn_restore_failure_snapshot_terminal(id, kind, rows, cols, replay_bytes)?;
+    let ssh_status = if kind == PanelKind::Ssh {
+        Some(SshConnectionStatus::Disconnected)
+    } else {
+        None
+    };
+
+    Ok(build_terminal_panel(
+        TerminalPanelBuildArgs {
+            id,
+            local_id,
+            title,
+            kind,
+            resume,
+            position,
+            size,
+            workspace_id,
+            session_binding,
+            template,
+            has_custom_name,
+            launch_command: command,
+            launch_args: args,
+            launch_cwd: cwd,
+            ssh_connection: saved_ssh_connection,
+        },
+        terminal,
+        ssh_status,
+    ))
+}
+
+pub(super) fn spawn_terminal(
+    id: PanelId,
+    workspace_id: WorkspaceId,
+    local_id: String,
+    opts: PanelOptions,
+) -> Result<Panel> {
+    let PanelOptions {
+        name,
+        name_is_custom,
+        command,
+        args,
+        cwd,
+        ssh_connection,
+        rows,
+        cols,
+        kind,
+        resume,
+        position,
+        size,
+        session_binding,
+        template,
+        transcript_root,
+        restore_as_disconnected_snapshot,
+        is_restore,
+        ..
+    } = opts;
+
+    let (transcript, replay_bytes, had_persisted_transcript_state) =
+        prepare_transcript_restore(id, kind, transcript_root, &local_id);
+    let saved_command = command.clone();
+    let saved_args = args.clone();
+    let saved_cwd = cwd.clone();
+    let saved_ssh_connection = ssh_connection.clone();
+    let resolved_launch = resolve_terminal_launch(
+        id,
+        kind,
+        &resume,
+        name.as_deref(),
+        command,
+        args,
+        ssh_connection,
+        session_binding,
+        saved_cwd.as_ref(),
+        transcript.as_ref(),
+        is_restore,
+    );
+    let ResolvedTerminalLaunch {
+        session_binding,
+        program,
+        launch_args,
+    } = resolved_launch;
+    let has_custom_name = name_is_custom.unwrap_or_else(|| name.is_some());
+    let title = name.unwrap_or_else(|| default_terminal_title(id, saved_ssh_connection.as_ref()));
+    let initial_ssh_status = if kind == PanelKind::Ssh {
+        Some(SshConnectionStatus::Connecting)
+    } else {
+        None
+    };
+    let env = agent_env(kind, &local_id);
+    let panel_args = TerminalPanelBuildArgs {
+        id,
+        local_id,
+        title,
+        kind,
+        resume,
+        position,
+        size,
+        workspace_id,
+        session_binding,
+        template,
+        has_custom_name,
+        launch_command: saved_command,
+        launch_args: saved_args,
+        launch_cwd: saved_cwd,
+        ssh_connection: saved_ssh_connection,
+    };
+    if restore_as_disconnected_snapshot && panel_args.kind == PanelKind::Ssh && had_persisted_transcript_state {
+        return spawn_disconnected_ssh_snapshot_panel(panel_args, rows, cols, replay_bytes);
+    }
+    let terminal = Terminal::spawn(TerminalSpawnOptions {
+        program,
+        args: launch_args,
+        cwd,
+        rows,
+        cols,
+        cell_width: DEFAULT_CELL_WIDTH,
+        cell_height: DEFAULT_CELL_HEIGHT,
+        scrollback_limit: scrollback_limit_for_kind(kind),
+        window_id: id.0,
+        replay_bytes,
+        env,
+        kitty_keyboard: kitty_keyboard_for_kind(kind),
+    })?;
+    tracing::info!("created panel '{}' (id={})", panel_args.title, panel_args.id.0);
+    Ok(build_terminal_panel(panel_args, terminal, initial_ssh_status))
+}
+
+fn spawn_restore_failure_snapshot_terminal(
+    id: PanelId,
+    kind: PanelKind,
+    rows: u16,
+    cols: u16,
+    replay_bytes: Vec<u8>,
+) -> Result<Terminal> {
+    let (program, args) = disconnected_snapshot_launch_command();
+    Terminal::spawn(TerminalSpawnOptions {
+        program,
+        args,
+        cwd: None,
+        rows,
+        cols,
+        cell_width: DEFAULT_CELL_WIDTH,
+        cell_height: DEFAULT_CELL_HEIGHT,
+        scrollback_limit: scrollback_limit_for_kind(kind),
+        window_id: id.0,
+        replay_bytes,
+        env: HashMap::new(),
+        kitty_keyboard: kitty_keyboard_for_kind(kind),
+    })
+}
+
+fn restore_failure_replay_bytes(title: &str, error_message: &str) -> Vec<u8> {
+    format!(
+        concat!(
+            "Horizon could not restore this panel.\r\n\r\n",
+            "Panel: {title}\r\n",
+            "Error: {error_message}\r\n\r\n",
+            "Fix the command or binary, then restart the panel.\r\n"
+        ),
+        title = title,
+        error_message = error_message
+    )
+    .into_bytes()
+}
+
+fn spawn_disconnected_snapshot_terminal(id: PanelId, rows: u16, cols: u16, replay_bytes: Vec<u8>) -> Result<Terminal> {
+    let (program, args) = disconnected_snapshot_launch_command();
+    Terminal::spawn(TerminalSpawnOptions {
+        program,
+        args,
+        cwd: None,
+        rows,
+        cols,
+        cell_width: DEFAULT_CELL_WIDTH,
+        cell_height: DEFAULT_CELL_HEIGHT,
+        scrollback_limit: scrollback_limit_for_kind(PanelKind::Ssh),
+        window_id: id.0,
+        replay_bytes,
+        env: HashMap::new(),
+        kitty_keyboard: kitty_keyboard_for_kind(PanelKind::Ssh),
+    })
+}
+
+pub(super) fn disconnected_snapshot_launch_command() -> (String, Vec<String>) {
+    if cfg!(windows) {
+        ("cmd.exe".to_string(), vec!["/C".to_string(), "exit".to_string()])
+    } else {
+        (default_shell(), vec!["-c".to_string(), "exit".to_string()])
+    }
+}
+
+fn spawn_disconnected_ssh_snapshot_panel(
+    panel_args: TerminalPanelBuildArgs,
+    rows: u16,
+    cols: u16,
+    replay_bytes: Vec<u8>,
+) -> Result<Panel> {
+    let terminal = spawn_disconnected_snapshot_terminal(panel_args.id, rows, cols, replay_bytes)?;
+    tracing::info!(
+        "restored disconnected ssh snapshot '{}' (id={})",
+        panel_args.title,
+        panel_args.id.0
+    );
+    Ok(build_terminal_panel(
+        panel_args,
+        terminal,
+        Some(SshConnectionStatus::Disconnected),
+    ))
+}
+
+fn build_terminal_panel(
+    panel_args: TerminalPanelBuildArgs,
+    terminal: Terminal,
+    ssh_status: Option<SshConnectionStatus>,
+) -> Panel {
+    let TerminalPanelBuildArgs {
+        id,
+        local_id,
+        title,
+        kind,
+        resume,
+        position,
+        size,
+        workspace_id,
+        session_binding,
+        template,
+        has_custom_name,
+        launch_command,
+        launch_args,
+        launch_cwd,
+        ssh_connection,
+    } = panel_args;
+    Panel {
+        id,
+        local_id,
+        title,
+        kind,
+        resume,
+        layout: PanelLayout {
+            position: position.unwrap_or_default(),
+            size: size.unwrap_or(DEFAULT_PANEL_SIZE),
+        },
+        visible: true,
+        workspace_id,
+        content: PanelContent::Terminal(terminal),
+        session_binding,
+        template,
+        launched_at_millis: current_unix_millis(),
+        has_custom_name,
+        had_recent_output: false,
+        agent_status: AgentStatus::default(),
+        last_output_at_millis: None,
+        terminal_title: String::new(),
+        launch_command,
+        launch_args,
+        launch_cwd,
+        ssh_connection,
+        ssh_status,
+    }
+}
+
+fn default_terminal_title(id: PanelId, ssh_connection: Option<&SshConnection>) -> String {
+    ssh_connection.map_or_else(
+        || format!("Terminal {}", id.0),
+        |connection| format!("SSH: {}", connection.display_label()),
+    )
+}
+
+pub(super) fn prepare_transcript_restore(
+    id: PanelId,
+    kind: PanelKind,
+    transcript_root: Option<PathBuf>,
+    local_id: &str,
+) -> (Option<PanelTranscript>, Vec<u8>, bool) {
+    let mut transcript = PanelTranscript::for_panel(kind, transcript_root, local_id);
+    let had_persisted_state = transcript.as_ref().is_some_and(PanelTranscript::has_persisted_state);
+    let replay_bytes = if let Some(active_transcript) = transcript.as_ref() {
+        match active_transcript.prepare_replay_bytes() {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::warn!(
+                    panel_id = id.0,
+                    kind = ?kind,
+                    "failed to prepare persisted transcript, starting fresh shell: {error}"
+                );
+                transcript = None;
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    (transcript, replay_bytes, had_persisted_state)
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -50,6 +50,11 @@ back into large multi-purpose modules.
   `board/arrangement/reordering.rs`.
 - Large board test surfaces should live in `board/tests/` topic files so
   `board.rs` can stay focused on production orchestration.
+- `panel.rs` owns panel models and content access; explicit restart logic lives
+  in `panel/lifecycle.rs`. `panel/spawn.rs` keeps content selection and command
+  resolution, while `panel/spawn/terminal.rs` owns terminal construction,
+  transcript restoration and disconnected/failure snapshots. These boundaries
+  preserve existing behavior and do not introduce remote execution ownership.
 - `terminal.rs` should keep the terminal types and shared imports; lifecycle,
   event handling, resize policy, selection logic, and content helpers belong in
   `terminal/` leaf modules.


### PR DESCRIPTION
## Purpose

Prepare the panel lifecycle boundary needed for copy-safe remote client references in #383.

## Changes

- Move panel restart into `panel/lifecycle.rs`.
- Move terminal creation and disconnected/failure restoration into `panel/spawn/terminal.rs`.
- Keep command resolution and static content factories in the existing spawn module; document the focused boundaries.

This is a mechanical prerequisite. Public APIs, command behavior, models, defaults, transcript behavior and existing test bodies are unchanged. No remote lifetime, UI, configuration, provider, dependency or release behavior changes.

## Validation

- Exact-body comparison against base `61c92f2e144ca9ef91f3bf9842152b04e2a4b439` proves all eleven moved function bodies unchanged, with equivalent signatures and effective visibility.
- The panel models/defaults and both complete existing test blocks are byte-identical.
- All 48 focused panel tests pass.
- Full matrix passed on final source and exact commit `4f79f0ee62f47ea2cc67d3d4133764af534140cd`: formatting, maintainability, version sync, default and speech workspace tests, and blocking, strict and advisory Clippy.
- Independent exact-tree full-diff review found no actionable in-scope findings.
- Four source files / 945 changed source lines, plus five architecture documentation lines. Native UI smoke is non-applicable to the proven mechanical move.

This does not complete #383. Follow with integrated remote references and non-local execution guards, then coordinator/task integration and the Remote Environments widget.

Metadata: assigned to the author; ambiguous review label, milestone and project are not selected.
