### PR TITLE
feat(remote): add explicit environment Stop controls

### DIFF
--- a/crates/horizon-ui/src/app/remote_environments.rs
+++ b/crates/horizon-ui/src/app/remote_environments.rs
@@ -2,6 +2,7 @@
 
 mod observation;
 mod paint;
+mod stop;
 
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 
@@ -20,6 +21,8 @@ pub(super) struct RemoteEnvironments {
     pending: Option<PendingLoad>,
     refresh_when_idle: bool,
     observation: observation::ObservationState,
+    stop: stop::StopState,
+    refresh_after_stop: bool,
 }
 
 struct InventoryPage {
@@ -56,6 +59,9 @@ enum InventoryAction {
     Retry,
     Select(usize),
     Observe,
+    RequestStop,
+    ConfirmStop,
+    CancelStop,
 }
 
 struct WakeOnDrop(Context);
@@ -81,6 +87,7 @@ impl RemoteEnvironments {
         self.selected = None;
         self.failure = None;
         self.observation.invalidate();
+        self.stop.invalidate();
         if let Some(pending) = &mut self.pending {
             pending.discard = true;
             self.refresh_when_idle = true;
@@ -93,6 +100,8 @@ impl RemoteEnvironments {
     fn close(&mut self) {
         self.open = false;
         self.observation.invalidate();
+        self.stop.invalidate();
+        self.refresh_after_stop = false;
         self.refresh_when_idle = false;
         if let Some(pending) = &mut self.pending {
             pending.discard = true;
@@ -104,6 +113,7 @@ impl RemoteEnvironments {
             return;
         }
         self.observation.invalidate();
+        self.stop.cancel_confirmation();
         let (tx, rx) = mpsc::sync_channel(1);
         let home = home.clone();
         let requested_cursor = cursor.clone();
@@ -147,6 +157,7 @@ impl RemoteEnvironments {
 
     fn accept_result(&mut self, cursor: Option<String>, result: Result<InventoryPage, LoadError>) {
         self.observation.invalidate();
+        self.stop.cancel_confirmation();
         match result {
             Ok(page) => {
                 let previous = self
@@ -169,12 +180,26 @@ impl RemoteEnvironments {
     }
 
     fn apply(&mut self, action: InventoryAction, home: &HorizonHome, ctx: &Context) {
+        if self.open
+            && self.pending.is_none()
+            && matches!(
+                action,
+                InventoryAction::Refresh | InventoryAction::First | InventoryAction::Next | InventoryAction::Retry
+            )
+        {
+            self.stop.invalidate();
+        }
         match action {
-            InventoryAction::None | InventoryAction::Observe => {}
+            InventoryAction::None
+            | InventoryAction::Observe
+            | InventoryAction::RequestStop
+            | InventoryAction::ConfirmStop => {}
+            InventoryAction::CancelStop => self.stop.cancel_confirmation(),
             InventoryAction::Close => self.close(),
             InventoryAction::Select(index) => {
                 if self.selected != Some(index) && self.page.as_ref().is_some_and(|page| index < page.rows.len()) {
                     self.observation.invalidate();
+                    self.stop.invalidate();
                     self.selected = Some(index);
                 }
             }
@@ -193,8 +218,9 @@ impl RemoteEnvironments {
         }
     }
 
-    pub(super) fn invalidate_observation(&mut self) {
+    pub(super) fn invalidate_provider_state(&mut self) {
         self.observation.invalidate();
+        self.stop.invalidate();
     }
 
     fn start_observation(
@@ -203,7 +229,7 @@ impl RemoteEnvironments {
         config: &horizon_core::remote_provider_config::RemoteProviderConfig,
         ctx: &Context,
     ) {
-        if !self.open || self.pending.is_some() {
+        if !self.open || self.pending.is_some() || self.stop.is_pending() {
             return;
         }
         if let Some(row) = self
@@ -212,6 +238,44 @@ impl RemoteEnvironments {
             .and_then(|page| self.selected.and_then(|index| page.rows.get(index)))
         {
             self.observation.start(home, config, &row.summary, ctx);
+        }
+    }
+
+    fn stop_action(
+        &mut self,
+        action: InventoryAction,
+        home: &HorizonHome,
+        config: &horizon_core::remote_provider_config::RemoteProviderConfig,
+        ctx: &Context,
+    ) {
+        if !self.open || self.pending.is_some() || self.observation.is_pending() {
+            return;
+        }
+        let Some(summary) = self
+            .page
+            .as_ref()
+            .and_then(|page| self.selected.and_then(|index| page.rows.get(index)))
+            .map(|row| row.summary.clone())
+        else {
+            return;
+        };
+        match action {
+            InventoryAction::RequestStop => self.stop.prepare(&summary, config, ctx),
+            InventoryAction::ConfirmStop if self.stop.start(home, config, &summary, ctx) => {
+                self.observation.invalidate();
+            }
+            _ => {}
+        }
+    }
+
+    fn drain_stop(&mut self, home: &HorizonHome, ctx: &Context) {
+        if self.stop.drain_result() {
+            self.observation.invalidate();
+            self.refresh_after_stop = self.open;
+        }
+        if self.refresh_after_stop && self.pending.is_none() {
+            self.refresh_after_stop = false;
+            self.start_load(home, ctx, self.page_cursor.clone());
         }
     }
 }
@@ -237,6 +301,7 @@ impl HorizonApp {
     pub(super) fn render_remote_environments(&mut self, ctx: &Context) -> Option<egui::InputState> {
         self.remote_environments.drain_result();
         self.remote_environments.observation.drain_result();
+        self.remote_environments.drain_stop(self.session_store.home(), ctx);
         if self.remote_environments.refresh_when_idle && self.remote_environments.pending.is_none() {
             self.remote_environments.refresh_when_idle = false;
             self.remote_environments
@@ -248,6 +313,14 @@ impl HorizonApp {
             let action = paint::show(ctx, &self.remote_environments);
             if matches!(action, InventoryAction::Observe) {
                 self.remote_environments.start_observation(
+                    self.session_store.home(),
+                    &self.template_config.remote,
+                    ctx,
+                );
+            }
+            if matches!(action, InventoryAction::RequestStop | InventoryAction::ConfirmStop) {
+                self.remote_environments.stop_action(
+                    action,
                     self.session_store.home(),
                     &self.template_config.remote,
                     ctx,

--- a/crates/horizon-ui/src/app/remote_environments/observation/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/observation/tests.rs
@@ -298,6 +298,6 @@ fn config_invalidation_after_empty_board_paint_requests_one_followup_frame() {
     app.apply_runtime_config(&config);
     assert_eq!(requests.load(Ordering::Relaxed), 1);
     assert!(app.remote_environments.observation.last_success.is_none());
-    app.remote_environments.invalidate_observation();
+    app.remote_environments.invalidate_provider_state();
     assert_eq!(requests.load(Ordering::Relaxed), 1, "no passive invalidation loop");
 }

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -150,6 +150,9 @@ fn render_controls(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut I
             ui.label("Loading saved inventory…");
         }
     });
+    if state.stop.is_pending() {
+        ui.label("An explicitly confirmed Stop is pending. Closing this overview does not cancel it.");
+    }
     if let Some(failure) = &state.failure {
         let message = match failure.error {
             LoadError::OpenStore => "Cannot open the remote inventory store. Check its permissions and format.",
@@ -193,6 +196,13 @@ fn render_content(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut In
     }
     if let Some(row) = state.selected.and_then(|index| page.rows.get(index)) {
         render_observation(ui, state, action);
+        super::stop::show(
+            ui,
+            &state.stop,
+            &row.summary,
+            state.pending.is_none() && !state.observation.is_pending(),
+            action,
+        );
         ui.separator();
         ui.strong("Saved environment details");
         ui.label(
@@ -222,7 +232,7 @@ fn render_observation(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mu
     ui.horizontal_wrapped(|ui| {
         ui.strong("Provider status");
         let check = ui.add_enabled(
-            state.pending.is_none() && !observation.is_pending(),
+            state.pending.is_none() && !observation.is_pending() && !state.stop.is_pending(),
             egui::Button::new("Check provider status"),
         );
         #[cfg(test)]

--- a/crates/horizon-ui/src/app/remote_environments/stop.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop.rs
@@ -1,0 +1,229 @@
+//! Explicit confirmation and one bounded background Stop; client closure is not cancellation.
+
+mod paint;
+
+use super::{Context, HorizonHome, InventoryAction, RemoteEnvironmentSummary, WakeOnDrop};
+use horizon_core::{
+    cloud_run::{CloudProvider, CloudWorkflowStore},
+    remote_provider_config::RemoteProviderConfig,
+    remote_workspace::{
+        RemoteRuntimePhase,
+        stop::{ConfiguredStopError, stop_configured_remote_environment},
+    },
+};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+
+#[derive(Default)]
+pub(super) struct StopState {
+    confirmation: Option<Confirmation>,
+    pending: Option<PendingStop>,
+    notice: Option<StopNotice>,
+    repaint_context: Option<Context>,
+}
+
+struct Confirmation {
+    expected: RemoteEnvironmentSummary,
+    config: RemoteProviderConfig,
+}
+
+struct PendingStop {
+    rx: Receiver<Result<RemoteEnvironmentSummary, StopError>>,
+    expected: RemoteEnvironmentSummary,
+    discard: bool,
+}
+
+struct StopNotice {
+    expected: RemoteEnvironmentSummary,
+    message: String,
+    succeeded: bool,
+}
+
+#[derive(Debug)]
+enum StopError {
+    WorkerUnavailable,
+    StorageUnavailable,
+    SelectionChanged,
+    Stop(ConfiguredStopError),
+}
+
+impl StopError {
+    fn message(self) -> String {
+        match self {
+            Self::WorkerUnavailable => {
+                "Stop could not finish. Refresh saved inventory before explicitly retrying.".into()
+            }
+            Self::StorageUnavailable => "The saved environment could not be safely accessed for Stop.".into(),
+            Self::SelectionChanged => {
+                "The Stop result does not match this environment. Refresh before retrying.".into()
+            }
+            Self::Stop(error) => error.to_string(),
+        }
+    }
+}
+
+impl StopState {
+    pub(super) fn is_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+
+    pub(super) fn cancel_confirmation(&mut self) {
+        if self.confirmation.take().is_some() {
+            self.wake();
+        }
+    }
+
+    pub(super) fn invalidate(&mut self) {
+        let had_confirmation = self.confirmation.take().is_some();
+        let had_notice = self.notice.take().is_some();
+        let pending_changed = self.pending.as_ref().is_some_and(|pending| !pending.discard);
+        if let Some(pending) = &mut self.pending {
+            pending.discard = true;
+        }
+        if had_confirmation || had_notice || pending_changed {
+            self.wake();
+        }
+    }
+
+    fn wake(&self) {
+        if let Some(ctx) = &self.repaint_context {
+            ctx.request_repaint();
+        }
+    }
+
+    pub(super) fn prepare(
+        &mut self,
+        expected: &RemoteEnvironmentSummary,
+        config: &RemoteProviderConfig,
+        ctx: &Context,
+    ) {
+        if self.is_pending() || !supported(expected) {
+            return;
+        }
+        self.repaint_context = Some(ctx.clone());
+        self.confirmation = Some(Confirmation {
+            expected: expected.clone(),
+            config: config.clone(),
+        });
+        self.notice = None;
+        ctx.request_repaint();
+    }
+
+    pub(super) fn start(
+        &mut self,
+        home: &HorizonHome,
+        config: &RemoteProviderConfig,
+        selected: &RemoteEnvironmentSummary,
+        ctx: &Context,
+    ) -> bool {
+        if self.is_pending() {
+            return false;
+        }
+        let Some(confirmation) = self.confirmation.take() else {
+            return false;
+        };
+        if confirmation.expected != *selected || confirmation.config != *config {
+            self.wake();
+            return false;
+        }
+        let expected = confirmation.expected.clone();
+        let (tx, rx) = mpsc::sync_channel(1);
+        let home = home.clone();
+        let wake = WakeOnDrop(ctx.clone());
+        let worker = std::thread::Builder::new()
+            .name("remote-environment-stop".into())
+            .spawn(move || {
+                let _wake = wake;
+                let result = execute(&home, &confirmation.config, &confirmation.expected);
+                let _ = tx.send(result);
+            });
+        match worker {
+            Ok(_) => {
+                self.pending = Some(PendingStop {
+                    rx,
+                    expected,
+                    discard: false,
+                });
+            }
+            Err(_) => self.notice = Some(StopNotice::new(expected, Err(StopError::WorkerUnavailable))),
+        }
+        ctx.request_repaint();
+        self.is_pending()
+    }
+
+    pub(super) fn drain_result(&mut self) -> bool {
+        let Some(pending) = self.pending.take() else {
+            return false;
+        };
+        let result = match pending.rx.try_recv() {
+            Ok(result) => result,
+            Err(TryRecvError::Empty) => {
+                self.pending = Some(pending);
+                return false;
+            }
+            Err(TryRecvError::Disconnected) => Err(StopError::WorkerUnavailable),
+        };
+        if !pending.discard {
+            self.notice = Some(StopNotice::new(pending.expected, result));
+        }
+        true
+    }
+}
+
+impl StopNotice {
+    fn new(expected: RemoteEnvironmentSummary, result: Result<RemoteEnvironmentSummary, StopError>) -> Self {
+        let result = result.and_then(|saved| {
+            if !same_target(&expected, &saved)
+                || saved.revision < expected.revision
+                || !matches!(saved.saved_phase, Some(RemoteRuntimePhase::Stopped { .. }))
+            {
+                return Err(StopError::SelectionChanged);
+            }
+            Ok(())
+        });
+        let succeeded = result.is_ok();
+        let message = match result {
+            Ok(()) => "Stop verified and saved. This is not a live provider check.".into(),
+            Err(error) => error.message(),
+        };
+        Self {
+            expected,
+            message,
+            succeeded,
+        }
+    }
+}
+
+fn supported(summary: &RemoteEnvironmentSummary) -> bool {
+    summary.provider == CloudProvider::LocalDocker && summary.worker_identity.is_some()
+}
+
+fn same_target(left: &RemoteEnvironmentSummary, right: &RemoteEnvironmentSummary) -> bool {
+    left.workspace_local_id == right.workspace_local_id
+        && left.owning_session_id == right.owning_session_id
+        && left.provider == right.provider
+        && left.profile == right.profile
+        && left.generation == right.generation
+        && left.worker_identity == right.worker_identity
+}
+
+fn execute(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    expected: &RemoteEnvironmentSummary,
+) -> Result<RemoteEnvironmentSummary, StopError> {
+    let store = CloudWorkflowStore::open(home).map_err(|_| StopError::StorageUnavailable)?;
+    stop_configured_remote_environment(&store, config, expected).map_err(StopError::Stop)
+}
+
+pub(super) fn show(
+    ui: &mut egui::Ui,
+    state: &StopState,
+    selected: &RemoteEnvironmentSummary,
+    idle: bool,
+    action: &mut InventoryAction,
+) {
+    paint::show(ui, state, selected, idle, action);
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-ui/src/app/remote_environments/stop.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop.rs
@@ -4,7 +4,7 @@ mod paint;
 
 use super::{Context, HorizonHome, InventoryAction, RemoteEnvironmentSummary, WakeOnDrop};
 use horizon_core::{
-    cloud_run::{CloudProvider, CloudWorkflowStore},
+    cloud_run::{CloudProvider, CloudWorkflowStore, WorkerLifetime},
     remote_provider_config::RemoteProviderConfig,
     remote_workspace::{
         RemoteRuntimePhase,
@@ -194,7 +194,9 @@ impl StopNotice {
 }
 
 fn supported(summary: &RemoteEnvironmentSummary) -> bool {
-    summary.provider == CloudProvider::LocalDocker && summary.worker_identity.is_some()
+    summary.provider == CloudProvider::LocalDocker
+        && summary.lifetime == WorkerLifetime::Persistent
+        && summary.worker_identity.is_some()
 }
 
 fn same_target(left: &RemoteEnvironmentSummary, right: &RemoteEnvironmentSummary) -> bool {

--- a/crates/horizon-ui/src/app/remote_environments/stop/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop/paint.rs
@@ -19,16 +19,20 @@ pub(super) fn show(
             egui::Button::new("Stop environment…"),
         );
         #[cfg(test)]
-        ui.ctx()
-            .data_mut(|data| data.insert_temp(egui::Id::new("stop-request-test"), request.rect));
+        ui.ctx().data_mut(|data| {
+            data.insert_temp(egui::Id::new("stop-request-test"), request.rect);
+            data.insert_temp(egui::Id::new("stop-request-enabled-test"), request.enabled());
+        });
         if request.clicked() {
             *action = InventoryAction::RequestStop;
         }
     });
     if !supported(selected) {
         ui.label(
-            RichText::new("Stop requires a retained local-provider worker. Cloud Stop is not supported yet.")
-                .color(theme::FG_DIM()),
+            RichText::new(
+                "Stop requires a retained persistent local-provider worker. Timed and cloud Stop are not supported yet.",
+            )
+            .color(theme::FG_DIM()),
         );
     }
     if let Some(confirmation) = &state.confirmation {

--- a/crates/horizon-ui/src/app/remote_environments/stop/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop/paint.rs
@@ -1,0 +1,102 @@
+//! Selected-environment Stop controls; painting grants no provider authority.
+
+use super::{Confirmation, InventoryAction, RemoteEnvironmentSummary, StopState, same_target, supported};
+use crate::theme;
+use egui::RichText;
+
+pub(super) fn show(
+    ui: &mut egui::Ui,
+    state: &StopState,
+    selected: &RemoteEnvironmentSummary,
+    idle: bool,
+    action: &mut InventoryAction,
+) {
+    ui.separator();
+    ui.horizontal_wrapped(|ui| {
+        ui.strong("Explicit Stop");
+        let request = ui.add_enabled(
+            idle && !state.is_pending() && supported(selected),
+            egui::Button::new("Stop environment…"),
+        );
+        #[cfg(test)]
+        ui.ctx()
+            .data_mut(|data| data.insert_temp(egui::Id::new("stop-request-test"), request.rect));
+        if request.clicked() {
+            *action = InventoryAction::RequestStop;
+        }
+    });
+    if !supported(selected) {
+        ui.label(
+            RichText::new("Stop requires a retained local-provider worker. Cloud Stop is not supported yet.")
+                .color(theme::FG_DIM()),
+        );
+    }
+    if let Some(confirmation) = &state.confirmation {
+        confirm(ui, confirmation, idle && !state.is_pending(), action);
+    }
+    if let Some(notice) = &state.notice
+        && same_target(&notice.expected, selected)
+    {
+        ui.label("Last explicit Stop result:");
+        ui.colored_label(
+            if notice.succeeded {
+                theme::FG()
+            } else {
+                theme::PALETTE_YELLOW()
+            },
+            &notice.message,
+        );
+        if !notice.succeeded {
+            ui.label("Saved intent and identity may remain. Refresh the saved page before explicitly retrying.");
+        }
+    }
+}
+
+fn confirm(ui: &mut egui::Ui, confirmation: &Confirmation, enabled: bool, action: &mut InventoryAction) {
+    let selected = &confirmation.expected;
+    ui.strong("Stop this environment?");
+    for (label, value) in [
+        ("Workspace", selected.workspace_local_id.as_str()),
+        ("Owning session", selected.owning_session_id.as_str()),
+        ("Provider profile", selected.profile.as_str()),
+        (
+            "Exact resource ID",
+            selected
+                .worker_identity
+                .as_ref()
+                .map_or("Unavailable", |identity| identity.resource_id.as_str()),
+        ),
+    ] {
+        ui.horizontal_wrapped(|ui| {
+            ui.label(label);
+            ui.add(
+                egui::Label::new(RichText::new(value).monospace())
+                    .wrap()
+                    .selectable(true),
+            );
+        });
+    }
+    ui.colored_label(
+        theme::PALETTE_YELLOW(),
+        "Stops every process in this worker. Unsaved process memory is lost.",
+    );
+    ui.label("Retains this local container and its files. No checkpoint or backup is created. This does not delete the environment.");
+    ui.horizontal_wrapped(|ui| {
+        let cancel = ui.button("Cancel");
+        let confirm = ui.add_enabled(
+            enabled,
+            egui::Button::new("Stop environment").stroke(egui::Stroke::new(1.0, theme::PALETTE_RED())),
+        );
+        #[cfg(test)]
+        ui.ctx().data_mut(|data| {
+            data.insert_temp(egui::Id::new("stop-cancel-test"), cancel.rect);
+            data.insert_temp(egui::Id::new("stop-confirm-test"), confirm.rect);
+        });
+        if cancel.clicked() {
+            *action = InventoryAction::CancelStop;
+        }
+        if confirm.clicked() {
+            *action = InventoryAction::ConfirmStop;
+        }
+    });
+}

--- a/crates/horizon-ui/src/app/remote_environments/stop/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop/tests.rs
@@ -1,0 +1,345 @@
+use super::super::{InventoryPage, RemoteEnvironments, paint as inventory_paint};
+use super::*;
+use horizon_core::cloud_run::{
+    CloudJobId, CloudWorkflowId, WorkerLifetime, interactive_worker::InteractiveWorkerIdentity,
+    local_docker::LocalDockerProfile,
+};
+
+fn summary() -> RemoteEnvironmentSummary {
+    let workflow_id = CloudWorkflowId::new();
+    let job_id = CloudJobId::new();
+    RemoteEnvironmentSummary {
+        workspace_local_id: "synthetic-workspace".into(),
+        owning_session_id: "00000000-0000-4000-8000-000000000001".into(),
+        revision: 1,
+        repository: "example/project".into(),
+        provider: CloudProvider::LocalDocker,
+        profile: "development".into(),
+        lifetime: WorkerLifetime::Persistent,
+        generation: 1,
+        saved_phase: Some(RemoteRuntimePhase::Reconciling),
+        workflow_id: Some(workflow_id),
+        job_id: Some(job_id),
+        worker_identity: Some(InteractiveWorkerIdentity {
+            provider: CloudProvider::LocalDocker,
+            workflow_id,
+            job_id,
+            resource_id: "a".repeat(64),
+        }),
+        checkpoint: None,
+        panel_count: 1,
+    }
+}
+
+fn config() -> RemoteProviderConfig {
+    RemoteProviderConfig {
+        local_docker: vec![LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///unused-stop-fixture/docker.sock".into(),
+        }],
+    }
+}
+
+fn completed(expected: &RemoteEnvironmentSummary) -> RemoteEnvironmentSummary {
+    let mut saved = expected.clone();
+    saved.revision += 2;
+    saved.saved_phase = Some(RemoteRuntimePhase::Stopped {
+        requested_at_millis: 1,
+        observed_at_millis: 2,
+    });
+    saved
+}
+
+fn pending(
+    state: &mut StopState,
+    expected: &RemoteEnvironmentSummary,
+) -> mpsc::SyncSender<Result<RemoteEnvironmentSummary, StopError>> {
+    let (tx, rx) = mpsc::sync_channel(1);
+    state.pending = Some(PendingStop {
+        rx,
+        expected: expected.clone(),
+        discard: false,
+    });
+    tx
+}
+
+fn page(expected: &RemoteEnvironmentSummary) -> InventoryPage {
+    let mut other = expected.clone();
+    other.workspace_local_id = "second-workspace".into();
+    InventoryPage {
+        rows: vec![
+            inventory_paint::InventoryRow::new(expected.clone()),
+            inventory_paint::InventoryRow::new(other),
+        ],
+        next_cursor: None,
+    }
+}
+
+fn view(expected: &RemoteEnvironmentSummary) -> RemoteEnvironments {
+    RemoteEnvironments {
+        open: true,
+        selected: Some(0),
+        page: Some(page(expected)),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn confirmation_is_inert_and_exact_selection_and_config_are_required() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let expected = summary();
+    let ctx = Context::default();
+    let mut state = StopState::default();
+    assert!(!state.start(&home, &config(), &expected, &ctx));
+    state.prepare(&expected, &config(), &ctx);
+    assert!(state.confirmation.is_some());
+    assert!(!home.cloud_workflow_store_path().exists());
+    state.cancel_confirmation();
+    assert!(!state.start(&home, &config(), &expected, &ctx));
+    state.prepare(&expected, &config(), &ctx);
+    let mut changed = expected.clone();
+    changed.revision += 1;
+    assert!(!state.start(&home, &config(), &changed, &ctx));
+    state.prepare(&expected, &config(), &ctx);
+    assert!(!state.start(&home, &RemoteProviderConfig::default(), &expected, &ctx));
+    for provider in [CloudProvider::Azure, CloudProvider::RunPod] {
+        changed.provider = provider;
+        state.prepare(&changed, &config(), &ctx);
+        assert!(state.confirmation.is_none());
+    }
+    changed = expected;
+    changed.worker_identity = None;
+    state.prepare(&changed, &config(), &ctx);
+    assert!(state.confirmation.is_none());
+    assert!(!state.is_pending());
+    assert!(!home.cloud_workflow_store_path().exists());
+}
+
+#[test]
+fn cancel_selection_page_and_close_clear_only_unconfirmed_intent() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let expected = summary();
+    let ctx = Context::default();
+    for action in [
+        InventoryAction::CancelStop,
+        InventoryAction::Select(1),
+        InventoryAction::Close,
+    ] {
+        let mut state = view(&expected);
+        state.stop_action(InventoryAction::RequestStop, &home, &config(), &ctx);
+        assert!(state.stop.confirmation.is_some());
+        state.apply(action, &home, &ctx);
+        state.stop_action(InventoryAction::ConfirmStop, &home, &config(), &ctx);
+        assert!(state.stop.confirmation.is_none());
+        assert!(!state.stop.is_pending());
+    }
+    let mut state = view(&expected);
+    state.stop.prepare(&expected, &config(), &ctx);
+    state.accept_result(None, Ok(page(&expected)));
+    assert!(state.stop.confirmation.is_none());
+    assert!(!home.cloud_workflow_store_path().exists());
+}
+
+#[test]
+fn confirmed_operation_stays_single_flight_through_close_and_invalidation() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let expected = summary();
+    let ctx = Context::default();
+    let mut state = view(&expected);
+    let tx = pending(&mut state.stop, &expected);
+    for _ in 0..100 {
+        state.close();
+        state.open = true;
+        state.stop.prepare(&expected, &config(), &ctx);
+        assert!(!state.stop.start(&home, &config(), &expected, &ctx));
+        state.start_observation(&home, &config(), &ctx);
+        assert!(!state.observation.is_pending());
+        assert!(!state.stop.drain_result());
+        assert!(state.stop.is_pending());
+    }
+    tx.send(Ok(completed(&expected))).expect("send");
+    assert!(state.stop.drain_result());
+    assert!(
+        state.stop.notice.is_none(),
+        "closed selection discards presentation only"
+    );
+    assert!(!state.stop.is_pending());
+    assert!(!home.cloud_workflow_store_path().exists());
+}
+
+#[test]
+fn result_remains_readable_after_saved_page_refresh_but_is_bound_to_exact_target() {
+    let expected = summary();
+    for succeed in [true, false] {
+        let mut state = view(&expected);
+        let result = if succeed {
+            Ok(completed(&expected))
+        } else {
+            Err(StopError::StorageUnavailable)
+        };
+        pending(&mut state.stop, &expected).send(result).expect("send");
+        assert!(state.stop.drain_result());
+        state.accept_result(None, Ok(page(&completed(&expected))));
+        let notice = state.stop.notice.as_ref().expect("last explicit result");
+        assert_eq!(notice.succeeded, succeed);
+        assert!(same_target(&notice.expected, &completed(&expected)));
+        let mut another = expected.clone();
+        another.worker_identity.as_mut().expect("identity").resource_id = "b".repeat(64);
+        assert!(!same_target(&notice.expected, &another));
+        another = expected.clone();
+        another.owning_session_id = "00000000-0000-4000-8000-000000000002".into();
+        assert!(!same_target(&notice.expected, &another));
+        assert!(!notice.message.is_empty());
+    }
+}
+
+#[test]
+fn manual_page_actions_discard_notices_but_retain_the_confirmed_operation() {
+    use super::super::{LoadError, LoadFailure};
+    let fixture = tempfile::tempdir().expect("fixture");
+    let expected = summary();
+    let ctx = Context::default();
+    for (index, action) in [
+        InventoryAction::Refresh,
+        InventoryAction::First,
+        InventoryAction::Next,
+        InventoryAction::Retry,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let home = HorizonHome::from_root(fixture.path().join(format!("navigation-{index}")));
+        let mut state = view(&expected);
+        state.page.as_mut().expect("page").next_cursor = Some("next-workspace".into());
+        state.page_cursor = Some("previous-workspace".into());
+        state.failure = Some(LoadFailure {
+            error: LoadError::ReadPage,
+            cursor: None,
+        });
+        state.stop.notice = Some(StopNotice::new(expected.clone(), Ok(completed(&expected))));
+        let tx = pending(&mut state.stop, &expected);
+        state.apply(action, &home, &ctx);
+        assert!(state.stop.notice.is_none());
+        assert!(state.stop.is_pending());
+        let load = state.pending.take().expect("explicit page read");
+        assert!(load.rx.recv_timeout(std::time::Duration::from_secs(2)).is_ok());
+        tx.send(Ok(completed(&expected))).expect("send");
+        assert!(state.stop.drain_result());
+        assert!(
+            state.stop.notice.is_none(),
+            "navigation discards the late presentation, not the operation"
+        );
+    }
+}
+
+#[test]
+fn unexpected_completion_and_disconnected_worker_never_claim_success() {
+    let expected = summary();
+    let mut changes = vec![completed(&expected); 4];
+    changes[0].workspace_local_id = "foreign-workspace".into();
+    changes[1].generation += 1;
+    changes[2].saved_phase = Some(RemoteRuntimePhase::Ready);
+    changes[3].revision = 0;
+    for changed in changes {
+        let notice = StopNotice::new(expected.clone(), Ok(changed));
+        assert!(!notice.succeeded);
+        assert!(notice.message.contains("does not match"));
+    }
+    let mut state = StopState::default();
+    drop(pending(&mut state, &expected));
+    assert!(state.drain_result());
+    let notice = state.notice.as_ref().expect("worker failure");
+    assert!(!notice.succeeded);
+    assert!(notice.message.contains("Refresh saved inventory"));
+}
+
+#[test]
+fn provider_reload_invalidates_confirmation_but_unrelated_visual_reload_does_not() {
+    let (_fixture, mut app) = crate::app::test_support::test_app();
+    let expected = summary();
+    app.remote_environments = view(&expected);
+    app.remote_environments
+        .stop
+        .prepare(&expected, &app.template_config.remote, &Context::default());
+    let mut updated = app.template_config.clone();
+    updated.window.width += 1.0;
+    app.apply_runtime_config(&updated);
+    assert!(app.remote_environments.stop.confirmation.is_some());
+    let tx = pending(&mut app.remote_environments.stop, &expected);
+    updated.remote = config();
+    app.apply_runtime_config(&updated);
+    assert!(app.remote_environments.stop.confirmation.is_none());
+    assert!(app.remote_environments.stop.is_pending());
+    tx.send(Ok(completed(&expected))).expect("send");
+    assert!(app.remote_environments.stop.drain_result());
+    assert!(app.remote_environments.stop.notice.is_none());
+}
+
+#[test]
+fn completion_queues_saved_refresh_behind_inventory_read_and_closed_view_does_not_load() {
+    use super::super::PendingLoad;
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    let expected = summary();
+    let ctx = Context::default();
+    let mut state = view(&expected);
+    let (inventory_tx, inventory_rx) = mpsc::sync_channel(1);
+    state.pending = Some(PendingLoad {
+        rx: inventory_rx,
+        cursor: None,
+        discard: false,
+    });
+    pending(&mut state.stop, &expected)
+        .send(Ok(completed(&expected)))
+        .expect("send");
+    state.drain_stop(&home, &ctx);
+    assert!(state.refresh_after_stop);
+    assert!(state.stop.notice.as_ref().is_some_and(|notice| notice.succeeded));
+    assert!(!home.cloud_workflow_store_path().exists());
+    inventory_tx.send(Ok(page(&expected))).expect("page");
+    state.drain_result();
+    state.drain_stop(&home, &ctx);
+    assert!(!state.refresh_after_stop);
+    let refresh = state.pending.take().expect("queued refresh started");
+    assert!(refresh.rx.recv_timeout(std::time::Duration::from_secs(2)).is_ok());
+    assert!(state.stop.notice.is_some());
+    let untouched = HorizonHome::from_root(fixture.path().join("closed"));
+    let tx = pending(&mut state.stop, &expected);
+    state.close();
+    tx.send(Ok(completed(&expected))).expect("send");
+    state.drain_stop(&untouched, &ctx);
+    assert!(!state.refresh_after_stop);
+    assert!(!untouched.cloud_workflow_store_path().exists());
+}
+
+#[test]
+fn confirmation_never_consumes_enter_as_an_implicit_stop() {
+    use crate::app::test_support::raw_input;
+    use crate::test_egui::DiscardTextures;
+    let ctx = Context::default();
+    let expected = summary();
+    let mut state = StopState::default();
+    state.prepare(&expected, &config(), &ctx);
+    for enter in [false, true] {
+        let mut input = raw_input([1100.0, 780.0], None);
+        if enter {
+            input.events.push(egui::Event::Key {
+                key: egui::Key::Enter,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::default(),
+            });
+        }
+        let mut action = InventoryAction::None;
+        let _ = ctx
+            .run_ui(input, |ui| show(ui, &state, &expected, true, &mut action))
+            .discard_textures();
+        assert!(matches!(action, InventoryAction::None));
+        assert!(state.confirmation.is_some());
+        assert!(!state.is_pending());
+    }
+}

--- a/crates/horizon-ui/src/app/remote_environments/stop/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop/tests.rs
@@ -102,7 +102,12 @@ fn confirmation_is_inert_and_exact_selection_and_config_are_required() {
     changed.revision += 1;
     assert!(!state.start(&home, &config(), &changed, &ctx));
     state.prepare(&expected, &config(), &ctx);
+    changed = expected.clone();
+    changed.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
+    assert!(!state.start(&home, &config(), &changed, &ctx));
+    state.prepare(&expected, &config(), &ctx);
     assert!(!state.start(&home, &RemoteProviderConfig::default(), &expected, &ctx));
+    changed = expected.clone();
     for provider in [CloudProvider::Azure, CloudProvider::RunPod] {
         changed.provider = provider;
         state.prepare(&changed, &config(), &ctx);
@@ -114,6 +119,46 @@ fn confirmation_is_inert_and_exact_selection_and_config_are_required() {
     assert!(state.confirmation.is_none());
     assert!(!state.is_pending());
     assert!(!home.cloud_workflow_store_path().exists());
+}
+
+#[test]
+fn retained_timed_workers_never_offer_or_prepare_stop_in_any_saved_stop_phase() {
+    use crate::app::test_support::raw_input;
+    use crate::test_egui::DiscardTextures;
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    for phase in [
+        RemoteRuntimePhase::Reconciling,
+        RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+        RemoteRuntimePhase::Stopped {
+            requested_at_millis: 1,
+            observed_at_millis: 2,
+        },
+    ] {
+        let ctx = Context::default();
+        let mut expected = summary();
+        expected.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
+        expected.saved_phase = Some(phase);
+        assert!(expected.worker_identity.is_some());
+        assert!(!supported(&expected));
+        let mut state = StopState::default();
+        let mut action = InventoryAction::None;
+        let _ = ctx
+            .run_ui(raw_input([1100.0, 780.0], None), |ui| {
+                show(ui, &state, &expected, true, &mut action);
+            })
+            .discard_textures();
+        assert_eq!(
+            ctx.data(|data| data.get_temp::<bool>(egui::Id::new("stop-request-enabled-test"))),
+            Some(false)
+        );
+        assert!(matches!(action, InventoryAction::None));
+        state.prepare(&expected, &config(), &ctx);
+        assert!(state.confirmation.is_none());
+        assert!(!state.start(&home, &config(), &expected, &ctx));
+        assert!(!state.is_pending());
+        assert!(!home.cloud_workflow_store_path().exists());
+    }
 }
 
 #[test]

--- a/crates/horizon-ui/src/app/settings/mod.rs
+++ b/crates/horizon-ui/src/app/settings/mod.rs
@@ -256,7 +256,7 @@ impl HorizonApp {
             self.sync_speech_global_hotkeys();
         }
         if self.template_config.remote != config.remote {
-            self.remote_environments.invalidate_observation();
+            self.remote_environments.invalidate_provider_state();
         }
         self.template_config = config.clone();
         self.shortcuts = resolve_shortcuts(config);

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -200,6 +200,11 @@ back into large multi-purpose modules.
   returning only overview-safe metadata. It preserves persistent-only admission;
   unsupported profiles and stale selections
   gain no fallback authority; failures may require refreshing retained Stop intent.
+- The overview's `remote_environments/stop.rs` owns only confirmation, single-flight
+  background execution and cached outcome presentation; its `stop/paint.rs` collects
+  explicit actions. Closing invalidates presentation, not an admitted operation.
+  Completion invalidates provider observations and refreshes saved inventory while
+  keeping its target-bound result readable. All mutation remains in core coordination.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership
   reconciliation. Its `models.rs` leaf owns profiles, persisted worker identity,
   lifecycle results and typed errors; `create_request.rs` owns serialized

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -202,7 +202,8 @@ back into large multi-purpose modules.
   gain no fallback authority; failures may require refreshing retained Stop intent.
 - The overview's `remote_environments/stop.rs` owns only confirmation, single-flight
   background execution and cached outcome presentation; its `stop/paint.rs` collects
-  explicit actions. Closing invalidates presentation, not an admitted operation.
+  explicit actions for retained persistent local workers; timed/cloud Stop stays
+  disabled. Closing invalidates presentation, not an admitted operation.
   Completion invalidates provider observations and refreshes saved inventory while
   keeping its target-bound result readable. All mutation remains in core coordination.
 - `cloud_run/runpod.rs` coordinates provider operations and exact ownership


### PR DESCRIPTION
## Purpose

Add explicitly confirmed Stop to the Remote Environments overview, using the
merged persistent-worker Stop coordinator. This is a focused step toward #383,
not completion of that issue.

## Behavior

- Select an exact retained persistent local environment, choose Stop, inspect
  workspace/owner/profile/full resource identity and consequences, then confirm.
  Every worker process stops and process memory is lost; the container/files
  remain. This does not disconnect only, delete, checkpoint or create a backup.
- Cancel, selection/page changes, refresh, Escape, unconfirmed client closure and
  provider-config changes cannot implicitly Stop. Visual-only reload preserves
  confirmation; timed/cloud workers and missing identities remain unsupported.
- Run one confirmed operation off the render thread. Disable overlapping Stop
  and provider checks; keep navigation responsive while pending. Overview closure
  discards presentation, not an admitted operation. Fresh startup requires an
  explicit retry and never resumes management automatically.
- Invalidate older provider observations on completion, refresh saved inventory
  and retain a readable target-bound result. Saved Stopped is not a live claim.

## Validation

- Independent full local review and final-base parity: clear on
  `b3d1009cee4a729bf999118be21defafebc72ed3` (tree `f2ef0a23`).
- Twenty-six targeted overview tests and precommit formatting, maintainability,
  version-sync and blocking/strict/pedantic lint tiers passed. Coverage includes
  timed records in every Stop phase, lifetime/config drift, inert confirmation,
  completion failures, stale results, automatic refresh and single-flight close.
- Final exact-head full matrix passed: default/speech workspace tests, formatting,
  maintainability, version-sync and blocking/strict/pedantic Clippy. The rebuilt
  debug binary is byte-identical to the inspected native candidate (`57b8c333`).
  The fresh real-provider API repeat passed all rejection/retention/retry/absence
  assertions; only its verified disposable worker and generated state were removed.
- Completed Linux native smoke on an isolated display, exact candidate PID and
  synthetic configuration: empty/populated overview, two owners/twenty records,
  pagination, modal input isolation, both themes, 800×600/1240×820 resize/Fit,
  exact confirmation/Enter/Cancel, selection/page/config invalidation and closure.
- An actual disposable retained worker kept the same task progressing after
  unconfirmed client closure with every saved record unchanged. Explicit Stop
  retained exact worker identity and binary repository/task bytes without its
  generated SSH key; only expected intent/completion phases and two revisions
  changed. All unrelated records stayed unchanged.
- Fresh-client delayed retry showed pending controls and responsive Escape,
  reopen and navigation. FinishedAt, restart count, request timestamp, saved
  snapshots and bytes remained unchanged. Verified absence preserved intent and
  never allocated a replacement. Only verified disposable fixtures were removed.
- Matched software-renderer samples showed no material regression: two settled
  four-second idle samples used 0.82/0.84 CPU seconds (candidate/baseline); matched
  empty-canvas and panel-chrome pointer totals were 12.17/12.51 and 12.23/12.50.
  Open-empty idle was 1.02/1.00 with matching frame counts. This is not a hardware
  GPU speedup claim. No provider polling or all-panel render work is added.

No release, cloud allocation, image publication, default-config migration,
existing-session mutation or remote backup/PC-off acceptance is included.
Reconnect, separate Cleanup/Delete, cloud integration and remote checkpointing
remain tracked in #383. Scope: seven source/test files, 822 changed source/test
lines, plus six architecture-documentation lines.
