### PR TITLE
Reserve remote worker SSH request identity before creation

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -4,6 +4,7 @@
 
 mod binding;
 mod guards;
+mod request;
 
 pub(super) use guards::{
     ensure_unbound_workflow, validate_creation_claim, validate_workflow_replacement, validate_workspace_write,
@@ -178,6 +179,7 @@ fn prepare_allocation(
         workflow_id,
         job_id,
         phase: RemoteRuntimePhase::Provisioning,
+        ssh_public_key: None,
         worker: None,
         ssh: None,
         cleanup: None,

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/request.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/request.rs
@@ -1,0 +1,503 @@
+//! Reserve the non-secret request identity before crossing the provider boundary.
+
+use super::super::{current_unix_millis, database::ensure_current_schema, validate_claim_target};
+use super::{CloudWorkflowStore, Error, RemoteRuntimePhase, StoredRemoteAllocation, WorkspaceReplacement, binding};
+use crate::cloud_run::interactive_worker::InteractiveWorkerRequest;
+use rusqlite::{TransactionBehavior, params};
+
+const CLAIM_LOOKUP: &str = "SELECT EXISTS(SELECT 1 FROM cloud_worker_creation_claims
+    INDEXED BY cloud_worker_creation_claims_workflow WHERE workflow_id = ?1)";
+
+impl StoredRemoteAllocation {
+    /// Reconstruct a request from its reserved key or a legacy, exact observed worker.
+    /// This does not authorize creation, attachment, or any provider operation.
+    /// # Errors
+    /// Rejects invalid snapshots or an allocation without a recorded client identity.
+    pub fn worker_request(&self) -> Result<InteractiveWorkerRequest, Error> {
+        let state = self.workspace.state();
+        state.validate()?;
+        let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+        let key = runtime
+            .ssh_public_key
+            .as_ref()
+            .or_else(|| runtime.worker.as_ref().map(|worker| &worker.ssh_public_key))
+            .ok_or(Error::RuntimeRequestRequired)?;
+        Ok(InteractiveWorkerRequest {
+            workflow_id: runtime.workflow_id,
+            job_id: runtime.job_id,
+            target: state.spec.target.clone(),
+            ssh_public_key: key.clone(),
+        })
+    }
+}
+
+impl CloudWorkflowStore {
+    /// Commit a canonical public client key to the exact allocation before creation.
+    /// The caller must already have durably retained the corresponding private key.
+    /// That private material never enters snapshots or this API. Run off the render thread.
+    ///
+    /// Reservation neither consumes nor renews a creation grant. A competing caller
+    /// reloads the winner; the same key is an idempotent read even after setup expires.
+    /// Missing identity after a claim, observation, or cancellation fails closed.
+    /// # Errors
+    /// Rejects stale/corrupt bindings, invalid or changed keys, late reservation,
+    /// expired setup, and storage failures without performing provider I/O.
+    pub fn reserve_remote_worker_request(
+        &self,
+        expected: &StoredRemoteAllocation,
+        ssh_public_key: &str,
+    ) -> Result<StoredRemoteAllocation, Error> {
+        let mut next = expected.workspace.state().clone();
+        let runtime = next.runtime.as_mut().ok_or(Error::UnboundRuntime)?;
+        if runtime.ssh_public_key.as_ref().is_some_and(|key| key != ssh_public_key) {
+            return Err(Error::ReplacementIdentityMismatch);
+        }
+        runtime.ssh_public_key = Some(ssh_public_key.into());
+        let replacement = WorkspaceReplacement::new(&expected.workspace, &next)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        ensure_current_schema(&transaction)?;
+        let row = binding::load_workspace(&transaction, &next.spec.workspace_local_id)?.ok_or(Error::UnboundRuntime)?;
+        let current = binding::recover(&transaction, &row)?;
+        if current != *expected {
+            return Err(Error::SnapshotConflict);
+        }
+        let runtime = current
+            .workspace
+            .state()
+            .runtime
+            .as_ref()
+            .ok_or(Error::UnboundRuntime)?;
+        if runtime.ssh_public_key.as_deref() == Some(ssh_public_key) {
+            return Ok(current);
+        }
+        if runtime.phase != RemoteRuntimePhase::Provisioning
+            || runtime.worker.is_some()
+            || runtime.cleanup.is_some()
+            || validate_claim_target(current.workflow.workflow(), runtime.job_id, &next.spec.target).is_err()
+        {
+            return Err(Error::RuntimeRequestUnavailable);
+        }
+        if current.workflow.workflow().retain_until_millis < current_unix_millis()? {
+            return Err(Error::RuntimeRequestUnavailable);
+        }
+        let claimed = transaction.query_row(CLAIM_LOOKUP, params![runtime.workflow_id.to_string()], |row| {
+            row.get::<_, bool>(0)
+        })?;
+        if claimed {
+            return Err(Error::RuntimeRequestUnavailable);
+        }
+        let workspace = replacement.persist(&transaction)?;
+        transaction.commit()?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: current.workflow,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_run::store::{CloudStoreError, encode_workflow};
+    use crate::remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteWorkspaceState};
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use std::sync::{Arc, Barrier};
+
+    const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+    fn public_key(byte: u8) -> String {
+        let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+        blob.extend([byte; 32]);
+        format!("ssh-ed25519 {}", STANDARD.encode(blob))
+    }
+
+    struct Fixture {
+        _directory: tempfile::TempDir,
+        store: CloudWorkflowStore,
+        allocation: StoredRemoteAllocation,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let directory = tempfile::tempdir().expect("temporary store");
+            let store =
+                CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+            let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+                "version": 1,
+                "spec": {
+                    "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                    "target": { "provider": "local_docker", "profile": "development",
+                        "image": format!("example/worker@sha256:{}", "a".repeat(64)),
+                        "disk_gib": 20, "lifetime": "persistent" },
+                    "repository": { "repository": "example/project", "commit": "b".repeat(40) }
+                }
+            }))
+            .expect("state");
+            let dormant = store.create_remote_workspace(OWNER, &state).expect("record");
+            let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+            Self {
+                _directory: directory,
+                store,
+                allocation,
+            }
+        }
+
+        fn reload(&self) -> StoredRemoteAllocation {
+            self.store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("load")
+                .expect("allocation")
+        }
+
+        fn claim(&self) -> bool {
+            let workflow = self.allocation.workflow().workflow();
+            self.store
+                .claim_worker_creation(
+                    workflow.id,
+                    workflow.nodes[0].id,
+                    &self.allocation.workspace().state().spec.target,
+                    "synthetic-worker",
+                )
+                .expect("claim")
+        }
+
+        fn expire(&self) {
+            let mut workflow = self.reload().workflow().workflow().clone();
+            workflow.created_at_millis = 1000;
+            workflow.updated_at_millis = 1000;
+            workflow.retain_until_millis = 2000;
+            rusqlite::Connection::open(self.store.path())
+                .expect("fixture connection")
+                .execute(
+                    "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000,
+                 retain_until_millis=2000, snapshot=?1 WHERE workflow_id=?2",
+                    params![encode_workflow(&workflow).expect("snapshot"), workflow.id.to_string()],
+                )
+                .expect("expired fixture");
+        }
+    }
+
+    #[test]
+    fn request_is_durable_before_creation_and_same_key_does_not_rewrite_it() {
+        let fixture = Fixture::new();
+        let before = fixture.allocation.workspace();
+        assert!(
+            !serde_json::to_string(before.state())
+                .expect("legacy shape")
+                .contains("ssh_public_key")
+        );
+        assert!(matches!(
+            fixture.allocation.worker_request(),
+            Err(Error::RuntimeRequestRequired)
+        ));
+        let saved = fixture
+            .store
+            .reserve_remote_worker_request(&fixture.allocation, &public_key(1))
+            .expect("reserve");
+        assert_eq!(saved.workspace().revision(), before.revision() + 1);
+        assert_eq!(saved.workflow(), fixture.allocation.workflow());
+        let request = saved.worker_request().expect("request");
+        assert_eq!(request.ssh_public_key, public_key(1));
+        assert_eq!(request.workflow_id, saved.workflow().workflow().id);
+        assert!(saved.workspace().state().spec.panels.is_empty());
+        let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("reopen");
+        let recovered = reopened
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("saved");
+        assert_eq!(recovered, saved);
+        assert_eq!(
+            reopened
+                .reserve_remote_worker_request(&saved, &public_key(1))
+                .expect("same key"),
+            saved
+        );
+        assert!(fixture.claim(), "reservation must not consume the one-shot grant");
+        assert!(!fixture.claim());
+        assert_eq!(fixture.reload().worker_request().expect("claimed recovery"), request);
+    }
+
+    #[test]
+    fn competing_keys_have_one_winner_and_stale_writers_cannot_change_it() {
+        let fixture = Fixture::new();
+        let barrier = Arc::new(Barrier::new(3));
+        let writers: Vec<_> = [1, 2]
+            .into_iter()
+            .map(|byte| {
+                let store = fixture.store.clone();
+                let expected = fixture.allocation.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.reserve_remote_worker_request(&expected, &public_key(byte))
+                })
+            })
+            .collect();
+        barrier.wait();
+        let results: Vec<_> = writers
+            .into_iter()
+            .map(|writer| writer.join().expect("writer"))
+            .collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(Error::SnapshotConflict)))
+                .count(),
+            1
+        );
+        let winner = results.into_iter().find_map(Result::ok).expect("winner");
+        assert_eq!(fixture.reload(), winner);
+        assert!(matches!(
+            fixture
+                .store
+                .reserve_remote_worker_request(&fixture.allocation, &public_key(1)),
+            Err(Error::SnapshotConflict)
+        ));
+        assert!(matches!(
+            fixture.store.reserve_remote_worker_request(&winner, &public_key(3)),
+            Err(Error::ReplacementIdentityMismatch)
+        ));
+    }
+
+    #[test]
+    fn generic_writes_cannot_install_replace_or_remove_request_identity() {
+        let fixture = Fixture::new();
+        let mut next = fixture.allocation.workspace().state().clone();
+        next.runtime.as_mut().expect("runtime").ssh_public_key = Some(public_key(1));
+        assert!(matches!(
+            fixture
+                .store
+                .replace_remote_workspace(fixture.allocation.workspace(), &next),
+            Err(Error::RuntimeRequestRequired)
+        ));
+        let saved = fixture
+            .store
+            .reserve_remote_worker_request(&fixture.allocation, &public_key(1))
+            .expect("reserve");
+        for key in [None, Some(public_key(2))] {
+            next.runtime.as_mut().expect("runtime").ssh_public_key = key;
+            assert!(matches!(
+                fixture.store.replace_remote_workspace(saved.workspace(), &next),
+                Err(Error::ReplacementIdentityMismatch)
+            ));
+        }
+        assert_eq!(fixture.reload(), saved);
+    }
+
+    #[test]
+    fn late_reservation_cannot_guess_identity_after_creation_or_setup_observation() {
+        for case in 0..4 {
+            let fixture = Fixture::new();
+            let mut next = fixture.allocation.workspace().state().clone();
+            match case {
+                0 => assert!(fixture.claim()),
+                1 => next.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Reconciling,
+                2 => {
+                    next.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+                        reason: RemoteCleanupReason::Cancelled,
+                        requested_at_millis: 1000,
+                    });
+                }
+                _ => {
+                    let mut workflow = fixture.allocation.workflow().workflow().clone();
+                    workflow.updated_at_millis += 1;
+                    workflow.nodes[0].state = crate::cloud_run::CloudJobState::Running;
+                    fixture
+                        .store
+                        .replace(fixture.allocation.workflow(), &workflow)
+                        .expect("observed workflow");
+                }
+            }
+            if matches!(case, 1 | 2) {
+                fixture
+                    .store
+                    .replace_remote_workspace(fixture.allocation.workspace(), &next)
+                    .expect("observation");
+            }
+            let observed = fixture.reload();
+            assert!(matches!(
+                fixture.store.reserve_remote_worker_request(&observed, &public_key(1)),
+                Err(Error::RuntimeRequestUnavailable)
+            ));
+            assert_eq!(fixture.reload(), observed);
+        }
+    }
+
+    #[test]
+    fn expiry_preserves_reserved_recovery_but_never_admits_new_identity() {
+        for reserved in [false, true] {
+            let fixture = Fixture::new();
+            if reserved {
+                fixture
+                    .store
+                    .reserve_remote_worker_request(&fixture.allocation, &public_key(1))
+                    .expect("reserve");
+            }
+            fixture.expire();
+            let observed = fixture.reload();
+            let result = fixture.store.reserve_remote_worker_request(&observed, &public_key(1));
+            if reserved {
+                assert_eq!(result.expect("idempotent recovery"), observed);
+                assert_eq!(
+                    observed.worker_request().expect("request").ssh_public_key,
+                    public_key(1)
+                );
+            } else {
+                assert!(matches!(result, Err(Error::RuntimeRequestUnavailable)));
+            }
+            assert_eq!(fixture.reload(), observed);
+        }
+    }
+
+    #[test]
+    fn malformed_keys_and_exhausted_revisions_leave_the_record_unchanged() {
+        let fixture = Fixture::new();
+        for key in [
+            String::new(),
+            "private-test-payload".into(),
+            "ssh-ed25519 invalid".into(),
+            format!("{} private-test-comment", public_key(1)),
+            format!(" {}", public_key(1)),
+        ] {
+            let error = fixture
+                .store
+                .reserve_remote_worker_request(&fixture.allocation, &key)
+                .expect_err("invalid key");
+            assert!(!error.to_string().contains("private-test"));
+            assert_eq!(fixture.reload(), fixture.allocation);
+        }
+        for reserved in [false, true] {
+            let fixture = Fixture::new();
+            if reserved {
+                fixture
+                    .store
+                    .reserve_remote_worker_request(&fixture.allocation, &public_key(1))
+                    .expect("reserve before exhaustion");
+            }
+            rusqlite::Connection::open(fixture.store.path())
+                .expect("fixture connection")
+                .execute(
+                    "UPDATE remote_workspaces SET revision=?1 WHERE workspace_local_id='workspace'",
+                    [i64::MAX],
+                )
+                .expect("exhaust revision");
+            let exhausted = fixture.reload();
+            let result = fixture.store.reserve_remote_worker_request(&exhausted, &public_key(1));
+            if reserved {
+                assert_eq!(result.expect("read-only reservation recovery"), exhausted);
+            } else {
+                assert!(matches!(result, Err(Error::RevisionExhausted)));
+            }
+            assert_eq!(fixture.reload(), exhausted);
+        }
+    }
+
+    #[test]
+    fn missing_or_corrupt_binding_never_adopts_a_request() {
+        for sql in [
+            "DELETE FROM remote_runtime_allocations",
+            "UPDATE remote_runtime_allocations SET session_id='00000000-0000-4000-8000-000000000002'",
+        ] {
+            let fixture = Fixture::new();
+            rusqlite::Connection::open(fixture.store.path())
+                .expect("fixture connection")
+                .execute(sql, [])
+                .expect("fault");
+            assert!(matches!(
+                fixture
+                    .store
+                    .reserve_remote_worker_request(&fixture.allocation, &public_key(1)),
+                Err(Error::UnboundRuntime | Error::Storage(CloudStoreError::InvalidRemoteAllocation))
+            ));
+            assert_eq!(
+                fixture.store.load_remote_workspace(OWNER, "workspace").expect("record"),
+                Some(fixture.allocation.workspace().clone())
+            );
+        }
+    }
+
+    #[test]
+    fn observed_worker_must_match_reserved_key_and_legacy_recovery_never_invents_one() {
+        for reserved in [false, true] {
+            let fixture = Fixture::new();
+            let saved = if reserved {
+                fixture
+                    .store
+                    .reserve_remote_worker_request(&fixture.allocation, &public_key(1))
+                    .expect("reserve")
+            } else {
+                fixture.allocation.clone()
+            };
+            let mut next = saved.workspace().state().clone();
+            let runtime = next.runtime.as_mut().expect("runtime");
+            runtime.worker = Some(
+                serde_json::from_value(serde_json::json!({
+                    "identity": { "provider": "local_docker", "workflow_id": runtime.workflow_id,
+                        "job_id": runtime.job_id, "resource_id": "synthetic-worker" },
+                    "target": next.spec.target, "ssh_public_key": public_key(1),
+                    "lease": { "lifetime": "persistent" }
+                }))
+                .expect("observed worker"),
+            );
+            fixture
+                .store
+                .replace_remote_workspace(saved.workspace(), &next)
+                .expect("observation");
+            let observed = fixture.reload();
+            assert_eq!(
+                observed.worker_request().expect("recovered request").ssh_public_key,
+                public_key(1)
+            );
+            if reserved {
+                next.runtime
+                    .as_mut()
+                    .expect("runtime")
+                    .worker
+                    .as_mut()
+                    .expect("worker")
+                    .ssh_public_key = public_key(2);
+                assert!(next.validate().is_err());
+            } else {
+                assert!(matches!(
+                    fixture.store.reserve_remote_worker_request(&observed, &public_key(1)),
+                    Err(Error::RuntimeRequestUnavailable)
+                ));
+                assert!(
+                    observed
+                        .workspace()
+                        .state()
+                        .runtime
+                        .as_ref()
+                        .expect("runtime")
+                        .ssh_public_key
+                        .is_none()
+                );
+            }
+            assert_eq!(fixture.reload(), observed);
+        }
+    }
+
+    #[test]
+    fn claim_lookup_uses_the_indexed_single_workflow_identity() {
+        let fixture = Fixture::new();
+        let connection = rusqlite::Connection::open(fixture.store.path()).expect("connection");
+        let mut statement = connection
+            .prepare(&format!("EXPLAIN QUERY PLAN {CLAIM_LOOKUP}"))
+            .expect("query plan");
+        let details: Vec<String> = statement
+            .query_map([fixture.allocation.workflow().workflow().id.to_string()], |row| {
+                row.get(3)
+            })
+            .expect("plan")
+            .collect::<Result<_, _>>()
+            .expect("details");
+        assert!(details.iter().any(|detail| detail.contains("SEARCH cloud_worker_creation_claims USING COVERING INDEX cloud_worker_creation_claims_workflow (workflow_id=?)")));
+        assert!(
+            !details
+                .iter()
+                .any(|detail| detail.contains("SCAN cloud_worker_creation_claims"))
+        );
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -152,6 +152,18 @@ impl CloudWorkflowStore {
         if expected.state.runtime.is_none() && next.runtime.is_some() {
             return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
         }
+        if next
+            .runtime
+            .as_ref()
+            .is_some_and(|runtime| runtime.ssh_public_key.is_some())
+            && expected
+                .state
+                .runtime
+                .as_ref()
+                .is_none_or(|runtime| runtime.ssh_public_key.is_none())
+        {
+            return Err(RemoteWorkspaceStoreError::RuntimeRequestRequired);
+        }
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         ensure_current_schema(&transaction)?;
@@ -442,6 +454,10 @@ pub enum RemoteWorkspaceStoreError {
     InvalidAllocationRetention,
     #[error("active remote snapshot has no verified workflow allocation; reconciliation is required")]
     UnboundRuntime,
+    #[error("remote SSH request identity requires an unclaimed allocation reservation")]
+    RuntimeRequestRequired,
+    #[error("remote allocation can no longer reserve a new SSH request identity")]
+    RuntimeRequestUnavailable,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
@@ -39,6 +39,7 @@ fn fixture(version: i64) -> Fixture {
         workflow_id: workflow.id,
         job_id: workflow.nodes[0].id,
         phase: RemoteRuntimePhase::Reconciling,
+        ssh_public_key: None,
         worker: None,
         ssh: None,
         cleanup: None,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests/writes.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests/writes.rs
@@ -46,6 +46,7 @@ fn fixture() -> Fixture {
         workflow_id: workflow.id,
         job_id: workflow.nodes[0].id,
         phase: RemoteRuntimePhase::Provisioning,
+        ssh_public_key: None,
         worker: None,
         ssh: None,
         cleanup: None,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/mod.rs
@@ -57,6 +57,7 @@ fn provisioning(mut state: RemoteWorkspaceState) -> RemoteWorkspaceState {
         workflow_id: CloudWorkflowId::new(),
         job_id: CloudJobId::new(),
         phase: RemoteRuntimePhase::Provisioning,
+        ssh_public_key: None,
         worker: None,
         ssh: None,
         cleanup: None,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -55,6 +55,10 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
             || previous.spec.target != next.spec.target
             || previous.spec.repository != next.spec.repository
             || runtime
+                .ssh_public_key
+                .as_ref()
+                .is_some_and(|key| next_runtime.ssh_public_key.as_ref() != Some(key))
+            || runtime
                 .worker
                 .as_ref()
                 .is_some_and(|worker| next_runtime.worker.as_ref() != Some(worker))

--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -76,7 +76,7 @@ impl TryFrom<WorkspaceSnapshot> for RemoteWorkspaceState {
     }
 }
 
-/// Desired workspace state survives deletion of its disposable worker.
+/// Desired workspace state survives explicit worker cleanup or verified worker loss.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RemoteWorkspaceSpec {
@@ -138,6 +138,9 @@ pub struct RemoteRuntimeGeneration {
     pub workflow_id: CloudWorkflowId,
     pub job_id: CloudJobId,
     pub phase: RemoteRuntimePhase,
+    /// Public client identity committed before provider creation; never private key material.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_public_key: Option<String>,
     /// Missing until an exact provider identity has been discovered and verified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worker: Option<InteractiveWorker>,

--- a/crates/horizon-core/src/remote_workspace/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/tests.rs
@@ -70,6 +70,7 @@ fn active() -> RemoteWorkspaceState {
             workflow_id,
             job_id,
             phase: RemoteRuntimePhase::Ready,
+            ssh_public_key: None,
             worker: Some(worker),
             ssh: Some(InteractiveWorkerSshEndpoint {
                 host: "127.0.0.1".into(),

--- a/crates/horizon-core/src/remote_workspace/validation.rs
+++ b/crates/horizon-core/src/remote_workspace/validation.rs
@@ -2,7 +2,10 @@ use super::{
     REMOTE_WORKSPACE_STATE_VERSION, RemotePanelBinding, RemoteRuntimeGeneration, RemoteRuntimePhase,
     RemoteWorkspaceError as Error, RemoteWorkspaceSpec, RemoteWorkspaceState, RepositoryCheckpoint,
 };
-use crate::{PanelKind, cloud_run::interactive_worker::valid_worker_target};
+use crate::{
+    PanelKind,
+    cloud_run::interactive_worker::{InteractiveWorkerRequest, valid_worker_target},
+};
 use std::collections::HashSet;
 
 const MAX_PANELS: usize = 256;
@@ -127,6 +130,20 @@ impl RemoteRuntimeGeneration {
         }
         if self.generation == 0 || self.generation != spec.generation {
             return Err(Error::InvalidRuntime("generation"));
+        }
+        if let Some(key) = &self.ssh_public_key {
+            let request = InteractiveWorkerRequest {
+                workflow_id: self.workflow_id,
+                job_id: self.job_id,
+                target: spec.target.clone(),
+                ssh_public_key: key.clone(),
+            };
+            if !request.is_valid_for(spec.target.provider)
+                || key.split(' ').count() != 2
+                || self.worker.as_ref().is_some_and(|worker| worker.ssh_public_key != *key)
+            {
+                return Err(Error::InvalidRuntime("SSH request identity"));
+            }
         }
         if let Some(worker) = &self.worker {
             if !worker.has_valid_shape()

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -121,6 +121,23 @@ The first trusted SSH endpoint may be recorded once while the runtime exists. On
 its host, port, user, and host key cannot be replaced or dropped within that
 runtime generation, even while reconnecting or reconciling.
 
+The optional runtime `ssh_public_key` is a canonical, comment-free public client
+identity, not private key material. The dedicated request reservation compares
+the complete current allocation under an immediate transaction before writing
+it. Initial reservation requires a still-provisioning, unexpired setup with no
+worker, cleanup intent, or consumed creation claim. The claim lookup is indexed
+by its single-worker workflow identity. Generic record replacement cannot install
+the key, and no replacement can change or clear it within the runtime.
+Concurrent callers reload the winning identity; same-key reservation is an
+idempotent read even after setup expiry. It neither consumes nor renews creation
+authority. Missing identity after a create claim must not be guessed or repaired
+with a new key. Request reconstruction uses this reservation, or the exact public
+key already present in a legacy observed worker; it grants no provider authority.
+Legacy snapshots without the field retain their wire representation. Older readers
+reject populated new fields rather than ignoring them. Secure private-key retention
+must precede reservation and remains a separate coordinator integration requirement.
+No private key, provider credential, provider I/O, or automatic cleanup is added.
+
 Domain-valid in-memory state can exceed the storage limits. Callers must persist
 intent successfully before provider side effects and surface storage-capacity
 errors without discarding the last saved runtime or cleanup record.


### PR DESCRIPTION
## Purpose

Retain the non-secret SSH request identity before an interactive worker creation
can cross the provider boundary. This advances #383 without adding provider calls
or changing remote resource lifetime.

## Behavior

- Reserve a canonical public client key against the complete current allocation
  in one transaction; reject stale, late, expired, claimed or observed setups.
- Preserve the key within the runtime and prevent generic snapshot writes from
  installing, replacing or removing it. Same-key recovery does not rewrite state.
- Reconstruct requests from that reservation or an exact legacy observed worker;
  reconstruction grants no provider or attachment authority.
- Keep private keys outside snapshots. Private-key retention must precede this
  reservation; coordinator sequencing remains a separate integration requirement.

## Validation

Nine new regressions cover persistence/reopen, competing reservations, immutable
identity, late claims/observations/cleanup, setup expiry, malformed keys/redaction,
revision exhaustion and read-only recovery, broken bindings, legacy recovery and
indexed query plans. Existing suites and the complete local default/speech,
format, maintainability, version and blocking/strict/pedantic matrix passed in
the exact worktree. Independent local review completed with no open findings.

No UI, provider resources, credentials, dependencies or config defaults changed.
No live-provider or PC-off acceptance is claimed by these tests.

Assignee follows repository convention; no unambiguous current label, milestone
or project convention was available.
