### PR TITLE
feat(remote): persist explicit workspace Stop intent

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -7,6 +7,7 @@ mod guards;
 mod recovery;
 mod request;
 mod setup;
+mod stop;
 
 pub(super) use guards::{
     ensure_unbound_workflow, validate_creation_claim, validate_workflow_replacement, validate_workspace_write,

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
@@ -31,6 +31,7 @@ impl StoredRemoteAllocation {
     pub(crate) fn recovery_request(&self) -> Result<InteractiveWorkerRequest, Error> {
         let runtime = self.workspace.state().runtime.as_ref().ok_or(Error::UnboundRuntime)?;
         if runtime.cleanup.is_some()
+            || runtime.phase.stop_requested_at_millis().is_some()
             || matches!(
                 runtime.phase,
                 RemoteRuntimePhase::Cancelling | RemoteRuntimePhase::Deleting

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/stop.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/stop.rs
@@ -1,0 +1,41 @@
+//! Exact-snapshot Stop-intent transitions; provider operations remain outside storage.
+
+use super::{CloudWorkflowStore, RemoteRuntimePhase, StoredRemoteAllocation, WorkspaceReplacement, binding};
+use crate::remote_workspace::stop::RemoteWorkspaceStopError as Error;
+use rusqlite::TransactionBehavior;
+
+impl CloudWorkflowStore {
+    pub(crate) fn record_remote_stop_phase(
+        &self,
+        expected: &StoredRemoteAllocation,
+        phase: RemoteRuntimePhase,
+    ) -> Result<StoredRemoteAllocation, Error> {
+        if phase.stop_requested_at_millis().is_none() {
+            return Err(Error::ManagementConflict);
+        }
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        super::super::database::ensure_current_schema(&transaction)?;
+        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)?
+            .ok_or(Error::MissingAllocation)?;
+        let current = binding::recover(&transaction, &row)?;
+        if current != *expected {
+            return Err(Error::StateChanged);
+        }
+        let mut next = current.workspace.state().clone();
+        let runtime = next.runtime.as_mut().ok_or(Error::MissingAllocation)?;
+        if runtime.cleanup.is_some() || runtime.worker.is_none() {
+            return Err(Error::ManagementConflict);
+        }
+        runtime.phase = phase;
+        if next == *current.workspace.state() {
+            return Ok(current);
+        }
+        let workspace = WorkspaceReplacement::new(&current.workspace, &next)?.persist(&transaction)?;
+        transaction.commit()?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: current.workflow,
+        })
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -16,7 +16,7 @@ use super::{
     CloudStoreError, CloudWorkflowStore, MAX_MATERIALIZED_SNAPSHOT_BYTES, MAX_RECOVERED_SNAPSHOT_BYTES,
     MAX_SNAPSHOT_BYTES, database::ensure_current_schema,
 };
-use crate::remote_workspace::{RemoteWorkspaceError, RemoteWorkspaceState};
+use crate::remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceError, RemoteWorkspaceState};
 pub(super) use validation::validate_key;
 use validation::{validate_replacement, validate_session_id};
 
@@ -152,6 +152,12 @@ impl CloudWorkflowStore {
         next: &RemoteWorkspaceState,
     ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
         let replacement = WorkspaceReplacement::new(expected, next)?;
+        if next.runtime.as_ref().is_some_and(|runtime| {
+            matches!(runtime.phase, RemoteRuntimePhase::Stopped { .. })
+                && expected.state.runtime.as_ref().map(|previous| previous.phase) != Some(runtime.phase)
+        }) {
+            return Err(RemoteWorkspaceStoreError::RuntimeStopConfirmationRequired);
+        }
         if expected.state.runtime.is_none() && next.runtime.is_some() {
             return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
         }
@@ -463,6 +469,8 @@ pub enum RemoteWorkspaceStoreError {
     RuntimeRequestUnavailable,
     #[error("remote workspace has pending management intent; reconnect cannot change it")]
     RuntimeRecoveryUnavailable,
+    #[error("remote Stop completion requires the verified coordinator")]
+    RuntimeStopConfirmationRequired,
     #[error("remote worker observation does not match the saved request or pinned identity")]
     InvalidWorkerObservation,
     #[error("remote allocation setup cannot create; non-creating recovery is required")]

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -48,6 +48,15 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
     {
         return Err(Error::NonMonotonicReplacement);
     }
+    if let Some(runtime) = &previous.runtime
+        && let Some(requested_at_millis) = runtime.phase.stop_requested_at_millis()
+        && next.runtime.as_ref().is_none_or(|next_runtime| {
+            next_runtime.phase.stop_requested_at_millis() != Some(requested_at_millis)
+                || (matches!(runtime.phase, RemoteRuntimePhase::Stopped { .. }) && next_runtime.phase != runtime.phase)
+        })
+    {
+        return Err(Error::NonMonotonicReplacement);
+    }
     if let (Some(runtime), Some(next_runtime)) = (&previous.runtime, &next.runtime)
         && (runtime.generation != next_runtime.generation
             || runtime.workflow_id != next_runtime.workflow_id

--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -1,6 +1,8 @@
-//! Durable remote workspace data, independent of providers, persistence I/O, and UI.
+//! Durable remote workspace data and explicit operation entrypoints.
+//! The data model is independent of provider, persistence I/O, and UI implementations.
 //! Snapshot validation is not permission to attach: fresh provider observation and lease checks remain required.
 
+pub mod stop;
 mod summary;
 #[cfg(test)]
 mod tests;
@@ -155,7 +157,7 @@ pub struct RemoteRuntimeGeneration {
 
 /// Dormant is represented by an absent runtime, never by a retained worker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum RemoteRuntimePhase {
     Provisioning,
     Reconciling,
@@ -165,6 +167,27 @@ pub enum RemoteRuntimePhase {
     Cancelling,
     Deleting,
     Failed,
+    /// Explicit retained Stop intent, never inferred from a client closing.
+    Stopping {
+        requested_at_millis: i64,
+    },
+    /// A saved point-in-time retention/inactivity observation, not current provider state.
+    Stopped {
+        requested_at_millis: i64,
+        observed_at_millis: i64,
+    },
+}
+
+impl RemoteRuntimePhase {
+    pub(crate) const fn stop_requested_at_millis(self) -> Option<i64> {
+        match self {
+            Self::Stopping { requested_at_millis }
+            | Self::Stopped {
+                requested_at_millis, ..
+            } => Some(requested_at_millis),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/horizon-core/src/remote_workspace/stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop.rs
@@ -1,0 +1,123 @@
+//! Explicit, durable Stop coordination. Client lifecycle never invokes this operation.
+
+use crate::{
+    cloud_run::{
+        CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
+        interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+    },
+    remote_workspace::RemoteRuntimePhase,
+};
+
+/// Record explicit Stop intent, stop only the retained worker, then record verified completion.
+/// Requires current owned workspace/workflow snapshots and an already retained exact worker.
+/// No private key, allocation, reconciliation, restart, deletion or fallback is attempted.
+/// Provider failures/absence preserve intent and identity for explicit retry by a fresh client.
+/// Stopped is saved point-in-time state, not a checkpoint or proof of current provider state.
+/// This synchronous operation must run off the render thread, only after explicit Stop admission.
+/// # Errors
+/// Rejects stale/unbound ownership, missing worker identity, competing management intent,
+/// provider mismatch/failure, absence and unverified completion. Errors redact provider payloads.
+pub fn stop_remote_workspace<P: InteractiveWorkerStopProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteWorkspace,
+) -> Result<StoredRemoteAllocation, RemoteWorkspaceStopError> {
+    use RemoteWorkspaceStopError as Error;
+    let allocation = store
+        .load_remote_allocation(expected.session_id(), &expected.state().spec.workspace_local_id)?
+        .ok_or(Error::MissingAllocation)?;
+    if allocation.workspace() != expected {
+        return Err(Error::StateChanged);
+    }
+    let runtime = expected.state().runtime.as_ref().ok_or(Error::MissingAllocation)?;
+    let worker = runtime.worker.as_ref().ok_or(Error::MissingWorker)?;
+    if !worker.is_valid_for(provider.provider()) {
+        return Err(Error::ProviderMismatch);
+    }
+    if runtime.cleanup.is_some() {
+        return Err(Error::ManagementConflict);
+    }
+    let now_millis = current_millis()?;
+    let requested_at_millis = runtime.phase.stop_requested_at_millis().unwrap_or(now_millis);
+    if requested_at_millis > now_millis {
+        return Err(Error::InvalidTimestamp);
+    }
+    let phase = if matches!(runtime.phase, RemoteRuntimePhase::Stopped { .. }) {
+        runtime.phase
+    } else {
+        RemoteRuntimePhase::Stopping { requested_at_millis }
+    };
+    let stopping = store.record_remote_stop_phase(&allocation, phase)?;
+    match provider.stop_worker(worker).map_err(|_| Error::ProviderUnavailable)? {
+        InteractiveWorkerStop::AlreadyAbsent => return Err(Error::ResourceAbsent),
+        InteractiveWorkerStop::Stopped => {}
+    }
+    let completed = if matches!(phase, RemoteRuntimePhase::Stopped { .. }) {
+        phase
+    } else {
+        let observed_at_millis = current_millis()?;
+        if observed_at_millis < requested_at_millis {
+            return Err(Error::InvalidTimestamp);
+        }
+        RemoteRuntimePhase::Stopped {
+            requested_at_millis,
+            observed_at_millis,
+        }
+    };
+    store.record_remote_stop_phase(&stopping, completed)
+}
+
+fn current_millis() -> Result<i64, RemoteWorkspaceStopError> {
+    i64::try_from(time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000)
+        .ok()
+        .filter(|millis| *millis >= 0)
+        .ok_or(RemoteWorkspaceStopError::InvalidTimestamp)
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteWorkspaceStopError {
+    #[error("no current owned allocation is available to stop")]
+    MissingAllocation,
+    #[error("saved environment has no exact retained worker to stop")]
+    MissingWorker,
+    #[error("saved environment changed; refresh before explicitly retrying Stop")]
+    StateChanged,
+    #[error("Stop provider does not match the saved worker")]
+    ProviderMismatch,
+    #[error("existing management intent does not permit this Stop request")]
+    ManagementConflict,
+    #[error("worker Stop could not be verified; saved intent and identity remain retained")]
+    ProviderUnavailable,
+    #[error("worker is absent; Stop cannot certify retained data, and saved intent remains")]
+    ResourceAbsent,
+    #[error("Stop timestamp could not be safely recorded")]
+    InvalidTimestamp,
+    #[error("owned remote Stop state could not be safely accessed")]
+    StorageUnavailable,
+}
+
+impl From<RemoteWorkspaceStoreError> for RemoteWorkspaceStopError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        match error {
+            RemoteWorkspaceStoreError::RevisionConflict { .. } | RemoteWorkspaceStoreError::SnapshotConflict => {
+                Self::StateChanged
+            }
+            _ => Self::StorageUnavailable,
+        }
+    }
+}
+
+impl From<CloudStoreError> for RemoteWorkspaceStopError {
+    fn from(_: CloudStoreError) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+impl From<rusqlite::Error> for RemoteWorkspaceStopError {
+    fn from(_: rusqlite::Error) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace/stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop.rs
@@ -3,13 +3,15 @@
 use crate::{
     cloud_run::{
         CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
+        WorkerLifetime,
         interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
     },
     remote_workspace::RemoteRuntimePhase,
 };
 
 /// Record explicit Stop intent, stop only the retained worker, then record verified completion.
-/// Requires current owned workspace/workflow snapshots and an already retained exact worker.
+/// Requires current owned workspace/workflow snapshots and an already retained exact persistent worker.
+/// Timed creation/expiry cleanup needs separate coordination before durable Stop can support it.
 /// No private key, allocation, reconciliation, restart, deletion or fallback is attempted.
 /// Provider failures/absence preserve intent and identity for explicit retry by a fresh client.
 /// Stopped is saved point-in-time state, not a checkpoint or proof of current provider state.
@@ -33,6 +35,9 @@ pub fn stop_remote_workspace<P: InteractiveWorkerStopProvider + ?Sized>(
     let worker = runtime.worker.as_ref().ok_or(Error::MissingWorker)?;
     if !worker.is_valid_for(provider.provider()) {
         return Err(Error::ProviderMismatch);
+    }
+    if worker.target.lifetime != WorkerLifetime::Persistent {
+        return Err(Error::UnsupportedLifetime);
     }
     if runtime.cleanup.is_some() {
         return Err(Error::ManagementConflict);
@@ -84,6 +89,8 @@ pub enum RemoteWorkspaceStopError {
     StateChanged,
     #[error("Stop provider does not match the saved worker")]
     ProviderMismatch,
+    #[error("durable workspace Stop requires a persistent execution policy")]
+    UnsupportedLifetime,
     #[error("existing management intent does not permit this Stop request")]
     ManagementConflict,
     #[error("worker Stop could not be verified; saved intent and identity remain retained")]

--- a/crates/horizon-core/src/remote_workspace/stop/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests.rs
@@ -1,0 +1,497 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{
+        ArtifactDigest, CloudProvider,
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+            InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerStatus,
+        },
+    },
+    remote_environment_observation::observe_remote_environment,
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteWorkspaceState, RepositoryCheckpoint},
+    remote_workspace_recovery::{RemoteWorkspaceRecoveryError, recover_remote_workspace},
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::Mutex;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+type Error = RemoteWorkspaceStopError;
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1, "spec":{
+                "workspace_local_id":"workspace", "working_directory":".", "generation":0,
+                "target":{"provider":"local_docker", "profile":"development", "disk_gib":20,
+                    "lifetime":"persistent", "image":format!("example/worker@sha256:{}", "a".repeat(64))},
+                "repository":{"repository":"example/project", "commit":"b".repeat(40)},
+                "panels":[{"panel_local_id":"terminal", "kind":"command", "task_handoff":"private-task-marker",
+                    "command":{"program":"printf", "args":["literal $()", "", "æøå"]}}]
+            }
+        }))
+        .expect("state");
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("dormant");
+        let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocate");
+        let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+        blob.extend([7; 32]);
+        let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
+        let reserved = store.reserve_remote_worker_request(&allocation, &key).expect("reserve");
+        let request = reserved.worker_request().expect("request");
+        let mut next = reserved.workspace().state().clone();
+        let runtime = next.runtime.as_mut().expect("runtime");
+        runtime.phase = RemoteRuntimePhase::Reconciling;
+        runtime.worker = Some(InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: request.target.provider,
+                workflow_id: request.workflow_id,
+                job_id: request.job_id,
+                resource_id: "a".repeat(64),
+            },
+            target: request.target,
+            ssh_public_key: request.ssh_public_key,
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        });
+        next.checkpoint = Some(RepositoryCheckpoint {
+            workspace_local_id: next.spec.workspace_local_id.clone(),
+            base_commit: next.spec.repository.commit.clone(),
+            manifest_digest: ArtifactDigest::parse_sha256("c".repeat(64)).expect("digest"),
+            runtime_generation: 1,
+            generation: 1,
+            captured_at_millis: 1,
+            recovery_artifact: Some(ArtifactDigest::parse_sha256("d".repeat(64)).expect("artifact")),
+        });
+        store
+            .replace_remote_workspace(reserved.workspace(), &next)
+            .expect("observed fixture");
+        Self { directory, store }
+    }
+
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn stop(&self, provider: &Provider) -> Result<StoredRemoteAllocation, Error> {
+        stop_remote_workspace(&self.store, provider, self.current().workspace())
+    }
+
+    fn phase(&self) -> RemoteRuntimePhase {
+        self.current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase
+    }
+}
+
+type StopHook = Box<dyn Fn(&InteractiveWorker) + Send + Sync>;
+
+struct Provider {
+    kind: CloudProvider,
+    result: Result<InteractiveWorkerStop, &'static str>,
+    calls: Mutex<[usize; 5]>,
+    on_stop: Option<StopHook>,
+}
+
+impl Provider {
+    fn new(result: Result<InteractiveWorkerStop, &'static str>) -> Self {
+        Self {
+            kind: CloudProvider::LocalDocker,
+            result,
+            calls: Mutex::new([0; 5]),
+            on_stop: None,
+        }
+    }
+
+    fn counts(&self) -> [usize; 5] {
+        *self.calls.lock().expect("counts")
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        self.calls.lock().expect("calls")[0] += 1;
+        Err(std::io::Error::other("no creation"))
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.calls.lock().expect("calls")[1] += 1;
+        Ok(None)
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.calls.lock().expect("calls")[2] += 1;
+        Ok(None)
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.calls.lock().expect("calls")[3] += 1;
+        Err(std::io::Error::other("no deletion"))
+    }
+}
+
+impl InteractiveWorkerStopProvider for Provider {
+    fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error> {
+        self.calls.lock().expect("calls")[4] += 1;
+        if let Some(action) = &self.on_stop {
+            action(worker);
+        }
+        self.result.map_err(std::io::Error::other)
+    }
+}
+
+#[test]
+fn explicit_stop_is_durable_before_provider_io_and_preserves_all_other_state() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let store = fixture.store.clone();
+    let mut provider = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+    provider.on_stop = Some(Box::new(move |worker| {
+        let saved = store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("read")
+            .expect("saved");
+        let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+        assert!(matches!(runtime.phase, RemoteRuntimePhase::Stopping { .. }));
+        assert_eq!(runtime.worker.as_ref(), Some(worker));
+    }));
+    let stopped = fixture.stop(&provider).expect("stop");
+    assert!(
+        matches!(fixture.phase(), RemoteRuntimePhase::Stopped { requested_at_millis, observed_at_millis }
+        if requested_at_millis > 0 && observed_at_millis >= requested_at_millis)
+    );
+    let mut original = before.workspace().state().clone();
+    original.runtime.as_mut().expect("runtime").phase = fixture.phase();
+    assert_eq!(stopped.workspace().state(), &original);
+    assert_eq!(stopped.workflow(), before.workflow());
+    assert_eq!(stopped.workspace().revision(), before.workspace().revision() + 2);
+    assert_eq!(provider.counts(), [0, 0, 0, 0, 1]);
+}
+
+#[test]
+fn provider_failure_and_absence_retain_intent_for_explicit_fresh_client_retry() {
+    for (result, error) in [
+        (Err("private-provider-marker"), Error::ProviderUnavailable),
+        (Ok(InteractiveWorkerStop::AlreadyAbsent), Error::ResourceAbsent),
+    ] {
+        let fixture = Fixture::new();
+        let before = fixture.current();
+        let provider = Provider::new(result);
+        let rejected = fixture.stop(&provider).expect_err("unverified Stop");
+        assert!(!rejected.to_string().contains("private-provider-marker"));
+        assert_eq!(rejected, error);
+        let pending = fixture.current();
+        let request = fixture.phase().stop_requested_at_millis().expect("durable intent");
+        assert!(matches!(fixture.phase(), RemoteRuntimePhase::Stopping { .. }));
+        assert_eq!(pending.workflow(), before.workflow());
+        assert_eq!(pending.workspace().state().spec, before.workspace().state().spec);
+        assert_eq!(
+            pending.workspace().state().checkpoint,
+            before.workspace().state().checkpoint
+        );
+        let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("reopen");
+        let retry = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+        let completed = stop_remote_workspace(&reopened, &retry, pending.workspace()).expect("explicit retry");
+        assert_eq!(fixture.phase().stop_requested_at_millis(), Some(request));
+        assert_eq!(
+            stop_remote_workspace(&reopened, &retry, completed.workspace()),
+            Ok(completed.clone())
+        );
+        assert_eq!(fixture.current(), completed);
+        assert_eq!(retry.counts(), [0, 0, 0, 0, 2]);
+        assert_eq!(provider.counts(), [0, 0, 0, 0, 1]);
+    }
+}
+
+#[test]
+fn stale_foreign_wrong_provider_and_competing_legacy_intent_fail_before_stop() {
+    let fixture = Fixture::new();
+    let original = fixture.current();
+    let mut provider = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+    provider.kind = CloudProvider::RunPod;
+    assert_eq!(fixture.stop(&provider), Err(Error::ProviderMismatch));
+    assert_eq!(fixture.current(), original);
+    provider.kind = CloudProvider::LocalDocker;
+    let foreign = Fixture::new();
+    assert_eq!(
+        stop_remote_workspace(&fixture.store, &provider, foreign.current().workspace()),
+        Err(Error::StateChanged)
+    );
+    let mut next = original.workspace().state().clone();
+    next.spec.working_directory = "nested".into();
+    let changed = fixture
+        .store
+        .replace_remote_workspace(original.workspace(), &next)
+        .expect("changed");
+    assert_eq!(
+        stop_remote_workspace(&fixture.store, &provider, original.workspace()),
+        Err(Error::StateChanged)
+    );
+    next.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::ApplicationExit,
+        requested_at_millis: 1,
+    });
+    fixture
+        .store
+        .replace_remote_workspace(&changed, &next)
+        .expect("legacy intent");
+    assert_eq!(fixture.stop(&provider), Err(Error::ManagementConflict));
+    assert_eq!(provider.counts(), [0; 5]);
+}
+
+#[test]
+fn post_stop_workspace_or_workflow_drift_cannot_record_false_completion() {
+    for change_workflow in [false, true] {
+        let fixture = Fixture::new();
+        let store = fixture.store.clone();
+        let mut provider = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+        provider.on_stop = Some(Box::new(move |_| {
+            let current = store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("read")
+                .expect("allocation");
+            if change_workflow {
+                let mut next = current.workflow().workflow().clone();
+                next.updated_at_millis += 1;
+                store.replace(current.workflow(), &next).expect("workflow update");
+            } else {
+                let mut next = current.workspace().state().clone();
+                next.spec.panels.clear();
+                store
+                    .replace_remote_workspace(current.workspace(), &next)
+                    .expect("panel detached");
+            }
+        }));
+        assert_eq!(fixture.stop(&provider), Err(Error::StateChanged));
+        assert!(matches!(fixture.phase(), RemoteRuntimePhase::Stopping { .. }));
+        assert_eq!(provider.counts(), [0, 0, 0, 0, 1]);
+    }
+}
+
+#[test]
+fn recovery_and_creation_remain_fenced_but_saved_inventory_is_observable() {
+    for result in [Err("lost response"), Ok(InteractiveWorkerStop::Stopped)] {
+        let fixture = Fixture::new();
+        let _ = fixture.stop(&Provider::new(result));
+        let saved = fixture.current();
+        let provider = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+        let identities = RemoteSshIdentityStore::new(&HorizonHome::from_root(fixture.directory.path().join("no-keys")));
+        assert_eq!(
+            recover_remote_workspace(&fixture.store, &identities, &provider, OWNER, "workspace")
+                .expect_err("management before identity access"),
+            RemoteWorkspaceRecoveryError::ManagementPending
+        );
+        let request = saved.worker_request().expect("retained request");
+        assert!(
+            fixture
+                .store
+                .claim_worker_creation(request.workflow_id, request.job_id, &request.target, "no-worker")
+                .is_err()
+        );
+        assert_eq!(provider.counts(), [0; 5]);
+        let observed =
+            observe_remote_environment(&fixture.store, &provider, saved.workspace()).expect("read-only inventory");
+        assert_eq!(observed.saved, saved.workspace().environment_summary());
+        assert!(observed.worker.is_none());
+        assert_eq!(fixture.current(), saved);
+        assert_eq!(provider.counts(), [0, 1, 0, 0, 0]);
+        assert!(!fixture.directory.path().join("no-keys").exists());
+    }
+}
+
+#[test]
+fn late_recovery_results_cannot_erase_a_new_stop_request() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    assert_eq!(
+        fixture.stop(&Provider::new(Err("uncertain response"))),
+        Err(Error::ProviderUnavailable)
+    );
+    let stopping = fixture.current();
+    assert!(matches!(
+        fixture.store.record_remote_worker_recovery(&before, None),
+        Err(RemoteWorkspaceStoreError::SnapshotConflict)
+    ));
+    assert!(matches!(
+        fixture.store.record_remote_worker_recovery(&stopping, None),
+        Err(RemoteWorkspaceStoreError::RuntimeRecoveryUnavailable)
+    ));
+    assert_eq!(fixture.current(), stopping);
+}
+
+#[test]
+fn generic_updates_cannot_manufacture_stop_completion() {
+    let fixture = Fixture::new();
+    for begin_stop in [false, true] {
+        if begin_stop {
+            assert_eq!(
+                fixture.stop(&Provider::new(Err("uncertain"))),
+                Err(Error::ProviderUnavailable)
+            );
+        }
+        let original = fixture.current();
+        let request = fixture.phase().stop_requested_at_millis().unwrap_or(1);
+        let mut next = original.workspace().state().clone();
+        next.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Stopped {
+            requested_at_millis: request,
+            observed_at_millis: request,
+        };
+        assert!(matches!(
+            fixture.store.replace_remote_workspace(original.workspace(), &next),
+            Err(RemoteWorkspaceStoreError::RuntimeStopConfirmationRequired)
+        ));
+        assert_eq!(fixture.current(), original);
+    }
+    assert!(fixture.stop(&Provider::new(Ok(InteractiveWorkerStop::Stopped))).is_ok());
+}
+
+#[test]
+fn generic_writes_cannot_erase_retarget_or_rewind_stop_intent() {
+    for result in [Err("uncertain"), Ok(InteractiveWorkerStop::Stopped)] {
+        let fixture = Fixture::new();
+        let _ = fixture.stop(&Provider::new(result));
+        let original = fixture.current();
+        let request = fixture.phase().stop_requested_at_millis().expect("request");
+        for replacement in [
+            None,
+            Some(RemoteRuntimePhase::Reconciling),
+            Some(RemoteRuntimePhase::Provisioning),
+            Some(RemoteRuntimePhase::Stopping {
+                requested_at_millis: request + 1,
+            }),
+            Some(RemoteRuntimePhase::Stopped {
+                requested_at_millis: request + 1,
+                observed_at_millis: request + 1,
+            }),
+        ] {
+            let mut next = original.workspace().state().clone();
+            if let Some(phase) = replacement {
+                next.runtime.as_mut().expect("runtime").phase = phase;
+            } else {
+                next.runtime = None;
+            }
+            assert!(
+                fixture
+                    .store
+                    .replace_remote_workspace(original.workspace(), &next)
+                    .is_err()
+            );
+            assert_eq!(fixture.current(), original);
+        }
+        if matches!(fixture.phase(), RemoteRuntimePhase::Stopped { .. }) {
+            let mut next = original.workspace().state().clone();
+            next.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Stopping {
+                requested_at_millis: request,
+            };
+            assert!(
+                fixture
+                    .store
+                    .replace_remote_workspace(original.workspace(), &next)
+                    .is_err()
+            );
+        }
+    }
+}
+
+#[test]
+fn phase_serialization_preserves_legacy_meanings_and_rejects_malformed_stop_state() {
+    for name in [
+        "provisioning",
+        "reconciling",
+        "materializing",
+        "ready",
+        "checkpointing",
+        "cancelling",
+        "deleting",
+        "failed",
+    ] {
+        let encoded = serde_json::json!(name);
+        let phase: RemoteRuntimePhase = serde_json::from_value(encoded.clone()).expect("legacy phase");
+        assert_eq!(serde_json::to_value(phase).expect("unchanged representation"), encoded);
+        assert!(phase.stop_requested_at_millis().is_none());
+    }
+    let fixture = Fixture::new();
+    for phase in [
+        serde_json::json!({"stopping":{"requested_at_millis":-1}}),
+        serde_json::json!({"stopped":{"requested_at_millis":2,"observed_at_millis":1}}),
+        serde_json::json!({"stopping":{}}),
+        serde_json::json!({"stopped":{"requested_at_millis":1}}),
+        serde_json::json!({"stopping":{"requested_at_millis":1,"unexpected":"private-marker"}}),
+    ] {
+        let mut encoded = serde_json::to_value(fixture.current().workspace().state()).expect("encode");
+        encoded["runtime"]["phase"] = phase;
+        assert!(serde_json::from_value::<RemoteWorkspaceState>(encoded).is_err());
+    }
+    for phase in [
+        RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+        RemoteRuntimePhase::Stopped {
+            requested_at_millis: 1,
+            observed_at_millis: 2,
+        },
+    ] {
+        let mut state = fixture.current().workspace().state().clone();
+        state.runtime.as_mut().expect("runtime").phase = phase;
+        let json = serde_json::to_value(&state).expect("encode");
+        assert_eq!(
+            serde_json::from_value::<RemoteWorkspaceState>(json).expect("round trip"),
+            state
+        );
+        state.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+            reason: RemoteCleanupReason::Cancelled,
+            requested_at_millis: 1,
+        });
+        assert!(state.validate().is_err());
+        state.runtime.as_mut().expect("runtime").cleanup = None;
+        state.runtime.as_mut().expect("runtime").worker = None;
+        assert!(state.validate().is_err());
+    }
+}
+
+#[test]
+fn a_missing_worker_or_future_request_never_reaches_provider_io() {
+    let fixture = Fixture::new();
+    let provider = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+    let original = fixture.current();
+    let mut next = original.workspace().state().clone();
+    next.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Stopping {
+        requested_at_millis: i64::MAX,
+    };
+    fixture
+        .store
+        .replace_remote_workspace(original.workspace(), &next)
+        .expect("future saved request");
+    assert_eq!(fixture.stop(&provider), Err(Error::InvalidTimestamp));
+    assert_eq!(provider.counts(), [0; 5]);
+    let mut dormant = next;
+    dormant.spec.workspace_local_id = "dormant".into();
+    dormant.runtime = None;
+    dormant.checkpoint = None;
+    let saved = fixture.store.create_remote_workspace(OWNER, &dormant).expect("dormant");
+    assert_eq!(
+        stop_remote_workspace(&fixture.store, &provider, &saved),
+        Err(Error::MissingAllocation)
+    );
+    let unobserved = fixture
+        .store
+        .allocate_remote_runtime(&saved, i64::MAX)
+        .expect("reserved allocation");
+    assert_eq!(
+        stop_remote_workspace(&fixture.store, &provider, unobserved.workspace()),
+        Err(Error::MissingWorker)
+    );
+    assert_eq!(provider.counts(), [0; 5]);
+}

