### PR TITLE
Retain Linux SSH client identities across local session closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ dependencies = [
  "profiling",
  "regex",
  "rusqlite",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ process-wrap = { version = "10.0.0", default-features = false, features = ["std"
 atomicwrites = "0.4.4"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 libc = "0.2.189"
+rustix = { version = "1.1.4", features = ["process"] }
 uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
 regex = "1.13.1"

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -35,6 +35,9 @@ git2.workspace = true
 regex.workspace = true
 atomicwrites.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix.workspace = true
+
 [dev-dependencies]
 horizon-browser = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -386,7 +386,7 @@ fn valid_ssh_username(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
-pub(super) fn valid_ssh_public_key(value: &str) -> bool {
+pub(crate) fn valid_ssh_public_key(value: &str) -> bool {
     valid_ed25519_key(value, true)
 }
 

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -20,6 +20,7 @@ mod managed_install;
 mod opencode_paths;
 mod panel;
 mod remote_hosts;
+pub mod remote_ssh_identity;
 pub mod remote_workspace;
 mod runtime_state;
 pub mod search;

--- a/crates/horizon-core/src/remote_ssh_identity.rs
+++ b/crates/horizon-core/src/remote_ssh_identity.rs
@@ -1,0 +1,122 @@
+//! Local private SSH identities are independent of client views and session files.
+//! They are not credentials for repository access and grant no provider authority.
+
+#[cfg(target_os = "linux")]
+mod command;
+#[cfg(target_os = "linux")]
+mod linux;
+
+use crate::{
+    HorizonHome,
+    cloud_run::{CloudJobId, CloudWorkflowId},
+};
+use std::path::{Path, PathBuf};
+
+/// A private filesystem location, never a serializable workspace snapshot.
+pub struct RemoteSshIdentityStore {
+    home: PathBuf,
+}
+
+/// Only the public key may be copied into the durable allocation request.
+pub struct RemoteSshIdentity {
+    private_key_path: PathBuf,
+    public_key: String,
+}
+
+impl RemoteSshIdentity {
+    #[must_use]
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+
+    /// Pass only as a local identity-file argument to the pinned SSH transport.
+    #[must_use]
+    pub fn private_key_path(&self) -> &Path {
+        &self.private_key_path
+    }
+}
+
+impl std::fmt::Debug for RemoteSshIdentity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("RemoteSshIdentity").finish_non_exhaustive()
+    }
+}
+
+impl RemoteSshIdentityStore {
+    #[must_use]
+    pub fn new(home: &HorizonHome) -> Self {
+        Self {
+            home: home.root().to_path_buf(),
+        }
+    }
+
+    /// Retain a candidate for a new, unclaimed allocation before reserving its public key.
+    /// Reuses an interrupted candidate for these exact IDs; never overwrites a key.
+    /// This operation must not be used to recover an already reserved/claimed allocation.
+    /// Run off the render thread. No key is removed on handle/store drop or client exit.
+    /// # Errors
+    /// Rejects insecure paths, unavailable key generation, storage failures and unsupported platforms.
+    pub fn prepare_new(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+    ) -> Result<RemoteSshIdentity, RemoteSshIdentityError> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::prepare(&self.home, workflow_id, job_id)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (&self.home, workflow_id, job_id);
+            Err(RemoteSshIdentityError::UnsupportedPlatform)
+        }
+    }
+
+    /// Load only the existing private identity matching the allocation's saved public key.
+    /// Missing, corrupt or mismatched keys fail closed; recovery never creates a replacement.
+    /// It performs no provider operations and does not authorize attachment by itself.
+    /// # Errors
+    /// Rejects missing/mismatched keys, insecure paths, key inspection failures and unsupported platforms.
+    pub fn recover(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        expected_public_key: &str,
+    ) -> Result<RemoteSshIdentity, RemoteSshIdentityError> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::recover(&self.home, workflow_id, job_id, expected_public_key)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (&self.home, workflow_id, job_id, expected_public_key);
+            Err(RemoteSshIdentityError::UnsupportedPlatform)
+        }
+    }
+}
+
+/// Errors deliberately omit key bytes, paths, subprocess output and command arguments.
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum RemoteSshIdentityError {
+    #[error("remote private SSH identity is missing; no replacement was generated")]
+    Missing,
+    #[error("remote private SSH identity does not match the saved public request")]
+    Mismatch,
+    #[error("remote SSH identity path is not a private regular file or directory")]
+    InsecurePath,
+    #[error("remote SSH identity storage operation failed")]
+    Storage,
+    #[error("remote SSH identity is invalid")]
+    InvalidIdentity,
+    #[error("OpenSSH key utility is unavailable")]
+    KeyUtilityUnavailable,
+    #[error("OpenSSH key operation failed")]
+    KeyUtilityFailed,
+    #[error("OpenSSH key operation exceeded its deadline")]
+    Deadline,
+    #[error("protected remote SSH identity storage is not yet supported on this platform")]
+    UnsupportedPlatform,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_ssh_identity/command.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/command.rs
@@ -1,0 +1,120 @@
+use super::RemoteSshIdentityError as Error;
+use std::{
+    io::Read,
+    path::Path,
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+const DEADLINE: Duration = Duration::from_secs(5);
+const PUBLIC_OUTPUT_LIMIT: u16 = 1024;
+
+pub(super) fn generate(path: &Path) -> Result<(), Error> {
+    let mut command = Command::new("ssh-keygen");
+    command
+        .args(["-q", "-t", "ed25519", "-N", "", "-C", "", "-f"])
+        .arg(path);
+    run(command, DEADLINE).map(|_| ())
+}
+
+pub(super) fn public_key(path: &Path) -> Result<String, Error> {
+    let mut command = Command::new("ssh-keygen");
+    command.args(["-y", "-P", "", "-f"]).arg(path);
+    let output = run(command, DEADLINE)?;
+    let key = String::from_utf8(output).map_err(|_| Error::InvalidIdentity)?;
+    Ok(key.trim_end_matches(['\r', '\n']).into())
+}
+
+fn run(mut command: Command, timeout: Duration) -> Result<Vec<u8>, Error> {
+    let started = Instant::now();
+    let child = command
+        .env("SSH_ASKPASS_REQUIRE", "never")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                Error::KeyUtilityUnavailable
+            } else {
+                Error::KeyUtilityFailed
+            }
+        })?;
+    let mut child = OwnedChild(child);
+    let stdout = child.0.stdout.take().ok_or(Error::KeyUtilityFailed)?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::Builder::new()
+        .name("remote-key-output".into())
+        .spawn(move || {
+            let mut output = Vec::new();
+            let result = stdout
+                .take(u64::from(PUBLIC_OUTPUT_LIMIT) + 1)
+                .read_to_end(&mut output)
+                .map(|_| output);
+            let _ = sender.send(result);
+        })
+        .map_err(|_| Error::KeyUtilityFailed)?;
+    loop {
+        if let Some(status) = child.0.try_wait().map_err(|_| Error::KeyUtilityFailed)? {
+            if !status.success() {
+                return Err(Error::KeyUtilityFailed);
+            }
+            break;
+        }
+        if started.elapsed() >= timeout {
+            return Err(Error::Deadline);
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    let output = receiver
+        .recv_timeout(timeout.saturating_sub(started.elapsed()))
+        .map_err(|_| Error::Deadline)?
+        .map_err(|_| Error::KeyUtilityFailed)?;
+    if output.len() > usize::from(PUBLIC_OUTPUT_LIMIT) {
+        return Err(Error::InvalidIdentity);
+    }
+    Ok(output)
+}
+
+struct OwnedChild(Child);
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        if !matches!(self.0.try_wait(), Ok(Some(_))) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_missing_and_overlong_command_output_is_redacted() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "printf private-test-marker >&2; exit 4"]);
+        let error = run(command, Duration::from_secs(2)).expect_err("failure");
+        assert_eq!(error, Error::KeyUtilityFailed);
+        assert!(!format!("{error:?} {error}").contains("private-test-marker"));
+        assert_eq!(
+            run(Command::new("/nonexistent-horizon-key-utility"), DEADLINE),
+            Err(Error::KeyUtilityUnavailable)
+        );
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "printf '%02000d' 0"]);
+        assert_eq!(run(command, DEADLINE), Err(Error::InvalidIdentity));
+    }
+
+    #[test]
+    fn command_deadline_is_bounded_and_reaps_its_owned_child() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "exec sleep 5"]);
+        let started = Instant::now();
+        assert_eq!(run(command, Duration::from_millis(40)), Err(Error::Deadline));
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}

