### PR TITLE
Show saved remote environments across sessions

### DIFF
--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -1,9 +1,12 @@
 //! Durable remote workspace data, independent of providers, persistence I/O, and UI.
 //! Snapshot validation is not permission to attach: fresh provider observation and lease checks remain required.
 
+mod summary;
 #[cfg(test)]
 mod tests;
 mod validation;
+
+pub use summary::RemoteEnvironmentSummary;
 
 pub(crate) use validation::valid_local_id;
 

--- a/crates/horizon-core/src/remote_workspace/summary.rs
+++ b/crates/horizon-core/src/remote_workspace/summary.rs
@@ -2,7 +2,8 @@
 
 use super::{RemoteRuntimePhase, RemoteWorkspaceState, RepositoryCheckpoint};
 use crate::cloud_run::{
-    CloudProvider, StoredRemoteWorkspace, WorkerLifetime, interactive_worker::InteractiveWorkerIdentity,
+    CloudJobId, CloudProvider, CloudWorkflowId, StoredRemoteWorkspace, WorkerLifetime,
+    interactive_worker::InteractiveWorkerIdentity,
 };
 
 /// Safe to retain in an overview without retaining task handoffs, commands or SSH keys.
@@ -18,6 +19,8 @@ pub struct RemoteEnvironmentSummary {
     pub lifetime: WorkerLifetime,
     pub generation: u64,
     pub saved_phase: Option<RemoteRuntimePhase>,
+    pub workflow_id: Option<CloudWorkflowId>,
+    pub job_id: Option<CloudJobId>,
     pub worker_identity: Option<InteractiveWorkerIdentity>,
     pub checkpoint: Option<RepositoryCheckpoint>,
     pub panel_count: usize,
@@ -43,6 +46,8 @@ impl RemoteEnvironmentSummary {
             lifetime: state.spec.target.lifetime,
             generation: state.spec.generation,
             saved_phase: state.runtime.as_ref().map(|runtime| runtime.phase),
+            workflow_id: state.runtime.as_ref().map(|runtime| runtime.workflow_id),
+            job_id: state.runtime.as_ref().map(|runtime| runtime.job_id),
             worker_identity: state
                 .runtime
                 .as_ref()
@@ -105,6 +110,8 @@ mod tests {
         assert_eq!(summary.panel_count, 1);
         assert_eq!(summary.lifetime, WorkerLifetime::Persistent);
         assert!(summary.saved_phase.is_none());
+        assert!(summary.workflow_id.is_none());
+        assert!(summary.job_id.is_none());
         assert!(summary.worker_identity.is_none());
         assert!(!format!("{summary:?}").contains("private-task-marker"));
     }
@@ -126,6 +133,9 @@ mod tests {
         });
         let summary = RemoteEnvironmentSummary::from_state("owner", 7, &state);
         assert_eq!(summary.saved_phase, Some(RemoteRuntimePhase::Reconciling));
+        let runtime = state.runtime.as_ref().expect("runtime");
+        assert_eq!(summary.workflow_id, Some(runtime.workflow_id));
+        assert_eq!(summary.job_id, Some(runtime.job_id));
         assert_eq!(summary.generation, 2);
         assert_eq!(summary.revision, 7);
         assert!(summary.worker_identity.is_none());

--- a/crates/horizon-core/src/remote_workspace/summary.rs
+++ b/crates/horizon-core/src/remote_workspace/summary.rs
@@ -1,0 +1,133 @@
+//! Compact saved inventory metadata. No live status or lifecycle authority is inferred.
+
+use super::{RemoteRuntimePhase, RemoteWorkspaceState, RepositoryCheckpoint};
+use crate::cloud_run::{
+    CloudProvider, StoredRemoteWorkspace, WorkerLifetime, interactive_worker::InteractiveWorkerIdentity,
+};
+
+/// Safe to retain in an overview without retaining task handoffs, commands or SSH keys.
+/// Saved setup phase is not a current provider observation, even when it is `Ready`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteEnvironmentSummary {
+    pub workspace_local_id: String,
+    pub owning_session_id: String,
+    pub revision: u64,
+    pub repository: String,
+    pub provider: CloudProvider,
+    pub profile: String,
+    pub lifetime: WorkerLifetime,
+    pub generation: u64,
+    pub saved_phase: Option<RemoteRuntimePhase>,
+    pub worker_identity: Option<InteractiveWorkerIdentity>,
+    pub checkpoint: Option<RepositoryCheckpoint>,
+    pub panel_count: usize,
+}
+
+impl StoredRemoteWorkspace {
+    /// Project a validated owned record without copying executable or secret-bearing payloads.
+    #[must_use]
+    pub fn environment_summary(&self) -> RemoteEnvironmentSummary {
+        RemoteEnvironmentSummary::from_state(self.session_id(), self.revision(), self.state())
+    }
+}
+
+impl RemoteEnvironmentSummary {
+    fn from_state(session_id: &str, revision: u64, state: &RemoteWorkspaceState) -> Self {
+        Self {
+            workspace_local_id: state.spec.workspace_local_id.clone(),
+            owning_session_id: session_id.into(),
+            revision,
+            repository: state.spec.repository.repository.clone(),
+            provider: state.spec.target.provider,
+            profile: state.spec.target.profile.clone(),
+            lifetime: state.spec.target.lifetime,
+            generation: state.spec.generation,
+            saved_phase: state.runtime.as_ref().map(|runtime| runtime.phase),
+            worker_identity: state
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.worker.as_ref().map(|worker| worker.identity.clone())),
+            checkpoint: state.checkpoint.clone(),
+            panel_count: state.spec.panels.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PanelKind;
+    use crate::cloud_run::{CloudJobId, CloudWorkflowId, GitCommitSha, GitSource, WorkerTarget};
+    use crate::remote_workspace::{RemotePanelBinding, RemoteRuntimeGeneration, RemoteWorkspaceSpec};
+
+    fn state() -> RemoteWorkspaceState {
+        RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+            workspace_local_id: "saved-environment".into(),
+            target: WorkerTarget {
+                provider: CloudProvider::LocalDocker,
+                profile: "development".into(),
+                image: format!("example/worker@sha256:{}", "a".repeat(64)),
+                disk_gib: 20,
+                lifetime: WorkerLifetime::Persistent,
+                max_hourly_cost_micros: None,
+            },
+            repository: GitSource {
+                repository: "example/project".into(),
+                commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+                branch: None,
+            },
+            working_directory: ".".into(),
+            generation: 0,
+            panels: vec![RemotePanelBinding {
+                panel_local_id: "saved-panel".into(),
+                kind: PanelKind::Shell,
+                command: None,
+                working_directory: None,
+                task_handoff: Some("private-task-marker".repeat(1000)),
+                agent_session_id: None,
+            }],
+        })
+        .expect("valid state")
+    }
+
+    #[test]
+    fn stored_summary_preserves_owner_without_task_payload() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store =
+            crate::cloud_run::CloudWorkflowStore::open_path(temp.path().join("private/store.sqlite3")).expect("store");
+        let owner = uuid::Uuid::new_v4().to_string();
+        let stored = store.create_remote_workspace(&owner, &state()).expect("record");
+        let summary = stored.environment_summary();
+        assert_eq!(summary.owning_session_id, owner);
+        assert_eq!(summary.workspace_local_id, "saved-environment");
+        assert_eq!(summary.repository, "example/project");
+        assert_eq!(summary.revision, 1);
+        assert_eq!(summary.panel_count, 1);
+        assert_eq!(summary.lifetime, WorkerLifetime::Persistent);
+        assert!(summary.saved_phase.is_none());
+        assert!(summary.worker_identity.is_none());
+        assert!(!format!("{summary:?}").contains("private-task-marker"));
+    }
+
+    #[test]
+    fn unobserved_runtime_is_not_replaced_with_a_display_identity() {
+        let mut state = state();
+        state.spec.generation = 2;
+        state.runtime = Some(RemoteRuntimeGeneration {
+            workspace_local_id: state.spec.workspace_local_id.clone(),
+            generation: 2,
+            workflow_id: CloudWorkflowId::new(),
+            job_id: CloudJobId::new(),
+            phase: RemoteRuntimePhase::Reconciling,
+            ssh_public_key: None,
+            worker: None,
+            ssh: None,
+            cleanup: None,
+        });
+        let summary = RemoteEnvironmentSummary::from_state("owner", 7, &state);
+        assert_eq!(summary.saved_phase, Some(RemoteRuntimePhase::Reconciling));
+        assert_eq!(summary.generation, 2);
+        assert_eq!(summary.revision, 7);
+        assert!(summary.worker_identity.is_none());
+    }
+}

