### PR TITLE
feat(remote): add explicit data-retaining worker stop

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use uuid::Uuid;
 mod artifact_digest;
 pub mod interactive_worker;
+pub mod interactive_worker_stop;
 pub mod local_docker;
 pub mod runpod;
 mod store;

--- a/crates/horizon-core/src/cloud_run/interactive_worker_stop.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker_stop.rs
@@ -1,0 +1,27 @@
+//! Opt-in compute Stop capability, separate from resource deletion and attachment.
+
+use super::interactive_worker::{InteractiveWorker, InteractiveWorkerProvider};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InteractiveWorkerStop {
+    /// The exact resource is retained and verified inactive, including an idempotent retry.
+    /// This does not certify successful task exit, preserved process memory or a checkpoint.
+    Stopped,
+    /// The exact resource was already absent before any stop command was attempted.
+    AlreadyAbsent,
+}
+
+/// An explicit, optional capability; unsupported providers must never substitute deletion.
+/// Callers own durable authorization/intent fencing and must invoke this off the render
+/// thread. Closing a client, view, session or application never grants Stop authority.
+pub trait InteractiveWorkerStopProvider: InteractiveWorkerProvider {
+    /// Stop only the exact persisted worker, retaining its resource and storage.
+    /// Implementations validate the handle before I/O, verify current ownership before
+    /// mutation, reject implicit resource deletion policies, and verify retained inactive
+    /// state afterward. They must not create, restart, delete, remove storage, run SSH,
+    /// or infer task success. A caller must separately protect/checkpoint in-memory work.
+    /// # Errors
+    /// Rejects malformed/foreign handles, uncertain ownership or data retention, failed
+    /// provider operations and unverified completion. Diagnostics must redact provider output.
+    fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error>;
+}

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 
 mod command;
 mod creation;
+mod stop;
 #[cfg(test)]
 mod tests;
 
