### PR TITLE
Observe remote environments without mutation

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
@@ -7,6 +7,27 @@ use crate::cloud_run::interactive_worker::{
 use rusqlite::TransactionBehavior;
 
 impl StoredRemoteAllocation {
+    pub(crate) fn validate_worker_observation(
+        &self,
+        observation: Option<&InteractiveWorkerStatus>,
+    ) -> Result<(), Error> {
+        let request = self.worker_request()?;
+        let runtime = self.workspace.state().runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+        if let Some(status) = observation {
+            validate_observation(status, &request)?;
+            if runtime.worker.as_ref().is_some_and(|worker| worker != &status.worker)
+                || runtime
+                    .ssh
+                    .as_ref()
+                    .zip(status.ssh.as_ref())
+                    .is_some_and(|(saved, observed)| saved != observed)
+            {
+                return Err(Error::InvalidWorkerObservation);
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn recovery_request(&self) -> Result<InteractiveWorkerRequest, Error> {
         let runtime = self.workspace.state().runtime.as_ref().ok_or(Error::UnboundRuntime)?;
         if runtime.cleanup.is_some()
@@ -38,20 +59,11 @@ impl CloudWorkflowStore {
         if current != *expected {
             return Err(Error::SnapshotConflict);
         }
-        let request = current.recovery_request()?;
+        current.recovery_request()?;
+        current.validate_worker_observation(observation)?;
         let mut next = current.workspace.state().clone();
         let runtime = next.runtime.as_mut().ok_or(Error::UnboundRuntime)?;
         if let Some(status) = observation {
-            validate_observation(status, &request)?;
-            if runtime.worker.as_ref().is_some_and(|worker| worker != &status.worker)
-                || runtime
-                    .ssh
-                    .as_ref()
-                    .zip(status.ssh.as_ref())
-                    .is_some_and(|(saved, observed)| saved != observed)
-            {
-                return Err(Error::InvalidWorkerObservation);
-            }
             runtime.worker = Some(status.worker.clone());
             if let Some(ssh) = &status.ssh {
                 runtime.ssh = Some(ssh.clone());

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -19,6 +19,7 @@ mod local_store;
 mod managed_install;
 mod opencode_paths;
 mod panel;
+pub mod remote_environment_observation;
 mod remote_hosts;
 pub mod remote_ssh_identity;
 pub mod remote_worker_status;

--- a/crates/horizon-core/src/remote_environment_observation.rs
+++ b/crates/horizon-core/src/remote_environment_observation.rs
@@ -1,0 +1,122 @@
+//! Read-only provider observations for the global remote-environment overview.
+//! Synchronous provider/store operations must run off the render thread.
+
+use crate::{
+    cloud_run::{
+        CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
+        interactive_worker::{InteractiveWorkerIdentity, InteractiveWorkerLifecycle, InteractiveWorkerProvider},
+    },
+    remote_workspace::RemoteEnvironmentSummary,
+};
+
+/// Saved metadata and a point-in-time provider observation, not lifecycle authority.
+/// Neither this result nor its timestamp certifies continued freshness or attachment readiness.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteEnvironmentObservation {
+    pub saved: RemoteEnvironmentSummary,
+    pub observed_at_millis: i64,
+    /// `None` means no exact worker was found. Saved identity remains in `saved`.
+    /// Absence never authorizes replacement, removal from inventory or cleanup.
+    pub worker: Option<ObservedRemoteWorker>,
+}
+
+/// Overview-safe projection. No task payload, SSH coordinates or key material is retained.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ObservedRemoteWorker {
+    pub identity: InteractiveWorkerIdentity,
+    /// Worker readiness is not workspace readiness or proof of retained task/repository state.
+    pub lifecycle: InteractiveWorkerLifecycle,
+}
+
+/// Inspect a retained exact worker, or non-creatively reconcile its reserved public request.
+/// Requires matching owned workspace/workflow snapshots around provider I/O. No private
+/// identity is opened, no store record is changed, and no create/stop/delete occurs.
+/// Pending management remains observable without changing or cancelling its intent.
+/// Provider implementations must bound read operations; invoke this off the render thread.
+/// # Errors
+/// Rejects unbound/missing requests, stale ownership, provider errors and mismatched
+/// resource/target/key/pin/lifetime observations. Errors redact provider and task payloads.
+pub fn observe_remote_environment<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteWorkspace,
+) -> Result<RemoteEnvironmentObservation, RemoteEnvironmentObservationError> {
+    let allocation = load_current(store, expected)?;
+    let request = allocation.worker_request()?;
+    if !request.is_valid_for(provider.provider()) {
+        return Err(RemoteEnvironmentObservationError::ProviderMismatch);
+    }
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteEnvironmentObservationError::MissingAllocation)?;
+    let observation = match &runtime.worker {
+        Some(worker) => provider.inspect_worker(worker),
+        None => provider.reconcile_worker(&request),
+    }
+    .map_err(|_| RemoteEnvironmentObservationError::ProviderUnavailable)?;
+    let current = load_current(store, expected)?;
+    if current != allocation {
+        return Err(RemoteEnvironmentObservationError::StateChanged);
+    }
+    current.validate_worker_observation(observation.as_ref())?;
+    let observed_at_millis = i64::try_from(time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000)
+        .map_err(|_| RemoteEnvironmentObservationError::InvalidObservation)?;
+    Ok(RemoteEnvironmentObservation {
+        saved: current.workspace().environment_summary(),
+        observed_at_millis,
+        worker: observation.map(|status| ObservedRemoteWorker {
+            identity: status.worker.identity,
+            lifecycle: status.lifecycle,
+        }),
+    })
+}
+
+fn load_current(
+    store: &CloudWorkflowStore,
+    expected: &StoredRemoteWorkspace,
+) -> Result<StoredRemoteAllocation, RemoteEnvironmentObservationError> {
+    let current = store
+        .load_remote_allocation(expected.session_id(), &expected.state().spec.workspace_local_id)?
+        .ok_or(RemoteEnvironmentObservationError::MissingAllocation)?;
+    if current.workspace() != expected {
+        return Err(RemoteEnvironmentObservationError::StateChanged);
+    }
+    Ok(current)
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum RemoteEnvironmentObservationError {
+    #[error("no owned allocation is available for this saved environment")]
+    MissingAllocation,
+    #[error("saved environment has no retained public worker request")]
+    MissingRequest,
+    #[error("observation provider does not match the saved environment")]
+    ProviderMismatch,
+    #[error("remote environment could not be observed; no resource or saved state was changed")]
+    ProviderUnavailable,
+    #[error("provider observation does not match the saved environment identity")]
+    InvalidObservation,
+    #[error("saved environment changed during observation; refresh before retrying")]
+    StateChanged,
+    #[error("owned remote environment could not be safely read from storage")]
+    StorageUnavailable,
+}
+
+impl From<RemoteWorkspaceStoreError> for RemoteEnvironmentObservationError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        match error {
+            RemoteWorkspaceStoreError::RuntimeRequestRequired => Self::MissingRequest,
+            RemoteWorkspaceStoreError::InvalidWorkerObservation => Self::InvalidObservation,
+            RemoteWorkspaceStoreError::SnapshotConflict | RemoteWorkspaceStoreError::RevisionConflict { .. } => {
+                Self::StateChanged
+            }
+            _ => Self::StorageUnavailable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_environment_observation/tests.rs
+++ b/crates/horizon-core/src/remote_environment_observation/tests.rs
@@ -1,0 +1,287 @@
+use super::*;
+use crate::{
+    cloud_run::{
+        ArtifactDigest, CloudProvider, WorkerLifetime,
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerLease,
+            InteractiveWorkerLifetime, InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus,
+        },
+    },
+    remote_workspace::{
+        RemoteCleanupIntent, RemoteCleanupReason, RemoteRuntimePhase, RemoteWorkspaceState, RepositoryCheckpoint,
+    },
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::Mutex;
+
+mod guards;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+type Error = RemoteEnvironmentObservationError;
+
+fn public_key(byte: u8) -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_request(WorkerLifetime::Persistent, true)
+    }
+
+    fn with_request(lifetime: WorkerLifetime, reserve: bool) -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/store.sqlite3")).expect("store");
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1, "spec":{
+                "workspace_local_id":"workspace", "working_directory":".", "generation":0,
+                "target":{"provider":"local_docker", "profile":"development", "disk_gib":20,
+                    "lifetime":"persistent", "image":format!("example/worker@sha256:{}", "a".repeat(64))},
+                "repository":{"repository":"example/project", "commit":"b".repeat(40)},
+                "panels":[{"panel_local_id":"terminal", "kind":"command",
+                    "command":{"program":"printf", "args":["private-task-marker"]}}]
+            }
+        }))
+        .expect("state");
+        state.spec.target.lifetime = lifetime;
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        if reserve {
+            // Synthetic public identity only: overview observation must not open a private key.
+            store
+                .reserve_remote_worker_request(&allocation, &public_key(1))
+                .expect("request");
+        }
+        Self {
+            _directory: directory,
+            store,
+        }
+    }
+
+    fn reload(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn status(&self) -> InteractiveWorkerStatus {
+        let request = self.reload().worker_request().expect("request");
+        let lifetime = match request.target.lifetime {
+            WorkerLifetime::Persistent => InteractiveWorkerLifetime::Persistent,
+            WorkerLifetime::TimeLimited { seconds } => InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                terminate_after: (time::OffsetDateTime::now_utc() + time::Duration::seconds(i64::from(seconds)))
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .expect("deadline"),
+            }),
+        };
+        InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::LocalDocker,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: "synthetic-worker".into(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime,
+            },
+            lifecycle: InteractiveWorkerLifecycle::Ready,
+            ssh: Some(InteractiveWorkerSshEndpoint {
+                host: "127.0.0.1".into(),
+                port: 2222,
+                username: "horizon".into(),
+                host_key: public_key(7),
+            }),
+        }
+    }
+
+    fn retain(&self, status: &InteractiveWorkerStatus) {
+        self.store
+            .record_remote_worker_recovery(&self.reload(), Some(status))
+            .expect("retained observation");
+    }
+
+    fn observe(&self, provider: &Provider) -> Result<RemoteEnvironmentObservation, Error> {
+        observe_remote_environment(&self.store, provider, self.reload().workspace())
+    }
+
+    fn counts(&self) -> [i64; 3] {
+        rusqlite::Connection::open(self.store.path())
+            .expect("database")
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM cloud_workflows), (SELECT COUNT(*) FROM remote_runtime_allocations),
+             (SELECT COUNT(*) FROM cloud_worker_creation_claims)",
+                [],
+                |row| Ok([row.get(0)?, row.get(1)?, row.get(2)?]),
+            )
+            .expect("counts")
+    }
+}
+
+struct Provider {
+    kind: CloudProvider,
+    status: Option<InteractiveWorkerStatus>,
+    calls: Mutex<Vec<&'static str>>,
+    during_read: Option<Box<dyn Fn() + Send + Sync>>,
+    fail: bool,
+}
+
+impl Provider {
+    fn new(status: Option<InteractiveWorkerStatus>) -> Self {
+        Self {
+            kind: CloudProvider::LocalDocker,
+            status,
+            calls: Mutex::default(),
+            during_read: None,
+            fail: false,
+        }
+    }
+
+    fn read(&self, operation: &'static str) -> Result<Option<InteractiveWorkerStatus>, std::io::Error> {
+        self.calls.lock().expect("calls").push(operation);
+        if let Some(action) = &self.during_read {
+            action();
+        }
+        if self.fail {
+            return Err(std::io::Error::other("private-provider-payload"));
+        }
+        Ok(self.status.clone())
+    }
+
+    fn calls(&self) -> Vec<&'static str> {
+        self.calls.lock().expect("calls").clone()
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        self.calls.lock().expect("calls").push("ensure");
+        Err(std::io::Error::other("forbidden create"))
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.read("reconcile")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.read("inspect")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.calls.lock().expect("calls").push("delete");
+        Err(std::io::Error::other("forbidden delete"))
+    }
+}
+
+#[test]
+fn public_request_observation_needs_no_private_key_and_never_adopts_the_worker() {
+    let fixture = Fixture::new();
+    let status = fixture.status();
+    let provider = Provider::new(Some(status.clone()));
+    let before = fixture.reload();
+    let result = fixture.observe(&provider).expect("observation");
+    assert_eq!(result.saved, before.workspace().environment_summary());
+    assert!(result.saved.worker_identity.is_none());
+    assert_eq!(
+        result.worker,
+        Some(ObservedRemoteWorker {
+            identity: status.worker.identity,
+            lifecycle: status.lifecycle
+        })
+    );
+    assert!(result.observed_at_millis > 0);
+    assert_eq!(provider.calls(), ["reconcile"]);
+    assert_eq!(fixture.reload(), before);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+    let debug = format!("{result:?}");
+    for secret in ["private-task-marker", "127.0.0.1", "ssh-ed25519"] {
+        assert!(!debug.contains(secret));
+    }
+}
+
+#[test]
+fn retained_identity_lifecycle_and_absence_do_not_change_saved_state() {
+    let fixture = Fixture::new();
+    let retained = fixture.status();
+    fixture.retain(&retained);
+    let before = fixture.reload();
+    for lifecycle in [
+        InteractiveWorkerLifecycle::Provisioning,
+        InteractiveWorkerLifecycle::Ready,
+        InteractiveWorkerLifecycle::Stopped,
+        InteractiveWorkerLifecycle::Failed,
+        InteractiveWorkerLifecycle::Deleting,
+        InteractiveWorkerLifecycle::Unknown,
+    ] {
+        let mut status = retained.clone();
+        status.lifecycle = lifecycle;
+        if lifecycle != InteractiveWorkerLifecycle::Ready {
+            status.ssh = None;
+        }
+        let provider = Provider::new(Some(status));
+        let result = fixture.observe(&provider).expect("observation");
+        assert_eq!(result.worker.expect("observed worker").lifecycle, lifecycle);
+        assert_eq!(provider.calls(), ["inspect"]);
+        assert_eq!(fixture.reload(), before);
+    }
+    let provider = Provider::new(None);
+    let result = fixture.observe(&provider).expect("absence");
+    assert!(result.worker.is_none());
+    assert_eq!(result.saved.worker_identity, Some(retained.worker.identity));
+    assert_eq!(provider.calls(), ["inspect"]);
+    assert_eq!(fixture.reload(), before);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn pending_management_and_checkpoint_are_observable_but_never_mutated() {
+    let fixture = Fixture::new();
+    let status = fixture.status();
+    fixture.retain(&status);
+    for phase in [RemoteRuntimePhase::Cancelling, RemoteRuntimePhase::Deleting] {
+        let before = fixture.reload();
+        let mut state = before.workspace().state().clone();
+        let runtime = state.runtime.as_mut().expect("runtime");
+        runtime.phase = phase;
+        runtime.cleanup = Some(RemoteCleanupIntent {
+            reason: RemoteCleanupReason::Cancelled,
+            requested_at_millis: 1,
+        });
+        state.checkpoint = Some(RepositoryCheckpoint {
+            workspace_local_id: "workspace".into(),
+            base_commit: state.spec.repository.commit.clone(),
+            manifest_digest: ArtifactDigest::parse_sha256("c".repeat(64)).expect("digest"),
+            runtime_generation: 1,
+            generation: 1,
+            captured_at_millis: 1,
+            recovery_artifact: None,
+        });
+        fixture
+            .store
+            .replace_remote_workspace(before.workspace(), &state)
+            .expect("management");
+        let expected = fixture.reload();
+        let provider = Provider::new(Some(status.clone()));
+        let result = fixture.observe(&provider).expect("read-only observation");
+        assert_eq!(result.saved.saved_phase, Some(phase));
+        assert_eq!(result.saved.checkpoint, state.checkpoint);
+        assert_eq!(fixture.reload(), expected);
+        assert_eq!(provider.calls(), ["inspect"]);
+        assert!(
+            fixture
+                .store
+                .record_remote_worker_recovery(&expected, Some(&status))
+                .is_err()
+        );
+    }
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}

--- a/crates/horizon-core/src/remote_environment_observation/tests/guards.rs
+++ b/crates/horizon-core/src/remote_environment_observation/tests/guards.rs
@@ -1,0 +1,172 @@
+use super::*;
+
+#[test]
+fn missing_requests_wrong_provider_and_stale_workspace_fail_before_io() {
+    let fixture = Fixture::with_request(WorkerLifetime::Persistent, false);
+    let provider = Provider::new(None);
+    assert_eq!(fixture.observe(&provider), Err(Error::MissingRequest));
+    assert!(provider.calls().is_empty());
+
+    let fixture = Fixture::new();
+    let mut provider = Provider::new(None);
+    provider.kind = CloudProvider::RunPod;
+    assert_eq!(fixture.observe(&provider), Err(Error::ProviderMismatch));
+    assert!(provider.calls().is_empty());
+    provider.kind = CloudProvider::LocalDocker;
+    let before = fixture.reload();
+    let mut state = before.workspace().state().clone();
+    state.spec.working_directory = "nested".into();
+    fixture
+        .store
+        .replace_remote_workspace(before.workspace(), &state)
+        .expect("changed workspace");
+    assert_eq!(
+        observe_remote_environment(&fixture.store, &provider, before.workspace()),
+        Err(Error::StateChanged)
+    );
+    assert!(provider.calls().is_empty());
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn wrong_owner_and_dormant_record_cannot_inspect_another_allocation() {
+    let fixture = Fixture::new();
+    let provider = Provider::new(None);
+    let mut dormant = fixture.reload().workspace().state().clone();
+    dormant.runtime = None;
+    dormant.spec.generation = 0;
+    let other_directory = tempfile::tempdir().expect("other store");
+    let other_store =
+        CloudWorkflowStore::open_path(other_directory.path().join("control/store.sqlite3")).expect("other store");
+    let foreign = other_store
+        .create_remote_workspace("00000000-0000-4000-8000-000000000002", &dormant)
+        .expect("foreign owner");
+    assert_eq!(
+        observe_remote_environment(&fixture.store, &provider, &foreign),
+        Err(Error::StorageUnavailable)
+    );
+    dormant.spec.workspace_local_id = "dormant".into();
+    let dormant = fixture.store.create_remote_workspace(OWNER, &dormant).expect("dormant");
+    assert_eq!(
+        observe_remote_environment(&fixture.store, &provider, &dormant),
+        Err(Error::MissingAllocation)
+    );
+    assert!(provider.calls().is_empty());
+}
+
+#[test]
+fn mismatched_observations_are_rejected_without_saved_identity_changes() {
+    let fixture = Fixture::new();
+    let original = fixture.status();
+    fixture.retain(&original);
+    let before = fixture.reload();
+    for fault in 0..13 {
+        let mut status = original.clone();
+        match fault {
+            0 => status.worker.identity.provider = CloudProvider::RunPod,
+            1 => status.worker.identity.workflow_id = crate::cloud_run::CloudWorkflowId::new(),
+            2 => status.worker.identity.job_id = crate::cloud_run::CloudJobId::new(),
+            3 => status.worker.identity.resource_id = "another-worker".into(),
+            4 => status.worker.target.profile = "another-profile".into(),
+            5 => status.worker.target.image = format!("example/worker@sha256:{}", "d".repeat(64)),
+            6 => status.worker.target.disk_gib += 1,
+            7 => status.worker.ssh_public_key = public_key(2),
+            8 => status.ssh.as_mut().expect("ssh").host_key = public_key(8),
+            9 => status.ssh.as_mut().expect("ssh").host = "127.0.0.2".into(),
+            10 => status.ssh.as_mut().expect("ssh").port = 2223,
+            11 => status.ssh.as_mut().expect("ssh").username = "another-user".into(),
+            12 => status.ssh = None,
+            _ => unreachable!(),
+        }
+        let provider = Provider::new(Some(status));
+        assert_eq!(
+            fixture.observe(&provider),
+            Err(Error::InvalidObservation),
+            "fault {fault}"
+        );
+        assert_eq!(provider.calls(), ["inspect"]);
+        assert_eq!(fixture.reload(), before);
+    }
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn late_workspace_or_workflow_changes_invalidate_presence_and_absence() {
+    for workflow_change in [false, true] {
+        for absent in [false, true] {
+            let fixture = Fixture::new();
+            let before = fixture.reload();
+            let mut provider = Provider::new((!absent).then(|| fixture.status()));
+            let expected = before.clone();
+            let store = fixture.store.clone();
+            provider.during_read = Some(Box::new(move || {
+                if workflow_change {
+                    let mut changed = expected.workflow().workflow().clone();
+                    changed.updated_at_millis += 1;
+                    store.replace(expected.workflow(), &changed).expect("workflow change");
+                } else {
+                    let mut changed = expected.workspace().state().clone();
+                    changed.spec.working_directory = "changed".into();
+                    store
+                        .replace_remote_workspace(expected.workspace(), &changed)
+                        .expect("workspace change");
+                }
+            }));
+            assert_eq!(
+                observe_remote_environment(&fixture.store, &provider, before.workspace()),
+                Err(Error::StateChanged)
+            );
+            assert_eq!(provider.calls(), ["reconcile"]);
+            assert_ne!(fixture.reload(), before);
+            assert_eq!(fixture.counts(), [1, 1, 0]);
+        }
+    }
+}
+
+#[test]
+fn provider_failures_are_redacted_and_do_not_become_absence() {
+    let fixture = Fixture::new();
+    let before = fixture.reload();
+    let mut provider = Provider::new(None);
+    provider.fail = true;
+    let error = fixture.observe(&provider).expect_err("provider failure");
+    assert_eq!(error, Error::ProviderUnavailable);
+    assert!(!format!("{error} {error:?}").contains("private-provider-payload"));
+    assert_eq!(fixture.reload(), before);
+    assert_eq!(provider.calls(), ["reconcile"]);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}
+
+#[test]
+fn expired_execution_lifetime_is_not_reported_ready_but_stopped_identity_is_visible() {
+    let fixture = Fixture::with_request(WorkerLifetime::TimeLimited { seconds: 3600 }, true);
+    let mut status = fixture.status();
+    let before = fixture.reload();
+    for deadline in ["2020-01-01T00:00:00Z", "2099-01-01T00:00:00Z"] {
+        status.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: deadline.into(),
+        });
+        let provider = Provider::new(Some(status.clone()));
+        assert_eq!(fixture.observe(&provider), Err(Error::InvalidObservation));
+        assert_eq!(provider.calls(), ["reconcile"]);
+        assert_eq!(fixture.reload(), before);
+    }
+    status.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+        terminate_after: "2020-01-01T00:00:00Z".into(),
+    });
+    status.lifecycle = InteractiveWorkerLifecycle::Stopped;
+    status.ssh = None;
+    let provider = Provider::new(Some(status));
+    assert_eq!(
+        fixture
+            .observe(&provider)
+            .expect("stopped")
+            .worker
+            .expect("identity")
+            .lifecycle,
+        InteractiveWorkerLifecycle::Stopped
+    );
+    assert_eq!(provider.calls(), ["reconcile"]);
+    assert_eq!(fixture.reload(), before);
+    assert_eq!(fixture.counts(), [1, 1, 0]);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -112,6 +112,10 @@ back into large multi-purpose modules.
   admission leaf checks exact snapshots without granting creation authority;
   claimed, observed or expired retries use non-creating recovery. Setup remains
   separate from attachment, task readiness and explicit remote management.
