### PR TITLE
feat(remote): admit configured workspace Stop requests

### DIFF
--- a/crates/horizon-core/src/remote_workspace/stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop.rs
@@ -1,5 +1,9 @@
 //! Explicit, durable Stop coordination. Client lifecycle never invokes this operation.
 
+mod configured;
+
+pub use configured::{ConfiguredStopError, stop_configured_remote_environment};
+
 use crate::{
     cloud_run::{
         CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,

--- a/crates/horizon-core/src/remote_workspace/stop/configured.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/configured.rs
@@ -11,11 +11,12 @@ use crate::{
 /// A saved summary alone is not user authorization: call only after explicit Stop
 /// confirmation, off the render thread. Closing a view or client never invokes this.
 /// Reloads the owned record and rejects any changed selection before recording intent.
+/// Only persistent execution is admitted; timed cleanup retains its separate policy.
 /// No ambient provider, private key, allocation, restart, deletion or fallback is used.
 /// Returns only safe overview metadata; saved completion is not a live observation,
 /// a task checkpoint, or a guarantee of preserved process memory.
 /// # Errors
-/// Rejects unsupported/unconfigured providers, stale or foreign selections, and
+/// Rejects unsupported/unconfigured providers, timed execution, stale or foreign selections, and
 /// unverified Stop outcomes. Provider failures can leave durable Stop intent: refresh
 /// the saved inventory before an explicit retry. Diagnostics redact private payloads.
 pub fn stop_configured_remote_environment(

--- a/crates/horizon-core/src/remote_workspace/stop/configured.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/configured.rs
@@ -1,0 +1,52 @@
+//! Explicit selected-environment admission into the durable Stop coordinator.
+
+use super::{RemoteWorkspaceStopError, stop_remote_workspace};
+use crate::{
+    cloud_run::{CloudProvider, CloudWorkflowStore, local_docker::LocalDockerInteractiveWorkerProvider},
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_workspace::RemoteEnvironmentSummary,
+};
+
+/// Stop one explicitly confirmed selection using its exact named local provider profile.
+/// A saved summary alone is not user authorization: call only after explicit Stop
+/// confirmation, off the render thread. Closing a view or client never invokes this.
+/// Reloads the owned record and rejects any changed selection before recording intent.
+/// No ambient provider, private key, allocation, restart, deletion or fallback is used.
+/// Returns only safe overview metadata; saved completion is not a live observation,
+/// a task checkpoint, or a guarantee of preserved process memory.
+/// # Errors
+/// Rejects unsupported/unconfigured providers, stale or foreign selections, and
+/// unverified Stop outcomes. Provider failures can leave durable Stop intent: refresh
+/// the saved inventory before an explicit retry. Diagnostics redact private payloads.
+pub fn stop_configured_remote_environment(
+    store: &CloudWorkflowStore,
+    config: &RemoteProviderConfig,
+    expected: &RemoteEnvironmentSummary,
+) -> Result<RemoteEnvironmentSummary, ConfiguredStopError> {
+    if expected.provider != CloudProvider::LocalDocker {
+        return Err(ConfiguredStopError::UnsupportedProvider);
+    }
+    let profile = config.local_docker_profile(&expected.profile)?;
+    let current = store
+        .load_remote_workspace(&expected.owning_session_id, &expected.workspace_local_id)
+        .map_err(RemoteWorkspaceStopError::from)?
+        .ok_or(RemoteWorkspaceStopError::MissingAllocation)?;
+    if current.environment_summary() != *expected {
+        return Err(RemoteWorkspaceStopError::StateChanged.into());
+    }
+    let provider = LocalDockerInteractiveWorkerProvider::new(profile.clone(), store.clone())
+        .map_err(|_| RemoteWorkspaceStopError::ProviderUnavailable)?;
+    Ok(stop_remote_workspace(store, &provider, &current)?
+        .workspace()
+        .environment_summary())
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum ConfiguredStopError {
+    #[error("explicit data-retaining Stop is not supported for this environment's provider")]
+    UnsupportedProvider,
+    #[error(transparent)]
+    Configuration(#[from] RemoteProviderConfigError),
+    #[error(transparent)]
+    Stop(#[from] RemoteWorkspaceStopError),
+}

--- a/crates/horizon-core/src/remote_workspace/stop/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests.rs
@@ -1,3 +1,5 @@
+mod configured;
+
 use super::*;
 use crate::{
     HorizonHome,

--- a/crates/horizon-core/src/remote_workspace/stop/tests/configured.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests/configured.rs
@@ -1,0 +1,206 @@
+use super::*;
+use crate::{
+    cloud_run::local_docker::LocalDockerProfile,
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_workspace::RemoteEnvironmentSummary,
+};
+
+fn config() -> RemoteProviderConfig {
+    RemoteProviderConfig {
+        local_docker: vec![LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///nonexistent-stop-fixture/docker.sock".into(),
+        }],
+    }
+}
+
+fn stop(fixture: &Fixture, config: &RemoteProviderConfig) -> Result<RemoteEnvironmentSummary, ConfiguredStopError> {
+    stop_configured_remote_environment(
+        &fixture.store,
+        config,
+        &fixture.current().workspace().environment_summary(),
+    )
+}
+
+#[test]
+fn unsupported_and_unconfigured_providers_cannot_record_stop_intent() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let mut expected = before.workspace().environment_summary();
+    for provider in [CloudProvider::Azure, CloudProvider::RunPod] {
+        expected.provider = provider;
+        assert_eq!(
+            stop_configured_remote_environment(&fixture.store, &RemoteProviderConfig::default(), &expected),
+            Err(ConfiguredStopError::UnsupportedProvider)
+        );
+    }
+    assert_eq!(
+        stop(&fixture, &RemoteProviderConfig::default()),
+        Err(ConfiguredStopError::Configuration(
+            RemoteProviderConfigError::UnconfiguredLocalProfile
+        ))
+    );
+    let mut profiles = config();
+    profiles.local_docker[0].name = "Development".into();
+    assert_eq!(
+        stop(&fixture, &profiles),
+        Err(ConfiguredStopError::Configuration(
+            RemoteProviderConfigError::UnconfiguredLocalProfile
+        ))
+    );
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn duplicate_and_invalid_profiles_fail_before_intent_without_echoing_values() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let mut profiles = config();
+    profiles.local_docker.push(profiles.local_docker[0].clone());
+    assert_eq!(
+        stop(&fixture, &profiles),
+        Err(ConfiguredStopError::Configuration(
+            RemoteProviderConfigError::DuplicateLocalProfile { index: 1 }
+        ))
+    );
+    profiles.local_docker.pop();
+    profiles.local_docker[0].docker_host = "tcp://private-endpoint-marker:1234".into();
+    let error = stop(&fixture, &profiles).expect_err("nonlocal endpoint");
+    assert_eq!(
+        error,
+        ConfiguredStopError::Configuration(RemoteProviderConfigError::InvalidLocalProfile { index: 0 })
+    );
+    assert!(!format!("{error:?} {error}").contains("private-endpoint-marker"));
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn every_changed_selection_field_is_rejected_before_provider_access() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let original = before.workspace().environment_summary();
+    let mut changed = vec![original.clone(); 11];
+    changed[0].revision += 1;
+    changed[1].repository = "another/repository".into();
+    changed[2].generation += 1;
+    changed[3].panel_count += 1;
+    changed[4].saved_phase = Some(RemoteRuntimePhase::Ready);
+    changed[5].checkpoint = None;
+    changed[6].workflow_id = Some(crate::cloud_run::CloudWorkflowId::new());
+    changed[7].job_id = Some(crate::cloud_run::CloudJobId::new());
+    changed[8].worker_identity.as_mut().expect("worker").resource_id = "b".repeat(64);
+    changed[9].worker_identity = None;
+    changed[10].profile = "another-profile".into();
+    let mut profiles = config();
+    profiles.local_docker.push(LocalDockerProfile {
+        name: "another-profile".into(),
+        docker_host: profiles.local_docker[0].docker_host.clone(),
+    });
+    for expected in changed {
+        assert_eq!(
+            stop_configured_remote_environment(&fixture.store, &profiles, &expected),
+            Err(ConfiguredStopError::Stop(Error::StateChanged))
+        );
+        assert_eq!(fixture.current(), before);
+    }
+    let mut next = before.workspace().state().clone();
+    next.spec.panels[0].task_handoff = Some("changed-private-task-marker".into());
+    let updated = fixture
+        .store
+        .replace_remote_workspace(before.workspace(), &next)
+        .expect("changed record");
+    assert_eq!(
+        stop_configured_remote_environment(&fixture.store, &config(), &original),
+        Err(ConfiguredStopError::Stop(Error::StateChanged))
+    );
+    assert_eq!(fixture.current().workspace(), &updated);
+}
+
+#[test]
+fn foreign_missing_and_malformed_selection_keys_cannot_mutate_records() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let original = before.workspace().environment_summary();
+    let mut foreign = original.clone();
+    foreign.owning_session_id = "00000000-0000-4000-8000-000000000002".into();
+    assert!(stop_configured_remote_environment(&fixture.store, &config(), &foreign).is_err());
+    let mut missing = original.clone();
+    missing.workspace_local_id = "missing-workspace".into();
+    assert_eq!(
+        stop_configured_remote_environment(&fixture.store, &config(), &missing),
+        Err(ConfiguredStopError::Stop(Error::MissingAllocation))
+    );
+    let mut malformed = original;
+    malformed.owning_session_id = "private-owner-marker".into();
+    let error = stop_configured_remote_environment(&fixture.store, &config(), &malformed).expect_err("owner");
+    assert!(!format!("{error:?} {error}").contains("private-owner-marker"));
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn legacy_management_and_missing_worker_never_become_a_stop_request() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let mut next = before.workspace().state().clone();
+    next.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::ApplicationExit,
+        requested_at_millis: 1,
+    });
+    let legacy = fixture
+        .store
+        .replace_remote_workspace(before.workspace(), &next)
+        .expect("legacy intent");
+    assert_eq!(
+        stop(&fixture, &config()),
+        Err(ConfiguredStopError::Stop(Error::ManagementConflict))
+    );
+    assert_eq!(fixture.current().workspace(), &legacy);
+    next.spec.workspace_local_id = "dormant".into();
+    next.runtime = None;
+    next.checkpoint = None;
+    let dormant = fixture.store.create_remote_workspace(OWNER, &next).expect("dormant");
+    assert_eq!(
+        stop_configured_remote_environment(&fixture.store, &config(), &dormant.environment_summary()),
+        Err(ConfiguredStopError::Stop(Error::MissingAllocation))
+    );
+    let unobserved = fixture
+        .store
+        .allocate_remote_runtime(&dormant, i64::MAX)
+        .expect("allocate");
+    assert_eq!(
+        stop_configured_remote_environment(&fixture.store, &config(), &unobserved.workspace().environment_summary()),
+        Err(ConfiguredStopError::Stop(Error::MissingWorker))
+    );
+    assert_eq!(
+        fixture.store.load_remote_allocation(OWNER, "dormant").expect("read"),
+        Some(unobserved)
+    );
+}
+
+#[test]
+fn unavailable_explicit_endpoint_retains_intent_and_requires_a_refreshed_retry() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let selected = before.workspace().environment_summary();
+    assert_eq!(
+        stop(&fixture, &config()),
+        Err(ConfiguredStopError::Stop(Error::ProviderUnavailable))
+    );
+    let stopping = fixture.current();
+    assert!(matches!(fixture.phase(), RemoteRuntimePhase::Stopping { .. }));
+    let mut expected = before.workspace().state().clone();
+    expected.runtime.as_mut().expect("runtime").phase = fixture.phase();
+    assert_eq!(stopping.workspace().state(), &expected);
+    assert_eq!(stopping.workspace().revision(), before.workspace().revision() + 1);
+    assert_eq!(stopping.workflow(), before.workflow());
+    let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("fresh client");
+    assert_eq!(
+        stop_configured_remote_environment(&reopened, &config(), &selected),
+        Err(ConfiguredStopError::Stop(Error::StateChanged))
+    );
+    assert_eq!(
+        stop_configured_remote_environment(&reopened, &config(), &stopping.workspace().environment_summary()),
+        Err(ConfiguredStopError::Stop(Error::ProviderUnavailable))
+    );
+    assert_eq!(fixture.current(), stopping);
+}

--- a/crates/horizon-core/src/remote_workspace/stop/tests/configured.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests/configured.rs
@@ -79,7 +79,7 @@ fn every_changed_selection_field_is_rejected_before_provider_access() {
     let fixture = Fixture::new();
     let before = fixture.current();
     let original = before.workspace().environment_summary();
-    let mut changed = vec![original.clone(); 11];
+    let mut changed = vec![original.clone(); 12];
     changed[0].revision += 1;
     changed[1].repository = "another/repository".into();
     changed[2].generation += 1;
@@ -91,6 +91,7 @@ fn every_changed_selection_field_is_rejected_before_provider_access() {
     changed[8].worker_identity.as_mut().expect("worker").resource_id = "b".repeat(64);
     changed[9].worker_identity = None;
     changed[10].profile = "another-profile".into();
+    changed[11].lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
     let mut profiles = config();
     profiles.local_docker.push(LocalDockerProfile {
         name: "another-profile".into(),
@@ -114,6 +115,28 @@ fn every_changed_selection_field_is_rejected_before_provider_access() {
         Err(ConfiguredStopError::Stop(Error::StateChanged))
     );
     assert_eq!(fixture.current().workspace(), &updated);
+}
+
+#[test]
+fn timed_allocations_with_a_valid_profile_are_rejected_without_intent() {
+    let future = time::OffsetDateTime::now_utc() + time::Duration::seconds(900);
+    for deadline in [future, time::OffsetDateTime::UNIX_EPOCH] {
+        let fixture = Fixture::with_lifetime(InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: deadline
+                .format(&time::format_description::well_known::Rfc3339)
+                .expect("valid deadline"),
+        }));
+        let before = fixture.current();
+        assert_eq!(
+            before.workspace().environment_summary().lifetime,
+            WorkerLifetime::TimeLimited { seconds: 900 }
+        );
+        assert_eq!(
+            stop(&fixture, &config()),
+            Err(ConfiguredStopError::Stop(Error::UnsupportedLifetime))
+        );
+        assert_eq!(fixture.current(), before);
+    }
 }
 
 #[test]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -194,6 +194,11 @@ back into large multi-purpose modules.
   reasons remain distinct; saved completion is not current provider status.
   This durable entrypoint admits only persistent execution: timed creation/expiry
   cleanup needs separate coordination before it can promise retained Stop intent.
+- `remote_workspace/stop/configured.rs` admits one explicitly confirmed saved
+  selection through its exact named local provider profile. It reloads the owned
+  record and compares the full summary/revision before durable Stop coordination,
+  returning only overview-safe metadata. Unsupported profiles and stale selections
+  gain no fallback authority; failures may require refreshing retained Stop intent.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -197,7 +197,8 @@ back into large multi-purpose modules.
 - `remote_workspace/stop/configured.rs` admits one explicitly confirmed saved
   selection through its exact named local provider profile. It reloads the owned
   record and compares the full summary/revision before durable Stop coordination,
-  returning only overview-safe metadata. Unsupported profiles and stale selections
+  returning only overview-safe metadata. It preserves persistent-only admission;
+  unsupported profiles and stale selections
   gain no fallback authority; failures may require refreshing retained Stop intent.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,


### PR DESCRIPTION
## Purpose

Admit one explicitly confirmed saved environment through its exact named local
provider profile into the durable Stop coordinator. Refs #383.

## Behavior

Reload and compare the complete owned summary/revision before Stop. Reject stale
or foreign selections, unsupported providers, unconfigured/duplicate/invalid
profiles and timed execution. Preserve the coordinator's persistent-only guard;
there is no ambient endpoint, private-key access, allocation, restart, deletion
or provider fallback. Return only overview-safe saved metadata, not live status.

Provider failure can leave durable intent, so callers must refresh before an
explicit retry. Ordinary client/view closure never invokes this API. UI controls,
cloud-provider Stop, checkpointing and the broader feature remain separate.

## Validation

- Seven focused regressions cover exact profile matching, complete summary drift
  including lifetime, foreign/malformed ownership, missing allocation/worker,
  legacy management intent, diagnostics redaction and genuine future/expired
  timed allocations with unchanged snapshots.
- Full exact-commit matrix passed on the actual merged prerequisite: format,
  maintainability, version sync, default/speech workspace tests and blocking,
  strict and pedantic Clippy. Independent local source and fixture reviews passed.
- Actual local-provider API smoke: stale/foreign/unconfigured selections left the
  same worker running and the logical store unchanged. Explicit Stop retained its
  exact inactive identity and synthetic repository/task bytes with the generated
  SSH key unavailable. Only expected Stop revisions changed; unrelated state stayed
  identical. Fresh-client retry caused no restart or duplicate allocation.
- After identity/image/label-verified cleanup of only the disposable test worker,
  absent-resource retry preserved saved identity/intent and created nothing.
  The generated synthetic store and keys were removed.

No UI, dependency, configuration-default, image or release change.
