### PR TITLE
Recover owned workspaces without creating workers

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -4,6 +4,7 @@
 
 mod binding;
 mod guards;
+mod recovery;
 mod request;
 
 pub(super) use guards::{

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
@@ -1,0 +1,89 @@
+//! Commit a non-creating observation only while both owned snapshots still match.
+
+use super::{CloudWorkflowStore, Error, RemoteRuntimePhase, StoredRemoteAllocation, WorkspaceReplacement, binding};
+use crate::cloud_run::interactive_worker::{
+    InteractiveWorkerLifecycle, InteractiveWorkerRequest, InteractiveWorkerStatus,
+};
+use rusqlite::TransactionBehavior;
+
+impl StoredRemoteAllocation {
+    pub(crate) fn recovery_request(&self) -> Result<InteractiveWorkerRequest, Error> {
+        let runtime = self.workspace.state().runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+        if runtime.cleanup.is_some()
+            || matches!(
+                runtime.phase,
+                RemoteRuntimePhase::Cancelling | RemoteRuntimePhase::Deleting
+            )
+        {
+            return Err(Error::RuntimeRecoveryUnavailable);
+        }
+        self.worker_request()
+    }
+}
+
+impl CloudWorkflowStore {
+    /// No observation authorizes creation or task startup. Reconciling deliberately
+    /// does not mark a workspace ready merely because its worker advertises SSH.
+    pub(crate) fn record_remote_worker_recovery(
+        &self,
+        expected: &StoredRemoteAllocation,
+        observation: Option<&InteractiveWorkerStatus>,
+    ) -> Result<StoredRemoteAllocation, Error> {
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        super::super::database::ensure_current_schema(&transaction)?;
+        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)?
+            .ok_or(Error::UnboundRuntime)?;
+        let current = binding::recover(&transaction, &row)?;
+        if current != *expected {
+            return Err(Error::SnapshotConflict);
+        }
+        let request = current.recovery_request()?;
+        let mut next = current.workspace.state().clone();
+        let runtime = next.runtime.as_mut().ok_or(Error::UnboundRuntime)?;
+        if let Some(status) = observation {
+            validate_observation(status, &request)?;
+            if runtime.worker.as_ref().is_some_and(|worker| worker != &status.worker)
+                || runtime
+                    .ssh
+                    .as_ref()
+                    .zip(status.ssh.as_ref())
+                    .is_some_and(|(saved, observed)| saved != observed)
+            {
+                return Err(Error::InvalidWorkerObservation);
+            }
+            runtime.worker = Some(status.worker.clone());
+            if let Some(ssh) = &status.ssh {
+                runtime.ssh = Some(ssh.clone());
+            }
+        }
+        // Absence never clears saved identity, panel intent, checkpoints, or permits replacement.
+        runtime.phase = RemoteRuntimePhase::Reconciling;
+        if next == *current.workspace.state() {
+            return Ok(current);
+        }
+        let workspace = WorkspaceReplacement::new(&current.workspace, &next)?.persist(&transaction)?;
+        transaction.commit()?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: current.workflow,
+        })
+    }
+}
+
+fn validate_observation(status: &InteractiveWorkerStatus, request: &InteractiveWorkerRequest) -> Result<(), Error> {
+    let worker = &status.worker;
+    if !request.is_valid_for(request.target.provider)
+        || !worker.is_valid_for(request.target.provider)
+        || worker.identity.workflow_id != request.workflow_id
+        || worker.identity.job_id != request.job_id
+        || worker.target != request.target
+        || worker.ssh_public_key != request.ssh_public_key
+        || status.ssh.as_ref().is_some_and(|ssh| !ssh.is_complete())
+        || (status.lifecycle == InteractiveWorkerLifecycle::Ready
+            && !status.is_ready_for(request, time::OffsetDateTime::now_utc()))
+    {
+        return Err(Error::InvalidWorkerObservation);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -461,6 +461,10 @@ pub enum RemoteWorkspaceStoreError {
     RuntimeRequestRequired,
     #[error("remote allocation can no longer reserve a new SSH request identity")]
     RuntimeRequestUnavailable,
+    #[error("remote workspace has pending management intent; reconnect cannot change it")]
+    RuntimeRecoveryUnavailable,
+    #[error("remote worker observation does not match the saved request or pinned identity")]
+    InvalidWorkerObservation,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -22,6 +22,7 @@ mod panel;
 mod remote_hosts;
 pub mod remote_ssh_identity;
 pub mod remote_workspace;
+pub mod remote_workspace_recovery;
 mod runtime_state;
 pub mod search;
 mod session_store;

--- a/crates/horizon-core/src/remote_workspace_recovery.rs
+++ b/crates/horizon-core/src/remote_workspace_recovery.rs
@@ -1,0 +1,127 @@
+//! Non-creating recovery of an owned runtime through its retained client identity.
+//! Synchronous provider/key/store operations must run off the render thread.
+
+use crate::{
+    cloud_run::{
+        CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation,
+        interactive_worker::{InteractiveWorkerProvider, InteractiveWorkerStatus},
+    },
+    remote_ssh_identity::{RemoteSshIdentity, RemoteSshIdentityError, RemoteSshIdentityStore},
+};
+
+/// A point-in-time recovery result, not a connection or permission to start tasks.
+/// Attachment still needs fresh ownership/lifetime/cost-policy checks, pinned SSH
+/// transport, and verified repository/task state. Dropping this value has no remote effect.
+pub struct RecoveredRemoteWorkspace {
+    allocation: StoredRemoteAllocation,
+    identity: RemoteSshIdentity,
+    observation: Option<InteractiveWorkerStatus>,
+}
+
+impl RecoveredRemoteWorkspace {
+    #[must_use]
+    pub fn allocation(&self) -> &StoredRemoteAllocation {
+        &self.allocation
+    }
+
+    #[must_use]
+    pub fn identity(&self) -> &RemoteSshIdentity {
+        &self.identity
+    }
+
+    /// `None` means the provider found no exact resource, never permission to create.
+    #[must_use]
+    pub fn observation(&self) -> Option<&InteractiveWorkerStatus> {
+        self.observation.as_ref()
+    }
+}
+
+impl std::fmt::Debug for RecoveredRemoteWorkspace {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RecoveredRemoteWorkspace")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Recover existing identity, inspect the saved resource (or reconcile a lost response),
+/// then atomically retain the exact worker and host pin without changing runtime IDs.
+/// No key preparation, allocation, creation claim, ensure, restart, stop or delete occurs.
+/// An absent worker remains reconciling; errors never initiate compensating cleanup.
+/// Provider implementations are responsible for bounded read operations.
+/// # Errors
+/// Fails closed on missing identity, ownership/snapshot drift, pending management,
+/// mismatched/expired ready observations, unsupported platforms and provider/store failures.
+pub fn recover_remote_workspace<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    session_id: &str,
+    workspace_local_id: &str,
+) -> Result<RecoveredRemoteWorkspace, RemoteWorkspaceRecoveryError> {
+    let allocation = store
+        .load_remote_allocation(session_id, workspace_local_id)?
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    let request = allocation.recovery_request()?;
+    if !request.is_valid_for(provider.provider()) {
+        return Err(RemoteWorkspaceRecoveryError::ProviderMismatch);
+    }
+    let identity = identities.recover(request.workflow_id, request.job_id, &request.ssh_public_key)?;
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    let observation = match &runtime.worker {
+        Some(worker) => provider.inspect_worker(worker),
+        None => provider.reconcile_worker(&request),
+    }
+    .map_err(|_| RemoteWorkspaceRecoveryError::ProviderUnavailable)?;
+    let allocation = store.record_remote_worker_recovery(&allocation, observation.as_ref())?;
+    Ok(RecoveredRemoteWorkspace {
+        allocation,
+        identity,
+        observation,
+    })
+}
+
+/// Errors redact provider responses, database detail, task content and private key paths.
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum RemoteWorkspaceRecoveryError {
+    #[error("no owned remote allocation is available; recovery did not allocate one")]
+    MissingAllocation,
+    #[error("remote workspace has no saved SSH request; recovery did not prepare one")]
+    MissingRequest,
+    #[error("remote workspace has pending management intent")]
+    ManagementPending,
+    #[error("remote workspace recovery provider does not match the saved target")]
+    ProviderMismatch,
+    #[error(transparent)]
+    Identity(#[from] RemoteSshIdentityError),
+    #[error("remote worker inspection failed; recovery did not create or delete anything")]
+    ProviderUnavailable,
+    #[error("remote worker observation does not match the saved request or pinned identity")]
+    InvalidObservation,
+    #[error("remote allocation changed during recovery; reload before retrying")]
+    StateChanged,
+    #[error("owned remote allocation could not be safely recovered from storage")]
+    StorageUnavailable,
+}
+
+impl From<RemoteWorkspaceStoreError> for RemoteWorkspaceRecoveryError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        match error {
+            RemoteWorkspaceStoreError::RuntimeRequestRequired => Self::MissingRequest,
+            RemoteWorkspaceStoreError::RuntimeRecoveryUnavailable => Self::ManagementPending,
+            RemoteWorkspaceStoreError::InvalidWorkerObservation => Self::InvalidObservation,
+            RemoteWorkspaceStoreError::SnapshotConflict | RemoteWorkspaceStoreError::RevisionConflict { .. } => {
+                Self::StateChanged
+            }
+            _ => Self::StorageUnavailable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace_recovery/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_recovery/tests.rs
@@ -1,0 +1,255 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{
+        CloudProvider, WorkerLifetime,
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+            InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerRequest,
+            InteractiveWorkerSshEndpoint,
+        },
+    },
+    remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteRuntimePhase, RemoteWorkspaceState},
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::Mutex;
+
+mod observations;
+#[cfg(target_os = "linux")]
+mod retained_identity;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+fn public_key(byte: u8) -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    identities: RemoteSshIdentityStore,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_lifetime(WorkerLifetime::Persistent)
+    }
+
+    fn with_lifetime(lifetime: WorkerLifetime) -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+        }
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": { "provider": "local_docker", "profile": "development",
+                    "image": format!("example/worker@sha256:{}", "a".repeat(64)),
+                    "disk_gib": 20, "lifetime": "persistent" },
+                "repository": { "repository": "example/project", "commit": "b".repeat(40) }
+            }
+        }))
+        .expect("state");
+        state.spec.target.lifetime = lifetime;
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("record");
+        store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        Self {
+            directory,
+            store,
+            identities: RemoteSshIdentityStore::new(&home),
+        }
+    }
+
+    fn reload(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn reserve(&self, key: &str) {
+        self.store
+            .reserve_remote_worker_request(&self.reload(), key)
+            .expect("reserve");
+    }
+
+    fn status(&self) -> InteractiveWorkerStatus {
+        let request = self.reload().worker_request().expect("request");
+        InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: request.target.provider,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: "synthetic-worker".into(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            lifecycle: InteractiveWorkerLifecycle::Ready,
+            ssh: Some(InteractiveWorkerSshEndpoint {
+                host: "127.0.0.1".into(),
+                port: 2222,
+                username: "horizon".into(),
+                host_key: public_key(7),
+            }),
+        }
+    }
+
+    fn run(&self, provider: &Provider) -> Result<RecoveredRemoteWorkspace, RemoteWorkspaceRecoveryError> {
+        recover_remote_workspace(&self.store, &self.identities, provider, OWNER, "workspace")
+    }
+
+    fn cancel(&self) {
+        let current = self.reload();
+        let mut next = current.workspace().state().clone();
+        let runtime = next.runtime.as_mut().expect("runtime");
+        runtime.phase = RemoteRuntimePhase::Cancelling;
+        runtime.cleanup = Some(RemoteCleanupIntent {
+            reason: RemoteCleanupReason::Cancelled,
+            requested_at_millis: 1,
+        });
+        self.store
+            .replace_remote_workspace(current.workspace(), &next)
+            .expect("cancel intent");
+    }
+
+    fn counts(&self) -> [i64; 3] {
+        rusqlite::Connection::open(self.store.path())
+            .expect("connection")
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM cloud_workflows), (SELECT COUNT(*) FROM remote_runtime_allocations),
+             (SELECT COUNT(*) FROM cloud_worker_creation_claims)",
+                [],
+                |row| Ok([row.get(0)?, row.get(1)?, row.get(2)?]),
+            )
+            .expect("counts")
+    }
+}
+
+struct Provider {
+    kind: CloudProvider,
+    status: Option<InteractiveWorkerStatus>,
+    calls: Mutex<[usize; 4]>,
+    during_read: Option<Box<dyn Fn() + Send + Sync>>,
+    fail: bool,
+}
+
+impl Provider {
+    fn new(status: Option<InteractiveWorkerStatus>) -> Self {
+        Self {
+            kind: CloudProvider::LocalDocker,
+            status,
+            calls: Mutex::new([0; 4]),
+            during_read: None,
+            fail: false,
+        }
+    }
+
+    fn calls(&self) -> [usize; 4] {
+        *self.calls.lock().expect("calls")
+    }
+
+    fn read(&self, index: usize) -> Result<Option<InteractiveWorkerStatus>, std::io::Error> {
+        self.calls.lock().expect("calls")[index] += 1;
+        if let Some(action) = &self.during_read {
+            action();
+        }
+        if self.fail {
+            return Err(std::io::Error::other("synthetic-private-provider-response"));
+        }
+        Ok(self.status.clone())
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        self.calls.lock().expect("calls")[0] += 1;
+        Err(std::io::Error::other("creation forbidden"))
+    }
+    fn reconcile_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        if let Some(status) = &self.status {
+            assert_eq!(request.workflow_id, status.worker.identity.workflow_id);
+        }
+        self.read(1)
+    }
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        assert_eq!(worker.identity.resource_id, "synthetic-worker");
+        self.read(2)
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.calls.lock().expect("calls")[3] += 1;
+        Err(std::io::Error::other("deletion forbidden"))
+    }
+}
+
+#[test]
+fn missing_request_wrong_owner_provider_and_management_fail_before_provider_io() {
+    let fixture = Fixture::new();
+    let mut provider = Provider::new(None);
+    assert_eq!(
+        fixture.run(&provider).expect_err("request"),
+        RemoteWorkspaceRecoveryError::MissingRequest
+    );
+    fixture.reserve(&public_key(1));
+    let saved = fixture.reload();
+    assert_eq!(
+        recover_remote_workspace(
+            &fixture.store,
+            &fixture.identities,
+            &provider,
+            "00000000-0000-4000-8000-000000000002",
+            "workspace"
+        )
+        .expect_err("owner"),
+        RemoteWorkspaceRecoveryError::StorageUnavailable
+    );
+    assert_eq!(
+        recover_remote_workspace(&fixture.store, &fixture.identities, &provider, OWNER, "absent").expect_err("absent"),
+        RemoteWorkspaceRecoveryError::MissingAllocation
+    );
+    provider.kind = CloudProvider::RunPod;
+    assert_eq!(
+        fixture.run(&provider).expect_err("provider"),
+        RemoteWorkspaceRecoveryError::ProviderMismatch
+    );
+    assert_eq!(fixture.reload(), saved);
+    fixture.cancel();
+    assert_eq!(
+        fixture.run(&provider).expect_err("management"),
+        RemoteWorkspaceRecoveryError::ManagementPending
+    );
+    assert_eq!(provider.calls(), [0; 4]);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+    assert!(fixture.directory.path().exists());
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_private_identity_platform_fails_before_provider_io() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let saved = fixture.reload();
+    let provider = Provider::new(None);
+    assert_eq!(
+        fixture.run(&provider).expect_err("unsupported"),
+        RemoteWorkspaceRecoveryError::Identity(RemoteSshIdentityError::UnsupportedPlatform)
+    );
+    assert_eq!(provider.calls(), [0; 4]);
+    assert_eq!(fixture.reload(), saved);
+}

