### PR TITLE
feat(worker): retain panel records with workspace data

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -184,16 +184,20 @@ panes remain available without reexecution. Status reports `running`, `exited`
 or `unavailable`, with an exit status only when tmux has one; an unknown result,
 including some signal terminations, is not reported as success.
 
-Markers live under `/var/lib/horizon/panels` and contain an intent digest, not
-command arguments or credentials. Sockets live under `/run/horizon/panels`.
+Markers live under `/workspace/.horizon-worker/panels` and contain an intent
+digest, not command arguments or credentials. Startup prepares this private root;
+task requests never recreate it if it disappears. Sockets remain under
+`/run/horizon/panels` and are not retained across runtime filesystem replacement.
 These locations rely on the worker's private root-owned directory boundary;
 tasks within one worker share that trust domain. The marker is not a process
-checkpoint: container/server loss cannot preserve a running process, and durable
-volumes, backup and explicit restart remain separate integration requirements.
+checkpoint: container/server loss cannot preserve a running process. With the
+workspace volume retained, both running and completed task identities become
+`unavailable` after server loss; even a repeated start must not execute them again.
+Durable backing storage, backup and explicit recovery remain separate requirements.
 This helper does not yet connect local panels, stop tasks or delete workspaces.
 
 With `bison`, `libevent-dev`, `libncurses-dev`, a C compiler and Make installed, build a
-disposable test binary under a new prefix, then run the twenty-nine regressions:
+disposable test binary under a new prefix, then run the worker regressions:
 
 ```bash
 test_root=$(mktemp -d /tmp/horizon-panel-tests.XXXXXX)
@@ -207,6 +211,8 @@ recreation after server loss. Structured-request coverage includes literal argv,
 non-creating status, disconnected progress, bounded/invalid input and redaction.
 Verification covers changed intent, absent/lost/completed tasks, exact literal
 arguments and unchanged ownership records while disconnected tasks keep running.
+Retention coverage replaces the runtime/socket filesystem and rejects missing,
+linked, insecure or foreign-owned state without replaying old task identities.
 Tests own only their private temporary directories
 and dedicated sockets. Keep the disposable tool prefix for repeated validation,
 then remove only that exact task-owned prefix when finished.
@@ -215,8 +221,9 @@ then remove only that exact task-owned prefix when finished.
 
 `host-identity.py` owns `/workspace/.horizon-worker/ssh.claim` and the private
 `ssh/` directory next to it. The initialization claim is durably recorded before
-key generation. A complete versioned marker is published only after both key
-files are synchronized. Repeated startup validates the original access-key digest,
+key generation. Version 2 readiness also requires the private sibling `panels/`
+directory: it is created and synchronized before readiness is published, together
+with both synchronized key files. Repeated startup validates the original access-key digest,
 marker and real private/public key pair; it does not generate another identity.
 The verified runtime copies remain at `/etc/ssh/ssh_host_ed25519_key{,.pub}` so
 trusted provider host-key inspection keeps its existing path.
@@ -233,6 +240,13 @@ permission to replace an identity. Existing unretained keys are not automaticall
 migrated. Key rotation, old-volume migration and whole-volume loss require a
 separate verified recovery operation. Never resolve a host-key mismatch by
 disabling client verification.
+
+Version 1 storage kept panel records on the runtime filesystem. It is rejected
+without automatic migration, key rotation or record replacement: missing old
+records cannot prove that a task was never started. Version 2 also rejects a
+missing/insecure retained panel root instead of creating an empty replacement.
+Do not edit the version or remove records to force startup. Existing running
+workers are not upgraded or stopped by this source change.
 
 Concurrent starters wait up to 30 seconds for readiness: two ten-second key
 operation budgets plus ten seconds of filesystem synchronization grace. This is
@@ -253,7 +267,8 @@ bash scripts/run-remote-worker-host-identity-smoke.sh --image horizon-remote-wor
 ```
 
 The smoke replaces the container filesystem while retaining its workspace volume,
