### PR TITLE
refactor(remote): extract pinned worker SSH options

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -23,6 +23,8 @@ pub mod remote_environment_observation;
 mod remote_hosts;
 pub mod remote_provider_config;
 pub mod remote_ssh_identity;
+#[cfg(target_os = "linux")]
+mod remote_worker_ssh;
 pub mod remote_worker_status;
 pub mod remote_workspace;
 pub mod remote_workspace_recovery;

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -1,0 +1,78 @@
+//! Crate-private pinned SSH command construction, not remote attachment authority.
+
+use crate::{
+    cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, remote_worker_status::RemotePanelStatusError as Error,
+};
+use std::{path::Path, process::Command};
+
+pub(crate) const HOST_ALIAS: &str = "horizon-retained-worker";
+
+pub(crate) fn prepared_command(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<Command, Error> {
+    if !endpoint.is_complete() {
+        return Err(Error::WorkerUnavailable);
+    }
+    let mut command = Command::new("ssh");
+    command.args(["-F", "none", "-S", "none", "-T"]);
+    for option in [
+        "BatchMode=yes",
+        "IdentitiesOnly=yes",
+        "IdentityAgent=none",
+        "AddKeysToAgent=no",
+        "PreferredAuthentications=publickey",
+        "PubkeyAcceptedAlgorithms=ssh-ed25519",
+        "PasswordAuthentication=no",
+        "KbdInteractiveAuthentication=no",
+        "NumberOfPasswordPrompts=0",
+        "StrictHostKeyChecking=yes",
+        "HostKeyAlgorithms=ssh-ed25519",
+        "UpdateHostKeys=no",
+        "GlobalKnownHostsFile=/dev/null",
+        "KnownHostsCommand=none",
+        "VerifyHostKeyDNS=no",
+        "CheckHostIP=no",
+        "ClearAllForwardings=yes",
+        "ForwardAgent=no",
+        "ForwardX11=no",
+        "PermitLocalCommand=no",
+        "ProxyCommand=none",
+        "ProxyJump=none",
+        "ConnectionAttempts=1",
+        "ConnectTimeout=5",
+        "ServerAliveInterval=2",
+        "ServerAliveCountMax=1",
+        "EscapeChar=none",
+    ] {
+        command.args(["-o", option]);
+    }
+    command.arg("-o").arg(format!("HostKeyAlias={HOST_ALIAS}"));
+    command.arg("-o").arg(path_option("IdentityFile", identity)?);
+    command.arg("-o").arg(path_option("UserKnownHostsFile", known_hosts)?);
+    command.args([
+        "-p",
+        &endpoint.port.to_string(),
+        "-l",
+        &endpoint.username,
+        "--",
+        &endpoint.host,
+    ]);
+    command.arg("/usr/local/bin/horizon-panel-session request");
+    command.env("SSH_ASKPASS_REQUIRE", "never");
+    Ok(command)
+}
+
+fn path_option(name: &str, path: &Path) -> Result<String, Error> {
+    let path = path
+        .to_str()
+        .filter(|_| path.is_absolute())
+        .ok_or(Error::UnsupportedPath)?;
+    if path.chars().any(|character| character.is_control() || character == '$') {
+        return Err(Error::UnsupportedPath);
+    }
+    // SSH applies its own configuration quoting and percent expansion after argv parsing.
+    let escaped = path.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%");
+    Ok(format!("{name}=\"{escaped}\""))
+}

--- a/crates/horizon-core/src/remote_worker_status/ssh.rs
+++ b/crates/horizon-core/src/remote_worker_status/ssh.rs
@@ -1,9 +1,12 @@
 use super::{RemotePanelStatusError as Error, command};
-use crate::{cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, remote_ssh_identity::RemoteSshIdentity};
-use std::{io::Write, path::Path, process::Command, time::Duration};
+use crate::{
+    cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+    remote_ssh_identity::RemoteSshIdentity,
+    remote_worker_ssh::{HOST_ALIAS, prepared_command},
+};
+use std::{io::Write, time::Duration};
 
 const DEADLINE: Duration = Duration::from_secs(10);
-const HOST_ALIAS: &str = "horizon-retained-worker";
 
 pub(super) fn request(
     identity: &RemoteSshIdentity,
@@ -16,74 +19,4 @@ pub(super) fn request(
     writeln!(known_hosts, "{HOST_ALIAS} {}", endpoint.host_key).map_err(|_| Error::TrustStorage)?;
     let command = prepared_command(identity.private_key_path(), known_hosts.path(), endpoint)?;
     command::run(command, input, DEADLINE)
-}
-
-pub(super) fn prepared_command(
-    identity: &Path,
-    known_hosts: &Path,
-    endpoint: &InteractiveWorkerSshEndpoint,
-) -> Result<Command, Error> {
-    if !endpoint.is_complete() {
-        return Err(Error::WorkerUnavailable);
-    }
-    let mut command = Command::new("ssh");
-    command.args(["-F", "none", "-S", "none", "-T"]);
-    for option in [
-        "BatchMode=yes",
-        "IdentitiesOnly=yes",
-        "IdentityAgent=none",
-        "AddKeysToAgent=no",
-        "PreferredAuthentications=publickey",
-        "PubkeyAcceptedAlgorithms=ssh-ed25519",
-        "PasswordAuthentication=no",
-        "KbdInteractiveAuthentication=no",
-        "NumberOfPasswordPrompts=0",
-        "StrictHostKeyChecking=yes",
-        "HostKeyAlgorithms=ssh-ed25519",
-        "UpdateHostKeys=no",
-        "GlobalKnownHostsFile=/dev/null",
-        "KnownHostsCommand=none",
-        "VerifyHostKeyDNS=no",
-        "CheckHostIP=no",
-        "ClearAllForwardings=yes",
-        "ForwardAgent=no",
-        "ForwardX11=no",
-        "PermitLocalCommand=no",
-        "ProxyCommand=none",
-        "ProxyJump=none",
-        "ConnectionAttempts=1",
-        "ConnectTimeout=5",
-        "ServerAliveInterval=2",
-        "ServerAliveCountMax=1",
-        "EscapeChar=none",
-    ] {
-        command.args(["-o", option]);
-    }
-    command.arg("-o").arg(format!("HostKeyAlias={HOST_ALIAS}"));
-    command.arg("-o").arg(path_option("IdentityFile", identity)?);
-    command.arg("-o").arg(path_option("UserKnownHostsFile", known_hosts)?);
-    command.args([
-        "-p",
-        &endpoint.port.to_string(),
-        "-l",
-        &endpoint.username,
-        "--",
-        &endpoint.host,
-    ]);
-    command.arg("/usr/local/bin/horizon-panel-session request");
-    command.env("SSH_ASKPASS_REQUIRE", "never");
-    Ok(command)
-}
-
-fn path_option(name: &str, path: &Path) -> Result<String, Error> {
-    let path = path
-        .to_str()
-        .filter(|_| path.is_absolute())
-        .ok_or(Error::UnsupportedPath)?;
-    if path.chars().any(|character| character.is_control() || character == '$') {
-        return Err(Error::UnsupportedPath);
-    }
-    // SSH applies its own configuration quoting and percent expansion after argv parsing.
-    let escaped = path.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%");
-    Ok(format!("{name}=\"{escaped}\""))
 }

--- a/crates/horizon-core/src/remote_worker_status/tests/ssh.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests/ssh.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::remote_worker_ssh as ssh;
 use std::{
     ffi::OsString,
     os::unix::{ffi::OsStringExt, fs::PermissionsExt},

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -132,12 +132,16 @@ back into large multi-purpose modules.
   stale overview summaries before passing the owned snapshot to the observation gate.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
-  wire types; `ssh.rs` isolates host pins and client options; `command.rs` owns
+  wire types; `ssh.rs` owns the query's private host-pin lifetime; `command.rs` owns
   bounded nonblocking local-child I/O. It neither grants attachment/task startup
   nor changes the general user-configured SSH API or remote execution lifetime.
   Explicit saved shell/command verification reuses those gates and compares
   literal argv plus the effective directory with the worker's retained intent;
   unresolved agent launch/handoff/resume semantics stay fail-closed.
+- `remote_worker_ssh.rs` centralizes crate-private pinned client options and SSH
+  path quoting without granting attachment authority. Status queries retain their
+  fixed noninteractive command, bounded I/O and public errors; the shared leaf does
+  not change general user-configured SSH or start an interactive connection.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply


### PR DESCRIPTION
## Purpose

Continue #383 with the mechanical prerequisite for non-creating reconnect: move
the existing pinned SSH options and path quoting into one crate-private leaf.

## Behavior

No behavior change. The extracted functions and host alias are byte-identical
after the visibility substitution. Existing queries retain their private trust
file lifetime, fixed noninteractive helper command, ten-second deadline, bounded
I/O, exact-state admission and public errors. General user-configured SSH is
unchanged. This does not add attachment, task startup or new public command APIs.

Four source/test files, 160 changed lines, plus six documentation lines. The
functional connection-lifetime and explicit reconnect work remains separate.

## Validation

- All 14 focused status, saved-intent, SSH-isolation, path-quoting and bounded-child
  regressions passed, including effective configuration checks with the SSH parser.
- Full exact-commit formatting, maintainability, version sync, default and speech
  workspace tests, and blocking/strict/pedantic Clippy passed on `b48e8139`.
- Independent local review and full diff inspection completed with no findings.
- Linux-only internal extraction; no UI, worker image, configuration, dependency,
  remote resource, release or cloud/PC-off acceptance changes.

Continues #383; does not close the overall issue.