--- a/crates/horizon-core/src/remote_workspace/stop/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests.rs
@@ -2,10 +2,11 @@ use super::*;
 use crate::{
     HorizonHome,
     cloud_run::{
-        ArtifactDigest, CloudProvider,
+        ArtifactDigest, CloudProvider, WorkerLifetime,
         interactive_worker::{
             InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
-            InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerStatus,
+            InteractiveWorkerLease, InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest,
+            InteractiveWorkerStatus,
         },
     },
     remote_environment_observation::observe_remote_environment,
@@ -26,9 +27,13 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
+        Self::with_lifetime(InteractiveWorkerLifetime::Persistent)
+    }
+
+    fn with_lifetime(lifetime: InteractiveWorkerLifetime) -> Self {
         let directory = tempfile::tempdir().expect("fixture");
         let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
-        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
             "version":1, "spec":{
                 "workspace_local_id":"workspace", "working_directory":".", "generation":0,
                 "target":{"provider":"local_docker", "profile":"development", "disk_gib":20,
@@ -39,6 +44,9 @@ impl Fixture {
             }
         }))
         .expect("state");
+        if matches!(lifetime, InteractiveWorkerLifetime::TimeLimited(_)) {
+            state.spec.target.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
+        }
         let dormant = store.create_remote_workspace(OWNER, &state).expect("dormant");
         let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocate");
         let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
