### PR TITLE
Verify retained remote task intent

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -166,7 +166,10 @@ its status. It never creates a marker, tmux server, session or replacement task.
 A changed intent is rejected; a missing task stays absent and a completed task
 stays retained. Controllers must use the saved launch intent instead of silently
 attaching a panel identity whose command has since changed. This check alone does
-not verify repository contents, remote durability or permission to attach.
+not verify repository contents, remote durability or permission to attach. Intent
+comparison is independent of current filesystem contents, so renaming or removing
+the original directory does not hide a retained running or completed task. Fresh
+task startup still resolves and confines its working directory to the repository.
 
 Before starting anything, the helper durably publishes one private no-overwrite
 marker for the runtime/panel pair. Repeating the same start can only inspect that
@@ -190,7 +193,7 @@ volumes, backup and explicit restart remain separate integration requirements.
 This helper does not yet connect local panels, stop tasks or delete workspaces.
 
 With `bison`, `libevent-dev`, `libncurses-dev`, a C compiler and Make installed, build a
-disposable test binary under a new prefix, then run the twenty-seven regressions:
+disposable test binary under a new prefix, then run the twenty-nine regressions:
 
 ```bash
 test_root=$(mktemp -d /tmp/horizon-panel-tests.XXXXXX)

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -160,6 +160,14 @@ intent rules. Interactive attachment still uses the separate `attach` command
 and PTY. Malformed request errors never echo stdin or task content. This protocol
 does not itself provide authenticated transport or authorize a new task.
 
+A `verify` request uses the same fields as `start`, but only compares the supplied
+directory and literal argv with the retained task's launch digest before returning
+its status. It never creates a marker, tmux server, session or replacement task.
+A changed intent is rejected; a missing task stays absent and a completed task
+stays retained. Controllers must use the saved launch intent instead of silently
+attaching a panel identity whose command has since changed. This check alone does
+not verify repository contents, remote durability or permission to attach.
+
 Before starting anything, the helper durably publishes one private no-overwrite
 marker for the runtime/panel pair. Repeating the same start can only inspect that
 task; a changed launch intent is rejected. Each runtime has a dedicated tmux
@@ -182,7 +190,7 @@ volumes, backup and explicit restart remain separate integration requirements.
 This helper does not yet connect local panels, stop tasks or delete workspaces.
 
 With `bison`, `libevent-dev`, `libncurses-dev`, a C compiler and Make installed, build a
-disposable test binary under a new prefix, then run the twenty-one regressions:
+disposable test binary under a new prefix, then run the twenty-seven regressions:
 
 ```bash
 test_root=$(mktemp -d /tmp/horizon-panel-tests.XXXXXX)
@@ -194,6 +202,8 @@ Coverage includes repeated PTY disconnects, retained completion, concurrent
 starts, literal semicolon/format arguments, locale-independent status and no
 recreation after server loss. Structured-request coverage includes literal argv,
 non-creating status, disconnected progress, bounded/invalid input and redaction.
+Verification covers changed intent, absent/lost/completed tasks, exact literal
+arguments and unchanged ownership records while disconnected tasks keep running.
 Tests own only their private temporary directories
 and dedicated sockets. Keep the disposable tool prefix for repeated validation,
 then remove only that exact task-owned prefix when finished.

--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -173,20 +173,25 @@ class PanelSessions:
             if candidate is not None:
                 candidate.unlink()
 
-    def launch_intent(self, directory, arguments):
+    @staticmethod
+    def intent_digest(directory, arguments):
         if not arguments or len(arguments) > 257 or not arguments[0] or arguments[0].startswith("-"):
             raise SessionError("invalid task command")
         if any("\0" in argument for argument in arguments) or sum(len(item.encode()) for item in arguments) > 65536:
             raise SessionError("task command exceeds its limit")
         requested = Path(directory)
-        if requested.is_absolute() or ".." in requested.parts:
-            raise SessionError("task directory must remain inside the repository")
-        repository = self.repository.resolve(strict=True)
-        working_directory = (repository / requested).resolve(strict=True)
-        if not working_directory.is_dir() or not working_directory.is_relative_to(repository):
+        if "\0" in directory or requested.is_absolute() or ".." in requested.parts:
             raise SessionError("task directory must remain inside the repository")
         payload = json.dumps([str(requested), arguments], ensure_ascii=True).encode()
