### PR TITLE
Keep remote panel tasks running across client disconnects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,10 @@ crates/*/**
 !containers/remote-worker/
 containers/remote-worker/**
 !containers/remote-worker/Dockerfile
+!containers/remote-worker/build-tmux.sh
 !containers/remote-worker/entrypoint.sh
 !containers/remote-worker/rust-path.sh
 !containers/remote-worker/session.sh
+!containers/remote-worker/panel-session.py
+!containers/remote-worker/tmux.conf
 !containers/remote-worker/sshd_config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
+  remote-panel-sessions:
+    name: Remote panel sessions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - run: sudo apt-get update && sudo apt-get install -y bison libevent-dev libncurses-dev pkg-config
+      - name: Build the pinned worker multiplexer
+        run: bash containers/remote-worker/build-tmux.sh "$RUNNER_TEMP/horizon-panel-tmux"
+      - name: Verify retained task sessions
+        run: PATH="$RUNNER_TEMP/horizon-panel-tmux/bin:$PATH" python3 -B containers/remote-worker/test_panel_sessions.py -v
+
   version-sync:
     name: Version Sync
     runs-on: ubuntu-latest

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -2,6 +2,13 @@ ARG WORKER_BASE_IMAGE=rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdc
 
 FROM node:24-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e AS node-runtime
 
+FROM ${WORKER_BASE_IMAGE} AS tmux-runtime
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends bison libevent-dev libncurses-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+COPY containers/remote-worker/build-tmux.sh /tmp/build-tmux.sh
+RUN bash /tmp/build-tmux.sh /opt/horizon-tmux
+
 FROM ${WORKER_BASE_IMAGE}
 
 ARG WORKER_BASE_IMAGE
@@ -54,6 +61,8 @@ RUN apt-get update \
         git-lfs \
         libasound2-dev \
         libgl-dev \
+        libevent-2.1-7 \
+        libtinfo6 \
         libvulkan-dev \
         libwayland-dev \
         libxcb-render0-dev \
@@ -65,8 +74,9 @@ RUN apt-get update \
         python3 \
         rsync \
         tar \
-        tmux \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=tmux-runtime /opt/horizon-tmux/bin/tmux /usr/local/bin/tmux
 
 RUN rustup toolchain install 1.95.0 --profile minimal \
     && rustup component add --toolchain 1.95.0 rustfmt clippy
@@ -140,10 +150,13 @@ WORKDIR /workspace/horizon
 
 COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entrypoint
 COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session
+COPY containers/remote-worker/panel-session.py /usr/local/bin/horizon-panel-session
+COPY containers/remote-worker/tmux.conf /etc/horizon/tmux.conf
 COPY containers/remote-worker/rust-path.sh /etc/profile.d/horizon-rust.sh
 COPY containers/remote-worker/sshd_config /etc/ssh/sshd_config.d/99-horizon-worker.conf
 
 RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-agent-session \
+    /usr/local/bin/horizon-panel-session \
     && chmod 0644 /etc/profile.d/horizon-rust.sh /etc/ssh/sshd_config.d/99-horizon-worker.conf \
     && git lfs install --system \
     && rm -f /etc/ssh/ssh_host_* \
@@ -167,7 +180,8 @@ RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-a
         /root/.pi \
         /root/.rustup \
         /root/.ssh \
-    && mkdir -p /run/sshd /workspace/horizon
+    && mkdir -p /run/sshd /workspace/horizon /var/lib/horizon \
+    && chmod 0700 /var/lib/horizon
 
 ARG WORKER_IMAGE_VERSION=0.1.0
 RUN if [ -z "${WORKER_IMAGE_VERSION}" ]; then \

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -11,7 +11,11 @@ client PC.
 The image contains the Rust toolchain, Horizon's Linux build dependencies,
 Git/Git LFS, GitHub CLI, rsync, tar, tmux, SSH, CA certificates, and the
 supported coding-agent CLIs. Their versions and both base-image digests are
-pinned in `Dockerfile`.
+pinned in `Dockerfile` and the checksum-verified `build-tmux.sh` helper. The
+worker and its CI tests use tmux 3.7c built without utmp integration; older
+distribution builds can lose child-exit notifications in the upstream
+[utempter race](https://github.com/tmux/tmux/issues/4559). This does not change
+the client machine's tmux installation or existing servers.
 
 ## Build
 
@@ -116,6 +120,61 @@ Docker smoke demonstrates disconnection semantics, not the real cloud PC-off gat
 Password authentication, keyboard-interactive authentication, SSH agent
 forwarding, X11 forwarding, and user-controlled SSH environment files are
 disabled. Root login is public-key-only.
+
+## Retained panel sessions
+
+After repository setup, `horizon-panel-session` provides separate explicit
+start and non-creating reconnect operations. Supply the exact runtime generation
+UUID and stable panel ID (letters, digits, underscores or hyphens, at most 128
+characters). For example, inside the worker:
+
+```bash
+horizon-panel-session start c8203298-3169-48d6-84fd-882d8d49a7b4 terminal_a . -- /bin/bash
+horizon-panel-session status c8203298-3169-48d6-84fd-882d8d49a7b4 terminal_a
+horizon-panel-session attach c8203298-3169-48d6-84fd-882d8d49a7b4 terminal_a
+```
+
+Attach requires a terminal, such as a verified SSH connection with PTY allocation.
+Working directories are relative to `/workspace/horizon`; traversal and symlinks
+escaping that repository are rejected. Arguments are passed directly through
+`horizon-agent-session`, never reconstructed as shell text. Use an explicit shell
+program only when shell evaluation is actually intended.
+
+Before starting anything, the helper durably publishes one private no-overwrite
+marker for the runtime/panel pair. Repeating the same start can only inspect that
+task; a changed launch intent is rejected. Each runtime has a dedicated tmux
+socket, and reconnect verifies a retained instance nonce before attaching. A lost
+start reply or missing server never grants permission to execute a replacement.
+An unavailable result needs an explicit recovery decision; do not remove the
+marker to make a retry work.
+
+Closing the last client does not destroy the server, session or task. Completed
+panes remain available without reexecution. Status reports `running`, `exited`
+or `unavailable`, with an exit status only when tmux has one; an unknown result,
+including some signal terminations, is not reported as success.
+
+Markers live under `/var/lib/horizon/panels` and contain an intent digest, not
+command arguments or credentials. Sockets live under `/run/horizon/panels`.
+These locations rely on the worker's private root-owned directory boundary;
+tasks within one worker share that trust domain. The marker is not a process
+checkpoint: container/server loss cannot preserve a running process, and durable
+volumes, backup and explicit restart remain separate integration requirements.
+This helper does not yet connect local panels, stop tasks or delete workspaces.
+
+With `bison`, `libevent-dev`, `libncurses-dev`, a C compiler and Make installed, build a
+disposable test binary under a new prefix, then run the fourteen regressions:
+
+```bash
+test_root=$(mktemp -d /tmp/horizon-panel-tests.XXXXXX)
+bash containers/remote-worker/build-tmux.sh "$test_root/tools"
+PATH="$test_root/tools/bin:$PATH" python3 -B containers/remote-worker/test_panel_sessions.py -v
+```
+
+Coverage includes repeated PTY disconnects, retained completion, concurrent
+starts, literal semicolon/format arguments, locale-independent status and no
+recreation after server loss. Tests own only their private temporary directories
+and dedicated sockets. Keep the disposable tool prefix for repeated validation,
+then remove only that exact task-owned prefix when finished.
 
 ## Local Docker provider
 

--- a/containers/remote-worker/build-tmux.sh
+++ b/containers/remote-worker/build-tmux.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One pinned worker/test dependency; never install over an existing prefix.
+readonly tmux_version=3.7c
+readonly tmux_sha256=7c60cae9a0e25288e2e24750aafc9e8800fc7fd4555e447e1b29ee4201cfb3bf
+if (($# != 1)) || [[ "$1" != /* || "$1" == / || -e "$1" || -L "$1" ]]; then
+  printf '%s\n' 'usage: build-tmux.sh <new absolute install prefix>' >&2
+  exit 64
+fi
+readonly tmux_prefix=$1
+tmux_build_root=$(mktemp -d /tmp/horizon-tmux-build.XXXXXX)
+readonly tmux_build_root
+case "${tmux_build_root}" in
+  /tmp/horizon-tmux-build.*) ;;
+  *) exit 64 ;;
+esac
+trap 'rm -rf -- "${tmux_build_root}"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+  "https://github.com/tmux/tmux/releases/download/${tmux_version}/tmux-${tmux_version}.tar.gz" \
+  --output "${tmux_build_root}/source.tar.gz"
+printf '%s  %s\n' "${tmux_sha256}" "${tmux_build_root}/source.tar.gz" | sha256sum --check --strict -
+tar --extract --gzip --file "${tmux_build_root}/source.tar.gz" --directory "${tmux_build_root}" --no-same-owner
+cd "${tmux_build_root}/tmux-${tmux_version}"
+./configure --prefix="${tmux_prefix}" --disable-utempter
+make -j2
+mkdir -m 0755 -- "${tmux_prefix}"
+mkdir -m 0755 -- "${tmux_prefix}/bin"
+install -m 0755 tmux "${tmux_prefix}/bin/tmux"
+test "$("${tmux_prefix}/bin/tmux" -V)" = "tmux ${tmux_version}"

--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Explicit one-shot task start and non-creating attachment inside one worker."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import uuid
+
+
+class SessionError(Exception):
+    """Messages contain no command, filesystem path or subprocess output."""
+
+
+def private_directory(path):
+    path.mkdir(mode=0o700, exist_ok=True)
+    check_directory(path)
+
+
+def check_directory(path):
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise SessionError("session state directory is not private")
+
+
+def sync_directory(path):
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+class PanelSessions:
+    def __init__(self, repository, state, sockets, config, wrapper):
+        self.repository = Path(repository)
+        self.state = Path(state)
+        self.sockets = Path(sockets)
+        self.config = Path(config)
+        self.wrapper = str(wrapper)
+
+    def identities(self, runtime, panel):
+        try:
+            parsed = uuid.UUID(runtime)
+        except ValueError as error:
+            raise SessionError("invalid runtime identity") from error
+        if str(parsed) != runtime or parsed.int == 0:
+            raise SessionError("invalid runtime identity")
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", panel):
+            raise SessionError("invalid panel identity")
+        return self.sockets / f"{runtime}.sock", f"horizon-panel-{panel}"
+
+    def tmux(self, runtime, *arguments, check=True):
+        socket, _ = self.identities(runtime, "validation")
+        try:
+            check_directory(self.sockets)
+        except FileNotFoundError:
+            pass
+        environment = dict(os.environ)
+        environment.pop("TMUX", None)
+        # tmux parses trailing semicolons as command separators even without a
+        # shell. Escape that parser layer for every argument, including cwd.
+        escaped = [argument[:-1] + "\\;" if argument.endswith(";") else argument for argument in arguments]
+        creation = [] if arguments[0] == "new-session" else ["-N"]
+        result = subprocess.run(
+            ["tmux", *creation, "-S", str(socket), "-f", str(self.config), *escaped],
+            stdin=subprocess.DEVNULL, capture_output=True, timeout=5,
+            env=environment, check=False,
+        )
+        if check and result.returncode:
+            raise SessionError("session operation did not complete")
+        return result
+
+    def marker_path(self, runtime, panel):
+        self.identities(runtime, panel)
+        return self.state / runtime / f"{panel}.json"
+
+    def read_marker(self, runtime, panel):
+        path = self.marker_path(runtime, panel)
+        check_directory(self.state)
+        check_directory(path.parent)
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        with os.fdopen(descriptor, "rb") as stream:
+            metadata = os.fstat(stream.fileno())
+            if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) & 0o077:
+                raise SessionError("session marker is not private")
+            raw = stream.read(4097)
+        if len(raw) > 4096:
+            raise SessionError("session marker exceeds its limit")
+        marker = json.loads(raw)
+        expected = {"version", "runtime", "panel", "nonce", "intent"}
+        if (
+            not isinstance(marker, dict) or set(marker) != expected
+            or type(marker["version"]) is not int or marker["version"] != 1
+            or marker["runtime"] != runtime or marker["panel"] != panel
+            or not isinstance(marker["nonce"], str)
+            or not re.fullmatch(r"[0-9a-f]{32}", marker["nonce"])
+            or not isinstance(marker["intent"], str)
+            or not re.fullmatch(r"[0-9a-f]{64}", marker["intent"])
+        ):
+            raise SessionError("session marker identity is invalid")
+        return marker
+
+    def publish_marker(self, runtime, panel, marker):
+        path = self.marker_path(runtime, panel)
+        private_directory(self.state)
+        private_directory(path.parent)
+        sync_directory(self.state.parent)
+        sync_directory(self.state)
+        candidate = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=path.parent, prefix=".claim-", delete=False) as stream:
+                candidate = Path(stream.name)
+                stream.write(json.dumps(marker, sort_keys=True).encode())
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.link(candidate, path, follow_symlinks=False)
+                won = True
+            except FileExistsError:
+                won = False
+            sync_directory(path.parent)
+            return won
+        finally:
+            if candidate is not None:
+                candidate.unlink()
+
+    def launch_intent(self, directory, arguments):
+        if not arguments or len(arguments) > 257 or not arguments[0] or arguments[0].startswith("-"):
+            raise SessionError("invalid task command")
+        if any("\0" in argument for argument in arguments) or sum(len(item.encode()) for item in arguments) > 65536:
+            raise SessionError("task command exceeds its limit")
+        requested = Path(directory)
+        if requested.is_absolute() or ".." in requested.parts:
+            raise SessionError("task directory must remain inside the repository")
+        repository = self.repository.resolve(strict=True)
+        working_directory = (repository / requested).resolve(strict=True)
+        if not working_directory.is_dir() or not working_directory.is_relative_to(repository):
+            raise SessionError("task directory must remain inside the repository")
+        payload = json.dumps([str(requested), arguments], ensure_ascii=True).encode()
+        return working_directory, hashlib.sha256(payload).hexdigest()
+
+    def start(self, runtime, panel, directory, arguments):
+        _, name = self.identities(runtime, panel)
+        working_directory, intent = self.launch_intent(directory, arguments)
+        try:
+            marker = self.read_marker(runtime, panel)
+        except FileNotFoundError:
+            marker = None
+        if marker is None:
+            if self.tmux(runtime, "has-session", "-t", f"={name}", check=False).returncode == 0:
+                raise SessionError("an unowned session already uses this panel identity")
+            marker = {"version": 1, "runtime": runtime, "panel": panel, "nonce": uuid.uuid4().hex, "intent": intent}
+            if self.publish_marker(runtime, panel, marker):
+                private_directory(self.sockets)
+                # The wrapper plus program always supplies multiple arguments to tmux,
+                # so task argv is executed directly, never reconstructed as shell text.
+                self.tmux(
+                    runtime, "new-session", "-d", "-s", name, "-c", str(working_directory).replace("#", "##"),
+                    "-e", f"HORIZON_PANEL_INSTANCE={marker['nonce']}", "--", self.wrapper, *arguments,
+                )
+            else:
+                marker = self.read_marker(runtime, panel)
+        if marker["intent"] != intent:
+            raise SessionError("panel launch intent differs from its retained task")
+        return self.status(runtime, panel)
+
+    def status(self, runtime, panel):
+        _, name = self.identities(runtime, panel)
+        marker = self.read_marker(runtime, panel)
+        observed = self.tmux(runtime, "show-environment", "-t", f"={name}", "HORIZON_PANEL_INSTANCE", check=False)
+        if observed.returncode:
+            return {"state": "unavailable", "panel": panel}
+        expected = f"HORIZON_PANEL_INSTANCE={marker['nonce']}\n".encode()
+        if observed.stdout != expected:
+            raise SessionError("session ownership does not match the retained task")
+        result = self.tmux(runtime, "list-panes", "-s", "-t", f"={name}", "-F", "#{pane_dead}|#{pane_dead_status}|#{pane_pid}")
+        fields = result.stdout.decode("ascii").strip().split("|")
+        if len(fields) != 3 or fields[0] not in ("0", "1") or not fields[2].isdigit():
+            raise SessionError("session status is invalid")
+        exited = fields[0] == "1"
+        if fields[1] and not fields[1].isdigit():
+            raise SessionError("session exit status is invalid")
+        return {"state": "exited" if exited else "running", "panel": panel, "pid": int(fields[2]),
+                "exit_status": int(fields[1]) if exited and fields[1] else None}
+
+    def attach(self, runtime, panel):
+        if self.status(runtime, panel)["state"] == "unavailable":
+            raise SessionError("retained task is unavailable; attachment never starts a replacement")
+        socket, name = self.identities(runtime, panel)
+        os.environ.pop("TMUX", None)
+        os.execvp("tmux", ["tmux", "-N", "-S", str(socket), "-f", str(self.config),
+                           "attach-session", "-t", f"={name}"])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("start", "status", "attach"))
+    parser.add_argument("runtime")
+    parser.add_argument("panel")
+    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    service = PanelSessions("/workspace/horizon", "/var/lib/horizon/panels", "/run/horizon/panels",
+                            "/etc/horizon/tmux.conf", "/usr/local/bin/horizon-agent-session")
+    try:
+        if arguments.operation == "start":
+            if len(arguments.arguments) < 3 or arguments.arguments[1] != "--":
+                raise SessionError("start requires a relative directory, --, and a program")
+            result = service.start(arguments.runtime, arguments.panel, arguments.arguments[0], arguments.arguments[2:])
+        elif arguments.arguments:
+            raise SessionError("unexpected session arguments")
+        elif arguments.operation == "attach":
+            service.attach(arguments.runtime, arguments.panel)
+            return
+        else:
+            result = service.status(arguments.runtime, arguments.panel)
+        print(json.dumps(result, sort_keys=True))
+    except SessionError as error:
+        print(f"panel session: {error}", file=sys.stderr)
+        sys.exit(1)
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        print("panel session: operation failed; no replacement task was requested", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -1,0 +1,257 @@
+"""Linux worker tests use only private temporary directories and dedicated sockets."""
+
+from concurrent.futures import ThreadPoolExecutor
+import importlib.util
+import json
+import os
+from pathlib import Path
+import pty
+import signal
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+import uuid
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("panel_session", HERE / "panel-session.py")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class PanelSessionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        result = MODULE.subprocess.run(["tmux", "-V"], capture_output=True, check=True, text=True, timeout=3)
+        if result.stdout.strip() != "tmux 3.7c":
+            raise RuntimeError("tests require the pinned worker tmux; see the remote-worker README")
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="hps-", dir="/tmp")
+        self.root = Path(self.temporary.name)
+        self.repository = self.root / "repo"
+        self.repository.mkdir()
+        (self.repository / "nested space").mkdir()
+        self.runtimes = [str(uuid.uuid4()), str(uuid.uuid4())]
+        self.service = MODULE.PanelSessions(self.repository, self.root / "state", self.root / "sockets",
+                                            HERE / "tmux.conf", "/usr/bin/env")
+
+    def tearDown(self):
+        for runtime in self.runtimes:
+            self.service.tmux(runtime, "kill-server", check=False)
+        self.temporary.cleanup()
+
+    def wait_for(self, predicate):
+        deadline = time.monotonic() + 4
+        while time.monotonic() < deadline:
+            result = predicate()
+            if result:
+                return result
+            time.sleep(0.02)
+        self.fail("task-owned fixture did not settle")
+
+    def command(self, text):
+        return [sys.executable, "-c", text]
+
+    def tick_command(self, filename="ticks"):
+        return self.command("import time\nfrom pathlib import Path\np=Path(" + repr(filename) + ")\n"
+                            "while True:\n with p.open('a') as f: f.write('tick\\n')\n time.sleep(0.03)")
+
+    def attach_and_disconnect(self, runtime, panel):
+        child, master = pty.fork()
+        if child == 0:
+            os.environ["TERM"] = "xterm-256color"
+            try:
+                self.service.attach(runtime, panel)
+            finally:
+                os._exit(1)
+        try:
+            self.wait_for(lambda: str(child).encode() in self.service.tmux(
+                runtime, "list-clients", "-F", "#{client_pid}", check=False).stdout.splitlines())
+        finally:
+            os.close(master)
+            deadline = time.monotonic() + 2
+            reaped = False
+            while time.monotonic() < deadline:
+                if os.waitpid(child, os.WNOHANG)[0] == child:
+                    reaped = True
+                    break
+                time.sleep(0.01)
+            if not reaped:
+                os.kill(child, signal.SIGTERM)
+                os.waitpid(child, 0)
+                self.fail("task-owned attachment did not exit after PTY loss")
+
+    def test_live_task_continues_after_last_client_disconnect_and_reuses_pid(self):
+        runtime = self.runtimes[0]
+        command = self.tick_command()
+        first = self.service.start(runtime, "panel_a", "nested space", command)
+        ticks = self.repository / "nested space" / "ticks"
+        self.wait_for(ticks.exists)
+        for _ in range(2):
+            self.attach_and_disconnect(runtime, "panel_a")
+        before = len(ticks.read_text().splitlines())
+        self.wait_for(lambda: len(ticks.read_text().splitlines()) > before + 2)
+        again = self.service.start(runtime, "panel_a", "nested space", command)
+        self.assertEqual(first["pid"], again["pid"])
+        self.assertEqual(again["state"], "running")
+        self.assertEqual(self.service.tmux(runtime, "list-clients", check=False).stdout, b"")
+
+    def test_exited_task_is_retained_and_not_reexecuted_on_start_or_attach(self):
+        runtime = self.runtimes[0]
+        command = self.command("from pathlib import Path; p=Path('runs'); p.open('a').write('once\\n'); raise SystemExit(42)")
+        first = self.service.start(runtime, "finished", ".", command)
+        self.wait_for(lambda: self.service.status(runtime, "finished")["exit_status"] == 42)
+        self.attach_and_disconnect(runtime, "finished")
+        again = self.service.start(runtime, "finished", ".", command)
+        self.assertEqual(first["pid"], again["pid"])
+        self.assertEqual(again["exit_status"], 42)
+        self.assertEqual((self.repository / "runs").read_text(), "once\n")
+
+    def test_claim_without_creation_stays_unavailable_and_never_restarts(self):
+        runtime = self.runtimes[0]
+        command = self.tick_command()
+        _, intent = self.service.launch_intent(".", command)
+        marker = {"version": 1, "runtime": runtime, "panel": "interrupted", "nonce": uuid.uuid4().hex, "intent": intent}
+        self.assertTrue(self.service.publish_marker(runtime, "interrupted", marker))
+        self.assertEqual(self.service.start(runtime, "interrupted", ".", command)["state"], "unavailable")
+        with self.assertRaises(MODULE.SessionError):
+            self.service.attach(runtime, "interrupted")
+        self.assertFalse((self.repository / "ticks").exists())
+
+    def test_signal_terminated_task_is_retained_without_reporting_success(self):
+        runtime = self.runtimes[0]
+        command = self.command("import os,signal; os.kill(os.getpid(), signal.SIGTERM)")
+        self.service.start(runtime, "signalled", ".", command)
+        self.wait_for(lambda: self.service.status(runtime, "signalled")["state"] == "exited")
+        result = self.service.start(runtime, "signalled", ".", command)
+        self.assertEqual(result["state"], "exited")
+        self.assertNotEqual(result["exit_status"], 0)
+
+    def test_status_works_with_a_minimal_non_utf8_worker_environment(self):
+        environment = {"PATH": os.environ["PATH"], "LC_ALL": "C", "TERM": "xterm-256color", "SHELL": "/bin/bash"}
+        with mock.patch.dict(os.environ, environment, clear=True):
+            status = self.service.start(self.runtimes[0], "minimal", ".", self.tick_command())
+            self.assertEqual(status["state"], "running")
+            self.assertEqual(self.service.status(self.runtimes[0], "minimal")["pid"], status["pid"])
+
+    def test_concurrent_starts_have_one_claim_and_one_task(self):
+        runtime = self.runtimes[0]
+        command = self.command("from pathlib import Path; import time; Path('runs').open('a').write('once\\n'); time.sleep(30)")
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _: self.service.start(runtime, "race", ".", command), range(2)))
+        self.wait_for(lambda: (self.repository / "runs").exists() and (self.repository / "runs").read_text() == "once\n")
+        self.assertEqual((self.repository / "runs").read_text(), "once\n")
+        self.assertTrue(all(result["state"] in ("running", "unavailable") for result in results))
+        self.assertEqual(len(self.service.tmux(runtime, "list-sessions").stdout.splitlines()), 1)
+
+    def test_argument_boundaries_are_literal_and_changed_intent_is_rejected(self):
+        runtime = self.runtimes[0]
+        literal = "$(touch injected); 'quoted' and spaces"
+        command = self.command("import json,sys; from pathlib import Path; Path('argv').write_text(json.dumps(sys.argv[1:]))") + [literal, ""]
+        self.service.start(runtime, "literal", ".", command)
+        self.wait_for(lambda: (self.repository / "argv").exists() and (self.repository / "argv").read_text() == json.dumps([literal, ""]))
+        self.assertEqual(json.loads((self.repository / "argv").read_text()), [literal, ""])
+        self.assertFalse((self.repository / "injected").exists())
+        marker = self.service.marker_path(runtime, "literal").read_text()
+        self.assertNotIn(literal, marker)
+        with self.assertRaises(MODULE.SessionError):
+            self.service.start(runtime, "literal", ".", self.tick_command())
+
+    def test_invalid_ids_and_escaping_directories_have_no_launch_side_effect(self):
+        runtime = self.runtimes[0]
+        outside = self.root / "outside"
+        outside.mkdir()
+        (self.repository / "escape").symlink_to(outside)
+        cases = [("bad", "panel", "."), (runtime, "panel:other", "."),
+                 (runtime, "panel", ".."), (runtime, "panel", "/tmp"), (runtime, "panel", "escape")]
+        for runtime_id, panel, directory in cases:
+            with self.assertRaises(MODULE.SessionError):
+                self.service.start(runtime_id, panel, directory, self.tick_command())
+        self.assertFalse(self.service.state.exists())
+
+    def test_two_runtimes_and_panels_do_not_share_ownership_or_processes(self):
+        first = self.service.start(self.runtimes[0], "same", ".", self.tick_command("a"))
+        second = self.service.start(self.runtimes[1], "same", ".", self.tick_command("b"))
+        third = self.service.start(self.runtimes[0], "other", ".", self.tick_command("c"))
+        self.assertEqual(len({first["pid"], second["pid"], third["pid"]}), 3)
+        self.service.tmux(self.runtimes[0], "set-environment", "-t", "=horizon-panel-same", "HORIZON_PANEL_INSTANCE", "wrong")
+        with self.assertRaises(MODULE.SessionError):
+            self.service.status(self.runtimes[0], "same")
+        self.assertEqual(self.service.status(self.runtimes[1], "same")["state"], "running")
+
+    def test_tmux_command_separators_remain_literal_arguments(self):
+        runtime = self.runtimes[0]
+        directory = self.repository / "trailing;"
+        directory.mkdir()
+        literals = ["payload;", ";", "display-message", "-p", "unexpected", "\\;", "\\\\;", "#comment", "#{l:literal}", "line\nbreak", ""]
+        command = self.command("import json,sys; from pathlib import Path; Path('argv').write_text(json.dumps(sys.argv[1:]))") + literals
+        self.service.start(runtime, "separators", "trailing;", command)
+        self.wait_for(lambda: (directory / "argv").exists() and (directory / "argv").read_text() == json.dumps(literals))
+        self.assertEqual(json.loads((directory / "argv").read_text()), literals)
+        self.assertEqual(len(self.service.tmux(runtime, "list-sessions").stdout.splitlines()), 1)
+
+    def test_tmux_directory_formats_cannot_escape_the_repository(self):
+        runtime = self.runtimes[0]
+        directory = self.repository / "#{l:..}"
+        directory.mkdir()
+        command = self.command("from pathlib import Path; Path('cwd').write_text(str(Path.cwd()))")
+        self.service.start(runtime, "format", "#{l:..}", command)
+        self.wait_for(lambda: ((directory / "cwd").exists() and (directory / "cwd").read_text() == str(directory))
+                      or (self.root / "cwd").exists())
+        self.assertFalse((self.root / "cwd").exists())
+        self.assertEqual((directory / "cwd").read_text(), str(directory))
+
+    def test_server_loss_between_verification_and_attach_cannot_run_startup_config(self):
+        runtime = self.runtimes[0]
+        self.service.start(runtime, "lost", ".", self.tick_command())
+        observed = self.service.status(runtime, "lost")
+        config = self.root / "unexpected.conf"
+        config.write_text("new-session -d -s horizon-panel-lost /bin/sleep 30\n")
+        self.service.config = config
+
+        def lose_server(*_):
+            self.service.tmux(runtime, "kill-server")
+            return observed
+
+        def execute(_, arguments):
+            result = MODULE.subprocess.run(arguments, stdin=MODULE.subprocess.DEVNULL,
+                                           capture_output=True, timeout=3, check=False)
+            self.assertNotEqual(result.returncode, 0)
+
+        with mock.patch.object(self.service, "status", side_effect=lose_server), mock.patch.object(MODULE.os, "execvp", side_effect=execute):
+            self.service.attach(runtime, "lost")
+        self.assertNotEqual(self.service.tmux(runtime, "has-session", "-t", "=horizon-panel-lost", check=False).returncode, 0)
+
+    def test_verified_server_loss_does_not_authorize_a_replacement_task(self):
+        runtime = self.runtimes[0]
+        command = self.tick_command()
+        self.service.start(runtime, "lost", ".", command)
+        self.service.tmux(runtime, "kill-server")
+        self.assertEqual(self.service.start(runtime, "lost", ".", command)["state"], "unavailable")
+
+    def test_unowned_sessions_and_future_or_insecure_markers_fail_closed(self):
+        runtime = self.runtimes[0]
+        MODULE.private_directory(self.service.sockets)
+        self.service.tmux(runtime, "new-session", "-d", "-s", "horizon-panel-unowned", "/bin/sleep", "30")
+        with self.assertRaises(MODULE.SessionError):
+            self.service.start(runtime, "unowned", ".", self.tick_command())
+        self.assertFalse(self.service.state.exists())
+        self.service.start(runtime, "owned", ".", self.tick_command())
+        path = self.service.marker_path(runtime, "owned")
+        original = path.read_text()
+        for version in (2, True):
+            marker = json.loads(original)
+            marker["version"] = version
+            path.write_text(json.dumps(marker))
+            with self.assertRaises(MODULE.SessionError):
+                self.service.status(runtime, "owned")
+        path.write_text(original)
+        path.chmod(0o644)
+        with self.assertRaises(MODULE.SessionError):
+            self.service.status(runtime, "owned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/containers/remote-worker/tmux.conf
+++ b/containers/remote-worker/tmux.conf
@@ -1,0 +1,6 @@
+# Load only for the dedicated runtime socket; never alter a user's default server.
+set-option -g destroy-unattached off
+set-option -s exit-unattached off
+set-window-option -g remain-on-exit on
+set-option -g history-limit 10000
+set-option -g update-environment ""

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -5,6 +5,13 @@ back into large multi-purpose modules.
 
 ## Module Boundaries
 
+### Remote worker image
+
+- `containers/remote-worker/panel-session.py` owns the worker-side one-shot task
+  marker and verified tmux status/attachment contract. Its dedicated `tmux.conf`
+  retains sessions independently of clients. Provider lifecycle, repository
+  transfer, durable backup and local panel integration remain separate concerns.
+
 ### `horizon-browser-protocol`
 
 - Owns the small serialized contract shared by browser engines and clients:

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -246,7 +246,7 @@ docker run --rm --entrypoint /bin/sh "${image}" -eu -c '
   test ! -e /root/.npmrc
   test -s /etc/ssl/certs/ca-certificates.crt
   for tool in \
-    cargo rustc git git-lfs gh rsync tar tmux ssh sshd ps \
+    cargo rustc git git-lfs gh rsync tar tmux ssh sshd ps horizon-panel-session \
     codex claude gemini opencode kilo pi grok
   do
     command -v "${tool}" >/dev/null
@@ -431,11 +431,11 @@ ssh_worker \
 persistent_worker_id=$(docker inspect --format '{{.Id}}' "${worker_b}")
 persistent_session_id=$(ssh_worker \
   "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
-  'tmux new-session -d -s horizon-smoke-persistent "while :; do date +%s > /workspace/horizon/smoke-progress.next; mv /workspace/horizon/smoke-progress.next /workspace/horizon/smoke-progress; sleep 1; done";
+  'horizon-panel-session start c8203298-3169-48d6-84fd-882d8d49a7b4 smoke . -- /bin/sh -c "while :; do date +%s > /workspace/horizon/smoke-progress.next; mv /workspace/horizon/smoke-progress.next /workspace/horizon/smoke-progress; sleep 1; done" > /workspace/horizon/start-status;
    for attempt in 1 2 3 4 5; do test -s /workspace/horizon/smoke-progress && break; sleep 1; done;
-   tmux display-message -p -t horizon-smoke-persistent "#{session_id}:#{pane_pid}"') ||
+   cat /workspace/horizon/start-status') ||
   fail "could not start the persistent remote session"
-[[ "${persistent_session_id}" =~ ^\$[0-9]+:[0-9]+$ ]] || fail "persistent session identity is invalid"
+[[ "${persistent_session_id}" == *'"state": "running"'* ]] || fail "persistent session did not start"
 wait_for_ssh_disconnect "${worker_b}"
 persistent_progress_before=$(docker exec "${worker_b}" cat /workspace/horizon/smoke-progress) ||
   fail "could not observe the disconnected task baseline"
@@ -571,10 +571,16 @@ done
   fail "remote task did not progress before any SSH client reconnected"
 persistent_session_after=$(ssh_worker \
   "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
-  'tmux display-message -p -t horizon-smoke-persistent "#{session_id}:#{pane_pid}"') ||
+  'horizon-panel-session status c8203298-3169-48d6-84fd-882d8d49a7b4 smoke') ||
   fail "could not reconnect to the persistent remote session"
 [[ "${persistent_session_after}" == "${persistent_session_id}" ]] ||
   fail "reconnecting replaced the running remote session or process"
+persistent_start_again=$(ssh_worker \
+  "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
+  'horizon-panel-session start c8203298-3169-48d6-84fd-882d8d49a7b4 smoke . -- /bin/sh -c "while :; do date +%s > /workspace/horizon/smoke-progress.next; mv /workspace/horizon/smoke-progress.next /workspace/horizon/smoke-progress; sleep 1; done"') ||
+  fail "could not verify the one-shot start marker after reconnect"
+[[ "${persistent_start_again}" == "${persistent_session_id}" ]] ||
+  fail "repeated start replaced the retained task"
 persistent_progress_after=$(ssh_worker \
   "${temp_dir}/client" "${temp_dir}/worker-b-known-hosts" "${worker_b_port}" \
   'cat /workspace/horizon/smoke-progress') || fail "could not observe progress after reconnect"


### PR DESCRIPTION
## Purpose

Keep worker-side panel tasks running independently of their attached clients,
advancing the persistent remote development contract in #383.

## Behavior

- Separate explicit one-shot start from nonce-verified, noncreating status and
  attach. Retain a durable no-overwrite marker before starting a task.
- Keep the task and completed pane after the last client disconnects. Repeated
  starts inspect the existing task; lost replies or server loss never authorize
  a replacement.
- Preserve literal argument and repository-directory boundaries through both
  tmux parsing layers, including semicolons and format characters. Prevent
  attachment from starting a server after a verification/connection race.
- Pin checksum-verified tmux 3.7c for the worker and CI tests, built without utmp
  integration. Older distribution builds can lose child-exit notifications in
  the upstream race tracked at https://github.com/tmux/tmux/issues/4559.

Private markers contain an intent digest, not task arguments or credentials.
Status keeps unknown exit results distinct from success. Worker tasks share the
documented private root-owned trust domain; this is not a per-task sandbox.

## Validation

- Fourteen real-process regressions, including repeated PTY attach/disconnect,
  retained nonzero/signal exits, concurrent starts, literal parser edge cases,
  non-UTF8 status and server loss during attachment.
- One hundred isolated fast-exit trials retained the expected nonzero result.
- The final locally built image passed the complete SSH/security smoke: task
  progress with no SSH clients, same worker/session/PID after reconnect, repeated
  start reuse, and explicit stop preserving the latest workspace data.
- Full format, maintainability, version, default/speech tests and blocking,
  strict and advisory Clippy passed in the final checkout. Independent local
  review is complete with no remaining actionable findings.

Integration with retained host identity (#421) preserves both implementations
and both CI jobs. On refreshed head `863d4d5`, the full source and exact-commit
matrices passed. The combined local image
`sha256:8770dd156694e5795af71b7ff0fbf972ed9a2bdcb3003116fc34976dd90e5719`
passed all 14 session tests and 17 host-identity tests, 100 fast-exit trials,
delayed concurrent initialization, retained-volume filesystem replacement with
pinned SSH, and the complete worker smoke with eight seconds of disconnected
task progress. Only disposable local smoke resources were used and cleaned.

The maintainer explicitly waived the repeatedly unavailable hosted-review gate
for this PR. Independent local review and the other validation/merge gates remain
required; hosted service-error responses are not completed code reviews.

No image was published and no existing worker or system tool was changed. Local
panel/coordinator wiring, explicit management actions, durable volumes/backups
and real cloud PC-off acceptance remain separate completion gates for #383.