@@ -58,7 +66,7 @@ impl Fixture {
             },
             target: request.target,
             ssh_public_key: request.ssh_public_key,
-            lifetime: InteractiveWorkerLifetime::Persistent,
+            lifetime,
         });
         next.checkpoint = Some(RepositoryCheckpoint {
             workspace_local_id: next.spec.workspace_local_id.clone(),
@@ -214,6 +222,51 @@ fn provider_failure_and_absence_retain_intent_for_explicit_fresh_client_retry() 
         assert_eq!(fixture.current(), completed);
         assert_eq!(retry.counts(), [0, 0, 0, 0, 2]);
         assert_eq!(provider.counts(), [0, 0, 0, 0, 1]);
+    }
+}
+
+#[test]
+fn time_limited_allocations_reject_durable_stop_without_intent_or_provider_changes() {
+    let future = time::OffsetDateTime::now_utc() + time::Duration::seconds(900);
+    for deadline in [future, time::OffsetDateTime::UNIX_EPOCH] {
+        for saved_phase in [
+            None,
+            Some(RemoteRuntimePhase::Stopping { requested_at_millis: 1 }),
+            Some(RemoteRuntimePhase::Stopped {
+                requested_at_millis: 1,
+                observed_at_millis: 1,
+            }),
+        ] {
+            let fixture = Fixture::with_lifetime(InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                terminate_after: deadline
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .expect("valid deadline"),
+            }));
+            if let Some(phase) = saved_phase {
+                fixture
+                    .store
+                    .record_remote_stop_phase(&fixture.current(), phase)
+                    .expect("previously saved timed intent");
+            }
+            let before = fixture.current();
+            assert_eq!(
+                before.workspace().state().spec.target.lifetime,
+                WorkerLifetime::TimeLimited { seconds: 900 }
+            );
+            let worker = before
+                .workspace()
+                .state()
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.worker.as_ref())
+                .expect("retained worker");
+            assert!(worker.is_valid_for(CloudProvider::LocalDocker));
+            assert!(worker.lifetime.as_time_limited().is_some());
+            let provider = Provider::new(Ok(InteractiveWorkerStop::Stopped));
+            assert_eq!(fixture.stop(&provider), Err(Error::UnsupportedLifetime));
+            assert_eq!(provider.counts(), [0; 5]);
+            assert_eq!(fixture.current(), before);
+        }
     }
 }
 

