### PR TITLE
Accept structured remote panel requests

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -143,6 +143,23 @@ escaping that repository are rejected. Arguments are passed directly through
 `horizon-agent-session`, never reconstructed as shell text. Use an explicit shell
 program only when shell evaluation is actually intended.
 
+Controllers can invoke the fixed command `horizon-panel-session request` and
+send one UTF-8 JSON object on stdin, then close stdin. This keeps task arguments
+out of a reconstructed remote shell command. Requests are bounded to 512 KiB,
+require version 1 and reject duplicate/unknown fields or invalid field types.
+For an explicit start:
+
+```json
+{"version":1,"operation":"start","runtime":"c8203298-3169-48d6-84fd-882d8d49a7b4","panel":"terminal_a","directory":".","argv":["/bin/bash"]}
+```
+
+A status request contains only `version`, `operation`, `runtime` and `panel`,
+with `operation` set to `status`. Both return the existing JSON status shape.
+Status never creates a session; repeating start retains the existing one-shot
+intent rules. Interactive attachment still uses the separate `attach` command
+and PTY. Malformed request errors never echo stdin or task content. This protocol
+does not itself provide authenticated transport or authorize a new task.
+
 Before starting anything, the helper durably publishes one private no-overwrite
 marker for the runtime/panel pair. Repeating the same start can only inspect that
 task; a changed launch intent is rejected. Each runtime has a dedicated tmux
@@ -165,7 +182,7 @@ volumes, backup and explicit restart remain separate integration requirements.
 This helper does not yet connect local panels, stop tasks or delete workspaces.
 
 With `bison`, `libevent-dev`, `libncurses-dev`, a C compiler and Make installed, build a