--- a/crates/horizon-ui/src/app/bootstrap.rs
+++ b/crates/horizon-ui/src/app/bootstrap.rs
@@ -178,7 +178,7 @@ impl HorizonApp {
             last_panel_output_at: Some(Instant::now()), browser_create_host: BrowserCreateHostState::default(),
             settings: None,
             speech_model_info_cache: settings::SpeechModelInfoCache::new(),
-            session_manager: None,
+            session_manager: None, remote_environments: super::remote_environments::RemoteEnvironments::default(),
             managed_install,
             surge_update_check_rx: None,
             surge_available_update: None,

--- a/crates/horizon-ui/src/app/lifecycle.rs
+++ b/crates/horizon-ui/src/app/lifecycle.rs
@@ -49,11 +49,13 @@ impl HorizonApp {
     }
 
     #[profiling::function]
-    pub(super) fn process_frame_inputs(&mut self, ctx: &Context) -> bool {
+    pub(super) fn process_frame_inputs(&mut self, ctx: &Context, inventory_captured_input: bool) -> bool {
         self.sync_panel_focus_from_pointer_press(ctx);
         // Speech runs before the fullscreen handler so that Escape cancels an
         // active recording instead of also exiting panel fullscreen.
-        self.handle_speech_input(ctx);
+        if !inventory_captured_input {
+            self.handle_speech_input(ctx);
+        }
         self.handle_fullscreen_toggle(ctx);
         self.handle_shortcuts(ctx);
         self.handle_root_file_drop(ctx);

--- a/crates/horizon-ui/src/app/mod.rs
+++ b/crates/horizon-ui/src/app/mod.rs
@@ -12,6 +12,7 @@ mod minimap;
 mod panel_chrome;
 mod panels;
 mod persistence;
+mod remote_environments;
 mod remote_hosts;
 mod root_chrome;
 mod root_viewport;
@@ -274,6 +275,7 @@ pub struct HorizonApp {
     settings: Option<SettingsEditor>,
     speech_model_info_cache: settings::SpeechModelInfoCache,
     session_manager: Option<RuntimeSessionManagerState>,
+    remote_environments: remote_environments::RemoteEnvironments,
     managed_install: Option<ManagedInstall>,
     surge_update_check_rx: Option<Receiver<UpdateCheckMessage>>,
     surge_available_update: Option<AvailableUpdate>,
@@ -346,6 +348,7 @@ impl eframe::App for HorizonApp {
             return;
         }
 
+        let inventory_interaction = self.render_remote_environments(ctx);
         let block_root_interaction = self.root_viewport_stabilization_blocks_interaction();
         let root_viewport_is_stable = self.poll_root_viewport_stabilizer(ctx);
         if block_root_interaction {
@@ -353,7 +356,7 @@ impl eframe::App for HorizonApp {
         }
 
         let (workspace_count_before, panel_count_before) = (self.board.workspaces.len(), self.board.panels.len());
-        let had_panel_output = self.process_frame_inputs(ctx);
+        let had_panel_output = self.process_frame_inputs(ctx, inventory_interaction.is_some());
         self.apply_panel_transitions();
         self.normalize_workspace_state(ctx);
         self.apply_pending_workspace_changes();
@@ -367,7 +370,7 @@ impl eframe::App for HorizonApp {
                 self.seed_initial_pan(ctx, aligned_leftmost_workspace, preserve_restored_selection);
             }
         }
-        self.render_active_view(ui, block_root_interaction);
+        self.render_active_view(ui, block_root_interaction || inventory_interaction.is_some());
         if block_root_interaction {
             Self::render_root_viewport_stabilizing_overlay(ctx);
         }
@@ -375,6 +378,9 @@ impl eframe::App for HorizonApp {
         self.finalize_frame(ctx, had_panel_output, workspace_count_before, panel_count_before);
         // Last, after every phase that can move or hide a panel this frame.
         self.restamp_browser_manifests_for_placement();
+        if let Some(input) = inventory_interaction {
+            Self::restore_remote_environment_input(ctx, input);
+        }
     }
 
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {

--- a/crates/horizon-ui/src/app/remote_environments.rs
+++ b/crates/horizon-ui/src/app/remote_environments.rs
@@ -1,0 +1,481 @@
+//! Lazy, single-flight saved inventory loading for the Remote Environments overview.
+
+mod paint;
+
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+
+use egui::Context;
+use horizon_core::{HorizonHome, cloud_run::CloudWorkflowStore, remote_workspace::RemoteEnvironmentSummary};
+
+use super::HorizonApp;
+
+#[derive(Default)]
+pub(super) struct RemoteEnvironments {
+    open: bool,
+    page: Option<InventoryPage>,
+    page_cursor: Option<String>,
+    selected: Option<usize>,
+    failure: Option<LoadFailure>,
+    pending: Option<PendingLoad>,
+    refresh_when_idle: bool,
+}
+
+struct InventoryPage {
+    rows: Vec<paint::InventoryRow>,
+    next_cursor: Option<String>,
+}
+
+struct PendingLoad {
+    rx: Receiver<Result<InventoryPage, LoadError>>,
+    cursor: Option<String>,
+    discard: bool,
+}
+
+struct LoadFailure {
+    error: LoadError,
+    cursor: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LoadError {
+    OpenStore,
+    ReadPage,
+    WorkerUnavailable,
+}
+
+#[derive(Clone, Copy, Default)]
+enum InventoryAction {
+    #[default]
+    None,
+    Close,
+    Refresh,
+    First,
+    Next,
+    Retry,
+    Select(usize),
+}
+
+struct WakeOnDrop(Context);
+
+impl Drop for WakeOnDrop {
+    fn drop(&mut self) {
+        self.0.request_repaint();
+    }
+}
+
+impl RemoteEnvironments {
+    pub(super) fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub(super) fn open(&mut self, home: &HorizonHome, ctx: &Context) {
+        if self.open {
+            return;
+        }
+        self.open = true;
+        self.page = None;
+        self.page_cursor = None;
+        self.selected = None;
+        self.failure = None;
+        if let Some(pending) = &mut self.pending {
+            pending.discard = true;
+            self.refresh_when_idle = true;
+        } else {
+            self.start_load(home, ctx, None);
+        }
+        ctx.request_repaint();
+    }
+
+    fn close(&mut self) {
+        self.open = false;
+        self.refresh_when_idle = false;
+        if let Some(pending) = &mut self.pending {
+            pending.discard = true;
+        }
+    }
+
+    fn start_load(&mut self, home: &HorizonHome, ctx: &Context, cursor: Option<String>) {
+        if !self.open || self.pending.is_some() {
+            return;
+        }
+        let (tx, rx) = mpsc::sync_channel(1);
+        let home = home.clone();
+        let requested_cursor = cursor.clone();
+        let wake = WakeOnDrop(ctx.clone());
+        let worker = std::thread::Builder::new()
+            .name("remote-environment-inventory".into())
+            .spawn(move || {
+                let _wake = wake;
+                let result = load_page(&home, requested_cursor.as_deref());
+                let _ = tx.send(result);
+            });
+        self.failure = None;
+        match worker {
+            Ok(_) => {
+                self.pending = Some(PendingLoad {
+                    rx,
+                    cursor,
+                    discard: false,
+                });
+            }
+            Err(_) => self.accept_result(cursor, Err(LoadError::WorkerUnavailable)),
+        }
+    }
+
+    fn drain_result(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        let result = match pending.rx.try_recv() {
+            Ok(result) => result,
+            Err(TryRecvError::Empty) => {
+                self.pending = Some(pending);
+                return;
+            }
+            Err(TryRecvError::Disconnected) => Err(LoadError::WorkerUnavailable),
+        };
+        if self.open && !pending.discard {
+            self.accept_result(pending.cursor, result);
+        }
+    }
+
+    fn accept_result(&mut self, cursor: Option<String>, result: Result<InventoryPage, LoadError>) {
+        match result {
+            Ok(page) => {
+                let previous = self
+                    .page
+                    .as_ref()
+                    .and_then(|page| self.selected.and_then(|index| page.rows.get(index)));
+                self.selected = previous
+                    .and_then(|previous| {
+                        page.rows
+                            .iter()
+                            .position(|row| row.summary.workspace_local_id == previous.summary.workspace_local_id)
+                    })
+                    .or_else(|| (!page.rows.is_empty()).then_some(0));
+                self.page = Some(page);
+                self.page_cursor = cursor;
+                self.failure = None;
+            }
+            Err(error) => self.failure = Some(LoadFailure { error, cursor }),
+        }
+    }
+
+    fn apply(&mut self, action: InventoryAction, home: &HorizonHome, ctx: &Context) {
+        match action {
+            InventoryAction::None => {}
+            InventoryAction::Close => self.close(),
+            InventoryAction::Select(index) => {
+                if self.page.as_ref().is_some_and(|page| index < page.rows.len()) {
+                    self.selected = Some(index);
+                }
+            }
+            InventoryAction::Refresh => self.start_load(home, ctx, self.page_cursor.clone()),
+            InventoryAction::First => self.start_load(home, ctx, None),
+            InventoryAction::Next => {
+                if let Some(cursor) = self.page.as_ref().and_then(|page| page.next_cursor.clone()) {
+                    self.start_load(home, ctx, Some(cursor));
+                }
+            }
+            InventoryAction::Retry => {
+                if let Some(failure) = &self.failure {
+                    self.start_load(home, ctx, failure.cursor.clone());
+                }
+            }
+        }
+    }
+}
+
+fn load_page(home: &HorizonHome, cursor: Option<&str>) -> Result<InventoryPage, LoadError> {
+    let store = CloudWorkflowStore::open(home).map_err(|_| LoadError::OpenStore)?;
+    let page = store
+        .list_remote_environment_page(cursor)
+        .map_err(|_| LoadError::ReadPage)?;
+    Ok(InventoryPage {
+        rows: page
+            .records
+            .iter()
+            .map(|record| paint::InventoryRow::new(record.environment_summary()))
+            .collect(),
+        next_cursor: page.next_cursor,
+    })
+}
+
+impl HorizonApp {
+    /// Render before root input routing, then consume the entire modal frame's input,
+    /// including dismissal. Remote inventory completion never requires idle polling.
+    pub(super) fn render_remote_environments(&mut self, ctx: &Context) -> Option<egui::InputState> {
+        self.remote_environments.drain_result();
+        if self.remote_environments.refresh_when_idle && self.remote_environments.pending.is_none() {
+            self.remote_environments.refresh_when_idle = false;
+            self.remote_environments
+                .start_load(self.session_store.home(), ctx, None);
+        }
+        let was_open = self.remote_environments.open;
+        if was_open {
+            self.handle_speech_input(ctx);
+            let action = paint::show(ctx, &self.remote_environments);
+            self.remote_environments.apply(action, self.session_store.home(), ctx);
+            let modal_input = ctx.input(Clone::clone);
+            self.suppress_root_viewport_interaction(ctx);
+            return Some(modal_input);
+        }
+        None
+    }
+
+    pub(super) fn restore_remote_environment_input(ctx: &Context, saved: egui::InputState) {
+        ctx.input_mut(|input| {
+            input.pointer = saved.pointer;
+            input.keys_down = saved.keys_down;
+            input.modifiers = saved.modifiers;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_page(next: Option<&str>) -> InventoryPage {
+        InventoryPage {
+            rows: Vec::new(),
+            next_cursor: next.map(String::from),
+        }
+    }
+
+    #[test]
+    fn failed_next_page_keeps_previous_page_and_exact_retry_cursor() {
+        let mut state = RemoteEnvironments {
+            open: true,
+            ..Default::default()
+        };
+        state.accept_result(None, Ok(empty_page(Some("page-two"))));
+        state.accept_result(Some("page-two".into()), Err(LoadError::ReadPage));
+        assert!(state.page_cursor.is_none());
+        assert_eq!(
+            state.page.as_ref().and_then(|page| page.next_cursor.as_deref()),
+            Some("page-two")
+        );
+        let failure = state.failure.as_ref().expect("failure");
+        assert_eq!(failure.cursor.as_deref(), Some("page-two"));
+        state.accept_result(Some("page-two".into()), Ok(empty_page(None)));
+        assert!(state.failure.is_none());
+        assert_eq!(state.page_cursor.as_deref(), Some("page-two"));
+        assert!(state.selected.is_none());
+    }
+
+    #[test]
+    fn repeated_reopen_retains_one_worker_and_discards_its_old_result() {
+        let ctx = Context::default();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = HorizonHome::from_root(temp.path().to_path_buf());
+        let (tx, rx) = mpsc::sync_channel(1);
+        let mut state = RemoteEnvironments {
+            open: true,
+            pending: Some(PendingLoad {
+                rx,
+                cursor: Some("old-page".into()),
+                discard: false,
+            }),
+            ..Default::default()
+        };
+        for _ in 0..100 {
+            state.close();
+            state.open(&home, &ctx);
+            state.start_load(&home, &ctx, None);
+            assert!(state.pending.as_ref().is_some_and(|pending| pending.discard));
+        }
+        tx.send(Ok(empty_page(Some("old-result")))).expect("send");
+        state.drain_result();
+        assert!(state.page.is_none());
+        assert!(state.pending.is_none());
+        assert!(state.refresh_when_idle);
+        assert!(!home.cloud_workflow_store_path().exists());
+    }
+
+    #[test]
+    fn closed_view_never_accepts_completion_or_requeues_refresh() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let mut state = RemoteEnvironments {
+            open: true,
+            pending: Some(PendingLoad {
+                rx,
+                cursor: None,
+                discard: false,
+            }),
+            refresh_when_idle: true,
+            ..Default::default()
+        };
+        state.close();
+        tx.send(Ok(empty_page(None))).expect("send");
+        state.drain_result();
+        assert!(state.page.is_none());
+        assert!(state.pending.is_none());
+        assert!(!state.refresh_when_idle);
+    }
+
+    #[test]
+    fn disconnected_worker_surfaces_error_without_erasing_last_page() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let mut state = RemoteEnvironments {
+            open: true,
+            page: Some(empty_page(None)),
+            pending: Some(PendingLoad {
+                rx,
+                cursor: None,
+                discard: false,
+            }),
+            ..Default::default()
+        };
+        drop(tx);
+        state.drain_result();
+        assert!(state.page.is_some());
+        assert!(state.pending.is_none());
+        assert_eq!(
+            state.failure.as_ref().map(|failure| failure.error),
+            Some(LoadError::WorkerUnavailable)
+        );
+    }
+
+    #[test]
+    fn modal_consumes_terminal_input_and_the_escape_dismissal_frame() {
+        use crate::app::test_support::{raw_input, test_app};
+        use crate::test_egui::DiscardTextures;
+        let (_temp, mut app) = test_app();
+        let ctx = Context::default();
+        app.remote_environments.open = true;
+        app.remote_environments.page = Some(empty_page(None));
+        let _ = ctx
+            .run_ui(raw_input([900.0, 680.0], None), |ui| {
+                assert!(app.render_remote_environments(ui).is_some());
+            })
+            .discard_textures();
+        let mut input = raw_input([900.0, 680.0], None);
+        input.events.push(egui::Event::Text("must-not-reach-terminal".into()));
+        input.events.push(egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: Some(egui::Key::Escape),
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        });
+        input
+            .dropped_files
+            .push(crate::app::test_support::dropped_file("/tmp/never-open-this-file"));
+        let _ = ctx
+            .run_ui(input, |ui| {
+                assert!(app.render_remote_environments(ui).is_some());
+                assert!(!app.remote_environments.open);
+                ui.input(|input| {
+                    assert!(input.events.is_empty());
+                    assert!(input.raw.events.is_empty());
+                    assert!(input.raw.dropped_files.is_empty());
+                    assert!(input.keys_down.is_empty());
+                });
+                assert!(app.terminal_keyboard_events.is_empty());
+                app.handle_shortcuts(ui);
+                assert!(app.board.panels.is_empty());
+            })
+            .discard_textures();
+    }
+
+    #[test]
+    fn loader_finds_owned_record_without_creating_a_local_session() {
+        use crate::app::test_support::raw_input;
+        use crate::test_egui::DiscardTextures;
+        use horizon_core::remote_workspace::RemoteWorkspaceState;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = HorizonHome::from_root(temp.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let owner = "00000000-0000-4000-8000-000000000001".to_string();
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "spec": {
+                "workspace_local_id": "detached-workspace",
+                "target": { "provider": "local_docker", "profile": "development",
+                    "image": format!("example/worker@sha256:{}", "a".repeat(64)),
+                    "disk_gib": 20, "lifetime": "persistent" },
+                "repository": { "repository": "example/project", "commit": "b".repeat(40) },
+                "working_directory": ".", "generation": 0, "panels": []
+            }
+        }))
+        .expect("state");
+        let stored = store.create_remote_workspace(&owner, &state).expect("record");
+        let page = load_page(&home, None).expect("page");
+        assert_eq!(page.rows.len(), 1);
+        assert_eq!(page.rows[0].summary, stored.environment_summary());
+        let ctx = Context::default();
+        let mut view = RemoteEnvironments {
+            open: true,
+            page: Some(empty_page(None)),
+            ..Default::default()
+        };
+        let render = |view: &RemoteEnvironments| {
+            for _ in 0..2 {
+                let _ = ctx
+                    .run_ui(raw_input([900.0, 680.0], None), |ui| {
+                        let _ = paint::show(ui, view);
+                    })
+                    .discard_textures();
+            }
+            ctx.data(|data| data.get_temp::<egui::Rect>(egui::Id::new("inventory-close-test")))
+                .expect("close control")
+                .top()
+        };
+        let empty_top = render(&view);
+        view.page = Some(page);
+        assert!(
+            render(&view) < empty_top - 100.0,
+            "populated dialog must grow beyond its cached empty height"
+        );
+        view.failure = Some(LoadFailure {
+            error: LoadError::ReadPage,
+            cursor: None,
+        });
+        assert!(render(&view) >= 32.0, "error controls must remain inside the viewport");
+        assert!(!home.sessions_dir().exists());
+        assert_eq!(
+            store.load_remote_workspace(&owner, "detached-workspace").expect("load"),
+            Some(stored)
+        );
+    }
+
+    #[test]
+    fn close_click_keeps_pointer_state_across_press_idle_and_release_frames() {
+        use crate::app::test_support::{raw_input, test_app};
+        use crate::test_egui::DiscardTextures;
+        let (_temp, mut app) = test_app();
+        let ctx = Context::default();
+        app.remote_environments.open = true;
+        app.remote_environments.page = Some(empty_page(None));
+        let mut frame = |events| {
+            let mut input = raw_input([900.0, 680.0], None);
+            input.events = events;
+            let _ = ctx
+                .run_ui(input, |ui| {
+                    let saved = app.render_remote_environments(ui).expect("modal frame");
+                    assert!(!ui.input(|input| input.pointer.primary_down()));
+                    HorizonApp::restore_remote_environment_input(ui, saved);
+                })
+                .discard_textures();
+        };
+        frame(Vec::new());
+        frame(Vec::new());
+        let position = ctx
+            .data(|data| data.get_temp::<egui::Rect>(egui::Id::new("inventory-close-test")))
+            .expect("close control")
+            .center();
+        let button = |pressed| egui::Event::PointerButton {
+            pos: position,
+            button: egui::PointerButton::Primary,
+            pressed,
+            modifiers: egui::Modifiers::NONE,
+        };
+        frame(vec![egui::Event::PointerMoved(position), button(true)]);
+        frame(Vec::new());
+        assert!(ctx.input(|input| input.pointer.primary_down()));
+        frame(vec![egui::Event::PointerMoved(position)]);
+        frame(vec![button(false)]);
+        assert!(!app.remote_environments.open);
+    }
+}

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -1,0 +1,227 @@
+//! Cached labels and action collection; no storage or provider calls while painting.
+
+use egui::{Align, Context, Layout, RichText};
+use horizon_core::{
+    cloud_run::{CloudProvider, WorkerLifetime},
+    remote_workspace::RemoteRuntimePhase,
+};
+
+use super::{InventoryAction, LoadError, RemoteEnvironmentSummary, RemoteEnvironments};
+use crate::theme;
+
+pub(super) struct InventoryRow {
+    pub(super) summary: RemoteEnvironmentSummary,
+    label: String,
+    details: Vec<(&'static str, String)>,
+}
+
+impl InventoryRow {
+    pub(super) fn new(summary: RemoteEnvironmentSummary) -> Self {
+        let provider = match summary.provider {
+            CloudProvider::Azure => "Azure",
+            CloudProvider::RunPod => "RunPod",
+            CloudProvider::LocalDocker => "Local Docker",
+        };
+        let label = format!(
+            "{} · {} · {provider} / {}",
+            summary.workspace_local_id, summary.repository, summary.profile
+        );
+        let lifetime = match summary.lifetime {
+            WorkerLifetime::Persistent => "Persistent".into(),
+            WorkerLifetime::TimeLimited { seconds } => format!("Time-limited ({seconds} seconds)"),
+        };
+        let mut details = vec![
+            ("Workspace ID", summary.workspace_local_id.clone()),
+            ("Owning session", summary.owning_session_id.clone()),
+            ("Saved revision", summary.revision.to_string()),
+            ("Runtime generation", summary.generation.to_string()),
+            ("Saved panel intents", summary.panel_count.to_string()),
+            ("Execution policy", lifetime),
+        ];
+        if let Some(identity) = &summary.worker_identity {
+            details.push(("Exact resource ID", identity.resource_id.clone()));
+            details.push(("Workflow ID", identity.workflow_id.to_string()));
+            details.push(("Job ID", identity.job_id.to_string()));
+        } else {
+            details.push((
+                "Exact resource ID",
+                "Not recorded; no resource discovery performed".into(),
+            ));
+        }
+        if let Some(checkpoint) = &summary.checkpoint {
+            details.push((
+                "Saved checkpoint",
+                format!("{} (runtime {})", checkpoint.generation, checkpoint.runtime_generation),
+            ));
+            details.push(("Captured at (Unix ms)", checkpoint.captured_at_millis.to_string()));
+            details.push(("Checkpoint commit", checkpoint.base_commit.as_str().into()));
+        } else {
+            details.push(("Saved checkpoint", "None recorded".into()));
+        }
+        Self {
+            summary,
+            label,
+            details,
+        }
+    }
+}
+
+pub(super) fn show(ctx: &Context, state: &RemoteEnvironments) -> InventoryAction {
+    let viewport = ctx.content_rect();
+    let width = (viewport.width() - 64.0).clamp(260.0, 820.0);
+    let mut action = InventoryAction::None;
+    let id = egui::Id::new("remote-environments");
+    let modal = egui::Modal::new(id)
+        .area(egui::Modal::default_area(id).order(egui::Order::Debug))
+        .frame(
+            egui::Frame::default()
+                .fill(theme::PANEL_BG())
+                .stroke(egui::Stroke::new(1.0, theme::BORDER_SUBTLE()))
+                .corner_radius(12)
+                .inner_margin(16),
+        )
+        .show(ctx, |ui| {
+            ui.set_width(width);
+            ui.horizontal(|ui| {
+                ui.heading("Remote Environments");
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    let close = ui.button("Close");
+                    #[cfg(test)]
+                    ui.ctx()
+                        .data_mut(|data| data.insert_temp(egui::Id::new("inventory-close-test"), close.rect));
+                    if close.clicked() {
+                        action = InventoryAction::Close;
+                    }
+                });
+            });
+            ui.label(
+                RichText::new("Saved inventory across all sessions. Live status, uptime and cost are not checked.")
+                    .color(theme::FG_DIM()),
+            );
+            ui.label(
+                RichText::new("Closing this overview does not stop or delete remote work.").color(theme::FG_DIM()),
+            );
+            ui.separator();
+            render_controls(ui, state, &mut action);
+            let content_height = if state.page.as_ref().is_some_and(|page| !page.rows.is_empty()) {
+                (viewport.height() - 96.0 - ui.min_rect().height()).max(80.0)
+            } else {
+                80.0
+            };
+            egui::ScrollArea::vertical()
+                .id_salt("remote-environments-content")
+                .max_height(content_height)
+                .min_scrolled_height(content_height)
+                .auto_shrink([false, false])
+                .show(ui, |ui| render_content(ui, state, &mut action));
+        });
+    if modal.should_close() {
+        InventoryAction::Close
+    } else {
+        action
+    }
+}
+
+fn render_controls(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut InventoryAction) {
+    let idle = state.pending.is_none();
+    ui.horizontal(|ui| {
+        if ui.add_enabled(idle, egui::Button::new("Refresh saved page")).clicked() {
+            *action = InventoryAction::Refresh;
+        }
+        let can_go_first =
+            state.page_cursor.is_some() || state.failure.as_ref().is_some_and(|failure| failure.cursor.is_some());
+        if ui
+            .add_enabled(idle && can_go_first, egui::Button::new("First page"))
+            .clicked()
+        {
+            *action = InventoryAction::First;
+        }
+        let has_next = state.page.as_ref().is_some_and(|page| page.next_cursor.is_some());
+        if ui
+            .add_enabled(idle && has_next, egui::Button::new("Next page"))
+            .clicked()
+        {
+            *action = InventoryAction::Next;
+        }
+        if !idle {
+            ui.label("Loading saved inventory…");
+        }
+    });
+    if let Some(failure) = &state.failure {
+        let message = match failure.error {
+            LoadError::OpenStore => "Cannot open the remote inventory store. Check its permissions and format.",
+            LoadError::ReadPage => "Cannot read this saved page. Its data may be invalid or incompatible.",
+            LoadError::WorkerUnavailable => "The inventory reader could not finish.",
+        };
+        ui.colored_label(theme::PALETTE_YELLOW(), message);
+        if state.page.is_some() {
+            ui.colored_label(
+                theme::PALETTE_YELLOW(),
+                "Showing the previous saved page; it may be stale.",
+            );
+        }
+        if ui.add_enabled(idle, egui::Button::new("Retry failed page")).clicked() {
+            *action = InventoryAction::Retry;
+        }
+    }
+}
+
+fn render_content(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut InventoryAction) {
+    let Some(page) = &state.page else {
+        return;
+    };
+    if page.rows.is_empty() {
+        ui.add_space(12.0);
+        ui.label(if state.page_cursor.is_none() {
+            "No saved remote environments. Local session files are not required for this inventory."
+        } else {
+            "No more saved environments on this page. Return to the first page to refresh the inventory."
+        });
+        return;
+    }
+    ui.label(RichText::new("Environment / profile — saved setup phase").color(theme::FG_DIM()));
+    for (index, row) in page.rows.iter().enumerate() {
+        ui.horizontal_wrapped(|ui| {
+            if ui.selectable_label(state.selected == Some(index), &row.label).clicked() {
+                *action = InventoryAction::Select(index);
+            }
+            ui.label(RichText::new(phase_label(row.summary.saved_phase)).color(theme::FG_DIM()));
+        });
+    }
+    if let Some(row) = state.selected.and_then(|index| page.rows.get(index)) {
+        ui.separator();
+        ui.strong("Saved environment details");
+        ui.label(
+            RichText::new("Ownership in this record is not permission to attach or manage a resource.")
+                .color(theme::FG_DIM()),
+        );
+        egui::Grid::new("remote-environment-details")
+            .num_columns(2)
+            .max_col_width((ui.available_width() - 180.0).max(100.0))
+            .show(ui, |ui| {
+                for (label, value) in &row.details {
+                    ui.label(*label);
+                    ui.add(
+                        egui::Label::new(RichText::new(value).monospace())
+                            .wrap()
+                            .selectable(true),
+                    );
+                    ui.end_row();
+                }
+            });
+    }
+}
+
+fn phase_label(phase: Option<RemoteRuntimePhase>) -> &'static str {
+    match phase {
+        None => "Dormant",
+        Some(RemoteRuntimePhase::Provisioning) => "Provisioning",
+        Some(RemoteRuntimePhase::Reconciling) => "Reconciling",
+        Some(RemoteRuntimePhase::Materializing) => "Materializing",
+        Some(RemoteRuntimePhase::Ready) => "Ready (saved, not live)",
+        Some(RemoteRuntimePhase::Checkpointing) => "Checkpointing",
+        Some(RemoteRuntimePhase::Cancelling) => "Cancelling",
+        Some(RemoteRuntimePhase::Deleting) => "Deleting",
+        Some(RemoteRuntimePhase::Failed) => "Failed",
+    }
+}

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -38,10 +38,14 @@ impl InventoryRow {
             ("Saved panel intents", summary.panel_count.to_string()),
             ("Execution policy", lifetime),
         ];
+        if let Some(workflow_id) = summary.workflow_id {
+            details.push(("Workflow ID", workflow_id.to_string()));
+        }
+        if let Some(job_id) = summary.job_id {
+            details.push(("Job ID", job_id.to_string()));
+        }
         if let Some(identity) = &summary.worker_identity {
             details.push(("Exact resource ID", identity.resource_id.clone()));
-            details.push(("Workflow ID", identity.workflow_id.to_string()));
-            details.push(("Job ID", identity.job_id.to_string()));
         } else {
             details.push((
                 "Exact resource ID",

--- a/crates/horizon-ui/src/app/root_chrome.rs
+++ b/crates/horizon-ui/src/app/root_chrome.rs
@@ -22,18 +22,20 @@ pub(super) const SIDEBAR_MIN_WIDTH: f32 = 168.0;
 pub(super) enum ToolbarAction {
     QuickNav,
     RemoteHosts,
+    Environments,
     Sessions,
     Update,
     Settings,
 }
 
 impl ToolbarAction {
-    const SECONDARY: [Self; 1] = [Self::RemoteHosts];
+    const SECONDARY: [Self; 2] = [Self::Environments, Self::RemoteHosts];
 
     pub(super) fn label(self) -> &'static str {
         match self {
             Self::QuickNav => "Quick Nav",
             Self::RemoteHosts => "Remote Hosts",
+            Self::Environments => "Environments",
             Self::Sessions => "Sessions",
             Self::Update => "Update",
             Self::Settings => "Settings",
@@ -94,7 +96,8 @@ pub(super) fn root_toolbar_layout(viewport: Rect, show_update: bool) -> RootTool
     );
 
     let states = [
-        (true, 1_usize, true),
+        (true, ToolbarAction::SECONDARY.len(), true),
+        (false, ToolbarAction::SECONDARY.len(), true),
         (false, 1_usize, true),
         (false, 0_usize, true),
         (false, 1_usize, false),
@@ -219,7 +222,7 @@ mod tests {
 
     #[test]
     fn toolbar_keeps_short_tagline_when_search_still_fits() {
-        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1024.0, 768.0));
+        let viewport = Rect::from_min_max(Pos2::ZERO, Pos2::new(1280.0, 768.0));
         let layout = root_toolbar_layout(viewport, false);
 
         assert!(layout.show_tagline);
@@ -262,7 +265,10 @@ mod tests {
         let layout = root_toolbar_layout(viewport, false);
 
         assert!(!layout.show_tagline);
-        assert_eq!(layout.overflow_actions, vec![ToolbarAction::RemoteHosts]);
+        assert_eq!(
+            layout.overflow_actions,
+            vec![ToolbarAction::Environments, ToolbarAction::RemoteHosts]
+        );
         assert!(layout.visible_items.contains(&ToolbarItem::FpsMeter));
         assert!(layout.visible_items.contains(&ToolbarItem::OverflowMenu));
         assert!((layout.search_rect.center().y - TOOLBAR_HEIGHT * 0.5).abs() <= f32::EPSILON);
@@ -300,6 +306,34 @@ mod tests {
                 .visible_items
                 .contains(&ToolbarItem::Action(ToolbarAction::Update))
         );
-        assert_eq!(layout.overflow_actions, vec![ToolbarAction::RemoteHosts]);
+        assert_eq!(
+            layout.overflow_actions,
+            vec![ToolbarAction::Environments, ToolbarAction::RemoteHosts]
+        );
+    }
+
+    #[test]
+    fn environments_and_existing_actions_remain_reachable_at_every_width() {
+        for width in [760.0, 800.0, 900.0, 1024.0, 1280.0] {
+            for update in [false, true] {
+                let layout = root_toolbar_layout(Rect::from_min_max(Pos2::ZERO, Pos2::new(width, 768.0)), update);
+                for action in [
+                    ToolbarAction::Environments,
+                    ToolbarAction::RemoteHosts,
+                    ToolbarAction::Sessions,
+                    ToolbarAction::Settings,
+                ] {
+                    let visible = layout
+                        .visible_items
+                        .iter()
+                        .filter(|item| **item == ToolbarItem::Action(action))
+                        .count();
+                    let overflow = layout.overflow_actions.iter().filter(|item| **item == action).count();
+                    assert_eq!(visible + overflow, 1, "{width}, {update}, {action:?}");
+                }
+                assert!(layout.brand_rect.max.x <= layout.search_rect.min.x);
+                assert!(layout.search_rect.max.x <= layout.actions_rect.min.x);
+            }
+        }
     }
 }

--- a/crates/horizon-ui/src/app/sidebar/toolbar.rs
+++ b/crates/horizon-ui/src/app/sidebar/toolbar.rs
@@ -182,7 +182,7 @@ impl HorizonApp {
                     response
                 }
             }
-            ToolbarAction::Sessions | ToolbarAction::Settings => ui.add(
+            ToolbarAction::Environments | ToolbarAction::Sessions | ToolbarAction::Settings => ui.add(
                 util::chrome_button(action.label())
                     .min_size(Vec2::new(action_button_width(action), ROOT_TOOLBAR_BUTTON_HEIGHT)),
             ),
@@ -218,6 +218,7 @@ impl HorizonApp {
         match action {
             ToolbarAction::QuickNav => self.open_command_palette(),
             ToolbarAction::RemoteHosts => self.toggle_remote_hosts_overlay(ctx),
+            ToolbarAction::Environments => self.remote_environments.open(self.session_store.home(), ctx),
             ToolbarAction::Sessions => self.toggle_session_manager(),
             ToolbarAction::Update => self.open_available_update(),
             ToolbarAction::Settings => self.toggle_settings(),
@@ -232,7 +233,7 @@ fn fps_meter_width() -> f32 {
 fn action_button_width(action: ToolbarAction) -> f32 {
     match action {
         ToolbarAction::QuickNav => 102.0,
-        ToolbarAction::RemoteHosts => 120.0,
+        ToolbarAction::RemoteHosts | ToolbarAction::Environments => 120.0,
         ToolbarAction::Sessions => 94.0,
         ToolbarAction::Update => 84.0,
         ToolbarAction::Settings => 92.0,

--- a/crates/horizon-ui/src/app/speech/input.rs
+++ b/crates/horizon-ui/src/app/speech/input.rs
@@ -413,6 +413,7 @@ impl HorizonApp {
             .as_ref()
             .is_some_and(crate::search_overlay::SearchOverlay::input_focused);
         let text_surface_active = self.settings.is_some()
+            || self.remote_environments.is_open()
             || self.command_palette.is_some()
             || search_capturing
             || self.renaming_panel.is_some()
@@ -532,11 +533,15 @@ impl HorizonApp {
                     .any(|(_, binding)| shortcuts::press_and_release_in_events(&input.events, *binding).0)
             });
             if gated_press {
-                let surface = gated_press_surface(
-                    self.settings.is_some(),
-                    self.command_palette.is_some(),
-                    search_capturing,
-                );
+                let surface = if self.remote_environments.is_open() {
+                    "the remote environments overview is open"
+                } else {
+                    gated_press_surface(
+                        self.settings.is_some(),
+                        self.command_palette.is_some(),
+                        search_capturing,
+                    )
+                };
                 events.push(SpeechEvent::Notice(format!("Push-to-talk press ignored: {surface}.")));
             }
         }
@@ -874,3 +879,61 @@ const fn should_release_desktop_target(text_dispatched: bool, active: bool, inse
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, feature = "speech"))]
+mod remote_environment_tests {
+    use super::*;
+    use crate::app::test_support::{raw_input, test_app};
+    use crate::test_egui::DiscardTextures;
+
+    #[test]
+    fn remote_environment_modal_gates_global_press_but_keeps_held_local_release() {
+        let (_temp, mut app) = test_app();
+        let ctx = Context::default();
+        let workspace = app.board.create_workspace("speech fixture");
+        let panel = app
+            .board
+            .create_panel(
+                horizon_core::PanelOptions {
+                    kind: horizon_core::PanelKind::Editor,
+                    ..Default::default()
+                },
+                workspace,
+            )
+            .expect("editor");
+        app.remote_environments.open(app.session_store.home(), &ctx);
+        let (mut speech, channels) = SpeechSystem::with_test_bindings(&["F1"]);
+        let mut notices = Vec::new();
+        let (engaged, _, _) = apply_global_hotkey_events(
+            &mut speech,
+            [horizon_cursor::HotkeyEvent::Pressed(0)],
+            Some(SpeechSink::Panel(panel)),
+            !app.speech_text_surface_active().0,
+            None,
+            &mut notices,
+        );
+        assert!(engaged.is_none());
+        assert!(!channels.capture_start_requested());
+        speech.start(SpeechSink::Panel(panel), 0);
+        assert!(channels.capture_start_requested());
+        app.speech = Some(speech);
+        app.speech_engaged_profile = Some(0);
+        let mut input = raw_input([900.0, 680.0], None);
+        input.events.push(egui::Event::Key {
+            key: egui::Key::F1,
+            physical_key: Some(egui::Key::F1),
+            pressed: false,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        });
+        let _ = ctx
+            .run_ui(input, |ui| {
+                let saved = app.render_remote_environments(ui).expect("modal frame");
+                HorizonApp::restore_remote_environment_input(ui, saved);
+            })
+            .discard_textures();
+        assert!(app.speech_engaged_profile.is_none());
+        assert!(app.speech.as_ref().and_then(SpeechSystem::recording_sink).is_none());
+        assert!(app.speech.as_ref().is_some_and(SpeechSystem::is_active));
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -179,6 +179,10 @@ back into large multi-purpose modules.
     context-menu handling and outcome application in `panels/interaction.rs`
   - `remote_hosts_overlay`: overlay state/input shell with query/filter,
     layout, and row/header paint helpers split into `remote_hosts_overlay/`
+  - `remote_environments`: single-flight saved-inventory loading and modal input
+    ownership, with cached labels and rendering in `remote_environments/paint`.
+    Compact record projection belongs to `horizon-core::remote_workspace::summary`;
+    the overview does not own provider actions or remote execution lifetime.
   - `sidebar`: sidebar rendering and deferred sidebar actions
   - `settings`: settings editor state and save/apply flows
   - `session`: startup bootstrap and session catalog/rebind flows, with startup


### PR DESCRIPTION
## Purpose

Add a global saved Remote Environments overview independent of local session
files, advancing the persistent remote-development plan in #383.

## Behavior

- Open Environments from the toolbar or narrow-window More menu. Page through
  saved environments across all owners, including dormant and detached records.
- Display exact workspace, owner, runtime and resource identities, saved panel
  intent count and checkpoint metadata without retaining commands, handoffs,
  private credentials or SSH keys in the overview.
- Clearly label saved setup state as unverified: the overview does not query
  live status, uptime or cost, and a saved owner is not management authority.
- Load bounded pages on a single background worker. Preserve the last good page
  after failure and retry the exact failed cursor; closing or reopening cannot
  spawn an unbounded set of readers or accept stale completion.
- Keep modal input out of terminals and root shortcuts, including dismissal and
  speech hotkeys. Preserve held-key releases and pointer state across frames.

## Validation

- Full source and exact-commit validation passed on `3213d182`: formatting, maintainability/version guards,
  default and speech workspace tests, blocking/strict/pedantic Clippy, both
  worker regression suites (14 panel and 17 host-identity cases), and debug build.
- Independent full-diff local review completed with no actionable findings.
- Isolated Linux/X11 native smoke passed: empty and 19-row global inventory
  across two owners without local sessions, paging and exact failed-cursor retry,
  stale-page warnings, selectable/long IDs and checkpoint details, modal keyboard
  isolation, dark/light themes, narrow-window overflow, resize/Fit, and reopen.
  All saved snapshots and revisions remained identical after normal application
  exit. No provider APIs, credentials or existing sessions were used.
- Matched software-renderer samples: fresh applications, identical 1100x780
  light config/shell/canvas, one Fit action and two five-second samples per phase.
  Process CPU seconds, candidate/baseline: idle 1.03/1.04, empty-canvas pointer
  14.34/14.36, panel-chrome pointer 14.64/14.52. No meaningful regression in these
  short samples; this is not hardware-GPU performance proof. Settled open-view
  samples were 0.70 and 0.77 CPU seconds per five seconds, without a reader loop.
- Review correction: retain workflow/job IDs directly from the saved runtime,
  independent of worker discovery. Regression tests and final native checks
  verify exact IDs for undiscovered runtimes, no invented IDs for dormant records,
  complete discovered-worker identities, and copying a runtime ID without execution.

## Boundaries

This slice is deliberately read-only. Closing the overview or application does
not stop or delete remote work. Reconnect, live observations, explicit Stop/Kill,
separate Cleanup/Delete, durable task/data integration and real cloud PC-off
acceptance remain separate completion gates for #383. No release, image
publication, paid resource allocation or existing-worker mutation is included.