--- a/crates/horizon-core/src/remote_ssh_identity/linux.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/linux.rs
@@ -3,8 +3,8 @@ use crate::cloud_run::{CloudJobId, CloudWorkflowId, interactive_worker::valid_ss
 use std::{
     fs::{self, File, OpenOptions},
     io,
-    os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt},
-    path::{Path, PathBuf},
+    os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
+    path::{Component, Path, PathBuf},
 };
 
 const KEY_FILE_LIMIT: u64 = 4096;
@@ -25,10 +25,13 @@ pub(super) fn prepare(home: &Path, workflow: CloudWorkflowId, job: CloudJobId) -
     let identity = load(&candidate)?;
     private_file(&candidate)?.sync_all().map_err(|_| Error::Storage)?;
     match atomicwrites::move_atomic(&candidate, &destination) {
-        Ok(()) => Ok(RemoteSshIdentity {
-            private_key_path: destination,
-            public_key: identity.public_key,
-        }),
+        Ok(()) => {
+            sync_directory(&directory)?;
+            Ok(RemoteSshIdentity {
+                private_key_path: destination,
+                public_key: identity.public_key,
+            })
+        }
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => retained(&destination, &directory),
         Err(_) => Err(Error::Storage),
     }
@@ -52,8 +55,8 @@ pub(super) fn recover(
 }
 
 fn directory(home: &Path, create: bool) -> Result<PathBuf, Error> {
-    check_directory(home, create, false)?;
-    let root = home.canonicalize().map_err(|_| Error::Storage)?;
+    let root = trusted_home(home)?;
+    check_directory(&root, create, false)?;
     let directory = root.join(STORE_DIRECTORY);
     check_directory(&directory, create, true)?;
     if create {
@@ -62,6 +65,30 @@ fn directory(home: &Path, create: bool) -> Result<PathBuf, Error> {
         sync_directory(&root)?;
     }
     Ok(directory)
+}
+
+fn trusted_home(home: &Path) -> Result<PathBuf, Error> {
+    let absolute = std::path::absolute(home).map_err(|_| Error::Storage)?;
+    if absolute.components().any(|component| component == Component::ParentDir) {
+        return Err(Error::InsecurePath);
+    }
+    let parent = absolute.parent().ok_or(Error::InsecurePath)?;
+    let uid = rustix::process::geteuid().as_raw();
+    let mut ancestor = PathBuf::new();
+    // Walk from the trusted root before creating anything. A sticky ancestor
+    // is safe only because every child below it must also belong to us or root.
+    for component in parent.components() {
+        ancestor.push(component);
+        let metadata = fs::symlink_metadata(&ancestor).map_err(|error| storage_error(&error))?;
+        let mode = metadata.permissions().mode();
+        if !metadata.is_dir()
+            || (metadata.uid() != uid && metadata.uid() != 0)
+            || (mode & 0o022 != 0 && mode & 0o1000 == 0)
+        {
+            return Err(Error::InsecurePath);
+        }
+    }
+    Ok(absolute)
 }
 
 fn check_directory(path: &Path, create: bool, private: bool) -> Result<(), Error> {
@@ -74,7 +101,10 @@ fn check_directory(path: &Path, create: bool, private: bool) -> Result<(), Error
     }
     let metadata = fs::symlink_metadata(path).map_err(|error| storage_error(&error))?;
     let forbidden = if private { 0o077 } else { 0o022 };
-    if !metadata.is_dir() || metadata.permissions().mode() & forbidden != 0 {
+    if !metadata.is_dir()
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.permissions().mode() & forbidden != 0
+    {
         return Err(Error::InsecurePath);
     }
     Ok(())
@@ -128,7 +158,10 @@ fn private_file(path: &Path) -> Result<File, Error> {
             }
         })?;
     let metadata = file.metadata().map_err(|_| Error::Storage)?;
