### PR TITLE
Coordinate owned remote workspace setup

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -6,6 +6,7 @@ mod binding;
 mod guards;
 mod recovery;
 mod request;
+mod setup;
 
 pub(super) use guards::{
     ensure_unbound_workflow, validate_creation_claim, validate_workflow_replacement, validate_workspace_write,

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/request.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/request.rs
@@ -5,7 +5,7 @@ use super::{CloudWorkflowStore, Error, RemoteRuntimePhase, StoredRemoteAllocatio
 use crate::cloud_run::interactive_worker::InteractiveWorkerRequest;
 use rusqlite::{TransactionBehavior, params};
 
-const CLAIM_LOOKUP: &str = "SELECT EXISTS(SELECT 1 FROM cloud_worker_creation_claims
+pub(super) const CLAIM_LOOKUP: &str = "SELECT EXISTS(SELECT 1 FROM cloud_worker_creation_claims
     INDEXED BY cloud_worker_creation_claims_workflow WHERE workflow_id = ?1)";
 
 impl StoredRemoteAllocation {

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
@@ -1,0 +1,32 @@
+//! Setup admission is a point-in-time check, never a provider creation grant.
+
+use super::super::{current_unix_millis, database::ensure_current_schema, validate_claim_target};
+use super::{CloudWorkflowStore, Error, RemoteRuntimePhase, StoredRemoteAllocation, binding, request::CLAIM_LOOKUP};
+
+impl CloudWorkflowStore {
+    pub(crate) fn validate_unclaimed_remote_setup(&self, expected: &StoredRemoteAllocation) -> Result<(), Error> {
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)?
+            .ok_or(Error::UnboundRuntime)?;
+        let current = binding::recover(&transaction, &row)?;
+        if current != *expected {
+            return Err(Error::SnapshotConflict);
+        }
+        let state = current.workspace.state();
+        let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+        if runtime.phase != RemoteRuntimePhase::Provisioning
+            || runtime.worker.is_some()
+            || runtime.cleanup.is_some()
+            || current.workflow.workflow().retain_until_millis < current_unix_millis()?
+            || validate_claim_target(current.workflow.workflow(), runtime.job_id, &state.spec.target).is_err()
+            || transaction.query_row(CLAIM_LOOKUP, [runtime.workflow_id.to_string()], |row| {
+                row.get::<_, bool>(0)
+            })?
+        {
+            return Err(Error::RuntimeSetupUnavailable);
+        }
+        Ok(())
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -465,6 +465,8 @@ pub enum RemoteWorkspaceStoreError {
     RuntimeRecoveryUnavailable,
     #[error("remote worker observation does not match the saved request or pinned identity")]
     InvalidWorkerObservation,
+    #[error("remote allocation setup cannot create; non-creating recovery is required")]
+    RuntimeSetupUnavailable,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -23,6 +23,7 @@ mod remote_hosts;
 pub mod remote_ssh_identity;
 pub mod remote_workspace;
 pub mod remote_workspace_recovery;
+pub mod remote_workspace_setup;
 mod runtime_state;
 pub mod search;
 mod session_store;

--- a/crates/horizon-core/src/remote_workspace_setup.rs
+++ b/crates/horizon-core/src/remote_workspace_setup.rs
@@ -56,7 +56,10 @@ pub fn retry_remote_workspace_setup<P: InteractiveWorkerProvider + ?Sized>(
     if !setup_available(store, expected)? {
         return recover(store, identities, provider, expected);
     }
-    let allocation = prepare_identity(store, identities, expected)?;
+    let allocation = match prepare_identity(store, identities, expected) {
+        Ok(allocation) => allocation,
+        Err(error) => return recover_preparation_failure(store, identities, provider, expected, error),
+    };
     // Key generation/inspection may take time. Recheck both owned snapshots before ensure.
     if !setup_available(store, &allocation)? {
         return recover(store, identities, provider, &allocation);
@@ -68,6 +71,20 @@ pub fn retry_remote_workspace_setup<P: InteractiveWorkerProvider + ?Sized>(
     store
         .record_remote_worker_recovery(&allocation, Some(observed.status()))
         .map_err(Into::into)
+}
+
+fn recover_preparation_failure<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+    error: RemoteWorkspaceSetupError,
+) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+    if setup_available(store, expected)? {
+        Err(error)
+    } else {
+        recover(store, identities, provider, expected)
+    }
 }
 
 fn setup_available(

--- a/crates/horizon-core/src/remote_workspace_setup.rs
+++ b/crates/horizon-core/src/remote_workspace_setup.rs
@@ -1,0 +1,141 @@
+//! Explicit initial setup and interrupted-setup retry, separate from client reconnect.
+//! All operations are synchronous and must run off the render thread.
+
+use crate::{
+    cloud_run::{
+        CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
+        interactive_worker::InteractiveWorkerProvider,
+    },
+    remote_ssh_identity::{RemoteSshIdentityError, RemoteSshIdentityStore},
+    remote_workspace_recovery::{RemoteWorkspaceRecoveryError, recover_remote_workspace},
+};
+
+/// Allocate once for an explicitly requested new worker, then retain its request before ensure.
+/// The provider must use this same store's durable creation fence; setup admission is not a grant.
+/// Failures preserve the allocated generation for explicit retry or non-creating recovery.
+/// This does not start tasks or authorize attachment. The coordinator issues no cleanup;
+/// the provider's explicit ensure operation retains its existing cleanup contract.
+/// # Errors
+/// Rejects unsupported identity platforms, provider/ownership drift, active runtimes,
+/// invalid setup retention, private-key failures and provider/observation failures.
+pub fn start_remote_workspace<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    expected: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+    if !cfg!(target_os = "linux") {
+        return Err(RemoteSshIdentityError::UnsupportedPlatform.into());
+    }
+    if expected.state().spec.target.provider != provider.provider() {
+        return Err(RemoteWorkspaceRecoveryError::ProviderMismatch.into());
+    }
+    let allocation = store.allocate_remote_runtime(expected, retain_until_millis)?;
+    retry_remote_workspace_setup(store, identities, provider, &allocation)
+}
+
+/// Resume only this exact allocation after an explicit setup retry action.
+/// A claimed/observed/expired setup uses non-creating recovery, never another ensure.
+/// Only a still-unclaimed setup with no saved client identity may prepare a key.
+/// A reserved identity must recover its existing private key without substitution.
+/// Concurrent callers are arbitrated by the store CAS and provider's durable fence.
+/// # Errors
+/// Rejects stale/corrupt ownership, missing or mismatched keys, pending management,
+/// unavailable providers and invalid observations. The coordinator issues no compensating
+/// stop/delete calls; an admitted provider ensure retains its existing cleanup contract.
+pub fn retry_remote_workspace_setup<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+    if expected.workspace().state().spec.target.provider != provider.provider() {
+        return Err(RemoteWorkspaceRecoveryError::ProviderMismatch.into());
+    }
+    if !setup_available(store, expected)? {
+        return recover(store, identities, provider, expected);
+    }
+    let allocation = prepare_identity(store, identities, expected)?;
+    // Key generation/inspection may take time. Recheck both owned snapshots before ensure.
+    if !setup_available(store, &allocation)? {
+        return recover(store, identities, provider, &allocation);
+    }
+    let request = allocation.worker_request()?;
+    let observed = provider
+        .ensure_worker(&request)
+        .map_err(|_| RemoteWorkspaceSetupError::ProviderUnavailable)?;
+    store
+        .record_remote_worker_recovery(&allocation, Some(observed.status()))
+        .map_err(Into::into)
+}
+
+fn setup_available(
+    store: &CloudWorkflowStore,
+    expected: &StoredRemoteAllocation,
+) -> Result<bool, RemoteWorkspaceSetupError> {
+    match store.validate_unclaimed_remote_setup(expected) {
+        Ok(()) => Ok(true),
+        Err(RemoteWorkspaceStoreError::RuntimeSetupUnavailable) => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn prepare_identity(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+    let runtime = expected
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    if let Some(public_key) = &runtime.ssh_public_key {
+        identities.recover(runtime.workflow_id, runtime.job_id, public_key)?;
+        return Ok(expected.clone());
+    }
+    let identity = identities.prepare_new(runtime.workflow_id, runtime.job_id)?;
+    store
+        .reserve_remote_worker_request(expected, identity.public_key())
+        .map_err(Into::into)
+}
+
+fn recover<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+    let workspace = expected.workspace();
+    recover_remote_workspace(
+        store,
+        identities,
+        provider,
+        workspace.session_id(),
+        &workspace.state().spec.workspace_local_id,
+    )
+    .map(|result| result.allocation().clone())
+    .map_err(Into::into)
+}
+
+/// Private identity, provider payloads and storage details never appear in setup diagnostics.
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum RemoteWorkspaceSetupError {
+    #[error(transparent)]
+    Recovery(#[from] RemoteWorkspaceRecoveryError),
+    #[error(transparent)]
+    Identity(#[from] RemoteSshIdentityError),
+    #[error("remote worker setup request failed; retain the allocation and use recovery before retrying")]
+    ProviderUnavailable,
+}
+
+impl From<RemoteWorkspaceStoreError> for RemoteWorkspaceSetupError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        Self::Recovery(error.into())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace_setup.rs
+++ b/crates/horizon-core/src/remote_workspace_setup.rs
@@ -123,6 +123,10 @@ fn recover<P: InteractiveWorkerProvider + ?Sized>(
 /// Private identity, provider payloads and storage details never appear in setup diagnostics.
 #[derive(Debug, thiserror::Error, Eq, PartialEq)]
 pub enum RemoteWorkspaceSetupError {
+    #[error("remote workspace already has an allocation; recover it or explicitly retry its setup")]
+    RuntimeAlreadyActive,
+    #[error("remote setup authorization must end after its valid creation timestamp")]
+    InvalidAllocationRetention,
     #[error(transparent)]
     Recovery(#[from] RemoteWorkspaceRecoveryError),
     #[error(transparent)]
@@ -133,7 +137,11 @@ pub enum RemoteWorkspaceSetupError {
 
 impl From<RemoteWorkspaceStoreError> for RemoteWorkspaceSetupError {
     fn from(error: RemoteWorkspaceStoreError) -> Self {
-        Self::Recovery(error.into())
+        match error {
+            RemoteWorkspaceStoreError::RuntimeAlreadyActive => Self::RuntimeAlreadyActive,
+            RemoteWorkspaceStoreError::InvalidAllocationRetention => Self::InvalidAllocationRetention,
+            _ => Self::Recovery(error.into()),
+        }
     }
 }
 

--- a/crates/horizon-core/src/remote_workspace_setup/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/tests.rs
@@ -1,0 +1,233 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{
+        CloudProvider,
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+            InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerRequest,
+            InteractiveWorkerSshEndpoint, InteractiveWorkerStatus,
+        },
+    },
+    remote_workspace::RemoteWorkspaceState,
+};
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+#[cfg(target_os = "linux")]
+mod lifecycle;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    identities: RemoteSshIdentityStore,
+    dormant: StoredRemoteWorkspace,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+        }
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": { "provider": "local_docker", "profile": "development",
+                    "image": format!("example/worker@sha256:{}", "a".repeat(64)),
+                    "disk_gib": 20, "lifetime": "persistent" },
+                "repository": { "repository": "example/project", "commit": "b".repeat(40) }
+            }
+        }))
+        .expect("state");
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("record");
+        Self {
+            directory,
+            store,
+            identities: RemoteSshIdentityStore::new(&home),
+            dormant,
+        }
+    }
+
+    fn provider(&self) -> Provider {
+        Provider {
+            kind: CloudProvider::LocalDocker,
+            store: self.store.clone(),
+            identities: RemoteSshIdentityStore::new(&HorizonHome::from_root(self.directory.path().join("home"))),
+            observation: Mutex::new(None),
+            calls: Mutex::new([0; 5]),
+            fail_response: AtomicBool::new(false),
+            invalid_observation: false,
+            after_create: None,
+        }
+    }
+
+    fn counts(&self) -> [i64; 3] {
+        rusqlite::Connection::open(self.store.path())
+            .expect("database")
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM cloud_workflows), (SELECT COUNT(*) FROM remote_runtime_allocations),
+             (SELECT COUNT(*) FROM cloud_worker_creation_claims)",
+                [],
+                |row| Ok([row.get(0)?, row.get(1)?, row.get(2)?]),
+            )
+            .expect("counts")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn reload(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn allocate(&self) -> StoredRemoteAllocation {
+        self.store
+            .allocate_remote_runtime(&self.dormant, i64::MAX)
+            .expect("allocate")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn retry(&self, provider: &Provider) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+        retry_remote_workspace_setup(&self.store, &self.identities, provider, &self.reload())
+    }
+}
+
+struct Provider {
+    kind: CloudProvider,
+    store: CloudWorkflowStore,
+    identities: RemoteSshIdentityStore,
+    observation: Mutex<Option<InteractiveWorkerStatus>>,
+    // ensure, create, reconcile, inspect, delete
+    calls: Mutex<[usize; 5]>,
+    fail_response: AtomicBool,
+    invalid_observation: bool,
+    after_create: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl Provider {
+    fn calls(&self) -> [usize; 5] {
+        *self.calls.lock().expect("calls")
+    }
+
+    fn read(&self, index: usize) -> Option<InteractiveWorkerStatus> {
+        self.calls.lock().expect("calls")[index] += 1;
+        self.observation.lock().expect("observation").clone()
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        let allocation = self
+            .store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("saved");
+        assert_eq!(allocation.worker_request().expect("durable public request"), *request);
+        self.identities
+            .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+            .expect("private identity retained before provider I/O");
+        self.calls.lock().expect("calls")[0] += 1;
+        let granted = self
+            .store
+            .claim_worker_creation(request.workflow_id, request.job_id, &request.target, "synthetic-worker")
+            .map_err(|_| std::io::Error::other("synthetic-private-store-failure"))?;
+        if granted {
+            self.calls.lock().expect("calls")[1] += 1;
+            *self.observation.lock().expect("observation") = Some(InteractiveWorkerStatus {
+                worker: InteractiveWorker {
+                    identity: InteractiveWorkerIdentity {
+                        provider: request.target.provider,
+                        workflow_id: request.workflow_id,
+                        job_id: request.job_id,
+                        resource_id: "synthetic-worker".into(),
+                    },
+                    target: request.target.clone(),
+                    ssh_public_key: request.ssh_public_key.clone(),
+                    lifetime: InteractiveWorkerLifetime::Persistent,
+                },
+                lifecycle: InteractiveWorkerLifecycle::Ready,
+                ssh: Some(InteractiveWorkerSshEndpoint {
+                    host: "127.0.0.1".into(),
+                    port: 2222,
+                    username: "horizon".into(),
+                    host_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcH".into(),
+                }),
+            });
+            if let Some(action) = &self.after_create {
+                action();
+            }
+        }
+        if self.fail_response.load(Ordering::SeqCst) {
+            return Err(std::io::Error::other("synthetic-private-provider-response"));
+        }
+        let mut status = self
+            .observation
+            .lock()
+            .expect("observation")
+            .clone()
+            .ok_or_else(|| std::io::Error::other("reconciliation required"))?;
+        if self.invalid_observation {
+            status.worker.identity.job_id = crate::cloud_run::CloudJobId::new();
+        }
+        Ok(if granted {
+            InteractiveWorkerEnsure::Created(status)
+        } else {
+            InteractiveWorkerEnsure::Reused(status)
+        })
+    }
+
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(self.read(2))
+    }
+
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        assert_eq!(worker.identity.resource_id, "synthetic-worker");
+        Ok(self.read(3))
+    }
+
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.calls.lock().expect("calls")[4] += 1;
+        Err(std::io::Error::other("deletion forbidden"))
+    }
+}
+
+#[test]
+fn unsupported_platform_or_wrong_provider_cannot_allocate_or_call_provider() {
+    let fixture = Fixture::new();
+    let mut provider = fixture.provider();
+    provider.kind = CloudProvider::RunPod;
+    let expected = if cfg!(target_os = "linux") {
+        RemoteWorkspaceRecoveryError::ProviderMismatch.into()
+    } else {
+        RemoteSshIdentityError::UnsupportedPlatform.into()
+    };
+    assert_eq!(
+        start_remote_workspace(
+            &fixture.store,
+            &fixture.identities,
+            &provider,
+            &fixture.dormant,
+            i64::MAX
+        ),
+        Err(expected)
+    );
+    assert_eq!(fixture.counts(), [0; 3]);
+    assert_eq!(provider.calls(), [0; 5]);
+}

