### PR TITLE
feat(repository): encode verified overlay bundles

### DIFF
--- a/crates/horizon-core/src/repository_overlay/bundle/codec/metadata.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/codec/metadata.rs
@@ -1,0 +1,114 @@
+use super::{MAX_CHANGES, OverlayCodecError, fingerprint};
+use crate::{
+    cloud_run::{ArtifactDigest, GitCommitSha, GitSource},
+    repository_overlay::{OverlayChange, OverlayContent, RepositoryOverlayPlan},
+};
+use serde::{
+    Deserialize, Deserializer,
+    de::{self, IgnoredAny, SeqAccess, Visitor},
+};
+use std::fmt;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Metadata {
+    domain: String,
+    version: u8,
+    repository: String,
+    commit: GitCommitSha,
+    branch: Option<String>,
+    #[serde(deserialize_with = "bounded_layer")]
+    index: Vec<Change>,
+    #[serde(deserialize_with = "bounded_layer")]
+    working_tree: Vec<Change>,
+}
+
+// A flat checked DTO avoids buffered enum/flatten deserialization of unrecognized fields.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Change {
+    path: String,
+    kind: Kind,
+    sha256: Option<ArtifactDigest>,
+    bytes: Option<u64>,
+    executable: Option<bool>,
+    target: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Kind {
+    Remove,
+    File,
+    Symlink,
+}
+
+impl Change {
+    fn validate(self) -> Result<OverlayChange, OverlayCodecError> {
+        let content = match (self.kind, self.sha256, self.bytes, self.executable, self.target) {
+            (Kind::Remove, None, None, None, None) => OverlayContent::Remove,
+            (Kind::File, Some(sha256), Some(bytes), Some(executable), None) => OverlayContent::File {
+                sha256,
+                bytes,
+                executable,
+            },
+            (Kind::Symlink, None, None, None, Some(target)) => OverlayContent::Symlink { target },
+            _ => return Err(OverlayCodecError::Malformed),
+        };
+        Ok(OverlayChange::new(self.path, content)?)
+    }
+}
+
+pub(super) fn decode(bytes: &[u8]) -> Result<RepositoryOverlayPlan, OverlayCodecError> {
+    let metadata: Metadata = serde_json::from_slice(bytes).map_err(|_| OverlayCodecError::Malformed)?;
+    if metadata.domain != "horizon.repository-overlay" || metadata.version != 1 {
+        return Err(OverlayCodecError::Unsupported);
+    }
+    let plan = RepositoryOverlayPlan::new(
+        GitSource {
+            repository: metadata.repository,
+            commit: metadata.commit,
+            branch: metadata.branch,
+        },
+        metadata
+            .index
+            .into_iter()
+            .map(Change::validate)
+            .collect::<Result<Vec<_>, _>>()?,
+        metadata
+            .working_tree
+            .into_iter()
+            .map(Change::validate)
+            .collect::<Result<Vec<_>, _>>()?,
+    )?;
+    if fingerprint::encode(&plan)? != bytes {
+        return Err(OverlayCodecError::NonCanonical);
+    }
+    Ok(plan)
+}
+
+fn bounded_layer<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<Change>, D::Error> {
+    struct LayerVisitor;
+    impl<'de> Visitor<'de> for LayerVisitor {
+        type Value = Vec<Change>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a bounded overlay layer")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut sequence: A) -> Result<Self::Value, A::Error> {
+            let mut changes = Vec::new();
+            while changes.len() < MAX_CHANGES {
+                let Some(change) = sequence.next_element()? else {
+                    return Ok(changes);
+                };
+                changes.push(change);
+            }
+            if sequence.next_element::<IgnoredAny>()?.is_some() {
+                return Err(de::Error::custom("overlay layer exceeds its change limit"));
+            }
+            Ok(changes)
+        }
+    }
+    deserializer.deserialize_seq(LayerVisitor)
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/codec/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/codec/mod.rs
@@ -1,0 +1,177 @@
+//! Bounded portable bytes, not export permission, authenticated transport or filesystem application.
+
+mod metadata;
+
+use super::super::{MAX_CHANGES, MAX_METADATA_BYTES, OverlayPlanError};
+use super::{OverlayBundleError, RepositoryOverlayBundle, RequiredBlobs, VerifiedOverlayBlob, fingerprint};
+
+const MAGIC: &[u8; 8] = b"HZOVLY\0\x01";
+const RECORD_HEADER_BYTES: usize = 64 + 8;
+// Allowed strings require at most doubled quote escaping; reserve fixed field overhead per change.
+const MAX_ENCODED_METADATA_BYTES: usize = 2 * MAX_METADATA_BYTES + 256 * MAX_CHANGES + 1024;
+
+/// Maximum complete version 1 encoding, including bounded metadata and per-blob framing.
+pub const MAX_ENCODED_BUNDLE_BYTES: usize =
+    super::MAX_BUNDLE_BYTES + MAX_ENCODED_METADATA_BYTES + MAX_CHANGES * RECORD_HEADER_BYTES + 16;
+
+/// Encode a verified bundle without I/O. This creates a separate owned copy of its payloads.
+/// Run off the UI thread; the caller remains responsible for any export authorization.
+/// # Errors
+/// Rejects encoding/size failures or inability to reserve the bounded output allocation.
+pub fn encode(bundle: &RepositoryOverlayBundle) -> Result<Box<[u8]>, OverlayCodecError> {
+    let metadata = fingerprint::encode(bundle.plan())?;
+    let count = bundle.blobs().len();
+    let length = encoded_length(metadata.len(), count, bundle.file_bytes())?;
+    let mut encoded = Vec::new();
+    encoded
+        .try_reserve_exact(length)
+        .map_err(|_| OverlayCodecError::Allocation)?;
+    encoded.extend_from_slice(MAGIC);
+    encoded.extend_from_slice(
+        &u32::try_from(metadata.len())
+            .map_err(|_| OverlayCodecError::Limit)?
+            .to_le_bytes(),
+    );
+    encoded.extend_from_slice(&metadata);
+    encoded.extend_from_slice(
+        &u32::try_from(count)
+            .map_err(|_| OverlayCodecError::Limit)?
+            .to_le_bytes(),
+    );
+    for blob in bundle.blobs() {
+        encoded.extend_from_slice(blob.sha256().as_str().as_bytes());
+        encoded.extend_from_slice(
+            &u64::try_from(blob.bytes().len())
+                .map_err(|_| OverlayCodecError::Limit)?
+                .to_le_bytes(),
+        );
+        encoded.extend_from_slice(blob.bytes());
+    }
+    Ok(encoded.into_boxed_slice())
+}
+
+fn encoded_length(metadata: usize, count: usize, payloads: usize) -> Result<usize, OverlayCodecError> {
+    if metadata > MAX_ENCODED_METADATA_BYTES || count > MAX_CHANGES || payloads > super::MAX_BUNDLE_BYTES {
+        return Err(OverlayCodecError::Limit);
+    }
+    count
+        .checked_mul(RECORD_HEADER_BYTES)
+        .and_then(|bytes| bytes.checked_add(16))
+        .and_then(|bytes| bytes.checked_add(metadata))
+        .and_then(|bytes| bytes.checked_add(payloads))
+        .filter(|bytes| *bytes <= MAX_ENCODED_BUNDLE_BYTES)
+        .ok_or(OverlayCodecError::Limit)
+}
+
+/// Decode explicitly supplied bytes, rechecking metadata, framing and every payload hash.
+/// This owns a separate bounded payload copy; it does not validate real filesystem topology.
+/// Run off the UI thread. Successful decoding grants no permission to apply or export the result.
+/// # Errors
+/// Rejects unsupported versions, noncanonical/malformed encodings, limit excess or invalid bundles.
+pub fn decode(encoded: &[u8]) -> Result<RepositoryOverlayBundle, OverlayCodecError> {
+    if encoded.len() > MAX_ENCODED_BUNDLE_BYTES {
+        return Err(OverlayCodecError::Limit);
+    }
+    let mut cursor = Cursor { remaining: encoded };
+    if cursor.take(MAGIC.len())? != MAGIC {
+        return Err(OverlayCodecError::Unsupported);
+    }
+    let metadata_bytes = usize::try_from(cursor.u32()?).map_err(|_| OverlayCodecError::Limit)?;
+    if metadata_bytes > MAX_ENCODED_METADATA_BYTES {
+        return Err(OverlayCodecError::Limit);
+    }
+    let plan = metadata::decode(cursor.take(metadata_bytes)?)?;
+    let mut required = RequiredBlobs::new(&plan)?;
+    let count = usize::try_from(cursor.u32()?).map_err(|_| OverlayCodecError::Limit)?;
+    if count > MAX_CHANGES {
+        return Err(OverlayCodecError::Limit);
+    }
+    if count != required.sizes.len() {
+        return Err(OverlayCodecError::Malformed);
+    }
+    let mut blobs = Vec::new();
+    blobs
+        .try_reserve_exact(count)
+        .map_err(|_| OverlayCodecError::Allocation)?;
+    let mut previous: Option<&str> = None;
+    for _ in 0..count {
+        let digest = std::str::from_utf8(cursor.take(64)?).map_err(|_| OverlayCodecError::Malformed)?;
+        if previous.is_some_and(|previous| previous >= digest) {
+            return Err(OverlayCodecError::NonCanonical);
+        }
+        let size = usize::try_from(cursor.u64()?).map_err(|_| OverlayCodecError::Limit)?;
+        let expected = required.sizes.remove(digest).ok_or(OverlayCodecError::Malformed)?;
+        if size != expected {
+            return Err(OverlayCodecError::Malformed);
+        }
+        blobs.push(verified_blob(cursor.take(size)?, digest)?);
+        previous = Some(digest);
+    }
+    if !cursor.remaining.is_empty() {
+        return Err(OverlayCodecError::NonCanonical);
+    }
+    drop(required);
+    Ok(RepositoryOverlayBundle::new(plan, blobs)?)
+}
+
+fn verified_blob(bytes: &[u8], digest: &str) -> Result<VerifiedOverlayBlob, OverlayCodecError> {
+    let mut owned = Vec::new();
+    owned
+        .try_reserve_exact(bytes.len())
+        .map_err(|_| OverlayCodecError::Allocation)?;
+    owned.extend_from_slice(bytes);
+    let blob = VerifiedOverlayBlob::new(owned)?;
+    if blob.sha256().as_str() != digest {
+        return Err(OverlayCodecError::Malformed);
+    }
+    Ok(blob)
+}
+
+struct Cursor<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Cursor<'a> {
+    fn take(&mut self, length: usize) -> Result<&'a [u8], OverlayCodecError> {
+        let (bytes, remaining) = self
+            .remaining
+            .split_at_checked(length)
+            .ok_or(OverlayCodecError::Malformed)?;
+        self.remaining = remaining;
+        Ok(bytes)
+    }
+
+    fn u32(&mut self) -> Result<u32, OverlayCodecError> {
+        Ok(u32::from_le_bytes(
+            self.take(4)?.try_into().map_err(|_| OverlayCodecError::Malformed)?,
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, OverlayCodecError> {
+        Ok(u64::from_le_bytes(
+            self.take(8)?.try_into().map_err(|_| OverlayCodecError::Malformed)?,
+        ))
+    }
+}
+
+/// Redacted format errors do not include input bytes, paths, identities or payload hashes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum OverlayCodecError {
+    #[error("repository bundle format is unsupported")]
+    Unsupported,
+    #[error("repository bundle encoding is malformed")]
+    Malformed,
+    #[error("repository bundle encoding is not canonical")]
+    NonCanonical,
+    #[error("repository bundle encoding exceeds a size limit")]
+    Limit,
+    #[error("repository bundle allocation could not be reserved")]
+    Allocation,
+    #[error(transparent)]
+    Plan(#[from] OverlayPlanError),
+    #[error(transparent)]
+    Bundle(#[from] OverlayBundleError),
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/bundle/codec/tests/malformed.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/codec/tests/malformed.rs
@@ -1,0 +1,239 @@
+use super::*;
+
+#[test]
+fn every_truncated_prefix_and_a_trailing_byte_are_rejected() {
+    let encoded = encode(&one_file()).expect("encoding");
+    for length in 0..encoded.len() {
+        assert!(decode(&encoded[..length]).is_err(), "prefix {length}");
+    }
+    let mut trailing = encoded.into_vec();
+    trailing.push(0);
+    assert_eq!(decode(&trailing), Err(OverlayCodecError::NonCanonical));
+}
+
+#[test]
+fn unknown_magic_and_format_or_metadata_versions_fail() {
+    for position in 0..8 {
+        let mut encoded = encode(&one_file()).expect("encoding").into_vec();
+        encoded[position] ^= 1;
+        assert_eq!(decode(&encoded), Err(OverlayCodecError::Unsupported));
+    }
+    for changed in [
+        changed_metadata(&one_file(), |metadata| {
+            metadata.replace("\"version\":1", "\"version\":2")
+        }),
+        changed_metadata(&one_file(), |metadata| {
+            metadata.replace("horizon.repository-overlay", "other.domain")
+        }),
+    ] {
+        assert_eq!(decode(&changed), Err(OverlayCodecError::Unsupported));
+    }
+}
+
+#[test]
+fn oversized_metadata_and_count_headers_fail_without_allocating_claimed_sizes() {
+    let mut encoded = MAGIC.to_vec();
+    encoded.extend_from_slice(&u32::MAX.to_le_bytes());
+    assert_eq!(decode(&encoded), Err(OverlayCodecError::Limit));
+    let encoded = encode(&one_file()).expect("encoding");
+    let metadata = &encoded[12..metadata_end(&encoded)];
+    assert_eq!(decode(&frame(metadata, u32::MAX, &[])), Err(OverlayCodecError::Limit));
+    assert_eq!(decode(&frame(metadata, 0, &[])), Err(OverlayCodecError::Malformed));
+    assert_eq!(decode(&frame(metadata, 2, &[])), Err(OverlayCodecError::Malformed));
+}
+
+#[test]
+fn invalid_json_duplicate_unknown_missing_and_wrong_variant_fields_fail() {
+    let original = one_file();
+    let encoded = encode(&original).expect("encoding");
+    let metadata = String::from_utf8(encoded[12..metadata_end(&encoded)].to_vec()).expect("metadata");
+    for invalid in [
+        String::from("[1,2,3]"),
+        String::from("not-json"),
+        metadata.replacen('{', "{\"extra\":true,", 1),
+        metadata.replacen('{', "{\"version\":1,", 1),
+        metadata.replace("\"path\":\"selected\"", "\"path\":\"selected\",\"path\":\"selected\""),
+        metadata.replace("\"kind\":\"file\"", "\"kind\":\"file\",\"kind\":\"file\""),
+        metadata.replace("\"kind\":\"file\"", "\"kind\":\"file\",\"extra\":true"),
+        metadata.replace("\"path\":\"selected\",", ""),
+        metadata.replace("\"executable\":true", "\"executable\":null"),
+        metadata.replace("\"executable\":true", "\"executable\":\"true\""),
+        metadata.replace("\"kind\":\"file\"", "\"kind\":\"unknown\""),
+        metadata.replace("\"kind\":\"file\"", "\"kind\":\"remove\""),
+        metadata.replace("\"kind\":\"file\"", "\"kind\":\"symlink\""),
+        metadata.replace("\"kind\":\"file\"", "\"kind\":\"file\",\"target\":\"elsewhere\""),
+        metadata.replace("\"bytes\":10", "\"bytes\":-1"),
+    ] {
+        assert!(decode(&frame(invalid.as_bytes(), 1, &encoded[metadata_end(&encoded) + 4..])).is_err());
+    }
+}
+
+#[test]
+fn semantically_equivalent_but_noncanonical_metadata_is_rejected() {
+    for changed in [
+        changed_metadata(&one_file(), |metadata| format!(" {metadata}")),
+        changed_metadata(&one_file(), |metadata| metadata.replace("\"branch\":null,", "")),
+        changed_metadata(&one_file(), |metadata| {
+            metadata.replace("\"path\":\"selected\"", "\"path\":\"\\u0073elected\"")
+        }),
+        changed_metadata(&one_file(), |metadata| {
+            metadata.replace("\"kind\":\"file\"", "\"kind\":\"file\",\"target\":null")
+        }),
+        changed_metadata(&one_file(), |metadata| {
+            let hash = ArtifactDigest::sha256(b"literal\0\xff\n");
+            metadata.replace(hash.as_str(), &hash.as_str().to_uppercase())
+        }),
+    ] {
+        assert_eq!(decode(&changed), Err(OverlayCodecError::NonCanonical));
+    }
+}
+
+#[test]
+fn source_path_link_and_metadata_limits_are_revalidated() {
+    for changed in [
+        changed_metadata(&one_file(), |metadata| {
+            metadata.replace("team/repo", "https://user:password@example.test/repo")
+        }),
+        changed_metadata(&one_file(), |metadata| metadata.replace("selected", "../escape")),
+        changed_metadata(&one_file(), |metadata| metadata.replace("selected", ".env")),
+        changed_metadata(&one_file(), |metadata| metadata.replace("selected", &"a".repeat(4097))),
+        changed_metadata(&one_file(), |metadata| {
+            metadata.replace("\"branch\":null", "\"branch\":\"../bad\"")
+        }),
+    ] {
+        assert!(matches!(decode(&changed), Err(OverlayCodecError::Plan(_))));
+    }
+    let link = bundle(
+        vec![],
+        vec![
+            OverlayChange::new(
+                "link".into(),
+                OverlayContent::Symlink {
+                    target: "allowed".into(),
+                },
+            )
+            .expect("link"),
+        ],
+        &[],
+    );
+    let changed = changed_metadata(&link, |metadata| metadata.replace("allowed", "../../escape"));
+    assert_eq!(
+        decode(&changed),
+        Err(OverlayCodecError::Plan(OverlayPlanError::InvalidLink))
+    );
+}
+
+#[test]
+fn declared_oversized_files_fail_before_payload_records_are_read() {
+    let oversized = changed_metadata(&one_file(), |metadata| {
+        metadata.replace("\"bytes\":10", "\"bytes\":67108865")
+    });
+    let end = metadata_end(&oversized);
+    assert_eq!(
+        decode(&oversized[..end]),
+        Err(OverlayCodecError::Bundle(OverlayBundleError::FileLimit))
+    );
+}
+
+#[test]
+fn forged_record_lengths_hashes_and_corrupted_payloads_fail() {
+    let encoded = encode(&one_file()).expect("encoding");
+    let record = metadata_end(&encoded) + 4;
+    for length in [0u64, 9, 11, u64::MAX] {
+        let mut changed = encoded.to_vec();
+        changed[record + 64..record + 72].copy_from_slice(&length.to_le_bytes());
+        assert!(decode(&changed).is_err());
+    }
+    for offset in [record, record + 63, record + 72] {
+        let mut changed = encoded.to_vec();
+        changed[offset] ^= 1;
+        assert!(decode(&changed).is_err());
+    }
+    let mut uppercase = encoded.to_vec();
+    uppercase[record..record + 64].make_ascii_uppercase();
+    assert!(decode(&uppercase).is_err());
+}
+
+#[test]
+fn duplicate_and_reordered_blob_records_cannot_bypass_canonical_membership() {
+    let original = bundle(
+        vec![file("a", b"a", false), file("b", b"b", false)],
+        vec![],
+        &[b"a", b"b"],
+    );
+    let encoded = encode(&original).expect("encoding");
+    let start = metadata_end(&encoded) + 4;
+    let first = &encoded[start..start + 73];
+    let second = &encoded[start + 73..];
+    for records in [[first, first].concat(), [second, first].concat()] {
+        assert_eq!(
+            decode(&frame(&encoded[12..start - 4], 2, &records)),
+            Err(OverlayCodecError::NonCanonical)
+        );
+    }
+}
+
+#[test]
+fn decoder_caps_layer_entries_before_growing_unbounded_collections() {
+    let changes = (0..=MAX_CHANGES)
+        .map(|index| format!("{{\"path\":\"file-{index:05}\",\"kind\":\"remove\"}}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let empty = bundle(vec![], vec![], &[]);
+    let oversized = changed_metadata(&empty, |metadata| {
+        metadata.replace("\"index\":[]", &format!("\"index\":[{changes}]"))
+    });
+    assert_eq!(decode(&oversized), Err(OverlayCodecError::Malformed));
+}
+
+#[test]
+fn exact_change_limit_is_accepted_but_the_shared_layer_budget_is_enforced() {
+    let changes = (0..MAX_CHANGES)
+        .map(|index| format!("{{\"path\":\"file-{index:05}\",\"kind\":\"remove\"}}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let empty = bundle(vec![], vec![], &[]);
+    let exact = changed_metadata(&empty, |metadata| {
+        metadata.replace("\"index\":[]", &format!("\"index\":[{changes}]"))
+    });
+    let decoded = decode(&exact).expect("exact entry boundary");
+    assert_eq!(decoded.plan().index().len(), MAX_CHANGES);
+    let exceeded = changed_metadata(&decoded, |metadata| {
+        metadata.replace(
+            "\"working_tree\":[]",
+            "\"working_tree\":[{\"path\":\"extra\",\"kind\":\"remove\"}]",
+        )
+    });
+    assert_eq!(
+        decode(&exceeded),
+        Err(OverlayCodecError::Plan(OverlayPlanError::ChangeLimit))
+    );
+}
+
+#[test]
+fn aggregate_payload_budget_is_checked_before_allocating_or_reading_records() {
+    let original = bundle(
+        vec![file("a", b"a", false), file("b", b"b", false), file("c", b"c", false)],
+        vec![],
+        &[b"a", b"b", b"c"],
+    );
+    let oversized = changed_metadata(&original, |metadata| {
+        metadata.replace("\"bytes\":1", "\"bytes\":67108864")
+    });
+    assert_eq!(
+        decode(&oversized[..metadata_end(&oversized)]),
+        Err(OverlayCodecError::Bundle(OverlayBundleError::BundleLimit))
+    );
+}
+
+#[test]
+fn malformed_input_diagnostics_are_redacted() {
+    let malformed = changed_metadata(&one_file(), |metadata| {
+        metadata.replace("team/repo", "private-secret-value")
+    });
+    let error = decode(&malformed).expect_err("invalid identity");
+    let diagnostic = format!("{error} {error:?}");
+    for private in ["private-secret-value", "selected", "literal", "team/repo"] {
+        assert!(!diagnostic.contains(private));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/codec/tests/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/codec/tests/mod.rs
@@ -1,0 +1,70 @@
+use super::*;
+use crate::{
+    cloud_run::{ArtifactDigest, GitCommitSha, GitSource},
+    repository_overlay::{OverlayChange, OverlayContent, RepositoryOverlayPlan},
+};
+
+mod malformed;
+mod roundtrip;
+
+fn source() -> GitSource {
+    GitSource {
+        repository: "team/repo".into(),
+        commit: GitCommitSha::parse("a".repeat(40)).expect("commit"),
+        branch: None,
+    }
+}
+
+fn file(path: &str, bytes: &[u8], executable: bool) -> OverlayChange {
+    OverlayChange::new(
+        path.into(),
+        OverlayContent::File {
+            sha256: ArtifactDigest::sha256(bytes),
+            bytes: bytes.len().try_into().expect("size"),
+            executable,
+        },
+    )
+    .expect("file")
+}
+
+fn bundle(index: Vec<OverlayChange>, working: Vec<OverlayChange>, blobs: &[&[u8]]) -> RepositoryOverlayBundle {
+    RepositoryOverlayBundle::new(
+        RepositoryOverlayPlan::new(source(), index, working).expect("plan"),
+        blobs
+            .iter()
+            .map(|bytes| VerifiedOverlayBlob::new(bytes.to_vec()).expect("blob")),
+    )
+    .expect("bundle")
+}
+
+fn one_file() -> RepositoryOverlayBundle {
+    bundle(
+        vec![file("selected", b"literal\0\xff\n", true)],
+        vec![],
+        &[b"literal\0\xff\n"],
+    )
+}
+
+fn metadata_end(encoded: &[u8]) -> usize {
+    12 + usize::try_from(u32::from_le_bytes(encoded[8..12].try_into().expect("header"))).expect("length")
+}
+
+fn frame(metadata: &[u8], count: u32, records: &[u8]) -> Vec<u8> {
+    let mut encoded = MAGIC.to_vec();
+    encoded.extend_from_slice(&u32::try_from(metadata.len()).expect("metadata length").to_le_bytes());
+    encoded.extend_from_slice(metadata);
+    encoded.extend_from_slice(&count.to_le_bytes());
+    encoded.extend_from_slice(records);
+    encoded
+}
+
+fn changed_metadata(bundle: &RepositoryOverlayBundle, change: impl FnOnce(String) -> String) -> Vec<u8> {
+    let encoded = encode(bundle).expect("encoding");
+    let end = metadata_end(&encoded);
+    let metadata = change(String::from_utf8(encoded[12..end].to_vec()).expect("metadata"));
+    frame(
+        metadata.as_bytes(),
+        bundle.blobs().len().try_into().expect("count"),
+        &encoded[end + 4..],
+    )
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/codec/tests/roundtrip.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/codec/tests/roundtrip.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+#[test]
+fn empty_bundle_has_fixed_versioned_framing_and_independent_digest() {
+    let bundle = bundle(vec![], vec![], &[]);
+    let encoded = encode(&bundle).expect("encoding");
+    let metadata = br#"{"domain":"horizon.repository-overlay","version":1,"repository":"team/repo","commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","branch":null,"index":[],"working_tree":[]}"#;
+    assert_eq!(metadata.len(), 171);
+    let mut expected = b"HZOVLY\0\x01\xab\0\0\0".to_vec();
+    expected.extend_from_slice(metadata);
+    expected.extend_from_slice(&[0; 4]);
+    assert_eq!(encoded.as_ref(), expected);
+    assert_eq!(encoded.len(), 187);
+    assert_eq!(
+        ArtifactDigest::sha256(&encoded).as_str(),
+        "4ca86fa8c01c45cbfd3becf3252a96a37770f5ed1c8afced48c00e011f268f53"
+    );
+    assert_eq!(decode(&encoded).expect("decoding"), bundle);
+}
+
+#[test]
+fn mixed_layers_links_modes_removals_and_literal_bytes_roundtrip() {
+    let staged = b"version https://git-lfs.github.com/spec/v1\nliteral-pointer\n";
+    let working = b"\0\xff\x80\n";
+    let path = "nested/quoted \" ø.txt";
+    let original = bundle(
+        vec![
+            file(path, staged, false),
+            OverlayChange::new("gone".into(), OverlayContent::Remove).expect("remove"),
+        ],
+        vec![
+            file(path, working, true),
+            file("untracked", b"", false),
+            OverlayChange::new("alias".into(), OverlayContent::Symlink { target: path.into() }).expect("link"),
+        ],
+        &[working, b"", staged],
+    );
+    let encoded = encode(&original).expect("encoding");
+    let decoded = decode(&encoded).expect("decoding");
+    assert_eq!(decoded, original);
+    assert_eq!(decoded.manifest_sha256(), original.manifest_sha256());
+    assert_eq!(encode(&decoded).expect("reencoding"), encoded);
+    assert_eq!(decoded.blob(&ArtifactDigest::sha256(working)), Some(working.as_slice()));
+}
+
+#[test]
+fn shared_payloads_have_one_canonical_record_despite_references_or_input_order() {
+    let first = bundle(
+        vec![file("z", b"z", false), file("a", b"a", false)],
+        vec![file("z", b"z", true)],
+        &[b"z", b"a"],
+    );
+    let second = bundle(
+        vec![file("a", b"a", false), file("z", b"z", false)],
+        vec![file("z", b"z", true)],
+        &[b"a", b"z"],
+    );
+    let encoded = encode(&first).expect("encoding");
+    assert_eq!(encoded, encode(&second).expect("encoding"));
+    let end = metadata_end(&encoded);
+    assert_eq!(&encoded[end..end + 4], &2u32.to_le_bytes());
+    let decoded = decode(&encoded).expect("decoding");
+    assert_eq!(decoded.blobs().len(), 2);
+    assert_eq!(decoded.file_bytes(), 2);
+    assert_eq!(decoded.plan().content_bytes(), 3);
+}
+
+#[test]
+fn encoding_and_decoding_own_copies_independent_of_other_buffers() {
+    let original = one_file();
+    let mut encoded = encode(&original).expect("encoding").into_vec();
+    let decoded = decode(&encoded).expect("decoding");
+    encoded.fill(0);
+    assert_eq!(decoded, original);
+    assert_ne!(encode(&original).expect("fresh encoding").as_ref(), encoded);
+}
+
+#[test]
+fn valid_metadata_changes_need_separate_expected_fingerprint_authorization() {
+    let original = one_file();
+    let changed = changed_metadata(&original, |metadata| metadata.replace("team/repo", "other/repo"));
+    let decoded = decode(&changed).expect("valid unsigned metadata");
+    assert_ne!(decoded.manifest_sha256(), original.manifest_sha256());
+    assert_eq!(
+        decoded.blobs().next().expect("blob").bytes(),
+        original.blobs().next().expect("blob").bytes()
+    );
+}
+
+#[test]
+fn encoded_size_budget_admits_the_exact_derived_boundary() {
+    assert_eq!(
+        encoded_length(
+            MAX_ENCODED_METADATA_BYTES,
+            MAX_CHANGES,
+            super::super::super::MAX_BUNDLE_BYTES
+        ),
+        Ok(MAX_ENCODED_BUNDLE_BYTES)
+    );
+    for (metadata, count, payloads) in [
+        (MAX_ENCODED_METADATA_BYTES + 1, 0, 0),
+        (0, MAX_CHANGES + 1, 0),
+        (0, 0, super::super::super::MAX_BUNDLE_BYTES + 1),
+        (usize::MAX, usize::MAX, usize::MAX),
+    ] {
+        assert_eq!(encoded_length(metadata, count, payloads), Err(OverlayCodecError::Limit));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/mod.rs
@@ -1,5 +1,6 @@
 //! Complete, hash-verified local payloads; not export approval, capture or filesystem safety.
 
+pub mod codec;
 mod fingerprint;
 
 use super::{OverlayContent, RepositoryOverlayPlan, reader::MAX_READ_BYTES};

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -145,6 +145,9 @@ back into large multi-purpose modules.
   or length-inconsistent payloads fail before a bundle is returned. It performs
   no I/O and grants no capture, export or recovery authority; streaming large
   overlays, coherent capture and safe materialization remain separate concerns.
+  `bundle/codec/` frames portable versioned bytes with bounded, constructor-checked
+  metadata decoding, canonical ordering and recomputed payload hashes. It does not
+  perform I/O or authorize export, extraction or repository writes.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Add a bounded portable representation of verified repository overlay bundles for #383.

## Behavior

- Encode the exact two-layer plan and sorted payloads in a canonical version 1 frame.
- Decode through the existing checked constructors, recomputing every payload hash and rejecting malformed, noncanonical, oversized or incomplete input.
- Preserve the existing manifest fingerprint, executable bits, literal links and separate staged/working contents.
- Keep all operations byte-slice-only, with redacted typed errors and explicit allocation limits. No new dependencies.

This format is unsigned and performs no capture, export approval, network transfer, filesystem application or checkpoint scheduling. Encoding and decoding own separate bounded payload copies and belong off the UI thread.

## Validation

- 19 focused format regressions, including golden framing, boundary counts, corrupt payloads and malformed metadata with otherwise valid records.
- Full exact-head workspace tests with and without speech; format, maintainability, version synchronization, blocking, strict and advisory Clippy tiers passed.
- Independent local review of the complete patch and its integration onto the actual prerequisite merge.
- Synthetic public-API integration: selected reads, distinct layers, executable bits, links/removal, exact round trip after a later local edit, corruption rejection and verified fixture cleanup.

No UI, provider or configuration behavior changed. No cloud resources, user repository contents or pre-existing processes were involved in validation.