-        return working_directory, hashlib.sha256(payload).hexdigest()
+        return hashlib.sha256(payload).hexdigest()
+
+    def launch_intent(self, directory, arguments):
+        intent = self.intent_digest(directory, arguments)
+        repository = self.repository.resolve(strict=True)
+        working_directory = (repository / directory).resolve(strict=True)
+        if not working_directory.is_dir() or not working_directory.is_relative_to(repository):
+            raise SessionError("task directory must remain inside the repository")
+        return working_directory, intent
 
     def start(self, runtime, panel, directory, arguments):
         _, name = self.identities(runtime, panel)
@@ -215,7 +220,7 @@ class PanelSessions:
 
     def verify(self, runtime, panel, directory, arguments):
         marker = self.read_marker(runtime, panel)
-        _, intent = self.launch_intent(directory, arguments)
+        intent = self.intent_digest(directory, arguments)
         if marker["intent"] != intent:
             raise SessionError("panel launch intent differs from its retained task")
         return self.status(runtime, panel)

--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -48,7 +48,7 @@ def execute_request(service, stream):
         raise SessionError("structured session request is invalid")
     if request.get("operation") == "status" and set(request) == common:
         return service.status(request["runtime"], request["panel"])
-    if request.get("operation") != "start" or set(request) != common | {"directory", "argv"}:
+    if request.get("operation") not in ("start", "verify") or set(request) != common | {"directory", "argv"}:
         raise SessionError("unsupported structured session request")
     if (
         not isinstance(request["directory"], str)
@@ -56,7 +56,8 @@ def execute_request(service, stream):
         or not all(isinstance(argument, str) for argument in request["argv"])
     ):
         raise SessionError("structured task intent is invalid")
-    return service.start(request["runtime"], request["panel"], request["directory"], request["argv"])
+    operation = service.verify if request["operation"] == "verify" else service.start
+    return operation(request["runtime"], request["panel"], request["directory"], request["argv"])
 
 
 def private_directory(path):
@@ -212,6 +213,13 @@ class PanelSessions:
             raise SessionError("panel launch intent differs from its retained task")
         return self.status(runtime, panel)
 
+    def verify(self, runtime, panel, directory, arguments):
+        marker = self.read_marker(runtime, panel)
+        _, intent = self.launch_intent(directory, arguments)
+        if marker["intent"] != intent:
+            raise SessionError("panel launch intent differs from its retained task")
+        return self.status(runtime, panel)
+
     def status(self, runtime, panel):
         _, name = self.identities(runtime, panel)
         marker = self.read_marker(runtime, panel)
@@ -243,7 +251,7 @@ class PanelSessions:
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     operations = parser.add_subparsers(dest="operation", required=True)
-    operations.add_parser("request", help="read one versioned start/status request from stdin")
+    operations.add_parser("request", help="read one versioned start/status/verify request from stdin")
     for operation in ("start", "status", "attach"):
         command = operations.add_parser(operation)
         command.add_argument("runtime")

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -131,6 +131,84 @@ class PanelSessionTests(unittest.TestCase):
         self.assertFalse(self.service.state.exists())
         self.assertFalse(self.service.sockets.exists())
 
