### PR TITLE
Inspect retained panels over pinned SSH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ process-wrap = { version = "10.0.0", default-features = false, features = ["std"
 atomicwrites = "0.4.4"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 libc = "0.2.189"
-rustix = { version = "1.1.4", features = ["process"] }
+rustix = { version = "1.1.4", features = ["fs", "process"] }
 uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
 regex = "1.13.1"

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -37,6 +37,7 @@ atomicwrites.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 horizon-browser = { workspace = true, features = ["test-support"] }

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -21,6 +21,7 @@ mod opencode_paths;
 mod panel;
 mod remote_hosts;
 pub mod remote_ssh_identity;
+pub mod remote_worker_status;
 pub mod remote_workspace;
 pub mod remote_workspace_recovery;
 pub mod remote_workspace_setup;

--- a/crates/horizon-core/src/remote_worker_status.rs
+++ b/crates/horizon-core/src/remote_worker_status.rs
@@ -1,0 +1,140 @@
+//! Bounded, non-creating panel inspection through the retained worker's pinned SSH identity.
+//! Calls are synchronous and must run off the render thread.
+
+#[cfg(target_os = "linux")]
+mod command;
+#[cfg(target_os = "linux")]
+mod protocol;
+#[cfg(target_os = "linux")]
+mod ssh;
+
+use crate::{cloud_run::CloudWorkflowStore, remote_workspace_recovery::RecoveredRemoteWorkspace};
+
+/// A point-in-time task observation, never permission to start or replace a task.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RemotePanelStatus {
+    Running { pid: u32 },
+    Exited { pid: u32, exit_status: Option<u8> },
+    Unavailable,
+}
+
+/// Inspect one saved panel after non-creating owned recovery. Both owned snapshots,
+/// exact worker/host identity and current lifetime are checked before and after I/O.
+/// The caller remains responsible for fresh provider/cost-policy admission. This
+/// neither marks the workspace Ready nor authorizes attachment or task execution.
+/// Dropping the local query never stops or deletes the worker or retained task.
+/// # Errors
+/// Rejects stale ownership, pending management, absent/non-ready workers, unknown
+/// panels, unsupported key paths/platforms, failed SSH and invalid/bounded output.
+pub fn inspect_remote_panel(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    panel_id: &str,
+) -> Result<RemotePanelStatus, RemotePanelStatusError> {
+    #[cfg(target_os = "linux")]
+    {
+        inspect_with(store, recovered, panel_id, ssh::request)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, recovered, panel_id);
+        Err(RemotePanelStatusError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_with(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    panel_id: &str,
+    execute: impl FnOnce(
+        &crate::remote_ssh_identity::RemoteSshIdentity,
+        &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+        &[u8],
+    ) -> Result<Vec<u8>, RemotePanelStatusError>,
+) -> Result<RemotePanelStatus, RemotePanelStatusError> {
+    let endpoint = validate_current(store, recovered, panel_id)?;
+    let request = protocol::request(recovered.allocation().worker_request()?.job_id, panel_id)?;
+    let response = execute(recovered.identity(), endpoint, &request)?;
+    let status = protocol::response(&response, panel_id)?;
+    validate_current(store, recovered, panel_id)?;
+    Ok(status)
+}
+
+#[cfg(target_os = "linux")]
+fn validate_current<'a>(
+    store: &CloudWorkflowStore,
+    recovered: &'a RecoveredRemoteWorkspace,
+    panel_id: &str,
+) -> Result<&'a crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, RemotePanelStatusError> {
+    use RemotePanelStatusError as Error;
+    let allocation = recovered.allocation();
+    let workspace = allocation.workspace();
+    let current = store.load_remote_allocation(workspace.session_id(), &workspace.state().spec.workspace_local_id)?;
+    if current.as_ref() != Some(allocation) {
+        return Err(Error::StateChanged);
+    }
+    let request = allocation.recovery_request()?;
+    if !workspace
+        .state()
+        .spec
+        .panels
+        .iter()
+        .any(|panel| panel.panel_local_id == panel_id)
+    {
+        return Err(Error::UnknownPanel);
+    }
+    let runtime = workspace.state().runtime.as_ref().ok_or(Error::WorkerUnavailable)?;
+    let observation = recovered.observation().ok_or(Error::WorkerUnavailable)?;
+    if !observation.is_ready_for(&request, time::OffsetDateTime::now_utc())
+        || recovered.identity().public_key() != request.ssh_public_key
+        || runtime.worker.as_ref() != Some(&observation.worker)
+        || runtime.ssh != observation.ssh
+    {
+        return Err(Error::WorkerUnavailable);
+    }
+    observation.ssh.as_ref().ok_or(Error::WorkerUnavailable)
+}
+
+/// No error includes private paths, task data, provider payloads or subprocess output.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemotePanelStatusError {
+    #[error("remote allocation changed; recover its current state before inspecting panels")]
+    StateChanged,
+    #[error("remote workspace has pending management intent")]
+    ManagementPending,
+    #[error("remote worker is not available through its retained pinned identity")]
+    WorkerUnavailable,
+    #[error("panel identity is not part of the owned remote workspace")]
+    UnknownPanel,
+    #[error("owned remote state could not be safely inspected")]
+    StorageUnavailable,
+    #[error("remote SSH identity or trust path is unsupported")]
+    UnsupportedPath,
+    #[error("private SSH trust material could not be prepared")]
+    TrustStorage,
+    #[error("SSH client is unavailable")]
+    ClientUnavailable,
+    #[error("remote panel query failed; no task was started or replaced")]
+    QueryFailed,
+    #[error("remote panel query exceeded its deadline")]
+    Deadline,
+    #[error("remote panel response is invalid or exceeds its size limit")]
+    InvalidResponse,
+    #[error("protected remote panel inspection is not yet supported on this platform")]
+    UnsupportedPlatform,
+}
+
+impl From<crate::cloud_run::RemoteWorkspaceStoreError> for RemotePanelStatusError {
+    fn from(error: crate::cloud_run::RemoteWorkspaceStoreError) -> Self {
+        use crate::cloud_run::RemoteWorkspaceStoreError as Store;
+        match error {
+            Store::SnapshotConflict | Store::RevisionConflict { .. } => Self::StateChanged,
+            Store::RuntimeRecoveryUnavailable => Self::ManagementPending,
+            _ => Self::StorageUnavailable,
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_worker_status/command.rs
+++ b/crates/horizon-core/src/remote_worker_status/command.rs
@@ -1,0 +1,93 @@
+use super::{RemotePanelStatusError as Error, protocol::RESPONSE_LIMIT};
+use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+use std::{
+    io::{self, Read, Write},
+    os::fd::AsFd,
+    process::{Child, ChildStdin, Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+pub(super) fn run(mut command: Command, input: &[u8], timeout: Duration) -> Result<Vec<u8>, Error> {
+    let started = Instant::now();
+    let child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                Error::ClientUnavailable
+            } else {
+                Error::QueryFailed
+            }
+        })?;
+    let mut child = OwnedChild(child);
+    let mut stdin = Some(child.0.stdin.take().ok_or(Error::QueryFailed)?);
+    let mut stdout = child.0.stdout.take().ok_or(Error::QueryFailed)?;
+    nonblocking(stdin.as_ref().ok_or(Error::QueryFailed)?)?;
+    nonblocking(&stdout)?;
+    let mut pending = input;
+    let mut output = Vec::new();
+    loop {
+        if started.elapsed() >= timeout {
+            return Err(Error::Deadline);
+        }
+        write_pending(&mut stdin, &mut pending)?;
+        let finished = read_available(&mut stdout, &mut output)?;
+        if let Some(status) = child.0.try_wait().map_err(|_| Error::QueryFailed)? {
+            if !status.success() || !pending.is_empty() {
+                return Err(Error::QueryFailed);
+            }
+            if finished {
+                return Ok(output);
+            }
+        }
+        thread::sleep(Duration::from_millis(10).min(timeout.saturating_sub(started.elapsed())));
+    }
+}
+
+fn nonblocking(fd: &impl AsFd) -> Result<(), Error> {
+    let flags = fcntl_getfl(fd).map_err(|_| Error::QueryFailed)?;
+    fcntl_setfl(fd, flags | OFlags::NONBLOCK).map_err(|_| Error::QueryFailed)
+}
+
+fn write_pending(stdin: &mut Option<ChildStdin>, pending: &mut &[u8]) -> Result<(), Error> {
+    if let Some(stream) = stdin {
+        match stream.write(pending) {
+            Ok(count) => *pending = &pending[count..],
+            Err(error) if matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) => {}
+            Err(_) => return Err(Error::QueryFailed),
+        }
+        if pending.is_empty() {
+            stdin.take();
+        }
+    }
+    Ok(())
+}
+
+fn read_available(stream: &mut impl Read, output: &mut Vec<u8>) -> Result<bool, Error> {
+    let mut buffer = [0; 1024];
+    // One read per pass keeps even a peer's endless output inside the elapsed-time budget.
+    match stream.read(&mut buffer) {
+        Ok(0) => Ok(true),
+        Ok(count) if output.len() + count <= RESPONSE_LIMIT => {
+            output.extend_from_slice(&buffer[..count]);
+            Ok(false)
+        }
+        Ok(_) => Err(Error::InvalidResponse),
+        Err(error) if matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) => Ok(false),
+        Err(_) => Err(Error::QueryFailed),
+    }
+}
+
+struct OwnedChild(Child);
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        if !matches!(self.0.try_wait(), Ok(Some(_))) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}

