### PR TITLE
Retain worker host identity on workspace storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ crates/*/**
 containers/remote-worker/**
 !containers/remote-worker/Dockerfile
 !containers/remote-worker/entrypoint.sh
+!containers/remote-worker/host-identity.py
 !containers/remote-worker/rust-path.sh
 !containers/remote-worker/session.sh
 !containers/remote-worker/sshd_config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
+  remote-host-identity:
+    name: Remote host identity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: python3 -B containers/remote-worker/test_host_identity.py -v
+
   version-sync:
     name: Version Sync
     runs-on: ubuntu-latest

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -139,11 +139,13 @@ RUN mkdir -p \
 WORKDIR /workspace/horizon
 
 COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entrypoint
+COPY containers/remote-worker/host-identity.py /usr/local/bin/horizon-worker-host-identity
 COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session
 COPY containers/remote-worker/rust-path.sh /etc/profile.d/horizon-rust.sh
 COPY containers/remote-worker/sshd_config /etc/ssh/sshd_config.d/99-horizon-worker.conf
 
 RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-agent-session \
+    /usr/local/bin/horizon-worker-host-identity \
     && chmod 0644 /etc/profile.d/horizon-rust.sh /etc/ssh/sshd_config.d/99-horizon-worker.conf \
     && git lfs install --system \
     && rm -f /etc/ssh/ssh_host_* \

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -143,6 +143,12 @@ migrated. Key rotation, old-volume migration and whole-volume loss require a
 separate verified recovery operation. Never resolve a host-key mismatch by
 disabling client verification.
 
+Concurrent starters wait up to 30 seconds for readiness: two ten-second key
+operation budgets plus ten seconds of filesystem synchronization grace. This is
+a bounded readiness wait, not a filesystem I/O deadline. A stalled or slower
+initialization fails closed for waiting starters; a later startup can validate
+the completed identity, but a timeout never authorizes replacement.
+
 Back up the complete private `.horizon-worker` directory with the repository;
 protect it as credential-bearing data. Host keys are unencrypted on disk and
 worker tasks share the root-owned trust domain. This is not a per-task sandbox,

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -72,6 +72,7 @@ Persistent example (stop and remove this exact container manually when finished)
 ```bash
 docker run --detach --name horizon-development \
   --publish 127.0.0.1::22 \
+  --mount type=volume,src=horizon-development-data,dst=/workspace \
   --env "HORIZON_SSH_PUBLIC_KEY=$(ssh-keygen -y -f /path/to/ephemeral-worker-key)" \
   --mount type=bind,src=/path/to/github-token,dst=/run/secrets/github-token,readonly \
   --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token \
@@ -85,10 +86,11 @@ the default product lifetime or a replacement for manual management.
 At startup the entrypoint:
 
 1. validates any supplied expiry, the public key, and optional secret file;
-2. creates a new SSH host identity in the container's writable layer;
-3. installs only the supplied public key for root login;
-4. copies the optional token to a root-only runtime file and configures shared
-   Git authentication once, before SSH accepts concurrent sessions; and
+2. installs only the supplied public key for root login;
+3. copies the optional token to a root-only runtime file and configures shared
+   Git authentication once, before SSH accepts concurrent sessions;
+4. prepares or strictly recovers the workspace-retained Ed25519 host identity
+   and materializes its verified runtime files before SSH starts; and
 5. starts a termination watchdog only when an explicit expiry was supplied.
 
 For explicitly time-limited workers, the in-container watchdog is defense in
@@ -105,17 +107,56 @@ through `horizon-agent-session`, which exposes the Rust toolchain, marks the
 session with `HORIZON=1`, and configures GitHub authentication only when the
 runtime token file exists. tmux provides reconnectable interactive sessions.
 
-This image change does not supply durable volumes, remote backup/checkpointing,
-provider restart recovery, or the Remote Environments overview. A stopped local
-container retains its writable layer until removed, but the example does not
-promise data survival after container deletion or provider loss. The full remote
-workspace must use the separately validated durable-storage design. A container
+The provider or operator must supply retained storage at `/workspace`; the image
+cannot prove that the backing storage is durable. The named volume in the example
+retains that directory across container removal, but not volume deletion or host
+loss. Remote backup/checkpointing, agent-state durability, provider restart
+coordination and the Remote Environments overview remain separate requirements.
+The full remote workspace must use the separately validated storage design. A container
 on the client PC also cannot keep running when that same PC powers off: local
 Docker smoke demonstrates disconnection semantics, not the real cloud PC-off gate.
 
 Password authentication, keyboard-interactive authentication, SSH agent
 forwarding, X11 forwarding, and user-controlled SSH environment files are
 disabled. Root login is public-key-only.
+
+## Retained SSH host identity
+
+`host-identity.py` owns `/workspace/.horizon-worker/ssh.claim` and the private
+`ssh/` directory next to it. The initialization claim is durably recorded before
+key generation. A complete versioned marker is published only after both key
+files are synchronized. Repeated startup validates the original access-key digest,
+marker and real private/public key pair; it does not generate another identity.
+The verified runtime copies remain at `/etc/ssh/ssh_host_ed25519_key{,.pub}` so
+trusted provider host-key inspection keeps its existing path.
+
+This requires a trusted Linux POSIX-permission filesystem. Workspace ancestors
+must have trusted ownership and no unprotected group/world write access. Identity
+directories and files must be owned by the worker user, with modes `0700` and
+`0600`. Symlinks, partial initialization, missing files, corruption, changed access
+keys and conflicting runtime keys fail before SSH starts. An interrupted first
+initialization may require explicit recovery; it is never silently retried as
+permission to replace an identity. Existing unretained keys are not automatically
+migrated. Key rotation, old-volume migration and whole-volume loss require a
+separate verified recovery operation. Never resolve a host-key mismatch by
+disabling client verification.
+
+Back up the complete private `.horizon-worker` directory with the repository;
+protect it as credential-bearing data. Host keys are unencrypted on disk and
+worker tasks share the root-owned trust domain. This is not a per-task sandbox,
+a backup service, or proof that interrupted processes resumed.
+
+Validate using synthetic fixtures and a task-owned local volume:
+
+```bash
+python3 -B containers/remote-worker/test_host_identity.py -v
+bash scripts/run-remote-worker-host-identity-smoke.sh --image horizon-remote-worker:0.1.0
+```
+
+The smoke replaces the container filesystem while retaining its workspace volume,
+checks the same host identity through pinned SSH, and rejects a different access
+key without modifying the original identity or workspace data. It removes only
+its own containers and volume; it neither publishes an image nor uses cloud resources.
 
 ## Local Docker provider
 

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -132,8 +132,10 @@ trusted provider host-key inspection keeps its existing path.
 
 This requires a trusted Linux POSIX-permission filesystem. Workspace ancestors
 must have trusted ownership and no unprotected group/world write access. Identity
-directories and files must be owned by the worker user, with modes `0700` and
-`0600`. Symlinks, partial initialization, missing files, corruption, changed access
+directories and files must be owned by the worker user with no group/world
+permission bits. New directories and files use modes `0700` and `0600`;
+existing entries may use other owner-only modes. Symlinks, partial initialization,
+missing files, corruption, changed access
 keys and conflicting runtime keys fail before SSH starts. An interrupted first
 initialization may require explicit recovery; it is never silently retried as
 permission to replace an identity. Existing unretained keys are not automatically

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -118,11 +118,7 @@ if [ -n "${github_token_file}" ]; then
     git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
 fi
 
-ssh-keygen -A >/dev/null
-if [ ! -s /etc/ssh/ssh_host_ed25519_key ]; then
-    printf '%s\n' "failed to generate the runtime SSH host key" >&2
-    exit 1
-fi
+/usr/local/bin/horizon-worker-host-identity
 
 if [ -n "${deadline_epoch}" ]; then
     now_epoch=$(date +%s)

--- a/containers/remote-worker/host-identity.py
+++ b/containers/remote-worker/host-identity.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Retain one SSH host identity on trusted workspace storage before serving SSH."""
+
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+
+LIMIT = 16 * 1024
+WAIT_SECONDS = 2
+KEY_NAME = "ssh_host_ed25519_key"
+ED25519_PREFIX = b"\x00\x00\x00\x0bssh-ed25519\x00\x00\x00\x20"
+
+
+class IdentityError(Exception):
+    """No sensitive path, key material or subprocess diagnostics in errors."""
+
+
+def fail():
+    raise IdentityError("retained SSH host identity is unavailable")
+
+
+def trusted_directory(path, private=False):
+    if not path.is_absolute() or ".." in path.parts:
+        fail()
+    for directory in (*reversed(path.parents), path):
+        info = directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or info.st_uid not in (0, os.geteuid()):
+            fail()
+        if info.st_mode & 0o022 and not info.st_mode & stat.S_ISVTX:
+            fail()
+    info = path.lstat()
+    if private and (info.st_uid != os.geteuid() or info.st_mode & 0o077):
+        fail()
+
+
+def read_file(path, private=True):
+    descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(descriptor, "rb") as stream:
+        info = os.fstat(stream.fileno())
+        if (not stat.S_ISREG(info.st_mode) or info.st_uid != os.geteuid()
+                or (private and info.st_mode & 0o077) or not 0 < info.st_size <= LIMIT):
+            fail()
+        value = stream.read(LIMIT + 1)
+        if not 0 < len(value) <= LIMIT:
+            fail()
+        return value
+
+
+def public_key(value):
+    text = value.decode("utf-8").rstrip("\n")
+    if any(ord(character) < 32 and character != "\t" for character in text):
+        fail()
+    fields = text.split()
+    if len(fields) < 2 or fields[0] != "ssh-ed25519":
+        fail()
+    payload = base64.b64decode(fields[1], validate=True)
+    if len(payload) != len(ED25519_PREFIX) + 32 or not payload.startswith(ED25519_PREFIX):
+        fail()
+    return " ".join(fields[:2])
+
+
+def keygen(*arguments):
+    result = subprocess.run(
+        ["/usr/bin/ssh-keygen", *map(str, arguments)], check=False, timeout=10,
+        stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        env={"PATH": "/usr/bin:/bin", "LC_ALL": "C"},
+    )
+    if result.returncode != 0 or len(result.stdout) > LIMIT:
+        fail()
+    return result.stdout
+
+
+def synchronize(path, directory=False):
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+    if directory:
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def publish(path, value):
+    with tempfile.NamedTemporaryFile(prefix=".identity-", dir=path.parent) as candidate:
+        candidate.write(value)
+        candidate.flush()
+        os.fsync(candidate.fileno())
+        os.link(candidate.name, path, follow_symlinks=False)
+        synchronize(path.parent, directory=True)
+
+
+def unique_object(fields):
+    result = {}
+    for key, value in fields:
+        if key in result:
+            fail()
+        result[key] = value
+    return result
+
+
+class HostIdentity:
+    def __init__(self, workspace, access_key, runtime_directory):
+        self.workspace = Path(workspace)
+        self.access_key = Path(access_key)
+        self.runtime_directory = Path(runtime_directory)
+        self.parent = self.workspace / ".horizon-worker"
+        self.directory = self.parent / "ssh"
+        self.claim = self.parent / "ssh.claim"
+        self.marker = self.directory / "ready.json"
+
+    def prepare(self):
+        trusted_directory(self.workspace)
+        trusted_directory(self.access_key.parent)
+        trusted_directory(self.runtime_directory)
+        access_digest = hashlib.sha256(public_key(read_file(self.access_key)).encode()).hexdigest()
+        self.parent.mkdir(mode=0o700, exist_ok=True)
+        trusted_directory(self.parent, private=True)
+        synchronize(self.workspace, directory=True)
+        if os.path.lexists(self.directory) and not os.path.lexists(self.claim):
+            fail()
+        try:
+            publish(self.claim, access_digest.encode())
+        except FileExistsError:
+            created = False
+        else:
+            created = True
+            self.directory.mkdir(mode=0o700)
+        if read_file(self.claim) != access_digest.encode():
+            fail()
+        synchronize(self.parent, directory=True)
+        if created:
+            trusted_directory(self.directory, private=True)
+            self.initialize(access_digest)
+        host_public_key = self.load(access_digest)
+        self.materialize(host_public_key)
+        return host_public_key
+
+    def initialize(self, access_digest):
+        # An existing runtime key needs an explicit migration, never replacement.
+        for suffix in ("", ".pub"):
+            if os.path.lexists(self.runtime_directory / (KEY_NAME + suffix)):
+                fail()
+        private_path = self.directory / KEY_NAME
+        keygen("-q", "-t", "ed25519", "-N", "", "-C", "", "-f", private_path)
+        for suffix in ("", ".pub"):
+            path = self.directory / (KEY_NAME + suffix)
+            path.chmod(0o600)
+            read_file(path)
+            synchronize(path)
+        host_public_key = public_key(keygen("-y", "-P", "", "-f", private_path))
+        marker = {"version": 1, "access_digest": access_digest, "host_public_key": host_public_key}
+        publish(self.marker, json.dumps(marker, sort_keys=True).encode())
+
+    def load(self, access_digest):
+        deadline = time.monotonic() + WAIT_SECONDS
+        while True:
+            try:
+                trusted_directory(self.directory, private=True)
+                encoded = read_file(self.marker)
+                break
+            except FileNotFoundError:
+                if time.monotonic() >= deadline:
+                    fail()
+                time.sleep(0.02)
+        marker = json.loads(encoded, object_pairs_hook=unique_object)
+        if (not isinstance(marker, dict)
+                or set(marker) != {"version", "access_digest", "host_public_key"}
+                or type(marker["version"]) is not int or marker["version"] != 1
+                or marker["access_digest"] != access_digest
+                or not isinstance(marker["host_public_key"], str)):
+            fail()
+        private_path = self.directory / KEY_NAME
+        read_file(private_path)
+        expected = marker["host_public_key"]
+        if (public_key(read_file(self.directory / (KEY_NAME + ".pub"))) != expected
+                or public_key(keygen("-y", "-P", "", "-f", private_path)) != expected):
+            fail()
+        synchronize(self.directory, directory=True)
+        return expected
+
+    def materialize(self, host_public_key):
+        private_path = self.runtime_directory / KEY_NAME
+        public_path = self.runtime_directory / (KEY_NAME + ".pub")
+        private_value = read_file(self.directory / KEY_NAME)
+        for path, value in ((private_path, private_value), (public_path, (host_public_key + "\n").encode())):
+            try:
+                publish(path, value)
+            except FileExistsError:
+                if read_file(path) != value:
+                    fail()
+            synchronize(path)
+        synchronize(self.runtime_directory, directory=True)
+
+
+def main():
+    try:
+        if len(sys.argv) != 1:
+            fail()
+        HostIdentity("/workspace", "/root/.ssh/authorized_keys", "/etc/ssh").prepare()
+    except (IdentityError, OSError, ValueError, RecursionError, subprocess.SubprocessError):
+        print("horizon-worker: retained SSH host identity is unavailable", file=sys.stderr)
+        return 64
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/containers/remote-worker/host-identity.py
+++ b/containers/remote-worker/host-identity.py
@@ -13,7 +13,10 @@ import tempfile
 import time
 
 LIMIT = 16 * 1024
-WAIT_SECONDS = 2
+KEYGEN_TIMEOUT_SECONDS = 10
+INITIALIZATION_SYNC_GRACE_SECONDS = 10
+# Generation and public-key inspection both finish before the readiness marker.
+WAIT_SECONDS = 2 * KEYGEN_TIMEOUT_SECONDS + INITIALIZATION_SYNC_GRACE_SECONDS
 KEY_NAME = "ssh_host_ed25519_key"
 ED25519_PREFIX = b"\x00\x00\x00\x0bssh-ed25519\x00\x00\x00\x20"
 
@@ -68,7 +71,7 @@ def public_key(value):
 
 def keygen(*arguments):
     result = subprocess.run(
-        ["/usr/bin/ssh-keygen", *map(str, arguments)], check=False, timeout=10,
+        ["/usr/bin/ssh-keygen", *map(str, arguments)], check=False, timeout=KEYGEN_TIMEOUT_SECONDS,
         stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
         env={"PATH": "/usr/bin:/bin", "LC_ALL": "C"},
     )

--- a/containers/remote-worker/sshd_config
+++ b/containers/remote-worker/sshd_config
@@ -1,4 +1,5 @@
 PasswordAuthentication no
+HostKey /etc/ssh/ssh_host_ed25519_key
 KbdInteractiveAuthentication no
 ChallengeResponseAuthentication no
 PermitEmptyPasswords no

--- a/containers/remote-worker/test_host_identity.py
+++ b/containers/remote-worker/test_host_identity.py
@@ -1,0 +1,208 @@
+"""Real OpenSSH regressions with private, synthetic filesystem fixtures only."""
+
+import base64
+import concurrent.futures
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+spec = importlib.util.spec_from_file_location("host_identity", Path(__file__).with_name("host-identity.py"))
+identity = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(identity)
+
+
+class HostIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="horizon-host-identity-")
+        self.root = Path(self.temporary.name)
+        self.root.chmod(0o700)
+        self.workspace = self.root / "workspace"
+        self.runtime = self.root / "runtime"
+        self.workspace.mkdir(mode=0o700)
+        self.runtime.mkdir(mode=0o700)
+        self.client = self.root / "client"
+        identity.keygen("-q", "-t", "ed25519", "-N", "", "-C", "", "-f", self.client)
+        self.access = self.client.with_suffix(".pub")
+        self.access.chmod(0o600)
+        self.store = self.new_store()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def new_store(self, runtime=None):
+        return identity.HostIdentity(self.workspace, self.access, runtime or self.runtime)
+
+    def snapshot(self):
+        return {str(path.relative_to(self.store.parent)): path.read_bytes()
+                for path in self.store.parent.rglob("*") if path.is_file() and not path.is_symlink()}
+
+    def assert_rejected_without_generation(self, store=None):
+        with mock.patch.object(identity, "WAIT_SECONDS", 0), mock.patch.object(identity, "keygen") as utility:
+            with self.assertRaises((identity.IdentityError, OSError, ValueError)):
+                (store or self.store).prepare()
+            utility.assert_not_called()
+
+    def test_same_key_after_reopen_and_loss_of_runtime_filesystem(self):
+        public = self.store.prepare()
+        before = self.snapshot()
+        self.assertEqual(public, self.new_store().prepare())
+        shutil.rmtree(self.runtime)
+        self.runtime.mkdir(mode=0o700)
+        self.assertEqual(public, self.new_store().prepare())
+        self.assertEqual(before, self.snapshot())
+        runtime_key = self.runtime / identity.KEY_NAME
+        self.assertEqual(public, identity.public_key(identity.keygen("-y", "-P", "", "-f", runtime_key)))
+        for path in (self.store.claim, self.store.marker, runtime_key):
+            self.assertEqual(0o600, path.stat().st_mode & 0o777)
+        self.assertEqual(0o700, self.store.directory.stat().st_mode & 0o777)
+
+    def test_separate_workspaces_never_share_host_identity(self):
+        first = self.store.prepare()
+        other_workspace = self.root / "other-workspace"
+        other_runtime = self.root / "other-runtime"
+        other_workspace.mkdir(mode=0o700)
+        other_runtime.mkdir(mode=0o700)
+        other = identity.HostIdentity(other_workspace, self.access, other_runtime)
+        self.assertNotEqual(first, other.prepare())
+
+    def test_concurrent_initialization_publishes_one_host_key(self):
+        destinations = [self.root / f"runtime-{index}" for index in range(8)]
+        for path in destinations:
+            path.mkdir(mode=0o700)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda path: self.new_store(path).prepare(), destinations))
+        self.assertEqual(1, len(set(results)))
+        self.assertEqual(1, len(list(self.store.directory.glob(identity.KEY_NAME))))
+
+    def test_different_client_cannot_adopt_retained_volume(self):
+        self.store.prepare()
+        before = self.snapshot()
+        self.access.write_bytes(b"ssh-ed25519 " + base64.b64encode(identity.ED25519_PREFIX + b"x" * 32))
+        self.assert_rejected_without_generation()
+        self.assertEqual(before, self.snapshot())
+
+    def test_incomplete_claim_never_generates_a_replacement(self):
+        self.store.prepare()
+        before_claim = self.store.claim.read_bytes()
+        shutil.rmtree(self.store.directory)
+        self.assert_rejected_without_generation()
+        self.assertEqual(before_claim, self.store.claim.read_bytes())
+        self.assertFalse(self.store.directory.exists())
+
+    def test_missing_marker_or_key_never_generates_replacement(self):
+        self.store.prepare()
+        for path in (self.store.marker, self.store.directory / identity.KEY_NAME,
+                     self.store.directory / (identity.KEY_NAME + ".pub")):
+            value = path.read_bytes()
+            path.unlink()
+            self.assert_rejected_without_generation()
+            path.write_bytes(value)
+            path.chmod(0o600)
+
+    def test_missing_claim_is_not_recreated_for_an_existing_store(self):
+        self.store.prepare()
+        self.store.claim.unlink()
+        before = self.snapshot()
+        self.assert_rejected_without_generation()
+        self.assertEqual(before, self.snapshot())
+
+    def test_corrupt_or_future_marker_leaves_original_keys_unchanged(self):
+        self.store.prepare()
+        original = json.loads(self.store.marker.read_bytes())
+        key = (self.store.directory / identity.KEY_NAME).read_bytes()
+        for value in (b"broken", b"[]", b"x" * (identity.LIMIT + 1),
+                      b'{"version": 2, ' + self.store.marker.read_bytes()[1:],
+                      json.dumps({**original, "version": 2}).encode(),
+                      json.dumps({**original, "version": True}).encode(),
+                      json.dumps({**original, "access_digest": "wrong"}).encode(),
+                      json.dumps({**original, "extra": 1}).encode()):
+            self.store.marker.write_bytes(value)
+            self.assert_rejected_without_generation()
+            self.assertEqual(key, (self.store.directory / identity.KEY_NAME).read_bytes())
+
+    def test_nonregular_claim_fails_without_blocking_or_creating_keys(self):
+        self.store.parent.mkdir(mode=0o700)
+        os.mkfifo(self.store.claim, 0o600)
+        self.assert_rejected_without_generation()
+        self.assertFalse(self.store.directory.exists())
+
+    def test_cli_diagnostics_never_include_private_error_details(self):
+        diagnostics = io.StringIO()
+        with mock.patch.object(identity.sys, "argv", ["host-identity"]), \
+                mock.patch.object(identity.sys, "stderr", diagnostics), \
+                mock.patch.object(identity.HostIdentity, "prepare", side_effect=OSError("synthetic-private-detail")):
+            self.assertEqual(64, identity.main())
+        self.assertEqual("horizon-worker: retained SSH host identity is unavailable\n", diagnostics.getvalue())
+
+    def test_insecure_files_and_symlinks_are_rejected(self):
+        self.store.prepare()
+        for path in (self.store.claim, self.store.marker, self.store.directory / identity.KEY_NAME):
+            path.chmod(0o644)
+            self.assert_rejected_without_generation()
+            path.chmod(0o600)
+            retained = path.with_name(path.name + ".retained")
+            path.rename(retained)
+            path.symlink_to(retained)
+            self.assert_rejected_without_generation()
+            path.unlink()
+            retained.rename(path)
+
+    def test_unsafe_workspace_and_linked_state_fail_before_key_generation(self):
+        self.workspace.chmod(0o777)
+        self.assert_rejected_without_generation()
+        self.assertFalse(self.store.parent.exists())
+        self.workspace.chmod(0o700)
+        elsewhere = self.root / "elsewhere"
+        elsewhere.mkdir(mode=0o700)
+        self.store.parent.symlink_to(elsewhere)
+        self.assert_rejected_without_generation()
+        self.assertEqual([], list(elsewhere.iterdir()))
+
+    def test_existing_runtime_key_is_not_silently_migrated_or_overwritten(self):
+        path = self.runtime / identity.KEY_NAME
+        path.write_bytes(b"legacy-private-key")
+        path.chmod(0o600)
+        self.assert_rejected_without_generation()
+        self.assertEqual(b"legacy-private-key", path.read_bytes())
+        self.assertFalse(self.store.marker.exists())
+
+    def test_changed_runtime_key_is_not_overwritten(self):
+        self.store.prepare()
+        path = self.runtime / identity.KEY_NAME
+        path.write_bytes(b"different-private-key")
+        before = self.snapshot()
+        with self.assertRaises(identity.IdentityError):
+            self.store.prepare()
+        self.assertEqual(before, self.snapshot())
+        self.assertEqual(b"different-private-key", path.read_bytes())
+
+    def test_claim_is_synced_before_generation_and_ready_before_materialization(self):
+        real_keygen = identity.keygen
+        observed = []
+        real_sync = identity.synchronize
+
+        def synchronize(path, directory=False):
+            observed.append((path, directory))
+            real_sync(path, directory)
+
+        def keygen(*arguments):
+            if "-q" in arguments:
+                self.assertTrue(self.store.claim.exists())
+                self.assertIn((self.store.parent, True), observed)
+                self.assertFalse((self.runtime / identity.KEY_NAME).exists())
+            return real_keygen(*arguments)
+
+        with mock.patch.object(identity, "synchronize", synchronize), mock.patch.object(identity, "keygen", keygen):
+            self.store.prepare()
+        self.assertTrue(self.store.marker.exists())
+        self.assertIn((self.store.directory, True), observed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/containers/remote-worker/test_host_identity.py
+++ b/containers/remote-worker/test_host_identity.py
@@ -80,6 +80,40 @@ class HostIdentityTests(unittest.TestCase):
         self.assertEqual(1, len(set(results)))
         self.assertEqual(1, len(list(self.store.directory.glob(identity.KEY_NAME))))
 
+    def test_follower_wait_covers_both_key_operations_before_readiness(self):
+        public = self.store.prepare()
+        before = self.snapshot()
+        real_read = identity.read_file
+        marker_attempts = []
+
+        def read_file(path, private=True):
+            if path == self.store.marker:
+                marker_attempts.append(path)
+                if len(marker_attempts) < 3:
+                    raise FileNotFoundError
+            return real_read(path, private)
+
+        elapsed = [0, 0, 2 * identity.KEYGEN_TIMEOUT_SECONDS]
+        with mock.patch.object(identity, "read_file", read_file), \
+                mock.patch.object(identity.time, "monotonic", side_effect=elapsed), \
+                mock.patch.object(identity.time, "sleep") as sleep:
+            self.assertEqual(public, self.new_store().prepare())
+        self.assertEqual(2, sleep.call_count)
+        self.assertEqual(before, self.snapshot())
+
+    def test_exhausted_follower_deadline_does_not_replace_identity(self):
+        self.store.prepare()
+        self.store.marker.unlink()
+        before = self.snapshot()
+        with mock.patch.object(identity.time, "monotonic", side_effect=[0, identity.WAIT_SECONDS]), \
+                mock.patch.object(identity.time, "sleep") as sleep, \
+                mock.patch.object(identity, "keygen") as utility:
+            with self.assertRaises(identity.IdentityError):
+                self.new_store().prepare()
+        utility.assert_not_called()
+        sleep.assert_not_called()
+        self.assertEqual(before, self.snapshot())
+
     def test_different_client_cannot_adopt_retained_volume(self):
         self.store.prepare()
         before = self.snapshot()

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -95,6 +95,11 @@ back into large multi-purpose modules.
   recovery, separately from the pure remote aggregate. Linux filesystem privacy
   and durable publication live in `remote_ssh_identity/linux.rs`; bounded key-utility
   execution lives in `command.rs`. Neither owns provider or remote task lifetime.
+- `containers/remote-worker/host-identity.py` owns workspace-retained server-key
+  initialization, validation and runtime materialization before SSH starts.
+  Its real-key regressions are separate from the retained-volume SSH smoke in
+  `scripts/run-remote-worker-host-identity-smoke.sh`. Neither owns volume allocation,
+  backup, provider restart or task supervision.
 - `cloud_run/worker_lifetime.rs` owns explicit execution lifetime and compatible
   target serialization. `interactive_worker.rs` validates observed lifetime
   against that policy; neither represents the client/creation ownership lease.

--- a/docs/architecture/remote-worker-host-identity.md
+++ b/docs/architecture/remote-worker-host-identity.md
@@ -1,0 +1,58 @@
+# ADR-383: Retain the worker SSH host identity on workspace storage
+
+Status: Proposed implementation; full remote restart integration pending.
+Date: 2026-09-06.
+Decider: Repository maintainer through issue #383 and reviewed delivery.
+
+## Context
+
+The persistent development contract requires verified reconnect after explicit
+stop or recovery, as well as after client disconnection. The previous image
+generated host keys only under `/etc/ssh`. A provider can retain `/workspace`
+while replacing its container filesystem. A new server key then invalidates the
+client's pinned identity. RunPod explicitly distinguishes container disk from
+retained volume storage in its [storage contract](https://docs.runpod.io/pods/storage/types).
+
+## Decision
+
+Retain the host key under the private `/workspace/.horizon-worker/ssh` directory.
+Record a no-overwrite access-key digest claim before generation, then synchronize
+the key pair before publishing a versioned readiness marker. Startup revalidates
+ownership, permissions, parent paths, marker and actual key-pair correspondence.
+Only a complete matching identity can be materialized into the existing runtime
+paths before SSH starts. A bounded wait admits concurrent initialization; a lost
+or damaged claim/key/marker never grants a replacement inside the retained store.
+
+The independent client's SSH pin remains mandatory. Retaining a key does not
+authorize adopting a volume, worker or runtime under a different provider identity.
+The provider/coordinator must still verify those identities. A missing entire
+volume cannot be distinguished from a fresh volume by this helper; recovery must
+not silently accept a new server key in that case.
+
+## Alternatives and trade-offs
+
+- Container-only keys are simple but fail verified reconnect when the runtime
+  filesystem is replaced. Automatically accepting a changed key breaks the trust
+  contract and is rejected.
+- External secret-manager storage would separate identity from workspace storage,
+  but adds a credential/service dependency. It remains a possible later backend.
+- A retained volume keeps initialization local and inspectable. It depends on
+  POSIX ownership/durability semantics and protected backups. It does not provide
+  encrypted key storage or isolation between same-root worker tasks.
+
+## Consequences and validation
+
+Keep provider inspection at `/etc/ssh/ssh_host_ed25519_key.pub`; configure only
+the verified Ed25519 host key. Refuse unsafe or incompatible state instead of
+overwriting keys. Recovery from interrupted first initialization, key rotation
+and legacy-key migration require explicit later workflows.
+
+Real-key tests cover restart, concurrent creation, mismatched access, damaged
+state and path permissions. A local SSH smoke destroys only its task-owned
+container filesystem while keeping its named volume and verifies the same host
+identity and repository data. This does not prove live cloud restart, persistence
+of agent/session state, volume-loss recovery or PC-off development.
+
+Remaining actions: integrate provider-retained volumes and remote backups;
+preserve task/agent state and session markers; implement explicit Stop/recovery;
+complete exact-head cloud acceptance without touching unrelated resources.

--- a/scripts/run-remote-worker-host-identity-smoke.sh
+++ b/scripts/run-remote-worker-host-identity-smoke.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# != 2 || $1 != --image || -z $2 ]]; then
+  printf '%s\n' 'usage: run-remote-worker-host-identity-smoke.sh --image <local-image>' >&2
+  exit 64
+fi
+image=$2
+for utility in docker ssh ssh-keygen; do
+  command -v "$utility" >/dev/null
+done
+docker image inspect "$image" >/dev/null
+fixture=$(mktemp -d /tmp/horizon-host-key-smoke.XXXXXX)
+smoke_id="horizon-host-key-${fixture##*.}-$$"
+volume="${smoke_id}-workspace"
+owned_volume=false
+containers=()
+
+fail() { printf 'Host identity smoke failed: %s\n' "$1" >&2; exit 1; }
+cleanup() {
+  local result=$? container
+  trap - EXIT
+  for container in "${containers[@]}"; do
+    if docker container inspect "$container" >/dev/null 2>&1; then
+      docker container rm --force "$container" >/dev/null || result=1
+    fi
+  done
+  if [[ $owned_volume == true ]]; then
+    docker volume rm "$volume" >/dev/null || result=1
+  fi
+  case "$fixture" in
+    /tmp/horizon-host-key-smoke.*) rm -r -- "$fixture" || result=1 ;;
+    *) result=1 ;;
+  esac
+  exit "$result"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+if docker volume inspect "$volume" >/dev/null 2>&1; then
+  fail 'task volume already exists'
+fi
+docker volume create --label "horizon.host-key-smoke=$smoke_id" "$volume" >/dev/null
+[[ $(docker volume inspect --format '{{index .Labels "horizon.host-key-smoke"}}' "$volume") == "$smoke_id" ]] ||
+  fail 'volume ownership mismatch'
+owned_volume=true
+ssh-keygen -q -t ed25519 -N '' -C '' -f "$fixture/client"
+ssh-keygen -q -t ed25519 -N '' -C '' -f "$fixture/other-client"
+client_public=$(<"$fixture/client.pub")
+other_public=$(<"$fixture/other-client.pub")
+expected_key=
+
+create_worker() {
+  local access=$1
+  created_id=$(docker create --pull=never --label "horizon.host-key-smoke=$smoke_id" \
+    --publish 127.0.0.1::22 --mount "type=volume,src=$volume,dst=/workspace" \
+    --env "HORIZON_SSH_PUBLIC_KEY=$access" "$image")
+  [[ $created_id =~ ^[a-f0-9]{64}$ ]] || fail 'invalid created container identity'
+  containers+=("$created_id")
+  docker start "$created_id" >/dev/null
+}
+
+wait_ready() {
+  local container=$1 attempt
+  port=$(docker port "$container" 22/tcp | sed -n 's/^127\.0\.0\.1://p')
+  [[ $port =~ ^[0-9]+$ ]] || fail 'missing loopback SSH port'
+  for attempt in {1..40}; do
+    if observed_key=$(docker exec "$container" cat /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null); then
+      [[ -z $expected_key || $observed_key == "$expected_key" ]] || fail 'retained host identity changed'
+      printf '[127.0.0.1]:%s %s\n' "$port" "${expected_key:-$observed_key}" >"$fixture/known-hosts"
+      if connect true 2>/dev/null; then return 0; fi
+    fi
+    [[ $(docker inspect --format '{{.State.Running}}' "$container") == true ]] || fail 'worker exited before SSH'
+    sleep 0.25
+  done
+  fail 'SSH startup timed out'
+}
+
+connect() {
+  ssh -F /dev/null -i "$fixture/client" -o BatchMode=yes -o IdentitiesOnly=yes \
+    -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$fixture/known-hosts" \
+    -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=2 -p "$port" root@127.0.0.1 "$@"
+}
+
+create_worker "$client_public"
+first_id=$created_id
+wait_ready "$first_id"
+expected_key=$observed_key
+connect 'printf "retained-workspace-data\n" > /workspace/horizon/retained.txt'
+docker stop --time 10 "$first_id" >/dev/null
+docker rm "$first_id" >/dev/null
+
+create_worker "$client_public"
+second_id=$created_id
+[[ $second_id != "$first_id" ]] || fail 'runtime filesystem was not replaced'
+wait_ready "$second_id"
+[[ $observed_key == "$expected_key" ]] || fail 'host identity changed after runtime filesystem loss'
+[[ $(connect 'cat /workspace/horizon/retained.txt') == retained-workspace-data ]] || fail 'workspace data was lost'
+docker stop --time 10 "$second_id" >/dev/null
+docker rm "$second_id" >/dev/null
+
+create_worker "$other_public"
+rejected_id=$created_id
+for attempt in {1..40}; do
+  [[ $(docker inspect --format '{{.State.Running}}' "$rejected_id") == true ]] || break
+  sleep 0.25
+done
+[[ $(docker inspect --format '{{.State.Running}}:{{.State.ExitCode}}' "$rejected_id") == false:64 ]] ||
+  fail 'retained volume accepted a different access identity'
+docker rm "$rejected_id" >/dev/null
+
+create_worker "$client_public"
+wait_ready "$created_id"
+[[ $observed_key == "$expected_key" ]] || fail 'rejected access changed the original host key'
+[[ $(connect 'cat /workspace/horizon/retained.txt') == retained-workspace-data ]] || fail 'rejected access changed data'
+printf '%s\n' 'PASS retained host key and workspace data after runtime filesystem replacement; wrong access key rejected'


### PR DESCRIPTION
## Purpose

Retain the worker's SSH server identity across loss of its container filesystem,
advancing the verified-reconnect and durable-storage requirements in #383.

## Behavior

- Store the host identity under private workspace storage. Record initialization
  before key generation and synchronize the complete key pair before readiness.
- On startup, validate the original access identity, exact schema, key pair and
  filesystem ownership/permissions. Missing, partial, corrupt, duplicate-field,
  linked or mismatched state cannot authorize a replacement in the retained store.
- Materialize verified runtime keys without overwrite before SSH starts. Keep
  the existing trusted provider inspection path and restrict the server to the
  verified Ed25519 identity.
- Require explicit workflows for legacy-key migration, rotation and recovery;
  preserve the independent client's host-key pin.

This requires provider/operator-retained storage at `/workspace` with trusted
Linux POSIX permission and durability semantics. Keys are unencrypted on disk;
same-root worker tasks share a trust domain. The helper cannot establish provider
ownership or distinguish whole-volume loss from a fresh volume. It does not add
volume allocation, backup, agent/session-state durability, Stop UI or automatic
restart/recovery.

## Validation

- Seventeen real-key regressions cover restart/filesystem loss, concurrent startup,
  missing claims/markers/keys, malformed/future/duplicate schema, changed access,
  unsafe paths/permissions, FIFO rejection, redacted CLI errors, delayed readiness
  and timeout without replacement.
- One hundred rounds of eight concurrent initializers retained one identity per
  round.
- Local retained-volume smoke replaced only task-owned container filesystems,
  verified the original pinned SSH identity and workspace data, rejected a wrong
  access identity, and proved the original identity remained usable afterward.
- The complete worker security/disconnect/explicit-stop smoke passed on the
  final candidate image; the same running task progressed with no SSH clients.
- Full format, maintainability, version, default/speech tests and blocking,
  strict and advisory Clippy passed in the final worktree and exact commit
  `3857bdae2e3970088abeee25b50b0378dfb76f80`. Independent local
  review is clear on the exact final tree.
- Clarified the distinction between newly created file modes and accepted
  existing owner-only modes after hosted review; the correction changes no
  runtime behavior. Both smoke lanes were repeated from the corrected checkout.
- Corrected a hosted-review timing finding: the bounded readiness wait now covers
  both key-operation budgets plus synchronization grace. The regression fails
  under the previous two-second policy; a real delayed initializer also passed
  inside the final image. Timeout preserves state and never grants replacement.

The candidate image is local only. No image publication, paid cloud resource,
actual user credential or existing worker/process was involved. Task-created
smoke containers and volumes were cleaned; #383 remains open for full integration
and exact cloud PC-off acceptance.