-disposable test binary under a new prefix, then run the fourteen regressions:
+disposable test binary under a new prefix, then run the twenty-one regressions:
 
 ```bash
 test_root=$(mktemp -d /tmp/horizon-panel-tests.XXXXXX)
@@ -175,7 +192,9 @@ PATH="$test_root/tools/bin:$PATH" python3 -B containers/remote-worker/test_panel
 
 Coverage includes repeated PTY disconnects, retained completion, concurrent
 starts, literal semicolon/format arguments, locale-independent status and no
-recreation after server loss. Tests own only their private temporary directories
+recreation after server loss. Structured-request coverage includes literal argv,
+non-creating status, disconnected progress, bounded/invalid input and redaction.
+Tests own only their private temporary directories
 and dedicated sockets. Keep the disposable tool prefix for repeated validation,
 then remove only that exact task-owned prefix when finished.
 

--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -13,9 +13,50 @@ import sys
 import tempfile
 import uuid
 
+MAX_REQUEST_BYTES = 512 * 1024
+
 
 class SessionError(Exception):
     """Messages contain no command, filesystem path or subprocess output."""
+
+
+def unique_fields(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise SessionError("structured session request contains duplicate fields")
+        result[key] = value
+    return result
+
+
+def execute_request(service, stream):
+    """One bounded UTF-8 request on stdin; task arguments never enter a shell string."""
+    raw = stream.read(MAX_REQUEST_BYTES + 1)
+    if len(raw) > MAX_REQUEST_BYTES:
+        raise SessionError("structured session request exceeds its limit")
+    try:
+        request = json.loads(raw.decode("utf-8"), object_pairs_hook=unique_fields)
+    except (ValueError, RecursionError) as error:
+        raise SessionError("structured session request is invalid") from error
+    common = {"version", "operation", "runtime", "panel"}
+    if (
+        not isinstance(request, dict)
+        or type(request.get("version")) is not int or request["version"] != 1
+        or not isinstance(request.get("runtime"), str)
+        or not isinstance(request.get("panel"), str)
+    ):
+        raise SessionError("structured session request is invalid")
+    if request.get("operation") == "status" and set(request) == common:
+        return service.status(request["runtime"], request["panel"])
+    if request.get("operation") != "start" or set(request) != common | {"directory", "argv"}:
+        raise SessionError("unsupported structured session request")
+    if (
+        not isinstance(request["directory"], str)
+        or not isinstance(request["argv"], list)
+        or not all(isinstance(argument, str) for argument in request["argv"])
+    ):
+        raise SessionError("structured task intent is invalid")
+    return service.start(request["runtime"], request["panel"], request["directory"], request["argv"])
 
 
 def private_directory(path):
@@ -201,15 +242,20 @@ class PanelSessions:
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("operation", choices=("start", "status", "attach"))
-    parser.add_argument("runtime")
-    parser.add_argument("panel")
-    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    operations = parser.add_subparsers(dest="operation", required=True)
+    operations.add_parser("request", help="read one versioned start/status request from stdin")
+    for operation in ("start", "status", "attach"):
+        command = operations.add_parser(operation)
+        command.add_argument("runtime")
+        command.add_argument("panel")
+        command.add_argument("arguments", nargs=argparse.REMAINDER)
     arguments = parser.parse_args()
     service = PanelSessions("/workspace/horizon", "/var/lib/horizon/panels", "/run/horizon/panels",
                             "/etc/horizon/tmux.conf", "/usr/local/bin/horizon-agent-session")
     try:
-        if arguments.operation == "start":
+        if arguments.operation == "request":
+            result = execute_request(service, sys.stdin.buffer)
+        elif arguments.operation == "start":
             if len(arguments.arguments) < 3 or arguments.arguments[1] != "--":
                 raise SessionError("start requires a relative directory, --, and a program")
             result = service.start(arguments.runtime, arguments.panel, arguments.arguments[0], arguments.arguments[2:])

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -2,6 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 import importlib.util
+import io
 import json
 import os
 from pathlib import Path
@@ -97,6 +98,87 @@ class PanelSessionTests(unittest.TestCase):
         self.assertEqual(first["pid"], again["pid"])
         self.assertEqual(again["state"], "running")
         self.assertEqual(self.service.tmux(runtime, "list-clients", check=False).stdout, b"")
+
+    def request(self, operation, panel="structured", **intent):
+        return {"version": 1, "operation": operation, "runtime": self.runtimes[0], "panel": panel, **intent}
+
+    def execute(self, request):
+        return MODULE.execute_request(self.service, io.BytesIO(json.dumps(request).encode()))
+
+    def test_structured_start_and_status_reuse_the_same_task_after_disconnect(self):
+        request = self.request("start", directory="nested space", argv=self.tick_command())
+        first = self.execute(request)
+        ticks = self.repository / "nested space" / "ticks"
+        self.wait_for(ticks.exists)
+        self.attach_and_disconnect(self.runtimes[0], "structured")
+        before = len(ticks.read_text().splitlines())
+        self.wait_for(lambda: len(ticks.read_text().splitlines()) > before + 2)
+        self.assertEqual(self.execute(self.request("status"))["pid"], first["pid"])
+        self.assertEqual(self.execute(request)["pid"], first["pid"])
+
+    def test_structured_payload_keeps_literal_argv_and_does_not_persist_task_content(self):
+        literals = ["", "$(touch injected);", "'quoted'", "line\nbreak", "\u00e6\u00f8\u00e5", "\\;", "#{l:..}"]
+        command = self.command("import json,sys; from pathlib import Path; Path('argv').write_text(json.dumps(sys.argv[1:]))") + literals
+        self.execute(self.request("start", directory=".", argv=command))
+        self.wait_for(lambda: (self.repository / "argv").exists() and (self.repository / "argv").read_text() == json.dumps(literals))
+        self.assertEqual(json.loads((self.repository / "argv").read_text()), literals)
+        self.assertFalse((self.repository / "injected").exists())
+        self.assertNotIn("touch injected", self.service.marker_path(self.runtimes[0], "structured").read_text())
+
+    def test_structured_status_never_creates_an_absent_task(self):
+        with self.assertRaises(FileNotFoundError):
+            self.execute(self.request("status"))
+        self.assertFalse(self.service.state.exists())
+        self.assertFalse(self.service.sockets.exists())
+
+    def test_structured_request_rejects_unknown_fields_versions_and_types_before_launch(self):
+        valid = self.request("start", directory=".", argv=self.tick_command())
+        cases = [None, [], {}, {**valid, "version": True}, {**valid, "version": 2},
+                 {**valid, "runtime": 7}, {**valid, "panel": []}, {**valid, "directory": None},
+                 {**valid, "argv": "sh"}, {**valid, "argv": ["sh", None]}, {**valid, "extra": "secret"},
+                 {**valid, "operation": "attach"}, {**valid, "operation": "status"},
+                 {**valid, "argv": []}, {**valid, "argv": ["-invalid"]},
+                 {**valid, "argv": ["sh", "\0"]}, {**valid, "directory": ".."},
+                 {**valid, "runtime": "invalid"}, {**valid, "panel": "panel;other"}]
+        for request in cases:
+            with self.subTest(request=request), self.assertRaises(MODULE.SessionError):
+                self.execute(request)
+        self.assertFalse(self.service.state.exists())
+        self.assertFalse(self.service.sockets.exists())
+
+    def test_structured_request_rejects_malformed_duplicate_and_oversized_input(self):
+        valid = json.dumps(self.request("start", directory=".", argv=self.tick_command())).encode()
+        duplicate = valid[:-1] + b',"version":1}'
+        cases = [b"", b"secret payload", b"\xff", b"[]", b'{} {}',
+                 duplicate, b"[" * 2000 + b"]" * 2000,
+                 b" " * (MODULE.MAX_REQUEST_BYTES + 1)]
+        for raw in cases:
+            with mock.patch.object(self.service, "start") as start, mock.patch.object(self.service, "status") as status:
+                with self.subTest(length=len(raw)), self.assertRaises(MODULE.SessionError) as caught:
+                    MODULE.execute_request(self.service, io.BytesIO(raw))
+                start.assert_not_called()
+                status.assert_not_called()
+            self.assertNotIn("secret payload", str(caught.exception))
+        self.assertFalse(self.service.state.exists())
+
+    def test_structured_input_read_is_bounded(self):
+        stream = mock.Mock()
+        stream.read.return_value = b" " * (MODULE.MAX_REQUEST_BYTES + 1)
+        with self.assertRaises(MODULE.SessionError):
+            MODULE.execute_request(self.service, stream)
+        stream.read.assert_called_once_with(MODULE.MAX_REQUEST_BYTES + 1)
+
+    def test_structured_cli_errors_do_not_echo_stdin_and_legacy_help_remains_available(self):
+        result = MODULE.subprocess.run([sys.executable, str(HERE / "panel-session.py"), "request"],
+                                       input=b"synthetic-private-request", capture_output=True, timeout=3, check=False)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, b"")
+        self.assertNotIn(b"synthetic-private-request", result.stderr)
+        self.assertNotIn(b"Traceback", result.stderr)
+        for operation in ("start", "status", "attach", "request"):
+            result = MODULE.subprocess.run([sys.executable, str(HERE / "panel-session.py"), operation, "--help"],
+                                           capture_output=True, timeout=3, check=False)
+            self.assertEqual(result.returncode, 0)
 
     def test_exited_task_is_retained_and_not_reexecuted_on_start_or_attach(self):
         runtime = self.runtimes[0]


### PR DESCRIPTION
## Purpose

Continue #383 with a bounded worker-side request protocol for retained panel
sessions. This is the transport prerequisite for literal task arguments over SSH.

## Behavior

- Accept one versioned UTF-8 JSON start/status request on stdin through the fixed
  `horizon-panel-session request` command, limited to 512 KiB.
- Reject duplicate or unknown fields, unsupported versions, malformed input and
  invalid launch data without echoing private task content.
- Preserve literal argv boundaries and existing one-shot task ownership. Status
  cannot create a task; repeated start cannot restart completed or lost sessions.
- Keep interactive attachment separate. Disconnecting the final client leaves
  the same worker and task running. Legacy start/status/attach commands remain.

This does not add client UI wiring, new worker creation, repository transfer,
credential transfer or durable remote storage. It does not complete #383.

## Validation

- All 21 worker regressions passed in the pinned local worker image with the
  candidate source mounted read-only, networking disabled and private temporary
  state; the disposable container was removed.
- Live pinned local SSH/PTY smoke: retained PID and progress after final-client
  disconnect, repeated-start idempotency, literal special-character/Unicode argv,
  retained exit status, redacted malformed input, and continued worker lifetime.
  Only exact task-owned containers and generated test keys were cleaned up.
- Independent source and fresh-main integration review are clear. Full source
  and exact-commit Horizon matrices passed on `96357a8`: formatting, maintainability, version
  sync, default/speech workspace tests, blocking/strict and advisory Clippy.
  All 21 worker regressions and the live SSH/PTY smoke were repeated successfully
  on that unchanged commit.

Linux worker and pinned tmux 3.7c are the runtime assumptions. Local disconnect
proof is not real-cloud PC-off acceptance. No paid resources, image publication
or release are included. Scope: two source/test files, 138 changed lines, plus
the worker protocol documentation.