-    if !metadata.is_file() || metadata.permissions().mode() & 0o077 != 0 {
+    if !metadata.is_file()
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.permissions().mode() & 0o077 != 0
+    {
         return Err(Error::InsecurePath);
     }
     if metadata.len() == 0 || metadata.len() > KEY_FILE_LIMIT {

--- a/crates/horizon-core/src/remote_ssh_identity/linux.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/linux.rs
@@ -1,0 +1,170 @@
+use super::{RemoteSshIdentity, RemoteSshIdentityError as Error, command};
+use crate::cloud_run::{CloudJobId, CloudWorkflowId, interactive_worker::valid_ssh_public_key};
+use std::{
+    fs::{self, File, OpenOptions},
+    io,
+    os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt},
+    path::{Path, PathBuf},
+};
+
+const KEY_FILE_LIMIT: u64 = 4096;
+const STORE_DIRECTORY: &str = "remote-ssh-identities";
+
+pub(super) fn prepare(home: &Path, workflow: CloudWorkflowId, job: CloudJobId) -> Result<RemoteSshIdentity, Error> {
+    let name = key_name(workflow, job)?;
+    let directory = directory(home, true)?;
+    let destination = directory.join(name);
+    match fs::symlink_metadata(&destination) {
+        Ok(_) => return retained(&destination, &directory),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(Error::Storage),
+    }
+    let staging = StagingDirectory::create(&directory)?;
+    let candidate = staging.0.join("identity");
+    command::generate(&candidate)?;
+    let identity = load(&candidate)?;
+    private_file(&candidate)?.sync_all().map_err(|_| Error::Storage)?;
+    match atomicwrites::move_atomic(&candidate, &destination) {
+        Ok(()) => Ok(RemoteSshIdentity {
+            private_key_path: destination,
+            public_key: identity.public_key,
+        }),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => retained(&destination, &directory),
+        Err(_) => Err(Error::Storage),
+    }
+}
+
+pub(super) fn recover(
+    home: &Path,
+    workflow: CloudWorkflowId,
+    job: CloudJobId,
+    expected: &str,
+) -> Result<RemoteSshIdentity, Error> {
+    if !valid_public_key(expected) {
+        return Err(Error::InvalidIdentity);
+    }
+    let name = key_name(workflow, job)?;
+    let identity = load(&directory(home, false)?.join(name))?;
+    if identity.public_key != expected {
+        return Err(Error::Mismatch);
+    }
+    Ok(identity)
+}
+
+fn directory(home: &Path, create: bool) -> Result<PathBuf, Error> {
+    check_directory(home, create, false)?;
+    let root = home.canonicalize().map_err(|_| Error::Storage)?;
+    let directory = root.join(STORE_DIRECTORY);
+    check_directory(&directory, create, true)?;
+    if create {
+        // Make both newly created directory entries durable before reserving a public request.
+        sync_directory(root.parent().ok_or(Error::InsecurePath)?)?;
+        sync_directory(&root)?;
+    }
+    Ok(directory)
+}
+
+fn check_directory(path: &Path, create: bool, private: bool) -> Result<(), Error> {
+    if create {
+        match fs::DirBuilder::new().mode(0o700).create(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(_) => return Err(Error::Storage),
+        }
+    }
+    let metadata = fs::symlink_metadata(path).map_err(|error| storage_error(&error))?;
+    let forbidden = if private { 0o077 } else { 0o022 };
+    if !metadata.is_dir() || metadata.permissions().mode() & forbidden != 0 {
+        return Err(Error::InsecurePath);
+    }
+    Ok(())
+}
+
+fn key_name(workflow: CloudWorkflowId, job: CloudJobId) -> Result<String, Error> {
+    if workflow.to_string() == uuid::Uuid::nil().to_string() || job.to_string() == uuid::Uuid::nil().to_string() {
+        return Err(Error::InvalidIdentity);
+    }
+    Ok(format!("{workflow}-{job}.key"))
+}
+
+fn retained(path: &Path, directory: &Path) -> Result<RemoteSshIdentity, Error> {
+    let identity = load(path)?;
+    private_file(path)?.sync_all().map_err(|_| Error::Storage)?;
+    sync_directory(directory)?;
+    Ok(identity)
+}
+
+fn sync_directory(path: &Path) -> Result<(), Error> {
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|_| Error::Storage)
+}
+
+fn load(path: &Path) -> Result<RemoteSshIdentity, Error> {
+    // Hold the inspected file open while the trusted key utility verifies its contents.
+    // The enclosing directories are owner-only; same-user tampering is outside this boundary.
+    let file = private_file(path)?;
+    let public_key = command::public_key(path)?;
+    if !valid_public_key(&public_key) {
+        return Err(Error::InvalidIdentity);
+    }
+    drop(file);
+    Ok(RemoteSshIdentity {
+        private_key_path: path.to_path_buf(),
+        public_key,
+    })
+}
+
+fn private_file(path: &Path) -> Result<File, Error> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| {
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                Error::InsecurePath
+            } else {
+                storage_error(&error)
+            }
+        })?;
+    let metadata = file.metadata().map_err(|_| Error::Storage)?;
+    if !metadata.is_file() || metadata.permissions().mode() & 0o077 != 0 {
+        return Err(Error::InsecurePath);
+    }
+    if metadata.len() == 0 || metadata.len() > KEY_FILE_LIMIT {
+        return Err(Error::InvalidIdentity);
+    }
+    Ok(file)
+}
+
+fn valid_public_key(key: &str) -> bool {
+    key.len() <= 128 && key.split(' ').count() == 2 && valid_ssh_public_key(key)
+}
+
+fn storage_error(error: &io::Error) -> Error {
+    if error.kind() == io::ErrorKind::NotFound {
+        Error::Missing
+    } else {
+        Error::Storage
+    }
+}
+
+struct StagingDirectory(PathBuf);
+
+impl StagingDirectory {
+    fn create(parent: &Path) -> Result<Self, Error> {
+        let path = parent.join(format!(".new-{}", uuid::Uuid::new_v4()));
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&path)
+            .map_err(|_| Error::Storage)?;
+        Ok(Self(path))
+    }
+}
+
+impl Drop for StagingDirectory {
+    fn drop(&mut self) {
+        // Only this successfully created random staging directory is owned by the operation.
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/crates/horizon-core/src/remote_ssh_identity/tests.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/tests.rs
@@ -1,0 +1,243 @@
+use super::*;
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use super::*;
+    use std::{
+        fs,
+        os::unix::fs::{PermissionsExt, symlink},
+        sync::{Arc, Barrier},
+    };
+
+    fn fixture() -> (tempfile::TempDir, RemoteSshIdentityStore, CloudWorkflowId, CloudJobId) {
+        let directory = tempfile::tempdir().expect("private fixture");
+        let store = RemoteSshIdentityStore::new(&HorizonHome::from_root(directory.path().join("home")));
+        (directory, store, CloudWorkflowId::new(), CloudJobId::new())
+    }
+
+    #[test]
+    fn retained_key_survives_store_drop_and_matches_the_reserved_public_identity() {
+        let (directory, store, workflow, job) = fixture();
+        let identity = store.prepare_new(workflow, job).expect("new identity");
+        let public = identity.public_key().to_string();
+        let path = identity.private_key_path().to_path_buf();
+        assert!(public.starts_with("ssh-ed25519 "));
+        assert_eq!(public.split(' ').count(), 2);
+        assert_eq!(fs::metadata(&path).expect("file").permissions().mode() & 0o777, 0o600);
+        assert_eq!(
+            fs::metadata(path.parent().expect("parent"))
+                .expect("directory")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert!(!format!("{identity:?}").contains(&public));
+        drop(identity);
+        drop(store);
+        let store = RemoteSshIdentityStore::new(&HorizonHome::from_root(directory.path().join("home")));
+        let recovered = store.recover(workflow, job, &public).expect("recovery");
+        assert_eq!(recovered.public_key(), public);
+        assert_eq!(recovered.private_key_path(), path);
+        assert_eq!(
+            store
+                .prepare_new(workflow, job)
+                .expect("interrupted setup candidate")
+                .public_key(),
+            public
+        );
+        assert_eq!(
+            fs::read_dir(path.parent().expect("parent")).expect("directory").count(),
+            1
+        );
+    }
+
+    #[test]
+    fn missing_or_mismatched_identity_never_generates_a_replacement() {
+        let (_directory, store, workflow, job) = fixture();
+        let identity = store.prepare_new(workflow, job).expect("identity");
+        let other = store
+            .prepare_new(CloudWorkflowId::new(), CloudJobId::new())
+            .expect("other");
+        assert_eq!(
+            store.recover(workflow, job, other.public_key()).expect_err("mismatch"),
+            RemoteSshIdentityError::Mismatch
+        );
+        assert_eq!(
+            store.recover(workflow, job, "secret-test-value").expect_err("invalid"),
+            RemoteSshIdentityError::InvalidIdentity
+        );
+        fs::remove_file(identity.private_key_path()).expect("simulate lost key");
+        assert_eq!(
+            store.recover(workflow, job, identity.public_key()).expect_err("lost"),
+            RemoteSshIdentityError::Missing
+        );
+        assert!(!identity.private_key_path().exists());
+    }
+
+    #[test]
+    fn concurrent_preparation_publishes_one_complete_key_and_reuses_the_winner() {
+        let (_directory, store, workflow, job) = fixture();
+        let store = Arc::new(store);
+        let barrier = Arc::new(Barrier::new(3));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.prepare_new(workflow, job)
+                })
+            })
+            .collect();
+        barrier.wait();
+        let identities: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread").expect("identity"))
+            .collect();
+        assert_eq!(identities[0].public_key(), identities[1].public_key());
+        assert_eq!(identities[0].private_key_path(), identities[1].private_key_path());
+        assert_eq!(
+            store
+                .recover(workflow, job, identities[0].public_key())
+                .expect("recovery")
+                .public_key(),
+            identities[0].public_key()
+        );
+    }
+
+    #[test]
+    fn insecure_paths_are_rejected_without_repairing_or_overwriting_them() {
+        let (_directory, store, workflow, job) = fixture();
+        let identity = store.prepare_new(workflow, job).expect("identity");
+        let key_path = identity.private_key_path();
+        fs::set_permissions(key_path, fs::Permissions::from_mode(0o644)).expect("fault");
+        assert_eq!(
+            store.recover(workflow, job, identity.public_key()).expect_err("unsafe"),
+            RemoteSshIdentityError::InsecurePath
+        );
+        assert_eq!(
+            store.prepare_new(workflow, job).expect_err("unsafe candidate"),
+            RemoteSshIdentityError::InsecurePath
+        );
+        assert_eq!(
+            fs::metadata(key_path).expect("file").permissions().mode() & 0o777,
+            0o644
+        );
+        fs::set_permissions(key_path, fs::Permissions::from_mode(0o600)).expect("restore");
+        fs::set_permissions(key_path.parent().expect("parent"), fs::Permissions::from_mode(0o755))
+            .expect("fault directory");
+        assert_eq!(
+            store
+                .recover(workflow, job, identity.public_key())
+                .expect_err("unsafe directory"),
+            RemoteSshIdentityError::InsecurePath
+        );
+    }
+
+    #[test]
+    fn symlinks_empty_and_oversized_keys_fail_closed() {
+        let (directory, store, workflow, job) = fixture();
+        let identity = store.prepare_new(workflow, job).expect("identity");
+        let key_path = identity.private_key_path();
+        let saved = directory.path().join("saved-key");
+        fs::rename(key_path, &saved).expect("save");
+        symlink(&saved, key_path).expect("symlink");
+        assert_eq!(
+            store
+                .recover(workflow, job, identity.public_key())
+                .expect_err("symlink"),
+            RemoteSshIdentityError::InsecurePath
+        );
+        fs::remove_file(key_path).expect("remove fixture link");
+        fs::rename(saved, key_path).expect("restore");
+        for content in [Vec::new(), vec![b'x'; 4097]] {
+            fs::write(key_path, content).expect("corrupt fixture");
+            assert_eq!(
+                store
+                    .recover(workflow, job, identity.public_key())
+                    .expect_err("corrupt"),
+                RemoteSshIdentityError::InvalidIdentity
+            );
+        }
+    }
+
+    #[test]
+    fn missing_store_recovery_is_read_only_and_directory_symlinks_are_rejected() {
+        let (directory, store, workflow, job) = fixture();
+        let key = store.prepare_new(workflow, job).expect("fixture key");
+        let missing = directory.path().join("missing");
+        let missing_store = RemoteSshIdentityStore::new(&HorizonHome::from_root(missing.clone()));
+        assert_eq!(
+            missing_store
+                .recover(workflow, job, key.public_key())
+                .expect_err("missing"),
+            RemoteSshIdentityError::Missing
+        );
+        assert!(!missing.exists());
+        let linked = directory.path().join("linked");
+        symlink(directory.path().join("home"), &linked).expect("linked home");
+        let linked_store = RemoteSshIdentityStore::new(&HorizonHome::from_root(linked));
+        assert_eq!(
+            linked_store.prepare_new(workflow, job).expect_err("linked home"),
+            RemoteSshIdentityError::InsecurePath
+        );
+    }
+
+    #[test]
+    fn invalid_ids_fail_before_writes_and_public_home_permissions_do_not_weaken_key_privacy() {
+        let (directory, store, workflow, job) = fixture();
+        let nil = "00000000-0000-0000-0000-000000000000";
+        assert_eq!(
+            store
+                .prepare_new(nil.parse().expect("nil workflow"), job)
+                .expect_err("nil"),
+            RemoteSshIdentityError::InvalidIdentity
+        );
+        assert_eq!(
+            store
+                .prepare_new(workflow, nil.parse().expect("nil job"))
+                .expect_err("nil"),
+            RemoteSshIdentityError::InvalidIdentity
+        );
+        let home = directory.path().join("home");
+        assert!(!home.exists());
+        fs::create_dir(&home).expect("home");
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o755)).expect("public directory");
+        let identity = store.prepare_new(workflow, job).expect("private child of public home");
+        assert_eq!(
+            fs::metadata(identity.private_key_path())
+                .expect("key")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o777)).expect("writable directory");
+        assert_eq!(
+            store
+                .recover(workflow, job, identity.public_key())
+                .expect_err("writable home"),
+            RemoteSshIdentityError::InsecurePath
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_never_writes_an_unprotected_key() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let home = directory.path().join("untouched");
+    let store = RemoteSshIdentityStore::new(&HorizonHome::from_root(home.clone()));
+    let workflow = CloudWorkflowId::new();
+    let job = CloudJobId::new();
+    assert_eq!(
+        store.prepare_new(workflow, job).expect_err("unsupported"),
+        RemoteSshIdentityError::UnsupportedPlatform
+    );
+    assert_eq!(
+        store.recover(workflow, job, "key").expect_err("unsupported"),
+        RemoteSshIdentityError::UnsupportedPlatform
+    );
+    assert!(!home.exists());
+}

