### PR TITLE
fix(remote): retain persistent workers after verification failures

### DIFF
--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -203,14 +203,11 @@ impl LocalDockerInteractiveWorkerProvider {
         create: &DockerCreateRequest,
         original: LocalDockerError,
     ) -> DockerResult<InteractiveWorkerEnsure> {
+        if create.terminate_after.is_none() {
+            return Err(persistent_reconciliation_error(container, create, original));
+        }
         let resource_id = container.id.clone();
         if !created_container_matches(container, create) {
-            if create.terminate_after.is_none()
-                && created_container_identity_matches(container, create)
-                && !lifetime_matches(container, None)
-            {
-                return Err(LocalDockerError::PersistentLifetimeMetadataConflict { resource_id });
-            }
             return Err(original);
         }
         if self.transport.delete(&resource_id).is_err() || !matches!(self.transport.inspect(&resource_id), Ok(None)) {

--- a/crates/horizon-core/src/cloud_run/local_docker.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker.rs
@@ -341,7 +341,9 @@ pub enum LocalDockerError {
     CreationCleanupFailed { resource_id: String },
     #[error("created local Docker worker {resource_id} has unexpected expiry metadata and requires manual inspection")]
     PersistentLifetimeMetadataConflict { resource_id: String },
-    #[error("persistent local Docker worker {resource_id} requires reconciliation after an uncertain create response")]
+    #[error(
+        "persistent local Docker worker {resource_id} was retained after post-creation verification failed; reconciliation is required"
+    )]
     PersistentCreationReconciliationRequired { resource_id: String },
     #[error("local Docker worker {resource_id} had an out-of-bounds lease and was deleted")]
     LeaseDeadlineRejected { resource_id: String },

--- a/crates/horizon-core/src/cloud_run/local_docker/tests.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests.rs
@@ -11,6 +11,12 @@ mod stop;
 
 #[derive(Clone, Default)]
 struct FakeDocker(Arc<Mutex<FakeState>>);
+
+enum HostKeyReadFault {
+    Disappear,
+    Stop,
+}
+
 #[derive(Default)]
 struct FakeState {
     creation: Option<fencing::CreationStore>,
@@ -28,7 +34,7 @@ struct FakeState {
     failed_inspections_after_create: usize,
     hidden_inspections_after_create: usize,
     binding_host: Option<String>,
-    disappear_during_key_read: bool,
+    host_key_read_fault: Option<HostKeyReadFault>,
     image_environment: Vec<String>,
 }
 impl FakeDocker {
@@ -105,9 +111,20 @@ impl DockerTransport for FakeDocker {
     fn read_host_key(&self, _resource_id: &str) -> Result<Option<String>, LocalDockerError> {
         let mut state = self.state();
         state.host_key_calls += 1;
-        if std::mem::take(&mut state.disappear_during_key_read) {
-            state.container = None;
-            return Err(ResourceAbsent);
+        match state.host_key_read_fault.take() {
+            Some(HostKeyReadFault::Disappear) => {
+                state.container = None;
+                return Err(ResourceAbsent);
+            }
+            Some(HostKeyReadFault::Stop) => {
+                let container = state.container.as_mut().expect("created worker");
+                container.running = false;
+                container.state = "exited".into();
+                return Err(CommandFailed {
+                    operation: "SSH host-key inspection",
+                });
+            }
+            None => {}
         }
         Ok(Some(format!("{} worker@local", ed25519_key(7))))
     }
@@ -148,7 +165,7 @@ fn disappearance_during_key_discovery_never_recreates_a_claimed_worker() {
     let provider = provider("local", fake.clone());
     let request = request();
     let worker = provider.ensure_worker(&request).expect("create").into_status().worker;
-    fake.state().disappear_during_key_read = true;
+    fake.state().host_key_read_fault = Some(HostKeyReadFault::Disappear);
     assert_eq!(provider.inspect_worker(&worker), Ok(None));
     assert_eq!(provider.ensure_worker(&request), Err(CreationReconciliationRequired));
     assert_eq!(fake.state().create_calls, 1);

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/fencing.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/fencing.rs
@@ -163,7 +163,7 @@ fn simultaneous_controllers_share_one_durable_creation_grant() {
 fn observed_disappearance_consumes_the_grant_before_observation_can_fail() {
     let request = lifetime::persistent_request();
     let fake = noncreating::seeded(&request);
-    fake.state().disappear_during_key_read = true;
+    fake.state().host_key_read_fault = Some(HostKeyReadFault::Disappear);
     let provider = provider_for("local", fake.clone(), &request);
     assert_eq!(provider.ensure_worker(&request), Err(ResourceAbsent));
     assert_eq!(claims(&provider.creation_store), 1);

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
@@ -141,6 +141,88 @@ fn persistent_lost_create_response_recovers_the_same_exact_worker() {
 }
 
 #[test]
+fn verification_after_concurrent_stop_preserves_only_persistent_workers() {
+    for persistent in [false, true] {
+        for uncertain in [false, true] {
+            let request = if persistent { persistent_request() } else { request() };
+            let fake = FakeDocker::default();
+            {
+                let mut state = fake.state();
+                state.host_key_read_fault = Some(HostKeyReadFault::Stop);
+                state.fail_create_after_insert = uncertain;
+            }
+            let provider = provider_for("local", fake.clone(), &request);
+            let expected = if persistent {
+                PersistentCreationReconciliationRequired {
+                    resource_id: "a".repeat(64),
+                }
+            } else {
+                CommandFailed {
+                    operation: "SSH host-key inspection",
+                }
+            };
+            let outcome = provider.ensure_worker(&request);
+            let retained = {
+                let state = fake.state();
+                assert_eq!((state.create_calls, state.host_key_calls), (1, 1));
+                assert_eq!(state.delete_calls, usize::from(!persistent));
+                state.container.clone()
+            };
+            assert_eq!(outcome, Err(expected));
+            if let Some(container) = retained {
+                assert!(persistent);
+                assert_eq!(container.id, "a".repeat(64));
+                assert!(!container.running);
+                assert_eq!(container.state, "exited");
+                assert_eq!(container.auto_remove, Some(false));
+                let worker = worker_for_request(&container, &request).expect("same retained identity");
+                drop(provider);
+                let reopened = provider_for("local", fake.clone(), &request);
+                let recovered = reopened.ensure_worker(&request).expect("non-creating retry");
+                assert!(matches!(recovered, InteractiveWorkerEnsure::Reused(_)));
+                assert_eq!(recovered.status().worker, worker);
+                assert_eq!(recovered.status().lifecycle, InteractiveWorkerLifecycle::Stopped);
+                assert!(recovered.status().ssh.is_none());
+                let state = fake.state();
+                assert_eq!((state.create_calls, state.delete_calls), (1, 0));
+            } else {
+                assert!(!persistent);
+            }
+        }
+    }
+}
+
+#[test]
+fn persistent_endpoint_verification_failure_retains_identity_without_claiming_readiness() {
+    for uncertain in [false, true] {
+        let request = persistent_request();
+        let fake = FakeDocker::default();
+        {
+            let mut state = fake.state();
+            state.binding_host = Some("0.0.0.0".into());
+            state.fail_create_after_insert = uncertain;
+        }
+        let provider = provider_for("local", fake.clone(), &request);
+        assert_eq!(
+            provider.ensure_worker(&request),
+            Err(PersistentCreationReconciliationRequired {
+                resource_id: "a".repeat(64),
+            })
+        );
+        assert_eq!(provider.reconcile_worker(&request), Err(InvalidSshEndpoint));
+        let state = fake.state();
+        assert_eq!(
+            (state.create_calls, state.delete_calls, state.host_key_calls),
+            (1, 0, 0)
+        );
+        assert_eq!(
+            state.container.as_ref().expect("retained for inspection").id,
+            "a".repeat(64)
+        );
+    }
+}
+
+#[test]
 fn unexpected_image_expiry_retains_the_created_identity_for_manual_inspection() {
     for entry in [
         TERMINATE_ENV.to_string(),

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/lifetime.rs
@@ -203,11 +203,19 @@ fn persistent_endpoint_verification_failure_retains_identity_without_claiming_re
             state.fail_create_after_insert = uncertain;
         }
         let provider = provider_for("local", fake.clone(), &request);
+        let error = provider.ensure_worker(&request).expect_err("post-create verification");
         assert_eq!(
-            provider.ensure_worker(&request),
-            Err(PersistentCreationReconciliationRequired {
+            error,
+            PersistentCreationReconciliationRequired {
                 resource_id: "a".repeat(64),
-            })
+            }
+        );
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "persistent local Docker worker {} was retained after post-creation verification failed; reconciliation is required",
+                "a".repeat(64)
+            )
         );
         assert_eq!(provider.reconcile_worker(&request), Err(InvalidSshEndpoint));
         let state = fake.state();

--- a/crates/horizon-core/src/cloud_run/local_docker/tests/noncreating.rs
+++ b/crates/horizon-core/src/cloud_run/local_docker/tests/noncreating.rs
@@ -26,7 +26,7 @@ fn absent_or_disappearing_recovery_never_creates_a_worker() {
     assert_read_only(&empty);
 
     let fake = seeded(&request);
-    fake.state().disappear_during_key_read = true;
+    fake.state().host_key_read_fault = Some(HostKeyReadFault::Disappear);
     assert_eq!(provider("local", fake.clone()).reconcile_worker(&request), Ok(None));
     assert_eq!(provider("local", fake.clone()).reconcile_worker(&request), Ok(None));
     assert_read_only(&fake);

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -175,6 +175,9 @@ back into large multi-purpose modules.
   never renews it. Explicit ensure also consumes the grant when accepting an
   exact existing worker, before observing its connection. Provider construction
   requires that store explicitly; non-creating inspection never claims a grant.
+  Persistent post-create verification failures retain the resource and consumed
+  grant for explicit non-creating recovery or management. An in-flight creation
+  response cannot undo another client's retained Stop through failure cleanup.
 - `cloud_run/interactive_worker_stop.rs` is an opt-in Stop contract, separate from
   deletion and client lifetime. The local adapter's `local_docker/stop.rs` verifies
   exact ownership and disabled automatic removal before a bounded stop, then


### PR DESCRIPTION
## Purpose

Keep persistent workspace data after post-creation verification fails, for #383.

## Behavior

A creation call may still be discovering the server identity when another client
recovers and explicitly stops that worker. The late read then fails against the
inactive container. Its failure cleanup must not delete a persistent resource
that another client has retained.

The direct-create failure path now uses the existing persistent reconciliation
outcome. The exact resource and consumed creation grant remain available for
explicit non-creating recovery or management. Verification failure does not
certify readiness or authorize automatic deletion/recreation. Existing ownership
and lifetime-conflict diagnostics remain intact; time-limited cleanup is unchanged.
The reconciliation diagnostic covers both direct verification failures and
uncertain create responses, and states that the persistent resource was retained.

## Reproduction and validation

- The deterministic concurrent-Stop regression fails on baseline production code
  because it records one deletion instead of zero, and passes with the fix.
- All 42 focused local-provider tests pass. New cases cover direct and lost-create
  responses, same-worker fresh-client retry, retained inactive state, unchanged
  timed cleanup and failed endpoint verification without a readiness claim.
- Full final-source and exact-commit validation passed: format, maintainability,
  version sync, default and speech workspace tests, blocking and strict Clippy,
  and the advisory pedantic tier.
- Actual owned local-provider retention and the two-client creation/recovery/Stop
  race passed again on the exact commit: the real late host-key read failed
  against the stopped worker, without deletion, recreation or late saved-state
  changes. Same-worker identity and synthetic file bytes remained unchanged;
  only the exact-owned disposable fixtures were cleaned up.
- Independent complete local source and fixture review passed.

No UI, configuration, dependency or release change. Durable Stop coordination
and timed-workspace management remain separate outcomes; this PR does not close
the complete remote-development issue.