-checks the same host identity through pinned SSH, and rejects a different access
+checks the same host identity through pinned SSH, retains task records without
+replaying completed or interrupted work, and rejects a different access
 key without modifying the original identity or workspace data. It removes only
 its own containers and volume; it neither publishes an image nor uses cloud resources.
 

--- a/containers/remote-worker/host-identity.py
+++ b/containers/remote-worker/host-identity.py
@@ -18,6 +18,7 @@ INITIALIZATION_SYNC_GRACE_SECONDS = 10
 # Generation and public-key inspection both finish before the readiness marker.
 WAIT_SECONDS = 2 * KEYGEN_TIMEOUT_SECONDS + INITIALIZATION_SYNC_GRACE_SECONDS
 KEY_NAME = "ssh_host_ed25519_key"
+STATE_VERSION = 2
 ED25519_PREFIX = b"\x00\x00\x00\x0bssh-ed25519\x00\x00\x00\x20"
 
 
@@ -116,6 +117,7 @@ class HostIdentity:
         self.runtime_directory = Path(runtime_directory)
         self.parent = self.workspace / ".horizon-worker"
         self.directory = self.parent / "ssh"
+        self.panels = self.parent / "panels"
         self.claim = self.parent / "ssh.claim"
         self.marker = self.directory / "ready.json"
 
@@ -151,6 +153,11 @@ class HostIdentity:
         for suffix in ("", ".pub"):
             if os.path.lexists(self.runtime_directory / (KEY_NAME + suffix)):
                 fail()
+        # Readiness also fences a lost task-state root from becoming a clean slate.
+        self.panels.mkdir(mode=0o700)
+        trusted_directory(self.panels, private=True)
+        synchronize(self.panels, directory=True)
+        synchronize(self.parent, directory=True)
         private_path = self.directory / KEY_NAME
         keygen("-q", "-t", "ed25519", "-N", "", "-C", "", "-f", private_path)
         for suffix in ("", ".pub"):
@@ -159,7 +166,7 @@ class HostIdentity:
             read_file(path)
             synchronize(path)
         host_public_key = public_key(keygen("-y", "-P", "", "-f", private_path))
-        marker = {"version": 1, "access_digest": access_digest, "host_public_key": host_public_key}
+        marker = {"version": STATE_VERSION, "access_digest": access_digest, "host_public_key": host_public_key}
         publish(self.marker, json.dumps(marker, sort_keys=True).encode())
 
     def load(self, access_digest):
@@ -176,10 +183,11 @@ class HostIdentity:
         marker = json.loads(encoded, object_pairs_hook=unique_object)
         if (not isinstance(marker, dict)
                 or set(marker) != {"version", "access_digest", "host_public_key"}
-                or type(marker["version"]) is not int or marker["version"] != 1
+                or type(marker["version"]) is not int or marker["version"] != STATE_VERSION
                 or marker["access_digest"] != access_digest
                 or not isinstance(marker["host_public_key"], str)):
             fail()
+        trusted_directory(self.panels, private=True)
         private_path = self.directory / KEY_NAME
         read_file(private_path)
         expected = marker["host_public_key"]

--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -67,7 +67,8 @@ def private_directory(path):
 
 def check_directory(path):
     metadata = path.lstat()
-    if not stat.S_ISDIR(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) & 0o077:
+    if (not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077):
         raise SessionError("session state directory is not private")
 
 
@@ -80,12 +81,17 @@ def sync_directory(path):
 
 
 class PanelSessions:
-    def __init__(self, repository, state, sockets, config, wrapper):
+    def __init__(self, repository, state, sockets, config, wrapper, *, require_existing_state=False):
         self.repository = Path(repository)
         self.state = Path(state)
         self.sockets = Path(sockets)
         self.config = Path(config)
         self.wrapper = str(wrapper)
+        self.require_existing_state = require_existing_state
+
+    def check_state_parent(self):
+        if self.require_existing_state:
+            check_directory(self.state.parent)
 
     def identities(self, runtime, panel):
         try:
@@ -125,12 +131,14 @@ class PanelSessions:
 
     def read_marker(self, runtime, panel):
         path = self.marker_path(runtime, panel)