+    def test_structured_verification_retains_exact_task_after_disconnect(self):
+        argv = self.tick_command()
+        first = self.execute(self.request("start", directory="nested space", argv=argv))
+        marker = self.service.marker_path(self.runtimes[0], "structured")
+        original = marker.read_bytes(), marker.stat().st_mtime_ns
+        ticks = self.repository / "nested space" / "ticks"
+        self.wait_for(ticks.exists)
+        self.attach_and_disconnect(self.runtimes[0], "structured")
+        before = len(ticks.read_text().splitlines())
+        with mock.patch.object(self.service, "start") as start, mock.patch.object(self.service, "attach") as attach:
+            verified = self.execute(self.request("verify", directory="nested space", argv=argv))
+            self.assertEqual(verified, first)
+            start.assert_not_called()
+            attach.assert_not_called()
+        self.wait_for(lambda: len(ticks.read_text().splitlines()) > before + 2)
+        self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), original)
+
+    def test_structured_verification_rejects_changed_directory_or_literal_arguments(self):
+        literals = ["", "$(touch injected);", "'quoted'", "line\nbreak", "æøå", "\\;", "#{l:..}"]
+        argv = self.tick_command() + literals
+        first = self.execute(self.request("start", directory=".", argv=argv))
+        marker = self.service.marker_path(self.runtimes[0], "structured")
+        original = marker.read_bytes(), marker.stat().st_mtime_ns
+        self.assertEqual(self.execute(self.request("verify", directory=".", argv=argv)), first)
+        for directory, changed in [("nested space", argv), (".", argv[:-1]), (".", argv + ["extra"]),
+                                   (".", argv[:-1] + ["different"])]:
+            with self.subTest(directory=directory, argument_count=len(changed)):
+                with mock.patch.object(self.service, "start") as start, self.assertRaises(MODULE.SessionError):
+                    self.execute(self.request("verify", directory=directory, argv=changed))
+                start.assert_not_called()
+        self.assertFalse((self.repository / "injected").exists())
+        self.assertEqual(self.execute(self.request("status"))["pid"], first["pid"])
+        self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), original)
+
+    def test_structured_verification_never_creates_an_absent_task(self):
+        with mock.patch.object(self.service, "start") as start, self.assertRaises(FileNotFoundError):
+            self.execute(self.request("verify", directory=".", argv=self.tick_command()))
+        start.assert_not_called()
+        self.assertFalse(self.service.state.exists())
+        self.assertFalse(self.service.sockets.exists())
+
+    def test_structured_verification_retains_completed_task_without_reexecution(self):
+        argv = self.command("from pathlib import Path; Path('runs').open('a').write('once\\n'); raise SystemExit(42)")
+        self.execute(self.request("start", directory=".", argv=argv))
+        def completed():
+            status = self.execute(self.request("status"))
+            return status if status["state"] == "exited" else None
+
+        finished = self.wait_for(completed)
+        for _ in range(2):
+            self.assertEqual(self.execute(self.request("verify", directory=".", argv=argv)), finished)
+        self.assertEqual(finished["exit_status"], 42)
+        self.assertEqual((self.repository / "runs").read_text(), "once\n")
+
+    def test_structured_verification_of_lost_server_never_starts_replacement(self):
+        argv = self.tick_command()
+        self.execute(self.request("start", directory=".", argv=argv))
+        marker = self.service.marker_path(self.runtimes[0], "structured").read_bytes()
+        self.service.tmux(self.runtimes[0], "kill-server")
+        verified = self.execute(self.request("verify", directory=".", argv=argv))
+        self.assertEqual(verified, {"state": "unavailable", "panel": "structured"})
+        self.assertNotEqual(self.service.tmux(self.runtimes[0], "list-sessions", check=False).returncode, 0)
+        self.assertEqual(self.service.marker_path(self.runtimes[0], "structured").read_bytes(), marker)
+
+    def test_structured_verification_rejects_incomplete_or_invalid_intent_before_inspection(self):
+        valid = self.request("verify", directory=".", argv=self.tick_command())
+        cases = [self.request("verify"), {**valid, "argv": "private task"},
+                 {**valid, "directory": None}, {**valid, "unexpected": "private task"}]
+        for request in cases:
+            with mock.patch.object(self.service, "status") as status, mock.patch.object(self.service, "start") as start:
+                with self.assertRaises(MODULE.SessionError) as caught:
+                    self.execute(request)
+                status.assert_not_called()
+                start.assert_not_called()
+                self.assertNotIn("private task", str(caught.exception))
+        self.assertFalse(self.service.state.exists())
+        self.assertFalse(self.service.sockets.exists())
+
     def test_structured_request_rejects_unknown_fields_versions_and_types_before_launch(self):
         valid = self.request("start", directory=".", argv=self.tick_command())
         cases = [None, [], {}, {**valid, "version": True}, {**valid, "version": 2},

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -148,6 +148,38 @@ class PanelSessionTests(unittest.TestCase):
         self.wait_for(lambda: len(ticks.read_text().splitlines()) > before + 2)
         self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), original)
 
