### PR TITLE
feat(repository): model exact-base overlay layers

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod remote_worker_status;
 pub mod remote_workspace;
 pub mod remote_workspace_recovery;
 pub mod remote_workspace_setup;
+pub mod repository_overlay;
 mod runtime_state;
 pub mod search;
 mod session_store;

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -1,0 +1,263 @@
+//! Inert, exact-base repository overlay metadata, not permission to capture or export files.
+//! Index changes are relative to the base; working-tree changes are relative to that index.
+//! Capture/apply must separately verify real filesystem topology, content hashes and approval.
+
+mod paths;
+
+use crate::cloud_run::{ArtifactDigest, GitSource};
+use std::{collections::BTreeMap, fmt};
+
+const MAX_CHANGES: usize = 16_384;
+const MAX_METADATA_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CONTENT_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+/// A file replacement, literal relative symlink, or removal of a file/link (never recursive).
+/// Index LFS pointer bytes and hydrated working-tree bytes have separate file identities.
+#[derive(Clone, Eq, PartialEq)]
+pub enum OverlayContent {
+    Remove,
+    File {
+        sha256: ArtifactDigest,
+        bytes: u64,
+        executable: bool,
+    },
+    Symlink {
+        target: String,
+    },
+}
+
+impl fmt::Debug for OverlayContent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Remove => formatter.write_str("Remove"),
+            Self::File { bytes, executable, .. } => formatter
+                .debug_struct("File")
+                .field("bytes", bytes)
+                .field("executable", executable)
+                .finish_non_exhaustive(),
+            Self::Symlink { .. } => formatter.debug_struct("Symlink").finish_non_exhaustive(),
+        }
+    }
+}
+
+/// One checked path/content description. Contains no regular-file bytes or host paths.
+#[derive(Clone, Eq, PartialEq)]
+pub struct OverlayChange {
+    path: String,
+    content: OverlayContent,
+}
+
+impl OverlayChange {
+    /// Validate metadata without following links or accessing a filesystem.
+    /// Paths use a normalized UTF-8 POSIX subset; unsupported names are rejected, not renamed.
+    /// # Errors
+    /// Rejects malformed/excluded paths, unsafe lexical link targets and oversized files.
+    pub fn new(path: String, content: OverlayContent) -> Result<Self, OverlayPlanError> {
+        paths::validate(&path)?;
+        match &content {
+            OverlayContent::File { bytes, .. } if *bytes > MAX_CONTENT_BYTES => {
+                return Err(OverlayPlanError::ContentLimit);
+            }
+            OverlayContent::Symlink { target } => paths::validate_link(&path, target)?,
+            _ => {}
+        }
+        Ok(Self { path, content })
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn content(&self) -> &OverlayContent {
+        &self.content
+    }
+}
+
+impl fmt::Debug for OverlayChange {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OverlayChange")
+            .field("content", &self.content)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A bounded two-layer plan tied to an exact commit, with deterministic path ordering.
+/// Renames are remove/add pairs; an untracked addition exists only in `working_tree`.
+/// This neither snapshots a repository nor certifies base-tree links or secret-free content.
+#[derive(Clone, Eq, PartialEq)]
+pub struct RepositoryOverlayPlan {
+    source: GitSource,
+    index: Vec<OverlayChange>,
+    working_tree: Vec<OverlayChange>,
+    content_bytes: u64,
+}
+
+impl RepositoryOverlayPlan {
+    /// Build an inert plan from metadata selected by a separate approval/capture boundary.
+    /// Each layer describes its resulting file/link states, not sequential filesystem writes.
+    /// A future applier must safely process removals before additions and recheck real nodes.
+    /// # Errors
+    /// Rejects invalid source identity, duplicate/overlapping paths and aggregate limit excess.
+    pub fn new(
+        source: GitSource,
+        index: impl IntoIterator<Item = OverlayChange>,
+        working_tree: impl IntoIterator<Item = OverlayChange>,
+    ) -> Result<Self, OverlayPlanError> {
+        source.validate().map_err(|_| OverlayPlanError::InvalidSource)?;
+        let mut budget = Budget::default();
+        budget.add_metadata(source.repository.len())?;
+        budget.add_metadata(source.commit.as_str().len())?;
+        budget.add_metadata(source.branch.as_ref().map_or(0, String::len))?;
+        let index = collect_layer(index, &mut budget)?;
+        let working_tree = collect_layer(working_tree, &mut budget)?;
+        validate_parents(&index, &[])?;
+        validate_parents(&[], &working_tree)?;
+        validate_parents(&index, &working_tree)?;
+        Ok(Self {
+            source,
+            index,
+            working_tree,
+            content_bytes: budget.content,
+        })
+    }
+
+    #[must_use]
+    pub fn source(&self) -> &GitSource {
+        &self.source
+    }
+
+    #[must_use]
+    pub fn index(&self) -> &[OverlayChange] {
+        &self.index
+    }
+
+    #[must_use]
+    pub fn working_tree(&self) -> &[OverlayChange] {
+        &self.working_tree
+    }
+
+    /// Conservative payload budget across both layers; shared digests are counted twice.
+    #[must_use]
+    pub fn content_bytes(&self) -> u64 {
+        self.content_bytes
+    }
+}
+
+impl fmt::Debug for RepositoryOverlayPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RepositoryOverlayPlan")
+            .field("index_changes", &self.index.len())
+            .field("working_tree_changes", &self.working_tree.len())
+            .field("content_bytes", &self.content_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Default)]
+struct Budget {
+    changes: usize,
+    metadata: usize,
+    content: u64,
+}
+
+impl Budget {
+    fn add_metadata(&mut self, bytes: usize) -> Result<(), OverlayPlanError> {
+        self.metadata = self
+            .metadata
+            .checked_add(bytes)
+            .filter(|total| *total <= MAX_METADATA_BYTES)
+            .ok_or(OverlayPlanError::MetadataLimit)?;
+        Ok(())
+    }
+
+    fn add(&mut self, change: &OverlayChange) -> Result<(), OverlayPlanError> {
+        if self.changes == MAX_CHANGES {
+            return Err(OverlayPlanError::ChangeLimit);
+        }
+        self.changes += 1;
+        self.add_metadata(change.path.len())?;
+        let bytes = match &change.content {
+            OverlayContent::Remove => 0,
+            OverlayContent::File { bytes, sha256, .. } => {
+                self.add_metadata(sha256.as_str().len())?;
+                *bytes
+            }
+            OverlayContent::Symlink { target } => {
+                self.add_metadata(target.len())?;
+                u64::try_from(target.len()).map_err(|_| OverlayPlanError::ContentLimit)?
+            }
+        };
+        self.content = self
+            .content
+            .checked_add(bytes)
+            .filter(|total| *total <= MAX_CONTENT_BYTES)
+            .ok_or(OverlayPlanError::ContentLimit)?;
+        Ok(())
+    }
+}
+
+fn collect_layer(
+    changes: impl IntoIterator<Item = OverlayChange>,
+    budget: &mut Budget,
+) -> Result<Vec<OverlayChange>, OverlayPlanError> {
+    let mut layer = Vec::new();
+    for change in changes {
+        budget.add(&change)?;
+        layer.push(change);
+    }
+    layer.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    if layer.windows(2).any(|pair| pair[0].path == pair[1].path) {
+        return Err(OverlayPlanError::DuplicatePath);
+    }
+    Ok(layer)
+}
+
+fn validate_parents(index: &[OverlayChange], working_tree: &[OverlayChange]) -> Result<(), OverlayPlanError> {
+    let mut present = BTreeMap::new();
+    for change in index.iter().chain(working_tree) {
+        present.insert(change.path.as_str(), !matches!(change.content, OverlayContent::Remove));
+    }
+    for (path, exists) in &present {
+        if !*exists {
+            continue;
+        }
+        let mut parent = *path;
+        while let Some((next, _)) = parent.rsplit_once('/') {
+            if present.get(next) == Some(&true) {
+                return Err(OverlayPlanError::ParentCollision);
+            }
+            parent = next;
+        }
+    }
+    Ok(())
+}
+
+/// Diagnostics omit repository, path, link target, digest and file content values.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum OverlayPlanError {
+    #[error("overlay source is not a valid exact repository identity")]
+    InvalidSource,
+    #[error("overlay path is not a supported normalized repository-relative path")]
+    InvalidPath,
+    #[error("overlay path is excluded by the repository transfer policy")]
+    ExcludedPath,
+    #[error("overlay symlink target does not remain within allowed repository paths")]
+    InvalidLink,
+    #[error("overlay layer contains multiple changes for the same path")]
+    DuplicatePath,
+    #[error("overlay file or symlink conflicts with a descendant path")]
+    ParentCollision,
+    #[error("overlay exceeds its total change limit")]
+    ChangeLimit,
+    #[error("overlay exceeds its metadata budget")]
+    MetadataLimit,
+    #[error("overlay exceeds its content budget")]
+    ContentLimit,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/paths.rs
+++ b/crates/horizon-core/src/repository_overlay/paths.rs
@@ -1,0 +1,91 @@
+//! Lexical transfer policy only; callers must separately validate real filesystem nodes.
+
+use super::OverlayPlanError as Error;
+use std::path::Path;
+
+const MAX_PATH_BYTES: usize = 4096;
+
+pub(super) fn validate(path: &str) -> Result<(), Error> {
+    if !supported_text(path) || path.split('/').any(|part| !valid_component(part)) {
+        return Err(Error::InvalidPath);
+    }
+    if path.split('/').any(excluded) {
+        return Err(Error::ExcludedPath);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_link(path: &str, target: &str) -> Result<(), Error> {
+    if !supported_text(target) || target.starts_with('/') {
+        return Err(Error::InvalidLink);
+    }
+    let mut resolved: Vec<_> = path.split('/').collect();
+    resolved.pop();
+    for part in target.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if resolved.pop().is_none() {
+                    return Err(Error::InvalidLink);
+                }
+            }
+            _ if !valid_component(part) || excluded(part) => return Err(Error::InvalidLink),
+            _ => resolved.push(part),
+        }
+    }
+    Ok(())
+}
+
+fn supported_text(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_PATH_BYTES
+        && !value
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '\\' | ':'))
+}
+
+fn valid_component(part: &str) -> bool {
+    !matches!(part, "" | "." | "..") && !part.ends_with(['.', ' '])
+}
+
+fn excluded(part: &str) -> bool {
+    let lower = part.to_ascii_lowercase();
+    lower == ".env"
+        || lower.starts_with(".env.")
+        || Path::new(part)
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("env"))
+        || lower == ".envrc"
+        || matches!(
+            lower.as_str(),
+            ".git"
+                | ".hg"
+                | ".svn"
+                | ".ssh"
+                | ".gnupg"
+                | ".aws"
+                | ".azure"
+                | ".kube"
+                | ".docker"
+                | ".config"
+                | ".codex"
+                | ".claude"
+                | ".claude.json"
+                | ".netrc"
+                | ".npmrc"
+                | ".pypirc"
+                | ".git-credentials"
+                | "credentials.json"
+                | "auth.json"
+                | "id_rsa"
+                | "id_ed25519"
+                | ".cache"
+                | "__pycache__"
+                | "node_modules"
+                | "target"
+                | ".venv"
+                | "venv"
+                | ".pytest_cache"
+                | ".mypy_cache"
+        )
+}