--- a/crates/horizon-core/src/remote_workspace_setup/tests/lifecycle.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/tests/lifecycle.rs
@@ -1,0 +1,401 @@
+use super::*;
+use crate::remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteRuntimePhase};
+
+fn retained_key(fixture: &Fixture) -> crate::remote_ssh_identity::RemoteSshIdentity {
+    let runtime = fixture.reload();
+    let runtime = runtime.workspace().state().runtime.as_ref().expect("runtime");
+    fixture
+        .identities
+        .prepare_new(runtime.workflow_id, runtime.job_id)
+        .expect("key")
+}
+
+#[test]
+fn explicit_start_retains_one_allocation_request_and_key_without_claiming_task_readiness() {
+    let fixture = Fixture::new();
+    let provider = fixture.provider();
+    let saved = start_remote_workspace(
+        &fixture.store,
+        &fixture.identities,
+        &provider,
+        &fixture.dormant,
+        i64::MAX,
+    )
+    .expect("start");
+    let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+    assert_eq!(runtime.phase, RemoteRuntimePhase::Reconciling);
+    assert!(runtime.worker.is_some());
+    assert!(runtime.ssh.is_some());
+    assert!(saved.workspace().state().spec.panels.is_empty());
+    assert_eq!(fixture.counts(), [1, 1, 1]);
+    assert_eq!(provider.calls(), [1, 1, 0, 0, 0]);
+    assert_eq!(fixture.retry(&provider).expect("noncreating retry"), saved);
+    assert_eq!(provider.calls(), [1, 1, 0, 1, 0]);
+    assert!(
+        start_remote_workspace(
+            &fixture.store,
+            &fixture.identities,
+            &provider,
+            &fixture.dormant,
+            i64::MAX
+        )
+        .is_err()
+    );
+    assert_eq!(fixture.counts(), [1, 1, 1]);
+}
+
+#[test]
+fn interruptions_before_key_reservation_or_creation_reuse_the_exact_generation() {
+    for interruption in 0..3 {
+        let fixture = Fixture::new();
+        let allocation = fixture.allocate();
+        let key = (interruption > 0).then(|| retained_key(&fixture));
+        let bytes = key
+            .as_ref()
+            .map(|key| std::fs::read(key.private_key_path()).expect("key bytes"));
+        if interruption == 2 {
+            fixture
+                .store
+                .reserve_remote_worker_request(&allocation, key.as_ref().expect("key").public_key())
+                .expect("reserve");
+        }
+        let provider = fixture.provider();
+        let saved = fixture.retry(&provider).expect("resume setup");
+        assert_eq!(saved.workflow(), allocation.workflow());
+        if let Some(key) = key {
+            assert_eq!(
+                saved.worker_request().expect("request").ssh_public_key,
+                key.public_key()
+            );
+            assert_eq!(
+                std::fs::read(key.private_key_path()).expect("retained bytes"),
+                bytes.expect("bytes")
+            );
+        }
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+        assert_eq!(provider.calls(), [1, 1, 0, 0, 0]);
+    }
+}
+
+#[test]
+fn lost_create_response_reopens_without_a_second_ensure_or_replacement() {
+    let fixture = Fixture::new();
+    let provider = fixture.provider();
+    provider.fail_response.store(true, Ordering::SeqCst);
+    let error = start_remote_workspace(
+        &fixture.store,
+        &fixture.identities,
+        &provider,
+        &fixture.dormant,
+        i64::MAX,
+    )
+    .expect_err("lost response");
+    assert_eq!(error, RemoteWorkspaceSetupError::ProviderUnavailable);
+    assert!(!format!("{error:?} {error}").contains("synthetic-private-provider-response"));
+    let before = fixture.reload();
+    assert!(
+        before
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_none()
+    );
+    let request = before.worker_request().expect("retained request");
+    let key = fixture
+        .identities
+        .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+        .expect("key");
+    let bytes = std::fs::read(key.private_key_path()).expect("key bytes");
+    let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("reopen");
+    let recovered = retry_remote_workspace_setup(&reopened, &fixture.identities, &provider, &before).expect("recover");
+    assert_eq!(recovered.worker_request().expect("same request"), request);
+    assert_eq!(provider.calls(), [1, 1, 1, 0, 0]);
+    *provider.observation.lock().expect("observation") = None;
+    assert_eq!(fixture.retry(&provider).expect("absence is not recreation"), recovered);
+    assert_eq!(provider.calls(), [1, 1, 1, 1, 0]);
+    assert_eq!(fixture.counts(), [1, 1, 1]);
+    assert_eq!(std::fs::read(key.private_key_path()).expect("retained"), bytes);
+}
+
+#[test]
+fn an_already_claimed_absent_worker_never_crosses_the_ensure_boundary() {
+    let fixture = Fixture::new();
+    let allocation = fixture.allocate();
+    let key = retained_key(&fixture);
+    let reserved = fixture
+        .store
+        .reserve_remote_worker_request(&allocation, key.public_key())
+        .expect("reserve");
+    let request = reserved.worker_request().expect("request");
+    assert!(
+        fixture
+            .store
+            .claim_worker_creation(request.workflow_id, request.job_id, &request.target, "synthetic-worker")
+            .expect("claim")
+    );
+    let provider = fixture.provider();
+    fixture.retry(&provider).expect("reconcile absent");
+    assert_eq!(provider.calls(), [0, 0, 1, 0, 0]);
+    assert_eq!(fixture.counts(), [1, 1, 1]);
+}
+
+#[test]
+fn missing_or_mismatched_reserved_private_keys_fail_without_regeneration() {
+    for missing in [false, true] {
+        let fixture = Fixture::new();
+        let allocation = fixture.allocate();
+        let key = retained_key(&fixture);
+        let saved = fixture
+            .store
+            .reserve_remote_worker_request(&allocation, key.public_key())
+            .expect("reserve");
+        let expected = if missing {
+            std::fs::remove_file(key.private_key_path()).expect("remove fixture key");
+            RemoteSshIdentityError::Missing
+        } else {
+            let other = fixture
+                .identities
+                .prepare_new(
+                    crate::cloud_run::CloudWorkflowId::new(),
+                    crate::cloud_run::CloudJobId::new(),
+                )
+                .expect("other key");
+            std::fs::write(
+                key.private_key_path(),
+                std::fs::read(other.private_key_path()).expect("other bytes"),
+            )
+            .expect("mismatch fixture");
+            RemoteSshIdentityError::Mismatch
+        };
+        let provider = fixture.provider();
+        assert_eq!(fixture.retry(&provider), Err(expected.into()));
+        assert_eq!(fixture.reload(), saved);
+        assert_eq!(provider.calls(), [0; 5]);
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+        if missing {
+            assert!(!key.private_key_path().exists());
+        }
+    }
+}
+
+#[test]
+fn setup_management_and_snapshot_changes_fail_closed_without_provider_cleanup() {
+    let fixture = Fixture::new();
+    let allocation = fixture.allocate();
+    let provider = fixture.provider();
+    let mut state = allocation.workspace().state().clone();
+    let runtime = state.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Cancelling;
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 1,
+    });
+    fixture
+        .store
+        .replace_remote_workspace(allocation.workspace(), &state)
+        .expect("intent");
+    assert_eq!(
+        retry_remote_workspace_setup(&fixture.store, &fixture.identities, &provider, &allocation),
+        Err(RemoteWorkspaceRecoveryError::StateChanged.into())
+    );
+    assert_eq!(
+        fixture.retry(&provider),
+        Err(RemoteWorkspaceRecoveryError::ManagementPending.into())
+    );
+    assert_eq!(provider.calls(), [0; 5]);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn a_late_provider_response_cannot_overwrite_newer_workspace_intent() {
+    let fixture = Fixture::new();
+    let mut provider = fixture.provider();
+    let store = fixture.store.clone();
+    provider.after_create = Some(Box::new(move || {
+        let allocation = store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation");
+        let mut state = allocation.workspace().state().clone();
+        state.spec.working_directory = "changed".into();
+        store
+            .replace_remote_workspace(allocation.workspace(), &state)
+            .expect("user edit");
+    }));
+    assert_eq!(
+        start_remote_workspace(
+            &fixture.store,
+            &fixture.identities,
+            &provider,
+            &fixture.dormant,
+            i64::MAX
+        ),
+        Err(RemoteWorkspaceRecoveryError::StateChanged.into())
+    );
+    assert_eq!(fixture.reload().workspace().state().spec.working_directory, "changed");
+    assert!(
+        fixture
+            .reload()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_none()
+    );
+    assert_eq!(provider.calls(), [1, 1, 0, 0, 0]);
+    fixture.retry(&provider).expect("recover only");
+    assert_eq!(provider.calls(), [1, 1, 1, 0, 0]);
+}
+
+#[test]
+fn concurrent_explicit_starts_allocate_once_and_concurrent_retries_create_once() {
+    for retry in [false, true] {
+        let fixture = Fixture::new();
+        if retry {
+            let allocation = fixture.allocate();
+            let key = retained_key(&fixture);
+            fixture
+                .store
+                .reserve_remote_worker_request(&allocation, key.public_key())
+                .expect("reserve");
+        }
+        let expected = retry.then(|| fixture.reload());
+        let provider = fixture.provider();
+        let barrier = std::sync::Barrier::new(2);
+        let results = std::thread::scope(|scope| {
+            let run = || {
+                barrier.wait();
+                if let Some(expected) = &expected {
+                    retry_remote_workspace_setup(&fixture.store, &fixture.identities, &provider, expected)
+                } else {
+                    start_remote_workspace(
+                        &fixture.store,
+                        &fixture.identities,
+                        &provider,
+                        &fixture.dormant,
+                        i64::MAX,
+                    )
+                }
+            };
+            let first = scope.spawn(run);
+            let second = scope.spawn(run);
+            [first.join().expect("first"), second.join().expect("second")]
+        });
+        assert!(results.iter().any(Result::is_ok));
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+        assert_eq!(provider.calls()[1], 1);
+        assert_eq!(provider.calls()[4], 0);
+    }
+}
+
+#[test]
+fn setup_expiry_never_renews_creation_or_prevents_recovery_of_a_persistent_worker() {
+    for created in [false, true] {
+        let fixture = Fixture::new();
+        let provider = fixture.provider();
+        if created {
+            provider.fail_response.store(true, Ordering::SeqCst);
+            assert!(
+                start_remote_workspace(
+                    &fixture.store,
+                    &fixture.identities,
+                    &provider,
+                    &fixture.dormant,
+                    i64::MAX
+                )
+                .is_err()
+            );
+        } else {
+            fixture.allocate();
+        }
+        let mut workflow = fixture.reload().workflow().workflow().clone();
+        workflow.created_at_millis = 1000;
+        workflow.updated_at_millis = 1000;
+        workflow.retain_until_millis = 2000;
+        rusqlite::Connection::open(fixture.store.path())
+            .expect("database")
+            .execute(
+                "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000, retain_until_millis=2000,
+             snapshot=?1 WHERE workflow_id=?2",
+                rusqlite::params![
+                    serde_json::to_vec(&workflow).expect("snapshot"),
+                    workflow.id.to_string()
+                ],
+            )
+            .expect("expired fixture");
+        let before = fixture.reload();
+        if created {
+            let recovered = fixture.retry(&provider).expect("persistent recovery");
+            assert_eq!(recovered.workflow(), before.workflow());
+            assert_eq!(provider.calls(), [1, 1, 1, 0, 0]);
+            assert_eq!(fixture.counts(), [1, 1, 1]);
+        } else {
+            assert_eq!(
+                fixture.retry(&provider),
+                Err(RemoteWorkspaceRecoveryError::MissingRequest.into())
+            );
+            assert_eq!(fixture.reload(), before);
+            assert_eq!(provider.calls(), [0; 5]);
+            assert_eq!(fixture.counts(), [1, 1, 0]);
+        }
+    }
+}
+
+#[test]
+fn wrong_observation_preserves_the_request_and_consumed_grant_without_cleanup() {
+    let fixture = Fixture::new();
+    let mut provider = fixture.provider();
+    provider.invalid_observation = true;
+    assert_eq!(
+        start_remote_workspace(
+            &fixture.store,
+            &fixture.identities,
+            &provider,
+            &fixture.dormant,
+            i64::MAX
+        ),
+        Err(RemoteWorkspaceRecoveryError::InvalidObservation.into())
+    );
+    let saved = fixture.reload();
+    assert!(saved.worker_request().is_ok());
+    assert!(
+        saved
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_none()
+    );
+    assert_eq!(provider.calls(), [1, 1, 0, 0, 0]);
+    assert_eq!(fixture.counts(), [1, 1, 1]);
+    fixture.retry(&provider).expect("noncreating recovery of actual worker");
+    assert_eq!(provider.calls(), [1, 1, 1, 0, 0]);
+}
+
+#[test]
+fn stale_workflow_snapshot_is_rejected_before_key_preparation_or_ensure() {
+    let fixture = Fixture::new();
+    let allocation = fixture.allocate();
+    let mut workflow = allocation.workflow().workflow().clone();
+    workflow.title = "Updated intent".into();
+    workflow.updated_at_millis += 1;
+    fixture
+        .store
+        .replace(allocation.workflow(), &workflow)
+        .expect("workflow edit");
+    let provider = fixture.provider();
+    assert_eq!(
+        retry_remote_workspace_setup(&fixture.store, &fixture.identities, &provider, &allocation),
+        Err(RemoteWorkspaceRecoveryError::StateChanged.into())
+    );
+    assert!(!fixture.directory.path().join("home/remote-ssh-identities").exists());
+    assert_eq!(provider.calls(), [0; 5]);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}