+        self.check_state_parent()
         check_directory(self.state)
         check_directory(path.parent)
         descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
         with os.fdopen(descriptor, "rb") as stream:
             metadata = os.fstat(stream.fileno())
-            if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) & 0o077:
+            if (not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.geteuid()
+                    or stat.S_IMODE(metadata.st_mode) & 0o077):
                 raise SessionError("session marker is not private")
             raw = stream.read(4097)
         if len(raw) > 4096:
@@ -151,7 +159,11 @@ class PanelSessions:
 
     def publish_marker(self, runtime, panel, marker):
         path = self.marker_path(runtime, panel)
-        private_directory(self.state)
+        self.check_state_parent()
+        if self.require_existing_state:
+            check_directory(self.state)
+        else:
+            private_directory(self.state)
         private_directory(path.parent)
         sync_directory(self.state.parent)
         sync_directory(self.state)
@@ -263,8 +275,9 @@ def main():
         command.add_argument("panel")
         command.add_argument("arguments", nargs=argparse.REMAINDER)
     arguments = parser.parse_args()
-    service = PanelSessions("/workspace/horizon", "/var/lib/horizon/panels", "/run/horizon/panels",
-                            "/etc/horizon/tmux.conf", "/usr/local/bin/horizon-agent-session")
+    service = PanelSessions("/workspace/horizon", "/workspace/.horizon-worker/panels", "/run/horizon/panels",
+                            "/etc/horizon/tmux.conf", "/usr/local/bin/horizon-agent-session",
+                            require_existing_state=True)
     try:
         if arguments.operation == "request":
             result = execute_request(service, sys.stdin.buffer)

--- a/containers/remote-worker/test_host_identity.py
+++ b/containers/remote-worker/test_host_identity.py
@@ -61,6 +61,58 @@ class HostIdentityTests(unittest.TestCase):
         for path in (self.store.claim, self.store.marker, runtime_key):
             self.assertEqual(0o600, path.stat().st_mode & 0o777)
         self.assertEqual(0o700, self.store.directory.stat().st_mode & 0o777)
+        self.assertEqual(0o700, self.store.panels.stat().st_mode & 0o777)
+        self.assertEqual(identity.STATE_VERSION, json.loads(self.store.marker.read_bytes())["version"])
+
+    def test_retained_panel_records_survive_runtime_filesystem_replacement(self):
+        public = self.store.prepare()
+        record = self.store.panels / "synthetic-record"
+        record.write_bytes(b"retained-task-claim\0")
+        record.chmod(0o600)
+        before = self.snapshot()
+        shutil.rmtree(self.runtime)
+        self.runtime.mkdir(mode=0o700)
+        self.assertEqual(public, self.new_store().prepare())
+        self.assertEqual(before, self.snapshot())
+
+    def test_missing_retained_panel_root_is_not_recreated(self):
+        self.store.prepare()
+        self.store.panels.rmdir()
+        before = self.snapshot()
+        self.assert_rejected_without_generation()
+        self.assertFalse(self.store.panels.exists())
+        self.assertEqual(before, self.snapshot())
+
+    def test_legacy_readiness_is_not_automatically_migrated(self):
+        self.store.prepare()
+        marker = json.loads(self.store.marker.read_bytes())
+        self.store.marker.write_bytes(json.dumps({**marker, "version": 1}).encode())
+        self.store.panels.rmdir()
+        before = self.snapshot()
+        self.assert_rejected_without_generation()
+        self.assertFalse(self.store.panels.exists())
+        self.assertEqual(before, self.snapshot())
+
+    def test_insecure_or_linked_panel_root_is_rejected_without_identity_replacement(self):
+        self.store.prepare()
+        before = self.snapshot()
+        self.store.panels.chmod(0o755)
+        self.assert_rejected_without_generation()
+        self.store.panels.chmod(0o700)
+        retained = self.store.panels.with_name("retained-panels")
+        self.store.panels.rename(retained)
+        self.store.panels.symlink_to(retained)
+        self.assert_rejected_without_generation()
+        self.assertEqual(before, self.snapshot())
+
+    def test_preexisting_unclaimed_panel_state_is_not_adopted(self):
+        self.store.parent.mkdir(mode=0o700)
+        self.store.panels.mkdir(mode=0o700)
+        record = self.store.panels / "unclaimed"
+        record.write_bytes(b"must-not-adopt-or-remove")
+        self.assert_rejected_without_generation()
+        self.assertEqual(b"must-not-adopt-or-remove", record.read_bytes())
+        self.assertFalse(self.store.marker.exists())
 
     def test_separate_workspaces_never_share_host_identity(self):
         first = self.store.prepare()