--- a/crates/horizon-core/src/repository_overlay/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/tests.rs
@@ -1,0 +1,301 @@
+use super::*;
+use crate::cloud_run::GitCommitSha;
+
+fn source() -> GitSource {
+    GitSource {
+        repository: "synthetic/project".into(),
+        commit: GitCommitSha::parse("a".repeat(40)).expect("commit"),
+        branch: None,
+    }
+}
+
+fn file(path: &str, marker: char, bytes: u64, executable: bool) -> OverlayChange {
+    OverlayChange::new(
+        path.into(),
+        OverlayContent::File {
+            sha256: ArtifactDigest::parse_sha256(marker.to_string().repeat(64)).expect("digest"),
+            bytes,
+            executable,
+        },
+    )
+    .expect("file")
+}
+
+fn remove(path: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Remove).expect("removal")
+}
+
+fn link(path: &str, target: &str) -> Result<OverlayChange, OverlayPlanError> {
+    OverlayChange::new(path.into(), OverlayContent::Symlink { target: target.into() })
+}
+
+#[test]
+fn layers_preserve_staged_unstaged_untracked_rename_modes_and_link_intent() {
+    let staged = file("renamed/script", 'b', 10, true);
+    let unstaged = file("renamed/script", 'c', 13, false);
+    let untracked = file("new directory/æøå", 'd', 5, false);
+    let symlink = link("links/current", "../renamed/script").expect("link");
+    let index = vec![staged.clone(), remove("original/script"), symlink.clone()];
+    let work = vec![untracked.clone(), unstaged.clone()];
+    let plan = RepositoryOverlayPlan::new(source(), index, work).expect("plan");
+    assert_eq!(plan.source(), &source());
+    assert_eq!(plan.index(), [symlink, remove("original/script"), staged]);
+    assert_eq!(plan.working_tree(), [untracked, unstaged]);
+    assert_eq!(plan.content_bytes(), 45);
+    assert_eq!(plan.index()[0].path(), "links/current");
+    assert_eq!(
+        plan.index()[0].content(),
+        &OverlayContent::Symlink {
+            target: "../renamed/script".into()
+        }
+    );
+}
+
+#[test]
+fn staged_lfs_pointer_and_hydrated_working_bytes_are_not_conflated() {
+    let pointer = file("assets/image.bin", 'a', 131, false);
+    let hydrated = file("assets/image.bin", 'b', 4096, false);
+    let plan = RepositoryOverlayPlan::new(source(), [pointer.clone()], [hydrated.clone()]).expect("plan");
+    assert_eq!(plan.index(), [pointer]);
+    assert_eq!(plan.working_tree(), [hydrated]);
+    assert_eq!(plan.content_bytes(), 4227);
+}
+
+#[test]
+fn output_order_is_deterministic_without_changing_layer_meaning() {
+    let changes = [file("z", 'a', 1, false), remove("b"), file("a", 'b', 2, true)];
+    let first = RepositoryOverlayPlan::new(source(), changes.clone(), []).expect("first");
+    let second = RepositoryOverlayPlan::new(source(), changes.into_iter().rev(), []).expect("second");
+    assert_eq!(first, second);
+    assert!(RepositoryOverlayPlan::new(source(), [], []).is_ok());
+}
+
+#[test]
+fn malformed_and_ambiguous_paths_are_rejected_not_normalized() {
+    for path in [
+        "",
+        ".",
+        "..",
+        "/outside",
+        "../outside",
+        "a/../b",
+        "a/./b",
+        "a//b",
+        "a/",
+        "C:/outside",
+        "//host/share",
+        "a\\b",
+        "a:stream",
+        "control\0name",
+        "line\nbreak",
+        "tab\tname",
+        "name.",
+        "name ",
+        "a/.git./config",
+    ] {
+        assert_eq!(
+            OverlayChange::new(path.into(), OverlayContent::Remove),
+            Err(OverlayPlanError::InvalidPath)
+        );
+    }
+    assert_eq!(
+        OverlayChange::new("a".repeat(4097), OverlayContent::Remove),
+        Err(OverlayPlanError::InvalidPath)
+    );
+    for path in [
+        "a b/file",
+        ".github/workflows/ci.yml",
+        "docs/.gitignore",
+        "æøå/雪",
+        "a-b_c.file",
+    ] {
+        assert!(OverlayChange::new(path.into(), OverlayContent::Remove).is_ok());
+    }
+}
+
+#[test]
+fn excluded_paths_apply_to_all_layers_and_all_content_kinds() {
+    for path in [
+        ".git/config",
+        "nested/.GiT/objects/a",
+        ".env",
+        "nested/.env.local",
+        "config/production.env",
+        "config/production.EnV",
+        "nested/.ENV.LOCAL",
+        ".envrc",
+        ".ssh/id_rsa",
+        ".aws/config",
+        ".azure/state",
+        ".kube/config",
+        ".docker/config.json",
+        ".config/tool/key",
+        ".codex/auth.json",
+        ".claude/state",
+        ".claude.json",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".git-credentials",
+        "nested/credentials.json",
+        "nested/auth.json",
+        "keys/id_ed25519",
+        "target/build",
+        "node_modules/pkg",
+        ".cache/data",
+        "__pycache__/module",
+        ".venv/bin/python",
+        "venv/bin/python",
+        ".pytest_cache/state",
+    ] {
+        for content in [
+            OverlayContent::Remove,
+            OverlayContent::Symlink { target: "safe".into() },
+            file("safe", 'a', 1, false).content().clone(),
+        ] {
+            assert_eq!(
+                OverlayChange::new(path.into(), content),
+                Err(OverlayPlanError::ExcludedPath)
+            );
+        }
+    }
+}
+
+#[test]
+fn links_preserve_literal_relative_targets_but_reject_escapes_and_exclusions() {
+    for target in ["../data/file", "./../data//file", ".", "../", "../æøå"] {
+        assert_eq!(
+            link("links/current", target).expect("safe lexical link").content(),
+            &OverlayContent::Symlink { target: target.into() }
+        );
+    }
+    for target in [
+        "",
+        "../../outside",
+        "/outside",
+        "C:/outside",
+        "\\host\\key",
+        "../.git/config",
+        "../.env",
+        "../keys/id_rsa",
+        "../name.",
+        "line\nbreak",
+    ] {
+        assert_eq!(link("links/current", target), Err(OverlayPlanError::InvalidLink));
+    }
+    assert_eq!(link("link", "../outside"), Err(OverlayPlanError::InvalidLink));
+    assert_eq!(link("link", &"a".repeat(4097)), Err(OverlayPlanError::InvalidLink));
+}
+
+#[test]
+fn duplicate_paths_are_rejected_per_layer_but_not_across_distinct_layers() {
+    let change = file("file", 'a', 1, false);
+    assert_eq!(
+        RepositoryOverlayPlan::new(source(), [change.clone(), remove("file")], []),
+        Err(OverlayPlanError::DuplicatePath)
+    );
+    assert_eq!(
+        RepositoryOverlayPlan::new(source(), [], [change.clone(), change.clone()]),
+        Err(OverlayPlanError::DuplicatePath)
+    );
+    assert!(RepositoryOverlayPlan::new(source(), [change], [remove("file")]).is_ok());
+}
+
+#[test]
+fn file_and_link_ancestors_cannot_contain_present_descendants() {
+    for parent in [file("a", 'a', 1, false), link("a", "other").expect("link")] {
+        let child = file("a/b/c", 'b', 1, false);
+        for (index, work) in [
+            (vec![parent.clone(), child.clone()], vec![]),
+            (vec![], vec![parent.clone(), child.clone()]),
+            (vec![parent.clone()], vec![child.clone()]),
+            (vec![child.clone()], vec![parent.clone()]),
+        ] {
+            assert_eq!(
+                RepositoryOverlayPlan::new(source(), index, work),
+                Err(OverlayPlanError::ParentCollision)
+            );
+        }
+    }
+}
+
+#[test]
+fn removals_allow_file_directory_and_link_replacements_without_recursive_deletion() {
+    let child = file("a/b", 'a', 1, false);
+    let parent = file("a", 'b', 1, true);
+    assert!(RepositoryOverlayPlan::new(source(), [remove("a"), child.clone()], []).is_ok());
+    assert!(RepositoryOverlayPlan::new(source(), [parent.clone(), remove("a/b")], []).is_ok());
+    assert!(RepositoryOverlayPlan::new(source(), [parent.clone()], [remove("a"), child.clone()]).is_ok());
+    assert!(RepositoryOverlayPlan::new(source(), [child], [remove("a/b"), parent]).is_ok());
+    assert!(
+        RepositoryOverlayPlan::new(
+            source(),
+            [link("a", "other").expect("link")],
+            [remove("a"), file("a/b", 'a', 1, false)]
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn invalid_source_never_enters_a_plan_and_diagnostics_are_redacted() {
+    let mut invalid = source();
+    invalid.repository = "https://synthetic-user:synthetic-secret@example.invalid/private".into();
+    let error = RepositoryOverlayPlan::new(invalid, [], []).expect_err("credential-bearing source");
+    assert_eq!(error, OverlayPlanError::InvalidSource);
+    assert!(!format!("{error:?} {error}").contains("synthetic-secret"));
+    let change = link("private-name", "private-target").expect("link");
+    let plan = RepositoryOverlayPlan::new(source(), [change.clone()], []).expect("plan");
+    let rendered = format!("{plan:?} {change:?} {:?}", change.content());
+    for private in ["synthetic/project", "private-name", "private-target"] {
+        assert!(!rendered.contains(private));
+    }
+}
+
+#[test]
+fn count_limit_is_shared_between_layers_and_stops_infinite_input() {
+    let index = (0..MAX_CHANGES).map(|number| remove(&format!("file-{number}")));
+    assert!(RepositoryOverlayPlan::new(source(), index, []).is_ok());
+    let index = (0..MAX_CHANGES).map(|number| remove(&format!("file-{number}")));
+    assert_eq!(
+        RepositoryOverlayPlan::new(source(), index, [remove("extra")]),
+        Err(OverlayPlanError::ChangeLimit)
+    );
+    let mut consumed = 0;
+    let infinite = std::iter::from_fn(|| {
+        consumed += 1;
+        Some(remove(&format!("file-{consumed}")))
+    });
+    assert_eq!(
+        RepositoryOverlayPlan::new(source(), infinite, []),
+        Err(OverlayPlanError::ChangeLimit)
+    );
+    assert_eq!(consumed, MAX_CHANGES + 1);
+}
+
+#[test]
+fn metadata_and_content_budgets_fail_closed_without_overflow_or_partial_plan() {
+    let long = "a".repeat(4000);
+    let metadata = (0..MAX_CHANGES).map(|number| remove(&format!("{long}/{number}")));
+    assert_eq!(
+        RepositoryOverlayPlan::new(source(), metadata, []),
+        Err(OverlayPlanError::MetadataLimit)
+    );
+    let full = file("file", 'a', MAX_CONTENT_BYTES, false);
+    assert!(RepositoryOverlayPlan::new(source(), [full.clone()], []).is_ok());
+    assert_eq!(
+        RepositoryOverlayPlan::new(source(), [full], [file("file", 'b', 1, false)]),
+        Err(OverlayPlanError::ContentLimit)
+    );
+    assert_eq!(
+        OverlayChange::new(
+            "file".into(),
+            OverlayContent::File {
+                sha256: ArtifactDigest::parse_sha256("a".repeat(64)).expect("digest"),
+                bytes: u64::MAX,
+                executable: false,
+            }
+        ),
+        Err(OverlayPlanError::ContentLimit)
+    );
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -127,6 +127,10 @@ back into large multi-purpose modules.
   Explicit saved shell/command verification reuses those gates and compares
   literal argv plus the effective directory with the worker's retained intent;
   unresolved agent launch/handoff/resume semantics stay fail-closed.
+- `repository_overlay/` owns bounded exact-base metadata for separate index and
+  working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
+  Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply
+  must independently validate approval, real node/link topology and content hashes.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Add the inert, exact-base repository overlay model needed by #383. Index changes
relative to the base commit remain separate from working-tree changes relative
to that index, preserving staged versus unstaged bytes and executable/link intent.

## Behavior and boundaries

- Immutable checked metadata preserves removals, binary-file digests/sizes,
  executable flags and literal relative link targets; renames are remove/add pairs.
- Deterministic ordering, shared count/metadata/payload budgets and duplicate or
  ancestor-conflict rejection fail closed. Diagnostics omit repository/path values.
- The lexical policy rejects traversal, ambiguous names and known credential,
  environment, Git-internal and cache paths. Unsupported names are not renamed.
- This performs no filesystem, Git, provider or transfer I/O. It is not export
  approval, a content secret scan, safe archive extraction, LFS hydration or remote
  durability. Capture/application must independently validate actual nodes, links,
  hashes and approval. No UI, configuration defaults or dependencies change.

## Validation

- Twelve focused regressions cover layer separation, binary/LFS identities,
  renames, modes, literal links, ordering, exclusions, malformed paths, collisions,
  safe file/directory replacement, redaction and shared resource limits.
- Full source and exact-commit validation: formatting, maintainability/version
  guards, default and speech workspace tests, blocking/strict/advisory Clippy.
- Independent local review completed on the candidate tree.
- Native/provider smoke is not applicable to this pure metadata-only outcome;
  no repository contents or existing resources were accessed by these tests.

Part of #383; does not close the issue.