--- a/crates/horizon-core/src/remote_worker_status/protocol.rs
+++ b/crates/horizon-core/src/remote_worker_status/protocol.rs
@@ -1,0 +1,60 @@
+use super::{RemotePanelStatus, RemotePanelStatusError as Error};
+use crate::cloud_run::CloudJobId;
+use serde::{Deserialize, Serialize};
+
+pub(super) const RESPONSE_LIMIT: usize = 4096;
+
+pub(super) fn request(runtime: CloudJobId, panel: &str) -> Result<Vec<u8>, Error> {
+    #[derive(Serialize)]
+    struct Request<'a> {
+        version: u8,
+        operation: &'static str,
+        runtime: CloudJobId,
+        panel: &'a str,
+    }
+    serde_json::to_vec(&Request {
+        version: 1,
+        operation: "status",
+        runtime,
+        panel,
+    })
+    .map_err(|_| Error::QueryFailed)
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+enum Response {
+    Running {
+        panel: String,
+        pid: u32,
+        exit_status: Option<u8>,
+    },
+    Exited {
+        panel: String,
+        pid: u32,
+        exit_status: Option<u8>,
+    },
+    Unavailable {
+        panel: String,
+    },
+}
+
+pub(super) fn response(bytes: &[u8], expected: &str) -> Result<RemotePanelStatus, Error> {
+    if bytes.len() > RESPONSE_LIMIT {
+        return Err(Error::InvalidResponse);
+    }
+    match serde_json::from_slice::<Response>(bytes).map_err(|_| Error::InvalidResponse)? {
+        Response::Running {
+            panel,
+            pid,
+            exit_status: None,
+        } if panel == expected && pid != 0 => Ok(RemotePanelStatus::Running { pid }),
+        Response::Exited {
+            panel,
+            pid,
+            exit_status,
+        } if panel == expected && pid != 0 => Ok(RemotePanelStatus::Exited { pid, exit_status }),
+        Response::Unavailable { panel } if panel == expected => Ok(RemotePanelStatus::Unavailable),
+        _ => Err(Error::InvalidResponse),
+    }
+}