@@ -152,7 +204,7 @@ class HostIdentityTests(unittest.TestCase):
         key = (self.store.directory / identity.KEY_NAME).read_bytes()
         for value in (b"broken", b"[]", b"x" * (identity.LIMIT + 1),
                       b'{"version": 2, ' + self.store.marker.read_bytes()[1:],
-                      json.dumps({**original, "version": 2}).encode(),
+                      json.dumps({**original, "version": identity.STATE_VERSION + 1}).encode(),
                       json.dumps({**original, "version": True}).encode(),
                       json.dumps({**original, "access_digest": "wrong"}).encode(),
                       json.dumps({**original, "extra": 1}).encode()):
@@ -229,6 +281,8 @@ class HostIdentityTests(unittest.TestCase):
             if "-q" in arguments:
                 self.assertTrue(self.store.claim.exists())
                 self.assertIn((self.store.parent, True), observed)
+                self.assertTrue(self.store.panels.is_dir())
+                self.assertIn((self.store.panels, True), observed)
                 self.assertFalse((self.runtime / identity.KEY_NAME).exists())
             return real_keygen(*arguments)
 

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -423,6 +423,67 @@ class PanelSessionTests(unittest.TestCase):
         self.service.tmux(runtime, "kill-server")
         self.assertEqual(self.service.start(runtime, "lost", ".", command)["state"], "unavailable")
 
+    def test_retained_markers_prevent_replay_after_runtime_filesystem_replacement(self):
+        runtime = self.runtimes[0]
+        self.service.require_existing_state = True
+        MODULE.private_directory(self.service.state)
+        running = self.tick_command()
+        completed = self.command("from pathlib import Path; Path('runs').open('a').write('once\\n'); raise SystemExit(42)")
+        self.service.start(runtime, "running", ".", running)
+        self.service.start(runtime, "completed", ".", completed)
+        self.wait_for(lambda: (self.repository / "ticks").exists())
+        self.wait_for(lambda: self.service.status(runtime, "completed")["state"] == "exited")
+        markers = {panel: self.service.marker_path(runtime, panel).read_bytes() for panel in ("running", "completed")}
+        self.service.tmux(runtime, "kill-server")
+        self.service = MODULE.PanelSessions(self.repository, self.service.state, self.root / "replacement-sockets",
+                                            HERE / "tmux.conf", "/usr/bin/env", require_existing_state=True)
+        ticks = (self.repository / "ticks").read_bytes()
+        for panel, command in (("running", running), ("completed", completed)):
+            expected = {"state": "unavailable", "panel": panel}
+            self.assertEqual(expected, self.service.status(runtime, panel))
+            self.assertEqual(expected, self.service.start(runtime, panel, ".", command))
+            self.assertEqual(expected, self.service.verify(runtime, panel, ".", command))
+            with self.assertRaises(MODULE.SessionError):
+                self.service.attach(runtime, panel)
+            self.assertEqual(markers[panel], self.service.marker_path(runtime, panel).read_bytes())
+        self.assertEqual("once\n", (self.repository / "runs").read_text())
+        self.assertEqual(ticks, (self.repository / "ticks").read_bytes())
+        self.assertFalse(self.service.sockets.exists())
+
+    def test_required_retained_root_is_never_recreated_by_start(self):
+        self.service.require_existing_state = True
+        for operation in (self.service.start, self.service.verify):
+            with self.assertRaises(FileNotFoundError):
+                operation(self.runtimes[0], "absent", ".", self.tick_command())
+        self.assertFalse(self.service.state.exists())
+        self.assertFalse(self.service.sockets.exists())
+
+    def test_linked_or_insecure_retained_parent_fails_before_task_creation(self):
+        parent = self.root / "retained-parent"
+        MODULE.private_directory(parent)
+        self.service.state = parent / "panels"
+        self.service.require_existing_state = True
+        MODULE.private_directory(self.service.state)
+        parent.chmod(0o755)
+        with self.assertRaises(MODULE.SessionError):
+            self.service.start(self.runtimes[0], "untrusted", ".", self.tick_command())
+        parent.chmod(0o700)
+        retained = self.root / "original-parent"
+        parent.rename(retained)
+        parent.symlink_to(retained)
+        with self.assertRaises(MODULE.SessionError):
+            self.service.start(self.runtimes[0], "untrusted", ".", self.tick_command())
+        self.assertEqual([], list((retained / "panels").iterdir()))
+        self.assertFalse(self.service.sockets.exists())
+
+    def test_foreign_owned_private_state_is_rejected(self):
+        self.service.start(self.runtimes[0], "owned", ".", self.tick_command())
+        before = self.service.marker_path(self.runtimes[0], "owned").read_bytes()
+        with mock.patch.object(MODULE.os, "geteuid", return_value=os.geteuid() + 1):
+            with self.assertRaises(MODULE.SessionError):
+                self.service.status(self.runtimes[0], "owned")
+        self.assertEqual(before, self.service.marker_path(self.runtimes[0], "owned").read_bytes())
+
     def test_unowned_sessions_and_future_or_insecure_markers_fail_closed(self):
         runtime = self.runtimes[0]
         MODULE.private_directory(self.service.sockets)

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -11,6 +11,11 @@ back into large multi-purpose modules.
   marker and verified tmux status/attachment contract. Its dedicated `tmux.conf`
   retains sessions independently of clients. Provider lifecycle, repository
   transfer, durable backup and local panel integration remain separate concerns.
