### PR TITLE
Recover remote workers without creating replacements

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -310,6 +310,23 @@ pub trait InteractiveWorkerProvider: Send + Sync {
     /// safely produce an exact worker identity.
     fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error>;
 
+    /// Recover an exact worker after losing a creation response, without creating.
+    ///
+    /// Resolve the deterministic request identity and reject ambiguous or
+    /// mismatched resources. Absence is an observation, never a creation grant.
+    /// This operation must not create, restart, delete, or consume a creation
+    /// claim, including for expired, over-budget, or stopped workers. A returned
+    /// observation does not establish the caller's durable ownership; attachment
+    /// also requires that ownership and fresh [`InteractiveWorkerStatus::is_ready_for`].
+    ///
+    /// # Errors
+    /// Rejects invalid requests before provider I/O and returns redacted errors
+    /// for failed, ambiguous, identity-mismatched, or policy-rejected recovery.
+    fn reconcile_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<Option<InteractiveWorkerStatus>, Self::Error>;
+
     /// Inspect only the exact persisted worker, returning `None` when absent.
     ///
     /// # Errors
@@ -441,6 +458,16 @@ mod tests {
         fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
             if !worker.is_valid_for(self.provider()) {
                 return Err(FakeError::InvalidWorker);
+            }
+            Ok(Some(self.status.clone()))
+        }
+
+        fn reconcile_worker(
+            &self,
+            request: &InteractiveWorkerRequest,
+        ) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+            if !request.is_valid_for(self.provider()) {
+                return Err(FakeError::InvalidRequest);
             }
             Ok(Some(self.status.clone()))
         }

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -259,6 +259,21 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
             result => result.map(Some),
         }
     }
+    fn reconcile_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        validate_request(request, &self.profile)?;
+        let name = container_name(request.workflow_id, request.job_id);
+        let Some(container) = self.transport.inspect(&name)? else {
+            return Ok(None);
+        };
+        let worker = worker_for_request(&container, request)?;
+        match self.observe(&container, worker) {
+            Err(LocalDockerError::ResourceAbsent) => Ok(None),
+            result => result.map(Some),
+        }
+    }
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
         self.validate_persisted_worker(worker)?;
         let resource_id = &worker.identity.resource_id;

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -5,6 +5,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
 
 mod lifetime;