--- a/crates/horizon-core/src/remote_workspace_recovery/tests/observations.rs
+++ b/crates/horizon-core/src/remote_workspace_recovery/tests/observations.rs
@@ -1,0 +1,273 @@
+use super::*;
+use crate::cloud_run::{CloudJobId, CloudWorkflowId, interactive_worker::InteractiveWorkerLease};
+
+#[test]
+fn absent_and_nonready_observations_preserve_identity_and_seal_creation_without_ready_promotion() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let initial = fixture.reload();
+    let mut status = fixture.status();
+    let discovered = fixture
+        .store
+        .record_remote_worker_recovery(&initial, Some(&status))
+        .expect("discovered");
+    assert_eq!(discovered.workflow(), initial.workflow());
+    assert_eq!(discovered.workspace().state().spec, initial.workspace().state().spec);
+    assert_eq!(
+        discovered.workspace().state().runtime.as_ref().expect("runtime").phase,
+        RemoteRuntimePhase::Reconciling
+    );
+    for lifecycle in [
+        InteractiveWorkerLifecycle::Stopped,
+        InteractiveWorkerLifecycle::Failed,
+        InteractiveWorkerLifecycle::Deleting,
+        InteractiveWorkerLifecycle::Unknown,
+        InteractiveWorkerLifecycle::Provisioning,
+    ] {
+        status.lifecycle = lifecycle;
+        status.ssh = None;
+        assert_eq!(
+            fixture
+                .store
+                .record_remote_worker_recovery(&discovered, Some(&status))
+                .expect("observed"),
+            discovered
+        );
+    }
+    assert_eq!(
+        fixture
+            .store
+            .record_remote_worker_recovery(&discovered, None)
+            .expect("absent"),
+        discovered
+    );
+    assert!(
+        fixture
+            .store
+            .claim_worker_creation(
+                status.worker.identity.workflow_id,
+                status.worker.identity.job_id,
+                &status.worker.target,
+                "synthetic-worker"
+            )
+            .is_err()
+    );
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn wrong_observations_never_persist_any_part_of_the_response() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let saved = fixture.reload();
+    for fault in 0..12 {
+        let mut status = fixture.status();
+        match fault {
+            0 => status.worker.identity.workflow_id = CloudWorkflowId::new(),
+            1 => status.worker.identity.job_id = CloudJobId::new(),
+            2 => status.worker.identity.provider = CloudProvider::RunPod,
+            3 => status.worker.identity.resource_id = "invalid resource".into(),
+            4 => status.worker.target.profile = "different".into(),
+            5 => status.worker.target.disk_gib += 1,
+            6 => status.worker.ssh_public_key = public_key(2),
+            7 => {
+                status.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                    terminate_after: "2020-01-01T00:00:00Z".into(),
+                });
+            }
+            8 => status.ssh = None,
+            9 => status.ssh.as_mut().expect("ssh").host_key = "untrusted".into(),
+            10 => status.ssh.as_mut().expect("ssh").port = 0,
+            11 => status.worker.target.lifetime = WorkerLifetime::TimeLimited { seconds: 3600 },
+            _ => unreachable!(),
+        }
+        assert!(
+            matches!(
+                fixture.store.record_remote_worker_recovery(&saved, Some(&status)),
+                Err(RemoteWorkspaceStoreError::InvalidWorkerObservation)
+            ),
+            "fault {fault}"
+        );
+        assert_eq!(fixture.reload(), saved);
+    }
+}
+
+#[test]
+fn exact_saved_worker_and_full_host_pin_cannot_rotate_on_recovery() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let original = fixture.status();
+    let saved = fixture
+        .store
+        .record_remote_worker_recovery(&fixture.reload(), Some(&original))
+        .expect("saved");
+    for fault in 0..5 {
+        let mut changed = original.clone();
+        match fault {
+            0 => changed.worker.identity.resource_id = "different-worker".into(),
+            1 => changed.ssh.as_mut().expect("ssh").host_key = public_key(8),
+            2 => changed.ssh.as_mut().expect("ssh").host = "127.0.0.2".into(),
+            3 => changed.ssh.as_mut().expect("ssh").port = 2223,
+            4 => changed.ssh.as_mut().expect("ssh").username = "different".into(),
+            _ => unreachable!(),
+        }
+        assert!(matches!(
+            fixture.store.record_remote_worker_recovery(&saved, Some(&changed)),
+            Err(RemoteWorkspaceStoreError::InvalidWorkerObservation)
+        ));
+        assert_eq!(fixture.reload(), saved);
+    }
+}
+
+#[test]
+fn stale_workspace_or_workflow_snapshot_cannot_commit_an_observation() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let old = fixture.reload();
+    let status = fixture.status();
+    let mut workflow = old.workflow().workflow().clone();
+    workflow.updated_at_millis += 1;
+    fixture.store.replace(old.workflow(), &workflow).expect("workflow edit");
+    let current = fixture.reload();
+    assert_eq!(current.workspace(), old.workspace());
+    assert!(matches!(
+        fixture.store.record_remote_worker_recovery(&old, Some(&status)),
+        Err(RemoteWorkspaceStoreError::SnapshotConflict)
+    ));
+    assert_eq!(fixture.reload(), current);
+    fixture.cancel();
+    let cancelled = fixture.reload();
+    assert!(matches!(
+        fixture.store.record_remote_worker_recovery(&current, Some(&status)),
+        Err(RemoteWorkspaceStoreError::SnapshotConflict)
+    ));
+    assert!(matches!(
+        fixture.store.record_remote_worker_recovery(&cancelled, Some(&status)),
+        Err(RemoteWorkspaceStoreError::RuntimeRecoveryUnavailable)
+    ));
+    assert_eq!(fixture.reload(), cancelled);
+}
+
+#[test]
+fn time_limited_readiness_uses_current_time_while_stopped_expired_identity_is_retained() {
+    let fixture = Fixture::with_lifetime(WorkerLifetime::TimeLimited { seconds: 3600 });
+    fixture.reserve(&public_key(1));
+    let saved = fixture.reload();
+    let mut status = fixture.status();
+    for seconds in [-600, 7200] {
+        let deadline = time::OffsetDateTime::now_utc() + time::Duration::seconds(seconds);
+        status.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: deadline
+                .format(&time::format_description::well_known::Rfc3339)
+                .expect("time"),
+        });
+        assert!(matches!(
+            fixture.store.record_remote_worker_recovery(&saved, Some(&status)),
+            Err(RemoteWorkspaceStoreError::InvalidWorkerObservation)
+        ));
+        assert_eq!(fixture.reload(), saved);
+    }
+    status.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+        terminate_after: "2020-01-01T00:00:00Z".into(),
+    });
+    status.lifecycle = InteractiveWorkerLifecycle::Stopped;
+    status.ssh = None;
+    let stopped = fixture
+        .store
+        .record_remote_worker_recovery(&saved, Some(&status))
+        .expect("exact stopped identity");
+    assert_eq!(
+        stopped
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .as_ref(),
+        Some(&status.worker)
+    );
+}
+
+#[test]
+fn reconciliation_preserves_saved_panels_checkpoints_and_does_not_preserve_stale_readiness() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let status = fixture.status();
+    let saved = fixture
+        .store
+        .record_remote_worker_recovery(&fixture.reload(), Some(&status))
+        .expect("saved");
+    let mut state = saved.workspace().state().clone();
+    state.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Ready;
+    state.spec.panels.push(crate::remote_workspace::RemotePanelBinding {
+        panel_local_id: "panel-one".into(),
+        kind: crate::PanelKind::Shell,
+        command: None,
+        working_directory: None,
+        task_handoff: Some("Retain this task".into()),
+        agent_session_id: None,
+    });
+    state.checkpoint = Some(crate::remote_workspace::RepositoryCheckpoint {
+        workspace_local_id: "workspace".into(),
+        base_commit: state.spec.repository.commit.clone(),
+        manifest_digest: crate::cloud_run::ArtifactDigest::parse_sha256("c".repeat(64)).expect("digest"),
+        runtime_generation: 1,
+        generation: 1,
+        captured_at_millis: 1000,
+        recovery_artifact: None,
+    });
+    fixture
+        .store
+        .replace_remote_workspace(saved.workspace(), &state)
+        .expect("ready fixture");
+    let recovered = fixture
+        .store
+        .record_remote_worker_recovery(&fixture.reload(), None)
+        .expect("missing worker");
+    let recovered_state = recovered.workspace().state();
+    assert_eq!(recovered_state.spec, state.spec);
+    assert_eq!(recovered_state.checkpoint, state.checkpoint);
+    let runtime = recovered_state.runtime.as_ref().expect("runtime");
+    assert_eq!(runtime.phase, RemoteRuntimePhase::Reconciling);
+    assert_eq!(runtime.worker, state.runtime.as_ref().expect("old runtime").worker);
+    assert_eq!(runtime.ssh, state.runtime.as_ref().expect("old runtime").ssh);
+}
+
+#[test]
+fn competing_observations_have_one_committed_identity() {
+    let fixture = Fixture::new();
+    fixture.reserve(&public_key(1));
+    let expected = fixture.reload();
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let writers: Vec<_> = (0..2)
+        .map(|index| {
+            let store = fixture.store.clone();
+            let expected = expected.clone();
+            let mut status = fixture.status();
+            status.worker.identity.resource_id = format!("synthetic-worker-{index}");
+            let barrier = std::sync::Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.record_remote_worker_recovery(&expected, Some(&status))
+            })
+        })
+        .collect();
+    let results: Vec<_> = writers
+        .into_iter()
+        .map(|writer| writer.join().expect("writer"))
+        .collect();
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Err(RemoteWorkspaceStoreError::SnapshotConflict)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        &fixture.reload(),
+        results.iter().find_map(|result| result.as_ref().ok()).expect("winner")
+    );
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}