+- `host-identity.py` publishes versioned startup readiness for the access-bound SSH
+  identity and private retained panel-state root. Task markers live beside the
+  identity on workspace storage; sockets remain runtime-only. Missing or legacy
+  readiness fails closed, and lost processes are not restarted from their markers.
+  Storage migration, process recovery and checkpointing are separate boundaries.
 
 ### `horizon-browser-protocol`
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -11,8 +11,8 @@ back into large multi-purpose modules.
   marker and verified tmux status/attachment contract. Its dedicated `tmux.conf`
   retains sessions independently of clients. Provider lifecycle, repository
   transfer, durable backup and local panel integration remain separate concerns.
-- `host-identity.py` publishes versioned startup readiness for the access-bound SSH
-  identity and private retained panel-state root. Task markers live beside the
+- `containers/remote-worker/host-identity.py` publishes versioned startup readiness
+  for the access-bound SSH identity and private retained panel-state root. Task markers live beside the
   identity on workspace storage; sockets remain runtime-only. Missing or legacy
   readiness fails closed, and lost processes are not restarted from their markers.
   Storage migration, process recovery and checkpointing are separate boundaries.

--- a/scripts/run-remote-worker-host-identity-smoke.sh
+++ b/scripts/run-remote-worker-host-identity-smoke.sh
@@ -6,10 +6,11 @@ if [[ $# != 2 || $1 != --image || -z $2 ]]; then
   exit 64
 fi
 image=$2
-for utility in docker ssh ssh-keygen; do
+for utility in docker ssh ssh-keygen python3; do
   command -v "$utility" >/dev/null
 done
-docker image inspect "$image" >/dev/null
+image_id=$(docker image inspect --format '{{.Id}}' "$image")
+[[ $image_id =~ ^sha256:[a-f0-9]{64}$ ]] || exit 1
 fixture=$(mktemp -d /tmp/horizon-host-key-smoke.XXXXXX)
 smoke_id="horizon-host-key-${fixture##*.}-$$"
 volume="${smoke_id}-workspace"
@@ -17,16 +18,33 @@ owned_volume=false
 containers=()
 
 fail() { printf 'Host identity smoke failed: %s\n' "$1" >&2; exit 1; }
+owned_worker() {
+  local observed
+  observed=$(docker container inspect --format '{{.Id}}|{{.Image}}|{{index .Config.Labels "horizon.host-key-smoke"}}' "$1") || return 1
+  [[ $observed == "$1|$image_id|$smoke_id" ]]
+}
+remove_worker() {
+  owned_worker "$1" || return 1
+  docker container rm --force "$1" >/dev/null
+}
+stop_worker() {
+  owned_worker "$1" || fail 'worker ownership changed before Stop'
+  docker stop --time 10 "$1" >/dev/null
+}
 cleanup() {
   local result=$? container
   trap - EXIT
   for container in "${containers[@]}"; do
     if docker container inspect "$container" >/dev/null 2>&1; then
-      docker container rm --force "$container" >/dev/null || result=1
+      remove_worker "$container" || result=1
     fi
   done
   if [[ $owned_volume == true ]]; then
-    docker volume rm "$volume" >/dev/null || result=1
+    if [[ $(docker volume inspect --format '{{index .Labels "horizon.host-key-smoke"}}' "$volume") == "$smoke_id" ]]; then
+      docker volume rm "$volume" >/dev/null || result=1
+    else
+      result=1
+    fi
   fi
   case "$fixture" in
     /tmp/horizon-host-key-smoke.*) rm -r -- "$fixture" || result=1 ;;
@@ -56,9 +74,10 @@ create_worker() {
   local access=$1
   created_id=$(docker create --pull=never --label "horizon.host-key-smoke=$smoke_id" \
     --publish 127.0.0.1::22 --mount "type=volume,src=$volume,dst=/workspace" \
-    --env "HORIZON_SSH_PUBLIC_KEY=$access" "$image")
+    --env "HORIZON_SSH_PUBLIC_KEY=$access" "$image_id")
   [[ $created_id =~ ^[a-f0-9]{64}$ ]] || fail 'invalid created container identity'
   containers+=("$created_id")
+  owned_worker "$created_id" || fail 'created worker ownership mismatch'
   docker start "$created_id" >/dev/null
 }
 
@@ -84,13 +103,71 @@ connect() {
     -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=2 -p "$port" root@127.0.0.1 "$@"
 }
 
+runtime=$(python3 -c 'import uuid; print(uuid.uuid4())')
+panel_request() {
+  python3 - "$runtime" "$1" "$2" <<'PY' | connect horizon-panel-session request
+import json
+import sys
+runtime, operation, panel = sys.argv[1:]
+command = "from pathlib import Path; import time; Path('panel-" + panel + "-runs').open('a').write('once\\n'); "
+if panel == "completed":
+    command += "raise SystemExit(42)"
+else:
+    command += "\nwhile True:\n with Path('panel-ticks').open('a') as stream: stream.write('tick\\n')\n time.sleep(0.05)"
+request = {"version": 1, "operation": operation, "runtime": runtime, "panel": panel}
+if operation != "status":
+    request.update(directory=".", argv=["/usr/bin/python3", "-c", command])
+print(json.dumps(request))
+PY
+}
+panel_state() {
+  panel_request "$1" "$2" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])'
+}
+panel_markers() {
+  connect "sha256sum /workspace/.horizon-worker/panels/$runtime/completed.json /workspace/.horizon-worker/panels/$runtime/progress.json"
+}
+panel_bytes() {
+  connect 'sha256sum /workspace/horizon/panel-completed-runs /workspace/horizon/panel-progress-runs /workspace/horizon/panel-ticks'
+}
+assert_no_replay() {
+  local panel
+  for panel in completed progress; do
+    [[ $(panel_state status "$panel") == unavailable ]] || fail 'lost task reported a live or completed process'
+    [[ $(panel_state start "$panel") == unavailable ]] || fail 'start replayed a retained task'
+    [[ $(panel_state verify "$panel") == unavailable ]] || fail 'verification replayed a retained task'
+    if connect horizon-panel-session attach "$runtime" "$panel" >/dev/null 2>&1; then
+      fail 'attachment accepted a lost task'
+    fi
+  done
+  [[ $(panel_markers) == "$retained_markers" ]] || fail 'task identity records changed'
+  [[ $(panel_bytes) == "$retained_bytes" ]] || fail 'task bytes changed without a new task'
+  if connect "tmux -N -S /run/horizon/panels/$runtime.sock list-sessions" >/dev/null 2>&1; then
+    fail 'a new task server was created'
+  fi
+}
+
 create_worker "$client_public"
 first_id=$created_id
 wait_ready "$first_id"
 expected_key=$observed_key
 connect 'printf "retained-workspace-data\n" > /workspace/horizon/retained.txt'