--- a/crates/horizon-core/src/remote_worker_status/protocol.rs
+++ b/crates/horizon-core/src/remote_worker_status/protocol.rs
@@ -27,11 +27,13 @@ enum Response {
     Running {
         panel: String,
         pid: u32,
+        #[serde(deserialize_with = "Option::deserialize")]
         exit_status: Option<u8>,
     },
     Exited {
         panel: String,
         pid: u32,
+        #[serde(deserialize_with = "Option::deserialize")]
         exit_status: Option<u8>,
     },
     Unavailable {

--- a/crates/horizon-core/src/remote_worker_status/ssh.rs
+++ b/crates/horizon-core/src/remote_worker_status/ssh.rs
@@ -1,0 +1,89 @@
+use super::{RemotePanelStatusError as Error, command};
+use crate::{cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, remote_ssh_identity::RemoteSshIdentity};
+use std::{io::Write, path::Path, process::Command, time::Duration};
+
+const DEADLINE: Duration = Duration::from_secs(10);
+const HOST_ALIAS: &str = "horizon-retained-worker";
+
+pub(super) fn request(
+    identity: &RemoteSshIdentity,
+    endpoint: &InteractiveWorkerSshEndpoint,
+    input: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // The recovered key's private parent avoids ambient temporary-directory trust.
+    let parent = identity.private_key_path().parent().ok_or(Error::UnsupportedPath)?;
+    let mut known_hosts = tempfile::NamedTempFile::new_in(parent).map_err(|_| Error::TrustStorage)?;
+    writeln!(known_hosts, "{HOST_ALIAS} {}", endpoint.host_key).map_err(|_| Error::TrustStorage)?;
+    let command = prepared_command(identity.private_key_path(), known_hosts.path(), endpoint)?;
+    command::run(command, input, DEADLINE)
+}
+
+pub(super) fn prepared_command(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<Command, Error> {
+    if !endpoint.is_complete() {
+        return Err(Error::WorkerUnavailable);
+    }
+    let mut command = Command::new("ssh");
+    command.args(["-F", "none", "-S", "none", "-T"]);
+    for option in [
+        "BatchMode=yes",
+        "IdentitiesOnly=yes",
+        "IdentityAgent=none",
+        "AddKeysToAgent=no",
+        "PreferredAuthentications=publickey",
+        "PubkeyAcceptedAlgorithms=ssh-ed25519",
+        "PasswordAuthentication=no",
+        "KbdInteractiveAuthentication=no",
+        "NumberOfPasswordPrompts=0",
+        "StrictHostKeyChecking=yes",
+        "HostKeyAlgorithms=ssh-ed25519",
+        "UpdateHostKeys=no",
+        "GlobalKnownHostsFile=/dev/null",
+        "KnownHostsCommand=none",
+        "VerifyHostKeyDNS=no",
+        "CheckHostIP=no",
+        "ClearAllForwardings=yes",
+        "ForwardAgent=no",
+        "ForwardX11=no",
+        "PermitLocalCommand=no",
+        "ProxyCommand=none",
+        "ProxyJump=none",
+        "ConnectionAttempts=1",
+        "ConnectTimeout=5",
+        "ServerAliveInterval=2",
+        "ServerAliveCountMax=1",
+        "EscapeChar=none",
+    ] {
+        command.args(["-o", option]);
+    }
+    command.arg("-o").arg(format!("HostKeyAlias={HOST_ALIAS}"));
+    command.arg("-o").arg(path_option("IdentityFile", identity)?);
+    command.arg("-o").arg(path_option("UserKnownHostsFile", known_hosts)?);
+    command.args([
+        "-p",
+        &endpoint.port.to_string(),
+        "-l",
+        &endpoint.username,
+        "--",
+        &endpoint.host,
+    ]);
+    command.arg("/usr/local/bin/horizon-panel-session request");
+    command.env("SSH_ASKPASS_REQUIRE", "never");
+    Ok(command)
+}
+
+fn path_option(name: &str, path: &Path) -> Result<String, Error> {
+    let path = path
+        .to_str()
+        .filter(|_| path.is_absolute())
+        .ok_or(Error::UnsupportedPath)?;
+    if path.chars().any(|character| character.is_control() || character == '$') {
+        return Err(Error::UnsupportedPath);
+    }
+    // SSH applies its own configuration quoting and percent expansion after argv parsing.
+    let escaped = path.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%");
+    Ok(format!("{name}=\"{escaped}\""))
+}

--- a/crates/horizon-core/src/remote_worker_status/tests.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests.rs
@@ -1,0 +1,250 @@
+use super::*;
+use crate::{
+    HorizonHome, PanelKind,
+    cloud_run::{CloudProvider, StoredRemoteAllocation, interactive_worker::*},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace::{RemotePanelBinding, RemoteWorkspaceState},
+    remote_workspace_recovery::recover_remote_workspace,
+};
+
+#[path = "tests/command.rs"]
+mod command_tests;
+#[path = "tests/ssh.rs"]
+mod ssh_tests;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+const RUNNING: &[u8] = br#"{"state":"running","panel":"terminal","pid":123,"exit_status":null}"#;
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    recovered: RecoveredRemoteWorkspace,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_lifecycle(InteractiveWorkerLifecycle::Ready)
+    }
+
+    fn with_lifecycle(lifecycle: InteractiveWorkerLifecycle) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+        let directory = tempfile::tempdir().expect("fixture");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private fixture");
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let identities = RemoteSshIdentityStore::new(&home);
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": { "provider": "local_docker", "profile": "development",
+                    "image": format!("example/worker@sha256:{}", "a".repeat(64)),
+                    "disk_gib": 20, "lifetime": "persistent" },
+                "repository": { "repository": "example/project", "commit": "b".repeat(40) }
+            }
+        }))
+        .expect("state");
+        state.spec.panels.push(RemotePanelBinding {
+            panel_local_id: "terminal".into(),
+            kind: PanelKind::Shell,
+            command: None,
+            working_directory: None,
+            task_handoff: None,
+            agent_session_id: None,
+        });
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");
+        let identity = identities
+            .prepare_new(runtime.workflow_id, runtime.job_id)
+            .expect("identity");
+        let allocation = store
+            .reserve_remote_worker_request(&allocation, identity.public_key())
+            .expect("request");
+        let request = allocation.worker_request().expect("request");
+        let status = InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: request.target.provider,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: "synthetic-worker".into(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            lifecycle,
+            ssh: Some(InteractiveWorkerSshEndpoint {
+                host: "127.0.0.1".into(),
+                port: 2222,
+                username: "horizon".into(),
+                host_key: identity.public_key().into(),
+            }),
+        };
+        let recovered = recover_remote_workspace(&store, &identities, &Provider(status), OWNER, "workspace")
+            .expect("noncreating recovery");
+        Self {
+            _directory: directory,
+            store,
+            recovered,
+        }
+    }
+
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn edit_intent(&self) {
+        let current = self.current();
+        let mut next = current.workspace().state().clone();
+        next.spec.working_directory = "src".into();
+        self.store
+            .replace_remote_workspace(current.workspace(), &next)
+            .expect("edit");
+    }
+}
+
+struct Provider(InteractiveWorkerStatus);
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.0.worker.identity.provider
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("fixture must never create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(Some(self.0.clone()))
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(Some(self.0.clone()))
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("fixture must never delete")
+    }
+}
+
+#[test]
+fn owned_status_is_noncreating_and_leaves_all_snapshots_and_private_identity_unchanged() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+    let result = inspect_with(
+        &fixture.store,
+        &fixture.recovered,
+        "terminal",
+        |identity, endpoint, input| {
+            assert_eq!(
+                identity.public_key(),
+                before.worker_request().expect("request").ssh_public_key
+            );
+            assert_eq!(
+                endpoint,
+                fixture
+                    .recovered
+                    .observation()
+                    .expect("observation")
+                    .ssh
+                    .as_ref()
+                    .expect("SSH")
+            );
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(input).expect("request"),
+                serde_json::json!({
+                    "version": 1, "operation": "status", "runtime": before.worker_request().expect("request").job_id,
+                    "panel": "terminal"
+                })
+            );
+            Ok(RUNNING.to_vec())
+        },
+    );
+    assert_eq!(result, Ok(RemotePanelStatus::Running { pid: 123 }));
+    assert_eq!(fixture.current(), before);
+    assert_eq!(
+        std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+        key
+    );
+}
+
+#[test]
+fn unknown_panels_and_stale_ownership_never_cross_the_ssh_boundary() {
+    let fixture = Fixture::new();
+    for panel in ["absent", "terminal;start", ""] {
+        assert_eq!(
+            inspect_with(&fixture.store, &fixture.recovered, panel, |_, _, _| panic!("no SSH")),
+            Err(RemotePanelStatusError::UnknownPanel)
+        );
+    }
+    fixture.edit_intent();
+    assert_eq!(
+        inspect_with(&fixture.store, &fixture.recovered, "terminal", |_, _, _| panic!(
+            "no SSH"
+        )),
+        Err(RemotePanelStatusError::StateChanged)
+    );
+}
+
+#[test]
+fn a_nonready_worker_cannot_be_queried_or_started() {
+    let fixture = Fixture::with_lifecycle(InteractiveWorkerLifecycle::Stopped);
+    assert_eq!(
+        inspect_with(&fixture.store, &fixture.recovered, "terminal", |_, _, _| panic!(
+            "no SSH"
+        )),
+        Err(RemotePanelStatusError::WorkerUnavailable)
+    );
+}
+
+#[test]
+fn late_status_cannot_hide_newer_management_or_workspace_intent() {
+    let fixture = Fixture::new();
+    assert_eq!(
+        inspect_with(&fixture.store, &fixture.recovered, "terminal", |_, _, _| {
+            fixture.edit_intent();
+            Ok(RUNNING.to_vec())
+        }),
+        Err(RemotePanelStatusError::StateChanged)
+    );
+    assert_eq!(fixture.current().workspace().state().spec.working_directory, "src");
+}
+
+#[test]
+fn status_protocol_preserves_unknown_completion_and_rejects_wrong_or_unbounded_results() {
+    assert_eq!(
+        protocol::response(br#"{"state":"unavailable","panel":"terminal"}"#, "terminal"),
+        Ok(RemotePanelStatus::Unavailable)
+    );
+    for exit_status in [None, Some(0), Some(42)] {
+        let bytes = serde_json::to_vec(
+            &serde_json::json!({"state":"exited","panel":"terminal","pid":123,"exit_status":exit_status}),
+        )
+        .expect("json");
+        assert_eq!(
+            protocol::response(&bytes, "terminal"),
+            Ok(RemotePanelStatus::Exited { pid: 123, exit_status })
+        );
+    }
+    for bytes in [
+        b"synthetic-private-response".as_slice(),
+        br#"{"state":"running","panel":"other","pid":123}"#,
+        br#"{"state":"running","panel":"terminal","pid":0}"#,
+        br#"{"state":"running","panel":"terminal","pid":123,"exit_status":0}"#,
+        br#"{"state":"exited","panel":"terminal","pid":123,"exit_status":256}"#,
+        br#"{"state":"unavailable","panel":"terminal","argv":["secret"]}"#,
+        br#"{"state":"running","panel":"terminal","panel":"other","pid":123}"#,
+    ] {
+        assert_eq!(
+            protocol::response(bytes, "terminal"),
+            Err(RemotePanelStatusError::InvalidResponse)
+        );
+    }
+    assert_eq!(
+        protocol::response(&vec![b' '; protocol::RESPONSE_LIMIT + 1], "terminal"),
+        Err(RemotePanelStatusError::InvalidResponse)
+    );
+}

--- a/crates/horizon-core/src/remote_worker_status/tests.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests.rs
@@ -231,6 +231,8 @@ fn status_protocol_preserves_unknown_completion_and_rejects_wrong_or_unbounded_r
     }
     for bytes in [
         b"synthetic-private-response".as_slice(),
+        br#"{"state":"running","panel":"terminal","pid":123}"#,
+        br#"{"state":"exited","panel":"terminal","pid":123}"#,
         br#"{"state":"running","panel":"other","pid":123}"#,
         br#"{"state":"running","panel":"terminal","pid":0}"#,
         br#"{"state":"running","panel":"terminal","pid":123,"exit_status":0}"#,

--- a/crates/horizon-core/src/remote_worker_status/tests/command.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests/command.rs
@@ -1,0 +1,68 @@
+use super::*;
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+fn shell(script: &str) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", script]);
+    command
+}
+
+#[test]
+fn bounded_command_closes_stdin_and_never_exposes_subprocess_errors() {
+    assert_eq!(
+        command::run(shell("exec cat"), RUNNING, Duration::from_secs(2)),
+        Ok(RUNNING.to_vec())
+    );
+    let error = command::run(
+        shell("printf synthetic-private-response >&2; exit 7"),
+        b"",
+        Duration::from_secs(2),
+    )
+    .expect_err("failure");
+    assert_eq!(error, RemotePanelStatusError::QueryFailed);
+    assert!(!format!("{error:?} {error}").contains("synthetic-private-response"));
+    assert_eq!(
+        command::run(
+            Command::new("/nonexistent-horizon-status-client"),
+            b"",
+            Duration::from_secs(2)
+        ),
+        Err(RemotePanelStatusError::ClientUnavailable)
+    );
+    assert_eq!(
+        command::run(shell("printf '%06000d' 0"), b"", Duration::from_secs(2)),
+        Err(RemotePanelStatusError::InvalidResponse)
+    );
+}
+
+#[test]
+fn stdin_backpressure_and_inherited_output_cannot_extend_the_deadline() {
+    for (script, input) in [("exec sleep 5", vec![b'x'; 1024 * 1024]), ("sleep 1 & exit 0", vec![])] {
+        let started = Instant::now();
+        assert_eq!(
+            command::run(shell(script), &input, Duration::from_millis(40)),
+            Err(RemotePanelStatusError::Deadline)
+        );
+        assert!(started.elapsed() < Duration::from_millis(800));
+    }
+}
+
+#[test]
+fn timed_out_client_is_reaped_without_signalling_any_other_process() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let pid_file = fixture.path().join("owned-child");
+    let mut child = shell("printf '%s' \"$$\" > \"$1\"; exec sleep 5");
+    child.arg("fixture").arg(&pid_file);
+    assert_eq!(
+        command::run(child, b"", Duration::from_millis(100)),
+        Err(RemotePanelStatusError::Deadline)
+    );
+    let pid: u32 = std::fs::read_to_string(pid_file)
+        .expect("owned PID")
+        .parse()
+        .expect("PID");
+    assert!(!std::path::Path::new("/proc").join(pid.to_string()).exists());
+}