+- `remote_environment_observation.rs` produces overview-safe, point-in-time
+  provider observations with exact snapshot checks but no private-key access or
+  saved-state writes. It shares allocation observation validation with recovery;
+  neither absence nor observed readiness grants management or attachment authority.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
   wire types; `ssh.rs` isolates host pins and client options; `command.rs` owns


### PR DESCRIPTION
## Purpose

Continue #383 with a read-only provider observation for the Remote Environments
overview. Saved metadata and live worker state must remain distinct.

## Behavior

- Inspect the exact retained resource or non-creatively reconcile its reserved
  public request. Match the owned workspace and workflow snapshots around I/O.
- Reuse existing resource, target, public identity, host pin and execution-lifetime
  validation. Discard mismatched or late results; provider failures are not absence.
- Return only the saved overview summary, observation time and observed worker
  identity/lifecycle. No task payload, SSH coordinates or key material is retained.
- Observe pending management without modifying it. Do not open private SSH keys,
  adopt workers, mutate saved records, consume creation grants or call create/delete.

This is a synchronous off-render-thread operation; concrete providers must bound
their reads. A point-in-time observation is not continued freshness, workspace
Ready, repository/task proof or authority to attach/manage. An absent resource
does not authorize replacement or removal from inventory. UI wiring remains separate.

## Validation

- Nine focused regressions: lifecycle/absence, stale and cross-owner records,
  public request without private keys, unchanged snapshots/checkpoints/management,
  provider/target/resource/key/pin mismatch, timed readiness, late workspace and
  workflow changes, redaction and zero create/delete/claim side effects.
- Independent source and final-base review passed. Full final-base source and
  exact-commit matrices passed on `2df725a`: formatting, maintainability, version
  sync, default/speech tests, blocking/strict and advisory Clippy.
- Real local-provider smoke repeated successfully on that exact commit with the fixture's private key temporarily
  unavailable: repeated observations before task start and after final PTY loss,
  unchanged workspace/workflow revisions, same worker/task PID, marker/key bytes
  and continued progress. Only the verified disposable worker/store/keys were removed.

Scope: five source/test files, 616 changed source/test lines plus architecture
notes. No UI/config/dependency changes, paid resources, image publication or release.
Local provider proof is not real-cloud PC-off acceptance or completion of #383.