--- a/crates/horizon-core/src/remote_workspace/validation.rs
+++ b/crates/horizon-core/src/remote_workspace/validation.rs
@@ -153,13 +153,15 @@ impl RemoteRuntimeGeneration {
             {
                 return Err(Error::InvalidRuntime("worker identity"));
             }
-        } else if matches!(
-            self.phase,
-            RemoteRuntimePhase::Materializing
-                | RemoteRuntimePhase::Ready
-                | RemoteRuntimePhase::Checkpointing
-                | RemoteRuntimePhase::Deleting
-        ) {
+        } else if self.phase.stop_requested_at_millis().is_some()
+            || matches!(
+                self.phase,
+                RemoteRuntimePhase::Materializing
+                    | RemoteRuntimePhase::Ready
+                    | RemoteRuntimePhase::Checkpointing
+                    | RemoteRuntimePhase::Deleting
+            )
+        {
             return Err(Error::InvalidRuntime("missing worker"));
         }
         if self
@@ -186,6 +188,14 @@ impl RemoteRuntimeGeneration {
             ) && self.cleanup.is_none())
         {
             return Err(Error::InvalidRuntime("cleanup intent"));
+        }
+        if let Some(requested_at_millis) = self.phase.stop_requested_at_millis()
+            && (requested_at_millis < 0
+                || self.cleanup.is_some()
+                || matches!(self.phase, RemoteRuntimePhase::Stopped { observed_at_millis, .. }
+                    if observed_at_millis < requested_at_millis))
+        {
+            return Err(Error::InvalidRuntime("Stop intent"));
         }
         Ok(())
     }

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -281,5 +281,7 @@ fn phase_label(phase: Option<RemoteRuntimePhase>) -> &'static str {
         Some(RemoteRuntimePhase::Cancelling) => "Cancelling",
         Some(RemoteRuntimePhase::Deleting) => "Deleting",
         Some(RemoteRuntimePhase::Failed) => "Failed",