+    def test_structured_verification_survives_running_task_directory_rename(self):
+        argv = self.tick_command()
+        first = self.execute(self.request("start", directory="nested space", argv=argv))
+        original = self.repository / "nested space"
+        self.wait_for(lambda: (original / "ticks").exists())
+        renamed = self.repository / "renamed"
+        original.rename(renamed)
+        marker = self.service.marker_path(self.runtimes[0], "structured")
+        retained = marker.read_bytes(), marker.stat().st_mtime_ns
+        before = len((renamed / "ticks").read_text().splitlines())
+        self.assertEqual(self.execute(self.request("verify", directory="nested space", argv=argv)), first)
+        self.wait_for(lambda: len((renamed / "ticks").read_text().splitlines()) > before + 2)
+        self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), retained)
+        with self.assertRaises(MODULE.SessionError):
+            self.execute(self.request("verify", directory="renamed", argv=argv))
+        with self.assertRaises(FileNotFoundError):
+            self.execute(self.request("start", panel="new", directory="nested space", argv=argv))
+        self.assertFalse(self.service.marker_path(self.runtimes[0], "new").exists())
+
+    def test_structured_verification_survives_completed_task_repository_removal(self):
+        argv = self.command("raise SystemExit(42)")
+        first = self.execute(self.request("start", directory="nested space", argv=argv))
+        self.wait_for(lambda: self.execute(self.request("status"))["state"] == "exited")
+        (self.repository / "nested space").rmdir()
+        self.repository.rmdir()
+        marker = self.service.marker_path(self.runtimes[0], "structured")
+        retained = marker.read_bytes(), marker.stat().st_mtime_ns
+        self.assertEqual(self.execute(self.request("verify", directory="nested space", argv=argv)),
+                         {"state":"exited", "panel":"structured", "pid":first["pid"], "exit_status":42})
+        self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), retained)
+        self.assertFalse(self.repository.exists())
+
     def test_structured_verification_rejects_changed_directory_or_literal_arguments(self):
         literals = ["", "$(touch injected);", "'quoted'", "line\nbreak", "æøå", "\\;", "#{l:..}"]
         argv = self.tick_command() + literals

--- a/crates/horizon-core/src/remote_worker_status.rs
+++ b/crates/horizon-core/src/remote_worker_status.rs
@@ -31,13 +31,43 @@ pub fn inspect_remote_panel(
     recovered: &RecoveredRemoteWorkspace,
     panel_id: &str,
 ) -> Result<RemotePanelStatus, RemotePanelStatusError> {
+    inspect(store, recovered, panel_id, Inspection::Status)
+}
+
+/// Compare the saved explicit shell/command intent with the retained task before
+/// returning its status. No task, marker or session is created or replaced.
+/// This does not certify repository contents, cost admission or attachment authority.
+/// Calls are synchronous and must run off the render thread.
+/// # Errors
+/// Rejects the same conditions as [`inspect_remote_panel`], plus incomplete or
+/// unsupported launch intent and a worker-side mismatch with its retained task.
+pub fn inspect_remote_panel_intent(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    panel_id: &str,
+) -> Result<RemotePanelStatus, RemotePanelStatusError> {
+    inspect(store, recovered, panel_id, Inspection::SavedIntent)
+}
+
+#[derive(Clone, Copy)]
+enum Inspection {
+    Status,
+    SavedIntent,
+}
+
+fn inspect(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    panel_id: &str,
+    inspection: Inspection,
+) -> Result<RemotePanelStatus, RemotePanelStatusError> {
     #[cfg(target_os = "linux")]
     {
-        inspect_with(store, recovered, panel_id, ssh::request)
+        inspect_with(store, recovered, panel_id, inspection, ssh::request)
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (store, recovered, panel_id);
+        let _ = (store, recovered, panel_id, inspection);
         Err(RemotePanelStatusError::UnsupportedPlatform)
     }
 }