-docker stop --time 10 "$first_id" >/dev/null
-docker rm "$first_id" >/dev/null
+panel_request start completed >/dev/null
+[[ $(panel_state start progress) == running ]] || fail 'progress task did not start'
+for attempt in {1..40}; do
+  [[ $(panel_state status completed) == exited ]] && break
+  sleep 0.1
+done
+[[ $(panel_state status completed) == exited ]] || fail 'completed task did not exit'
+before_ticks=$(connect 'wc -l < /workspace/horizon/panel-ticks')
+for attempt in {1..40}; do
+  after_ticks=$(connect 'wc -l < /workspace/horizon/panel-ticks')
+  (( after_ticks > before_ticks )) && break
+  sleep 0.1
+done
+(( after_ticks > before_ticks )) || fail 'task did not progress between disconnected clients'
+retained_markers=$(panel_markers)
+stop_worker "$first_id"
+remove_worker "$first_id"
 
 create_worker "$client_public"
 second_id=$created_id
@@ -98,8 +175,14 @@ second_id=$created_id
 wait_ready "$second_id"
 [[ $observed_key == "$expected_key" ]] || fail 'host identity changed after runtime filesystem loss'
 [[ $(connect 'cat /workspace/horizon/retained.txt') == retained-workspace-data ]] || fail 'workspace data was lost'
