### PR TITLE
Fence local worker creation across retries

### DIFF
--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -1,7 +1,7 @@
 //! Local Docker implementation of persistent and time-limited interactive workers.
 
 use super::{
-    CLOUD_RUN_PROTOCOL_VERSION, CloudProvider, WorkerLifetime, WorkerTarget,
+    CLOUD_RUN_PROTOCOL_VERSION, CloudProvider, CloudWorkflowStore, WorkerLifetime, WorkerTarget,
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
         InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
@@ -16,6 +16,7 @@ use std::{
 use thiserror::Error;
 
 mod command;
+mod creation;
 #[cfg(test)]
 mod tests;
 
@@ -49,18 +50,22 @@ pub struct LocalDockerProfile {
 pub struct LocalDockerInteractiveWorkerProvider {
     transport: Box<dyn DockerTransport>,
     profile: LocalDockerProfile,
+    creation_store: CloudWorkflowStore,
 }
 
 impl LocalDockerInteractiveWorkerProvider {
     /// Build a provider pinned to an explicit local Unix socket or Windows named pipe.
+    /// Creation requires an existing workflow's durable one-shot grant in this store.
+    /// Reconnect callers must use non-creating inspection/reconciliation, never ensure.
     ///
     /// # Errors
     /// Returns [`LocalDockerError::NonLocalDockerHost`] for ambient or remote daemon endpoints.
-    pub fn new(profile: LocalDockerProfile) -> Result<Self, LocalDockerError> {
+    pub fn new(profile: LocalDockerProfile, creation_store: CloudWorkflowStore) -> Result<Self, LocalDockerError> {
         valid_local_docker_host(&profile.docker_host)
             .then(|| Self {
                 transport: Box::new(command::DockerCli::new(&profile.docker_host)),
                 profile,
+                creation_store,
             })
             .ok_or(LocalDockerError::NonLocalDockerHost)
     }
@@ -241,12 +246,11 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
         validate_request(request, &self.profile)?;
         let container_name = container_name(request.workflow_id, request.job_id);
         if let Some(container) = self.transport.inspect(&container_name)? {
-            match self.ensure_existing(request, &container) {
-                Err(LocalDockerError::ResourceAbsent) => {}
-                result => return result.map(InteractiveWorkerEnsure::Reused),
-            }
+            return self
+                .ensure_existing(request, &container)
+                .map(InteractiveWorkerEnsure::Reused);
         }
-        self.create_worker(request, &container_name)
+        self.create_once(request, &container_name)
     }
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
         self.validate_persisted_worker(worker)?;
@@ -298,6 +302,10 @@ pub enum LocalDockerError {
     InvalidPersistedWorker,
     #[error("local Docker provider requires an explicit local Unix socket or Windows named pipe")]
     NonLocalDockerHost,
+    #[error("local worker creation grant could not be safely read or recorded")]
+    CreationFenceFailed,
+    #[error("local worker creation was already claimed; non-creating reconciliation is required")]
+    CreationReconciliationRequired,
     #[error("required command 'docker' is unavailable")]
     DockerUnavailable,
     #[error("local Docker command exceeds the portable argument limit during {operation}")]

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -246,6 +246,10 @@ impl InteractiveWorkerProvider for LocalDockerInteractiveWorkerProvider {
         validate_request(request, &self.profile)?;
         let container_name = container_name(request.workflow_id, request.job_id);
         if let Some(container) = self.transport.inspect(&container_name)? {
+            worker_for_request(&container, request)?;
+            // Fence adoption before observation, but never re-claim during an
+            // already-authorized create's reconciliation or trigger its cleanup.
+            self.claim_creation(request, &container_name)?;
             return self
                 .ensure_existing(request, &container)
                 .map(InteractiveWorkerEnsure::Reused);

--- a/crates/horizon-core/src/cloud_run/local_docker/creation.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/creation.rs
@@ -6,15 +6,18 @@ use super::{
 };
 
 impl LocalDockerInteractiveWorkerProvider {
+    pub(super) fn claim_creation(&self, request: &InteractiveWorkerRequest, name: &str) -> DockerResult<bool> {
+        self.creation_store
+            .claim_worker_creation(request.workflow_id, request.job_id, &request.target, name)
+            .map_err(|_| LocalDockerError::CreationFenceFailed)
+    }
+
     pub(super) fn create_once(
         &self,
         request: &InteractiveWorkerRequest,
         name: &str,
     ) -> DockerResult<InteractiveWorkerEnsure> {
-        let granted = self
-            .creation_store
-            .claim_worker_creation(request.workflow_id, request.job_id, &request.target, name)
-            .map_err(|_| LocalDockerError::CreationFenceFailed)?;
+        let granted = self.claim_creation(request, name)?;
         if !granted {
             // Another controller may have completed creation since the first lookup.
             // This retry is read-only even if the resource is stopped, missing or expired.

--- a/crates/horizon-core/src/cloud_run/local_docker/creation.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/creation.rs
@@ -1,0 +1,29 @@
+//! Durable creation authority is separate from resource inspection and client lifetime.
+
+use super::{
+    DockerResult, InteractiveWorkerEnsure, InteractiveWorkerProvider, InteractiveWorkerRequest, LocalDockerError,
+    LocalDockerInteractiveWorkerProvider,
+};
+
+impl LocalDockerInteractiveWorkerProvider {
+    pub(super) fn create_once(
+        &self,
+        request: &InteractiveWorkerRequest,
+        name: &str,
+    ) -> DockerResult<InteractiveWorkerEnsure> {
+        let granted = self
+            .creation_store
+            .claim_worker_creation(request.workflow_id, request.job_id, &request.target, name)
+            .map_err(|_| LocalDockerError::CreationFenceFailed)?;
+        if !granted {
+            // Another controller may have completed creation since the first lookup.
+            // This retry is read-only even if the resource is stopped, missing or expired.
+            return self
+                .reconcile_worker(request)?
+                .map(InteractiveWorkerEnsure::Reused)
+                .ok_or(LocalDockerError::CreationReconciliationRequired);
+        }
+        // Keep the consumed grant after every outcome, including an uncertain response.
+        self.create_worker(request, name)
+    }
+}

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -19,6 +19,7 @@ struct FakeState {
     create_calls: usize,
     delete_calls: usize,
     fail_create_after_insert: bool,
+    corrupt_fence_after_create: Option<CloudWorkflowStore>,
     reject_create: bool,
     create_response_id: Option<String>,
     failed_inspections_after_create: usize,
@@ -81,6 +82,15 @@ impl DockerTransport for FakeDocker {
                 port: 49_152,
             }],
         });
+        if let Some(store) = &state.corrupt_fence_after_create {
+            rusqlite::Connection::open(store.path())
+                .expect("database")
+                .execute(
+                    "UPDATE cloud_workflows SET snapshot=?1",
+                    [b"synthetic-private-snapshot".as_slice()],
+                )
+                .expect("post-create fixture failure");
+        }
         if state.fail_create_after_insert {
             return Err(CommandFailed {
                 operation: "container creation",

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -4,6 +4,7 @@ use LocalDockerError::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
 
+mod fencing;
 mod lifetime;
 mod noncreating;
 
@@ -11,6 +12,7 @@ mod noncreating;
 struct FakeDocker(Arc<Mutex<FakeState>>);
 #[derive(Default)]
 struct FakeState {
+    creation: Option<fencing::CreationStore>,
     container: Option<DockerContainer>,
     inspect_calls: usize,
     host_key_calls: usize,
@@ -124,20 +126,15 @@ pub(super) fn request() -> InteractiveWorkerRequest {
 }
 
 #[test]
-fn disappearance_during_key_discovery_is_absent_or_recreated() {
+fn disappearance_during_key_discovery_never_recreates_a_claimed_worker() {
     let fake = FakeDocker::default();
     let provider = provider("local", fake.clone());
     let request = request();
     let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
     fake.state().disappear_during_key_read = true;
     assert_eq!(provider.inspect_worker(&worker), Ok(None));
-    provider.ensure_worker(&request).expect("recreate");
-    fake.state().disappear_during_key_read = true;
-    assert!(matches!(
-        provider.ensure_worker(&request),
-        Ok(InteractiveWorkerEnsure::Created(_))
-    ));
-    assert_eq!(fake.state().create_calls, 3);
+    assert_eq!(provider.ensure_worker(&request), Err(CreationReconciliationRequired));
+    assert_eq!(fake.state().create_calls, 1);
 }
 fn profile(name: &str, docker_host: &str) -> LocalDockerProfile {
     LocalDockerProfile {
@@ -146,9 +143,23 @@ fn profile(name: &str, docker_host: &str) -> LocalDockerProfile {
     }
 }
 fn provider(name: &str, fake: FakeDocker) -> LocalDockerInteractiveWorkerProvider {
+    provider_for(name, fake, &request())
+}
+fn provider_for(
+    name: &str,
+    fake: FakeDocker,
+    request: &InteractiveWorkerRequest,
+) -> LocalDockerInteractiveWorkerProvider {
+    let creation_store = fake
+        .state()
+        .creation
+        .get_or_insert_with(|| fencing::CreationStore::new(request))
+        .store
+        .clone();
     LocalDockerInteractiveWorkerProvider {
         transport: Box::new(fake),
         profile: profile(name, "unix:///var/run/docker.sock"),
+        creation_store,
     }
 }
 
@@ -226,7 +237,11 @@ fn creates_reuses_inspects_and_deletes_one_exact_worker() {
 
 #[test]
 fn rejects_preflight_and_resource_drift_without_unsafe_io() {
-    let remote = LocalDockerInteractiveWorkerProvider::new(profile("local", "ssh://remote.example/run/docker.sock"));
+    let fixture = fencing::CreationStore::new(&request());
+    let remote = LocalDockerInteractiveWorkerProvider::new(
+        profile("local", "ssh://remote.example/run/docker.sock"),
+        fixture.store.clone(),
+    );
     assert_eq!(remote.err(), Some(NonLocalDockerHost));
     let other = provider("other", FakeDocker::default());
     let fake = FakeDocker::default();

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/fencing.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/fencing.rs
@@ -101,6 +101,23 @@ fn a_failed_first_create_keeps_its_grant_and_a_retry_cannot_create() {
 }
 
 #[test]
+fn already_fenced_uncertain_creation_never_turns_a_store_failure_into_worker_cleanup() {
+    let request = request();
+    let fake = FakeDocker::default();
+    fake.state().fail_create_after_insert = true;
+    let provider = provider_for("local", fake.clone(), &request);
+    fake.state().corrupt_fence_after_create = Some(provider.creation_store.clone());
+    let outcome = provider.ensure_worker(&request);
+    {
+        let state = fake.state();
+        assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+        assert!(state.container.is_some());
+    }
+    assert_eq!(claims(&provider.creation_store), 1);
+    assert!(matches!(outcome, Ok(InteractiveWorkerEnsure::Reused(_))));
+}
+
+#[test]
 fn simultaneous_controllers_share_one_durable_creation_grant() {
     let request = lifetime::persistent_request();
     let fake = FakeDocker::default();
@@ -143,14 +160,68 @@ fn simultaneous_controllers_share_one_durable_creation_grant() {
 }
 
 #[test]
-fn observed_disappearance_does_not_fall_through_to_creation_even_with_an_unused_grant() {
+fn observed_disappearance_consumes_the_grant_before_observation_can_fail() {
     let request = lifetime::persistent_request();
     let fake = noncreating::seeded(&request);
     fake.state().disappear_during_key_read = true;
     let provider = provider_for("local", fake.clone(), &request);
     assert_eq!(provider.ensure_worker(&request), Err(ResourceAbsent));
-    assert_eq!(claims(&provider.creation_store), 0);
+    assert_eq!(claims(&provider.creation_store), 1);
+    assert_eq!(provider.ensure_worker(&request), Err(CreationReconciliationRequired));
     noncreating::assert_read_only(&fake);
+}
+
+#[test]
+fn accepting_an_unclaimed_existing_worker_permanently_fences_later_recreation() {
+    let request = lifetime::persistent_request();
+    let fake = noncreating::seeded(&request);
+    let provider = provider_for("local", fake.clone(), &request);
+    assert_eq!(claims(&provider.creation_store), 0);
+    assert!(matches!(
+        provider.ensure_worker(&request),
+        Ok(InteractiveWorkerEnsure::Reused(_))
+    ));
+    let path = provider.creation_store.path().to_path_buf();
+    drop(provider);
+    fake.state().container = None;
+    let reopened = LocalDockerInteractiveWorkerProvider {
+        transport: Box::new(fake.clone()),
+        profile: profile("local", "unix:///var/run/docker.sock"),
+        creation_store: CloudWorkflowStore::open_path(path).expect("reopened fence"),
+    };
+    assert_eq!(reopened.ensure_worker(&request), Err(CreationReconciliationRequired));
+    assert_eq!(claims(&reopened.creation_store), 1);
+    noncreating::assert_read_only(&fake);
+}
+
+#[test]
+fn wrong_existing_identity_or_unavailable_fence_cannot_be_accepted_or_created() {
+    for corrupt_store in [false, true] {
+        let request = lifetime::persistent_request();
+        let fake = noncreating::seeded(&request);
+        let provider = provider_for("local", fake.clone(), &request);
+        let expected = if corrupt_store {
+            rusqlite::Connection::open(provider.creation_store.path())
+                .expect("database")
+                .execute(
+                    "UPDATE cloud_workflows SET snapshot=?1",
+                    [b"synthetic-private-snapshot".as_slice()],
+                )
+                .expect("corrupt fixture");
+            CreationFenceFailed
+        } else {
+            fake.state()
+                .container
+                .as_mut()
+                .expect("fixture")
+                .labels
+                .insert(SSH_KEY_LABEL.into(), ed25519_key(9));
+            ResourceIdentityMismatch
+        };
+        assert_eq!(provider.ensure_worker(&request), Err(expected));
+        assert_eq!(claims(&provider.creation_store), 0);
+        noncreating::assert_read_only(&fake);
+    }
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/fencing.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/fencing.rs
@@ -1,0 +1,288 @@
+use super::*;
+use crate::cloud_run::{CloudJobState, CloudProgress, CloudWorkflow, RetryPolicy, WorkflowNode, WorkflowNodeKind};
+
+pub(super) struct CreationStore {
+    pub(super) store: CloudWorkflowStore,
+    _directory: tempfile::TempDir,
+}
+
+impl CreationStore {
+    pub(super) fn new(request: &InteractiveWorkerRequest) -> Self {
+        let directory = tempfile::tempdir().expect("isolated creation fence");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+        store
+            .create(&CloudWorkflow {
+                protocol_version: CLOUD_RUN_PROTOCOL_VERSION,
+                id: request.workflow_id,
+                title: "Local worker fixture".into(),
+                created_at_millis: 1000,
+                updated_at_millis: 1000,
+                retain_until_millis: i64::MAX,
+                nodes: vec![WorkflowNode {
+                    id: request.job_id,
+                    logical_key: "worker".into(),
+                    label: "Worker".into(),
+                    kind: WorkflowNodeKind::Build,
+                    state: CloudJobState::Queued,
+                    outcome: None,
+                    progress: CloudProgress::Pending,
+                    weight: 1,
+                    attempt: 1,
+                    retry: RetryPolicy::default(),
+                    supersedes: None,
+                    depends_on: vec![],
+                    source: None,
+                    worker: Some(request.target.clone()),
+                    input_artifact_ids: vec![],
+                    outputs: vec![],
+                    approval: None,
+                    release: None,
+                    environment_lease: None,
+                }],
+            })
+            .expect("workflow");
+        Self {
+            store,
+            _directory: directory,
+        }
+    }
+}
+
+fn claims(store: &CloudWorkflowStore) -> i64 {
+    rusqlite::Connection::open(store.path())
+        .expect("database")
+        .query_row("SELECT COUNT(*) FROM cloud_worker_creation_claims", [], |row| {
+            row.get(0)
+        })
+        .expect("claims")
+}
+
+#[test]
+fn creation_claim_survives_controller_drop_and_resource_absence() {
+    let request = lifetime::persistent_request();
+    let fake = FakeDocker::default();
+    let first = provider_for("local", fake.clone(), &request);
+    let worker = first
+        .ensure_worker(&request)
+        .expect("first creation")
+        .into_status()
+        .worker;
+    assert_eq!(claims(&first.creation_store), 1);
+    let path = first.creation_store.path().to_path_buf();
+    drop(first);
+    fake.state().container = None;
+    let reopened = LocalDockerInteractiveWorkerProvider {
+        transport: Box::new(fake.clone()),
+        profile: profile("local", "unix:///var/run/docker.sock"),
+        creation_store: CloudWorkflowStore::open_path(path).expect("reopen fence"),
+    };
+    assert_eq!(reopened.inspect_worker(&worker), Ok(None));
+    assert_eq!(reopened.reconcile_worker(&request), Ok(None));
+    for _ in 0..3 {
+        assert_eq!(reopened.ensure_worker(&request), Err(CreationReconciliationRequired));
+    }
+    assert_eq!(claims(&reopened.creation_store), 1);
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+}
+
+#[test]
+fn a_failed_first_create_keeps_its_grant_and_a_retry_cannot_create() {
+    let request = lifetime::persistent_request();
+    let fake = FakeDocker::default();
+    fake.state().reject_create = true;
+    let provider = provider_for("local", fake.clone(), &request);
+    assert!(provider.ensure_worker(&request).is_err());
+    fake.state().reject_create = false;
+    assert_eq!(provider.ensure_worker(&request), Err(CreationReconciliationRequired));
+    assert_eq!(claims(&provider.creation_store), 1);
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+}
+
+#[test]
+fn simultaneous_controllers_share_one_durable_creation_grant() {
+    let request = lifetime::persistent_request();
+    let fake = FakeDocker::default();
+    let providers = [
+        provider_for("local", fake.clone(), &request),
+        provider_for("local", fake.clone(), &request),
+    ];
+    let store = providers[0].creation_store.clone();
+    let barrier = Arc::new(std::sync::Barrier::new(2));
+    let handles: Vec<_> = providers
+        .into_iter()
+        .map(|provider| {
+            let barrier = Arc::clone(&barrier);
+            let request = request.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                provider.ensure_worker(&request)
+            })
+        })
+        .collect();
+    let results: Vec<_> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("controller"))
+        .collect();
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Ok(InteractiveWorkerEnsure::Created(_))))
+            .count(),
+        1
+    );
+    assert!(
+        results
+            .iter()
+            .all(|result| matches!(result, Ok(_) | Err(CreationReconciliationRequired)))
+    );
+    assert_eq!(claims(&store), 1);
+    let state = fake.state();
+    assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+}
+
+#[test]
+fn observed_disappearance_does_not_fall_through_to_creation_even_with_an_unused_grant() {
+    let request = lifetime::persistent_request();
+    let fake = noncreating::seeded(&request);
+    fake.state().disappear_during_key_read = true;
+    let provider = provider_for("local", fake.clone(), &request);
+    assert_eq!(provider.ensure_worker(&request), Err(ResourceAbsent));
+    assert_eq!(claims(&provider.creation_store), 0);
+    noncreating::assert_read_only(&fake);
+}
+
+#[test]
+fn expired_or_corrupt_fences_fail_before_any_creation_without_leaking_storage_detail() {
+    for corrupt in [false, true] {
+        let fake = FakeDocker::default();
+        let request = request();
+        let provider = provider("local", fake.clone());
+        let connection = rusqlite::Connection::open(provider.creation_store.path()).expect("database");
+        if corrupt {
+            connection
+                .execute(
+                    "UPDATE cloud_workflows SET snapshot=?1",
+                    [b"synthetic-private-snapshot".as_slice()],
+                )
+                .expect("corrupt");
+        } else {
+            let mut workflow = provider
+                .creation_store
+                .load(request.workflow_id)
+                .expect("load")
+                .expect("workflow")
+                .workflow()
+                .clone();
+            workflow.retain_until_millis = 2000;
+            connection
+                .execute(
+                    "UPDATE cloud_workflows SET retain_until_millis=2000, snapshot=?1",
+                    [serde_json::to_vec(&workflow).expect("expired snapshot")],
+                )
+                .expect("expire");
+        }
+        let error = provider.ensure_worker(&request).expect_err("fence failed");
+        assert_eq!(error, CreationFenceFailed);
+        assert!(!format!("{error:?} {error}").contains("synthetic-private-snapshot"));
+        assert_eq!(claims(&provider.creation_store), 0);
+        noncreating::assert_read_only(&fake);
+    }
+}
+
+#[test]
+fn noncreating_inspection_and_reconciliation_do_not_consume_a_grant() {
+    let request = request();
+    let fake = FakeDocker::default();
+    let provider = provider("local", fake.clone());
+    assert_eq!(provider.reconcile_worker(&request), Ok(None));
+    assert_eq!(claims(&provider.creation_store), 0);
+    let seeded = noncreating::seeded(&request);
+    let reader = provider_for("local", seeded.clone(), &request);
+    let observed = reader.reconcile_worker(&request).expect("reconcile").expect("existing");
+    assert_eq!(reader.inspect_worker(&observed.worker), Ok(Some(observed)));
+    assert_eq!(claims(&reader.creation_store), 0);
+    noncreating::assert_read_only(&seeded);
+}
+
+#[test]
+fn missing_or_mismatched_workflow_targets_cannot_claim_creation() {
+    for fault in 0..3 {
+        let fake = FakeDocker::default();
+        let provider = provider("local", fake.clone());
+        let mut changed = request();
+        match fault {
+            0 => changed.workflow_id = crate::cloud_run::CloudWorkflowId::new(),
+            1 => changed.job_id = crate::cloud_run::CloudJobId::new(),
+            _ => changed.target.disk_gib += 1,
+        }
+        assert_eq!(provider.ensure_worker(&changed), Err(CreationFenceFailed));
+        assert_eq!(claims(&provider.creation_store), 0);
+        noncreating::assert_read_only(&fake);
+    }
+}
+
+#[test]
+fn owned_allocations_use_the_same_fence_and_management_intent_denies_new_creation() {
+    use crate::remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteRuntimePhase, RemoteWorkspaceState};
+    const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+    for cancel in [false, true] {
+        let directory = tempfile::tempdir().expect("owned fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": lifetime::persistent_request().target,
+                "repository": { "repository": "example/project", "commit": "b".repeat(40) }
+            }
+        }))
+        .expect("state");
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        let allocation = store
+            .reserve_remote_worker_request(&allocation, &ed25519_key(3))
+            .expect("request");
+        let request = allocation.worker_request().expect("request");
+        let fake = FakeDocker::default();
+        let provider = LocalDockerInteractiveWorkerProvider {
+            transport: Box::new(fake.clone()),
+            profile: profile("local", "unix:///var/run/docker.sock"),
+            creation_store: store.clone(),
+        };
+        if cancel {
+            let mut state = allocation.workspace().state().clone();
+            let runtime = state.runtime.as_mut().expect("runtime");
+            runtime.phase = RemoteRuntimePhase::Cancelling;
+            runtime.cleanup = Some(RemoteCleanupIntent {
+                reason: RemoteCleanupReason::Cancelled,
+                requested_at_millis: 1000,
+            });
+            store
+                .replace_remote_workspace(allocation.workspace(), &state)
+                .expect("management intent");
+            assert_eq!(provider.ensure_worker(&request), Err(CreationFenceFailed));
+            assert_eq!(claims(&store), 0);
+            noncreating::assert_read_only(&fake);
+        } else {
+            assert!(matches!(
+                provider.ensure_worker(&request),
+                Ok(InteractiveWorkerEnsure::Created(_))
+            ));
+            assert_eq!(claims(&store), 1);
+            fake.state().container = None;
+            assert_eq!(provider.ensure_worker(&request), Err(CreationReconciliationRequired));
+            assert_eq!(fake.state().create_calls, 1);
+            assert_eq!(fake.state().delete_calls, 0);
+        }
+        assert_eq!(
+            store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("reload")
+                .expect("allocation")
+                .workflow(),
+            allocation.workflow()
+        );
+    }
+}

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn persistent_request() -> InteractiveWorkerRequest {
+pub(super) fn persistent_request() -> InteractiveWorkerRequest {
     let mut request = request();
     request.target.lifetime = WorkerLifetime::Persistent;
     request
@@ -10,7 +10,7 @@ fn persistent_request() -> InteractiveWorkerRequest {
 fn persistent_worker_is_reused_after_controller_drop_without_an_expiry() {
     let request = persistent_request();
     let fake = FakeDocker::default();
-    let original = provider("local", fake.clone());
+    let original = provider_for("local", fake.clone(), &request);
     let created = original.ensure_worker(&request).expect("create persistent worker");
     assert!(matches!(created, InteractiveWorkerEnsure::Created(_)));
     let status = created.into_status();
@@ -25,7 +25,7 @@ fn persistent_worker_is_reused_after_controller_drop_without_an_expiry() {
     let encoded = serde_json::to_string(&status.worker).expect("persist handle");
     let worker: InteractiveWorker = serde_json::from_str(&encoded).expect("restore handle");
     drop(original);
-    let reopened = provider("local", fake.clone());
+    let reopened = provider_for("local", fake.clone(), &request);
     assert_eq!(reopened.inspect_worker(&worker), Ok(Some(status.clone())));
     assert_eq!(
         reopened.ensure_worker(&request),
@@ -43,7 +43,7 @@ fn persistent_worker_is_reused_after_controller_drop_without_an_expiry() {
 fn a_stopped_or_missing_persistent_worker_is_not_recreated_by_inspection() {
     let request = persistent_request();
     let fake = FakeDocker::default();
-    let provider = provider("local", fake.clone());
+    let provider = provider_for("local", fake.clone(), &request);
     let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
     {
         let mut state = fake.state();
@@ -73,7 +73,7 @@ fn persistent_metadata_drift_never_authorizes_reuse_or_deletion() {
     for drift in 0..6 {
         let request = persistent_request();
         let fake = FakeDocker::default();
-        let provider = provider("local", fake.clone());
+        let provider = provider_for("local", fake.clone(), &request);
         let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
         {
             let mut state = fake.state();
@@ -113,7 +113,7 @@ fn persistent_metadata_drift_never_authorizes_reuse_or_deletion() {
 fn a_timed_worker_is_never_adopted_as_persistent_or_vice_versa() {
     for initial in [request(), persistent_request()] {
         let fake = FakeDocker::default();
-        let provider = provider("local", fake.clone());
+        let provider = provider_for("local", fake.clone(), &initial);
         provider.ensure_worker(&initial).expect("create original policy");
         let mut changed = initial;
         changed.target.lifetime = match changed.target.lifetime {
@@ -130,7 +130,7 @@ fn a_timed_worker_is_never_adopted_as_persistent_or_vice_versa() {
 fn persistent_lost_create_response_recovers_the_same_exact_worker() {
     let fake = FakeDocker::default();
     fake.state().fail_create_after_insert = true;
-    let provider = provider("local", fake.clone());
+    let provider = provider_for("local", fake.clone(), &persistent_request());
     let result = provider
         .ensure_worker(&persistent_request())
         .expect("reconcile creation");
@@ -149,7 +149,7 @@ fn unexpected_image_expiry_retains_the_created_identity_for_manual_inspection() 
     ] {
         let fake = FakeDocker::default();
         fake.state().image_environment.push(entry);
-        let result = provider("local", fake.clone()).ensure_worker(&persistent_request());
+        let result = provider_for("local", fake.clone(), &persistent_request()).ensure_worker(&persistent_request());
         assert_eq!(
             result,
             Err(PersistentLifetimeMetadataConflict {
@@ -200,7 +200,7 @@ fn timed_lifetime_rejects_bare_or_duplicate_expiry_without_deletion() {
 fn a_persistent_create_race_never_deletes_the_recovered_peers_worker() {
     let request = persistent_request();
     let fake = FakeDocker::default();
-    let provider = provider("local", fake.clone());
+    let provider = provider_for("local", fake.clone(), &request);
     let worker = provider
         .ensure_worker(&request)
         .expect("peer creates worker")
@@ -212,14 +212,9 @@ fn a_persistent_create_race_never_deletes_the_recovered_peers_worker() {
         state.reject_create = true;
         state.container.as_mut().expect("peer worker").ssh_bindings[0].host = "0.0.0.0".into();
     }
-    assert_eq!(
-        provider.ensure_worker(&request),
-        Err(PersistentCreationReconciliationRequired {
-            resource_id: worker.identity.resource_id.clone()
-        })
-    );
+    assert_eq!(provider.ensure_worker(&request), Err(InvalidSshEndpoint));
     let state = fake.state();
-    assert_eq!((state.create_calls, state.delete_calls), (2, 0));
+    assert_eq!((state.create_calls, state.delete_calls), (1, 0));
     assert_eq!(
         state.container.as_ref().expect("peer worker retained").id,
         worker.identity.resource_id

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/noncreating.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/noncreating.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cloud_run::CloudJobId;
 
-fn seeded(request: &InteractiveWorkerRequest) -> FakeDocker {
+pub(super) fn seeded(request: &InteractiveWorkerRequest) -> FakeDocker {
     let fake = FakeDocker::default();
     let name = container_name(request.workflow_id, request.job_id);
     fake.create(&DockerCreateRequest::new(request, &name).expect("fixture"))
@@ -10,7 +10,7 @@ fn seeded(request: &InteractiveWorkerRequest) -> FakeDocker {
     fake
 }
 
-fn assert_read_only(fake: &FakeDocker) {
+pub(super) fn assert_read_only(fake: &FakeDocker) {
     let state = fake.state();
     assert_eq!((state.create_calls, state.delete_calls), (0, 0));
 }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -116,6 +116,10 @@ back into large multi-purpose modules.
   target serialization. `interactive_worker.rs` validates observed lifetime
   against that policy; neither represents the client/creation ownership lease.
   Missing or malformed legacy metadata never selects persistent execution.
+- The local worker adapter's `local_docker/creation.rs` uses the existing durable
+  workflow store to grant at most one creation attempt. A consumed grant permits
+  only non-creating reconciliation; store failure, client drop or resource loss
+  never renews it. Provider construction requires that store explicitly.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -119,7 +119,9 @@ back into large multi-purpose modules.
 - The local worker adapter's `local_docker/creation.rs` uses the existing durable
   workflow store to grant at most one creation attempt. A consumed grant permits
   only non-creating reconciliation; store failure, client drop or resource loss
-  never renews it. Provider construction requires that store explicitly.
+  never renews it. Explicit ensure also consumes the grant when accepting an
+  exact existing worker, before observing its connection. Provider construction
+  requires that store explicitly; non-creating inspection never claims a grant.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized


### PR DESCRIPTION
## Purpose

Prevent a missing local worker from being silently recreated under the same
workflow/job identity. Refs #383.

The local provider constructor now requires the existing durable workflow store.
First creation must consume its transactional one-shot grant. A consumed grant
permits only non-creating reconciliation; failures, lost responses, controller
restart and resource absence never renew it. Disappearance during observation
returns absence instead of falling through to creation. Explicit ensure also
fences an exact pre-existing worker before observation, so later disappearance
cannot leave a legacy creation grant available.

## Behavior and scope

- Existing request/target/ownership admission and durable store transactions are reused.
- Store errors are redacted and no failed creation resets its grant.
- Reconnect remains inspect/reconcile. Existing timed ensure cleanup is unchanged;
  this change does not make ensure a read-only operation.
- First-create coordination, retained-key ordering, storage durability, cost
  policy and UI integration remain separate acceptance gates.
- No dependency, default configuration or UI change; no live resource mutation.

## Validation

All 31 focused provider regressions pass, including eleven new fence tests for
simultaneous/reopened controllers, failed first creation, disappearance, expired/
corrupt/missing/mismatched workflows, owned allocation, pending management and
read-only recovery. Added reuse/disappearance/reopen and post-create store-failure
coverage. Old tests now assert one creation attempt instead of repeated recreation.
All three lint tiers pass and independent local/integration review is clear.

The patch is based on main `4c71d032`. The full source matrix passes: format,
maintainability, version sync, workspace default/speech tests with warnings denied
and all three lint tiers. Review correction `f38c88d` has independent exact-tree
review and the complete source matrix passed. The complete exact-commit matrix
also passed on `f38c88d` before push. An unrelated browser CLI deadline-report
test failed once; three isolated repeats and the complete unchanged-head rerun
passed. No browser code was changed.