@@ -47,6 +77,7 @@ fn inspect_with(
     store: &CloudWorkflowStore,
     recovered: &RecoveredRemoteWorkspace,
     panel_id: &str,
+    inspection: Inspection,
     execute: impl FnOnce(
         &crate::remote_ssh_identity::RemoteSshIdentity,
         &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
@@ -54,7 +85,12 @@ fn inspect_with(
     ) -> Result<Vec<u8>, RemotePanelStatusError>,
 ) -> Result<RemotePanelStatus, RemotePanelStatusError> {
     let endpoint = validate_current(store, recovered, panel_id)?;
-    let request = protocol::request(recovered.allocation().worker_request()?.job_id, panel_id)?;
+    let allocation = recovered.allocation();
+    let runtime = allocation.worker_request()?.job_id;
+    let request = match inspection {
+        Inspection::Status => protocol::request(runtime, panel_id),
+        Inspection::SavedIntent => protocol::intent_request(runtime, &allocation.workspace().state().spec, panel_id),
+    }?;
     let response = execute(recovered.identity(), endpoint, &request)?;
     let status = protocol::response(&response, panel_id)?;
     validate_current(store, recovered, panel_id)?;
@@ -107,6 +143,8 @@ pub enum RemotePanelStatusError {
     WorkerUnavailable,
     #[error("panel identity is not part of the owned remote workspace")]
     UnknownPanel,
+    #[error("saved panel does not contain a fully supported explicit launch intent")]
+    UnsupportedIntent,
     #[error("owned remote state could not be safely inspected")]
     StorageUnavailable,
     #[error("remote SSH identity or trust path is unsupported")]

--- a/crates/horizon-core/src/remote_worker_status/protocol.rs
+++ b/crates/horizon-core/src/remote_worker_status/protocol.rs
@@ -1,8 +1,10 @@
 use super::{RemotePanelStatus, RemotePanelStatusError as Error};
-use crate::cloud_run::CloudJobId;
+use crate::{PanelKind, cloud_run::CloudJobId, remote_workspace::RemoteWorkspaceSpec};
 use serde::{Deserialize, Serialize};
 
 pub(super) const RESPONSE_LIMIT: usize = 4096;
+const REQUEST_LIMIT: usize = 512 * 1024;
+const REQUEST_VERSION: u8 = 1;
 
 pub(super) fn request(runtime: CloudJobId, panel: &str) -> Result<Vec<u8>, Error> {
     #[derive(Serialize)]
@@ -12,13 +14,56 @@ pub(super) fn request(runtime: CloudJobId, panel: &str) -> Result<Vec<u8>, Error
         runtime: CloudJobId,
         panel: &'a str,
     }
-    serde_json::to_vec(&Request {
-        version: 1,
+    encode_request(&Request {
+        version: REQUEST_VERSION,
         operation: "status",
         runtime,
         panel,
     })
-    .map_err(|_| Error::QueryFailed)
+}
+
+pub(super) fn intent_request(runtime: CloudJobId, spec: &RemoteWorkspaceSpec, panel: &str) -> Result<Vec<u8>, Error> {
+    #[derive(Serialize)]
+    struct Request<'a> {
+        version: u8,
+        operation: &'static str,
+        runtime: CloudJobId,
+        panel: &'a str,
+        directory: &'a str,
+        argv: Vec<&'a str>,
+    }
+    let binding = spec
+        .panels
+        .iter()
+        .find(|binding| binding.panel_local_id == panel)
+        .ok_or(Error::UnknownPanel)?;
+    if !matches!(binding.kind, PanelKind::Shell | PanelKind::Command)
+        || binding.task_handoff.is_some()
+        || binding.agent_session_id.is_some()
+    {
+        return Err(Error::UnsupportedIntent);
+    }
+    let command = binding.command.as_ref().ok_or(Error::UnsupportedIntent)?;
+    let directory = binding.working_directory.as_deref().unwrap_or(&spec.working_directory);
+    let mut argv = Vec::with_capacity(1 + command.args.len());
+    argv.push(command.program.as_str());
+    argv.extend(command.args.iter().map(String::as_str));
+    encode_request(&Request {
+        version: REQUEST_VERSION,
+        operation: "verify",
+        runtime,
+        panel,
+        directory,
+        argv,
+    })
+}
+
+fn encode_request(request: &impl Serialize) -> Result<Vec<u8>, Error> {
+    let bytes = serde_json::to_vec(request).map_err(|_| Error::QueryFailed)?;
+    if bytes.len() > REQUEST_LIMIT {
+        return Err(Error::UnsupportedIntent);
+    }
+    Ok(bytes)
 }
 
 #[derive(Deserialize)]

--- a/crates/horizon-core/src/remote_worker_status/tests.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests.rs
@@ -9,6 +9,8 @@ use crate::{
 
 #[path = "tests/command.rs"]
 mod command_tests;
+#[path = "tests/intent.rs"]
+mod intent_tests;
 #[path = "tests/ssh.rs"]
 mod ssh_tests;
 
@@ -16,7 +18,7 @@ const OWNER: &str = "00000000-0000-4000-8000-000000000001";
 const RUNNING: &[u8] = br#"{"state":"running","panel":"terminal","pid":123,"exit_status":null}"#;
 
 struct Fixture {
-    _directory: tempfile::TempDir,
+    directory: tempfile::TempDir,
     store: CloudWorkflowStore,
     recovered: RecoveredRemoteWorkspace,
 }
@@ -85,7 +87,7 @@ impl Fixture {
         let recovered = recover_remote_workspace(&store, &identities, &Provider(status), OWNER, "workspace")
             .expect("noncreating recovery");
         Self {
-            _directory: directory,
+            directory,
             store,
             recovered,
         }
@@ -138,6 +140,7 @@ fn owned_status_is_noncreating_and_leaves_all_snapshots_and_private_identity_unc
         &fixture.store,
         &fixture.recovered,
         "terminal",
+        Inspection::Status,
         |identity, endpoint, input| {
             assert_eq!(
                 identity.public_key(),
@@ -176,15 +179,25 @@ fn unknown_panels_and_stale_ownership_never_cross_the_ssh_boundary() {
     let fixture = Fixture::new();
     for panel in ["absent", "terminal;start", ""] {
         assert_eq!(
-            inspect_with(&fixture.store, &fixture.recovered, panel, |_, _, _| panic!("no SSH")),
+            inspect_with(
+                &fixture.store,
+                &fixture.recovered,
+                panel,
+                Inspection::Status,
+                |_, _, _| panic!("no SSH")
+            ),
             Err(RemotePanelStatusError::UnknownPanel)
         );
     }
     fixture.edit_intent();
     assert_eq!(
-        inspect_with(&fixture.store, &fixture.recovered, "terminal", |_, _, _| panic!(
-            "no SSH"
-        )),
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::Status,
+            |_, _, _| panic!("no SSH")
+        ),
         Err(RemotePanelStatusError::StateChanged)
     );
 }
@@ -193,9 +206,13 @@ fn unknown_panels_and_stale_ownership_never_cross_the_ssh_boundary() {
 fn a_nonready_worker_cannot_be_queried_or_started() {
     let fixture = Fixture::with_lifecycle(InteractiveWorkerLifecycle::Stopped);
     assert_eq!(
-        inspect_with(&fixture.store, &fixture.recovered, "terminal", |_, _, _| panic!(
-            "no SSH"
-        )),
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::Status,
+            |_, _, _| panic!("no SSH")
+        ),
         Err(RemotePanelStatusError::WorkerUnavailable)
     );
 }
@@ -204,10 +221,16 @@ fn a_nonready_worker_cannot_be_queried_or_started() {
 fn late_status_cannot_hide_newer_management_or_workspace_intent() {
     let fixture = Fixture::new();
     assert_eq!(
-        inspect_with(&fixture.store, &fixture.recovered, "terminal", |_, _, _| {
-            fixture.edit_intent();
-            Ok(RUNNING.to_vec())
-        }),
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::Status,
+            |_, _, _| {
+                fixture.edit_intent();
+                Ok(RUNNING.to_vec())
+            }
+        ),
         Err(RemotePanelStatusError::StateChanged)
     );
     assert_eq!(fixture.current().workspace().state().spec.working_directory, "src");

--- a/crates/horizon-core/src/remote_worker_status/tests/intent.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests/intent.rs
@@ -1,0 +1,196 @@
+use super::*;
+use crate::remote_workspace::{
+    RemoteCleanupIntent, RemoteCleanupReason, RemotePanelCommand, RemoteRuntimePhase, RemoteWorkspaceSpec,
+};
+
+fn command() -> RemotePanelCommand {
+    RemotePanelCommand {
+        program: "example-program".into(),
+        args: ["", "$(private);", "æøå", "line\nbreak", "'quote'", "\\", "#{l:..}"]
+            .map(String::from)
+            .to_vec(),
+    }
+}
+
+fn set_intent(fixture: &mut Fixture, edit: impl FnOnce(&mut RemoteWorkspaceSpec)) {
+    let current = fixture.current();
+    let mut next = current.workspace().state().clone();
+    edit(&mut next.spec);
+    fixture
+        .store
+        .replace_remote_workspace(current.workspace(), &next)
+        .expect("edit intent");
+    let observation = fixture.recovered.observation().expect("observation").clone();
+    let identities = RemoteSshIdentityStore::new(&HorizonHome::from_root(fixture.directory.path().join("home")));
+    fixture.recovered =
+        recover_remote_workspace(&fixture.store, &identities, &Provider(observation), OWNER, "workspace")
+            .expect("recover current intent");
+}
+
+#[test]
+fn saved_intent_preserves_literal_arguments_and_repository_relative_directory() {
+    for override_directory in [None, Some("nested space")] {
+        let mut fixture = Fixture::new();
+        set_intent(&mut fixture, |spec| {
+            spec.working_directory = "workspace directory".into();
+            spec.panels[0].command = Some(command());
+            spec.panels[0].working_directory = override_directory.map(String::from);
+        });
+        let before = fixture.current();
+        let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+        let result = inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::SavedIntent,
+            |_, _, input| {
+                let mut argv = vec![command().program];
+                argv.extend(command().args);
+                assert_eq!(
+                    serde_json::from_slice::<serde_json::Value>(input).expect("JSON"),
+                    serde_json::json!({
+                        "version": 1, "operation": "verify", "runtime": before.worker_request().expect("request").job_id,
+                        "panel": "terminal", "directory": override_directory.unwrap_or("workspace directory"), "argv": argv
+                    })
+                );
+                Ok(RUNNING.to_vec())
+            },
+        );
+        assert_eq!(result, Ok(RemotePanelStatus::Running { pid: 123 }));
+        assert_eq!(fixture.current(), before);
+        assert_eq!(
+            std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+            key
+        );
+    }
+}
+
+#[test]
+fn incomplete_or_unresolved_agent_intent_never_reaches_ssh() {
+    let mut fixture = Fixture::new();
+    assert_eq!(
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::SavedIntent,
+            |_, _, _| panic!("no SSH")
+        ),
+        Err(RemotePanelStatusError::UnsupportedIntent)
+    );
+    for (kind, handoff, resume) in [
+        (PanelKind::Claude, None, None),
+        (PanelKind::Command, Some("private task context"), None),
+        (PanelKind::Claude, None, Some("retained-agent-session")),
+    ] {
+        set_intent(&mut fixture, |spec| {
+            spec.panels[0].command = Some(command());
+            spec.panels[0].kind = kind;
+            spec.panels[0].task_handoff = handoff.map(String::from);
+            spec.panels[0].agent_session_id = resume.map(String::from);
+        });
+        assert_eq!(
+            inspect_with(
+                &fixture.store,
+                &fixture.recovered,
+                "terminal",
+                Inspection::SavedIntent,
+                |_, _, _| panic!("no SSH")
+            ),
+            Err(RemotePanelStatusError::UnsupportedIntent)
+        );
+    }
+}
+
+#[test]
+fn pending_management_invalidates_both_inspection_modes_without_ssh() {
+    let mut fixture = Fixture::new();
+    set_intent(&mut fixture, |spec| spec.panels[0].command = Some(command()));
+    let before = fixture.current();
+    let mut next = before.workspace().state().clone();
+    let runtime = next.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Cancelling;
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 1,
+    });
+    fixture
+        .store
+        .replace_remote_workspace(before.workspace(), &next)
+        .expect("management intent");
+    for inspection in [Inspection::Status, Inspection::SavedIntent] {
+        assert_eq!(
+            inspect_with(
+                &fixture.store,
+                &fixture.recovered,
+                "terminal",
+                inspection,
+                |_, _, _| panic!("no SSH")
+            ),
+            Err(RemotePanelStatusError::StateChanged)
+        );
+    }
+    assert_eq!(fixture.current().workspace().state(), &next);
+}
+
+#[test]
+fn verification_retains_shared_ownership_lifetime_and_late_result_gates() {
+    let mut fixture = Fixture::new();
+    set_intent(&mut fixture, |spec| spec.panels[0].command = Some(command()));
+    assert_eq!(
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "absent",
+            Inspection::SavedIntent,
+            |_, _, _| panic!("no SSH")
+        ),
+        Err(RemotePanelStatusError::UnknownPanel)
+    );
+    let before = fixture.current();
+    assert_eq!(
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::SavedIntent,
+            |_, _, _| Err(RemotePanelStatusError::QueryFailed)
+        ),
+        Err(RemotePanelStatusError::QueryFailed)
+    );
+    assert_eq!(fixture.current(), before);
+    assert_eq!(
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::SavedIntent,
+            |_, _, _| {
+                fixture.edit_intent();
+                Ok(RUNNING.to_vec())
+            }
+        ),
+        Err(RemotePanelStatusError::StateChanged)
+    );
+    assert_eq!(
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::SavedIntent,
+            |_, _, _| panic!("no SSH")
+        ),
+        Err(RemotePanelStatusError::StateChanged)
+    );
+    let fixture = Fixture::with_lifecycle(InteractiveWorkerLifecycle::Stopped);
+    assert_eq!(
+        inspect_with(
+            &fixture.store,
+            &fixture.recovered,
+            "terminal",
+            Inspection::SavedIntent,
+            |_, _, _| panic!("no SSH")
+        ),
+        Err(RemotePanelStatusError::WorkerUnavailable)
+    );
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -117,6 +117,9 @@ back into large multi-purpose modules.
   wire types; `ssh.rs` isolates host pins and client options; `command.rs` owns
   bounded nonblocking local-child I/O. It neither grants attachment/task startup
   nor changes the general user-configured SSH API or remote execution lifetime.
