### PR TITLE
feat(repository): verify bounded overlay bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror 2.0.20",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ libc = "0.2.189"
 rustix = { version = "1.1.4", features = ["fs", "process"] }
 uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
+sha2 = { version = "0.11.0", default-features = false }
 regex = "1.13.1"
 arboard = "3.6.1"
 atspi = { version = "0.30.0", default-features = false, features = ["connection", "proxies", "tokio", "zbus"] }

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -32,6 +32,7 @@ libc.workspace = true
 uuid.workspace = true
 comrak = { version = "0.54", default-features = false }
 git2.workspace = true
+sha2.workspace = true
 regex.workspace = true
 atomicwrites.workspace = true
 

--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 use std::{collections::HashSet, fmt};
 use thiserror::Error;
 use uuid::Uuid;
+mod artifact_digest;
 pub mod interactive_worker;
 pub mod local_docker;
 pub mod runpod;

--- a/crates/horizon-core/src/cloud_run/artifact_digest.rs
+++ b/crates/horizon-core/src/cloud_run/artifact_digest.rs
@@ -1,0 +1,44 @@
+use super::ArtifactDigest;
+use sha2::{Digest, Sha256};
+
+impl ArtifactDigest {
+    /// Hash already-owned bytes without I/O. This does not authenticate or authorize their source.
+    #[must_use]
+    pub fn sha256(bytes: &[u8]) -> Self {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut encoded = String::with_capacity(64);
+        for byte in Sha256::digest(bytes) {
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+        Self(encoded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashes_known_byte_vectors_with_canonical_lowercase_hex() {
+        for (bytes, expected) in [
+            (
+                b"".as_slice(),
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ),
+            (
+                b"abc".as_slice(),
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            ),
+            (
+                [0, 255, 128, 13, 10].as_slice(),
+                "6171db06a1c89b1ff8ab77e479d5df976ccd88a7b63567b4b18f413649e12ff3",
+            ),
+        ] {
+            let digest = ArtifactDigest::sha256(bytes);
+            assert_eq!(digest.as_str(), expected);
+            assert_eq!(ArtifactDigest::parse_sha256(expected), Ok(digest));
+        }
+        assert_ne!(ArtifactDigest::sha256(b"a\0b"), ArtifactDigest::sha256(b"ab"));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/fingerprint.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/fingerprint.rs
@@ -1,0 +1,75 @@
+use super::super::OverlayChange;
+use super::{ArtifactDigest, OverlayBundleError, OverlayContent, RepositoryOverlayPlan};
+use serde::Serialize;
+
+/// Fixed versioned field order; plan construction already sorts both layers by path.
+#[derive(Serialize)]
+struct Manifest<'a> {
+    domain: &'static str,
+    version: u8,
+    repository: &'a str,
+    commit: &'a str,
+    branch: Option<&'a str>,
+    index: Vec<Change<'a>>,
+    working_tree: Vec<Change<'a>>,
+}
+
+#[derive(Serialize)]
+struct Change<'a> {
+    path: &'a str,
+    #[serde(flatten)]
+    content: Content<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Content<'a> {
+    Remove,
+    File {
+        sha256: &'a str,
+        bytes: u64,
+        executable: bool,
+    },
+    Symlink {
+        target: &'a str,
+    },
+}
+
+pub(super) fn digest(plan: &RepositoryOverlayPlan) -> Result<ArtifactDigest, OverlayBundleError> {
+    Ok(ArtifactDigest::sha256(&encode(plan)?))
+}
+
+fn layer(changes: &[OverlayChange]) -> Vec<Change<'_>> {
+    changes
+        .iter()
+        .map(|change| Change {
+            path: change.path(),
+            content: match change.content() {
+                OverlayContent::Remove => Content::Remove,
+                OverlayContent::File {
+                    sha256,
+                    bytes,
+                    executable,
+                } => Content::File {
+                    sha256: sha256.as_str(),
+                    bytes: *bytes,
+                    executable: *executable,
+                },
+                OverlayContent::Symlink { target } => Content::Symlink { target },
+            },
+        })
+        .collect()
+}
+
+pub(super) fn encode(plan: &RepositoryOverlayPlan) -> Result<Vec<u8>, OverlayBundleError> {
+    serde_json::to_vec(&Manifest {
+        domain: "horizon.repository-overlay",
+        version: 1,
+        repository: &plan.source().repository,
+        commit: plan.source().commit.as_str(),
+        branch: plan.source().branch.as_deref(),
+        index: layer(plan.index()),
+        working_tree: layer(plan.working_tree()),
+    })
+    .map_err(|_| OverlayBundleError::Encoding)
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/mod.rs
@@ -1,0 +1,197 @@
+//! Complete, hash-verified local payloads; not export approval, capture or filesystem safety.
+
+mod fingerprint;
+
+use super::{OverlayContent, RepositoryOverlayPlan, reader::MAX_READ_BYTES};
+use crate::cloud_run::ArtifactDigest;
+use std::{collections::BTreeMap, fmt};
+
+/// Aggregate distinct regular-file payload bound for this in-memory boundary.
+pub const MAX_BUNDLE_BYTES: usize = 128 * 1024 * 1024;
+
+/// Locally hashed, bounded file bytes. Hash equality does not establish content secrecy or trust.
+#[derive(Eq, PartialEq)]
+pub struct VerifiedOverlayBlob {
+    sha256: ArtifactDigest,
+    bytes: Box<[u8]>,
+}
+
+impl VerifiedOverlayBlob {
+    /// Hash an owned payload without cloning it, discarding spare allocation capacity.
+    /// Run hashing off the UI thread.
+    /// # Errors
+    /// Rejects payloads exceeding the selected-reader per-file byte bound before hashing.
+    pub fn new(bytes: Vec<u8>) -> Result<Self, OverlayBundleError> {
+        if bytes.len() > MAX_READ_BYTES {
+            return Err(OverlayBundleError::FileLimit);
+        }
+        Ok(Self {
+            sha256: ArtifactDigest::sha256(&bytes),
+            bytes: bytes.into_boxed_slice(),
+        })
+    }
+
+    #[must_use]
+    pub fn sha256(&self) -> &ArtifactDigest {
+        &self.sha256
+    }
+
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl fmt::Debug for VerifiedOverlayBlob {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VerifiedOverlayBlob")
+            .field("bytes", &self.bytes.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Owns exactly the regular-file bytes named by both plan layers, with a stable metadata digest.
+/// This is not an atomic repository snapshot, signature, approval, archive or transfer operation.
+#[derive(Eq, PartialEq)]
+pub struct RepositoryOverlayBundle {
+    plan: RepositoryOverlayPlan,
+    blobs: BTreeMap<String, VerifiedOverlayBlob>,
+    file_bytes: usize,
+    manifest_sha256: ArtifactDigest,
+}
+
+impl RepositoryOverlayBundle {
+    /// Verify completeness and exact lengths before publishing an immutable local bundle.
+    /// Duplicate path contents share one supplied blob; extra payloads are never retained.
+    /// # Errors
+    /// Rejects inconsistent/oversized plans, missing/extra/duplicate blobs or wrong file lengths.
+    pub fn new(
+        plan: RepositoryOverlayPlan,
+        blobs: impl IntoIterator<Item = VerifiedOverlayBlob>,
+    ) -> Result<Self, OverlayBundleError> {
+        let mut required = RequiredBlobs::new(&plan)?;
+        let file_bytes = required.bytes;
+        let mut verified = BTreeMap::new();
+        for blob in blobs {
+            let digest = blob.sha256.as_str();
+            if verified.contains_key(digest) {
+                return Err(OverlayBundleError::DuplicateBlob);
+            }
+            let bytes = required
+                .sizes
+                .remove(digest)
+                .ok_or(OverlayBundleError::UnexpectedBlob)?;
+            if bytes != blob.bytes.len() {
+                return Err(OverlayBundleError::SizeMismatch);
+            }
+            verified.insert(digest.to_owned(), blob);
+        }
+        if !required.sizes.is_empty() {
+            return Err(OverlayBundleError::MissingBlob);
+        }
+        drop(required);
+        let manifest_sha256 = fingerprint::digest(&plan)?;
+        Ok(Self {
+            plan,
+            blobs: verified,
+            file_bytes,
+            manifest_sha256,
+        })
+    }
+
+    #[must_use]
+    pub fn plan(&self) -> &RepositoryOverlayPlan {
+        &self.plan
+    }
+
+    /// Explicit access to a verified payload; no unplanned payload can be returned.
+    #[must_use]
+    pub fn blob(&self, digest: &ArtifactDigest) -> Option<&[u8]> {
+        self.blobs.get(digest.as_str()).map(|blob| blob.bytes.as_ref())
+    }
+
+    #[must_use]
+    pub fn blobs(&self) -> impl ExactSizeIterator<Item = &VerifiedOverlayBlob> {
+        self.blobs.values()
+    }
+
+    /// Distinct regular-file bytes, unlike the plan's conservative per-reference payload count.
+    #[must_use]
+    pub fn file_bytes(&self) -> usize {
+        self.file_bytes
+    }
+
+    /// Version 1 canonical metadata fingerprint, including both layers and their file hashes.
+    /// Equality is not an authorization decision or proof of coherent capture or safe application.
+    #[must_use]
+    pub fn manifest_sha256(&self) -> &ArtifactDigest {
+        &self.manifest_sha256
+    }
+}
+
+impl fmt::Debug for RepositoryOverlayBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RepositoryOverlayBundle")
+            .field("blobs", &self.blobs.len())
+            .field("file_bytes", &self.file_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+struct RequiredBlobs<'a> {
+    sizes: BTreeMap<&'a str, usize>,
+    bytes: usize,
+}
+
+impl<'a> RequiredBlobs<'a> {
+    fn new(plan: &'a RepositoryOverlayPlan) -> Result<Self, OverlayBundleError> {
+        let mut required = Self {
+            sizes: BTreeMap::new(),
+            bytes: 0,
+        };
+        for change in plan.index().iter().chain(plan.working_tree()) {
+            if let OverlayContent::File { sha256, bytes, .. } = change.content() {
+                let bytes = usize::try_from(*bytes)
+                    .ok()
+                    .filter(|bytes| *bytes <= MAX_READ_BYTES)
+                    .ok_or(OverlayBundleError::FileLimit)?;
+                if let Some(previous) = required.sizes.insert(sha256.as_str(), bytes) {
+                    if previous != bytes {
+                        return Err(OverlayBundleError::SizeMismatch);
+                    }
+                } else {
+                    required.bytes = required
+                        .bytes
+                        .checked_add(bytes)
+                        .filter(|bytes| *bytes <= MAX_BUNDLE_BYTES)
+                        .ok_or(OverlayBundleError::BundleLimit)?;
+                }
+            }
+        }
+        Ok(required)
+    }
+}
+
+/// Redacted diagnostics never include file content, source, path or digest values.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum OverlayBundleError {
+    #[error("overlay file exceeds the in-memory payload limit")]
+    FileLimit,
+    #[error("overlay bundle exceeds the in-memory payload budget")]
+    BundleLimit,
+    #[error("overlay file lengths do not agree with verified content")]
+    SizeMismatch,
+    #[error("overlay bundle is missing a required file payload")]
+    MissingBlob,
+    #[error("overlay bundle contains an unplanned file payload")]
+    UnexpectedBlob,
+    #[error("overlay bundle contains duplicate file payloads")]
+    DuplicateBlob,
+    #[error("overlay bundle metadata could not be fingerprinted")]
+    Encoding,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/bundle/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/tests.rs
@@ -1,0 +1,350 @@
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::OverlayChange,
+};
+
+fn source() -> GitSource {
+    GitSource {
+        repository: "team/repo".into(),
+        commit: GitCommitSha::parse("a".repeat(40)).expect("commit"),
+        branch: Some("feature/work".into()),
+    }
+}
+
+fn file(path: &str, bytes: &[u8], executable: bool) -> OverlayChange {
+    described_file(path, ArtifactDigest::sha256(bytes), bytes.len(), executable)
+}
+
+fn described_file(path: &str, sha256: ArtifactDigest, bytes: usize, executable: bool) -> OverlayChange {
+    OverlayChange::new(
+        path.into(),
+        OverlayContent::File {
+            sha256,
+            bytes: u64::try_from(bytes).expect("size"),
+            executable,
+        },
+    )
+    .expect("file")
+}
+
+fn remove(path: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Remove).expect("removal")
+}
+
+fn link(path: &str, target: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Symlink { target: target.into() }).expect("link")
+}
+
+fn plan(index: Vec<OverlayChange>, working_tree: Vec<OverlayChange>) -> RepositoryOverlayPlan {
+    RepositoryOverlayPlan::new(source(), index, working_tree).expect("plan")
+}
+
+fn blob(bytes: &[u8]) -> VerifiedOverlayBlob {
+    VerifiedOverlayBlob::new(bytes.to_vec()).expect("blob")
+}
+
+#[test]
+fn staged_working_and_untracked_bytes_stay_distinct_and_literal() {
+    let index = b"version https://git-lfs.github.com/spec/v1\noid sha256:synthetic\nsize 4\n";
+    let working = b"\0\xff\x80\n";
+    let untracked = b"local-new-file\n";
+    let plan = plan(
+        vec![file("asset", index, false), remove("old-name")],
+        vec![
+            file("asset", working, true),
+            file("new-name", untracked, false),
+            link("alias", "asset"),
+        ],
+    );
+    let bundle =
+        RepositoryOverlayBundle::new(plan.clone(), [blob(working), blob(index), blob(untracked)]).expect("bundle");
+    assert_eq!(bundle.plan(), &plan);
+    for bytes in [index.as_slice(), working.as_slice(), untracked.as_slice()] {
+        assert_eq!(bundle.blob(&ArtifactDigest::sha256(bytes)), Some(bytes));
+    }
+    assert_eq!(bundle.blobs().len(), 3);
+    assert_eq!(bundle.file_bytes(), index.len() + working.len() + untracked.len());
+    assert!(bundle.blob(&ArtifactDigest::sha256(b"not selected")).is_none());
+}
+
+#[test]
+fn shared_content_requires_one_blob_across_paths_and_layers() {
+    let plan = plan(
+        vec![file("a", b"same", false)],
+        vec![file("a", b"same", true), file("b", b"same", false)],
+    );
+    let bundle = RepositoryOverlayBundle::new(plan, [blob(b"same")]).expect("bundle");
+    assert_eq!(bundle.file_bytes(), 4);
+    assert_eq!(bundle.plan().content_bytes(), 12);
+    assert_eq!(bundle.blobs().len(), 1);
+    assert_eq!(bundle.blobs().next().expect("blob").bytes(), b"same");
+}
+
+#[test]
+fn empty_files_and_metadata_only_bundles_are_complete() {
+    for plan in [
+        plan(vec![], vec![]),
+        plan(vec![remove("gone")], vec![link("link", "destination")]),
+    ] {
+        let bundle = RepositoryOverlayBundle::new(plan, []).expect("metadata bundle");
+        assert_eq!(bundle.file_bytes(), 0);
+        assert_eq!(bundle.blobs().len(), 0);
+    }
+    let plan = plan(vec![file("empty", b"", false)], vec![]);
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan.clone(), []),
+        Err(OverlayBundleError::MissingBlob)
+    );
+    let bundle = RepositoryOverlayBundle::new(plan, [blob(b"")]).expect("empty file");
+    assert_eq!(bundle.file_bytes(), 0);
+    assert_eq!(bundle.blobs().len(), 1);
+}
+
+#[test]
+fn missing_unplanned_substituted_and_duplicate_payloads_fail() {
+    let plan = plan(vec![file("selected", b"expected", false)], vec![]);
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan.clone(), []),
+        Err(OverlayBundleError::MissingBlob)
+    );
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan.clone(), [blob(b"different")]),
+        Err(OverlayBundleError::UnexpectedBlob)
+    );
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan.clone(), [blob(b"expected"), blob(b"extra")]),
+        Err(OverlayBundleError::UnexpectedBlob)
+    );
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan, [blob(b"expected"), blob(b"expected")]),
+        Err(OverlayBundleError::DuplicateBlob)
+    );
+}
+
+#[test]
+fn declared_lengths_must_match_hash_verified_payloads() {
+    let plan = plan(
+        vec![described_file("wrong-size", ArtifactDigest::sha256(b"abc"), 2, false)],
+        vec![],
+    );
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan, [blob(b"abc")]),
+        Err(OverlayBundleError::SizeMismatch)
+    );
+}
+
+#[test]
+fn conflicting_sizes_for_one_digest_fail_before_consuming_payloads() {
+    let plan = plan(
+        vec![file("a", b"abc", false)],
+        vec![described_file("b", ArtifactDigest::sha256(b"abc"), 2, false)],
+    );
+    let contents = std::iter::once_with(|| panic!("invalid metadata must not consume payloads"));
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan, contents),
+        Err(OverlayBundleError::SizeMismatch)
+    );
+}
+
+#[test]
+fn declared_payload_limits_fail_before_consuming_payloads() {
+    let oversized_file = plan(
+        vec![described_file(
+            "huge",
+            ArtifactDigest::sha256(b"a"),
+            MAX_READ_BYTES + 1,
+            false,
+        )],
+        vec![],
+    );
+    let oversized_bundle = plan(
+        vec![
+            described_file("a", ArtifactDigest::sha256(b"a"), MAX_READ_BYTES, false),
+            described_file("b", ArtifactDigest::sha256(b"b"), MAX_READ_BYTES, false),
+            described_file("c", ArtifactDigest::sha256(b"c"), 1, false),
+        ],
+        vec![],
+    );
+    for (plan, expected) in [
+        (oversized_file, OverlayBundleError::FileLimit),
+        (oversized_bundle, OverlayBundleError::BundleLimit),
+    ] {
+        let contents = std::iter::once_with(|| panic!("over-budget metadata must not consume payloads"));
+        assert_eq!(RepositoryOverlayBundle::new(plan, contents), Err(expected));
+    }
+}
+
+#[test]
+fn exact_aggregate_limit_is_admitted_and_shared_references_are_not_double_charged() {
+    let plan = plan(
+        vec![
+            described_file("a", ArtifactDigest::sha256(b"a"), MAX_READ_BYTES, false),
+            described_file("b", ArtifactDigest::sha256(b"b"), MAX_READ_BYTES, false),
+        ],
+        vec![described_file("a", ArtifactDigest::sha256(b"a"), MAX_READ_BYTES, true)],
+    );
+    assert_eq!(RequiredBlobs::new(&plan).expect("budget").bytes, MAX_BUNDLE_BYTES);
+    assert_eq!(
+        RepositoryOverlayBundle::new(plan, []),
+        Err(OverlayBundleError::MissingBlob)
+    );
+}
+
+#[test]
+fn blob_does_not_retain_unbounded_spare_allocation_capacity() {
+    for content in [b"abc".as_slice(), b"".as_slice()] {
+        let mut bytes = Vec::with_capacity(4096);
+        bytes.extend_from_slice(content);
+        let blob = VerifiedOverlayBlob::new(bytes).expect("bounded storage");
+        assert_eq!(blob.bytes(), content);
+        assert_eq!(blob.sha256(), &ArtifactDigest::sha256(content));
+        assert_eq!(blob.bytes.into_vec().capacity(), content.len());
+    }
+}
+
+#[test]
+fn actual_blob_limit_includes_the_exact_boundary() {
+    assert!(VerifiedOverlayBlob::new(vec![0; MAX_READ_BYTES]).is_ok());
+    assert_eq!(
+        VerifiedOverlayBlob::new(vec![0; MAX_READ_BYTES + 1]),
+        Err(OverlayBundleError::FileLimit)
+    );
+}
+
+#[test]
+fn input_order_does_not_change_the_immutable_bundle_or_fingerprint() {
+    let first = plan(
+        vec![file("z", b"z", true), file("a", b"a", false)],
+        vec![link("link", "z"), remove("old")],
+    );
+    let second = plan(
+        vec![file("a", b"a", false), file("z", b"z", true)],
+        vec![remove("old"), link("link", "z")],
+    );
+    let first = RepositoryOverlayBundle::new(first, [blob(b"z"), blob(b"a")]).expect("first");
+    let second = RepositoryOverlayBundle::new(second, [blob(b"a"), blob(b"z")]).expect("second");
+    assert_eq!(first, second);
+    assert_eq!(first.manifest_sha256(), second.manifest_sha256());
+}
+
+#[test]
+fn versioned_fingerprint_has_a_fixed_canonical_encoding_and_independent_digest() {
+    let plan = plan(
+        vec![file("staged.txt", b"abc", true), remove("gone.txt")],
+        vec![file("staged.txt", b"", false), link("link", "staged.txt")],
+    );
+    let expected = concat!(
+        r#"{"domain":"horizon.repository-overlay","version":1,"repository":"team/repo","commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","branch":"feature/work","index":["#,
+        r#"{"path":"gone.txt","kind":"remove"},{"path":"staged.txt","kind":"file","sha256":"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad","bytes":3,"executable":true}],"working_tree":["#,
+        r#"{"path":"link","kind":"symlink","target":"staged.txt"},{"path":"staged.txt","kind":"file","sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","bytes":0,"executable":false}]}"#,
+    );
+    assert_eq!(fingerprint::encode(&plan).expect("encoding"), expected.as_bytes());
+    let bundle = RepositoryOverlayBundle::new(plan, [blob(b""), blob(b"abc")]).expect("bundle");
+    assert_eq!(
+        bundle.manifest_sha256().as_str(),
+        "8227e6d7087c20ddd446055fa52373082d3ef1bea3b514d8ffdc5af169955daf"
+    );
+}
+
+#[test]
+fn fingerprint_encoding_preserves_literal_quotes_spaces_and_unicode() {
+    let path = "nested/quoted \" ø.txt";
+    let plan = plan(vec![file(path, b"data", false)], vec![link("alias", path)]);
+    let encoded: serde_json::Value =
+        serde_json::from_slice(&fingerprint::encode(&plan).expect("encoding")).expect("json");
+    assert_eq!(encoded["index"][0]["path"], path);
+    assert_eq!(encoded["working_tree"][0]["target"], path);
+}
+
+#[test]
+fn fingerprint_binds_source_exact_base_branch_and_each_layer_semantic() {
+    let original = plan(
+        vec![file("file", b"abc", false)],
+        vec![link("alias", "file"), remove("gone")],
+    );
+    let digest = fingerprint::digest(&original).expect("digest");
+    let mut variants = vec![
+        plan(
+            vec![],
+            vec![file("file", b"abc", false), link("alias", "file"), remove("gone")],
+        ),
+        plan(
+            vec![file("renamed", b"abc", false)],
+            vec![link("alias", "file"), remove("gone")],
+        ),
+        plan(
+            vec![file("file", b"xyz", false)],
+            vec![link("alias", "file"), remove("gone")],
+        ),
+        plan(
+            vec![file("file", b"abc", true)],
+            vec![link("alias", "file"), remove("gone")],
+        ),
+        plan(
+            vec![file("file", b"abc", false)],
+            vec![link("alias", "other"), remove("gone")],
+        ),
+        plan(vec![file("file", b"abc", false)], vec![link("alias", "file")]),
+        plan(
+            vec![described_file("file", ArtifactDigest::sha256(b"abc"), 4, false)],
+            vec![link("alias", "file"), remove("gone")],
+        ),
+    ];
+    for changed_source in [
+        GitSource {
+            repository: "other/repo".into(),
+            ..source()
+        },
+        GitSource {
+            commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            ..source()
+        },
+        GitSource {
+            branch: None,
+            ..source()
+        },
+        GitSource {
+            branch: Some("different".into()),
+            ..source()
+        },
+    ] {
+        variants.push(
+            RepositoryOverlayPlan::new(
+                changed_source,
+                original.index().to_vec(),
+                original.working_tree().to_vec(),
+            )
+            .expect("variant"),
+        );
+    }
+    for variant in variants {
+        assert_ne!(fingerprint::digest(&variant).expect("digest"), digest);
+    }
+}
+
+#[test]
+fn diagnostics_do_not_include_source_paths_digests_or_contents() {
+    let payload = blob(b"private-content");
+    let digest = payload.sha256().as_str().to_owned();
+    let debug = format!("{payload:?}");
+    let bundle = RepositoryOverlayBundle::new(
+        plan(
+            vec![file("private-name", b"private-content", false)],
+            vec![link("private-link", "private-target")],
+        ),
+        [payload],
+    )
+    .expect("bundle");
+    let debug = format!("{debug} {bundle:?}");
+    for private in [
+        "private-content",
+        "private-name",
+        "private-link",
+        "private-target",
+        source().repository.as_str(),
+        digest.as_str(),
+    ] {
+        assert!(!debug.contains(private));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -2,6 +2,7 @@
 //! Index changes are relative to the base; working-tree changes are relative to that index.
 //! Capture/apply must separately verify real filesystem topology, content hashes and approval.
 
+pub mod bundle;
 mod paths;
 pub mod reader;
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -135,6 +135,11 @@ back into large multi-purpose modules.
   Linux directory using kernel confinement, byte limits and change checks. It does
   not enumerate repositories, follow link targets, hash, authorize or transfer data;
   unsupported platforms fail closed without a weaker filesystem fallback.
+  Its `bundle/` boundary owns a complete bounded set of SHA-256-verified file
+  payloads and fingerprints exact two-layer metadata. Missing, extra, duplicate
+  or length-inconsistent payloads fail before a bundle is returned. It performs
+  no I/O and grants no capture, export or recovery authority; streaming large
+  overlays, coherent capture and safe materialization remain separate concerns.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Provide a complete, immutable local file bundle for the exact-base, two-layer
repository overlay model. This is a focused prerequisite for #383, not completion
of repository capture, transfer or remote checkpointing.

## Behavior

- Hash actual owned file bytes using the existing locked SHA-256 library; retain
  no spare vector allocation. Limit each file to 64 MiB and distinct payloads to
  128 MiB at this in-memory boundary.
- Require exactly one verified payload per distinct planned file hash. Reject
  missing, extra, duplicate, length-inconsistent or oversized content.
- Preserve staged versus working-tree contents, executable bits, literal links
  and removals; shared contents use one owned payload.
- Fingerprint repository identity, exact commit, optional branch and both ordered
  layers with a fixed version 1 canonical encoding. Debug/errors omit content,
  paths and identities.

No filesystem, Git, provider, network or configuration operation is added. A
fingerprint is not export approval, a signature, secret detection, an atomic
snapshot or safe materialization. Hashing belongs off the UI thread. Larger
overlays need a separate streaming boundary. The explicit SHA-256 dependency was
already resolved at the same version; the lockfile gains only one dependency edge.

## Validation

- 15 bundle regressions, including spare capacity, byte limits, membership,
  shared contents, canonical encoding and all fingerprinted semantics.
- Independent known SHA-256 vectors and a separately recomputed golden manifest.
- Full repository matrix, full-diff self-review and independent local review.
- Standalone Linux public-API smoke: confined selected files/literal links feed
  distinct overlay layers; excluded paths fail; later local edits cannot replace
  immutable bundle bytes or its fingerprint. Only synthetic fixture data is used.

Native UI and paid-cloud smoke are not applicable to this local data-only slice.