--- a/crates/horizon-core/src/remote_workspace_setup/tests/lifecycle.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/tests/lifecycle.rs
@@ -10,6 +10,24 @@ fn retained_key(fixture: &Fixture) -> crate::remote_ssh_identity::RemoteSshIdent
         .expect("key")
 }
 
+fn expire_setup(fixture: &Fixture) {
+    let mut workflow = fixture.reload().workflow().workflow().clone();
+    workflow.created_at_millis = 1000;
+    workflow.updated_at_millis = 1000;
+    workflow.retain_until_millis = 2000;
+    rusqlite::Connection::open(fixture.store.path())
+        .expect("database")
+        .execute(
+            "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000, retain_until_millis=2000,
+             snapshot=?1 WHERE workflow_id=?2",
+            rusqlite::params![
+                serde_json::to_vec(&workflow).expect("snapshot"),
+                workflow.id.to_string()
+            ],
+        )
+        .expect("expired fixture");
+}
+
 #[test]
 fn explicit_start_retains_one_allocation_request_and_key_without_claiming_task_readiness() {
     let fixture = Fixture::new();
@@ -347,21 +365,7 @@ fn setup_expiry_never_renews_creation_or_prevents_recovery_of_a_persistent_worke
         } else {
             fixture.allocate();
         }