+  Explicit saved shell/command verification reuses those gates and compares
+  literal argv plus the effective directory with the worker's retained intent;
+  unresolved agent launch/handoff/resume semantics stay fail-closed.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Continue #383 with non-creating verification that a retained remote task matches
the saved explicit shell/command intent. Panel identity alone is not that proof.

## Behavior

- Add a structured worker `verify` request using the saved directory and literal
  argv. Compare against the existing launch digest before inspecting the retained
  task, without creating markers, sessions or replacement processes.
- Add `inspect_remote_panel_intent`, reusing exact owned snapshots, lifetime,
  management-state checks and bounded pinned SSH before/after the request.
- Preserve per-panel directory overrides relative to the repository root and
  literal empty, Unicode, newline, quote and shell-metacharacter arguments.
- Reject changed intent, missing explicit commands and unresolved agent launch,
  handoff or resume semantics. Never silently invent defaults or discard context.
- Compare the retained digest without resolving today's filesystem. Running tasks
  remain verifiable after directory rename, and completed tasks after repository
  removal. Fresh starts still strictly resolve and confine their working directory.

Existing status and legacy worker commands retain their behavior. This does not
start or attach tasks, mark the workspace Ready, certify repository contents or
durable remote storage, or complete #383. Calls are synchronous/off-render-thread;
protected client identity handling remains Linux-only.