--- a/crates/horizon-core/src/remote_ssh_identity/tests.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/tests.rs
@@ -11,6 +11,7 @@ mod linux_tests {
 
     fn fixture() -> (tempfile::TempDir, RemoteSshIdentityStore, CloudWorkflowId, CloudJobId) {
         let directory = tempfile::tempdir().expect("private fixture");
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).expect("private fixture mode");
         let store = RemoteSshIdentityStore::new(&HorizonHome::from_root(directory.path().join("home")));
         (directory, store, CloudWorkflowId::new(), CloudJobId::new())
     }
@@ -181,6 +182,67 @@ mod linux_tests {
         assert_eq!(
             linked_store.prepare_new(workflow, job).expect_err("linked home"),
             RemoteSshIdentityError::InsecurePath
+        );
+    }
+
+    #[test]
+    fn writable_parents_and_ancestors_fail_before_creating_an_identity_store() {
+        let (directory, _, workflow, job) = fixture();
+        let parent = directory.path().join("parent");
+        fs::create_dir(&parent).expect("parent");
+        let home = parent.join("home");
+        let store = RemoteSshIdentityStore::new(&HorizonHome::from_root(home.clone()));
+        for unsafe_directory in [&parent, &directory.path().to_path_buf()] {
+            for permissions in [0o770, 0o777] {
+                fs::set_permissions(unsafe_directory, fs::Permissions::from_mode(permissions)).expect("fault");
+                assert_eq!(
+                    store.prepare_new(workflow, job).expect_err("writable ancestor"),
+                    RemoteSshIdentityError::InsecurePath
+                );
+                assert!(!home.exists());
+            }
+            fs::set_permissions(unsafe_directory, fs::Permissions::from_mode(0o700)).expect("restore");
+        }
+        let identity = store.prepare_new(workflow, job).expect("trusted chain");
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o777)).expect("fault after creation");
+        assert_eq!(
+            store
+                .recover(workflow, job, identity.public_key())
+                .expect_err("unsafe recovery"),
+            RemoteSshIdentityError::InsecurePath
+        );
+        assert!(identity.private_key_path().exists());
+    }
+
+    #[test]
+    fn symlinked_or_traversing_ancestors_fail_before_writes() {
+        let (directory, _, workflow, job) = fixture();
+        let target = directory.path().join("target");
+        fs::create_dir(&target).expect("target");
+        let linked = directory.path().join("linked");
+        symlink(&target, &linked).expect("linked ancestor");
+        for home in [linked.join("home"), target.join("..").join("home")] {
+            let store = RemoteSshIdentityStore::new(&HorizonHome::from_root(home));
+            assert_eq!(
+                store.prepare_new(workflow, job).expect_err("untrusted path"),
+                RemoteSshIdentityError::InsecurePath
+            );
+        }
+        assert!(!target.join("home").exists());
+        assert!(!directory.path().join("home").exists());
+    }
+
+    #[test]
+    fn sticky_shared_ancestor_with_owned_children_preserves_identity_privacy() {
+        let (directory, store, workflow, job) = fixture();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o1777)).expect("sticky ancestor");
+        let identity = store.prepare_new(workflow, job).expect("owned private child");
+        assert_eq!(
+            store
+                .recover(workflow, job, identity.public_key())
+                .expect("recover")
+                .public_key(),
+            identity.public_key()
         );
     }
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -91,6 +91,10 @@ back into large multi-purpose modules.
   panels, exact runtime generation, and repository checkpoint metadata.
   Its validation is pure: provider I/O, runtime-state migration, coordination,
   repository transfer, and UI integration belong in later focused modules.