-        let mut workflow = fixture.reload().workflow().workflow().clone();
-        workflow.created_at_millis = 1000;
-        workflow.updated_at_millis = 1000;
-        workflow.retain_until_millis = 2000;
-        rusqlite::Connection::open(fixture.store.path())
-            .expect("database")
-            .execute(
-                "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000, retain_until_millis=2000,
-             snapshot=?1 WHERE workflow_id=?2",
-                rusqlite::params![
-                    serde_json::to_vec(&workflow).expect("snapshot"),
-                    workflow.id.to_string()
-                ],
-            )
-            .expect("expired fixture");
+        expire_setup(&fixture);
         let before = fixture.reload();
         if created {
             let recovered = fixture.retry(&provider).expect("persistent recovery");
@@ -432,4 +436,38 @@ fn stale_workflow_snapshot_is_rejected_before_key_preparation_or_ensure() {
     assert!(!fixture.directory.path().join("home/remote-ssh-identities").exists());
     assert_eq!(provider.calls(), [0; 5]);
     assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn failed_identity_preparation_rechecks_expiry_without_losing_an_available_setups_error() {
+    for expired in [false, true] {
+        let fixture = Fixture::new();
+        let allocation = fixture.allocate();
+        assert!(setup_available(&fixture.store, &allocation).expect("admitted"));
+        let key = retained_key(&fixture);
+        let bytes = std::fs::read(key.private_key_path()).expect("retained key");
+        let provider = fixture.provider();
+        if expired {
+            expire_setup(&fixture);
+        }
+        let current = fixture.reload();
+        let error = if expired {
+            prepare_identity(&fixture.store, &fixture.identities, &current).expect_err("reservation after expiry")
+        } else {
+            RemoteSshIdentityError::KeyUtilityFailed.into()
+        };
+        let expected = if expired {
+            RemoteWorkspaceRecoveryError::MissingRequest.into()
+        } else {
+            RemoteSshIdentityError::KeyUtilityFailed.into()
+        };
+        assert_eq!(
+            recover_preparation_failure(&fixture.store, &fixture.identities, &provider, &current, error),
+            Err(expected)
+        );
+        assert_eq!(fixture.reload(), current);
+        assert_eq!(std::fs::read(key.private_key_path()).expect("retained key"), bytes);
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+        assert_eq!(provider.calls(), [0; 5]);
+    }
 }

--- a/crates/horizon-core/src/remote_workspace_setup/tests/lifecycle.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/tests/lifecycle.rs
@@ -45,6 +45,40 @@ fn explicit_start_retains_one_allocation_request_and_key_without_claiming_task_r
 }
 
 #[test]
+fn invalid_setup_retention_is_actionable_without_allocating_or_preparing_keys() {
+    let fixture = Fixture::new();
+    let provider = fixture.provider();
+    assert_eq!(
+        start_remote_workspace(&fixture.store, &fixture.identities, &provider, &fixture.dormant, 0),
+        Err(RemoteWorkspaceSetupError::InvalidAllocationRetention)
+    );
+    assert_eq!(fixture.counts(), [0; 3]);
+    assert_eq!(provider.calls(), [0; 5]);
+    assert!(!fixture.directory.path().join("home/remote-ssh-identities").exists());
+}
+
+#[test]
+fn an_existing_allocation_requires_recovery_instead_of_reporting_storage_failure() {
+    let fixture = Fixture::new();
+    let allocation = fixture.allocate();
+    let provider = fixture.provider();
+    assert_eq!(
+        start_remote_workspace(
+            &fixture.store,
+            &fixture.identities,
+            &provider,
+            allocation.workspace(),
+            i64::MAX
+        ),
+        Err(RemoteWorkspaceSetupError::RuntimeAlreadyActive)
+    );
+    assert_eq!(fixture.reload(), allocation);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+    assert_eq!(provider.calls(), [0; 5]);
+    assert!(!fixture.directory.path().join("home/remote-ssh-identities").exists());
+}
+
+#[test]
 fn interruptions_before_key_reservation_or_creation_reuse_the_exact_generation() {
     for interruption in 0..3 {
         let fixture = Fixture::new();

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -107,6 +107,11 @@ back into large multi-purpose modules.
   `cloud_run/store/remote_allocations/recovery.rs` atomically checks both snapshots
   before retaining exact worker/host identity and marking reconciliation; neither
   absence nor client drop grants creation, restart or remote cleanup.
+- `remote_workspace_setup.rs` sequences explicit allocation, retained private
+  identity, public request reservation and fenced provider ensure. Its store
+  admission leaf checks exact snapshots without granting creation authority;
+  claimed, observed or expired retries use non-creating recovery. Setup remains
+  separate from attachment, task readiness and explicit remote management.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Continue #383 with an explicit setup coordinator for an owned remote workspace.
Initial setup and interrupted setup retry remain separate from reconnecting to
existing work.

## Behavior

- Allocate one runtime generation and retain its private identity plus exact
  public request before provider creation.
- Recheck owned workspace/workflow snapshots after identity I/O; provider creation
  still requires the same store's durable one-shot fence.
- Recheck setup admission after failed identity preparation too: an expired setup
  enters non-creating recovery, while a still-admitted failure keeps its original error.
- Route claimed, observed or expired setup attempts through non-creating recovery.
  Keep the allocation and identity after uncertain failures; never substitute keys.
- Validate and record observations atomically, leaving the runtime Reconciling.
  This does not claim task readiness or authorize attachment. The coordinator
  does not call stop/delete; admitted provider ensure retains its existing contract.

Private identity storage remains Linux-only. Calls are synchronous and belong off
the render thread. UI wiring, task attachment, live provider acceptance and remote
data durability remain separate work under #383.

## Validation

- Fifteen focused regressions using isolated real storage/private identities and
  a fake provider consuming the actual creation grant: concurrent starts/retries,
  interrupted setup, uncertain responses, missing/mismatched identities, stale
  snapshots, pending management, expiry, invalid observations and precise rejection
  of an existing allocation or invalid setup deadline without side effects.
  A deterministic post-preparation expiry test verifies read-only recovery,
  retained private-key bytes and zero provider calls.
- Full source and exact-commit validation on `21559a1` in this worktree:
  formatting, maintainability, version sync,
  default/speech workspace tests with warnings denied, blocking/strict Clippy
  and advisory pedantic Clippy.
- Independent local source and final-base integration review completed without
  actionable findings. No UI/config/dependency changes; no paid resource used.

Scope: eight source/test files, 910 changed source/test lines, plus architecture
notes. No release or image publication is included.