-docker stop --time 10 "$second_id" >/dev/null
-docker rm "$second_id" >/dev/null
+for panel in completed progress; do
+  [[ $(connect "cat /workspace/horizon/panel-$panel-runs") == once ]] || fail 'a task ran more than once'
+done
+(( $(connect 'wc -l < /workspace/horizon/panel-ticks') >= after_ticks )) || fail 'task progress was lost'
+retained_bytes=$(panel_bytes)
+assert_no_replay
+stop_worker "$second_id"
+remove_worker "$second_id"
 
 create_worker "$other_public"
 rejected_id=$created_id
@@ -109,10 +192,11 @@ for attempt in {1..40}; do
 done
 [[ $(docker inspect --format '{{.State.Running}}:{{.State.ExitCode}}' "$rejected_id") == false:64 ]] ||
   fail 'retained volume accepted a different access identity'
-docker rm "$rejected_id" >/dev/null
+remove_worker "$rejected_id"
 
 create_worker "$client_public"
 wait_ready "$created_id"
 [[ $observed_key == "$expected_key" ]] || fail 'rejected access changed the original host key'
 [[ $(connect 'cat /workspace/horizon/retained.txt') == retained-workspace-data ]] || fail 'rejected access changed data'
-printf '%s\n' 'PASS retained host key and workspace data after runtime filesystem replacement; wrong access key rejected'
+assert_no_replay
+printf '%s\n' 'PASS retained host key, workspace bytes and task claims after runtime filesystem replacement; no task replay; wrong access key rejected'