--- a/crates/horizon-core/src/remote_worker_status/tests/ssh.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests/ssh.rs
@@ -1,0 +1,87 @@
+use super::*;
+use std::{
+    ffi::OsString,
+    os::unix::{ffi::OsStringExt, fs::PermissionsExt},
+    path::Path,
+    process::Command,
+};
+
+#[test]
+fn isolated_options_disable_ambient_authentication_trust_and_command_hooks() {
+    let fixture = Fixture::new();
+    let endpoint = fixture
+        .recovered
+        .observation()
+        .expect("observation")
+        .ssh
+        .as_ref()
+        .expect("SSH");
+    let known_hosts = tempfile::NamedTempFile::new().expect("known hosts");
+    let command = ssh::prepared_command(
+        fixture.recovered.identity().private_key_path(),
+        known_hosts.path(),
+        endpoint,
+    )
+    .expect("command");
+    assert_eq!(
+        known_hosts.as_file().metadata().expect("mode").permissions().mode() & 0o077,
+        0
+    );
+    let args: Vec<_> = command.get_args().map(|arg| arg.to_str().expect("UTF8")).collect();
+    assert_eq!(&args[..5], ["-F", "none", "-S", "none", "-T"]);
+    assert_eq!(args.last(), Some(&"/usr/local/bin/horizon-panel-session request"));
+    let output = Command::new("ssh")
+        .arg("-G")
+        .args(command.get_args())
+        .output()
+        .expect("SSH config parser");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let effective = String::from_utf8(output.stdout).expect("config");
+    for expected in [
+        "batchmode yes",
+        "identitiesonly yes",
+        "identityagent none",
+        "stricthostkeychecking true",
+        "updatehostkeys false",
+        "clearallforwardings yes",
+        "permitlocalcommand no",
+        "forwardagent no",
+        "hostkeyalias horizon-retained-worker",
+        "hostkeyalgorithms ssh-ed25519",
+    ] {
+        assert!(effective.lines().any(|line| line == expected), "missing {expected}");
+    }
+}
+
+#[test]
+fn path_options_preserve_config_quoting_and_percent_tokens_without_environment_expansion() {
+    let fixture = Fixture::new();
+    let endpoint = fixture
+        .recovered
+        .observation()
+        .expect("observation")
+        .ssh
+        .as_ref()
+        .expect("SSH");
+    let path = Path::new("/tmp/synthetic space/percent%h/quote\"back\\slash");
+    let command = ssh::prepared_command(path, path, endpoint).expect("literal path");
+    let args: Vec<_> = command.get_args().map(|arg| arg.to_str().expect("UTF8")).collect();
+    assert!(args.contains(&"IdentityFile=\"/tmp/synthetic space/percent%%h/quote\\\"back\\\\slash\""));
+    let parsed = Command::new("ssh")
+        .arg("-G")
+        .args(command.get_args())
+        .output()
+        .expect("parser");
+    assert!(parsed.status.success());
+    for path in ["relative", "/tmp/${PRIVATE}/key", "/tmp/new\nline", "/tmp/null\0byte"] {
+        assert_eq!(
+            ssh::prepared_command(Path::new(path), Path::new("/tmp/known"), endpoint).expect_err("path"),
+            RemotePanelStatusError::UnsupportedPath
+        );
+    }
+    let invalid = OsString::from_vec(vec![b'/', 255]);
+    assert_eq!(
+        ssh::prepared_command(Path::new(&invalid), Path::new("/tmp/known"), endpoint).expect_err("UTF8"),
+        RemotePanelStatusError::UnsupportedPath
+    );
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -112,6 +112,11 @@ back into large multi-purpose modules.
   admission leaf checks exact snapshots without granting creation authority;
   claimed, observed or expired retries use non-creating recovery. Setup remains
   separate from attachment, task readiness and explicit remote management.
+- `remote_worker_status.rs` gates non-creating panel inspection on exact owned
+  recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
+  wire types; `ssh.rs` isolates host pins and client options; `command.rs` owns
+  bounded nonblocking local-child I/O. It neither grants attachment/task startup
+  nor changes the general user-configured SSH API or remote execution lifetime.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Continue #383 with owned, non-creating status inspection of retained remote panel
sessions over pinned SSH. This follows the structured worker request protocol.

## Behavior

- Inspect only a panel saved in an owned recovered allocation. Check both exact
  workspace/workflow snapshots, management state, retained identity, exact worker,
  endpoint and execution lifetime before and after the query.
- Send a status-only JSON request on stdin to a fixed worker command. Return a
  strict, bounded running/exited/unavailable observation; never start a task,
  create a worker, attach a terminal or mark the workspace Ready.
- Use the recovered private identity and trusted host pin with no ambient SSH
  config, agent, connection sharing, proxy hooks, forwarding or host-key learning.
  Preserve literal spaces, percent characters, quotes and backslashes in key
  paths; reject unsupported expansion/control/non-UTF-8 paths explicitly.
- Bound local child I/O and completion to ten seconds and the response to 4 KiB.
  Dispose only the owned local SSH child and temporary trust file. Remote tasks,
  workers and retained private keys are unchanged.

Calls are synchronous and belong off the render thread. Protected private-key
handling remains Linux-only. Fresh provider/cost admission, task-intent and
repository verification, interactive attachment, UI wiring and remote durability
remain separate requirements; a status result is not attachment authority.

## Validation

- Ten focused regressions: stale/unknown/pending-management allocations, worker
  state and late intent changes, strict response types and required exit-status
  fields (including explicit null), native SSH option/path
  parsing, bounded output, backpressure, inherited pipes, deadline and owned-child
  reaping/redaction.
- Real public-API smoke using candidate-matched dependencies and a pinned local
  worker image: retained PID and progress, authentication through special-character
  key paths, rejection of an otherwise-working worker's wrong host pin, unchanged
  private keys and no trust-file leftovers. Only exact disposable workers/keys
  are removed; this is local SSH proof, not real-cloud PC-off acceptance.
- Full source and exact-commit Horizon matrices passed on `7290997`: formatting,
  maintainability, version sync, default/speech tests with warnings denied,
  blocking/strict and advisory Clippy. Independent final-base integration review
  is clear on the identical tree, including the required-field correction. The public-API SSH smoke was rebuilt and
  repeated successfully against that exact commit and the merged worker helper.

Uses existing pinned `tempfile` 3.27.0 as a Linux production dependency for
private trust-file lifetime management, and enables `fs` on existing `rustix` for
nonblocking pipes. No dependency version or lockfile change. No UI/config changes,
paid resources, image publication or release. Scope: eight source/test files,
792 changed source/test lines, plus two manifests and architecture notes.
