### PR TITLE
Preserve inert remote workspace client references

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -153,6 +153,7 @@ impl Board {
     ///
     /// Returns an error if the runtime state cannot be restored.
     pub fn from_runtime_state_with_transcripts(state: &RuntimeState, transcript_root: Option<&Path>) -> Result<Self> {
+        state.validate_remote_references()?;
         let mut board = Self::new();
 
         for workspace_state in &state.workspaces {

--- a/crates/horizon-core/src/board/tests/workspace.rs
+++ b/crates/horizon-core/src/board/tests/workspace.rs
@@ -453,6 +453,7 @@ fn restored_empty_workspaces_are_removed_during_cleanup() {
         workspaces: vec![
             WorkspaceState {
                 local_id: "empty".to_string(),
+                remote_workspace: None,
                 name: "empty".to_string(),
                 cwd: None,
                 position: Some([0.0, 40.0]),
@@ -462,6 +463,7 @@ fn restored_empty_workspaces_are_removed_during_cleanup() {
             },
             WorkspaceState {
                 local_id: "filled".to_string(),
+                remote_workspace: None,
                 name: "filled".to_string(),
                 cwd: None,
                 position: Some([640.0, 40.0]),
@@ -469,6 +471,7 @@ fn restored_empty_workspaces_are_removed_during_cleanup() {
                 layout: None,
                 panels: vec![PanelState {
                     local_id: "panel".to_string(),
+                    remote_workspace: None,
                     name: "notes".to_string(),
                     name_is_custom: None,
                     kind: PanelKind::Editor,
@@ -506,6 +509,7 @@ fn restored_workspace_layout_is_preserved_after_panel_recreation() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "grid".to_string(),
+            remote_workspace: None,
             name: "grid".to_string(),
             cwd: None,
             position: Some([0.0, 40.0]),
@@ -514,6 +518,7 @@ fn restored_workspace_layout_is_preserved_after_panel_recreation() {
             panels: vec![
                 PanelState {
                     local_id: "panel-a".to_string(),
+                    remote_workspace: None,
                     name: "a".to_string(),
                     name_is_custom: None,
                     kind: PanelKind::Editor,
@@ -534,6 +539,7 @@ fn restored_workspace_layout_is_preserved_after_panel_recreation() {
                 },
                 PanelState {
                     local_id: "panel-b".to_string(),
+                    remote_workspace: None,
                     name: "b".to_string(),
                     name_is_custom: None,
                     kind: PanelKind::Editor,
@@ -570,6 +576,7 @@ fn persisted_ssh_panels_restore_as_disconnected_snapshots() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "remote".to_string(),
+            remote_workspace: None,
             name: "Remote".to_string(),
             cwd: None,
             position: Some([0.0, 40.0]),
@@ -577,6 +584,7 @@ fn persisted_ssh_panels_restore_as_disconnected_snapshots() {
             layout: None,
             panels: vec![PanelState {
                 local_id: "ssh-panel".to_string(),
+                remote_workspace: None,
                 name: "prod".to_string(),
                 name_is_custom: None,
                 kind: PanelKind::Ssh,
@@ -622,6 +630,7 @@ fn runtime_restore_keeps_remaining_panels_when_one_spawn_fails() {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
             name: "Workspace".to_string(),
+            remote_workspace: None,
             cwd: None,
             position: Some([0.0, 40.0]),
             template: None,
@@ -629,6 +638,7 @@ fn runtime_restore_keeps_remaining_panels_when_one_spawn_fails() {
             panels: vec![
                 PanelState {
                     local_id: "notes".to_string(),
+                    remote_workspace: None,
                     name: "Notes".to_string(),
                     name_is_custom: None,
                     kind: PanelKind::Editor,
@@ -649,6 +659,7 @@ fn runtime_restore_keeps_remaining_panels_when_one_spawn_fails() {
                 },
                 PanelState {
                     local_id: "broken-codex".to_string(),
+                    remote_workspace: None,
                     name: "Broken Codex".to_string(),
                     name_is_custom: None,
                     kind: PanelKind::Codex,

--- a/crates/horizon-core/src/board/workspaces.rs
+++ b/crates/horizon-core/src/board/workspaces.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::layout::WS_COLLISION_GAP;
 use crate::panel::{DEFAULT_PANEL_SIZE, Panel, PanelId, PanelOptions};
 use crate::runtime_state::WorkspaceState;
@@ -81,6 +81,19 @@ impl Board {
         workspace: WorkspaceId,
         spawn_panel: impl FnOnce(PanelId, WorkspaceId, PanelOptions) -> Result<Panel>,
     ) -> Result<PanelId> {
+        if let Some(reference) = self
+            .workspace(workspace)
+            .and_then(|workspace| workspace.remote_workspace.as_ref())
+        {
+            if opts
+                .remote_workspace
+                .as_ref()
+                .is_some_and(|panel_reference| panel_reference != reference)
+            {
+                return Err(Error::State("remote panel reference differs from its workspace".into()));
+            }
+            opts.remote_workspace = Some(reference.clone());
+        }
         let id = PanelId(self.next_panel_id);
         self.next_panel_id += 1;
         let explicit_position = opts.position.is_some();
@@ -192,7 +205,11 @@ impl Board {
         if let Some(ws_id) = ws_id {
             let is_empty = self.workspaces.iter().any(|ws| ws.id == ws_id && ws.panels.is_empty());
             if is_empty {
-                if !self.retained_empty_workspaces.contains(&ws_id) {
+                if !self.retained_empty_workspaces.contains(&ws_id)
+                    && self
+                        .workspace(ws_id)
+                        .is_none_or(|workspace| workspace.remote_workspace.is_none())
+                {
                     self.workspaces.retain(|ws| ws.id != ws_id);
                     self.attention.retain(|item| item.workspace_id != ws_id);
                     if self.active_workspace == Some(ws_id) {
@@ -244,7 +261,23 @@ impl Board {
             return;
         }
 
-        let Some(target_id) = self.workspaces.iter().find(|ws| ws.id != id).map(|ws| ws.id) else {
+        let Some(target_id) = self
+            .workspaces
+            .iter()
+            .find(|ws| {
+                ws.id != id
+                    && self
+                        .panels
+                        .iter()
+                        .filter(|panel| panel.workspace_id == id)
+                        .all(|panel| {
+                            ws.remote_workspace
+                                .as_ref()
+                                .is_none_or(|reference| panel.remote_workspace() == Some(reference))
+                        })
+            })
+            .map(|ws| ws.id)
+        else {
             return;
         };
 
@@ -269,6 +302,13 @@ impl Board {
             return;
         };
         if source_workspace_id == workspace_id || self.workspace(workspace_id).is_none() {
+            return;
+        }
+        if let Some(reference) = self
+            .workspace(workspace_id)
+            .and_then(|workspace| workspace.remote_workspace.as_ref())
+            && self.panel(panel_id).and_then(Panel::remote_workspace) != Some(reference)
+        {
             return;
         }
 
@@ -337,7 +377,11 @@ impl Board {
         let empty_ids: Vec<_> = self
             .workspaces
             .iter()
-            .filter(|ws| ws.panels.is_empty() && !self.retained_empty_workspaces.contains(&ws.id))
+            .filter(|ws| {
+                ws.panels.is_empty()
+                    && ws.remote_workspace.is_none()
+                    && !self.retained_empty_workspaces.contains(&ws.id)
+            })
             .map(|ws| ws.id)
             .collect();
         for ws_id in empty_ids {
@@ -555,6 +599,7 @@ impl Board {
         let id = self.create_workspace(&workspace_state.name);
         if let Some(workspace) = self.workspace_mut(id) {
             workspace.local_id.clone_from(&workspace_state.local_id);
+            workspace.remote_workspace.clone_from(&workspace_state.remote_workspace);
             workspace.position = workspace_state.position.unwrap_or(workspace.position);
             workspace.cwd = workspace_state.cwd.as_deref().map(Config::expand_tilde);
             workspace.template.clone_from(&workspace_state.template);

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -66,8 +66,8 @@ pub use remote_hosts::{
 };
 pub use runtime_state::{
     AgentSessionBinding, AgentSessionBootstrapCatalog, AgentSessionCatalog, AgentSessionKey, AgentSessionRecord,
-    BrowserProfileState, DetachedWorkspaceState, PanelState, PanelTemplateRef, RuntimeState, WorkspaceState,
-    WorkspaceTemplateRef, live_claude_session_ids, new_local_id,
+    BrowserProfileState, DetachedWorkspaceState, PanelState, PanelTemplateRef, RemoteWorkspaceReference, RuntimeState,
+    WorkspaceState, WorkspaceTemplateRef, live_claude_session_ids, new_local_id,
 };
 pub use search::{PanelSearchResult, SearchMatch, SearchOptions, SearchResults, search_board};
 pub use session_store::{

--- a/crates/horizon-core/src/panel.rs
+++ b/crates/horizon-core/src/panel.rs
@@ -12,7 +12,7 @@ use crate::agents::{AGENT_WORKING_SCAN_ROWS, AgentStatus, is_agent_working_line}
 use crate::editor::{MarkdownEditor, PanelContent};
 use crate::error::Result;
 use crate::git_changes::DiffViewer;
-use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef};
+use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef, RemoteWorkspaceReference};
 use crate::ssh::{SshConnection, SshConnectionStatus};
 use crate::terminal::{AgentNotification, Terminal};
 #[cfg(test)]
@@ -146,6 +146,7 @@ pub struct PanelOptions {
     /// Whether the panel participates in layout, rendering, and input.
     pub visible: bool,
     pub local_id: Option<String>,
+    pub remote_workspace: Option<RemoteWorkspaceReference>,
     pub session_binding: Option<AgentSessionBinding>,
     pub template: Option<PanelTemplateRef>,
     /// Active `browser` config section, so spawn honors `--config` and
@@ -175,6 +176,7 @@ impl Default for PanelOptions {
             size: None,
             visible: true,
             local_id: None,
+            remote_workspace: None,
             session_binding: None,
             template: None,
             browser_config: None,
@@ -188,6 +190,7 @@ impl Default for PanelOptions {
 pub struct Panel {
     pub id: PanelId,
     pub local_id: String,
+    remote_workspace: Option<RemoteWorkspaceReference>,
     pub title: String,
     pub terminal_title: String,
     pub kind: PanelKind,
@@ -236,6 +239,12 @@ pub struct PanelProcessOutput {
 }
 
 impl Panel {
+    /// Execution identity is independent of the panel's visual workspace.
+    #[must_use]
+    pub fn remote_workspace(&self) -> Option<&RemoteWorkspaceReference> {
+        self.remote_workspace.as_ref()
+    }
+
     /// Convenience accessor for the terminal content (if this panel holds one).
     #[must_use]
     pub fn terminal(&self) -> Option<&Terminal> {
@@ -319,6 +328,7 @@ impl Panel {
         Self {
             id,
             local_id: format!("panel-{}", id.0),
+            remote_workspace: None,
             title: kind.display_name().to_string(),
             terminal_title: String::new(),
             kind,
@@ -696,6 +706,7 @@ mod tests {
         Panel {
             id: PanelId(1),
             local_id: "panel-1".to_string(),
+            remote_workspace: None,
             title: title.to_string(),
             terminal_title: terminal_title.to_string(),
             kind: PanelKind::Usage,

--- a/crates/horizon-core/src/panel/lifecycle.rs
+++ b/crates/horizon-core/src/panel/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::editor::{MarkdownEditor, PanelContent};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::runtime_state::claude_session_transcript_exists;
 use crate::ssh::SshConnectionStatus;
 use crate::terminal::{Terminal, TerminalSpawnOptions};
@@ -25,6 +25,11 @@ impl Panel {
     /// Returns an error if a terminal cannot be spawned or a file-backed
     /// editor cannot be reopened.
     pub fn restart(&mut self) -> Result<()> {
+        if self.remote_workspace.is_some() {
+            return Err(Error::State(
+                "Remote connection pending. Restart cannot run this remote task locally.".into(),
+            ));
+        }
         if let PanelContent::GitChanges(_) = &self.content {
             return Ok(());
         }

--- a/crates/horizon-core/src/panel/spawn.rs
+++ b/crates/horizon-core/src/panel/spawn.rs
@@ -98,6 +98,7 @@ impl StaticPanelSeed {
         Panel {
             id: self.id,
             local_id: self.local_id,
+            remote_workspace: None,
             title,
             terminal_title: String::new(),
             kind,
@@ -126,6 +127,9 @@ impl StaticPanelSeed {
 }
 
 pub(super) fn spawn_panel(id: PanelId, workspace_id: WorkspaceId, mut opts: PanelOptions) -> Result<Panel> {
+    if opts.remote_workspace.is_some() {
+        return restore_failure_panel(id, workspace_id, opts, "Remote connection pending");
+    }
     let local_id = opts.local_id.clone().unwrap_or_else(new_local_id);
 
     match opts.kind {

--- a/crates/horizon-core/src/panel/spawn/terminal.rs
+++ b/crates/horizon-core/src/panel/spawn/terminal.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::agents::AgentStatus;
 use crate::editor::PanelContent;
 use crate::error::Result;
-use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef, new_local_id};
+use crate::runtime_state::{AgentSessionBinding, PanelTemplateRef, RemoteWorkspaceReference, new_local_id};
 use crate::ssh::{SshConnection, SshConnectionStatus};
 use crate::terminal::{Terminal, TerminalSpawnOptions};
 use crate::transcript::PanelTranscript;
@@ -22,6 +22,7 @@ use super::{
 struct TerminalPanelBuildArgs {
     id: PanelId,
     local_id: String,
+    remote_workspace: Option<RemoteWorkspaceReference>,
     title: String,
     kind: PanelKind,
     resume: PanelResume,
@@ -44,6 +45,19 @@ pub(in crate::panel) fn restore_failure_panel(
     error_message: &str,
 ) -> Result<Panel> {
     let local_id = opts.local_id.clone().unwrap_or_else(new_local_id);
+    if opts.remote_workspace.is_some() {
+        RemoteWorkspaceReference::validate_client_panel(
+            &local_id,
+            opts.kind,
+            &opts.resume,
+            opts.session_binding.as_ref(),
+        )?;
+    }
+    let remote_replay = opts.remote_workspace.as_ref().map(|_| {
+        let (_, mut replay, _) = prepare_transcript_restore(id, opts.kind, opts.transcript_root.clone(), &local_id);
+        replay.extend_from_slice(b"\r\nRemote connection pending.\r\nThis saved view has not started its task locally.\r\nLocal Restart cannot launch a remote task.\r\n");
+        replay
+    });
     let PanelOptions {
         name,
         name_is_custom,
@@ -59,14 +73,24 @@ pub(in crate::panel) fn restore_failure_panel(
         size,
         session_binding,
         template,
+        remote_workspace,
         ..
     } = opts;
 
     let saved_ssh_connection = ssh_connection.clone();
     let has_custom_name = name_is_custom.unwrap_or_else(|| name.is_some());
     let title = name.unwrap_or_else(|| default_terminal_title(id, saved_ssh_connection.as_ref()));
-    let replay_bytes = restore_failure_replay_bytes(&title, error_message);
-    let terminal = spawn_restore_failure_snapshot_terminal(id, kind, rows, cols, replay_bytes)?;
+    let terminal = if let Some(replay) = remote_replay {
+        spawn_remote_snapshot_terminal(id, rows, cols, replay)?
+    } else {
+        spawn_restore_failure_snapshot_terminal(
+            id,
+            kind,
+            rows,
+            cols,
+            restore_failure_replay_bytes(&title, error_message),
+        )?
+    };
     let ssh_status = if kind == PanelKind::Ssh {
         Some(SshConnectionStatus::Disconnected)
     } else {
@@ -77,6 +101,7 @@ pub(in crate::panel) fn restore_failure_panel(
         TerminalPanelBuildArgs {
             id,
             local_id,
+            remote_workspace,
             title,
             kind,
             resume,
@@ -158,6 +183,7 @@ pub(super) fn spawn_terminal(
     let panel_args = TerminalPanelBuildArgs {
         id,
         local_id,
+        remote_workspace: None,
         title,
         kind,
         resume,
@@ -191,6 +217,28 @@ pub(super) fn spawn_terminal(
     })?;
     tracing::info!("created panel '{}' (id={})", panel_args.title, panel_args.id.0);
     Ok(build_terminal_panel(panel_args, terminal, initial_ssh_status))
+}
+
+fn spawn_remote_snapshot_terminal(id: PanelId, rows: u16, cols: u16, replay_bytes: Vec<u8>) -> Result<Terminal> {
+    let (program, args) = if cfg!(windows) {
+        ("cmd.exe", vec!["/D".into(), "/C".into(), "exit".into()])
+    } else {
+        ("/bin/sh", vec!["-c".into(), "exit".into()])
+    };
+    Terminal::spawn(TerminalSpawnOptions {
+        program: program.into(),
+        args,
+        cwd: None,
+        rows,
+        cols,
+        cell_width: DEFAULT_CELL_WIDTH,
+        cell_height: DEFAULT_CELL_HEIGHT,
+        scrollback_limit: scrollback_limit_for_kind(PanelKind::Ssh),
+        window_id: id.0,
+        replay_bytes,
+        env: HashMap::new(),
+        kitty_keyboard: false,
+    })
 }
 
 fn spawn_restore_failure_snapshot_terminal(
@@ -284,6 +332,7 @@ fn build_terminal_panel(
     let TerminalPanelBuildArgs {
         id,
         local_id,
+        remote_workspace,
         title,
         kind,
         resume,
@@ -301,6 +350,7 @@ fn build_terminal_panel(
     Panel {
         id,
         local_id,
+        remote_workspace,
         title,
         kind,
         resume,
@@ -349,7 +399,7 @@ pub(super) fn prepare_transcript_restore(
                 tracing::warn!(
                     panel_id = id.0,
                     kind = ?kind,
-                    "failed to prepare persisted transcript, starting fresh shell: {error}"
+                    "failed to prepare persisted transcript: {error}"
                 );
                 transcript = None;
                 Vec::new()

--- a/crates/horizon-core/src/runtime_state.rs
+++ b/crates/horizon-core/src/runtime_state.rs
@@ -15,6 +15,7 @@ use crate::config::{Config, WindowConfig};
 use crate::error::{Error, Result};
 use crate::layout::workspace_slot_width;
 use crate::panel::PanelKind;
+use crate::remote_workspace::valid_local_id;
 use crate::terminal::Terminal;
 use crate::view::CanvasViewState;
 
@@ -22,10 +23,10 @@ pub use agent_sessions::{AgentSessionBootstrapCatalog, AgentSessionCatalog, Agen
 pub use claude_live_sessions::{claude_session_transcript_exists, live_claude_session_ids};
 pub use models::{
     AgentSessionBinding, AgentSessionKey, BrowserProfileState, DetachedWorkspaceState, PanelState, PanelTemplateRef,
-    WorkspaceState, WorkspaceTemplateRef,
+    RemoteWorkspaceReference, WorkspaceState, WorkspaceTemplateRef,
 };
 
-const RUNTIME_STATE_VERSION: u32 = 2;
+const RUNTIME_STATE_VERSION: u32 = 3;
 const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_COLS: u16 = 80;
 const MAX_CLAUDE_SESSION_FILES: usize = 64;
@@ -40,7 +41,7 @@ const PI_SESSION_TAIL_BYTES: u64 = 64 * 1024;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RuntimeState {
-    #[serde(with = "versioning")]
+    #[serde(default = "legacy_runtime_version", with = "versioning")]
     pub version: u32,
     pub window: Option<WindowConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -101,6 +102,7 @@ impl RuntimeState {
 
         let content = std::fs::read_to_string(path)?;
         let mut state = serde_yaml::from_str::<Self>(&content).map_err(|error| Error::State(error.to_string()))?;
+        state.validate_remote_references()?;
         state.ensure_local_ids();
         state.migrate_canvas_view();
         state.version = RUNTIME_STATE_VERSION;
@@ -113,6 +115,7 @@ impl RuntimeState {
     ///
     /// Returns an error if serialization fails or the state version is unsupported.
     pub fn to_yaml(&self) -> Result<String> {
+        self.validate_remote_references()?;
         serde_yaml::to_string(self).map_err(|error| Error::State(error.to_string()))
     }
 
@@ -135,6 +138,11 @@ impl RuntimeState {
     }
 
     pub fn ensure_local_ids(&mut self) {
+        // Remote-bearing snapshots require complete identities. Never repair away
+        // an invalid binding before the load/save/restore validation boundary.
+        if self.has_remote_references() {
+            return;
+        }
         if self.version == 0 {
             self.version = RUNTIME_STATE_VERSION;
         }
@@ -164,6 +172,52 @@ impl RuntimeState {
                 }
             }
         }
+    }
+
+    fn has_remote_references(&self) -> bool {
+        self.workspaces.iter().any(|workspace| {
+            workspace.remote_workspace.is_some()
+                || workspace.panels.iter().any(|panel| panel.remote_workspace.is_some())
+        })
+    }
+
+    /// Validate client references without provider I/O or ownership adoption.
+    /// # Errors
+    /// Remote-bearing snapshots require version 3, unique stable identities and
+    /// SSH views with no local agent resume or incompatible workspace reference.
+    pub fn validate_remote_references(&self) -> Result<()> {
+        if !self.has_remote_references() {
+            return Ok(());
+        }
+        if self.version != RUNTIME_STATE_VERSION {
+            return Err(Error::State("remote references require runtime state version 3".into()));
+        }
+        let mut workspace_ids = HashSet::new();
+        let mut panel_ids = HashSet::new();
+        for workspace in &self.workspaces {
+            if !valid_local_id(&workspace.local_id) || !workspace_ids.insert(&workspace.local_id) {
+                return Err(Error::State(
+                    "invalid or duplicate remote-view workspace identity".into(),
+                ));
+            }
+            for panel in &workspace.panels {
+                if !valid_local_id(&panel.local_id) || !panel_ids.insert(&panel.local_id) {
+                    return Err(Error::State("invalid or duplicate remote-view panel identity".into()));
+                }
+                if workspace.remote_workspace.is_some() && panel.remote_workspace != workspace.remote_workspace {
+                    return Err(Error::State("remote panel reference differs from its workspace".into()));
+                }
+                if panel.remote_workspace.is_some() {
+                    RemoteWorkspaceReference::validate_client_panel(
+                        &panel.local_id,
+                        panel.kind,
+                        &panel.resume,
+                        panel.session_binding.as_ref(),
+                    )?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Give browser panels fresh process-artifact identities when a persisted
@@ -222,6 +276,7 @@ impl RuntimeState {
 
                         PanelState {
                             local_id: panel.local_id.clone(),
+                            remote_workspace: panel.remote_workspace().cloned(),
                             name: panel.title.clone(),
                             name_is_custom: Some(panel.name_is_custom()),
                             kind: panel.kind,
@@ -262,6 +317,7 @@ impl RuntimeState {
 
                 WorkspaceState {
                     local_id: workspace.local_id.clone(),
+                    remote_workspace: workspace.remote_workspace.clone(),
                     name: workspace.name.clone(),
                     cwd: workspace.cwd.as_ref().map(|path| path.display().to_string()),
                     position: Some(workspace.position),
@@ -292,6 +348,10 @@ impl RuntimeState {
             browser: crate::browser::BrowserConfig::default(),
         }
     }
+}
+
+fn legacy_runtime_version() -> u32 {
+    0
 }
 
 impl Default for RuntimeState {

--- a/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
+++ b/crates/horizon-core/src/runtime_state/agent_sessions/tests.rs
@@ -158,6 +158,7 @@ fn bootstrap_assigns_distinct_sessions_per_group() {
     let mut state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "termgalore".to_string(),
             cwd: Some("/repo".to_string()),
             position: None,
@@ -276,6 +277,7 @@ fn bootstrap_never_assigns_sessions_open_in_other_processes() {
     let mut state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "termgalore".to_string(),
             cwd: Some("/repo".to_string()),
             position: None,

--- a/crates/horizon-core/src/runtime_state/models.rs
+++ b/crates/horizon-core/src/runtime_state/models.rs
@@ -1,13 +1,93 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Deserializer, Serialize};
+use uuid::Uuid;
 
 use crate::board::WorkspaceLayout;
 use crate::config::{Config, TerminalConfig, WindowConfig, WorkspaceConfig};
+use crate::error::{Error, Result};
 use crate::panel::{PanelKind, PanelOptions, PanelResume};
+use crate::remote_workspace::valid_local_id;
 use crate::ssh::SshConnection;
 
 use super::{DEFAULT_COLS, DEFAULT_ROWS, new_local_id, normalize_cwd};
+
+/// A client reference, never an allocation grant or proof of ownership.
+/// Remote task kinds and agent resumes live in the separately owned aggregate;
+/// client panels are SSH transport views, not local agent sessions.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(try_from = "RemoteReferenceFields")]
+pub struct RemoteWorkspaceReference {
+    owner_session_id: String,
+    workspace_local_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteReferenceFields {
+    owner_session_id: String,
+    workspace_local_id: String,
+}
+
+impl RemoteWorkspaceReference {
+    /// Create an inert reference with canonical identities.
+    /// # Errors
+    /// Rejects malformed, nil or noncanonical owner UUIDs and invalid workspace ids.
+    pub fn new(owner_session_id: String, workspace_local_id: String) -> Result<Self> {
+        let valid_owner =
+            Uuid::parse_str(&owner_session_id).is_ok_and(|id| !id.is_nil() && id.to_string() == owner_session_id);
+        if !valid_owner || !valid_local_id(&workspace_local_id) {
+            return Err(Error::State("invalid remote workspace reference".into()));
+        }
+        Ok(Self {
+            owner_session_id,
+            workspace_local_id,
+        })
+    }
+
+    /// Claimed owner only. Callers must compare the actual resolved client session
+    /// before using that session for the store's exact-owner lookup.
+    #[must_use]
+    pub fn owner_session_id(&self) -> &str {
+        &self.owner_session_id
+    }
+
+    #[must_use]
+    pub fn workspace_local_id(&self) -> &str {
+        &self.workspace_local_id
+    }
+
+    pub(crate) fn validate_client_panel(
+        local_id: &str,
+        kind: PanelKind,
+        resume: &PanelResume,
+        binding: Option<&AgentSessionBinding>,
+    ) -> Result<()> {
+        if !valid_local_id(local_id) || kind != PanelKind::Ssh || *resume != PanelResume::Fresh || binding.is_some() {
+            return Err(Error::State(
+                "remote client panels require a stable SSH view without local agent bindings".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<RemoteReferenceFields> for RemoteWorkspaceReference {
+    type Error = Error;
+
+    fn try_from(fields: RemoteReferenceFields) -> Result<Self> {
+        Self::new(fields.owner_session_id, fields.workspace_local_id)
+    }
+}
+
+fn deserialize_remote_reference<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<RemoteWorkspaceReference>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    RemoteWorkspaceReference::deserialize(deserializer).map(Some)
+}
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -20,6 +100,12 @@ pub struct DetachedWorkspaceState {
 #[serde(default)]
 pub struct WorkspaceState {
     pub local_id: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_remote_reference"
+    )]
+    pub remote_workspace: Option<RemoteWorkspaceReference>,
     pub name: String,
     pub cwd: Option<String>,
     pub position: Option<[f32; 2]>,
@@ -86,6 +172,7 @@ impl WorkspaceState {
 
         Self {
             local_id: new_local_id(),
+            remote_workspace: None,
             name: workspace.name.clone(),
             cwd: workspace_cwd,
             position: Some(resolved_position),
@@ -103,6 +190,12 @@ impl WorkspaceState {
 #[serde(default)]
 pub struct PanelState {
     pub local_id: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_remote_reference"
+    )]
+    pub remote_workspace: Option<RemoteWorkspaceReference>,
     pub name: String,
     /// Whether `name` was explicitly chosen rather than generated. Missing
     /// values retain the legacy restore behavior for older runtime snapshots.
@@ -198,6 +291,7 @@ impl PanelState {
 
         Self {
             local_id: new_local_id(),
+            remote_workspace: None,
             name: panel.name.clone(),
             name_is_custom: Some(!panel.name.is_empty()),
             kind: panel.kind,
@@ -267,6 +361,7 @@ impl PanelState {
             size: self.size,
             visible: self.browser_profile.as_ref().is_none_or(|profile| !profile.hidden),
             local_id: Some(self.local_id.clone()),
+            remote_workspace: self.remote_workspace.clone(),
             session_binding: self.session_binding.clone(),
             template: self.template.clone(),
             browser_config: (self.kind == PanelKind::Browser).then(|| self.browser_config_for_restore(browser_config)),
@@ -281,6 +376,7 @@ impl Default for PanelState {
     fn default() -> Self {
         Self {
             local_id: String::new(),
+            remote_workspace: None,
             name: String::new(),
             name_is_custom: None,
             kind: PanelKind::default(),

--- a/crates/horizon-core/src/runtime_state/tests/mod.rs
+++ b/crates/horizon-core/src/runtime_state/tests/mod.rs
@@ -1,4 +1,5 @@
 mod panels;
+mod remote_references;
 mod versioning;
 mod workspaces;
 

--- a/crates/horizon-core/src/runtime_state/tests/remote_references.rs
+++ b/crates/horizon-core/src/runtime_state/tests/remote_references.rs
@@ -1,0 +1,452 @@
+use super::*;
+use crate::cloud_run::{CloudProvider, CloudWorkflowStore, GitCommitSha, GitSource, WorkerLifetime, WorkerTarget};
+use crate::remote_workspace::{RemotePanelBinding, RemoteWorkspaceSpec, RemoteWorkspaceState};
+use crate::{HorizonHome, Panel, PanelId, SessionStore, WorkspaceId};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+
+fn reference(owner: &str) -> RemoteWorkspaceReference {
+    RemoteWorkspaceReference::new(owner.into(), "remote-environment".into()).expect("reference")
+}
+
+fn snapshot(owner: &str) -> RuntimeState {
+    RuntimeState {
+        workspaces: vec![WorkspaceState {
+            local_id: "remote-view".into(),
+            name: "Remote workspace".into(),
+            remote_workspace: Some(reference(owner)),
+            panels: vec![PanelState {
+                local_id: "remote-panel".into(),
+                name: "Remote task".into(),
+                kind: PanelKind::Ssh,
+                remote_workspace: Some(reference(owner)),
+                ..PanelState::default()
+            }],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    }
+}
+
+fn marker_command(path: &Path) -> (String, Vec<String>) {
+    if cfg!(windows) {
+        (
+            "cmd.exe".into(),
+            vec![
+                "/D".into(),
+                "/C".into(),
+                format!("echo unexpected>\"{}\"", path.display()),
+            ],
+        )
+    } else {
+        (
+            "/bin/sh".into(),
+            vec![
+                "-c".into(),
+                ": > \"$1\"".into(),
+                "marker".into(),
+                path.display().to_string(),
+            ],
+        )
+    }
+}
+
+#[test]
+fn reference_serialization_rejects_ambiguous_or_malformed_identity() {
+    let original = reference(OWNER);
+    let value = serde_json::to_value(&original).expect("reference value");
+    assert_eq!(
+        value,
+        json!({"owner_session_id": OWNER, "workspace_local_id": "remote-environment"})
+    );
+    assert_eq!(
+        serde_json::from_value::<RemoteWorkspaceReference>(value.clone()).expect("roundtrip"),
+        original
+    );
+    for invalid in [
+        Value::Null,
+        json!({}),
+        json!({"owner_session_id": OWNER, "workspace_local_id": "../escape"}),
+        json!({"owner_session_id": "00000000-0000-0000-0000-000000000000", "workspace_local_id": "remote"}),
+        json!({"owner_session_id": "11111111111141118111111111111111", "workspace_local_id": "remote"}),
+        json!({"owner_session_id": "not-a-session", "workspace_local_id": "remote"}),
+        json!({"owner_session_id": OWNER, "workspace_local_id": "remote", "grant": true}),
+    ] {
+        assert!(serde_json::from_value::<RemoteWorkspaceReference>(invalid).is_err());
+    }
+    let duplicate = format!("owner_session_id: {OWNER}\nowner_session_id: {OWNER}\nworkspace_local_id: remote\n");
+    assert!(serde_yaml::from_str::<RemoteWorkspaceReference>(&duplicate).is_err());
+    for field_path in [
+        "/workspaces/0/remote_workspace",
+        "/workspaces/0/panels/0/remote_workspace",
+    ] {
+        let mut state = serde_json::to_value(snapshot(OWNER)).expect("state value");
+        *state.pointer_mut(field_path).expect("reference field") = Value::Null;
+        assert!(serde_json::from_value::<RuntimeState>(state).is_err());
+    }
+}
+
+#[test]
+fn remote_snapshots_require_explicit_current_version_and_unrepaired_ids() {
+    let directory = tempfile::tempdir().expect("directory");
+    let path = directory.path().join("runtime.yaml");
+    let original = snapshot(OWNER).to_yaml().expect("snapshot");
+    for version in [None, Some(0), Some(1), Some(2)] {
+        let header = version.map_or_else(String::new, |value| format!("version: {value}\n"));
+        let yaml = original.replacen("version: 3\n", &header, 1);
+        std::fs::write(&path, &yaml).expect("fixture");
+        assert!(RuntimeState::load(&path).is_err());
+        assert_eq!(std::fs::read_to_string(&path).expect("retained"), yaml);
+    }
+    for invalid in invalid_snapshots() {
+        let yaml = serde_yaml::to_string(&invalid).expect("invalid fixture");
+        let mut unmodified = invalid.clone();
+        unmodified.ensure_local_ids();
+        assert_eq!(serde_yaml::to_string(&unmodified).expect("identity retained"), yaml);
+        assert!(invalid.to_yaml().is_err());
+        assert!(Board::from_runtime_state(&invalid).is_err());
+        std::fs::write(&path, &yaml).expect("fixture");
+        assert!(RuntimeState::load(&path).is_err());
+        assert_eq!(std::fs::read_to_string(&path).expect("retained"), yaml);
+    }
+}
+
+fn invalid_snapshots() -> Vec<RuntimeState> {
+    let mut missing_workspace = snapshot(OWNER);
+    missing_workspace.workspaces[0].local_id.clear();
+    let mut missing_panel = snapshot(OWNER);
+    missing_panel.workspaces[0].panels[0].local_id.clear();
+    let mut duplicate_workspace = snapshot(OWNER);
+    duplicate_workspace
+        .workspaces
+        .push(duplicate_workspace.workspaces[0].clone());
+    let mut duplicate_panel = snapshot(OWNER);
+    let repeated = duplicate_panel.workspaces[0].panels[0].clone();
+    duplicate_panel.workspaces[0].panels.push(repeated);
+    let mut missing_reference = snapshot(OWNER);
+    missing_reference.workspaces[0].panels[0].remote_workspace = None;
+    let mut wrong_reference = snapshot(OWNER);
+    wrong_reference.workspaces[0].panels[0].remote_workspace = Some(reference("22222222-2222-4222-8222-222222222222"));
+    vec![
+        missing_workspace,
+        missing_panel,
+        duplicate_workspace,
+        duplicate_panel,
+        missing_reference,
+        wrong_reference,
+    ]
+}
+
+#[test]
+fn remote_views_never_execute_saved_commands_on_restore_or_restart() {
+    let directory = tempfile::tempdir().expect("directory");
+    let marker = directory.path().join("must-not-run");
+    let (program, args) = marker_command(&marker);
+    let mut state = snapshot(OWNER);
+    state.workspaces[0].panels[0].command = Some(program.clone());
+    state.workspaces[0].panels[0].args.clone_from(&args);
+    for transcript_root in [None, Some(directory.path())] {
+        if transcript_root.is_some() {
+            std::fs::write(directory.path().join("remote-panel.bin"), b"Retained remote output\r\n")
+                .expect("transcript");
+        }
+        let mut board = Board::from_runtime_state_with_transcripts(&state, transcript_root).expect("deferred board");
+        let panel = &mut board.panels[0];
+        assert!(panel.wait_for_shutdown(Duration::from_secs(2)));
+        assert!(!marker.exists());
+        let content = panel.terminal().expect("snapshot terminal").last_lines_text(24);
+        assert!(content.contains("Remote connection pending"));
+        assert_eq!(content.contains("Retained remote output"), transcript_root.is_some());
+        let identity = panel.id;
+        assert!(
+            panel
+                .restart()
+                .expect_err("remote restart blocked")
+                .to_string()
+                .contains("locally")
+        );
+        assert!(board.restart_panel(identity).is_err());
+        let saved = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+        assert_eq!(
+            saved.workspaces[0].remote_workspace,
+            state.workspaces[0].remote_workspace
+        );
+        assert_eq!(
+            saved.workspaces[0].panels[0].remote_workspace,
+            state.workspaces[0].panels[0].remote_workspace
+        );
+        assert_eq!(saved.workspaces[0].panels[0].command.as_deref(), Some(program.as_str()));
+        assert_eq!(saved.workspaces[0].panels[0].args, args);
+        assert!(!marker.exists());
+    }
+    let mut control = Panel::spawn(
+        PanelId(9),
+        WorkspaceId(9),
+        PanelOptions {
+            kind: PanelKind::Ssh,
+            command: Some(program),
+            args,
+            ..PanelOptions::default()
+        },
+    )
+    .expect("ordinary SSH command positive control");
+    assert!(control.wait_for_shutdown(Duration::from_secs(2)));
+    assert!(marker.exists(), "the same unguarded saved command really executes");
+}
+
+#[test]
+fn remote_views_reject_local_content_factories_and_agent_bindings() {
+    for kind in [
+        PanelKind::Shell,
+        PanelKind::Command,
+        PanelKind::Claude,
+        PanelKind::Codex,
+        PanelKind::Pi,
+        PanelKind::OpenCode,
+        PanelKind::Gemini,
+        PanelKind::KiloCode,
+        PanelKind::Grok,
+        PanelKind::Editor,
+        PanelKind::GitChanges,
+        PanelKind::Usage,
+        PanelKind::Browser,
+    ] {
+        let mut state = snapshot(OWNER);
+        state.workspaces[0].panels[0].kind = kind;
+        assert!(state.to_yaml().is_err());
+        assert!(Board::from_runtime_state(&state).is_err());
+        let options = state.workspaces[0].panels[0].to_panel_options(&state.browser);
+        assert!(Panel::spawn(PanelId(1), WorkspaceId(1), options).is_err());
+    }
+    let mut state = snapshot(OWNER);
+    assert!(!state.needs_agent_binding_bootstrap());
+    assert!(!state.normalize_agent_bindings(&HashSet::new()));
+    state.workspaces[0].panels[0].resume = PanelResume::Last;
+    assert!(state.to_yaml().is_err());
+    state.workspaces[0].panels[0].resume = PanelResume::Fresh;
+    state.workspaces[0].panels[0].session_binding = Some(AgentSessionBinding::new(
+        PanelKind::Pi,
+        "remote-task".into(),
+        None,
+        None,
+        None,
+    ));
+    assert!(state.to_yaml().is_err());
+}
+
+#[test]
+fn moving_or_closing_views_preserves_remote_identity_and_empty_workspaces() {
+    let mut board = Board::from_runtime_state(&snapshot(OWNER)).expect("board");
+    let remote_id = board.workspaces[0].id;
+    let panel_id = board.panels[0].id;
+    let local_id = board.create_workspace("Local");
+    board.assign_panel_to_workspace(panel_id, local_id);
+    assert_eq!(
+        board.panel(panel_id).expect("moved").remote_workspace(),
+        Some(&reference(OWNER))
+    );
+    board.remove_empty_workspaces();
+    assert!(board.workspace(remote_id).is_some());
+    let detached = vec![DetachedWorkspaceState {
+        workspace_local_id: "remote-view".into(),
+        window: WindowConfig::default(),
+    }];
+    let saved = RuntimeState::from_board_with_detached_workspaces(
+        &board,
+        WindowConfig::default(),
+        CanvasViewState::default(),
+        detached,
+    );
+    assert!(saved.to_yaml().is_ok());
+    assert_eq!(saved.detached_workspaces[0].workspace_local_id, "remote-view");
+    let mut restored = Board::from_runtime_state(&saved).expect("moved reference restored");
+    assert!(restored.panels[0].restart().is_err());
+    board.assign_panel_to_workspace(panel_id, remote_id);
+    board.close_panel(panel_id);
+    board.remove_empty_workspaces();
+    assert!(board.panels.is_empty());
+    assert_eq!(
+        board
+            .workspace(remote_id)
+            .expect("empty remote view retained")
+            .remote_workspace,
+        Some(reference(OWNER))
+    );
+}
+
+#[test]
+fn incompatible_workspace_moves_and_removal_cannot_reinterpret_execution() {
+    let mut state = snapshot(OWNER);
+    let mut other = snapshot("22222222-2222-4222-8222-222222222222").workspaces.remove(0);
+    other.local_id = "other-view".into();
+    other.panels.clear();
+    state.workspaces.push(other);
+    let mut board = Board::from_runtime_state(&state).expect("board");
+    let source = board.workspaces[0].id;
+    let target = board.workspaces[1].id;
+    let panel = board.panels[0].id;
+    board.assign_panel_to_workspace(panel, target);
+    assert_eq!(board.panel(panel).expect("panel").workspace_id, source);
+    board.remove_workspace(source);
+    assert!(board.workspace(source).is_some());
+    assert!(board.create_panel(PanelOptions::default(), source).is_err());
+    let local = board.create_workspace("Local destination");
+    board.remove_workspace(source);
+    assert!(board.workspace(source).is_none());
+    assert_eq!(board.panel(panel).expect("relocated").workspace_id, local);
+    assert_eq!(
+        board.panel(panel).expect("relocated").remote_workspace(),
+        Some(&reference(OWNER))
+    );
+    assert!(board.restart_panel(panel).is_err());
+}
+
+#[test]
+fn copied_and_deleted_client_sessions_do_not_adopt_or_remove_remote_aggregates() {
+    let directory = tempfile::tempdir().expect("directory");
+    let home = HorizonHome::from_root(directory.path().to_path_buf());
+    let sessions = SessionStore::new(home.clone(), home.config_path());
+    let source = sessions
+        .create_session_from_runtime(RuntimeState::default())
+        .expect("source session");
+    let state = snapshot(&source.session_id);
+    sessions
+        .save_runtime_state(&source.session_id, &state)
+        .expect("save references");
+    let cloud = CloudWorkflowStore::open(&home).expect("private cloud store");
+    let original = cloud
+        .create_remote_workspace(&source.session_id, &aggregate())
+        .expect("owned aggregate");
+    let bytes = std::fs::read(&source.runtime_state_path).expect("source bytes");
+    std::fs::write(source.transcript_root.join("remote-panel.bin"), b"retained output").expect("transcript");
+    let copy = sessions.duplicate_session(&source.session_id).expect("copy");
+    assert_ne!(copy.session_id, source.session_id);
+    assert_eq!(
+        copy.runtime_state.workspaces[0].remote_workspace,
+        Some(reference(&source.session_id))
+    );
+    assert!(
+        cloud
+            .load_remote_workspace(&copy.session_id, "remote-environment")
+            .is_err()
+    );
+    let mut board = Board::from_runtime_state(&copy.runtime_state).expect("inert foreign view");
+    assert!(board.panels[0].restart().is_err());
+    board.shutdown_terminal_panels();
+    assert_eq!(
+        std::fs::read(&source.runtime_state_path).expect("unchanged source"),
+        bytes
+    );
+    assert_eq!(
+        std::fs::read(copy.transcript_root.join("remote-panel.bin")).expect("copied output"),
+        b"retained output"
+    );
+    sessions.delete_session(&copy.session_id).expect("delete copied client");
+    sessions
+        .delete_session(&source.session_id)
+        .expect("delete original client");
+    drop(cloud);
+    let reopened = CloudWorkflowStore::open(&home).expect("reopen inventory");
+    assert_eq!(
+        reopened
+            .list_remote_workspaces(&source.session_id)
+            .expect("retained inventory"),
+        vec![original]
+    );
+}
+
+fn aggregate() -> RemoteWorkspaceState {
+    RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: "remote-environment".into(),
+        target: WorkerTarget {
+            provider: CloudProvider::LocalDocker,
+            profile: "synthetic".into(),
+            image: format!("registry.example/worker@sha256:{}", "a".repeat(64)),
+            disk_gib: 20,
+            lifetime: WorkerLifetime::Persistent,
+            max_hourly_cost_micros: None,
+        },
+        repository: GitSource {
+            repository: "owner/project".into(),
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        working_directory: ".".into(),
+        generation: 0,
+        panels: vec![RemotePanelBinding {
+            panel_local_id: "remote-panel".into(),
+            kind: PanelKind::Pi,
+            command: None,
+            working_directory: Some("src".into()),
+            task_handoff: Some("Continue synthetic task".into()),
+            agent_session_id: Some("remote-native-session".into()),
+        }],
+    })
+    .expect("aggregate")
+}
+
+#[test]
+fn rejected_remote_session_operations_preserve_saved_files() {
+    let directory = tempfile::tempdir().expect("directory");
+    let home = HorizonHome::from_root(directory.path().to_path_buf());
+    let store = SessionStore::new(home.clone(), home.config_path());
+    let session = store.create_session_from_runtime(snapshot(OWNER)).expect("session");
+    let metadata = std::fs::read(home.session_meta_path(&session.session_id)).expect("metadata");
+    let index = std::fs::read(home.session_index_path()).expect("index");
+    let original = std::fs::read(&session.runtime_state_path).expect("runtime");
+    for invalid in invalid_snapshots() {
+        assert!(store.save_runtime_state(&session.session_id, &invalid).is_err());
+        assert_eq!(
+            std::fs::read(&session.runtime_state_path).expect("saved runtime"),
+            original
+        );
+        assert!(store.create_session_from_runtime(invalid.clone()).is_err());
+        let yaml = serde_yaml::to_string(&invalid).expect("invalid fixture");
+        std::fs::write(&session.runtime_state_path, &yaml).expect("write corrupt fixture");
+        assert!(store.resume_session(&session.session_id).is_err());
+        assert!(store.duplicate_session(&session.session_id).is_err());
+        assert!(store.delete_session(&session.session_id).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&session.runtime_state_path).expect("retained fixture"),
+            yaml
+        );
+        assert_eq!(
+            std::fs::read(home.session_meta_path(&session.session_id)).expect("retained metadata"),
+            metadata
+        );
+        assert_eq!(std::fs::read(home.session_index_path()).expect("retained index"), index);
+        std::fs::write(&session.runtime_state_path, &original).expect("restore test fixture");
+    }
+}
+
+#[test]
+fn new_remote_ssh_views_inherit_workspace_identity_without_starting_tasks() {
+    let directory = tempfile::tempdir().expect("directory");
+    let marker = directory.path().join("must-not-start");
+    let (program, args) = marker_command(&marker);
+    let mut state = snapshot(OWNER);
+    state.workspaces[0].panels.clear();
+    let mut board = Board::from_runtime_state(&state).expect("empty remote board");
+    let workspace = board.workspaces[0].id;
+    let panel_id = board
+        .create_panel(
+            PanelOptions {
+                kind: PanelKind::Ssh,
+                command: Some(program),
+                args,
+                ..PanelOptions::default()
+            },
+            workspace,
+        )
+        .expect("new deferred view");
+    let panel = board.panel_mut(panel_id).expect("panel");
+    assert!(panel.wait_for_shutdown(Duration::from_secs(2)));
+    assert_eq!(panel.remote_workspace(), Some(&reference(OWNER)));
+    assert!(!marker.exists());
+    assert!(panel.restart().is_err());
+    let saved = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    assert!(saved.to_yaml().is_ok());
+    assert_eq!(saved.workspaces[0].panels[0].remote_workspace, Some(reference(OWNER)));
+}

--- a/crates/horizon-core/src/workspace.rs
+++ b/crates/horizon-core/src/workspace.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::board::WorkspaceLayout;
 use crate::panel::PanelId;
-use crate::runtime_state::{WorkspaceTemplateRef, new_local_id};
+use crate::runtime_state::{RemoteWorkspaceReference, WorkspaceTemplateRef, new_local_id};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct WorkspaceId(pub u64);
@@ -12,6 +12,7 @@ pub struct WorkspaceId(pub u64);
 pub struct Workspace {
     pub id: WorkspaceId,
     pub local_id: String,
+    pub remote_workspace: Option<RemoteWorkspaceReference>,
     pub name: String,
     pub color_idx: usize,
     pub panels: Vec<PanelId>,
@@ -42,6 +43,7 @@ impl Workspace {
         Self {
             id,
             local_id: new_local_id(),
+            remote_workspace: None,
             name,
             color_idx,
             panels: Vec::new(),

--- a/crates/horizon-ui/src/app/session/tests.rs
+++ b/crates/horizon-ui/src/app/session/tests.rs
@@ -71,6 +71,7 @@ fn runtime_state_needs_bootstrap_for_unbound_last_agent_panel() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "alpha".to_string(),
             cwd: None,
             position: None,
@@ -95,6 +96,7 @@ fn runtime_state_needs_bootstrap_for_unbound_last_opencode_panel() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "alpha".to_string(),
             cwd: None,
             position: None,
@@ -119,6 +121,7 @@ fn runtime_state_needs_bootstrap_for_unbound_last_pi_panel() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "alpha".to_string(),
             cwd: None,
             position: None,
@@ -143,6 +146,7 @@ fn runtime_state_needs_bootstrap_for_a_persisted_codex_binding() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "alpha".to_string(),
             cwd: None,
             position: None,
@@ -692,6 +696,7 @@ fn runtime_state_skips_bootstrap_for_agents_without_exact_session_catalogs() {
     let state = RuntimeState {
         workspaces: vec![WorkspaceState {
             local_id: "workspace".to_string(),
+            remote_workspace: None,
             name: "alpha".to_string(),
             cwd: None,
             position: None,

--- a/crates/horizon-ui/src/app/ssh_upload.rs
+++ b/crates/horizon-ui/src/app/ssh_upload.rs
@@ -98,6 +98,21 @@ impl HorizonApp {
         dropped: &[egui::DroppedFileHandle],
         viewport_id: ViewportId,
     ) -> bool {
+        if let Some(workspace_id) = self
+            .board
+            .panel(panel_id)
+            .filter(|panel| panel.remote_workspace().is_some())
+            .map(|panel| panel.workspace_id)
+        {
+            self.board.create_attention(
+                workspace_id,
+                Some(panel_id),
+                "remote",
+                "Remote connection pending. File upload cannot use this view's saved SSH settings.",
+                horizon_core::AttentionSeverity::Medium,
+            );
+            return true;
+        }
         let Some((panel_kind, host_label, connection)) = self.board.panel(panel_id).map(|panel| {
             (
                 panel.kind,
@@ -475,6 +490,76 @@ mod tests {
     use crate::app::ssh_upload::worker::LocalUploadFile;
     use std::path::PathBuf;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn remote_file_drops_do_not_probe_saved_ssh_metadata_in_owner_or_copied_sessions() {
+        use crate::app::test_support::{dropped_file, test_app};
+        use horizon_core::{
+            Board, CanvasViewState, PanelKind, PanelOptions, RemoteWorkspaceReference, RuntimeState, SshConnection,
+            WindowConfig,
+        };
+
+        let (directory, mut app) = test_app();
+        let source = app
+            .session_store
+            .create_session_from_runtime(RuntimeState::default())
+            .expect("source");
+        let workspace = app.board.create_workspace("Remote reference");
+        let marker = directory.path().join("unexpected-proxy-command");
+        let connection = SshConnection {
+            host: "unverified.example.invalid".into(),
+            extra_args: vec![
+                "-o".into(),
+                format!("ProxyCommand=printf unexpected > '{}'", marker.display()),
+            ],
+            ..SshConnection::default()
+        };
+        app.board
+            .create_panel(
+                PanelOptions {
+                    kind: PanelKind::Ssh,
+                    local_id: Some("remote-panel".into()),
+                    remote_workspace: Some(
+                        RemoteWorkspaceReference::new(source.session_id.clone(), "remote-environment".into())
+                            .expect("reference"),
+                    ),
+                    ssh_connection: Some(connection.clone()),
+                    ..PanelOptions::default()
+                },
+                workspace,
+            )
+            .expect("deferred view");
+        let state = RuntimeState::from_board(&app.board, WindowConfig::default(), CanvasViewState::default());
+        app.session_store
+            .save_runtime_state(&source.session_id, &state)
+            .expect("save source");
+        let source = app
+            .session_store
+            .resume_session(&source.session_id)
+            .expect("resume source");
+        let copy = app
+            .session_store
+            .duplicate_session(&source.session_id)
+            .expect("copy client");
+        assert_ne!(source.session_id, copy.session_id);
+        let upload = directory.path().join("synthetic-upload.txt");
+        std::fs::write(&upload, b"synthetic upload").expect("upload fixture");
+        for session in [source, copy] {
+            app.activate_persistent_session(&session);
+            app.board = Board::from_runtime_state(&session.runtime_state).expect("restore view");
+            let panel = &app.board.panels[0];
+            assert_eq!(panel.ssh_connection.as_ref(), Some(&connection));
+            let panel_id = panel.id;
+            assert!(app.maybe_start_ssh_file_drop(panel_id, &[dropped_file(upload.clone())], egui::ViewportId::ROOT));
+            assert!(
+                app.ssh_upload_flow.is_none(),
+                "no preparation worker or transport may be constructed"
+            );
+            assert!(app.board.unresolved_attention_for_panel(panel_id).is_some());
+            assert!(app.board.restart_panel(panel_id).is_err());
+            assert!(!marker.exists());
+        }
+    }
 
     #[test]
     fn parent_remote_path_preserves_root() {

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -53,8 +53,9 @@ back into large multi-purpose modules.
 - `panel.rs` owns panel models and content access; explicit restart logic lives
   in `panel/lifecycle.rs`. `panel/spawn.rs` keeps content selection and command
   resolution, while `panel/spawn/terminal.rs` owns terminal construction,
-  transcript restoration and disconnected/failure snapshots. These boundaries
-  preserve existing behavior and do not introduce remote execution ownership.
+  transcript restoration and disconnected/failure snapshots. Remote client views
+  retain an execution reference independently of visual workspace membership;
+  both creation and restart defer remote attachment without local task fallback.
 - `terminal.rs` should keep the terminal types and shared imports; lifecycle,
   event handling, resize policy, selection logic, and content helpers belong in
   `terminal/` leaf modules.
@@ -74,6 +75,13 @@ back into large multi-purpose modules.
   on read and write serialization boundaries; supported legacy snapshots still
   migrate in memory. Agent binding orchestration, discovery, and external-store
   parsing belong in `runtime_state/` helper modules.
+  Runtime v3 carries opaque owner-session/workspace references through board
+  saves and session copies. Remote-bearing snapshots require complete stable IDs
+  before migration, save or restore; they never repair missing remote identities.
+  A copied reference does not authorize its claimed owner. Future reconciliation
+  must validate the actual resolved session against the exact-owner store.
+  Remote panels are SSH client views; task kinds and remote agent-native resumes
+  remain in `remote_workspace/`, separate from local agent catalog/binding logic.
   Binding validation and assignment live in
   `runtime_state/binding_bootstrap.rs`; provider-specific session-store parsing
   belongs in focused leaves such as `runtime_state/agent_sessions/codex.rs`.


### PR DESCRIPTION
## Purpose

Advance #383 with copy-safe remote workspace references. This is the client
persistence boundary, not worker provisioning, remote attachment or full feature
completion.

## Behavior

- Version-3 runtime snapshots retain validated opaque owner/workspace references
  through save, copy and movement. Malformed or ambiguous remote identities fail
  closed instead of being repaired into a different execution identity.
- Remote SSH views restore retained output with a clear disconnected banner.
  Restore, Restart/Reconnect and SSH file-drop preparation cannot execute saved
  task commands or transport settings locally.
- Closing the last panel in a workspace-marked remote view keeps that empty
  workspace reference. Explicitly closing a panel-only view may remove its local
  reference; the independently stored remote aggregate and task intent remain.
  Moving into a local visual workspace preserves remote identity; incompatible
  remote moves cannot reinterpret it. Local session deletion leaves remote
  aggregates intact. Inventory must discover environments without local views.
- Ordinary local/SSH/agent paths remain unchanged. No provider calls, resource
  allocation/deletion, dependency, default configuration or release is introduced.

## Validation

- Full local matrix on the exact candidate: format, maintainability, version sync,
  default and speech workspace tests, blocking/strict/advisory Clippy, debug build.
  Core suite: 668 tests; UI suites: 546 default and 590 speech tests.
- Nine focused core regressions plus a UI regression for populated SSH settings
  in both owning and copied sessions. The latter proves no upload preparation
  worker or probe starts and the synthetic execution marker stays absent.
- Independent local review completed on the exact tree; actionable findings fixed.
- Isolated Linux native UI smoke passed launch, retained/missing transcript,
  context-menu Reconnect denial, move, grid, resize/refit, close-last, save/reopen
  and copied-session flows. Captured screenshots were inspected at launch and
  after resize/fit; normal local input remained usable. The saved-command marker
  never appeared; original owner references and the source snapshot were preserved.
- Test instances used private state, a read-only host filesystem, no network and
  a task-owned virtual display. All candidate instances closed normally. File-drop
  safety is integration-test proof, not a claim of native drag-and-drop coverage.
- Temporary UI smoke plan removed after validation. Short software-rendered idle
  and pointer samples are responsiveness evidence, not a performance improvement claim.

## Scope and follow-up

One integrated outcome: 16 source/test files, 862 changed source/test lines;
three fixture-only files add absent-reference fields. This uses the maintainer's
recorded standing approval for the cohesive integration scope.

Coordinator/task integration, the Remote Environments widget, remote durability,
provider acceptance and real PC-off proof remain required in #383.
Assignee follows convention; review label, milestone and project are skipped
because no unambiguous current convention was established.