+mod noncreating;
 
 #[derive(Clone, Default)]
 struct FakeDocker(Arc<Mutex<FakeState>>);

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/noncreating.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/noncreating.rs
@@ -1,0 +1,136 @@
+use super::*;
+use crate::cloud_run::CloudJobId;
+
+fn seeded(request: &InteractiveWorkerRequest) -> FakeDocker {
+    let fake = FakeDocker::default();
+    let name = container_name(request.workflow_id, request.job_id);
+    fake.create(&DockerCreateRequest::new(request, &name).expect("fixture"))
+        .expect("seed resource without a saved handle");
+    fake.state().create_calls = 0;
+    fake
+}
+
+fn assert_read_only(fake: &FakeDocker) {
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (0, 0));
+}
+
+#[test]
+fn absent_or_disappearing_recovery_never_creates_a_worker() {
+    let mut request = request();
+    request.target.lifetime = WorkerLifetime::Persistent;
+    let empty = FakeDocker::default();
+    for _ in 0..3 {
+        assert_eq!(provider("local", empty.clone()).reconcile_worker(&request), Ok(None));
+    }
+    assert_read_only(&empty);
+
+    let fake = seeded(&request);
+    fake.state().disappear_during_key_read = true;
+    assert_eq!(provider("local", fake.clone()).reconcile_worker(&request), Ok(None));
+    assert_eq!(provider("local", fake.clone()).reconcile_worker(&request), Ok(None));
+    assert_read_only(&fake);
+}
+
+#[test]
+fn recovery_preserves_identity_across_controllers_and_nonrunning_states() {
+    let mut request = request();
+    request.target.lifetime = WorkerLifetime::Persistent;
+    let fake = seeded(&request);
+    let original = provider("local", fake.clone())
+        .reconcile_worker(&request)
+        .expect("recover")
+        .expect("existing");
+    assert!(original.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+    for (state_name, exit_code, expected) in [
+        ("created", 0, InteractiveWorkerLifecycle::Provisioning),
+        ("exited", 0, InteractiveWorkerLifecycle::Stopped),
+        ("dead", 1, InteractiveWorkerLifecycle::Failed),
+        ("unrecognized", 0, InteractiveWorkerLifecycle::Unknown),
+    ] {
+        {
+            let mut state = fake.state();
+            let container = state.container.as_mut().expect("resource");
+            container.state = state_name.into();
+            container.running = false;
+            container.exit_code = exit_code;
+        }
+        let observed = provider("local", fake.clone())
+            .reconcile_worker(&request)
+            .expect("recover")
+            .expect("retained");
+        assert_eq!(observed.worker, original.worker);
+        assert_eq!(observed.lifecycle, expected);
+        assert!(!observed.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+        assert_read_only(&fake);
+    }
+}
+
+#[test]
+fn expired_recovery_retains_identity_without_cleanup_or_attachment() {
+    let request = request();
+    let fake = seeded(&request);
+    {
+        let mut state = fake.state();
+        let container = state.container.as_mut().expect("resource");
+        let expired = "2000-01-01T00:00:00Z";
+        container.labels.insert(TERMINATE_LABEL.into(), expired.into());
+        container
+            .environment
+            .retain(|entry| !environment_key_matches(entry, TERMINATE_ENV));
+        container.environment.push(format!("{TERMINATE_ENV}={expired}"));
+    }
+    let observed = provider("local", fake.clone())
+        .reconcile_worker(&request)
+        .expect("read-only expired recovery")
+        .expect("retained");
+    assert!(!observed.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+    assert_read_only(&fake);
+    assert!(fake.state().container.is_some());
+}
+
+#[test]
+fn malformed_requests_and_resource_drift_cannot_authorize_recovery_effects() {
+    let mut request = request();
+    request.target.lifetime = WorkerLifetime::Persistent;
+    let fake = FakeDocker::default();
+    for drift in 0..4 {
+        let mut invalid = request.clone();
+        match drift {
+            0 => invalid.target.provider = CloudProvider::RunPod,
+            1 => invalid.target.profile = "different".into(),
+            2 => invalid.target.image = "mutable:latest".into(),
+            _ => invalid.ssh_public_key = "invalid".into(),
+        }
+        assert_eq!(
+            provider("local", fake.clone()).reconcile_worker(&invalid),
+            Err(InvalidTarget)
+        );
+    }
+    assert_eq!(fake.state().inspect_calls, 0);
+    assert_read_only(&fake);
+    for drift in 0..5 {
+        let fake = seeded(&request);
+        {
+            let mut state = fake.state();
+            let container = state.container.as_mut().expect("resource");
+            match drift {
+                0 => {
+                    container.labels.insert(JOB_LABEL.into(), CloudJobId::new().to_string());
+                }
+                1 => container.image = "different:latest".into(),
+                2 => container.environment.push(format!("{TERMINATE_ENV}=")),
+                3 => {
+                    container.labels.insert(TARGET_LABEL.into(), "{}".into());
+                }
+                _ => container.environment.push(format!("{SSH_PUBLIC_KEY_ENV}=invalid")),
+            }
+        }
+        assert_eq!(
+            provider("local", fake.clone()).reconcile_worker(&request),
+            Err(ResourceIdentityMismatch)
+        );
+        assert_read_only(&fake);
+        assert!(fake.state().container.is_some());
+    }
+}

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -1,7 +1,9 @@
 //! `RunPod` Secure Cloud lifecycle adapter for durable cloud workers.
 use super::{
     CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime, WorkerTarget,
-    interactive_worker::{InteractiveWorkerLease, InteractiveWorkerLifetime, valid_ssh_public_key},
+    interactive_worker::{
+        InteractiveWorkerLease, InteractiveWorkerLifetime, InteractiveWorkerRequest, valid_ssh_public_key,
+    },
     validation::valid_worker_image,
 };
 use serde::{Deserialize, Deserializer, de};
@@ -218,6 +220,52 @@ impl RunPodClient {
                 error
             }
         })
+    }
+    fn reconcile_interactive_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+        profile: &RunPodProfile,
+    ) -> Result<Option<RunPodWorkerStatus>, RunPodError> {
+        if !request.is_valid_for(CloudProvider::RunPod) {
+            return Err(RunPodError::InvalidTarget);
+        }
+        validate_target(&request.target, profile)?;
+        let name = resource_name(request.workflow_id, request.job_id);
+        let matches = self.reconcile_by_name(&name)?;
+        let pod = match matches.as_slice() {
+            [] => return Ok(None),
+            [pod] => pod,
+            _ => {
+                return Err(RunPodError::AmbiguousResource {
+                    name,
+                    count: matches.len(),
+                });
+            }
+        };
+        let Some(current) = self.transport.get(&pod.id)? else {
+            return Ok(None);
+        };
+        if current.id != pod.id {
+            return Err(RunPodError::ResourceIdentityMismatch);
+        }
+        let status = status_from_pod(
+            &current,
+            request.workflow_id,
+            request.job_id,
+            &request.target,
+            None,
+            Some(&request.ssh_public_key),
+        )?;
+        if let Some(maximum) = request.target.max_hourly_cost_micros
+            && status.worker.hourly_cost_micros.is_none_or(|actual| actual > maximum)
+        {
+            return Err(RunPodError::WorkerRecoveryCostRejected {
+                actual: status.worker.hourly_cost_micros,
+                worker: Box::new(status.worker),
+                maximum,
+            });
+        }
+        Ok(Some(status))
     }
     fn reconcile_by_name(&self, name: &str) -> Result<Vec<ApiPod>, RunPodError> {
         let mut matches = BTreeMap::new();

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -160,6 +160,15 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
             .map(|status| status.map(|status| self.adapt_status(status, &target, &ssh_public_key)))
     }
 
