### PR TITLE
feat(repository): retain verified overlay bundles

### DIFF
--- a/crates/horizon-core/src/repository_overlay/bundle/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod codec;
 mod fingerprint;
+pub mod store;
 
 use super::{OverlayContent, RepositoryOverlayPlan, reader::MAX_READ_BYTES};
 use crate::cloud_run::ArtifactDigest;

--- a/crates/horizon-core/src/repository_overlay/bundle/store/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/linux.rs
@@ -1,0 +1,152 @@
+use super::{ArtifactDigest, BundleStoreError as Error, codec};
+use crate::repository_overlay::reader::{
+    RepositoryReadError, SelectedRepositoryReader,
+    linux::{RegularFileRead, Root},
+};
+use rustix::fs::{AtFlags, CWD, Mode, OFlags, ResolveFlags, linkat, openat2};
+use std::{
+    fs::File,
+    io::{self, Write},
+    os::{fd::AsRawFd, unix::fs::MetadataExt},
+    path::Path,
+};
+
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+pub(super) struct Directory {
+    reader: Root,
+    directory: File,
+}
+
+impl Directory {
+    pub(super) fn open(path: &Path) -> Result<Self, Error> {
+        let reader = SelectedRepositoryReader::open(path)?.root;
+        let directory = File::from(
+            openat2(
+                reader.handle(),
+                ".",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            )
+            .map_err(storage_error)?,
+        );
+        let result = Self { reader, directory };
+        result.verify()?;
+        Ok(result)
+    }
+
+    fn verify(&self) -> Result<(), Error> {
+        let metadata = self.directory.metadata().map_err(|_| Error::UnsafeDirectory)?;
+        if !metadata.is_dir()
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o700
+            || metadata.nlink() == 0
+        {
+            return Err(Error::UnsafeDirectory);
+        }
+        Ok(())
+    }
+
+    pub(super) fn read(&self, digest: &ArtifactDigest) -> Result<Option<RegularFileRead>, Error> {
+        self.verify()?;
+        match self
+            .reader
+            .read_private_file(&name(digest), codec::MAX_ENCODED_BUNDLE_BYTES)
+        {
+            Ok(record) => Ok(Some(record)),
+            Err(RepositoryReadError::Missing) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) fn put(&self, digest: &ArtifactDigest, bytes: &[u8]) -> Result<(), Error> {
+        self.put_with_sync(digest, bytes, File::sync_all)
+    }
+
+    fn put_with_sync(
+        &self,
+        digest: &ArtifactDigest,
+        bytes: &[u8],
+        mut sync: impl FnMut(&File) -> io::Result<()>,
+    ) -> Result<(), Error> {
+        if let Some(record) = self.read(digest)? {
+            return self.synchronize_existing(&record, bytes, sync);
+        }
+        let mut file = self.anonymous()?;
+        file.write_all(bytes).map_err(|_| Error::WriteFailed)?;
+        sync(&file).map_err(|_| Error::WriteFailed)?;
+        self.verify()?;
+        // Only this held anonymous inode is followed; linkat never replaces the destination.
+        match linkat(
+            CWD,
+            format!("/proc/self/fd/{}", file.as_raw_fd()),
+            &self.directory,
+            name(digest),
+            AtFlags::SYMLINK_FOLLOW,
+        ) {
+            Ok(()) => {
+                sync(&file).map_err(|_| Error::WriteFailed)?;
+                sync(&self.directory).map_err(|_| Error::WriteFailed)
+            }
+            Err(rustix::io::Errno::EXIST) => {
+                let record = self.read(digest)?.ok_or(Error::Missing)?;
+                self.synchronize_existing(&record, bytes, sync)
+            }
+            Err(error) => Err(storage_error(error)),
+        }
+    }
+
+    fn anonymous(&self) -> Result<File, Error> {
+        self.verify()?;
+        let file = File::from(
+            openat2(
+                &self.directory,
+                ".",
+                OFlags::TMPFILE | OFlags::RDWR | OFlags::CLOEXEC,
+                Mode::RUSR | Mode::WUSR,
+                CONFINED,
+            )
+            .map_err(storage_error)?,
+        );
+        let metadata = file.metadata().map_err(|_| Error::WriteFailed)?;
+        if !metadata.is_file()
+            || metadata.nlink() != 0
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o600
+        {
+            return Err(Error::WriteFailed);
+        }
+        Ok(file)
+    }
+
+    fn synchronize_existing(
+        &self,
+        record: &RegularFileRead,
+        bytes: &[u8],
+        mut sync: impl FnMut(&File) -> io::Result<()>,
+    ) -> Result<(), Error> {
+        if record.bytes != bytes {
+            return Err(Error::Conflict);
+        }
+        sync(&record.file).map_err(|_| Error::WriteFailed)?;
+        sync(&self.directory).map_err(|_| Error::WriteFailed)
+    }
+}
+
+fn name(digest: &ArtifactDigest) -> String {
+    format!("{}.hzov", digest.as_str())
+}
+
+fn storage_error(error: rustix::io::Errno) -> Error {
+    match error {
+        rustix::io::Errno::NOSYS | rustix::io::Errno::INVAL | rustix::io::Errno::OPNOTSUPP => Error::Unsupported,
+        _ => Error::WriteFailed,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/bundle/store/linux/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/linux/tests.rs
@@ -1,0 +1,124 @@
+use super::super::tests::private_fixture;
+use super::*;
+use std::{fs, sync::Barrier, thread};
+
+#[test]
+fn partial_anonymous_write_never_has_a_name_and_is_discarded_on_close() {
+    let fixture = private_fixture();
+    let directory = Directory::open(fixture.path()).expect("directory");
+    let mut partial = directory.anonymous().expect("anonymous file");
+    partial.write_all(b"partial input").expect("partial write");
+    assert_eq!(partial.metadata().expect("inode").nlink(), 0);
+    assert_eq!(fs::read_dir(fixture.path()).expect("directory").count(), 0);
+    drop(partial);
+    assert_eq!(fs::read_dir(fixture.path()).expect("no orphan name").count(), 0);
+}
+
+#[test]
+fn each_sync_failure_is_reported_and_explicit_retry_retains_any_published_inode() {
+    for failed_sync in 1..=3 {
+        let fixture = private_fixture();
+        let directory = Directory::open(fixture.path()).expect("directory");
+        let digest = ArtifactDigest::sha256(b"synthetic publication identity");
+        let bytes = b"complete synthetic bytes";
+        let mut calls = 0;
+        let result = directory.put_with_sync(&digest, bytes, |file| {
+            calls += 1;
+            if calls == failed_sync {
+                Err(io::Error::other("synthetic fsync failure"))
+            } else {
+                file.sync_all()
+            }
+        });
+        assert_eq!(result, Err(Error::WriteFailed));
+        let before = directory.read(&digest).expect("read outcome");
+        assert_eq!(before.is_some(), failed_sync > 1);
+        let inode = before
+            .as_ref()
+            .map(|record| record.file.metadata().expect("published inode").ino());
+        directory.put(&digest, bytes).expect("explicit retry");
+        let retained = directory.read(&digest).expect("retry read").expect("complete record");
+        assert_eq!(retained.bytes, bytes);
+        if let Some(inode) = inode {
+            assert_eq!(retained.file.metadata().expect("same inode").ino(), inode);
+        }
+        assert_eq!(fs::read_dir(fixture.path()).expect("one record").count(), 1);
+    }
+}
+
+#[test]
+fn existing_record_retry_requires_both_synchronization_steps() {
+    let fixture = private_fixture();
+    let directory = Directory::open(fixture.path()).expect("directory");
+    let digest = ArtifactDigest::sha256(b"identity");
+    directory.put(&digest, b"bytes").expect("initial publication");
+    for failed_sync in 1..=2 {
+        let mut calls = 0;
+        assert_eq!(
+            directory.put_with_sync(&digest, b"bytes", |file| {
+                calls += 1;
+                if calls == failed_sync {
+                    Err(io::Error::other("sync failure"))
+                } else {
+                    file.sync_all()
+                }
+            }),
+            Err(Error::WriteFailed)
+        );
+        assert_eq!(directory.read(&digest).expect("read").expect("record").bytes, b"bytes");
+    }
+}
+
+#[test]
+fn no_replace_publication_preserves_the_winner_of_a_conflicting_race() {
+    let fixture = private_fixture();
+    let digest = ArtifactDigest::sha256(b"shared name");
+    let barrier = Barrier::new(2);
+    let results = thread::scope(|scope| {
+        let root = fixture.path();
+        let identity = &digest;
+        let start = &barrier;
+        let handles: Vec<_> = [b"first".as_slice(), b"second"]
+            .into_iter()
+            .map(|bytes| {
+                scope.spawn(move || {
+                    let directory = Directory::open(root).expect("independent directory");
+                    let mut synchronized_data = false;
+                    directory.put_with_sync(identity, bytes, |file| {
+                        file.sync_all()?;
+                        if !synchronized_data {
+                            synchronized_data = true;
+                            start.wait();
+                        }
+                        Ok(())
+                    })
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("writer"))
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results.iter().filter(|result| **result == Err(Error::Conflict)).count(),
+        1
+    );
+    let directory = Directory::open(fixture.path()).expect("fresh directory");
+    let record = directory.read(&digest).expect("read").expect("winner");
+    assert!(record.bytes == b"first" || record.bytes == b"second");
+    assert_eq!(fs::read_dir(fixture.path()).expect("one winner").count(), 1);
+}
+
+#[test]
+fn unsupported_filesystems_have_no_weaker_publication_fallback() {
+    for error in [
+        rustix::io::Errno::NOSYS,
+        rustix::io::Errno::INVAL,
+        rustix::io::Errno::OPNOTSUPP,
+    ] {
+        assert_eq!(storage_error(error), Error::Unsupported);
+    }
+    assert_eq!(storage_error(rustix::io::Errno::ROFS), Error::WriteFailed);
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/store/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/mod.rs
@@ -1,0 +1,109 @@
+//! Explicit private bundle persistence, not capture, export approval or scheduled remote backup.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+use super::{RepositoryOverlayBundle, codec};
+use crate::{cloud_run::ArtifactDigest, repository_overlay::reader::RepositoryReadError};
+use std::{fmt, path::Path};
+
+/// Immutable digest-named records in an explicitly selected, existing private directory.
+/// The caller owns storage selection, authorization, capacity and retention policy.
+/// No overwrite, deletion, directory creation, inventory or permission repair is exposed.
+pub struct RepositoryBundleStore {
+    #[cfg(target_os = "linux")]
+    directory: linux::Directory,
+}
+
+impl RepositoryBundleStore {
+    /// Pin an owned `0700` directory without following symlinked ancestors.
+    /// Linux confinement and anonymous-file publication support are required for writes.
+    /// # Errors
+    /// Rejects unsupported platforms, inaccessible/unsafe roots and non-private ownership.
+    pub fn open(root: &Path) -> Result<Self, BundleStoreError> {
+        #[cfg(target_os = "linux")]
+        {
+            Ok(Self {
+                directory: linux::Directory::open(root)?,
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = root;
+            Err(BundleStoreError::Unsupported)
+        }
+    }
+
+    /// Synchronize and atomically publish complete bytes, never replacing an existing record.
+    /// Identical retries verify and synchronize the existing file and directory again.
+    /// A failure can leave a complete published record; retry explicitly with the same bundle.
+    /// Run off the UI thread: bounded buffers do not bound filesystem latency. Encoding plus
+    /// a retry comparison can hold two encoding buffers alongside the caller's bundle.
+    /// # Errors
+    /// Rejects unsupported storage, unsafe/conflicting existing records or synchronization failure.
+    pub fn put(&self, bundle: &RepositoryOverlayBundle) -> Result<ArtifactDigest, BundleStoreError> {
+        #[cfg(target_os = "linux")]
+        {
+            let bytes = codec::encode(bundle)?;
+            self.directory.put(bundle.manifest_sha256(), &bytes)?;
+            Ok(bundle.manifest_sha256().clone())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = bundle;
+            Err(BundleStoreError::Unsupported)
+        }
+    }
+
+    /// Read one private bounded record and revalidate its encoding, payloads and exact digest.
+    /// Does not establish a signature, coherent capture, storage replication or apply authority.
+    /// Run off the UI thread; decoding owns a separate bounded payload copy.
+    /// # Errors
+    /// Rejects missing, unsafe, oversized, corrupt or wrongly named records without modifying them.
+    pub fn get(&self, digest: &ArtifactDigest) -> Result<RepositoryOverlayBundle, BundleStoreError> {
+        #[cfg(target_os = "linux")]
+        {
+            let record = self.directory.read(digest)?.ok_or(BundleStoreError::Missing)?;
+            let bundle = codec::decode(&record.bytes)?;
+            if bundle.manifest_sha256() != digest {
+                return Err(BundleStoreError::DigestMismatch);
+            }
+            Ok(bundle)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = digest;
+            Err(BundleStoreError::Unsupported)
+        }
+    }
+}
+
+impl fmt::Debug for RepositoryBundleStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("RepositoryBundleStore").finish_non_exhaustive()
+    }
+}
+
+/// Storage failures contain no paths, identities, digests or bundle contents.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BundleStoreError {
+    #[error("safe bundle storage is unsupported on this platform or filesystem")]
+    Unsupported,
+    #[error("bundle storage requires an existing private owned directory")]
+    UnsafeDirectory,
+    #[error("requested repository bundle is missing")]
+    Missing,
+    #[error("existing repository bundle conflicts with the requested contents")]
+    Conflict,
+    #[error("stored repository bundle does not match its requested digest")]
+    DigestMismatch,
+    #[error("repository bundle could not be durably stored")]
+    WriteFailed,
+    #[error(transparent)]
+    Read(#[from] RepositoryReadError),
+    #[error(transparent)]
+    Codec(#[from] codec::OverlayCodecError),
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/bundle/store/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/tests.rs
@@ -1,0 +1,330 @@
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{OverlayChange, OverlayContent, RepositoryOverlayPlan, bundle::VerifiedOverlayBlob},
+};
+
+fn bundle(payload: &[u8]) -> RepositoryOverlayBundle {
+    let staged = VerifiedOverlayBlob::new(b"staged bytes".to_vec()).expect("staged blob");
+    let working = VerifiedOverlayBlob::new(payload.to_vec()).expect("working blob");
+    let change = |blob: &VerifiedOverlayBlob, executable| {
+        OverlayChange::new(
+            "selected".into(),
+            OverlayContent::File {
+                sha256: blob.sha256().clone(),
+                bytes: blob.bytes().len().try_into().expect("size"),
+                executable,
+            },
+        )
+        .expect("file change")
+    };
+    let plan = RepositoryOverlayPlan::new(
+        GitSource {
+            repository: "team/repo".into(),
+            commit: GitCommitSha::parse("a".repeat(40)).expect("commit"),
+            branch: None,
+        },
+        [
+            change(&staged, false),
+            OverlayChange::new("removed".into(), OverlayContent::Remove).expect("removal"),
+        ],
+        [
+            change(&working, true),
+            OverlayChange::new(
+                "alias".into(),
+                OverlayContent::Symlink {
+                    target: "selected".into(),
+                },
+            )
+            .expect("literal link"),
+        ],
+    )
+    .expect("plan");
+    RepositoryOverlayBundle::new(plan, [staged, working]).expect("bundle")
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_never_creates_files_or_falls_back() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    assert!(matches!(
+        RepositoryBundleStore::open(fixture.path()),
+        Err(BundleStoreError::Unsupported)
+    ));
+    let store = RepositoryBundleStore {};
+    let value = bundle(b"local bytes");
+    assert_eq!(store.put(&value), Err(BundleStoreError::Unsupported));
+    assert_eq!(store.get(value.manifest_sha256()), Err(BundleStoreError::Unsupported));
+    assert_eq!(std::fs::read_dir(fixture.path()).expect("directory").count(), 0);
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn private_fixture() -> tempfile::TempDir {
+    use std::os::unix::fs::PermissionsExt;
+    tempfile::Builder::new()
+        .permissions(std::fs::Permissions::from_mode(0o700))
+        .tempdir()
+        .expect("private fixture")
+}
+
+#[cfg(target_os = "linux")]
+mod supported {
+    use super::*;
+    use std::{
+        fs::{self, File, OpenOptions},
+        io::Write,
+        os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt, symlink},
+        path::PathBuf,
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    fn record_path(root: &Path, value: &RepositoryOverlayBundle) -> PathBuf {
+        root.join(format!("{}.hzov", value.manifest_sha256().as_str()))
+    }
+
+    fn private_directory(root: &Path) {
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(root)
+            .expect("private directory");
+    }
+
+    fn private_file(path: &Path, bytes: &[u8]) {
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+            .expect("private file")
+            .write_all(bytes)
+            .expect("fixture bytes");
+    }
+
+    #[test]
+    fn reopen_and_identical_retry_preserve_layers_inode_mode_and_bytes() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        let value = bundle(b"working\0\xff\n");
+        let digest = store.put(&value).expect("publish");
+        assert_eq!(&digest, value.manifest_sha256());
+        let path = record_path(fixture.path(), &value);
+        let before = fs::metadata(&path).expect("record metadata");
+        assert_eq!(before.mode() & 0o7777, 0o600);
+        assert_eq!(before.nlink(), 1);
+        assert_eq!(
+            fs::read(&path).expect("record"),
+            codec::encode(&value).expect("canonical bytes").as_ref()
+        );
+        drop(store);
+        let fresh = RepositoryBundleStore::open(fixture.path()).expect("fresh store");
+        assert_eq!(fresh.get(&digest).expect("reopen"), value);
+        assert_eq!(fresh.put(&value).expect("idempotent retry"), digest);
+        let after = fs::metadata(&path).expect("same record");
+        assert_eq!(
+            (before.ino(), before.mtime(), before.mtime_nsec()),
+            (after.ino(), after.mtime(), after.mtime_nsec())
+        );
+        assert_eq!(fs::read_dir(fixture.path()).expect("records").count(), 1);
+    }
+
+    #[test]
+    fn distinct_bundles_and_empty_payloads_coexist_without_overwrite() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        for bytes in [b"first".as_slice(), b"second", b""] {
+            let value = bundle(bytes);
+            let digest = store.put(&value).expect("publish");
+            assert_eq!(store.get(&digest).expect("read"), value);
+        }
+        assert_eq!(fs::read_dir(fixture.path()).expect("records").count(), 3);
+    }
+
+    #[test]
+    fn concurrent_independent_writers_converge_to_one_complete_record() {
+        let fixture = private_fixture();
+        let value = Arc::new(bundle(b"same bytes"));
+        let barrier = Barrier::new(8);
+        thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let store = RepositoryBundleStore::open(fixture.path()).expect("independent store");
+                        barrier.wait();
+                        store.put(&value).expect("concurrent publish")
+                    })
+                })
+                .collect();
+            for handle in handles {
+                assert_eq!(&handle.join().expect("writer"), value.manifest_sha256());
+            }
+        });
+        let fresh = RepositoryBundleStore::open(fixture.path()).expect("fresh store");
+        assert_eq!(fresh.get(value.manifest_sha256()).expect("complete record"), *value);
+        assert_eq!(fs::read_dir(fixture.path()).expect("records").count(), 1);
+    }
+
+    #[test]
+    fn renamed_root_never_selects_a_replacement_directory() {
+        let fixture = private_fixture();
+        let selected = fixture.path().join("selected");
+        let retained = fixture.path().join("retained");
+        private_directory(&selected);
+        let original = RepositoryBundleStore::open(&selected).expect("original store");
+        fs::rename(&selected, &retained).expect("rename root");
+        private_directory(&selected);
+        let value = bundle(b"pinned root");
+        original.put(&value).expect("write pinned directory");
+        assert_eq!(fs::read_dir(&selected).expect("replacement").count(), 0);
+        assert_eq!(
+            RepositoryBundleStore::open(&selected)
+                .expect("replacement store")
+                .get(value.manifest_sha256()),
+            Err(BundleStoreError::Missing)
+        );
+        assert_eq!(
+            RepositoryBundleStore::open(&retained)
+                .expect("retained store")
+                .get(value.manifest_sha256())
+                .expect("original bytes"),
+            value
+        );
+    }
+
+    #[test]
+    fn missing_nonprivate_and_linked_roots_are_not_created_or_repaired() {
+        let fixture = private_fixture();
+        let missing = fixture.path().join("absent");
+        assert!(RepositoryBundleStore::open(&missing).is_err());
+        assert!(!missing.exists());
+        assert!(RepositoryBundleStore::open(Path::new("relative")).is_err());
+        let public = fixture.path().join("public");
+        private_directory(&public);
+        fs::set_permissions(&public, fs::Permissions::from_mode(0o755)).expect("nonprivate mode");
+        assert!(matches!(
+            RepositoryBundleStore::open(&public),
+            Err(BundleStoreError::UnsafeDirectory)
+        ));
+        assert_eq!(fs::metadata(&public).expect("unchanged root").mode() & 0o7777, 0o755);
+        symlink(fixture.path(), fixture.path().join("linked")).expect("root symlink");
+        assert!(RepositoryBundleStore::open(&fixture.path().join("linked")).is_err());
+    }
+
+    #[test]
+    fn root_permissions_are_rechecked_after_open() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        let value = bundle(b"private bytes");
+        fs::set_permissions(fixture.path(), fs::Permissions::from_mode(0o750)).expect("permission change");
+        assert_eq!(
+            store.get(value.manifest_sha256()),
+            Err(BundleStoreError::UnsafeDirectory)
+        );
+        assert_eq!(store.put(&value), Err(BundleStoreError::UnsafeDirectory));
+        assert_eq!(fs::read_dir(fixture.path()).expect("unchanged directory").count(), 0);
+    }
+
+    #[test]
+    fn corrupt_existing_record_is_never_overwritten_or_returned() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        let value = bundle(b"payload secret marker");
+        let digest = store.put(&value).expect("publish");
+        let path = record_path(fixture.path(), &value);
+        let mut corrupted = fs::read(&path).expect("record");
+        *corrupted.last_mut().expect("payload") ^= 1;
+        fs::write(&path, &corrupted).expect("corrupt owned fixture");
+        assert!(matches!(store.get(&digest), Err(BundleStoreError::Codec(_))));
+        assert_eq!(store.put(&value), Err(BundleStoreError::Conflict));
+        assert_eq!(fs::read(&path).expect("preserved corrupt record"), corrupted);
+    }
+
+    #[test]
+    fn valid_bundle_under_the_wrong_digest_is_rejected_and_preserved() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        let wanted = bundle(b"wanted");
+        let different = codec::encode(&bundle(b"different")).expect("other canonical bundle");
+        let path = record_path(fixture.path(), &wanted);
+        private_file(&path, &different);
+        assert_eq!(
+            store.get(wanted.manifest_sha256()),
+            Err(BundleStoreError::DigestMismatch)
+        );
+        assert_eq!(store.put(&wanted), Err(BundleStoreError::Conflict));
+        assert_eq!(fs::read(&path).expect("unchanged record"), different.as_ref());
+    }
+
+    #[test]
+    fn unsafe_record_nodes_are_never_followed_read_or_replaced() {
+        for kind in ["symlink", "hardlink", "fifo", "directory", "nonprivate"] {
+            let fixture = private_fixture();
+            let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+            let value = bundle(b"new contents");
+            let target = fixture.path().join("untouched");
+            private_file(&target, b"untouched synthetic contents");
+            let path = record_path(fixture.path(), &value);
+            match kind {
+                "symlink" => symlink(&target, &path).expect("symlink"),
+                "hardlink" => fs::hard_link(&target, &path).expect("hardlink"),
+                "fifo" => rustix::fs::mkfifoat(rustix::fs::CWD, &path, rustix::fs::Mode::RUSR | rustix::fs::Mode::WUSR)
+                    .expect("fifo"),
+                "directory" => private_directory(&path),
+                _ => {
+                    private_file(&path, b"not private");
+                    fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).expect("nonprivate mode");
+                }
+            }
+            let before = fs::symlink_metadata(&path).expect("node");
+            assert!(store.get(value.manifest_sha256()).is_err(), "{kind}");
+            assert!(store.put(&value).is_err(), "{kind}");
+            let after = fs::symlink_metadata(&path).expect("unchanged node");
+            assert_eq!((before.ino(), before.mode()), (after.ino(), after.mode()));
+            assert_eq!(
+                fs::read(&target).expect("untouched target"),
+                b"untouched synthetic contents"
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_sparse_record_is_rejected_before_content_allocation() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        let value = bundle(b"small");
+        let path = record_path(fixture.path(), &value);
+        private_file(&path, b"");
+        let size = u64::try_from(codec::MAX_ENCODED_BUNDLE_BYTES).expect("limit") + 1;
+        File::options()
+            .write(true)
+            .open(&path)
+            .expect("sparse fixture")
+            .set_len(size)
+            .expect("sparse length");
+        assert_eq!(
+            store.get(value.manifest_sha256()),
+            Err(BundleStoreError::Read(RepositoryReadError::TooLarge))
+        );
+        assert_eq!(
+            store.put(&value),
+            Err(BundleStoreError::Read(RepositoryReadError::TooLarge))
+        );
+        assert_eq!(fs::metadata(&path).expect("preserved sparse fixture").len(), size);
+    }
+
+    #[test]
+    fn diagnostics_never_include_paths_digests_or_payloads() {
+        let fixture = private_fixture();
+        let store = RepositoryBundleStore::open(fixture.path()).expect("store");
+        let value = bundle(b"sensitive fixture marker");
+        let error = store.get(value.manifest_sha256()).expect_err("missing");
+        let diagnostic = format!("{store:?} {error:?} {error}");
+        for excluded in [
+            fixture.path().to_str().expect("path"),
+            value.manifest_sha256().as_str(),
+            "sensitive fixture marker",
+        ] {
+            assert!(!diagnostic.contains(excluded));
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/reader/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/linux.rs
@@ -10,9 +10,18 @@ use std::{
     path::Path,
 };
 
-pub(super) struct Root(File);
+pub(in crate::repository_overlay) struct Root(File);
+
+pub(in crate::repository_overlay) struct RegularFileRead {
+    pub file: File,
+    pub bytes: Vec<u8>,
+}
 
 impl Root {
+    pub(in crate::repository_overlay) fn handle(&self) -> &File {
+        &self.0
+    }
+
     pub(super) fn open(path: &Path) -> Result<Self, Error> {
         let descriptor = openat2(
             CWD,
@@ -54,6 +63,24 @@ impl Root {
         Ok(content)
     }
 
+    pub(in crate::repository_overlay) fn read_private_file(
+        &self,
+        path: &str,
+        limit: usize,
+    ) -> Result<RegularFileRead, Error> {
+        let node = self.pin(path)?;
+        if !node.metadata.is_file()
+            || node.metadata.uid() != rustix::process::geteuid().as_raw()
+            || node.metadata.mode() & 0o7777 != 0o600
+        {
+            return Err(Error::UnsupportedNode);
+        }
+        let content = node.read_regular(limit)?;
+        node.verify(&node.file.metadata().map_err(|_| Error::ReadFailed)?)?;
+        self.verify_path(path, &node)?;
+        Ok(content)
+    }
+
     fn verify_path(&self, path: &str, node: &PinnedNode) -> Result<(), Error> {
         let current = self.pin(path).map_err(|_| Error::Changed)?;
         node.verify(&current.metadata)
@@ -75,6 +102,13 @@ impl PinnedNode {
     }
 
     fn regular(&self, limit: usize) -> Result<Node, Error> {
+        Ok(Node::File {
+            bytes: self.read_regular(limit)?.bytes,
+            executable: self.metadata.mode() & 0o100 != 0,
+        })
+    }
+
+    fn read_regular(&self, limit: usize) -> Result<RegularFileRead, Error> {
         let declared = usize::try_from(self.metadata.len()).map_err(|_| Error::TooLarge)?;
         if declared > limit {
             return Err(Error::TooLarge);
@@ -89,10 +123,7 @@ impl PinnedNode {
         self.verify(&file.metadata().map_err(|_| Error::ReadFailed)?)?;
         let bytes = read_limited(&mut file, declared, limit)?;
         self.verify(&file.metadata().map_err(|_| Error::ReadFailed)?)?;
-        Ok(Node::File {
-            bytes,
-            executable: self.metadata.mode() & 0o100 != 0,
-        })
+        Ok(RegularFileRead { file, bytes })
     }
 
     fn link(&self, path: &str, limit: usize) -> Result<Node, Error> {
@@ -129,6 +160,7 @@ fn read_limited(reader: impl Read, declared: usize, limit: usize) -> Result<Vec<
 struct Fingerprint {
     device: u64,
     inode: u64,
+    owner: u32,
     bytes: u64,
     mode: u32,
     links: u64,
@@ -140,6 +172,7 @@ fn fingerprint(metadata: &Metadata) -> Fingerprint {
     Fingerprint {
         device: metadata.dev(),
         inode: metadata.ino(),
+        owner: metadata.uid(),
         bytes: metadata.len(),
         mode: metadata.mode(),
         links: metadata.nlink(),

--- a/crates/horizon-core/src/repository_overlay/reader/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/mod.rs
@@ -2,7 +2,7 @@
 //! Linux confinement is required; unsupported platforms fail without a weaker fallback.
 
 #[cfg(target_os = "linux")]
-mod linux;
+pub(super) mod linux;
 
 use super::{OverlayPlanError, paths};
 use std::{
@@ -37,7 +37,7 @@ impl fmt::Debug for SelectedRepositoryNode {
 /// This does not discover or verify a Git root, enumerate files or authorize export.
 pub struct SelectedRepositoryReader {
     #[cfg(target_os = "linux")]
-    root: linux::Root,
+    pub(super) root: linux::Root,
 }
 
 impl SelectedRepositoryReader {

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -148,6 +148,10 @@ back into large multi-purpose modules.
   `bundle/codec/` frames portable versioned bytes with bounded, constructor-checked
   metadata decoding, canonical ordering and recomputed payload hashes. It does not
   perform I/O or authorize export, extraction or repository writes.
+  `bundle/store/` explicitly persists immutable digest-named records in a nominated
+  private Linux directory, reusing the reader's pinned inode checks. Anonymous
+  writes, no-replace publication and file/directory synchronization precede success;
+  retrieval revalidates the complete codec and digest. This is not scheduled backup.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Retain verified repository overlay bundles across execution-container lifetimes for #383.

## Behavior

- Open an explicitly selected existing, privately owned directory using the confined Linux reader.
- Write canonical bytes to an unnamed private file, synchronize them, and atomically publish the digest-named record without replacement.
- Verify and synchronize identical retries; reject conflicting or unsafe records without overwriting or repairing them.
- Retrieve through the same bounded pinned-inode reader, revalidating framing, all payload hashes and the requested manifest digest.

The caller supplies authorization, storage selection, capacity and retention policy. This API does not create directories, delete files, enumerate repositories, export data, apply patches, replicate backups or schedule checkpoints. It requires Linux confinement, private owned storage and filesystem support for anonymous publication; unsupported environments fail closed. Calls belong off the UI thread, and byte limits do not bound filesystem latency. Synchronization failures can leave a complete published record for explicit verification and retry.

## Validation

- All 75 overlay regressions passed, including 16 new storage tests covering publication synchronization faults, concurrent writers, exact retries, confinement, private permissions, corruption and size limits.
- Full exact-commit workspace tests with and without speech; formatting, maintainability, version synchronization, blocking, strict and advisory Clippy passed, followed by a repeated public-API retained-volume smoke.
- Independent local review of the complete source/test diff and the synthetic retained-volume integration harness.
- Locked/offline public-API integration in fresh no-network execution containers sharing a new temporary volume: exact contents, inode and metadata survived reopening; retries preserved the record; ownership/mode violations and corruption were rejected without replacement. Only exact-owned synthetic fixtures were removed after verification.

The integration proves fresh-process/container persistence on a local retained volume, not physical power-loss durability, daemon/host restart, remote backup or a coherent Git snapshot. No UI, configuration, cloud resource, image publication, user repository contents or pre-existing process changed. Hosted review and exact-head checks remain required before merging.
