### PR TITLE
feat(remote): check provider status in environment overview

### DIFF
--- a/crates/horizon-core/src/remote_environment_observation.rs
+++ b/crates/horizon-core/src/remote_environment_observation.rs
@@ -1,6 +1,10 @@
 //! Read-only provider observations for the global remote-environment overview.
 //! Synchronous provider/store operations must run off the render thread.
 
+mod configured;
+
+pub use configured::{ConfiguredObservationError, observe_configured_remote_environment};
+
 use crate::{
     cloud_run::{
         CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
@@ -18,6 +22,17 @@ pub struct RemoteEnvironmentObservation {
     /// `None` means no exact worker was found. Saved identity remains in `saved`.
     /// Absence never authorizes replacement, removal from inventory or cleanup.
     pub worker: Option<ObservedRemoteWorker>,
+}
+
+impl RemoteEnvironmentObservation {
+    /// Absolute UTC timestamp for a cached point-in-time observation label.
+    #[must_use]
+    pub fn observed_at_rfc3339(&self) -> Option<String> {
+        time::OffsetDateTime::from_unix_timestamp_nanos(i128::from(self.observed_at_millis) * 1_000_000)
+            .ok()?
+            .format(&time::format_description::well_known::Rfc3339)
+            .ok()
+    }
 }
 
 /// Overview-safe projection. No task payload, SSH coordinates or key material is retained.

--- a/crates/horizon-core/src/remote_environment_observation/configured.rs
+++ b/crates/horizon-core/src/remote_environment_observation/configured.rs
@@ -1,0 +1,45 @@
+//! Join an overview selection to its exact saved profile and owned allocation.
+
+use super::{RemoteEnvironmentObservation, RemoteEnvironmentObservationError, observe_remote_environment};
+use crate::{
+    cloud_run::{CloudProvider, CloudWorkflowStore, local_docker::LocalDockerInteractiveWorkerProvider},
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_workspace::RemoteEnvironmentSummary,
+};
+
+/// Check one saved selection using only its explicitly configured provider profile.
+/// This synchronous read belongs off the render thread. It never allocates, adopts,
+/// manages or attaches a worker, and does not need the retained private SSH key.
+/// # Errors
+/// Rejects unsupported/unconfigured providers, stale selections and unsafe or failed
+/// observations. Diagnostics do not include provider output or executable task data.
+pub fn observe_configured_remote_environment(
+    store: &CloudWorkflowStore,
+    config: &RemoteProviderConfig,
+    expected: &RemoteEnvironmentSummary,
+) -> Result<RemoteEnvironmentObservation, ConfiguredObservationError> {
+    if expected.provider != CloudProvider::LocalDocker {
+        return Err(ConfiguredObservationError::UnsupportedProvider);
+    }
+    let profile = config.local_docker_profile(&expected.profile)?;
+    let current = store
+        .load_remote_workspace(&expected.owning_session_id, &expected.workspace_local_id)
+        .map_err(RemoteEnvironmentObservationError::from)?
+        .ok_or(RemoteEnvironmentObservationError::MissingAllocation)?;
+    if current.environment_summary() != *expected {
+        return Err(RemoteEnvironmentObservationError::StateChanged.into());
+    }
+    let provider = LocalDockerInteractiveWorkerProvider::new(profile.clone(), store.clone())
+        .map_err(|_| RemoteEnvironmentObservationError::ProviderUnavailable)?;
+    Ok(observe_remote_environment(store, &provider, &current)?)
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum ConfiguredObservationError {
+    #[error("provider checks are not yet supported for this environment's provider")]
+    UnsupportedProvider,
+    #[error(transparent)]
+    Configuration(#[from] RemoteProviderConfigError),
+    #[error(transparent)]
+    Observation(#[from] RemoteEnvironmentObservationError),
+}

--- a/crates/horizon-core/src/remote_environment_observation/tests.rs
+++ b/crates/horizon-core/src/remote_environment_observation/tests.rs
@@ -14,6 +14,7 @@ use crate::{
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::Mutex;
 
+mod configured;
 mod guards;
 
 const OWNER: &str = "00000000-0000-4000-8000-000000000001";

--- a/crates/horizon-core/src/remote_environment_observation/tests/configured.rs
+++ b/crates/horizon-core/src/remote_environment_observation/tests/configured.rs
@@ -1,0 +1,104 @@
+use super::*;
+use crate::{
+    cloud_run::local_docker::LocalDockerProfile,
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+};
+
+fn config() -> RemoteProviderConfig {
+    RemoteProviderConfig {
+        local_docker: vec![LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///nonexistent-observation-fixture/docker.sock".into(),
+        }],
+    }
+}
+
+fn check(
+    fixture: &Fixture,
+    config: &RemoteProviderConfig,
+) -> Result<RemoteEnvironmentObservation, ConfiguredObservationError> {
+    observe_configured_remote_environment(
+        &fixture.store,
+        config,
+        &fixture.reload().workspace().environment_summary(),
+    )
+}
+
+#[test]
+fn configuration_rejects_missing_duplicate_and_invalid_profiles_without_mutation() {
+    let fixture = Fixture::new();
+    let before = fixture.reload();
+    let counts = fixture.counts();
+    assert_eq!(
+        check(&fixture, &RemoteProviderConfig::default()),
+        Err(ConfiguredObservationError::Configuration(
+            RemoteProviderConfigError::UnconfiguredLocalProfile
+        ))
+    );
+    let mut profiles = config();
+    profiles.local_docker.push(profiles.local_docker[0].clone());
+    assert_eq!(
+        check(&fixture, &profiles),
+        Err(ConfiguredObservationError::Configuration(
+            RemoteProviderConfigError::DuplicateLocalProfile { index: 1 }
+        ))
+    );
+    profiles.local_docker.pop();
+    profiles.local_docker[0].docker_host = "tcp://private-endpoint-marker:1234".into();
+    let error = check(&fixture, &profiles).expect_err("nonlocal endpoint");
+    assert!(!format!("{error:?} {error}").contains("private-endpoint-marker"));
+    assert_eq!(fixture.reload(), before);
+    assert_eq!(fixture.counts(), counts);
+}
+
+#[test]
+fn stale_or_foreign_summary_is_rejected_before_provider_access() {
+    let fixture = Fixture::new();
+    let before = fixture.reload();
+    let expected = before.workspace().environment_summary();
+    let mut changes = vec![expected.clone(); 4];
+    changes[0].revision += 1;
+    changes[1].repository = "another/repository".into();
+    changes[2].generation += 1;
+    changes[3].panel_count += 1;
+    for changed in changes {
+        assert_eq!(
+            observe_configured_remote_environment(&fixture.store, &config(), &changed),
+            Err(ConfiguredObservationError::Observation(Error::StateChanged))
+        );
+    }
+    let mut foreign = expected;
+    foreign.owning_session_id = "00000000-0000-4000-8000-000000000002".into();
+    assert!(observe_configured_remote_environment(&fixture.store, &config(), &foreign).is_err());
+    assert_eq!(fixture.reload(), before);
+}
+
+#[test]
+fn unsupported_provider_and_unreserved_allocation_fail_closed() {
+    let fixture = Fixture::with_request(WorkerLifetime::Persistent, false);
+    assert_eq!(
+        check(&fixture, &config()),
+        Err(ConfiguredObservationError::Observation(Error::MissingRequest))
+    );
+    let mut expected = fixture.reload().workspace().environment_summary();
+    for provider in [CloudProvider::Azure, CloudProvider::RunPod] {
+        expected.provider = provider;
+        assert_eq!(
+            observe_configured_remote_environment(&fixture.store, &RemoteProviderConfig::default(), &expected),
+            Err(ConfiguredObservationError::UnsupportedProvider)
+        );
+    }
+}
+
+#[test]
+fn unavailable_explicit_endpoint_does_not_change_saved_state() {
+    let fixture = Fixture::new();
+    let before = fixture.reload();
+    let counts = fixture.counts();
+    assert_eq!(
+        check(&fixture, &config()),
+        Err(ConfiguredObservationError::Observation(Error::ProviderUnavailable))
+    );
+    assert_eq!(fixture.reload(), before);
+    assert_eq!(fixture.counts(), counts);
+}

--- a/crates/horizon-ui/src/app/remote_environments.rs
+++ b/crates/horizon-ui/src/app/remote_environments.rs
@@ -1,5 +1,6 @@
 //! Lazy, single-flight saved inventory loading for the Remote Environments overview.
 
+mod observation;
 mod paint;
 
 use std::sync::mpsc::{self, Receiver, TryRecvError};
@@ -18,6 +19,7 @@ pub(super) struct RemoteEnvironments {
     failure: Option<LoadFailure>,
     pending: Option<PendingLoad>,
     refresh_when_idle: bool,
+    observation: observation::ObservationState,
 }
 
 struct InventoryPage {
@@ -53,6 +55,7 @@ enum InventoryAction {
     Next,
     Retry,
     Select(usize),
+    Observe,
 }
 
 struct WakeOnDrop(Context);
@@ -77,6 +80,7 @@ impl RemoteEnvironments {
         self.page_cursor = None;
         self.selected = None;
         self.failure = None;
+        self.observation.invalidate();
         if let Some(pending) = &mut self.pending {
             pending.discard = true;
             self.refresh_when_idle = true;
@@ -88,6 +92,7 @@ impl RemoteEnvironments {
 
     fn close(&mut self) {
         self.open = false;
+        self.observation.invalidate();
         self.refresh_when_idle = false;
         if let Some(pending) = &mut self.pending {
             pending.discard = true;
@@ -98,6 +103,7 @@ impl RemoteEnvironments {
         if !self.open || self.pending.is_some() {
             return;
         }
+        self.observation.invalidate();
         let (tx, rx) = mpsc::sync_channel(1);
         let home = home.clone();
         let requested_cursor = cursor.clone();
@@ -140,6 +146,7 @@ impl RemoteEnvironments {
     }
 
     fn accept_result(&mut self, cursor: Option<String>, result: Result<InventoryPage, LoadError>) {
+        self.observation.invalidate();
         match result {
             Ok(page) => {
                 let previous = self
@@ -163,10 +170,11 @@ impl RemoteEnvironments {
 
     fn apply(&mut self, action: InventoryAction, home: &HorizonHome, ctx: &Context) {
         match action {
-            InventoryAction::None => {}
+            InventoryAction::None | InventoryAction::Observe => {}
             InventoryAction::Close => self.close(),
             InventoryAction::Select(index) => {
-                if self.page.as_ref().is_some_and(|page| index < page.rows.len()) {
+                if self.selected != Some(index) && self.page.as_ref().is_some_and(|page| index < page.rows.len()) {
+                    self.observation.invalidate();
                     self.selected = Some(index);
                 }
             }
@@ -182,6 +190,28 @@ impl RemoteEnvironments {
                     self.start_load(home, ctx, failure.cursor.clone());
                 }
             }
+        }
+    }
+
+    pub(super) fn invalidate_observation(&mut self) {
+        self.observation.invalidate();
+    }
+
+    fn start_observation(
+        &mut self,
+        home: &HorizonHome,
+        config: &horizon_core::remote_provider_config::RemoteProviderConfig,
+        ctx: &Context,
+    ) {
+        if !self.open || self.pending.is_some() {
+            return;
+        }
+        if let Some(row) = self
+            .page
+            .as_ref()
+            .and_then(|page| self.selected.and_then(|index| page.rows.get(index)))
+        {
+            self.observation.start(home, config, &row.summary, ctx);
         }
     }
 }
@@ -206,6 +236,7 @@ impl HorizonApp {
     /// including dismissal. Remote inventory completion never requires idle polling.
     pub(super) fn render_remote_environments(&mut self, ctx: &Context) -> Option<egui::InputState> {
         self.remote_environments.drain_result();
+        self.remote_environments.observation.drain_result();
         if self.remote_environments.refresh_when_idle && self.remote_environments.pending.is_none() {
             self.remote_environments.refresh_when_idle = false;
             self.remote_environments
@@ -215,6 +246,13 @@ impl HorizonApp {
         if was_open {
             self.handle_speech_input(ctx);
             let action = paint::show(ctx, &self.remote_environments);
+            if matches!(action, InventoryAction::Observe) {
+                self.remote_environments.start_observation(
+                    self.session_store.home(),
+                    &self.template_config.remote,
+                    ctx,
+                );
+            }
             self.remote_environments.apply(action, self.session_store.home(), ctx);
             let modal_input = ctx.input(Clone::clone);
             self.suppress_root_viewport_interaction(ctx);

--- a/crates/horizon-ui/src/app/remote_environments/observation.rs
+++ b/crates/horizon-ui/src/app/remote_environments/observation.rs
@@ -41,9 +41,7 @@ enum ObservationError {
 impl ObservationError {
     fn message(self) -> String {
         match self {
-            Self::WorkerUnavailable => {
-                "The provider check could not finish; retry when the previous check has settled.".into()
-            }
+            Self::WorkerUnavailable => "The provider check failed to start or finish; you can retry now.".into(),
             Self::StorageUnavailable => {
                 "The saved environment could not be safely read; refresh the saved page before retrying.".into()
             }

--- a/crates/horizon-ui/src/app/remote_environments/observation.rs
+++ b/crates/horizon-ui/src/app/remote_environments/observation.rs
@@ -1,0 +1,185 @@
+//! One explicit provider read at a time; cached presentation changes only on events.
+
+use super::{Context, HorizonHome, RemoteEnvironmentSummary, WakeOnDrop};
+use horizon_core::{
+    cloud_run::{CloudWorkflowStore, interactive_worker::InteractiveWorkerLifecycle},
+    remote_environment_observation::{
+        ConfiguredObservationError, RemoteEnvironmentObservation, observe_configured_remote_environment,
+    },
+    remote_provider_config::RemoteProviderConfig,
+};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+
+#[derive(Default)]
+pub(super) struct ObservationState {
+    pub(super) last_success: Option<CachedObservation>,
+    pub(super) failure: Option<String>,
+    pending: Option<PendingObservation>,
+    repaint_context: Option<Context>,
+}
+
+pub(super) struct CachedObservation {
+    pub(super) lifecycle: &'static str,
+    pub(super) checked_at: String,
+    pub(super) resource_id: Option<String>,
+}
+
+struct PendingObservation {
+    rx: Receiver<Result<RemoteEnvironmentObservation, ObservationError>>,
+    expected: RemoteEnvironmentSummary,
+    discard: bool,
+}
+
+#[derive(Debug)]
+enum ObservationError {
+    WorkerUnavailable,
+    StorageUnavailable,
+    SelectionChanged,
+    Check(ConfiguredObservationError),
+}
+
+impl ObservationError {
+    fn message(self) -> String {
+        match self {
+            Self::WorkerUnavailable => {
+                "The provider check could not finish; retry when the previous check has settled.".into()
+            }
+            Self::StorageUnavailable => {
+                "The saved environment could not be safely read; refresh the saved page before retrying.".into()
+            }
+            Self::SelectionChanged => {
+                "The provider result does not match the selected saved environment; refresh before retrying.".into()
+            }
+            Self::Check(error) => error.to_string(),
+        }
+    }
+}
+
+impl ObservationState {
+    pub(super) fn is_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+
+    pub(super) fn pending_label(&self) -> &'static str {
+        if self.pending.as_ref().is_some_and(|pending| pending.discard) {
+            "Waiting for previous check to finish…"
+        } else {
+            "Checking provider…"
+        }
+    }
+
+    pub(super) fn invalidate(&mut self) {
+        let changed = self.last_success.is_some()
+            || self.failure.is_some()
+            || self.pending.as_ref().is_some_and(|pending| !pending.discard);
+        self.last_success = None;
+        self.failure = None;
+        if let Some(pending) = &mut self.pending {
+            pending.discard = true;
+        }
+        // Config reload can invalidate after this frame's modal was painted.
+        if changed && let Some(ctx) = &self.repaint_context {
+            ctx.request_repaint();
+        }
+    }
+
+    pub(super) fn start(
+        &mut self,
+        home: &HorizonHome,
+        config: &RemoteProviderConfig,
+        expected: &RemoteEnvironmentSummary,
+        ctx: &Context,
+    ) {
+        if self.pending.is_some() {
+            return;
+        }
+        self.repaint_context = Some(ctx.clone());
+        let (tx, rx) = mpsc::sync_channel(1);
+        let selected = expected.clone();
+        let config = config.clone();
+        let home = home.clone();
+        let wake = WakeOnDrop(ctx.clone());
+        let worker = std::thread::Builder::new()
+            .name("remote-environment-observation".into())
+            .spawn(move || {
+                let _wake = wake;
+                let result = check(&home, &config, &selected);
+                let _ = tx.send(result);
+            });
+        self.failure = None;
+        match worker {
+            Ok(_) => {
+                self.pending = Some(PendingObservation {
+                    rx,
+                    expected: expected.clone(),
+                    discard: false,
+                });
+            }
+            Err(_) => self.failure = Some(ObservationError::WorkerUnavailable.message()),
+        }
+    }
+
+    pub(super) fn drain_result(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        let result = match pending.rx.try_recv() {
+            Ok(result) => result,
+            Err(TryRecvError::Empty) => {
+                self.pending = Some(pending);
+                return;
+            }
+            Err(TryRecvError::Disconnected) => Err(ObservationError::WorkerUnavailable),
+        };
+        if pending.discard {
+            return;
+        }
+        let result = result.and_then(|observation| {
+            if observation.saved != pending.expected {
+                return Err(ObservationError::SelectionChanged);
+            }
+            Ok(CachedObservation::new(observation))
+        });
+        match result {
+            Ok(observation) => {
+                self.last_success = Some(observation);
+                self.failure = None;
+            }
+            Err(error) => self.failure = Some(error.message()),
+        }
+    }
+}
+
+impl CachedObservation {
+    fn new(observation: RemoteEnvironmentObservation) -> Self {
+        let checked_at = observation
+            .observed_at_rfc3339()
+            .unwrap_or_else(|| format!("{} Unix ms", observation.observed_at_millis));
+        let lifecycle = match observation.worker.as_ref().map(|worker| worker.lifecycle) {
+            None => "No exact worker found (saved identity retained)",
+            Some(InteractiveWorkerLifecycle::Provisioning) => "Worker provisioning",
+            Some(InteractiveWorkerLifecycle::Ready) => "Worker ready (not workspace readiness)",
+            Some(InteractiveWorkerLifecycle::Stopped) => "Worker stopped",
+            Some(InteractiveWorkerLifecycle::Failed) => "Worker failed",
+            Some(InteractiveWorkerLifecycle::Deleting) => "Worker deleting",
+            Some(InteractiveWorkerLifecycle::Unknown) => "Worker status unknown",
+        };
+        Self {
+            lifecycle,
+            checked_at,
+            resource_id: observation.worker.map(|worker| worker.identity.resource_id),
+        }
+    }
+}
+
+fn check(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    expected: &RemoteEnvironmentSummary,
+) -> Result<RemoteEnvironmentObservation, ObservationError> {
+    let store = CloudWorkflowStore::open(home).map_err(|_| ObservationError::StorageUnavailable)?;
+    observe_configured_remote_environment(&store, config, expected).map_err(ObservationError::Check)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-ui/src/app/remote_environments/observation/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/observation/tests.rs
@@ -112,12 +112,11 @@ fn failed_repeat_and_disconnected_worker_preserve_timestamped_success() {
     );
     drop(pending(&mut state));
     state.drain_result();
-    assert!(
-        state
-            .failure
-            .as_ref()
-            .is_some_and(|error| error.contains("could not finish"))
+    assert_eq!(
+        state.failure.as_deref(),
+        Some("The provider check failed to start or finish; you can retry now.")
     );
+    assert!(!state.is_pending(), "a failed check releases the single-flight slot");
     assert!(state.last_success.is_some());
 }
 

--- a/crates/horizon-ui/src/app/remote_environments/observation/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/observation/tests.rs
@@ -1,0 +1,304 @@
+use super::super::{InventoryAction, InventoryPage, RemoteEnvironments, paint};
+use super::*;
+use horizon_core::{
+    cloud_run::{
+        CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime, interactive_worker::InteractiveWorkerIdentity,
+    },
+    remote_environment_observation::ObservedRemoteWorker,
+    remote_workspace::RemoteRuntimePhase,
+};
+
+fn summary() -> RemoteEnvironmentSummary {
+    RemoteEnvironmentSummary {
+        workspace_local_id: "synthetic-workspace".into(),
+        owning_session_id: "00000000-0000-4000-8000-000000000001".into(),
+        revision: 1,
+        repository: "example/project".into(),
+        provider: CloudProvider::LocalDocker,
+        profile: "development".into(),
+        lifetime: WorkerLifetime::Persistent,
+        generation: 1,
+        saved_phase: Some(RemoteRuntimePhase::Ready),
+        workflow_id: None,
+        job_id: None,
+        worker_identity: None,
+        checkpoint: None,
+        panel_count: 1,
+    }
+}
+
+fn result() -> RemoteEnvironmentObservation {
+    RemoteEnvironmentObservation {
+        saved: summary(),
+        observed_at_millis: 1_000,
+        worker: None,
+    }
+}
+
+fn pending(state: &mut ObservationState) -> mpsc::SyncSender<Result<RemoteEnvironmentObservation, ObservationError>> {
+    let (tx, rx) = mpsc::sync_channel(1);
+    state.pending = Some(PendingObservation {
+        rx,
+        expected: summary(),
+        discard: false,
+    });
+    tx
+}
+
+#[test]
+fn successful_observation_is_cached_with_absolute_timestamp_without_adoption() {
+    let mut state = ObservationState::default();
+    pending(&mut state).send(Ok(result())).expect("send");
+    state.drain_result();
+    let cached = state.last_success.as_ref().expect("cached success");
+    assert_eq!(cached.checked_at, "1970-01-01T00:00:01Z");
+    assert!(cached.lifecycle.contains("No exact worker found"));
+    assert!(cached.resource_id.is_none());
+    assert!(!state.is_pending());
+    assert!(state.failure.is_none());
+}
+
+#[test]
+fn all_lifecycles_are_distinct_from_workspace_readiness() {
+    for lifecycle in [
+        InteractiveWorkerLifecycle::Provisioning,
+        InteractiveWorkerLifecycle::Ready,
+        InteractiveWorkerLifecycle::Stopped,
+        InteractiveWorkerLifecycle::Failed,
+        InteractiveWorkerLifecycle::Deleting,
+        InteractiveWorkerLifecycle::Unknown,
+    ] {
+        let mut observed = result();
+        observed.worker = Some(ObservedRemoteWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::LocalDocker,
+                workflow_id: CloudWorkflowId::new(),
+                job_id: CloudJobId::new(),
+                resource_id: "observed-resource-only".into(),
+            },
+            lifecycle,
+        });
+        let cached = CachedObservation::new(observed);
+        assert!(cached.lifecycle.starts_with("Worker "));
+        if lifecycle == InteractiveWorkerLifecycle::Ready {
+            assert!(cached.lifecycle.contains("not workspace readiness"));
+        }
+        assert_eq!(cached.resource_id.as_deref(), Some("observed-resource-only"));
+    }
+    let mut invalid_time = result();
+    invalid_time.observed_at_millis = i64::MAX;
+    assert!(CachedObservation::new(invalid_time).checked_at.ends_with("Unix ms"));
+}
+
+#[test]
+fn failed_repeat_and_disconnected_worker_preserve_timestamped_success() {
+    let mut state = ObservationState {
+        last_success: Some(CachedObservation::new(result())),
+        ..Default::default()
+    };
+    pending(&mut state)
+        .send(Err(ObservationError::StorageUnavailable))
+        .expect("send");
+    state.drain_result();
+    assert!(
+        state
+            .failure
+            .as_ref()
+            .is_some_and(|error| error.contains("safely read"))
+    );
+    assert_eq!(
+        state.last_success.as_ref().expect("old success").checked_at,
+        "1970-01-01T00:00:01Z"
+    );
+    drop(pending(&mut state));
+    state.drain_result();
+    assert!(
+        state
+            .failure
+            .as_ref()
+            .is_some_and(|error| error.contains("could not finish"))
+    );
+    assert!(state.last_success.is_some());
+}
+
+#[test]
+fn repeated_invalidation_retains_single_flight_and_discards_late_results() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let mut state = ObservationState {
+        last_success: Some(CachedObservation::new(result())),
+        ..Default::default()
+    };
+    let tx = pending(&mut state);
+    for _ in 0..100 {
+        state.invalidate();
+        state.start(&home, &RemoteProviderConfig::default(), &summary(), &Context::default());
+        state.drain_result();
+        assert!(state.is_pending());
+        assert!(state.pending_label().contains("previous check"));
+        assert!(state.last_success.is_none());
+    }
+    assert!(!home.cloud_workflow_store_path().exists());
+    tx.send(Ok(result())).expect("send");
+    state.drain_result();
+    assert!(!state.is_pending());
+    assert!(state.last_success.is_none());
+    assert!(state.failure.is_none());
+}
+
+#[test]
+fn unexpected_saved_snapshot_never_relabels_selection() {
+    let mut state = ObservationState::default();
+    let tx = pending(&mut state);
+    let mut changed = result();
+    changed.saved.revision += 1;
+    tx.send(Ok(changed)).expect("send");
+    state.drain_result();
+    assert!(state.last_success.is_none());
+    assert!(
+        state
+            .failure
+            .as_ref()
+            .is_some_and(|error| error.contains("selected saved environment"))
+    );
+}
+
+fn view() -> RemoteEnvironments {
+    let first = summary();
+    let mut second = first.clone();
+    second.workspace_local_id = "second-workspace".into();
+    RemoteEnvironments {
+        open: true,
+        selected: Some(0),
+        page: Some(InventoryPage {
+            rows: vec![paint::InventoryRow::new(first), paint::InventoryRow::new(second)],
+            next_cursor: None,
+        }),
+        observation: ObservationState {
+            last_success: Some(CachedObservation::new(result())),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn selection_close_and_page_replacement_invalidate_pending_and_cached_results() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let mut state = view();
+    let tx = pending(&mut state.observation);
+    state.apply(InventoryAction::Select(0), &home, &Context::default());
+    assert!(state.observation.last_success.is_some(), "same selection remains valid");
+    state.apply(InventoryAction::Select(1), &home, &Context::default());
+    assert!(state.observation.last_success.is_none());
+    tx.send(Ok(result())).expect("send");
+    state.observation.drain_result();
+    assert!(state.observation.last_success.is_none());
+    for close in [true, false] {
+        let mut state = view();
+        let tx = pending(&mut state.observation);
+        if close {
+            state.close();
+        } else {
+            state.accept_result(
+                None,
+                Ok(InventoryPage {
+                    rows: Vec::new(),
+                    next_cursor: None,
+                }),
+            );
+        }
+        tx.send(Ok(result())).expect("send");
+        state.observation.drain_result();
+        assert!(state.observation.last_success.is_none());
+    }
+}
+
+#[test]
+fn runtime_config_change_invalidates_only_provider_settings() {
+    let (_fixture, mut app) = crate::app::test_support::test_app();
+    app.remote_environments = view();
+    let tx = pending(&mut app.remote_environments.observation);
+    let mut config = app.template_config.clone();
+    config.window.width += 1.0;
+    app.apply_runtime_config(&config);
+    assert!(app.remote_environments.observation.last_success.is_some());
+    config
+        .remote
+        .local_docker
+        .push(horizon_core::cloud_run::local_docker::LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///unused-fixture/docker.sock".into(),
+        });
+    app.apply_runtime_config(&config);
+    tx.send(Ok(result())).expect("send");
+    app.remote_environments.observation.drain_result();
+    assert!(app.remote_environments.observation.last_success.is_none());
+    assert!(app.remote_environments.observation.failure.is_none());
+}
+
+#[test]
+fn closed_or_unselected_overview_never_starts_a_check() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let mut state = view();
+    state.close();
+    state.start_observation(&home, &RemoteProviderConfig::default(), &Context::default());
+    state.open = true;
+    state.selected = None;
+    state.start_observation(&home, &RemoteProviderConfig::default(), &Context::default());
+    assert!(!state.observation.is_pending());
+    assert!(!home.cloud_workflow_store_path().exists());
+}
+
+#[test]
+fn config_invalidation_after_empty_board_paint_requests_one_followup_frame() {
+    use crate::app::test_support::raw_input;
+    use crate::test_egui::DiscardTextures;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    let (_fixture, mut app) = crate::app::test_support::test_app();
+    assert!(app.board.panels.is_empty());
+    let ctx = Context::default();
+    app.remote_environments = view();
+    app.remote_environments.observation.repaint_context = Some(ctx.clone());
+    pending(&mut app.remote_environments.observation)
+        .send(Ok(result()))
+        .expect("send");
+    for frame in 0..30 {
+        let mut input = raw_input([900.0, 680.0], None);
+        input.time = Some(f64::from(frame) * 0.1);
+        let _ = ctx
+            .run_ui(input, |ui| {
+                let _ = app.render_remote_environments(ui);
+            })
+            .discard_textures();
+        if !ctx.has_requested_repaint() {
+            break;
+        }
+    }
+    assert!(!ctx.has_requested_repaint(), "settled status should not poll repaint");
+    let requests = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&requests);
+    ctx.set_request_repaint_callback(move |_| {
+        observed.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut config = app.template_config.clone();
+    app.apply_runtime_config(&config);
+    assert_eq!(requests.load(Ordering::Relaxed), 0);
+    config
+        .remote
+        .local_docker
+        .push(horizon_core::cloud_run::local_docker::LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///unused-fixture/docker.sock".into(),
+        });
+    app.apply_runtime_config(&config);
+    assert_eq!(requests.load(Ordering::Relaxed), 1);
+    assert!(app.remote_environments.observation.last_success.is_none());
+    app.remote_environments.invalidate_observation();
+    assert_eq!(requests.load(Ordering::Relaxed), 1, "no passive invalidation loop");
+}

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -47,10 +47,7 @@ impl InventoryRow {
         if let Some(identity) = &summary.worker_identity {
             details.push(("Exact resource ID", identity.resource_id.clone()));
         } else {
-            details.push((
-                "Exact resource ID",
-                "Not recorded; no resource discovery performed".into(),
-            ));
+            details.push(("Exact resource ID", "No resource identity recorded".into()));
         }
         if let Some(checkpoint) = &summary.checkpoint {
             details.push((
@@ -99,8 +96,10 @@ pub(super) fn show(ctx: &Context, state: &RemoteEnvironments) -> InventoryAction
                 });
             });
             ui.label(
-                RichText::new("Saved inventory across all sessions. Live status, uptime and cost are not checked.")
-                    .color(theme::FG_DIM()),
+                RichText::new(
+                    "Saved inventory across all sessions. Provider checks are manual; uptime and cost are not checked.",
+                )
+                .color(theme::FG_DIM()),
             );
             ui.label(
                 RichText::new("Closing this overview does not stop or delete remote work.").color(theme::FG_DIM()),
@@ -193,6 +192,7 @@ fn render_content(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut In
         });
     }
     if let Some(row) = state.selected.and_then(|index| page.rows.get(index)) {
+        render_observation(ui, state, action);
         ui.separator();
         ui.strong("Saved environment details");
         ui.label(
@@ -214,6 +214,60 @@ fn render_content(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut In
                 }
             });
     }
+}
+
+fn render_observation(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut InventoryAction) {
+    let observation = &state.observation;
+    ui.separator();
+    ui.horizontal_wrapped(|ui| {
+        ui.strong("Provider status");
+        let check = ui.add_enabled(
+            state.pending.is_none() && !observation.is_pending(),
+            egui::Button::new("Check provider status"),
+        );
+        #[cfg(test)]
+        ui.ctx()
+            .data_mut(|data| data.insert_temp(egui::Id::new("observation-check-test"), check.rect));
+        if check.clicked() {
+            *action = InventoryAction::Observe;
+        }
+        if observation.is_pending() {
+            ui.label(observation.pending_label());
+        }
+    });
+    if let Some(previous) = &observation.last_success {
+        ui.label(previous.lifecycle);
+        ui.horizontal_wrapped(|ui| {
+            ui.label("Last successful check (UTC):");
+            ui.monospace(&previous.checked_at);
+        });
+        if let Some(resource_id) = &previous.resource_id {
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Observed resource ID:");
+                ui.add(
+                    egui::Label::new(RichText::new(resource_id).monospace())
+                        .wrap()
+                        .selectable(true),
+                );
+            });
+        }
+        ui.label(RichText::new("Point-in-time observation, not continuous monitoring.").color(theme::FG_DIM()));
+    } else if !observation.is_pending() {
+        ui.label("Provider status has not been checked.");
+    }
+    if let Some(error) = &observation.failure {
+        ui.colored_label(theme::PALETTE_YELLOW(), error);
+        if observation.last_success.is_some() {
+            ui.colored_label(
+                theme::PALETTE_YELLOW(),
+                "Latest check failed; the previous observation may be stale.",
+            );
+        }
+    }
+    ui.label(
+        RichText::new("Task, repository and SSH readiness are not checked. No resource or saved state is changed.")
+            .color(theme::FG_DIM()),
+    );
 }
 
 fn phase_label(phase: Option<RemoteRuntimePhase>) -> &'static str {

--- a/crates/horizon-ui/src/app/settings/mod.rs
+++ b/crates/horizon-ui/src/app/settings/mod.rs
@@ -255,6 +255,9 @@ impl HorizonApp {
             tracing::info!("speech configuration changed; speech system rebuilt");
             self.sync_speech_global_hotkeys();
         }
+        if self.template_config.remote != config.remote {
+            self.remote_environments.invalidate_observation();
+        }
         self.template_config = config.clone();
         self.shortcuts = resolve_shortcuts(config);
         self.action_commands_cache =

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -128,6 +128,8 @@ back into large multi-purpose modules.
   provider observations with exact snapshot checks but no private-key access or
   saved-state writes. It shares allocation observation validation with recovery;
   neither absence nor observed readiness grants management or attachment authority.
+  Its `configured` adapter resolves an explicit named local profile and rejects
+  stale overview summaries before passing the owned snapshot to the observation gate.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
   wire types; `ssh.rs` isolates host pins and client options; `command.rs` owns
@@ -247,6 +249,9 @@ back into large multi-purpose modules.
     layout, and row/header paint helpers split into `remote_hosts_overlay/`
   - `remote_environments`: single-flight saved-inventory loading and modal input
     ownership, with cached labels and rendering in `remote_environments/paint`.
+    `remote_environments/observation` owns single-flight manual provider checks,
+    event-based invalidation and cached point-in-time labels, never provider I/O
+    on the render thread or passive repaint polling.
     Compact record projection belongs to `horizon-core::remote_workspace::summary`;
     the overview does not own provider actions or remote execution lifetime.
   - `sidebar`: sidebar rendering and deferred sidebar actions


### PR DESCRIPTION
## Purpose

Add manual provider checks to the Remote Environments overview for #383.

## Behavior

- Check only the explicitly selected saved environment through its exact configured local profile. Reload and compare the complete saved summary before contacting the provider.
- Run one bounded check off the render thread. Cache a timestamped result; invalidate it on selection, page, configuration, close or reopen changes, and discard late results.
- Keep saved setup phase distinct from observed worker lifecycle. Worker Ready does not certify task, repository or authenticated session readiness.
- Preserve saved identities when no exact worker exists. Show bounded, redacted failures without losing saved metadata.
- No automatic polling, allocation, adoption, attachment, Stop or Delete. Opening/closing the overview and closing the client do not manage worker lifetime.

The initial adapter uses an explicitly configured local container engine. Other providers remain explicitly unsupported. Reads do not need the retained private session key.

## Validation

- Independent complete local review and final source/harness continuity review.
- Corrected retry wording after worker-thread/channel failure; deterministic coverage verifies immediate retry is available and older timestamped success remains qualified. The full exact-commit matrix and applicable native/API lanes were repeated for this correction.
- Exact-commit full validation passed: workspace/default and speech tests, formatting, maintainability, version synchronization, blocking/strict/advisory lint tiers.
- Native debug validation passed on the current source: empty and populated global inventory across two owners, modal keyboard isolation, pagination, missing/unconfigured/unsupported states, compact and large layouts, both built-in themes, configuration invalidation, unavailable endpoint and retry, Fit, normal close and fresh-client repeat.
- Real configured-provider checks passed with the generated private key withheld. The same retained worker/task kept progressing after final terminal attachment loss and client closure/reopening. All 20 synthetic saved records and their revisions remained unchanged.
- Real absent-worker observation after exact-owned test cleanup preserved the saved identity and revisions without recreating a worker. Only disposable synthetic fixtures were removed.
- Matched current-base/candidate debug traces used two 4-second idle samples per closed/open lane and two 40-position pointer passes per empty/chrome lane. Frame counts matched; total CPU stayed comparable, with no new idle polling. This is a short software-renderer regression check, not a hardware speedup claim.

Native smoke plans were temporary validation artifacts and removed after completion. No user configuration, pre-existing process, paid resource or published image changed. This slice does not complete cloud or PC-off acceptance for #383.
