### PR TITLE
List remote environments independently of local sessions

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -10,8 +10,8 @@ mod store;
 mod validation;
 mod worker_lifetime;
 pub use store::{
-    CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
-    StoredWorkflow,
+    CloudStoreError, CloudWorkflowStore, RemoteEnvironmentPage, RemoteWorkspaceStoreError, StoredRemoteAllocation,
+    StoredRemoteWorkspace, StoredWorkflow,
 };
 pub use worker_lifetime::WorkerLifetime;
 pub const CLOUD_RUN_PROTOCOL_VERSION: u32 = 1;

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -6,7 +6,7 @@ mod remote_workspaces;
 mod workflow_writes;
 
 pub use remote_allocations::StoredRemoteAllocation;
-pub use remote_workspaces::{RemoteWorkspaceStoreError, StoredRemoteWorkspace};
+pub use remote_workspaces::{RemoteEnvironmentPage, RemoteWorkspaceStoreError, StoredRemoteWorkspace};
 use workflow_writes::PreparedWorkflowInsert;
 
 use std::collections::HashMap;

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -3,7 +3,10 @@
 //! Operations are synchronous and must run off the render thread.
 
 pub(super) mod creation_fences;
+mod inventory;
 mod validation;
+
+pub use inventory::RemoteEnvironmentPage;
 
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/inventory.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/inventory.rs
@@ -1,0 +1,112 @@
+//! Bounded remote-environment inventory independent of local session files.
+
+use rusqlite::params;
+
+use super::{RemoteWorkspaceStoreError, StoredRemoteWorkspace, WorkspaceRow, decode, validate_key};
+use crate::cloud_run::store::{
+    CloudWorkflowStore, MAX_MATERIALIZED_SNAPSHOT_BYTES, MAX_RECOVERED_SNAPSHOT_BYTES, MAX_SNAPSHOT_BYTES,
+    database::ensure_current_schema,
+};
+use crate::remote_workspace::valid_local_id;
+
+const PAGE_SIZE: usize = MAX_RECOVERED_SNAPSHOT_BYTES / MAX_SNAPSHOT_BYTES;
+const PAGE_QUERY: &str = "SELECT CAST(substr(CAST(workspace_local_id AS BLOB), 1, 129) AS TEXT),
+                               CAST(substr(CAST(session_id AS BLOB), 1, 37) AS TEXT), revision,
+                               substr(snapshot, 1, ?4)
+    FROM remote_workspaces WHERE workspace_local_id >= ?1 AND (?2 IS NULL OR workspace_local_id != ?2)
+    ORDER BY workspace_local_id LIMIT ?3";
+
+/// Saved records, not fresh provider observations or permission to manage compute.
+/// Each page is a consistent database read; separate pages may observe later writes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteEnvironmentPage {
+    pub records: Vec<StoredRemoteWorkspace>,
+    /// Exclusive workspace identity cursor. None means no later record existed at this read.
+    /// Restart from the first page to see insertions at or before a previous cursor.
+    pub next_cursor: Option<String>,
+}
+
+impl CloudWorkflowStore {
+    /// List at most 16 saved remote environments across every owning session.
+    /// Does not consult client snapshots, filter runtime state/expiry, or call providers.
+    /// Run off the render thread and revalidate ownership and provider identity before actions.
+    ///
+    /// # Errors
+    /// Rejects invalid cursors, corrupt/oversized selected records, incompatible schema,
+    /// or storage failures. Never treats a failed read as an empty or partial page.
+    pub fn list_remote_environment_page(
+        &self,
+        after_workspace_id: Option<&str>,
+    ) -> Result<RemoteEnvironmentPage, RemoteWorkspaceStoreError> {
+        if after_workspace_id.is_some_and(|id| !valid_local_id(id)) {
+            return Err(RemoteWorkspaceStoreError::InvalidWorkspaceId);
+        }
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        let limit = i64::try_from(PAGE_SIZE).map_err(|_| RemoteWorkspaceStoreError::RecoveryLimitExceeded)?;
+        let mut statement = transaction.prepare(PAGE_QUERY)?;
+        let rows = statement.query_map(
+            params![
+                after_workspace_id.unwrap_or_default(),
+                after_workspace_id,
+                limit,
+                MAX_MATERIALIZED_SNAPSHOT_BYTES
+            ],
+            |row| Ok((row.get::<_, String>(0)?, WorkspaceRow::from_row(row, 1)?)),
+        )?;
+        let mut records = Vec::with_capacity(PAGE_SIZE);
+        for row in rows {
+            let (workspace_local_id, row) = row?;
+            validate_key(&row.session_id, &workspace_local_id)?;
+            let owner = row.session_id.clone();
+            records.push(decode(&owner, &workspace_local_id, row)?);
+        }
+        let mut next_cursor = None;
+        if let Some(last) = records.last() {
+            let last_id = &last.state().spec.workspace_local_id;
+            // Probe only the index, never materialize an extra potentially oversized snapshot.
+            let has_more: bool = transaction.query_row(
+                "SELECT EXISTS(SELECT 1 FROM remote_workspaces WHERE workspace_local_id > ?1)",
+                [last_id],
+                |row| row.get(0),
+            )?;
+            if has_more {
+                next_cursor = Some(last_id.clone());
+            }
+        }
+        Ok(RemoteEnvironmentPage { records, next_cursor })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inventory_uses_a_bounded_primary_key_range_without_sorting() {
+        let directory = tempfile::tempdir().expect("private fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control-plane/store.sqlite3")).expect("store");
+        let connection = store.connection().expect("connection");
+        let mut statement = connection
+            .prepare(&format!("EXPLAIN QUERY PLAN {PAGE_QUERY}"))
+            .expect("query plan");
+        let plan: Vec<String> = statement
+            .query_map(
+                params!["workspace-0016", "workspace-0016", 16, MAX_MATERIALIZED_SNAPSHOT_BYTES],
+                |row| row.get(3),
+            )
+            .expect("plan rows")
+            .collect::<Result<_, _>>()
+            .expect("plan details");
+        assert!(
+            plan.iter()
+                .any(|detail| detail.contains("SEARCH remote_workspaces USING INDEX"))
+        );
+        assert!(
+            plan.iter()
+                .all(|detail| !detail.contains("TEMP B-TREE") && !detail.contains("SCAN"))
+        );
+        assert_eq!(PAGE_SIZE, 16);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/inventory.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/inventory.rs
@@ -1,0 +1,178 @@
+use super::*;
+
+#[test]
+fn inventory_pages_all_owners_without_client_sessions_and_survives_reopen() {
+    let (_directory, store) = store();
+    let mut expected = Vec::new();
+    for index in (0..35).rev() {
+        let owner = if index % 2 == 0 { OWNER } else { OTHER_OWNER };
+        let mut state = workspace(&format!("workspace-{index:04}"));
+        state.spec.panels.clear();
+        expected.push(store.create_remote_workspace(owner, &state).expect("record"));
+    }
+    expected.sort_by(|left, right| {
+        left.state()
+            .spec
+            .workspace_local_id
+            .cmp(&right.state().spec.workspace_local_id)
+    });
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen without client sessions");
+    let mut cursor = None;
+    let mut recovered = Vec::new();
+    for count in [16, 16, 3] {
+        let page = reopened.list_remote_environment_page(cursor.as_deref()).expect("page");
+        assert_eq!(page.records.len(), count);
+        cursor = page.next_cursor;
+        recovered.extend(page.records);
+    }
+    assert!(cursor.is_none());
+    assert_eq!(recovered, expected);
+    assert!(recovered.iter().all(|record| record.revision() == 1));
+}
+
+#[test]
+fn inventory_empty_exact_page_and_terminal_cursor_are_unambiguous() {
+    let (_directory, store) = store();
+    let page = store.list_remote_environment_page(None).expect("empty store");
+    assert!(page.records.is_empty());
+    assert!(page.next_cursor.is_none());
+    seed_workspaces(&store, std::iter::repeat_n(None, 16));
+    let page = store.list_remote_environment_page(None).expect("exact page");
+    assert_eq!(page.records.len(), 16);
+    assert!(page.next_cursor.is_none());
+    for cursor in ["workspace-0015", "zz-missing"] {
+        let page = store.list_remote_environment_page(Some(cursor)).expect("after last");
+        assert!(page.records.is_empty());
+        assert!(page.next_cursor.is_none());
+    }
+}
+
+#[test]
+fn inventory_keyset_does_not_replay_earlier_rows_when_records_are_added() {
+    let (_directory, store) = store();
+    seed_workspaces(&store, std::iter::repeat_n(None, 17));
+    let first = store.list_remote_environment_page(None).expect("first page");
+    assert_eq!(first.next_cursor.as_deref(), Some("workspace-0015"));
+    store
+        .create_remote_workspace(OTHER_OWNER, &workspace("a-new-record"))
+        .expect("earlier insertion");
+    store
+        .create_remote_workspace(OTHER_OWNER, &workspace("z-new-record"))
+        .expect("later insertion");
+    let second = store
+        .list_remote_environment_page(first.next_cursor.as_deref())
+        .expect("next page");
+    let ids: Vec<_> = second
+        .records
+        .iter()
+        .map(|record| record.state().spec.workspace_local_id.as_str())
+        .collect();
+    assert_eq!(ids, ["workspace-0016", "z-new-record"]);
+    assert!(second.next_cursor.is_none());
+    assert_eq!(
+        store.list_remote_environment_page(None).expect("refresh").records[0]
+            .state()
+            .spec
+            .workspace_local_id,
+        "a-new-record"
+    );
+}
+
+#[test]
+fn inventory_keeps_dormant_failed_and_expired_legacy_records_without_mutation() {
+    let (_directory, store) = store();
+    let dormant = store
+        .create_remote_workspace(OTHER_OWNER, &workspace("a-dormant"))
+        .expect("dormant");
+    let mut failed = provisioning(workspace("b-failed"));
+    failed.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Failed;
+    let failed = seed_legacy_workspace(&store, &failed);
+    let mut legacy = ownership::expired_runtime();
+    legacy.spec.workspace_local_id = "c-expired".into();
+    legacy.runtime.as_mut().expect("runtime").workspace_local_id = "c-expired".into();
+    let legacy = seed_legacy_workspace(&store, &legacy);
+    let connection = Connection::open(store.path()).expect("raw store");
+    let before: Vec<(String, i64, Vec<u8>)> = connection
+        .prepare("SELECT workspace_local_id, revision, snapshot FROM remote_workspaces ORDER BY workspace_local_id")
+        .expect("before query")
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .expect("before rows")
+        .collect::<Result<_, _>>()
+        .expect("before");
+    assert_eq!(
+        store.list_remote_environment_page(None).expect("inventory").records,
+        [dormant, failed, legacy]
+    );
+    let after: Vec<(String, i64, Vec<u8>)> = connection
+        .prepare("SELECT workspace_local_id, revision, snapshot FROM remote_workspaces ORDER BY workspace_local_id")
+        .expect("after query")
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .expect("after rows")
+        .collect::<Result<_, _>>()
+        .expect("after");
+    assert_eq!(before, after);
+}
+
+#[test]
+fn inventory_rejects_invalid_cursors_before_opening_the_store() {
+    let (_directory, store) = store();
+    Connection::open(store.path())
+        .expect("raw store")
+        .pragma_update(None, "user_version", 999)
+        .expect("future schema");
+    for invalid in ["", "../escape", "workspace/escape", "new\nline", &"x".repeat(129)] {
+        assert!(matches!(
+            store.list_remote_environment_page(Some(invalid)),
+            Err(RemoteWorkspaceStoreError::InvalidWorkspaceId)
+        ));
+    }
+    assert!(matches!(
+        store.list_remote_environment_page(None),
+        Err(RemoteWorkspaceStoreError::Storage(CloudStoreError::UnsupportedSchema(
+            999
+        )))
+    ));
+}
+
+#[test]
+fn inventory_fails_closed_on_selected_corruption_without_echoing_content() {
+    for corruption in [
+        "UPDATE remote_workspaces SET session_id = 'invalid-owner' WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET session_id = '22222222-2222-4222-8222-222222222222' WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET workspace_local_id = 'invalid/id' WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET workspace_local_id = '' WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET workspace_local_id = workspace_local_id || char(0) || 'tail' WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET session_id = session_id || char(0) || 'tail' WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET snapshot = CAST('sensitive-task-payload' AS BLOB) WHERE workspace_local_id = 'workspace-0001'",
+        "UPDATE remote_workspaces SET snapshot = zeroblob(4194305) WHERE workspace_local_id = 'workspace-0001'",
+    ] {
+        let (_directory, store) = store();
+        seed_workspaces(&store, [None; 2]);
+        Connection::open(store.path())
+            .expect("raw store")
+            .execute_batch(corruption)
+            .expect("corrupt fixture");
+        let error = store.list_remote_environment_page(None).expect_err("no partial page");
+        assert!(!error.to_string().contains("sensitive-task-payload"));
+    }
+}
+
+#[test]
+fn inventory_does_not_materialize_or_validate_records_beyond_its_page() {
+    let (_directory, store) = store();
+    seed_workspaces(&store, std::iter::repeat_n(Some(MAX_SNAPSHOT_BYTES), 16).chain([None]));
+    let connection = Connection::open(store.path()).expect("raw store");
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET snapshot = zeroblob(?1) WHERE workspace_local_id = 'workspace-0016'",
+            [MAX_MATERIALIZED_SNAPSHOT_BYTES],
+        )
+        .expect("oversize next page");
+    let page = store.list_remote_environment_page(None).expect("maximum-size page");
+    assert_eq!(page.records.len(), 16);
+    assert_eq!(page.next_cursor.as_deref(), Some("workspace-0015"));
+    assert!(matches!(
+        store.list_remote_environment_page(page.next_cursor.as_deref()),
+        Err(RemoteWorkspaceStoreError::SnapshotTooLarge)
+    ));
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
@@ -64,6 +64,7 @@ fn provisioning(mut state: RemoteWorkspaceState) -> RemoteWorkspaceState {
     state
 }
 
+mod inventory;
 mod migration;
 mod ownership;
 mod recovery;

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -114,6 +114,15 @@ transaction so accepted writes cannot make recovery exceed its budget.
 All record operations run synchronously off the render thread. This storage
 boundary exposes no automatic retention or record-deletion API.
 
+The Remote Environments inventory reads across every owning session without
+consulting local session files or filtering unattached, failed, or expired records.
+Keyset pages contain at most 16 validated snapshots (64 MiB serialized maximum).
+The continuation probe reads only the identity index, not a seventeenth snapshot.
+Each page is a consistent read; refresh from the beginning to see new identities
+inserted before an earlier cursor. Invalid selected records fail the whole page,
+never masquerading as an empty inventory. Saved records are not fresh provider
+observations, allocation ownership proof, or permission for lifecycle actions.
+
 Once recorded, the exact cleanup reason and request timestamp remain immutable
 while that runtime exists. Later cleanup observations cannot replace the original
 intent or reset its age; only verified runtime disposal can retire it.


### PR DESCRIPTION
## Purpose

Advance #383 with a bounded inventory of saved remote environments across all
owning sessions. Removing local session files or closing every local view must
not hide still-owned remote records from the forthcoming overview.

## Behavior

- Return stable keyset pages of at most 16 validated records across all owners.
- Preserve dormant, failed and expired records; do not consult local session lists.
- Bound identity and snapshot reads before materialization; probe continuation
  in the same transaction without reading a seventeenth snapshot.
- Reject selected corruption as a failed page, never an empty/partial success.
- Keep saved records distinct from fresh provider status and lifecycle authority.

Separate pages may observe later writes; restarting from the beginning includes
new identities inserted before an old cursor. This adds no provider calls,
resource creation/deletion, schema/default changes or UI. The widget and runtime
coordinator remain required before #383 is complete.

## Validation

- Full local validation matrix passed on the exact commit: format,
  maintainability, version sync, default and speech tests, blocking/strict/advisory
  Clippy tiers.
- Eight regressions cover multi-owner paging, zero attached panels and absent
  client sessions, reopen, empty/exact/terminal pages, concurrent insert ordering,
  retained legacy runtime state, invalid cursors/schema, corrupt bounded metadata,
  maximum-size snapshots and indexed query planning.
- Complete diff and independent local review completed. No UI smoke applies to
  this store-only API; synthetic tests do not claim live provider/PC-off proof.

Six source/test files, 300 changed lines, plus the focused storage ADR update.