+        Some(RemoteRuntimePhase::Stopping { .. }) => "Stop requested (saved)",
+        Some(RemoteRuntimePhase::Stopped { .. }) => "Stopped (saved, not live)",
     }
 }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -192,6 +192,8 @@ back into large multi-purpose modules.
   provider I/O. Generic writes cannot manufacture completion or erase/rewind its request,
   and setup/recovery cannot consume it as normal client activity. Legacy cleanup
   reasons remain distinct; saved completion is not current provider status.
+  This durable entrypoint admits only persistent execution: timed creation/expiry
+  cleanup needs separate coordination before it can promise retained Stop intent.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -186,6 +186,12 @@ back into large multi-purpose modules.
   verifies the same resource is retained and inactive. Lost responses need that
   independent proof; absence is not retained storage. Durable management intent,
   checkpointing and user-facing actions remain separate caller responsibilities.
+- `remote_workspace/stop.rs` coordinates an explicit exact-worker Stop around
+  durable `Stopping`/`Stopped` phases. The allocation store's `stop.rs` commits
+  each phase against both owned snapshots without holding a transaction across
+  provider I/O. Generic writes cannot manufacture completion or erase/rewind its request,
+  and setup/recovery cannot consume it as normal client activity. Legacy cleanup
+  reasons remain distinct; saved completion is not current provider status.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized


