### PR TITLE
feat(repository): confine selected file reads

### DIFF
--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -3,6 +3,7 @@
 //! Capture/apply must separately verify real filesystem topology, content hashes and approval.
 
 mod paths;
+pub mod reader;
 
 use crate::cloud_run::{ArtifactDigest, GitSource};
 use std::{collections::BTreeMap, fmt};

--- a/crates/horizon-core/src/repository_overlay/paths.rs
+++ b/crates/horizon-core/src/repository_overlay/paths.rs
@@ -3,7 +3,7 @@
 use super::OverlayPlanError as Error;
 use std::path::Path;
 
-const MAX_PATH_BYTES: usize = 4096;
+pub(super) const MAX_PATH_BYTES: usize = 4096;
 
 pub(super) fn validate(path: &str) -> Result<(), Error> {
     if !supported_text(path) || path.split('/').any(|part| !valid_component(part)) {

--- a/crates/horizon-core/src/repository_overlay/reader/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/linux.rs
@@ -1,0 +1,161 @@
+use super::{RepositoryReadError as Error, SelectedRepositoryNode as Node, paths};
+use rustix::fs::{CWD, Mode, OFlags, ResolveFlags, openat2, readlinkat_raw};
+use std::{
+    fs::{File, Metadata, OpenOptions},
+    io::Read,
+    os::{
+        fd::AsRawFd,
+        unix::fs::{MetadataExt, OpenOptionsExt},
+    },
+    path::Path,
+};
+
+pub(super) struct Root(File);
+
+impl Root {
+    pub(super) fn open(path: &Path) -> Result<Self, Error> {
+        let descriptor = openat2(
+            CWD,
+            path,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS,
+        )
+        .map_err(open_error)?;
+        Ok(Self(File::from(descriptor)))
+    }
+
+    fn pin(&self, path: &str) -> Result<PinnedNode, Error> {
+        let descriptor = openat2(
+            &self.0,
+            path,
+            OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+            ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS | ResolveFlags::NO_XDEV,
+        )
+        .map_err(open_error)?;
+        let file = File::from(descriptor);
+        let metadata = file.metadata().map_err(|_| Error::ReadFailed)?;
+        if !(metadata.is_file() || metadata.is_symlink()) || metadata.nlink() != 1 {
+            return Err(Error::UnsupportedNode);
+        }
+        Ok(PinnedNode { file, metadata })
+    }
+
+    pub(super) fn read(&self, path: &str, limit: usize) -> Result<Node, Error> {
+        let node = self.pin(path)?;
+        let content = if node.metadata.is_symlink() {
+            node.link(path, limit)?
+        } else {
+            node.regular(limit)?
+        };
+        node.verify(&node.file.metadata().map_err(|_| Error::ReadFailed)?)?;
+        self.verify_path(path, &node)?;
+        Ok(content)
+    }
+
+    fn verify_path(&self, path: &str, node: &PinnedNode) -> Result<(), Error> {
+        let current = self.pin(path).map_err(|_| Error::Changed)?;
+        node.verify(&current.metadata)
+    }
+}
+
+struct PinnedNode {
+    file: File,
+    metadata: Metadata,
+}
+
+impl PinnedNode {
+    fn verify(&self, current: &Metadata) -> Result<(), Error> {
+        if fingerprint(&self.metadata) == fingerprint(current) {
+            Ok(())
+        } else {
+            Err(Error::Changed)
+        }
+    }
+
+    fn regular(&self, limit: usize) -> Result<Node, Error> {
+        let declared = usize::try_from(self.metadata.len()).map_err(|_| Error::TooLarge)?;
+        if declared > limit {
+            return Err(Error::TooLarge);
+        }
+        // The held O_PATH handle already identifies a regular inode. Reopen that
+        // inode, not its mutable name, so a path swap cannot open a device or FIFO.
+        let mut file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(format!("/proc/self/fd/{}", self.file.as_raw_fd()))
+            .map_err(|_| Error::ReadFailed)?;
+        self.verify(&file.metadata().map_err(|_| Error::ReadFailed)?)?;
+        let bytes = read_limited(&mut file, declared, limit)?;
+        self.verify(&file.metadata().map_err(|_| Error::ReadFailed)?)?;
+        Ok(Node::File {
+            bytes,
+            executable: self.metadata.mode() & 0o100 != 0,
+        })
+    }
+
+    fn link(&self, path: &str, limit: usize) -> Result<Node, Error> {
+        let mut buffer = [0u8; paths::MAX_PATH_BYTES + 1];
+        let length = readlinkat_raw(&self.file, "", &mut buffer[..]).map_err(|_| Error::ReadFailed)?;
+        if length == buffer.len() || length > limit {
+            return Err(Error::TooLarge);
+        }
+        let target = std::str::from_utf8(&buffer[..length])
+            .map_err(|_| Error::UnsafePath)?
+            .to_owned();
+        paths::validate_link(path, &target)?;
+        Ok(Node::Symlink { target })
+    }
+}
+
+fn read_limited(reader: impl Read, declared: usize, limit: usize) -> Result<Vec<u8>, Error> {
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(declared + 1).map_err(|_| Error::TooLarge)?;
+    reader
+        .take(limit as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| Error::ReadFailed)?;
+    if bytes.len() > limit {
+        return Err(Error::TooLarge);
+    }
+    if bytes.len() != declared {
+        return Err(Error::Changed);
+    }
+    Ok(bytes)
+}
+
+#[derive(Eq, PartialEq)]
+struct Fingerprint {
+    device: u64,
+    inode: u64,
+    bytes: u64,
+    mode: u32,
+    links: u64,
+    modified: (i64, i64),
+    changed: (i64, i64),
+}
+
+fn fingerprint(metadata: &Metadata) -> Fingerprint {
+    Fingerprint {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        bytes: metadata.len(),
+        mode: metadata.mode(),
+        links: metadata.nlink(),
+        modified: (metadata.mtime(), metadata.mtime_nsec()),
+        changed: (metadata.ctime(), metadata.ctime_nsec()),
+    }
+}
+
+fn open_error(error: rustix::io::Errno) -> Error {
+    match error {
+        rustix::io::Errno::NOSYS | rustix::io::Errno::INVAL => Error::Unsupported,
+        rustix::io::Errno::NOENT => Error::Missing,
+        rustix::io::Errno::LOOP | rustix::io::Errno::XDEV | rustix::io::Errno::AGAIN => Error::UnsafePath,
+        _ => Error::ReadFailed,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/reader/linux/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/linux/tests.rs
@@ -1,0 +1,84 @@
+use super::*;
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+};
+
+#[test]
+fn pinned_regular_node_rejects_in_place_content_or_mode_changes() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let path = directory.path().join("file");
+    fs::write(&path, b"a").expect("file");
+    let root = Root::open(directory.path()).expect("root");
+    let node = root.pin("file").expect("pin");
+    fs::write(&path, b"different length").expect("mutation");
+    assert_eq!(node.regular(100), Err(Error::Changed));
+    let node = root.pin("file").expect("new pin");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).expect("mode mutation");
+    assert_eq!(node.regular(100), Err(Error::Changed));
+}
+
+#[test]
+fn replacement_after_pinning_never_redirects_a_content_open() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let path = directory.path().join("file");
+    fs::write(&path, b"selected").expect("file");
+    let root = Root::open(directory.path()).expect("root");
+    let node = root.pin("file").expect("pin");
+    fs::rename(&path, directory.path().join("retained")).expect("rename");
+    rustix::fs::mkfifoat(CWD, &path, Mode::RUSR | Mode::WUSR).expect("replacement fifo");
+    // Renaming may change ctime; either rejection or the pinned old bytes are safe.
+    let result = node.regular(100);
+    assert!(
+        result == Err(Error::Changed)
+            || result
+                == Ok(Node::File {
+                    bytes: b"selected".to_vec(),
+                    executable: false
+                })
+    );
+    assert_eq!(root.verify_path("file", &node), Err(Error::Changed));
+}
+
+#[test]
+fn changed_parent_and_link_identity_fail_final_revalidation() {
+    let directory = tempfile::tempdir().expect("fixture");
+    fs::create_dir(directory.path().join("parent")).expect("parent");
+    fs::write(directory.path().join("parent/file"), b"selected").expect("file");
+    let root = Root::open(directory.path()).expect("root");
+    let node = root.pin("parent/file").expect("pin");
+    fs::rename(directory.path().join("parent"), directory.path().join("retained")).expect("rename");
+    symlink("retained", directory.path().join("parent")).expect("linked parent");
+    assert_eq!(root.verify_path("parent/file", &node), Err(Error::Changed));
+    symlink("old", directory.path().join("link")).expect("link");
+    let link = root.pin("link").expect("pin link");
+    fs::remove_file(directory.path().join("link")).expect("replace owned link");
+    symlink("new", directory.path().join("link")).expect("replacement link");
+    assert_eq!(link.link("link", 100), Ok(Node::Symlink { target: "old".into() }));
+    assert_eq!(root.verify_path("link", &link), Err(Error::Changed));
+}
+
+#[test]
+fn confinement_errors_never_trigger_fallback_or_unbounded_retries() {
+    for errno in [
+        rustix::io::Errno::LOOP,
+        rustix::io::Errno::XDEV,
+        rustix::io::Errno::AGAIN,
+    ] {
+        assert_eq!(open_error(errno), Error::UnsafePath);
+    }
+    for errno in [rustix::io::Errno::NOSYS, rustix::io::Errno::INVAL] {
+        assert_eq!(open_error(errno), Error::Unsupported);
+    }
+    assert_eq!(open_error(rustix::io::Errno::ACCESS), Error::ReadFailed);
+}
+
+#[test]
+fn growing_or_truncated_input_is_rejected_without_partial_or_unbounded_results() {
+    let mut input = std::io::Cursor::new(b"original and concurrent growth");
+    assert_eq!(read_limited(&mut input, 4, 8), Err(Error::TooLarge));
+    assert_eq!(input.position(), 9);
+    assert_eq!(read_limited(&b"grown"[..], 4, 8), Err(Error::Changed));
+    assert_eq!(read_limited(&b"short"[..], 8, 8), Err(Error::Changed));
+    assert_eq!(read_limited(&b"exact"[..], 5, 5), Ok(b"exact".to_vec()));
+}