## Validation

- All 29 worker regressions passed in an isolated, read-only, network-disabled
  pinned worker image. New coverage includes absent/lost/completed tasks, changed
  intent, literal arguments, unchanged markers and progress after disconnect.
- Four new client regressions; all 14 inspection tests passed, including exact
  request shape, effective directory, unsupported intent, ownership/management
  changes, late results and non-ready workers.
- Raw-worker pinned SSH smoke and lock-matched public-API smoke passed: exact
  retained PID/progress, changed saved-command rejection, unchanged marker/key
  bytes, no trust-file leftovers and wrong-host-pin rejection. Only exact
  disposable local workers and generated keys were removed.
- Real local-provider integration passed: explicit setup created one persistent
  worker, fresh client processes recovered/retried it after final PTY loss, and
  verification retained its exact task PID. Duplicate setup was rejected; no new
  generation, task replay, marker/key changes or lost progress. Exact test workers,
  stores and generated client keys were verified and removed after the run.
- Independent final-base review is clear. Full source and exact-commit Horizon
  matrices passed on `c36092a`, based on merged #427: formatting, maintainability,
  version sync, default/speech tests, blocking/strict and advisory Clippy. All 29
  worker regressions and all three SSH/API/provider smoke lanes were repeated
  successfully on that unchanged commit with candidate-matched dependencies,
  including real running-task directory rename through the public SSH API.

Scope: six source/test files, 481 changed source/test lines, plus worker and
architecture documentation. No UI/config/dependency change, paid resources,
image publication or release. Local SSH proof is not real-cloud PC-off acceptance.