--- a/scripts/run-remote-worker-host-identity-smoke.sh
+++ b/scripts/run-remote-worker-host-identity-smoke.sh
@@ -98,9 +98,30 @@ wait_ready() {
 }
 
 connect() {
-  ssh -F /dev/null -i "$fixture/client" -o BatchMode=yes -o IdentitiesOnly=yes \
+  python3 -c '
+import subprocess
+import sys
+try:
+    result = subprocess.run(sys.argv[1:], timeout=15, check=False)
+except subprocess.TimeoutExpired:
+    print("Host identity smoke failed: SSH command timed out", file=sys.stderr)
+    raise SystemExit(124)
+raise SystemExit(result.returncode)
+' ssh -F /dev/null -i "$fixture/client" -o BatchMode=yes -o IdentitiesOnly=yes \
     -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$fixture/known-hosts" \
     -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=2 -p "$port" root@127.0.0.1 "$@"
+}
+
+assert_ssh_rejection() {
+  local description=$1 result=0
+  shift
+  connect "$@" >/dev/null 2>&1 || result=$?
+  case "$result" in
+    1) ;;
+    0) fail "$description unexpectedly succeeded" ;;
+    124) fail "$description did not finish within its deadline" ;;
+    *) fail "$description did not return the expected rejection" ;;
+  esac
 }
 
 runtime=$(python3 -c 'import uuid; print(uuid.uuid4())')
@@ -135,15 +156,11 @@ assert_no_replay() {
     [[ $(panel_state status "$panel") == unavailable ]] || fail 'lost task reported a live or completed process'
     [[ $(panel_state start "$panel") == unavailable ]] || fail 'start replayed a retained task'
     [[ $(panel_state verify "$panel") == unavailable ]] || fail 'verification replayed a retained task'
-    if connect horizon-panel-session attach "$runtime" "$panel" >/dev/null 2>&1; then
-      fail 'attachment accepted a lost task'
-    fi
+    assert_ssh_rejection 'lost-task attachment' horizon-panel-session attach "$runtime" "$panel"
   done
   [[ $(panel_markers) == "$retained_markers" ]] || fail 'task identity records changed'
   [[ $(panel_bytes) == "$retained_bytes" ]] || fail 'task bytes changed without a new task'
-  if connect "tmux -N -S /run/horizon/panels/$runtime.sock list-sessions" >/dev/null 2>&1; then
-    fail 'a new task server was created'
-  fi
+  assert_ssh_rejection 'lost-task server query' "tmux -N -S /run/horizon/panels/$runtime.sock list-sessions"
 }
 
 create_worker "$client_public"


### PR DESCRIPTION
## Purpose

Retain the worker's one-shot task-start records with workspace data so replacing
only the runtime filesystem cannot silently run an old task again. This is a
focused prerequisite for #383, which remains open.

## Behavior

- Store task records under `/workspace/.horizon-worker/panels`; keep tmux sockets runtime-only.
- Publish version 2 startup readiness only after synchronizing the private retained
  panel root and SSH identity. Reopening requires that root to remain private and owned.
- Refuse to recreate a missing retained root from a task request or worker startup.
- Keep existing start/verify/attach semantics: after process loss, retained tasks
  are unavailable, not resumed, and repeated requests do not execute them again.
- Reject legacy version 1 storage without automatic migration, key rotation or record
  replacement. Missing runtime-only records cannot establish that a task never ran.

Existing running workers and provider settings are untouched. This does not
publish an image, allocate cloud resources, perform storage migration, checkpoint
processes or provide remote backup. A trusted Linux POSIX filesystem and retained
workspace storage remain prerequisites; tasks share the worker's trust domain.

## Validation

- 22 real-key identity tests and 33 pinned-tmux panel tests, using read-only isolated
  worker containers with private temporary files and no network.
- Full repository matrix, full-diff self-review and independent local review.
- Exact-source local image checks and a disposable retained-volume smoke through
  pinned SSH: synthetic task records, repository bytes and host identity survive
  runtime filesystem replacement; completed/interrupted work is not replayed by
  start, verify or attach; a different access identity is rejected.
- Cleanup verifies full task-owned container IDs, image identity and labels, and
  the exact volume's ownership. No existing user environment is stopped or removed.
- Every smoke SSH probe has a 15-second child deadline. Negative attachment and
  server queries require the expected rejection; timeouts/transport failures cannot
  pass. Exact-function fault tests cover unexpected success, rejection, timeout,
  connection failure and signal-style status, including the actual child deadline.

Native UI smoke is not applicable to this worker-only change. Local volume tests
do not substitute for the remaining paid-cloud PC-off acceptance gate in #383.