--- a/crates/horizon-core/src/repository_overlay/reader/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/mod.rs
@@ -1,0 +1,122 @@
+//! Bounded reads of individually selected nodes, not repository capture or export approval.
+//! Linux confinement is required; unsupported platforms fail without a weaker fallback.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+use super::{OverlayPlanError, paths};
+use std::{
+    fmt,
+    path::{Component, Path},
+};
+
+/// Maximum regular-file payload per read; larger files require a future streaming boundary.
+pub const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
+
+/// Local bytes or a literal link target. Does not certify content safety or a coherent snapshot.
+#[derive(Eq, PartialEq)]
+pub enum SelectedRepositoryNode {
+    File { bytes: Vec<u8>, executable: bool },
+    Symlink { target: String },
+}
+
+impl fmt::Debug for SelectedRepositoryNode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::File { bytes, executable } => formatter
+                .debug_struct("File")
+                .field("bytes", &bytes.len())
+                .field("executable", executable)
+                .finish_non_exhaustive(),
+            Self::Symlink { .. } => formatter.debug_struct("Symlink").finish_non_exhaustive(),
+        }
+    }
+}
+
+/// Pins an explicitly selected directory object; renaming it does not select a replacement.
+/// This does not discover or verify a Git root, enumerate files or authorize export.
+pub struct SelectedRepositoryReader {
+    #[cfg(target_os = "linux")]
+    root: linux::Root,
+}
+
+impl SelectedRepositoryReader {
+    /// Open only the nominated absolute directory, with no symlinked ancestors.
+    /// # Errors
+    /// Rejects unsupported confinement, invalid roots and inaccessible directories.
+    pub fn open(root: &Path) -> Result<Self, RepositoryReadError> {
+        if !root.is_absolute() || root.parent().is_none() || root.components().any(|part| part == Component::ParentDir)
+        {
+            return Err(RepositoryReadError::InvalidRoot);
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Ok(Self {
+                root: linux::Root::open(root)?,
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        Err(RepositoryReadError::Unsupported)
+    }
+
+    /// Read one allowed path without following its symlink target or linked parents.
+    /// Byte bounds do not bound wall-clock time on a blocked filesystem. Run off the UI thread.
+    /// # Errors
+    /// Rejects invalid policy/limits, unsupported nodes, unsafe resolution and detected changes.
+    pub fn read(&self, path: &str, byte_limit: usize) -> Result<SelectedRepositoryNode, RepositoryReadError> {
+        paths::validate(path)?;
+        if byte_limit > MAX_READ_BYTES {
+            return Err(RepositoryReadError::InvalidLimit);
+        }
+        #[cfg(target_os = "linux")]
+        {
+            self.root.read(path, byte_limit)
+        }
+        #[cfg(not(target_os = "linux"))]
+        Err(RepositoryReadError::Unsupported)
+    }
+}
+
+/// Redacted errors never include filesystem paths or contents.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RepositoryReadError {
+    #[error("safe repository reads are unsupported on this platform or kernel")]
+    Unsupported,
+    #[error("repository reader requires a selected absolute directory")]
+    InvalidRoot,
+    #[error("repository read limit exceeds the supported payload bound")]
+    InvalidLimit,
+    #[error(transparent)]
+    Policy(#[from] OverlayPlanError),
+    #[error("selected repository node is missing")]
+    Missing,
+    #[error("selected repository path cannot be safely confined")]
+    UnsafePath,
+    #[error("selected repository node type or hardlink is unsupported")]
+    UnsupportedNode,
+    #[error("selected repository node changed during the read")]
+    Changed,
+    #[error("selected repository node exceeds the read limit")]
+    TooLarge,
+    #[error("selected repository node could not be read")]
+    ReadFailed,
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;
+
+#[cfg(all(test, not(target_os = "linux")))]
+mod unsupported_tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_platform_never_falls_back_to_unconfined_reads() {
+        let directory = tempfile::tempdir().expect("fixture");
+        assert!(matches!(
+            SelectedRepositoryReader::open(directory.path()),
+            Err(RepositoryReadError::Unsupported)
+        ));
+        let reader = SelectedRepositoryReader {};
+        assert_eq!(reader.read("file", 10), Err(RepositoryReadError::Unsupported));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/reader/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/tests.rs
@@ -1,0 +1,180 @@
+use super::{RepositoryReadError as Error, SelectedRepositoryNode as Node, *};
+use std::{
+    fs,
+    os::unix::{
+        fs::{PermissionsExt, symlink},
+        net::UnixListener,
+    },
+};
+
+#[test]
+fn reads_exact_binary_nested_unicode_empty_bytes_and_owner_executable_mode() {
+    let directory = tempfile::tempdir().expect("fixture");
+    fs::create_dir(directory.path().join("nested")).expect("directory");
+    let path = directory.path().join("nested/æøå");
+    fs::write(&path, [0, 255, 10, 128]).expect("bytes");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o740)).expect("mode");
+    fs::write(directory.path().join("empty"), []).expect("empty");
+    let reader = SelectedRepositoryReader::open(directory.path()).expect("root");
+    assert_eq!(
+        reader.read("nested/æøå", 4),
+        Ok(Node::File {
+            bytes: vec![0, 255, 10, 128],
+            executable: true
+        })
+    );
+    assert_eq!(
+        reader.read("empty", 0),
+        Ok(Node::File {
+            bytes: vec![],
+            executable: false
+        })
+    );
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o611)).expect("group/other executable");
+    assert_eq!(
+        reader.read("nested/æøå", 4),
+        Ok(Node::File {
+            bytes: vec![0, 255, 10, 128],
+            executable: false
+        })
+    );
+    assert_eq!(fs::read(&path).expect("unchanged bytes"), [0, 255, 10, 128]);
+}
+
+#[test]
+fn path_policy_runs_before_any_node_read_and_errors_are_redacted() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let reader = SelectedRepositoryReader::open(directory.path()).expect("root");
+    for path in [
+        "../outside",
+        "/outside",
+        "C:/outside",
+        "a\\b",
+        "a//b",
+        ".git/config",
+        ".env",
+        "target/cache",
+        "keys/id_rsa",
+    ] {
+        let result = reader.read(path, 100);
+        assert!(matches!(result, Err(Error::Policy(_))));
+        assert!(!format!("{result:?}").contains(path));
+    }
+    assert_eq!(reader.read("private-missing", 100), Err(Error::Missing));
+    assert!(!format!("{:?}", reader.read("private-missing", 100)).contains("private-missing"));
+}
+
+#[test]
+fn limits_cover_declared_and_actual_payloads_without_truncation() {
+    let directory = tempfile::tempdir().expect("fixture");
+    fs::write(directory.path().join("file"), b"abcd").expect("file");
+    let reader = SelectedRepositoryReader::open(directory.path()).expect("root");
+    assert_eq!(reader.read("file", 3), Err(Error::TooLarge));
+    assert_eq!(reader.read("file", 0), Err(Error::TooLarge));
+    assert!(reader.read("file", 4).is_ok());
+    assert_eq!(reader.read("file", usize::MAX), Err(Error::InvalidLimit));
+    let large = fs::File::create(directory.path().join("large")).expect("sparse file");
+    large.set_len(MAX_READ_BYTES as u64 + 1).expect("size");
+    assert_eq!(reader.read("large", MAX_READ_BYTES), Err(Error::TooLarge));
+}
+
+#[test]
+fn links_are_literal_bounded_and_never_followed() {
+    let directory = tempfile::tempdir().expect("fixture");
+    fs::create_dir(directory.path().join("links")).expect("links");
+    symlink("./../missing//file", directory.path().join("links/current")).expect("dangling literal link");
+    let reader = SelectedRepositoryReader::open(directory.path()).expect("root");
+    let target = "./../missing//file";
+    let node = reader.read("links/current", target.len()).expect("literal link");
+    assert_eq!(node, Node::Symlink { target: target.into() });
+    assert!(!format!("{node:?}").contains("missing"));
+    assert_eq!(reader.read("links/current", target.len() - 1), Err(Error::TooLarge));
+    for (name, target) in [
+        ("escape", "../../outside"),
+        ("absolute", "/outside"),
+        ("excluded", "../.env"),
+    ] {
+        symlink(target, directory.path().join("links").join(name)).expect("unsafe link fixture");
+        assert!(matches!(
+            reader.read(&format!("links/{name}"), 100),
+            Err(Error::Policy(OverlayPlanError::InvalidLink))
+        ));
+    }
+}
+
+#[test]
+fn linked_roots_and_parents_are_rejected_including_in_root_aliases() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let root = directory.path().join("root");
+    fs::create_dir(&root).expect("root");
+    fs::write(root.join("file"), b"inside").expect("inside");
+    fs::write(directory.path().join("outside"), b"never read").expect("outside");
+    symlink(&root, directory.path().join("alias")).expect("root alias");
+    assert!(matches!(
+        SelectedRepositoryReader::open(&directory.path().join("alias")),
+        Err(Error::UnsafePath)
+    ));
+    symlink(directory.path(), root.join("escape")).expect("parent escape");
+    symlink(".", root.join("alias")).expect("internal parent alias");
+    let reader = SelectedRepositoryReader::open(&root).expect("root");
+    assert_eq!(reader.read("escape/outside", 100), Err(Error::UnsafePath));
+    assert_eq!(reader.read("alias/file", 100), Err(Error::UnsafePath));
+    assert_eq!(
+        fs::read(directory.path().join("outside")).expect("outside intact"),
+        b"never read"
+    );
+}
+
+#[test]
+fn directories_fifos_sockets_and_hardlinks_fail_without_opening_for_content() {
+    let directory = tempfile::tempdir().expect("fixture");
+    fs::create_dir(directory.path().join("subdirectory")).expect("directory");
+    rustix::fs::mkfifoat(
+        rustix::fs::CWD,
+        directory.path().join("fifo"),
+        rustix::fs::Mode::RUSR | rustix::fs::Mode::WUSR,
+    )
+    .expect("fifo");
+    let _socket = UnixListener::bind(directory.path().join("socket")).expect("socket");
+    fs::write(directory.path().join("original"), b"bytes").expect("file");
+    fs::hard_link(directory.path().join("original"), directory.path().join("hardlink")).expect("hardlink");
+    let reader = SelectedRepositoryReader::open(directory.path()).expect("root");
+    for path in ["subdirectory", "fifo", "socket", "original", "hardlink"] {
+        assert_eq!(reader.read(path, 100), Err(Error::UnsupportedNode));
+    }
+}
+
+#[test]
+fn root_handle_does_not_switch_to_a_replacement_at_its_old_path() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let root = directory.path().join("root");
+    fs::create_dir(&root).expect("root");
+    fs::write(root.join("file"), b"selected").expect("selected file");
+    let reader = SelectedRepositoryReader::open(&root).expect("root");
+    fs::rename(&root, directory.path().join("retained")).expect("rename");
+    fs::create_dir(&root).expect("replacement root");
+    fs::write(root.join("file"), b"not selected").expect("replacement file");
+    assert_eq!(
+        reader.read("file", 100),
+        Ok(Node::File {
+            bytes: b"selected".to_vec(),
+            executable: false
+        })
+    );
+}
+
+#[test]
+fn invalid_roots_and_content_debug_do_not_leak_values() {
+    for path in ["relative", "/", "/tmp/../private"] {
+        assert!(matches!(
+            SelectedRepositoryReader::open(Path::new(path)),
+            Err(Error::InvalidRoot)
+        ));
+    }
+    let node = Node::File {
+        bytes: b"private-source".to_vec(),
+        executable: true,
+    };
+    assert!(!format!("{node:?}").contains("private-source"));
+    assert!(!format!("{node:?}").contains("112, 114"));
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -131,6 +131,10 @@ back into large multi-purpose modules.
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply
   must independently validate approval, real node/link topology and content hashes.
+  Its separate `reader/` boundary reads one explicitly selected node under a pinned
+  Linux directory using kernel confinement, byte limits and change checks. It does
+  not enumerate repositories, follow link targets, hash, authorize or transfer data;
+  unsupported platforms fail closed without a weaker filesystem fallback.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Add the selected-node filesystem read boundary needed by #383 repository capture.
This is separate from the inert overlay model and performs no automatic capture,
Git discovery, transfer, provider action or workspace lifecycle change.

## Behavior and limits

- Pin an explicitly selected absolute directory. On Linux, kernel path resolution
  rejects linked parents, escapes, magic links and mount crossings.
- Inspect a node without opening it for content. Read only regular single-link
  files or literal symlinks, with a caller-selected payload bound capped at 64 MiB.
  Device files, FIFOs, sockets, directories and hardlinks fail closed.
- Reopen the already-inspected regular inode through its held descriptor, not a
  mutable name; check identity, size, mode and timestamps before/after reading
  and against the final nominated path. Never follow a captured link target.
- Reuse the lexical exclusion policy; errors and Debug omit paths and content.
- Non-Linux platforms and unavailable kernel confinement return unsupported
  errors without a weaker fallback. No dependency or configuration changes.

This is not export approval, a content secret scan, an atomic repository snapshot,
link-graph validation, hashing, large-file streaming, transfer or checkpointing.
Byte bounds do not impose a deadline on a blocked filesystem; future orchestration
must run this off the UI thread and handle cancellation separately.

## Validation

- Thirteen focused Linux regressions: binary/empty/nested/Unicode files, executable
  mode, literal links, exclusions, limits and actual growth/truncation, root
  replacement, deterministic content/mode/path changes, FIFOs/sockets/hardlinks,
  redaction and fail-closed confinement errors. Non-Linux rejection has a cfg test.
- Full source and final-base exact-commit matrices: formatting, maintainability,
  version guard, default/speech workspace tests and blocking/strict/advisory Clippy.
- Independent local review of the final source tree.
- Public-API smoke in a disposable read-only Linux namespace verifies selected
  synthetic bytes, bind-mount crossing rejection and namespace-device rejection.
  No existing repository contents or provider resources used; namespace exits normally.
- Native UI smoke is not applicable: no UI code or callers change.

Part of #383; does not close the feature issue.