--- a/crates/horizon-core/src/remote_workspace_recovery/tests/retained_identity.rs
+++ b/crates/horizon-core/src/remote_workspace_recovery/tests/retained_identity.rs
@@ -1,0 +1,153 @@
+use super::*;
+
+fn fixture() -> Fixture {
+    let fixture = Fixture::new();
+    let saved = fixture.reload();
+    let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+    let identity = fixture
+        .identities
+        .prepare_new(runtime.workflow_id, runtime.job_id)
+        .expect("key");
+    fixture.reserve(identity.public_key());
+    fixture
+}
+
+#[test]
+fn lost_response_reopens_same_worker_and_private_key_without_ensure_or_cleanup() {
+    let fixture = fixture();
+    let initial = fixture.reload();
+    let provider = Provider::new(Some(fixture.status()));
+    let recovered = fixture.run(&provider).expect("recover lost response");
+    let saved = recovered.allocation().clone();
+    let path = recovered.identity().private_key_path().to_path_buf();
+    let key_bytes = std::fs::read(&path).expect("key bytes");
+    assert_eq!(recovered.observation(), provider.status.as_ref());
+    assert_eq!(saved.workflow(), initial.workflow());
+    assert_eq!(provider.calls(), [0, 1, 0, 0]);
+    assert!(!format!("{recovered:?}").contains(&path.to_string_lossy().into_owned()));
+    drop(recovered);
+    let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("reopen");
+    let identities = RemoteSshIdentityStore::new(&HorizonHome::from_root(fixture.directory.path().join("home")));
+    let recovered = recover_remote_workspace(&reopened, &identities, &provider, OWNER, "workspace").expect("inspect");
+    assert_eq!(recovered.allocation(), &saved);
+    assert_eq!(recovered.identity().private_key_path(), path);
+    drop(recovered);
+    assert_eq!(provider.calls(), [0, 1, 1, 0]);
+    assert_eq!(std::fs::read(path).expect("retained key"), key_bytes);
+    assert!(
+        saved.workspace().state().spec.panels.is_empty(),
+        "zero panels never own lifetime"
+    );
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn missing_and_mismatched_private_keys_never_recreate_identity_or_call_provider() {
+    let fixture = fixture();
+    let provider = Provider::new(None);
+    let saved = fixture.reload();
+    let request = saved.worker_request().expect("request");
+    let key = fixture
+        .identities
+        .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+        .expect("key");
+    let bytes = std::fs::read(key.private_key_path()).expect("bytes");
+    let other = fixture
+        .identities
+        .prepare_new(
+            crate::cloud_run::CloudWorkflowId::new(),
+            crate::cloud_run::CloudJobId::new(),
+        )
+        .expect("other key");
+    std::fs::write(
+        key.private_key_path(),
+        std::fs::read(other.private_key_path()).expect("other bytes"),
+    )
+    .expect("fault");
+    assert_eq!(
+        fixture.run(&provider).expect_err("mismatch"),
+        RemoteWorkspaceRecoveryError::Identity(RemoteSshIdentityError::Mismatch)
+    );
+    std::fs::write(key.private_key_path(), bytes).expect("restore fixture");
+    std::fs::remove_file(key.private_key_path()).expect("simulate missing fixture key");
+    assert_eq!(
+        fixture.run(&provider).expect_err("missing"),
+        RemoteWorkspaceRecoveryError::Identity(RemoteSshIdentityError::Missing)
+    );
+    assert!(!key.private_key_path().exists());
+    assert_eq!(provider.calls(), [0; 4]);
+    assert_eq!(fixture.reload(), saved);
+}
+
+#[test]
+fn expired_setup_and_absent_worker_do_not_renew_or_allocate() {
+    let fixture = fixture();
+    let mut workflow = fixture.reload().workflow().workflow().clone();
+    workflow.created_at_millis = 1000;
+    workflow.updated_at_millis = 1000;
+    workflow.retain_until_millis = 2000;
+    rusqlite::Connection::open(fixture.store.path())
+        .expect("connection")
+        .execute(
+            "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000, retain_until_millis=2000,
+         snapshot=?1 WHERE workflow_id=?2",
+            rusqlite::params![
+                serde_json::to_vec(&workflow).expect("snapshot"),
+                workflow.id.to_string()
+            ],
+        )
+        .expect("expired fixture");
+    let expired = fixture.reload();
+    let provider = Provider::new(Some(fixture.status()));
+    let recovered = fixture.run(&provider).expect("persistent recovery after setup expiry");
+    assert_eq!(recovered.allocation().workflow(), expired.workflow());
+    let saved = recovered.allocation().clone();
+    let absent = Provider::new(None);
+    let recovered = fixture.run(&absent).expect("absent is not replacement authority");
+    assert!(recovered.observation().is_none());
+    assert_eq!(recovered.allocation(), &saved);
+    assert_eq!(absent.calls(), [0, 0, 1, 0]);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn slow_provider_cannot_overwrite_newer_intent_and_provider_errors_are_redacted() {
+    let fixture = fixture();
+    let mut provider = Provider::new(Some(fixture.status()));
+    let store = fixture.store.clone();
+    provider.during_read = Some(Box::new(move || {
+        let current = store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation");
+        let mut state = current.workspace().state().clone();
+        state.spec.working_directory = "changed".into();
+        store
+            .replace_remote_workspace(current.workspace(), &state)
+            .expect("user edit");
+    }));
+    assert_eq!(
+        fixture.run(&provider).expect_err("stale"),
+        RemoteWorkspaceRecoveryError::StateChanged
+    );
+    assert_eq!(fixture.reload().workspace().state().spec.working_directory, "changed");
+    assert!(
+        fixture
+            .reload()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_none()
+    );
+    provider.during_read = None;
+    provider.fail = true;
+    let saved = fixture.reload();
+    let error = fixture.run(&provider).expect_err("provider failed");
+    assert_eq!(error, RemoteWorkspaceRecoveryError::ProviderUnavailable);
+    assert!(!format!("{error:?} {error}").contains("synthetic-private-provider-response"));
+    assert_eq!(fixture.reload(), saved);
+    assert_eq!(provider.calls(), [0, 2, 0, 0]);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -102,6 +102,11 @@ back into large multi-purpose modules.
   recovery, separately from the pure remote aggregate. Linux filesystem privacy
   and durable publication live in `remote_ssh_identity/linux.rs`; bounded key-utility
   execution lives in `command.rs`. Neither owns provider or remote task lifetime.
+- `remote_workspace_recovery.rs` joins owned allocations, retained client keys and
+  non-creating provider inspection. Its result is not task/attachment authority.
+  `cloud_run/store/remote_allocations/recovery.rs` atomically checks both snapshots
+  before retaining exact worker/host identity and marking reconciliation; neither
+  absence nor client drop grants creation, restart or remote cleanup.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Add the owned, non-creating recovery boundary for remote workspaces. Refs #383.

Load the saved allocation and matching retained private client identity before
inspecting its exact worker, or reconciling an unresolved creation response.
Atomically compare both owned snapshots before retaining the exact worker and
full SSH endpoint/host pin. Missing resources preserve saved state; recovery
never generates keys, creates claims, ensures/restarts workers or deletes them.

## Behavior and limits

- Recovery remains Reconciling, even when the worker advertises ready SSH.
  Repository/task verification, fresh cost-policy checks and pinned attachment
  remain separate gates.
- Changed ownership/snapshots, missing or mismatched keys, pending management,
  wrong observations and host-pin drift fail closed. Provider errors are redacted.
- Empty panel sets, handle drop, reopen and expired setup do not own remote lifetime.
  Stopped/absent workers are not reported as resumed running tasks.
- Existing protected private-key support is Linux-only; other platforms still
  reject recovery before provider I/O. No UI, dependency or configuration change.
- This is a core integration slice, not live-cloud PC-off acceptance or completion
  of the remote-workspace product. Verified endpoint relocation is separate.

## Validation

Twelve focused recovery regressions pass with isolated databases, retained real
client keys on Linux and deterministic provider counters. Coverage includes
competing writers, stale workspace/workflow revisions, full identity/pin matching,
current lifetime bounds, lost responses, absent/stopped resources, panel/checkpoint
retention, setup expiry, key loss/mismatch and redacted provider failures.
Ensure/delete calls stay zero; workflow/allocation/creation-claim counts stay 1/1/0.

Full source validation passed: format, maintainability, version sync, workspace
default/speech tests with warnings denied, blocking and strict Clippy, and the
advisory pedantic tier. Independent local review is clear on the exact tree.
The full matrix also passed on exact commit `22c403c` before push.