+- `remote_ssh_identity.rs` exposes retained local client-key preparation and strict
+  recovery, separately from the pure remote aggregate. Linux filesystem privacy
+  and durable publication live in `remote_ssh_identity/linux.rs`; bounded key-utility
+  execution lives in `command.rs`. Neither owns provider or remote task lifetime.
 - `cloud_run/worker_lifetime.rs` owns explicit execution lifetime and compatible
   target serialization. `interactive_worker.rs` validates observed lifetime
   against that policy; neither represents the client/creation ownership lease.

--- a/docs/architecture/remote-ssh-identity.md
+++ b/docs/architecture/remote-ssh-identity.md
@@ -1,0 +1,61 @@
+# Retained remote SSH client identity
+
+Remote worker connections use a dedicated per-allocation client key, not a user's
+general SSH identity or repository credentials. The private key belongs to a
+local private identity store independent of board/session files. Closing handles,
+panels or Horizon does not remove it or perform any provider operation.
+
+The current implementation supports Linux clients with a trusted local
+POSIX-permission filesystem and OpenSSH `ssh-keygen` on PATH. Arbitrary network
+shares are outside this boundary. Other platforms explicitly fail before writes:
+macOS inherited ACLs can grant access independently of the checked mode bits,
+and Windows requires its own ACL-aware implementation. Both need dedicated
+permission checks and current-head platform smoke before enabling key storage.
+This boundary is not a completed cross-platform remote-workspace feature.
+
+## Ordering and recovery
+
+For a new, unclaimed allocation, `prepare_new` retains one key under its exact
+workflow/job UUIDs. An interrupted setup may reuse that existing candidate.
+Independent processes generate in separate owner-only staging directories and
+publish without overwrite; a loser reloads the winning complete key. Files and
+directory entries are synchronized before the candidate is returned. An error
+after publication may leave a valid retained candidate; callers must not delete it
+as failure cleanup or create a second allocation merely to retry.
+
+Only after durable key retention may the coordinator reserve the public identity
+in the allocation store, then consume the one-shot provider creation grant.
+`prepare_new` is not a recovery path for a reserved or claimed allocation.
+`recover` only loads an existing key and derives its public key with OpenSSH,
+comparing it exactly to the saved request. Missing, invalid, insecure or mismatched
+keys fail visibly without replacement, key rotation or a provider call. The
+coordinator must preserve the remote worker and surface recovery instructions.
+
+## Private storage boundary
+
+The configured Horizon home must have an existing trusted parent, must not be a
+symlink and must not be writable by other users. The dedicated identity directory
+is owner-only (`0700`); private regular files are owner-only (`0600` when created).
+Keys are unencrypted OpenSSH files protected by filesystem permissions; an
+encrypted vault or OS keychain is not claimed by this implementation.
+Symlinks, non-regular files, broad permissions and oversized/empty files are
+rejected, not silently repaired. Same-user filesystem tampering is outside this
+permission boundary, as with other local private stores. The filesystem must
+support durable same-filesystem no-overwrite publication.
+
+Private bytes are never serialized or read into application strings. Public-key
+derivation has bounded output and a five-second process deadline, with prompts
+disabled and diagnostics discarded. Errors and identity debug formatting omit
+paths, key bytes and subprocess output. Key utility processes are task-owned and
+reaped on completion or error; remote processes are never affected.
+
+The existing public-key validator and atomic file publication dependency are
+reused. No cryptographic format implementation, new dependency, credential upload,
+default configuration or automatic key deletion is introduced. Explicit key
+retirement must remain separate from ordinary disconnection and cannot precede
+verified remote cleanup and the required user decision.
+
+OpenSSH option behavior follows its [key utility manual](https://man.openbsd.org/ssh-keygen.1).
+Atomic publication uses the existing dependency's no-overwrite move and directory
+synchronization; the Rust file synchronization contract is documented by
+[File::sync_all](https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_all).

--- a/docs/architecture/remote-ssh-identity.md
+++ b/docs/architecture/remote-ssh-identity.md
@@ -33,9 +33,13 @@ coordinator must preserve the remote worker and surface recovery instructions.
 
 ## Private storage boundary
 
-The configured Horizon home must have an existing trusted parent, must not be a
-symlink and must not be writable by other users. The dedicated identity directory
-is owner-only (`0700`); private regular files are owner-only (`0600` when created).
+Every existing ancestor of the configured Horizon home is checked from the root
+before any write. Ancestors must be directories owned by the effective user or
+root, without symlinks or parent traversal. Shared writable ancestors require the
+sticky bit; owned children beneath them cannot be renamed by other users. The
+home itself must belong to the effective user and must not be writable by others.
+The dedicated identity directory and private regular files must also belong to
+that user and be owner-only (`0700` and `0600` when created).
 Keys are unencrypted OpenSSH files protected by filesystem permissions; an
 encrypted vault or OS keychain is not claimed by this implementation.
 Symlinks, non-regular files, broad permissions and oversized/empty files are
@@ -50,8 +54,11 @@ paths, key bytes and subprocess output. Key utility processes are task-owned and
 reaped on completion or error; remote processes are never affected.
 
 The existing public-key validator and atomic file publication dependency are
-reused. No cryptographic format implementation, new dependency, credential upload,
-default configuration or automatic key deletion is introduced. Explicit key
+reused. A Linux-only direct `rustix` dependency provides the safe effective-user-ID
+API without unsafe code; the version already exists in the dependency graph and
+was verified as the latest stable on crates.io. No cryptographic format
+implementation, credential upload, default configuration or automatic key
+deletion is introduced. Explicit key
 retirement must remain separate from ordinary disconnection and cannot precede
 verified remote cleanup and the required user decision.
 


### PR DESCRIPTION
## Purpose

Retain a dedicated SSH client identity for each remote allocation independently
of local session files, advancing #383's reconnect-after-exit path.

## Behavior

- On Linux, prepare an owner-only OpenSSH key for a new, unclaimed workflow/job;
  synchronize and publish without overwrite, reusing the winner after a race or
  interrupted setup. Public-key reservation must follow durable private storage.
- Recover only an existing private key matching the saved public request. A
  missing, corrupt, insecure or mismatched key fails without replacement.
- Keep private material out of snapshots, debug output and errors. Dropping a
  view, identity or store neither removes the key nor performs a provider action.
- Check the complete parent chain before writes, rejecting unsafe ownership,
  symlinks, traversal and writable non-sticky ancestors. Enforce effective-user
  ownership for home, identity directory and private files.
- Reject non-regular files, broad permissions and invalid sizes. Bound
  key-utility output and execution time, disable prompts and discard diagnostics.

This implementation requires a trusted local Linux POSIX-permission filesystem.
Keys are unencrypted files protected by filesystem permissions, not an encrypted
vault. macOS and Windows explicitly fail before writes until their ACL-aware
implementations and platform smoke are complete. A Linux-only direct rustix
dependency provides the safe effective-user-ID API; its latest stable version
already existed transitively. No config default, UI action or provider integration
is included.

## Validation

Twelve Linux regressions use real OpenSSH key generation and private temporary
fixtures for restart/reopen, concurrent publication, exact-key recovery, missing
keys, redaction, permission/symlink/size rejection, invalid IDs and deadlines.
They also cover writable parents and ancestors before creation and recovery,
symlinked/traversing ancestors, and sticky shared ancestors with owned children.
The unsupported-platform guard has a no-write regression for platform CI.
The complete local format, maintainability, version, default/speech tests and
blocking/strict/pedantic matrix passed in the exact final worktree. Independent
local review completed with no remaining actionable findings.

No user credentials or existing remote environments were accessed or changed.
Coordinator wiring, platform-specific ACL support and real PC-off acceptance
remain separate completion gates for #383.