@@ -340,6 +341,14 @@ pub enum LocalDockerError {
     InvalidHostKey,
     #[error("local Docker worker {resource_id} deletion could not be verified")]
     DeletionVerificationFailed { resource_id: String },
+    #[error("local worker Stop requires verified disabled automatic removal")]
+    StopRetentionUnverified,
+    #[error("local worker state does not permit a verified data-retaining Stop")]
+    StopStateUnverified,
+    #[error("local worker disappeared during Stop; data retention could not be verified")]
+    StopResourceLost,
+    #[error("local worker did not remain inactive after Stop")]
+    StopVerificationFailed,
 }
 
 trait DockerTransport: Send + Sync {
@@ -348,6 +357,7 @@ trait DockerTransport: Send + Sync {
     fn create(&self, request: &DockerCreateRequest) -> DockerResult<String>;
     fn read_host_key(&self, resource_id: &str) -> DockerResult<Option<String>>;
     fn delete(&self, resource_id: &str) -> DockerResult<bool>;
+    fn stop(&self, resource_id: &str) -> DockerResult<()>;
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct DockerContainer {
@@ -357,6 +367,7 @@ struct DockerContainer {
     labels: BTreeMap<String, String>,
     environment: Vec<String>,
     restart_policy: String,
+    auto_remove: Option<bool>,
     running: bool,
     state: String,
     exit_code: i64,

--- a/crates/horizon-core/src/cloud_run/local_docker/command.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/command.rs
@@ -14,6 +14,7 @@ use std::{
 
 const COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const RESPONSE_LIMIT_BYTES: usize = 1024 * 1024;
+const STOP_GRACE_SECONDS: &str = "10";
 
 pub(super) struct DockerCli {
     executable: OsString,
@@ -137,6 +138,17 @@ impl DockerTransport for DockerCli {
             })
         }
     }
+    fn stop(&self, resource_id: &str) -> DockerResult<()> {
+        let args = ["container", "stop", "--timeout", STOP_GRACE_SECONDS, "--", resource_id];
+        let output = self.output(args, "container stop", COMMAND_TIMEOUT)?;
+        output
+            .status
+            .success()
+            .then_some(())
+            .ok_or(LocalDockerError::CommandFailed {
+                operation: "container stop",
+            })
+    }
 }
 
 fn command_fits(command: &Command) -> bool {
@@ -256,6 +268,7 @@ fn parse_inspection(value: &str) -> DockerResult<DockerContainer> {
         labels: record.config.labels.unwrap_or_default(),
         environment: record.config.env.unwrap_or_default(),
         restart_policy: record.host_config.restart_policy.name,
+        auto_remove: record.host_config.auto_remove,
         running: record.state.running,
         state: record.state.status,
         exit_code: record.state.exit_code,
@@ -287,6 +300,7 @@ struct InspectionConfig {
 #[serde(rename_all = "PascalCase")]
 struct InspectionHostConfig {
     restart_policy: InspectionRestartPolicy,
+    auto_remove: Option<bool>,
 }
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -328,6 +342,19 @@ mod tests {
         assert_eq!(parsed.ssh_bindings.len(), 1);
         assert_eq!(parsed.ssh_bindings[0].host, "127.0.0.1");
         assert_eq!(parsed.ssh_bindings[0].port, 49_152);
+        assert_eq!(parsed.auto_remove, None);
+        for automatic_removal in [false, true] {
+            let mut value: serde_json::Value = serde_json::from_str(value).expect("fixture");
+            value[0]["HostConfig"]["AutoRemove"] = automatic_removal.into();
+            assert_eq!(
+                parse_inspection(&value.to_string()).expect("inspection").auto_remove,
+                Some(automatic_removal)
+            );
+        }
+        let mut malformed: serde_json::Value = serde_json::from_str(value).expect("fixture");
+        malformed[0]["HostConfig"]["AutoRemove"] = "private-malformed-marker".into();
+        let error = parse_inspection(&malformed.to_string()).expect_err("malformed automatic removal");
+        assert!(!error.to_string().contains("private-malformed-marker"));
         assert!(parse_inspection("[]").is_err());
     }
 

--- a/crates/horizon-core/src/cloud_run/local_docker/stop.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/stop.rs
@@ -1,0 +1,43 @@
+//! Exact-owned, data-retaining Stop; no creation, deletion or SSH path.
+
+use super::{
+    DockerContainer, DockerResult, InteractiveWorker, LocalDockerError, LocalDockerInteractiveWorkerProvider,
+    verify_container_for_worker,
+};
+use crate::cloud_run::interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider};
+
+impl InteractiveWorkerStopProvider for LocalDockerInteractiveWorkerProvider {
+    fn stop_worker(&self, worker: &InteractiveWorker) -> DockerResult<InteractiveWorkerStop> {
+        self.validate_persisted_worker(worker)?;
+        let resource_id = &worker.identity.resource_id;
+        let Some(before) = self.transport.inspect(resource_id)? else {
+            return Ok(InteractiveWorkerStop::AlreadyAbsent);
+        };
+        if verify_stop_state(&before, worker)? {
+            return Ok(InteractiveWorkerStop::Stopped);
+        }
+        let stopping = self.transport.stop(resource_id);
+        let after = self
+            .transport
+            .inspect(resource_id)?
+            .ok_or(LocalDockerError::StopResourceLost)?;
+        if verify_stop_state(&after, worker)? {
+            return Ok(InteractiveWorkerStop::Stopped);
+        }
+        stopping?;
+        Err(LocalDockerError::StopVerificationFailed)
+    }
+}
+
+/// Returns true only for a known retained/inactive state, regardless of task exit code.
+fn verify_stop_state(container: &DockerContainer, worker: &InteractiveWorker) -> DockerResult<bool> {
+    verify_container_for_worker(container, worker)?;
+    if container.auto_remove != Some(false) {
+        return Err(LocalDockerError::StopRetentionUnverified);
+    }
+    match (container.state.as_str(), container.running) {
+        ("created" | "exited", false) => Ok(true),
+        ("running" | "paused" | "restarting", true) => Ok(false),
+        _ => Err(LocalDockerError::StopStateUnverified),
+    }
+}

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 mod fencing;
 mod lifetime;
 mod noncreating;
+mod stop;
 
 #[derive(Clone, Default)]
 struct FakeDocker(Arc<Mutex<FakeState>>);
@@ -18,6 +19,8 @@ struct FakeState {
     host_key_calls: usize,
     create_calls: usize,
     delete_calls: usize,
+    stop_calls: usize,
+    stop_behavior: stop::StopBehavior,
     fail_create_after_insert: bool,
     corrupt_fence_after_create: Option<CloudWorkflowStore>,
     reject_create: bool,
@@ -74,6 +77,7 @@ impl DockerTransport for FakeDocker {
             labels: request.labels.clone(),
             environment,
             restart_policy: "no".to_string(),
+            auto_remove: Some(false),
             running: true,
             state: "running".to_string(),
             exit_code: 0,
@@ -112,6 +116,9 @@ impl DockerTransport for FakeDocker {
         state.delete_calls += 1;
         state.container = None;
         Ok(true)
+    }
+    fn stop(&self, resource_id: &str) -> DockerResult<()> {
+        stop::stop_fake(&mut self.state(), resource_id)
     }
 }
 fn ed25519_key(seed: u8) -> String {

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/stop.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/stop.rs
@@ -1,0 +1,258 @@
+use super::*;
+use crate::cloud_run::interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider};
+
+#[derive(Clone, Copy, Default)]
+pub(super) enum StopBehavior {
+    #[default]
+    Stops,
+    FailsActive,
+    FailsAfterStop,
+    Disappears,
+    ChangesIdentity,
+    KeepsRunning,
+    UnknownState,
+    FailsInspection,
+    ChangesRetention,
+}
+
+pub(super) fn stop_fake(state: &mut FakeState, resource_id: &str) -> DockerResult<()> {
+    state.stop_calls += 1;
+    let container = state.container.as_mut().expect("existing worker");
+    assert_eq!(resource_id, container.id);
+    if matches!(
+        state.stop_behavior,
+        StopBehavior::FailsActive | StopBehavior::KeepsRunning
+    ) {
+        return if matches!(state.stop_behavior, StopBehavior::FailsActive) {
+            Err(CommandFailed {
+                operation: "container stop",
+            })
+        } else {
+            Ok(())
+        };
+    }
+    container.running = false;
+    container.state = "exited".into();
+    container.exit_code = 137;
+    match state.stop_behavior {
+        StopBehavior::Stops | StopBehavior::FailsActive | StopBehavior::KeepsRunning => {}
+        StopBehavior::FailsAfterStop => {
+            return Err(CommandTimedOut {
+                operation: "container stop",
+            });
+        }
+        StopBehavior::Disappears => state.container = None,
+        StopBehavior::ChangesIdentity => container.name = "foreign-worker".into(),
+        StopBehavior::UnknownState => container.state = "unknown-fixture-state".into(),
+        StopBehavior::FailsInspection => state.failed_inspections_after_create = 1,
+        StopBehavior::ChangesRetention => container.auto_remove = Some(true),
+    }
+    Ok(())
+}
+
+fn fixture() -> (FakeDocker, LocalDockerInteractiveWorkerProvider, InteractiveWorker) {
+    let fake = FakeDocker::default();
+    let mut request = request();
+    request.target.lifetime = WorkerLifetime::Persistent;
+    let provider = provider_for("local", fake.clone(), &request);
+    let worker = provider
+        .ensure_worker(&request)
+        .expect("create fixture")
+        .into_status()
+        .worker;
+    {
+        let mut state = fake.state();
+        state.inspect_calls = 0;
+        state.host_key_calls = 0;
+        state.create_calls = 0;
+    }
+    (fake, provider, worker)
+}
+
+fn no_mutation(fake: &FakeDocker) {
+    let state = fake.state();
+    assert_eq!(
+        (
+            state.stop_calls,
+            state.create_calls,
+            state.delete_calls,
+            state.host_key_calls
+        ),
+        (0, 0, 0, 0)
+    );
+}
+
+#[test]
+fn stop_retains_exact_identity_without_create_delete_ssh_or_repeat_signal() {
+    let (fake, provider, worker) = fixture();
+    let before = fake.state().container.clone().expect("container");
+    assert_eq!(provider.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    assert_eq!(provider.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    let state = fake.state();
+    let mut expected = before;
+    expected.running = false;
+    expected.state = "exited".into();
+    expected.exit_code = 137;
+    assert_eq!(state.container.as_ref(), Some(&expected));
+    assert_eq!(
+        (
+            state.stop_calls,
+            state.create_calls,
+            state.delete_calls,
+            state.host_key_calls
+        ),
+        (1, 0, 0, 0)
+    );
+    assert_eq!(state.inspect_calls, 3);
+}
+
+#[test]
+fn known_active_states_receive_one_exact_stop_and_require_retained_inactive_state() {
+    for status in ["running", "paused", "restarting"] {
+        let (fake, provider, worker) = fixture();
+        fake.state().container.as_mut().expect("container").state = status.into();
+        assert_eq!(provider.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+        let state = fake.state();
+        assert_eq!(state.stop_calls, 1);
+        assert_eq!(state.inspect_calls, 2);
+        assert_eq!(
+            state.container.as_ref().expect("retained").id,
+            worker.identity.resource_id
+        );
+        assert!(!state.container.as_ref().expect("retained").running);
+        assert_eq!(
+            (state.create_calls, state.delete_calls, state.host_key_calls),
+            (0, 0, 0)
+        );
+    }
+}
+
+#[test]
+fn malformed_or_foreign_handles_fail_before_provider_io() {
+    let (fake, provider, worker) = fixture();
+    let mut changes = vec![worker.clone(); 5];
+    changes[0].identity.provider = CloudProvider::RunPod;
+    changes[1].target.profile = "different-profile".into();
+    changes[2].identity.resource_id = "-unsafe-resource".into();
+    changes[3].ssh_public_key = "invalid-private-marker".into();
+    changes[4].target.lifetime = WorkerLifetime::TimeLimited { seconds: 30 };
+    for changed in changes {
+        assert_eq!(provider.stop_worker(&changed), Err(InvalidPersistedWorker));
+    }
+    assert_eq!(fake.state().inspect_calls, 0);
+    no_mutation(&fake);
+}
+
+#[test]
+fn exact_identity_and_lifetime_mismatches_refuse_to_stop() {
+    let (fake, provider, worker) = fixture();
+    let before = fake.state().container.clone().expect("container");
+    let mut changed = vec![before.clone(); 7];
+    changed[0].name = "another-worker".into();
+    changed[1].image = "another-image".into();
+    changed[2].labels.insert(JOB_LABEL.into(), "another-job".into());
+    changed[3].labels.insert(TARGET_LABEL.into(), "{}".into());
+    changed[4].environment.push(format!("{SSH_PUBLIC_KEY_ENV}=invalid-key"));
+    changed[5].restart_policy = "always".into();
+    changed[6]
+        .labels
+        .insert(TERMINATE_LABEL.into(), "unexpected-deadline".into());
+    for container in changed {
+        fake.state().container = Some(container);
+        assert_eq!(provider.stop_worker(&worker), Err(ResourceIdentityMismatch));
+    }
+    no_mutation(&fake);
+}
+
+#[test]
+fn automatic_removal_must_be_explicitly_disabled_even_for_inactive_workers() {
+    let (fake, provider, worker) = fixture();
+    for auto_remove in [None, Some(true)] {
+        for running in [true, false] {
+            let mut state = fake.state();
+            let container = state.container.as_mut().expect("container");
+            container.auto_remove = auto_remove;
+            container.running = running;
+            container.state = if running { "running" } else { "exited" }.into();
+            drop(state);
+            assert_eq!(provider.stop_worker(&worker), Err(StopRetentionUnverified));
+        }
+    }
+    no_mutation(&fake);
+}
+
+#[test]
+fn known_inactive_and_absent_workers_do_not_receive_stop_commands() {
+    let (fake, provider, worker) = fixture();
+    for status in ["created", "exited"] {
+        let mut state = fake.state();
+        let container = state.container.as_mut().expect("container");
+        container.running = false;
+        container.state = status.into();
+        drop(state);
+        assert_eq!(provider.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    }
+    fake.state().container = None;
+    assert_eq!(provider.stop_worker(&worker), Ok(InteractiveWorkerStop::AlreadyAbsent));
+    no_mutation(&fake);
+}
+
+#[test]
+fn deleting_dead_unknown_and_inconsistent_states_fail_before_stop() {
+    let (fake, provider, worker) = fixture();
+    for (status, running) in [
+        ("removing", false),
+        ("dead", false),
+        ("unknown", true),
+        ("running", false),
+        ("exited", true),
+    ] {
+        let mut state = fake.state();
+        let container = state.container.as_mut().expect("container");
+        container.running = running;
+        container.state = status.into();
+        drop(state);
+        assert_eq!(provider.stop_worker(&worker), Err(StopStateUnverified));
+    }
+    no_mutation(&fake);
+}
+
+#[test]
+fn lost_response_is_success_only_after_exact_retained_inactive_verification() {
+    let (fake, provider, worker) = fixture();
+    fake.state().stop_behavior = StopBehavior::FailsAfterStop;
+    assert_eq!(provider.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    assert_eq!(fake.state().stop_calls, 1);
+}
+
+#[test]
+fn stop_failures_and_postflight_identity_retention_or_state_drift_fail_closed() {
+    for (behavior, error) in [
+        (
+            StopBehavior::FailsActive,
+            CommandFailed {
+                operation: "container stop",
+            },
+        ),
+        (StopBehavior::KeepsRunning, StopVerificationFailed),
+        (StopBehavior::Disappears, StopResourceLost),
+        (StopBehavior::ChangesIdentity, ResourceIdentityMismatch),
+        (StopBehavior::UnknownState, StopStateUnverified),
+        (StopBehavior::FailsInspection, invalid_response("container inspection")),
+        (StopBehavior::ChangesRetention, StopRetentionUnverified),
+    ] {
+        let (fake, provider, worker) = fixture();
+        fake.state().stop_behavior = behavior;
+        assert_eq!(provider.stop_worker(&worker), Err(error));
+        let state = fake.state();
+        assert_eq!(
+            (
+                state.stop_calls,
+                state.create_calls,
+                state.delete_calls,
+                state.host_key_calls
+            ),
+            (1, 0, 0, 0)
+        );
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -160,6 +160,12 @@ back into large multi-purpose modules.
   never renews it. Explicit ensure also consumes the grant when accepting an
   exact existing worker, before observing its connection. Provider construction
   requires that store explicitly; non-creating inspection never claims a grant.
+- `cloud_run/interactive_worker_stop.rs` is an opt-in Stop contract, separate from
+  deletion and client lifetime. The local adapter's `local_docker/stop.rs` verifies
+  exact ownership and disabled automatic removal before a bounded stop, then
+  verifies the same resource is retained and inactive. Lost responses need that
+  independent proof; absence is not retained storage. Durable management intent,
+  checkpointing and user-facing actions remain separate caller responsibilities.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized


### PR DESCRIPTION
## Purpose

Add an explicit, optional worker Stop capability as a focused prerequisite for #383.
Stop is separate from Delete and is never triggered by closing a client, panel,
workspace view or application.

## Behavior

- Validate the persisted handle and exact current resource ownership before mutation.
- Refuse automatic-removal, unknown retention and inconsistent/deleting worker states.
- Use a bounded stop, then independently verify the same resource is retained and inactive.
- Treat an already-absent resource distinctly; a resource disappearing during Stop is a retention failure.
- Resolve a lost command response only through verified retained/inactive state, with no create, restart, delete, SSH or store-write fallback.

This implements the local container provider capability only. Durable management
intent and user-facing controls remain follow-on work. Stopped does not mean a
successful task exit, preserved process memory or a checkpoint. No settings,
dependency, worker-image or UI change; #383 remains open.

## Validation

- Full required local matrix: formatting, maintainability, version sync, default
  and speech workspace tests, blocking/strict/advisory Clippy.
- Forty focused local-adapter tests, including nine Stop regressions covering
  identity drift, automatic removal, invalid states, idempotence and uncertain outcomes.
- Independent local full-diff review: no actionable findings.
- Actual public-API smoke against one newly created disposable local worker:
  the same container stayed inactive and retained byte-identical synthetic
  repository/task files with its private SSH key unavailable; stored snapshots,
  revisions and the full logical database digest were unchanged. A fresh-client
  retry did not restart or replace the worker. Exact-identity cleanup followed
  the retention proof; a subsequent Stop returned already-absent without recreation.

The live smoke used an existing immutable local image and an explicitly selected
local daemon. No paid resources, pre-existing environments, release or publication.

## Review continuity

Supersedes #432 solely to retry hosted review in a fresh PR context after eleven
service-error completions. The implementation commit, scope and exact-head local
validation evidence are unchanged; the original history is retained. No review
or merge gate is waived.