### PR DESCRIPTION
## Purpose

Persist explicit Stop intent before touching a retained worker, for #383.

## Behavior

The coordinator admits only an exact, already retained persistent worker and
current owned workspace/workflow snapshots. It records an immutable Stop request
before provider I/O, then records completion only after the provider verifies the
same resource is retained and inactive. Errors and absent resources keep the
saved request and identity for an explicit fresh-client retry.

Generic writes cannot manufacture completion, erase or rewind Stop intent.
Ordinary setup/recovery and their late results cannot consume that intent as
normal reconnect activity. Timed execution is rejected before intent or provider
I/O; its existing cleanup policy remains separate. Legacy cleanup reasons keep
their original meaning.

The overview distinguishes a saved Stop request and saved completion from live
provider status. Closing panels, the overview or the application never invokes
Stop. This slice adds no management button, automatic retry, resume, deletion,
checkpoint, backup or preserved-process-memory guarantee.

## Validation

- Eleven focused regressions cover durable intent, exact snapshot races,
  stale ownership, immutable retries, errors/absence, generic-write bypasses,
  setup/recovery fencing, legacy serialization and genuine timed allocations.
- Full final-source and exact-commit validation passed: format, maintainability,
  version sync, default and speech workspace tests, and blocking, strict and
  pedantic Clippy. The exact workspace-wide debug build is byte-identical to the
  inspected native candidate. The actual coordinator smoke passed again on the
  clean final commit.
- Current native overview-label/layout checks passed in both themes and at small
  and large sizes, with scrolling, refresh, empty/populated inventory, launch/Fit,
  modal input isolation and fresh-client saved-state checks. The complete logical
  inventory digest stayed unchanged through normal client closures/reopening.
- Matched baseline/candidate samples used two four-second idle samples and two
  forty-position pointer traces per surface, at 100 ms intervals, on the same
  isolated software-renderer display. Closed-idle CPU totals were 0.85/0.82 s,
  empty-canvas 12.54/12.51 s, panel-chrome 12.58/12.59 s and open-empty 1.05/1.07 s.
  Corresponding samples had identical frame counts; no continuous redraw or
  material regression was observed. These are local checks, not cloud/GPU claims.
- Actual local-provider Stop retained the exact inactive worker and synthetic
  repository/task bytes without its generated SSH key. Fresh-client retry did not
  restart or allocate; only expected intent/completion revisions changed. An
  absent-resource retry retained saved identity and did not claim preserved data.
  Only the exact identity/image/label-verified disposable fixtures were removed.
- Complete independent local source and fixture review passed.

No dependency, configuration-default or release change. Cloud-provider Stop and
the broader remote-development workflow remain separate, uncompleted outcomes.