+    fn reconcile_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.client
+            .reconcile_interactive_worker(request, &self.profile)
+            .map(|status| status.map(|status| self.adapt_status(status, &request.target, &request.ssh_public_key)))
+    }
+
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
         let ssh_public_key = worker.ssh_public_key.clone();
         let worker = runpod_worker(worker)?;

--- a/crates/horizon-core/src/cloud_run/runpod/models.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/models.rs
@@ -212,6 +212,12 @@ pub enum RunPodError {
     },
     #[error("RunPod hourly cost was rejected but exact-resource cleanup failed")]
     CostRejectionCleanupFailed { worker: Box<RunPodWorker> },
+    #[error("worker recovery hourly cost was rejected; it was not deleted and may remain billable")]
+    WorkerRecoveryCostRejected {
+        worker: Box<RunPodWorker>,
+        actual: Option<u64>,
+        maximum: u64,
+    },
     #[error("persistent worker hourly cost was rejected; it was not deleted and may remain billable")]
     PersistentWorkerCostRejected {
         worker: Box<RunPodWorker>,

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -8,6 +8,7 @@ use super::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
 
+mod noncreating;
 mod persistence;
 mod reconciliation;
 mod snapshots;

--- a/crates/horizon-core/src/cloud_run/runpod/tests/noncreating.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/noncreating.rs
@@ -1,0 +1,239 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn read_only_provider(transport: FakeTransport) -> (RunPodInteractiveWorkerProvider, Arc<AtomicUsize>) {
+    let claims = Arc::new(AtomicUsize::new(0));
+    let calls = claims.clone();
+    let client = RunPodClient {
+        transport: Box::new(transport),
+        creation_fence: Box::new(move |_, _, _: &WorkerTarget, _: &str| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        }),
+    };
+    (
+        RunPodInteractiveWorkerProvider::new(client, profile(), FakeHostKeySource::new(Some(ed25519_key(73)))),
+        claims,
+    )
+}
+
+fn assert_read_only(transport: &FakeTransport, claims: &AtomicUsize) {
+    let state = transport.0.lock().expect("state");
+    assert!(state.create_requests.is_empty());
+    assert!(state.deleted.is_empty());
+    assert_eq!(claims.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn repeated_absence_never_consumes_an_available_creation_grant() {
+    let request = persistence::persistent_request();
+    let transport = FakeTransport::default();
+    for _ in 0..3 {
+        let (provider, claims) = read_only_provider(transport.clone());
+        assert_eq!(provider.reconcile_worker(&request), Ok(None));
+        assert_read_only(&transport, &claims);
+    }
+    assert_eq!(
+        transport.0.lock().expect("state").list_calls,
+        3 * (1 + http::PROPAGATION_BACKOFF_MS.len())
+    );
+}
+
+#[test]
+fn disappearance_during_discovery_returns_absence_not_cached_readiness() {
+    let request = persistence::persistent_request();
+    let pod = persistence::persistent_pod(&request);
+    let transport = FakeTransport::default();
+    transport.0.lock().expect("state").scripted_lists = vec![vec![pod.clone()]];
+    let (provider, claims) = read_only_provider(transport.clone());
+    assert_eq!(provider.reconcile_worker(&request), Ok(None));
+    assert_eq!(transport.0.lock().expect("state").inspected, vec![pod.id]);
+    assert_read_only(&transport, &claims);
+}
+
+#[test]
+fn exact_refresh_rejects_errors_identity_drift_and_new_cost_without_cleanup() {
+    let request = persistence::persistent_request();
+    for drift in 0..5 {
+        let original = persistence::persistent_pod(&request);
+        let mut fresh = original.clone();
+        match drift {
+            0 => fresh.id = "redirected-resource".into(),
+            1 => {
+                fresh.env.insert(SSH_PUBLIC_KEY_ENV.into(), ed25519_key(99));
+            }
+            2 => fresh.image = "different:latest".into(),
+            3 => fresh.cost = Some(750_001),
+            _ => {}
+        }
+        let transport = FakeTransport::with_pods(vec![original.clone()]);
+        transport.0.lock().expect("state").scripted_gets = vec![if drift == 4 {
+            Err(RunPodError::RequestFailed {
+                operation: "pod inspection",
+            })
+        } else {
+            Ok(Some(fresh))
+        }];
+        let (provider, claims) = read_only_provider(transport.clone());
+        let error = provider
+            .reconcile_worker(&request)
+            .expect_err("fresh read is authoritative");
+        if drift == 3 {
+            assert!(matches!(
+                error,
+                RunPodError::WorkerRecoveryCostRejected {
+                    actual: Some(750_001),
+                    ..
+                }
+            ));
+        } else if drift == 4 {
+            assert!(matches!(
+                error,
+                RunPodError::RequestFailed {
+                    operation: "pod inspection"
+                }
+            ));
+        } else {
+            assert_eq!(error, RunPodError::ResourceIdentityMismatch);
+        }
+        assert_eq!(transport.0.lock().expect("state").inspected, vec![original.id]);
+        assert_read_only(&transport, &claims);
+    }
+}
+
+#[test]
+fn lost_handle_recovery_retains_the_same_worker_and_never_restarts_stopped_tasks() {
+    let request = persistence::persistent_request();
+    let transport = FakeTransport::with_pods(vec![persistence::persistent_pod(&request)]);
+    let (provider, claims) = read_only_provider(transport.clone());
+    let original = provider.reconcile_worker(&request).expect("recover").expect("existing");
+    assert!(original.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+    assert_read_only(&transport, &claims);
+    drop(provider);
+    for (state, expected) in [
+        ("EXITED", InteractiveWorkerLifecycle::Stopped),
+        ("ERROR", InteractiveWorkerLifecycle::Failed),
+        ("unknown", InteractiveWorkerLifecycle::Unknown),
+    ] {
+        transport.0.lock().expect("state").pods[0].status = Some(state.into());
+        let (provider, claims) = read_only_provider(transport.clone());
+        let recovered = provider.reconcile_worker(&request).expect("recover").expect("retained");
+        assert_eq!(recovered.worker, original.worker);
+        assert_eq!(recovered.lifecycle, expected);
+        assert!(!recovered.is_ready_for(&request, time::OffsetDateTime::now_utc()));
+        assert_read_only(&transport, &claims);
+    }
+}
+
+#[test]
+fn invalid_or_ambiguous_resources_do_not_create_or_delete() {
+    let request = persistence::persistent_request();
+    let good = persistence::persistent_pod(&request);
+    for drift in 0..6 {
+        let mut pod = good.clone();
+        match drift {
+            0 => {
+                pod.env.insert(JOB_ENV.into(), CloudJobId::new().to_string());
+            }
+            1 => {
+                pod.env.insert(SSH_PUBLIC_KEY_ENV.into(), ed25519_key(99));
+            }
+            2 => {
+                pod.env.insert(TERMINATE_ENV.into(), String::new());
+            }
+            3 => pod.image = "mutable:latest".into(),
+            4 => pod.name = "different".into(),
+            _ => {
+                pod.env.remove(LIFETIME_ENV);
+            }
+        }
+        let transport = FakeTransport::with_pods(vec![pod]);
+        let (provider, claims) = read_only_provider(transport.clone());
+        assert_eq!(
+            provider.reconcile_worker(&request),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        assert_read_only(&transport, &claims);
+    }
+    let mut duplicate = good.clone();
+    duplicate.id = "other-exact-id".into();
+    let transport = FakeTransport::with_pods(vec![good, duplicate]);
+    let (provider, claims) = read_only_provider(transport.clone());
+    assert!(matches!(
+        provider.reconcile_worker(&request),
+        Err(RunPodError::AmbiguousResource { count: 2, .. })
+    ));
+    assert_read_only(&transport, &claims);
+}
+
+#[test]
+fn malformed_recovery_requests_fail_before_any_transport_or_claim() {
+    let request = persistence::persistent_request();
+    let transport = FakeTransport::default();
+    let (provider, claims) = read_only_provider(transport.clone());
+    for drift in 0..4 {
+        let mut invalid = request.clone();
+        match drift {
+            0 => invalid.target.provider = CloudProvider::LocalDocker,
+            1 => invalid.target.profile = "different".into(),
+            2 => invalid.target.image = "mutable:latest".into(),
+            _ => invalid.ssh_public_key = "invalid".into(),
+        }
+        assert_eq!(provider.reconcile_worker(&invalid), Err(RunPodError::InvalidTarget));
+    }
+    assert_eq!(transport.0.lock().expect("state").list_calls, 0);
+    assert_read_only(&transport, &claims);
+}
+
+#[test]
+fn expired_and_over_budget_recovery_never_performs_automatic_cleanup() {
+    let timed = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+    let mut pod = running_pod(timed.workflow_id, timed.job_id, &timed.target);
+    pod.env.insert(SSH_PUBLIC_KEY_ENV.into(), timed.ssh_public_key.clone());
+    pod.env.insert(TERMINATE_ENV.into(), "2000-01-01T00:00:00Z".into());
+    let transport = FakeTransport::with_pods(vec![pod]);
+    let (provider, claims) = read_only_provider(transport.clone());
+    let expired = provider
+        .reconcile_worker(&timed)
+        .expect("recover expired")
+        .expect("retained");
+    assert!(!expired.is_ready_for(&timed, time::OffsetDateTime::now_utc()));
+    assert_read_only(&transport, &claims);
+
+    for persistent in [false, true] {
+        for cost in [None, Some(750_001)] {
+            let request = if persistent {
+                persistence::persistent_request()
+            } else {
+                timed.clone()
+            };
+            let mut pod = if persistent {
+                persistence::persistent_pod(&request)
+            } else {
+                let mut pod = running_pod(request.workflow_id, request.job_id, &request.target);
+                pod.env
+                    .insert(SSH_PUBLIC_KEY_ENV.into(), request.ssh_public_key.clone());
+                pod
+            };
+            pod.cost = cost;
+            let transport = FakeTransport::with_pods(vec![pod]);
+            let (provider, claims) = read_only_provider(transport.clone());
+            let error = provider
+                .reconcile_worker(&request)
+                .expect_err("read-only cost rejection");
+            assert!(error.to_string().contains("not deleted and may remain billable"));
+            let RunPodError::WorkerRecoveryCostRejected {
+                worker,
+                actual,
+                maximum,
+            } = error
+            else {
+                panic!("cost error")
+            };
+            assert_eq!(worker.pod_id, "pod_123456");
+            assert_eq!(actual, cost);
+            assert_eq!(maximum, 750_000);
+            assert_read_only(&transport, &claims);
+        }
+    }
+}

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -60,6 +60,14 @@ errors include the worker and observed limit and warn that billing may continue.
 This covers newly created resources too, because another client may already be
 using the worker. Reconciliation identities alone do not establish ownership.
 Only explicit, freshly identity-verified deletion removes persistent compute.
+Recovery after losing a create response has an explicit non-creating provider
+operation. It resolves the deterministic request identity without consuming a
+creation claim, and absence never falls through to create. Stopped, expired,
+ambiguous, and identity-mismatched resources do not trigger restart or cleanup.
+Cost-rejected recovery retains the exact observed identity and reports that it
+may remain billable, for both lifetime policies. The bounded lookup is separate
+from ensure and exact-handle inspection; callers still require durable ownership,
+fresh lifetime validation and a trusted pinned endpoint before attachment.
 Provider-wide manual management and the remaining remote implementations still
 need integration. Schema and synthetic-transport tests do not establish live
 provider scheduling, storage durability or PC-off acceptance.


### PR DESCRIPTION
## Purpose

Advance #383 with explicit non-creating worker recovery when a creation response
was lost before the client persisted an exact resource handle.

## Behavior

- Add `InteractiveWorkerProvider::reconcile_worker` to both existing adapters.
  Absence returns `None`; recovery never creates, starts, deletes, or consumes a
  creation grant. Existing explicit ensure/cleanup behavior is unchanged.
- Resolve deterministic request identity and reject ambiguous or mismatched
  resources. Polled GPU discovery ends with a fresh exact-ID read; disappearing
  resources cannot be returned as cached ready workers.
- Preserve stopped, expired and unknown resources without automatic cleanup.
  Cost-rejected recovery retains the exact worker and warns billing may continue.
  Attachment still requires durable ownership, fresh lifetime validation and a
  trusted pinned SSH endpoint.

## Validation

- Eleven focused synthetic regressions pass across both adapters: repeated
  absence, controller replacement, lost handles, stopped/failed/unknown states,
  malformed requests, ambiguity, identity drift, expiry, cost rejection and
  disappearance/fresh-state drift during discovery. Tests assert zero create,
  delete and creation-claim calls. The disappearance regression failed before
  the final-read fix and passes afterward.
- Full exact-candidate local matrix: formatting, maintainability, version sync,
  default/speech workspace tests, blocking/strict/advisory Clippy.
- Independent local review completed on the exact tree; actionable findings fixed.
- No new UI or live-provider mutation; these are synthetic transport tests, not
  a claim of real cloud scheduling, durability or PC-off acceptance.

## Scope

One recovery outcome: nine source/test files, 484 changed source/test lines,
plus eight architecture-document lines. No dependency, configuration default,
resource publication or release change.

Coordinator/task integration, durable remote storage, the Remote Environments
widget and real provider acceptance remain required in #383.
Assignee follows convention; ambiguous label/milestone/project metadata is skipped.
