### PR TITLE
feat(remote): configure explicit local provider profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,29 @@ Use key names like `Plus`, `Minus`, `Comma`, `Escape`, and `F11` in YAML instead
 
 Fresh configs already ship the agent, browser, git, markdown, and usage presets above. Existing configs gain missing defaults through migration (Grok, Pi, Browser, and the others) without overwriting presets you renamed.
 
+### Remote provider profiles
+
+Remote provider settings are empty by default. Local Docker profiles require an
+explicit local Unix socket or Windows named pipe; Horizon does not infer a Docker
+context, environment variable or default endpoint. Profile names must be unique
+and match the saved environment's profile exactly, including letter case.
+
+```yaml
+remote:
+  local_docker:
+    - name: development
+      docker_host: unix:///path/to/docker.sock
+    - name: windows
+      docker_host: npipe:////./pipe/docker_engine
+```
+
+Replace the example socket with your explicitly selected local daemon. The new
+block rejects unknown fields and remote TCP/SSH endpoints. Keep credentials out
+of this configuration. Loading or saving profiles does not connect to a provider,
+create a workspace, attach to a task, or stop/delete remote work. Empty settings
+are omitted when saving, so existing files need no migration for this feature.
+Provider-backed overview controls and workspace setup remain separate integration work.
+
 ### Launch flags
 
 | Flag | What it does |

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -346,10 +346,7 @@ pub trait InteractiveWorkerProvider: Send + Sync {
 
 pub(crate) fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider) -> bool {
     target.provider == provider
-        && !target.profile.trim().is_empty()
-        && target.profile.trim() == target.profile
-        && target.profile.len() <= 191
-        && !target.profile.chars().any(char::is_control)
+        && valid_worker_profile_name(&target.profile)
         && valid_immutable_image(&target.image)
         && target.disk_gib > 0
         && target.lifetime.is_valid()
@@ -358,6 +355,10 @@ pub(crate) fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider
             .time_limit_seconds()
             .is_none_or(|seconds| seconds <= MAX_INTERACTIVE_WORKER_LEASE_SECONDS)
         && target.max_hourly_cost_micros != Some(0)
+}
+
+pub(crate) fn valid_worker_profile_name(name: &str) -> bool {
+    !name.trim().is_empty() && name.trim() == name && name.len() <= 191 && !name.chars().any(char::is_control)
 }
 
 fn valid_immutable_image(value: &str) -> bool {

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -6,6 +6,7 @@ use super::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
         InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
         InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus, valid_ssh_public_key,
+        valid_worker_profile_name,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -46,6 +47,21 @@ pub struct LocalDockerProfile {
     pub docker_host: String,
 }
 
+impl LocalDockerProfile {
+    /// Validate explicit configuration without contacting a daemon or consulting the environment.
+    /// # Errors
+    /// Returns [`LocalDockerError::InvalidTarget`] for malformed profile names and
+    /// [`LocalDockerError::NonLocalDockerHost`] for ambient or remote daemon endpoints.
+    pub fn validate(&self) -> Result<(), LocalDockerError> {
+        if !valid_worker_profile_name(&self.name) {
+            return Err(LocalDockerError::InvalidTarget);
+        }
+        valid_local_docker_host(&self.docker_host)
+            .then_some(())
+            .ok_or(LocalDockerError::NonLocalDockerHost)
+    }
+}
+
 /// Interactive worker provider backed by an explicitly selected local Docker daemon.
 pub struct LocalDockerInteractiveWorkerProvider {
     transport: Box<dyn DockerTransport>,
@@ -59,15 +75,14 @@ impl LocalDockerInteractiveWorkerProvider {
     /// Reconnect callers must use non-creating inspection/reconciliation, never ensure.
     ///
     /// # Errors
-    /// Returns [`LocalDockerError::NonLocalDockerHost`] for ambient or remote daemon endpoints.
+    /// Returns an error for an invalid profile name or a non-local daemon endpoint.
     pub fn new(profile: LocalDockerProfile, creation_store: CloudWorkflowStore) -> Result<Self, LocalDockerError> {
-        valid_local_docker_host(&profile.docker_host)
-            .then(|| Self {
-                transport: Box::new(command::DockerCli::new(&profile.docker_host)),
-                profile,
-                creation_store,
-            })
-            .ok_or(LocalDockerError::NonLocalDockerHost)
+        profile.validate()?;
+        Ok(Self {
+            transport: Box::new(command::DockerCli::new(&profile.docker_host)),
+            profile,
+            creation_store,
+        })
     }
     fn ensure_existing(
         &self,

--- a/crates/horizon-core/src/config.rs
+++ b/crates/horizon-core/src/config.rs
@@ -6,6 +6,7 @@ use crate::config_migration::{self, CURRENT_CONFIG_VERSION};
 use crate::error::{Error, Result};
 use crate::horizon_home::HorizonHome;
 use crate::panel::{PanelKind, PanelResume};
+use crate::remote_provider_config::RemoteProviderConfig;
 use crate::shortcuts::{AppShortcuts, ShortcutBinding};
 pub use crate::speech_config::{SpeechBackend, SpeechConfig, SpeechHotkeyMode, SpeechProfile, SpeechTask};
 use crate::ssh::{SshConnection, discover_ssh_hosts};
@@ -36,6 +37,8 @@ pub struct Config {
     pub features: FeaturesConfig,
     #[serde(default)]
     pub browser: crate::browser::BrowserConfig,
+    #[serde(default, skip_serializing_if = "RemoteProviderConfig::is_empty")]
+    pub remote: RemoteProviderConfig,
     #[serde(default = "default_presets")]
     pub presets: Vec<PresetConfig>,
     #[serde(default)]
@@ -59,6 +62,7 @@ impl Default for Config {
             overlays: OverlaysConfig::default(),
             features: FeaturesConfig::default(),
             browser: crate::browser::BrowserConfig::default(),
+            remote: RemoteProviderConfig::default(),
             presets: default_presets(),
             workspaces: Vec::new(),
         }
@@ -413,7 +417,7 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if any configured shortcut is invalid or duplicated.
+    /// Returns an error if a configured shortcut, feature, connection or provider profile is invalid.
     pub fn validate(&self) -> Result<()> {
         if !(1..=100).contains(&self.browser.quality) {
             return Err(Error::Config(format!(
@@ -421,6 +425,9 @@ impl Config {
                 self.browser.quality
             )));
         }
+        self.remote
+            .validate()
+            .map_err(|error| Error::Config(error.to_string()))?;
         let shortcuts = self.shortcuts.resolve()?;
         crate::speech_config::validate_speech(&self.features.speech, &shortcuts)?;
         validate_ssh_connections(&self.presets, &self.workspaces)?;

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -21,6 +21,7 @@ mod opencode_paths;
 mod panel;
 pub mod remote_environment_observation;
 mod remote_hosts;
+pub mod remote_provider_config;
 pub mod remote_ssh_identity;
 pub mod remote_worker_status;
 pub mod remote_workspace;

--- a/crates/horizon-core/src/remote_provider_config.rs
+++ b/crates/horizon-core/src/remote_provider_config.rs
@@ -1,0 +1,78 @@
+//! Explicit non-secret provider configuration, independent of provider I/O and UI.
+
+use crate::cloud_run::local_docker::LocalDockerProfile;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Empty by default: no ambient daemon, context or profile is implicitly selected.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RemoteProviderConfig {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub local_docker: Vec<LocalDockerProfile>,
+}
+
+impl<'de> Deserialize<'de> for RemoteProviderConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Fields {
+            #[serde(default)]
+            local_docker: Vec<LocalDockerProfile>,
+        }
+
+        // Parser errors can contain malformed values, even in a non-secret configuration block.
+        Fields::deserialize(deserializer)
+            .map(|fields| Self {
+                local_docker: fields.local_docker,
+            })
+            .map_err(|_| serde::de::Error::custom("invalid remote provider configuration"))
+    }
+}
+
+impl RemoteProviderConfig {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.local_docker.is_empty()
+    }
+
+    /// Validate explicit names and local endpoints without provider or credential access.
+    /// Profile names match saved worker targets exactly, including letter case.
+    /// # Errors
+    /// Rejects malformed profiles and duplicate names without echoing configured values.
+    pub fn validate(&self) -> Result<(), RemoteProviderConfigError> {
+        let mut names = HashSet::new();
+        for (index, profile) in self.local_docker.iter().enumerate() {
+            profile
+                .validate()
+                .map_err(|_| RemoteProviderConfigError::InvalidLocalProfile { index })?;
+            if !names.insert(profile.name.as_str()) {
+                return Err(RemoteProviderConfigError::DuplicateLocalProfile { index });
+            }
+        }
+        Ok(())
+    }
+
+    /// Resolve only an explicitly named profile. No default or environment fallback exists.
+    /// # Errors
+    /// Rejects invalid configuration or a name that has not been configured exactly.
+    pub fn local_docker_profile(&self, name: &str) -> Result<&LocalDockerProfile, RemoteProviderConfigError> {
+        self.validate()?;
+        self.local_docker
+            .iter()
+            .find(|profile| profile.name == name)
+            .ok_or(RemoteProviderConfigError::UnconfiguredLocalProfile)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteProviderConfigError {
+    #[error("remote.local_docker[{index}] requires a valid name and an explicit local socket or named pipe")]
+    InvalidLocalProfile { index: usize },
+    #[error("remote.local_docker[{index}] repeats an earlier profile name")]
+    DuplicateLocalProfile { index: usize },
+    #[error("no local provider profile exactly matches this saved environment")]
+    UnconfiguredLocalProfile,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_provider_config/tests.rs
+++ b/crates/horizon-core/src/remote_provider_config/tests.rs
@@ -1,0 +1,202 @@
+use super::*;
+use crate::cloud_run::{
+    CloudWorkflowStore,
+    interactive_worker::valid_worker_profile_name,
+    local_docker::{LocalDockerError, LocalDockerInteractiveWorkerProvider},
+};
+
+mod config;
+
+fn profile(name: &str, docker_host: &str) -> LocalDockerProfile {
+    LocalDockerProfile {
+        name: name.into(),
+        docker_host: docker_host.into(),
+    }
+}
+
+fn config(profiles: Vec<LocalDockerProfile>) -> RemoteProviderConfig {
+    RemoteProviderConfig { local_docker: profiles }
+}
+
+#[test]
+fn empty_configuration_has_no_implicit_profile() {
+    let empty = RemoteProviderConfig::default();
+    assert!(empty.is_empty());
+    assert_eq!(empty.validate(), Ok(()));
+    assert_eq!(
+        serde_yaml::from_str::<RemoteProviderConfig>("{}").expect("config"),
+        empty
+    );
+    for name in ["", "default", "local", "DOCKER_HOST", "DOCKER_CONTEXT"] {
+        assert_eq!(
+            empty.local_docker_profile(name),
+            Err(RemoteProviderConfigError::UnconfiguredLocalProfile)
+        );
+    }
+    assert_eq!(serde_yaml::to_string(&empty).expect("serialize"), "{}\n");
+}
+
+#[test]
+fn explicit_local_endpoints_round_trip_without_default_selection() {
+    let expected = config(vec![
+        profile("Desktop", "unix:///explicit path/not-connected.sock"),
+        profile("Named pipe", "npipe:////./pipe/explicit-daemon"),
+    ]);
+    assert!(!expected.is_empty());
+    assert_eq!(expected.validate(), Ok(()));
+    let yaml = serde_yaml::to_string(&expected).expect("serialize");
+    let restored: RemoteProviderConfig = serde_yaml::from_str(&yaml).expect("parse");
+    assert_eq!(restored, expected);
+    for configured in &expected.local_docker {
+        assert_eq!(restored.local_docker_profile(&configured.name), Ok(configured));
+    }
+    assert_eq!(
+        restored.local_docker_profile(""),
+        Err(RemoteProviderConfigError::UnconfiguredLocalProfile)
+    );
+}
+
+#[test]
+fn profile_names_match_target_validation_and_lookup_is_exact() {
+    for name in [
+        String::new(),
+        " ".into(),
+        " local".into(),
+        "local ".into(),
+        "local\nname".into(),
+        "local\0name".into(),
+        "a".repeat(192),
+        "ø".repeat(96),
+    ] {
+        let invalid = profile(&name, "unix:///explicit.sock");
+        assert!(!valid_worker_profile_name(&name));
+        assert_eq!(invalid.validate(), Err(LocalDockerError::InvalidTarget));
+        assert_eq!(
+            config(vec![invalid]).validate(),
+            Err(RemoteProviderConfigError::InvalidLocalProfile { index: 0 })
+        );
+    }
+    for name in ["a".repeat(191), "ø".repeat(95), "Team machine".into()] {
+        assert!(valid_worker_profile_name(&name));
+        assert_eq!(profile(&name, "unix:///explicit.sock").validate(), Ok(()));
+    }
+    let exact = config(vec![profile("Local", "unix:///explicit.sock")]);
+    for name in ["local", "LOCAL", " Local", "Local "] {
+        assert_eq!(
+            exact.local_docker_profile(name),
+            Err(RemoteProviderConfigError::UnconfiguredLocalProfile)
+        );
+    }
+    let distinct = config(vec![
+        profile("Local", "unix:///one.sock"),
+        profile("local", "unix:///two.sock"),
+    ]);
+    assert_eq!(distinct.validate(), Ok(()));
+    assert_eq!(distinct.local_docker_profile("local"), Ok(&distinct.local_docker[1]));
+}
+
+#[test]
+fn duplicate_names_cannot_select_a_different_endpoint() {
+    let ambiguous = config(vec![
+        profile("local", "unix:///one.sock"),
+        profile("local", "unix:///two.sock"),
+    ]);
+    assert_eq!(
+        ambiguous.validate(),
+        Err(RemoteProviderConfigError::DuplicateLocalProfile { index: 1 })
+    );
+    assert_eq!(
+        ambiguous.local_docker_profile("local"),
+        Err(RemoteProviderConfigError::DuplicateLocalProfile { index: 1 })
+    );
+}
+
+#[test]
+fn ambient_remote_and_malformed_endpoints_are_rejected() {
+    for host in [
+        "",
+        "default",
+        "/var/run/docker.sock",
+        "unix://relative.sock",
+        "unix:///",
+        "unix:///path\n/socket",
+        "npipe:////./pipe/",
+        "npipe:////./pipe/name\0",
+        "tcp://127.0.0.1:2375",
+        "ssh://example.invalid",
+        "https://example.invalid",
+    ] {
+        let invalid = profile("local", host);
+        assert_eq!(invalid.validate(), Err(LocalDockerError::NonLocalDockerHost));
+        let candidate = config(vec![profile("first", "unix:///first.sock"), invalid]);
+        assert_eq!(
+            candidate.validate(),
+            Err(RemoteProviderConfigError::InvalidLocalProfile { index: 1 })
+        );
+        assert_eq!(
+            candidate.local_docker_profile("first"),
+            Err(RemoteProviderConfigError::InvalidLocalProfile { index: 1 })
+        );
+    }
+}
+
+#[test]
+fn new_config_blocks_reject_unknown_or_missing_fields() {
+    for yaml in [
+        "implicit: true",
+        "local_docker: [{name: local}]",
+        "local_docker: [{docker_host: 'unix:///explicit.sock'}]",
+        "local_docker: [{name: local, docker_host: 'unix:///explicit.sock', api_key: synthetic-private-marker}]",
+    ] {
+        let error = serde_yaml::from_str::<RemoteProviderConfig>(yaml).expect_err("invalid schema");
+        assert!(!error.to_string().contains("synthetic-private-marker"));
+    }
+}
+
+#[test]
+fn malformed_profile_shapes_do_not_echo_values() {
+    for yaml in [
+        "local_docker: synthetic-private-marker",
+        "local_docker: [synthetic-private-marker]",
+        "local_docker: [{name: local, docker_host: [synthetic-private-marker]}]",
+        "synthetic-private-marker: true",
+    ] {
+        let error = serde_yaml::from_str::<RemoteProviderConfig>(yaml).expect_err("invalid shape");
+        assert!(!error.to_string().contains("synthetic-private-marker"));
+    }
+}
+
+#[test]
+fn configuration_errors_do_not_echo_profile_or_endpoint_values() {
+    let marker = "synthetic-private-marker";
+    let invalid = config(vec![profile(marker, &format!("ssh://{marker}"))]);
+    let error = invalid.validate().expect_err("invalid endpoint");
+    assert!(!format!("{error:?}: {error}").contains(marker));
+    let duplicates = config(vec![
+        profile(marker, "unix:///one.sock"),
+        profile(marker, "unix:///two.sock"),
+    ]);
+    let error = duplicates.validate().expect_err("duplicate");
+    assert!(!format!("{error:?}: {error}").contains(marker));
+    let empty = RemoteProviderConfig::default();
+    let error = empty.local_docker_profile(marker).expect_err("missing profile");
+    assert!(!format!("{error:?}: {error}").contains(marker));
+}
+
+#[test]
+fn provider_constructor_uses_same_validation_without_connecting() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = CloudWorkflowStore::open_path(temp.path().join("private/store.sqlite3")).expect("store");
+    assert!(matches!(
+        LocalDockerInteractiveWorkerProvider::new(profile(" local", "unix:///explicit.sock"), store.clone()),
+        Err(LocalDockerError::InvalidTarget)
+    ));
+    assert!(matches!(
+        LocalDockerInteractiveWorkerProvider::new(profile("local", "ssh://example.invalid"), store.clone()),
+        Err(LocalDockerError::NonLocalDockerHost)
+    ));
+    assert!(
+        LocalDockerInteractiveWorkerProvider::new(profile("local", "unix:///not-created/not-connected.sock"), store)
+            .is_ok()
+    );
+}

--- a/crates/horizon-core/src/remote_provider_config/tests/config.rs
+++ b/crates/horizon-core/src/remote_provider_config/tests/config.rs
@@ -1,0 +1,99 @@
+use super::*;
+use crate::Config;
+
+const EXPLICIT_PROFILES: &str = "remote:
+  local_docker:
+    - name: development
+      docker_host: unix:///explicit path/not-connected.sock
+    - name: windows
+      docker_host: npipe:////./pipe/explicit-daemon
+";
+
+#[test]
+fn old_and_default_configurations_remain_empty_without_a_migration() {
+    for configuration in [
+        Config::default(),
+        Config::from_yaml("{}").expect("minimal"),
+        Config::from_yaml("version: 1\npresets: []\n").expect("legacy"),
+        Config::from_yaml("remote: {}\n").expect("empty remote"),
+        Config::from_yaml("remote:\n  local_docker: []\n").expect("empty profiles"),
+    ] {
+        assert!(configuration.remote.is_empty());
+        let yaml = configuration.to_yaml().expect("serialize");
+        assert!(!yaml.contains("\nremote:"));
+        let restored = Config::from_yaml(&yaml).expect("round trip");
+        assert!(restored.remote.is_empty());
+        assert_eq!(restored.version, configuration.version);
+    }
+}
+
+#[test]
+fn explicit_profiles_round_trip_through_the_full_configuration() {
+    let configuration = Config::from_yaml(EXPLICIT_PROFILES).expect("configuration");
+    let expected = super::config(vec![
+        profile("development", "unix:///explicit path/not-connected.sock"),
+        profile("windows", "npipe:////./pipe/explicit-daemon"),
+    ]);
+    assert_eq!(configuration.remote, expected);
+    let yaml = configuration.to_yaml().expect("serialize");
+    assert_eq!(Config::from_yaml(&yaml).expect("round trip").remote, expected);
+    assert_eq!(
+        configuration.remote.local_docker_profile("development"),
+        Ok(&expected.local_docker[0])
+    );
+}
+
+#[test]
+fn full_configuration_semantically_validates_profiles() {
+    for remote in [
+        "local_docker: [{name: ' local', docker_host: 'unix:///explicit.sock'}]",
+        "local_docker: [{name: local, docker_host: 'tcp://127.0.0.1:2375'}]",
+        "local_docker: [{name: local, docker_host: 'unix:///one.sock'}, {name: local, docker_host: 'unix:///two.sock'}]",
+    ] {
+        assert!(Config::from_yaml(&format!("remote:\n  {remote}\n")).is_err());
+    }
+    let mut edited = Config::default();
+    edited.remote.local_docker.push(profile("", "unix:///explicit.sock"));
+    assert!(edited.validate().is_err());
+}
+
+#[test]
+fn full_configuration_redacts_malformed_profile_values() {
+    for remote in [
+        "synthetic-private-marker",
+        "{local_docker: synthetic-private-marker}",
+        "{local_docker: [synthetic-private-marker]}",
+        "{local_docker: [{name: local, docker_host: [synthetic-private-marker]}]}",
+        "{synthetic-private-marker: true}",
+        "{local_docker: [{name: synthetic-private-marker, docker_host: 'ssh://synthetic-private-marker'}]}",
+    ] {
+        let error = Config::from_yaml(&format!("remote: {remote}\n")).expect_err("invalid remote configuration");
+        assert!(!format!("{error:?}: {error}").contains("synthetic-private-marker"));
+    }
+}
+
+#[test]
+fn explicit_profile_load_does_not_connect_or_rewrite_current_config() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("config.yaml");
+    let yaml = format!("version: {}\n{EXPLICIT_PROFILES}", Config::default().version);
+    std::fs::write(&path, &yaml).expect("fixture");
+    let loaded = Config::load(Some(&path)).expect("load without daemon");
+    assert_eq!(loaded.remote.local_docker.len(), 2);
+    assert_eq!(std::fs::read_to_string(&path).expect("unchanged config"), yaml);
+    assert_eq!(std::fs::read_dir(temp.path()).expect("directory").count(), 1);
+}
+
+#[test]
+fn existing_config_migration_preserves_explicit_remote_profiles() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("config.yaml");
+    let original = format!("version: 1\n{EXPLICIT_PROFILES}");
+    std::fs::write(&path, &original).expect("legacy fixture");
+    let before = Config::from_yaml(&original).expect("legacy parse");
+    let migrated = Config::load(Some(&path)).expect("migrate");
+    assert_eq!(migrated.version, Config::default().version);
+    assert_eq!(migrated.remote, before.remote);
+    let saved = std::fs::read_to_string(&path).expect("migrated config");
+    assert_eq!(Config::from_yaml(&saved).expect("reopen").remote, before.remote);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -106,6 +106,10 @@ back into large multi-purpose modules.
   panels, exact runtime generation, and repository checkpoint metadata.
   Its validation is pure: provider I/O, runtime-state migration, coordination,
   repository transfer, and UI integration belong in later focused modules.
+- `remote_provider_config.rs` owns explicit non-secret provider profiles, empty
+  defaults, exact lookup and redacted validation. The main configuration delegates
+  to it; local profile construction shares target-name and local-endpoint rules.
+  Configuration loading never selects an ambient daemon or performs provider I/O.
 - `remote_ssh_identity.rs` exposes retained local client-key preparation and strict
   recovery, separately from the pure remote aggregate. Linux filesystem privacy
   and durable publication live in `remote_ssh_identity/linux.rs`; bounded key-utility


### PR DESCRIPTION
## Purpose

Add explicit, named local-container provider profiles as a focused foundation for
the Remote Environments workflow in #383.

## Behavior

- Optional `remote.local_docker` settings select an exact saved profile name and
  local socket or named-pipe endpoint. No implicit profile, environment/context
  fallback, credentials, or provider connection during configuration loading.
- Reject duplicate names, invalid profiles and nonlocal endpoints. Malformed
  configuration diagnostics do not echo supplied values.
- Preserve existing config defaults, migration, serialization and user settings
  when the new section is omitted. Live overview wiring remains separate work.

## Validation

- Independent local review completed on the final source tree.
- All 15 focused profile/configuration tests passed.
- Full validation passed both before commit and on this exact commit: format,
  maintainability/version checks, default/speech workspace tests, blocking and
  strict Clippy, and the advisory pedantic lane.
- Read-only default, synthetic and existing-config parity checks passed without
  rewriting user settings.
- Exact-commit local smoke loaded a named profile from YAML and exercised the
  actual provider against an already-local, immutable test image. Empty, missing
  and duplicate profiles failed before allocation; an explicit endpoint remained
  effective with conflicting environment/context settings in the child process.
- Keyless observations before task creation and after final attachment loss
  preserved worker/task identity, stored revisions and continued progress. Only
  the exact label/identity-verified disposable worker and fixture data were removed.

No paid cloud resource, image publication, release or existing user process was
changed. This PR does not complete #383 or claim cloud/offline acceptance.
