### PR TITLE
feat(remote): attach to retained worker panels

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -21,6 +21,7 @@ mod opencode_paths;
 mod panel;
 pub mod remote_environment_observation;
 mod remote_hosts;
+pub mod remote_panel_attachment;
 pub mod remote_provider_config;
 pub mod remote_ssh_identity;
 #[cfg(target_os = "linux")]

--- a/crates/horizon-core/src/remote_panel_attachment.rs
+++ b/crates/horizon-core/src/remote_panel_attachment.rs
@@ -75,7 +75,7 @@ impl std::fmt::Debug for RemotePanelConnectionAttempt {
     }
 }
 
-/// Recover one exact persistent allocation and verify saved shell/command intent,
+/// Inspect one exact persistent allocation and verify saved shell/command intent,
 /// then launch a pinned local SSH PTY that can only attach an existing worker pane.
 /// The caller must explicitly admit the actual session, provider profile and cost
 /// policy; a copied reference or old observation is not permission to call this.
@@ -137,7 +137,8 @@ fn attach_with<P: InteractiveWorkerProvider + ?Sized>(
     if !spec.panels.iter().any(|panel| panel.panel_local_id == request.panel_id) {
         return Err(RemotePanelStatusError::UnknownPanel.into());
     }
-    let recovered = crate::remote_workspace_recovery::recover_remote_allocation(store, identities, provider, expected)?;
+    let recovered = crate::remote_workspace_recovery::inspect_remote_allocation(identities, provider, expected)?;
+    check_current(store, expected)?;
     let observed_status = inspect(store, &recovered, request.panel_id)?;
     if observed_status == RemotePanelStatus::Unavailable {
         return Err(RemotePanelAttachError::TaskUnavailable);

--- a/crates/horizon-core/src/remote_panel_attachment.rs
+++ b/crates/horizon-core/src/remote_panel_attachment.rs
@@ -1,0 +1,226 @@
+//! Explicit, non-creating attachment to one retained panel. Run off the render thread.
+
+use crate::{
+    Terminal,
+    cloud_run::{
+        CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation,
+        interactive_worker::InteractiveWorkerProvider,
+    },
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_worker_status::{RemotePanelStatus, RemotePanelStatusError},
+    remote_workspace_recovery::RemoteWorkspaceRecoveryError,
+};
+
+/// Presentation inputs only: no executable, credential, environment or persisted SSH argv.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemotePanelTerminalSize {
+    pub rows: u16,
+    pub cols: u16,
+    pub cell_width: u16,
+    pub cell_height: u16,
+    pub scrollback_limit: usize,
+    pub window_id: u64,
+    pub kitty_keyboard: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct RemotePanelAttachRequest<'a> {
+    pub allocation: &'a StoredRemoteAllocation,
+    pub panel_id: &'a str,
+    pub terminal: RemotePanelTerminalSize,
+}
+
+/// A local connection attempt, not authenticated attachment or workspace readiness.
+/// Dropping it closes only local transport. It never stops a worker or replays a task.
+pub struct RemotePanelConnectionAttempt {
+    allocation: StoredRemoteAllocation,
+    panel_id: String,
+    observed_status: RemotePanelStatus,
+    terminal: Terminal,
+}
+
+impl RemotePanelConnectionAttempt {
+    #[must_use]
+    pub fn allocation(&self) -> &StoredRemoteAllocation {
+        &self.allocation
+    }
+
+    #[must_use]
+    pub fn panel_id(&self) -> &str {
+        &self.panel_id
+    }
+
+    /// Point-in-time status from saved-intent verification, not proof of attachment.
+    #[must_use]
+    pub fn observed_status(&self) -> &RemotePanelStatus {
+        &self.observed_status
+    }
+
+    /// Consume only after checking the actual client session and disconnected target panel.
+    /// Rechecks owned snapshots before handing off the input-capable local terminal.
+    /// This is point-in-time admission, not continuous revocation or an atomic Stop fence.
+    /// # Errors
+    /// A stale attempt is discarded by closing only its local transport.
+    pub fn into_terminal(self, store: &CloudWorkflowStore) -> Result<Terminal, RemotePanelAttachError> {
+        check_current(store, &self.allocation)?;
+        Ok(self.terminal)
+    }
+}
+
+impl std::fmt::Debug for RemotePanelConnectionAttempt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RemotePanelConnectionAttempt")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Recover one exact persistent allocation and verify saved shell/command intent,
+/// then launch a pinned local SSH PTY that can only attach an existing worker pane.
+/// The caller must explicitly admit the actual session, provider profile and cost
+/// policy; a copied reference or old observation is not permission to call this.
+/// No key creation, allocation, ensure, task startup, Stop, Delete or fallback occurs.
+/// Exited panes remain inspectable without task replay. No repository readiness,
+/// agent resume, authenticated attachment or saved Ready promotion is implied.
+/// # Errors
+/// Rejects stale/foreign snapshots, unsupported lifetime/platform/intent, pending
+/// management, missing identity/task, changed pins and unavailable local transport.
+pub fn attach_remote_panel<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    request: RemotePanelAttachRequest<'_>,
+) -> Result<RemotePanelConnectionAttempt, RemotePanelAttachError> {
+    #[cfg(target_os = "linux")]
+    {
+        attach_with(
+            store,
+            identities,
+            provider,
+            request,
+            crate::remote_worker_status::inspect_remote_panel_intent,
+            spawn_pinned,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, identities, provider, request);
+        Err(RemotePanelAttachError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn attach_with<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    request: RemotePanelAttachRequest<'_>,
+    inspect: impl FnOnce(
+        &CloudWorkflowStore,
+        &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+        &str,
+    ) -> Result<RemotePanelStatus, RemotePanelStatusError>,
+    spawn: impl FnOnce(
+        &CloudWorkflowStore,
+        &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+        &str,
+        RemotePanelTerminalSize,
+    ) -> Result<Terminal, RemotePanelAttachError>,
+) -> Result<RemotePanelConnectionAttempt, RemotePanelAttachError> {
+    let expected = request.allocation;
+    check_current(store, expected)?;
+    expected.recovery_request()?;
+    let spec = &expected.workspace().state().spec;
+    if spec.target.lifetime != crate::cloud_run::WorkerLifetime::Persistent {
+        return Err(RemotePanelAttachError::UnsupportedLifetime);
+    }
+    if !spec.panels.iter().any(|panel| panel.panel_local_id == request.panel_id) {
+        return Err(RemotePanelStatusError::UnknownPanel.into());
+    }
+    let recovered = crate::remote_workspace_recovery::recover_remote_allocation(store, identities, provider, expected)?;
+    let observed_status = inspect(store, &recovered, request.panel_id)?;
+    if observed_status == RemotePanelStatus::Unavailable {
+        return Err(RemotePanelAttachError::TaskUnavailable);
+    }
+    check_current(store, recovered.allocation())?;
+    let terminal = spawn(store, &recovered, request.panel_id, request.terminal)?;
+    check_current(store, recovered.allocation())?;
+    Ok(RemotePanelConnectionAttempt {
+        allocation: recovered.allocation().clone(),
+        panel_id: request.panel_id.into(),
+        observed_status,
+        terminal,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_pinned(
+    store: &CloudWorkflowStore,
+    recovered: &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+    panel_id: &str,
+    size: RemotePanelTerminalSize,
+) -> Result<Terminal, RemotePanelAttachError> {
+    let endpoint = recovered
+        .observation()
+        .and_then(|status| status.ssh.as_ref())
+        .ok_or(RemotePanelStatusError::WorkerUnavailable)?;
+    let runtime = recovered.allocation().recovery_request()?.job_id;
+    let prepared =
+        crate::remote_worker_ssh::PreparedAttachment::new(recovered.identity(), endpoint, runtime, panel_id)?;
+    check_current(store, recovered.allocation())?;
+    prepared
+        .spawn(crate::terminal::TerminalSpawnOptions {
+            program: String::new(),
+            args: Vec::new(),
+            cwd: None,
+            rows: size.rows,
+            cols: size.cols,
+            cell_width: size.cell_width,
+            cell_height: size.cell_height,
+            scrollback_limit: size.scrollback_limit,
+            window_id: size.window_id,
+            replay_bytes: Vec::new(),
+            env: std::collections::HashMap::new(),
+            kitty_keyboard: size.kitty_keyboard,
+        })
+        .map_err(|_| RemotePanelAttachError::TransportUnavailable)
+}
+
+fn check_current(store: &CloudWorkflowStore, expected: &StoredRemoteAllocation) -> Result<(), RemotePanelAttachError> {
+    let current = store.load_remote_allocation(
+        expected.workspace().session_id(),
+        &expected.workspace().state().spec.workspace_local_id,
+    )?;
+    if current.as_ref() != Some(expected) {
+        return Err(RemotePanelAttachError::StateChanged);
+    }
+    Ok(())
+}
+
+/// Diagnostics omit provider output, task content, SSH arguments and private paths.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemotePanelAttachError {
+    #[error("remote allocation changed; discard this connection attempt and refresh")]
+    StateChanged,
+    #[error("protected attachment currently requires persistent execution")]
+    UnsupportedLifetime,
+    #[error("retained panel is unavailable; no task was started or replaced")]
+    TaskUnavailable,
+    #[error("local remote connection could not be started")]
+    TransportUnavailable,
+    #[error("protected remote panel attachment is not yet supported on this platform")]
+    UnsupportedPlatform,
+    #[error(transparent)]
+    Recovery(#[from] RemoteWorkspaceRecoveryError),
+    #[error(transparent)]
+    Inspection(#[from] RemotePanelStatusError),
+}
+
+impl From<RemoteWorkspaceStoreError> for RemotePanelAttachError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        RemoteWorkspaceRecoveryError::from(error).into()
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_panel_attachment/tests.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests.rs
@@ -1,0 +1,485 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{CloudProvider, WorkerLifetime, interactive_worker::*},
+    remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
+    terminal::TerminalSpawnOptions,
+};
+use std::{
+    os::unix::fs::PermissionsExt,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    identities: RemoteSshIdentityStore,
+    provider: Provider,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_lifetime(WorkerLifetime::Persistent)
+    }
+
+    fn with_lifetime(lifetime: WorkerLifetime) -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let identities = RemoteSshIdentityStore::new(&home);
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1, "spec":{
+                "workspace_local_id":"workspace", "working_directory":".", "generation":0,
+                "target":{"provider":"local_docker", "profile":"development", "disk_gib":20,
+                    "lifetime":"persistent", "image":format!("example/worker@sha256:{}", "a".repeat(64))},
+                "repository":{"repository":"example/project", "commit":"b".repeat(40)},
+                "panels":[{"panel_local_id":"terminal", "kind":"command",
+                    "command":{"program":"printf", "args":["synthetic task"]}}]
+            }
+        }))
+        .expect("state");
+        state.spec.target.lifetime = lifetime;
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");
+        let identity = identities
+            .prepare_new(runtime.workflow_id, runtime.job_id)
+            .expect("identity");
+        let reserved = store
+            .reserve_remote_worker_request(&allocation, identity.public_key())
+            .expect("request");
+        let request = reserved.worker_request().expect("request");
+        let observed_lifetime = match lifetime {
+            WorkerLifetime::Persistent => InteractiveWorkerLifetime::Persistent,
+            WorkerLifetime::TimeLimited { seconds } => InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                terminate_after: (time::OffsetDateTime::now_utc() + time::Duration::seconds(i64::from(seconds)))
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .expect("deadline"),
+            }),
+        };
+        let provider = Provider {
+            status: Some(InteractiveWorkerStatus {
+                worker: InteractiveWorker {
+                    identity: InteractiveWorkerIdentity {
+                        provider: request.target.provider,
+                        workflow_id: request.workflow_id,
+                        job_id: request.job_id,
+                        resource_id: "synthetic-worker".into(),
+                    },
+                    target: request.target,
+                    ssh_public_key: request.ssh_public_key,
+                    lifetime: observed_lifetime,
+                },
+                lifecycle: InteractiveWorkerLifecycle::Ready,
+                ssh: Some(InteractiveWorkerSshEndpoint {
+                    host: "127.0.0.1".into(),
+                    port: 2222,
+                    username: "horizon".into(),
+                    host_key: identity.public_key().into(),
+                }),
+            }),
+            calls: Mutex::new(0),
+            on_inspect: None,
+        };
+        store
+            .record_remote_worker_recovery(&reserved, provider.status.as_ref())
+            .expect("recovery");
+        *provider.calls.lock().expect("calls") = 0;
+        Self {
+            _directory: directory,
+            store,
+            identities,
+            provider,
+        }
+    }
+
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn request(allocation: &StoredRemoteAllocation) -> RemotePanelAttachRequest<'_> {
+        RemotePanelAttachRequest {
+            allocation,
+            panel_id: "terminal",
+            terminal: terminal_size(),
+        }
+    }
+}
+
+struct Provider {
+    status: Option<InteractiveWorkerStatus>,
+    calls: Mutex<usize>,
+    on_inspect: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::LocalDocker
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no creation")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no deletion")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("retained fixture must use its exact worker")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        *self.calls.lock().expect("calls") += 1;
+        if let Some(action) = &self.on_inspect {
+            action();
+        }
+        Ok(self.status.clone())
+    }
+}
+
+fn terminal_size() -> RemotePanelTerminalSize {
+    RemotePanelTerminalSize {
+        rows: 24,
+        cols: 80,
+        cell_width: 8,
+        cell_height: 16,
+        scrollback_limit: 128,
+        window_id: 1,
+        kitty_keyboard: false,
+    }
+}
+
+fn local_options(script: &str) -> TerminalSpawnOptions {
+    let size = terminal_size();
+    TerminalSpawnOptions {
+        program: "/bin/sh".into(),
+        args: vec!["-c".into(), script.into()],
+        cwd: None,
+        rows: size.rows,
+        cols: size.cols,
+        cell_width: size.cell_width,
+        cell_height: size.cell_height,
+        scrollback_limit: size.scrollback_limit,
+        window_id: size.window_id,
+        kitty_keyboard: size.kitty_keyboard,
+        replay_bytes: vec![],
+        env: std::collections::HashMap::new(),
+    }
+}
+
+fn invalidate(store: &CloudWorkflowStore) {
+    let current = store
+        .load_remote_allocation(OWNER, "workspace")
+        .expect("load")
+        .expect("allocation");
+    let mut next = current.workspace().state().clone();
+    next.spec.working_directory = "changed".into();
+    store
+        .replace_remote_workspace(current.workspace(), &next)
+        .expect("edit");
+}
+
+fn running() -> RemotePanelStatus {
+    RemotePanelStatus::Running { pid: 123 }
+}
+
+#[test]
+fn fresh_running_and_exited_attempts_preserve_snapshots_and_never_promote_readiness() {
+    for status in [
+        running(),
+        RemotePanelStatus::Exited {
+            pid: 123,
+            exit_status: Some(7),
+        },
+    ] {
+        let fixture = Fixture::new();
+        let before = fixture.current();
+        let attempt = attach_with(
+            &fixture.store,
+            &fixture.identities,
+            &fixture.provider,
+            Fixture::request(&before),
+            |_, recovered, panel| {
+                assert_eq!(recovered.allocation(), &before);
+                assert_eq!(panel, "terminal");
+                Ok(status.clone())
+            },
+            |_, _, _, _| Ok(Terminal::spawn(local_options("exit 0")).expect("local fixture")),
+        )
+        .expect("attempt");
+        assert_eq!(attempt.allocation(), &before);
+        assert_eq!(attempt.panel_id(), "terminal");
+        assert_eq!(attempt.observed_status(), &status);
+        assert!(!format!("{attempt:?}").contains("synthetic"));
+        assert_eq!(fixture.current(), before);
+        let mut terminal = attempt.into_terminal(&fixture.store).expect("current handoff");
+        assert!(terminal.shutdown_with_timeout(Duration::from_secs(2)));
+        assert_eq!(fixture.current(), before);
+        assert_eq!(*fixture.provider.calls.lock().expect("calls"), 1);
+    }
+}
+
+#[test]
+fn stale_missing_panel_timed_and_pending_management_never_inspect_or_spawn() {
+    for case in 0..4 {
+        let fixture = if case == 2 {
+            Fixture::with_lifetime(WorkerLifetime::TimeLimited { seconds: 900 })
+        } else {
+            Fixture::new()
+        };
+        let original = fixture.current();
+        if case == 0 {
+            invalidate(&fixture.store);
+        }
+        if case == 3 {
+            fixture
+                .store
+                .record_remote_stop_phase(&original, RemoteRuntimePhase::Stopping { requested_at_millis: 1 })
+                .expect("stop intent");
+        }
+        let expected = if case == 0 { original } else { fixture.current() };
+        let mut request = Fixture::request(&expected);
+        if case == 1 {
+            request.panel_id = "absent;start";
+        }
+        assert!(
+            attach_with(
+                &fixture.store,
+                &fixture.identities,
+                &fixture.provider,
+                request,
+                |_, _, _| panic!("no query"),
+                |_, _, _, _| panic!("no spawn")
+            )
+            .is_err()
+        );
+        assert_eq!(*fixture.provider.calls.lock().expect("calls"), 0);
+    }
+}
+
+#[test]
+fn missing_key_absent_worker_and_unsupported_intent_never_spawn_or_replace() {
+    let mut fixture = Fixture::new();
+    let before = fixture.current();
+    fixture.provider.status = None;
+    let result = attach_with(
+        &fixture.store,
+        &fixture.identities,
+        &fixture.provider,
+        Fixture::request(&before),
+        |_, recovered, _| {
+            assert!(recovered.observation().is_none());
+            Ok(RemotePanelStatus::Unavailable)
+        },
+        |_, _, _, _| panic!("no spawn"),
+    );
+    assert_eq!(
+        result.expect_err("missing task"),
+        RemotePanelAttachError::TaskUnavailable
+    );
+    assert_eq!(fixture.current(), before);
+    assert_eq!(
+        attach_with(
+            &fixture.store,
+            &fixture.identities,
+            &fixture.provider,
+            Fixture::request(&before),
+            |_, _, _| Err(RemotePanelStatusError::UnsupportedIntent),
+            |_, _, _, _| panic!("no spawn")
+        )
+        .expect_err("intent"),
+        RemotePanelAttachError::Inspection(RemotePanelStatusError::UnsupportedIntent)
+    );
+    let request = before.worker_request().expect("request");
+    let identity = fixture
+        .identities
+        .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+        .expect("key");
+    std::fs::remove_file(identity.private_key_path()).expect("simulate loss of fixture key");
+    assert!(
+        attach_with(
+            &fixture.store,
+            &fixture.identities,
+            &fixture.provider,
+            Fixture::request(&before),
+            |_, _, _| panic!("no query"),
+            |_, _, _, _| panic!("no spawn")
+        )
+        .is_err()
+    );
+    assert!(!identity.private_key_path().exists());
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn public_admission_rejects_absent_nonready_and_foreign_allocations_without_ssh() {
+    for lifecycle in [
+        None,
+        Some(InteractiveWorkerLifecycle::Stopped),
+        Some(InteractiveWorkerLifecycle::Unknown),
+    ] {
+        let mut fixture = Fixture::new();
+        let before = fixture.current();
+        if let Some(lifecycle) = lifecycle {
+            fixture.provider.status.as_mut().expect("worker").lifecycle = lifecycle;
+        } else {
+            fixture.provider.status = None;
+        }
+        assert_eq!(
+            attach_remote_panel(
+                &fixture.store,
+                &fixture.identities,
+                &fixture.provider,
+                Fixture::request(&before)
+            )
+            .expect_err("not ready"),
+            RemotePanelAttachError::Inspection(RemotePanelStatusError::WorkerUnavailable)
+        );
+        assert_eq!(fixture.current(), before);
+    }
+    let fixture = Fixture::new();
+    let foreign = Fixture::new();
+    assert_eq!(
+        attach_remote_panel(
+            &fixture.store,
+            &fixture.identities,
+            &fixture.provider,
+            Fixture::request(&foreign.current())
+        )
+        .expect_err("foreign"),
+        RemotePanelAttachError::StateChanged
+    );
+    assert_eq!(*fixture.provider.calls.lock().expect("calls"), 0);
+}
+
+#[test]
+fn provider_and_query_drift_cannot_authorize_a_later_local_launch() {
+    for provider_drift in [true, false] {
+        let mut fixture = Fixture::new();
+        let before = fixture.current();
+        if provider_drift {
+            let store = fixture.store.clone();
+            fixture.provider.on_inspect = Some(Box::new(move || invalidate(&store)));
+        }
+        assert!(
+            attach_with(
+                &fixture.store,
+                &fixture.identities,
+                &fixture.provider,
+                Fixture::request(&before),
+                |store, _, _| {
+                    assert!(!provider_drift);
+                    invalidate(store);
+                    Ok(running())
+                },
+                |_, _, _, _| panic!("no spawn")
+            )
+            .is_err()
+        );
+        assert_eq!(
+            fixture.current().workspace().revision(),
+            before.workspace().revision() + 1
+        );
+    }
+}
+
+#[test]
+fn drift_after_local_start_or_before_consumption_discards_the_attempt() {
+    for drift_at_spawn in [true, false] {
+        let fixture = Fixture::new();
+        let before = fixture.current();
+        let result = attach_with(
+            &fixture.store,
+            &fixture.identities,
+            &fixture.provider,
+            Fixture::request(&before),
+            |_, _, _| Ok(running()),
+            |store, _, _, _| {
+                let terminal = Terminal::spawn(local_options("exit 0")).expect("local fixture");
+                if drift_at_spawn {
+                    invalidate(store);
+                }
+                Ok(terminal)
+            },
+        );
+        if drift_at_spawn {
+            assert_eq!(result.expect_err("late start"), RemotePanelAttachError::StateChanged);
+        } else {
+            let attempt = result.expect("attempt");
+            invalidate(&fixture.store);
+            assert!(matches!(
+                attempt.into_terminal(&fixture.store),
+                Err(RemotePanelAttachError::StateChanged)
+            ));
+        }
+    }
+}
+
+fn await_removed(path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(!path.exists(), "owned trust must be released after local teardown");
+}
+
+#[test]
+fn private_trust_survives_immediate_drop_timeout_and_async_join_until_owned_teardown() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    for mode in 0..3 {
+        let directory = tempfile::tempdir().expect("fixture");
+        let trust = tempfile::NamedTempFile::new_in(directory.path()).expect("trust");
+        let path = trust.path().to_path_buf();
+        let release = directory.path().join("release");
+        let mut options =
+            local_options("i=0; while [ ! -f \"$1\" ] && [ \"$i\" -lt 200 ]; do i=$((i+1)); sleep 0.01; done");
+        options
+            .args
+            .extend(["fixture".into(), release.to_string_lossy().into_owned()]);
+        let mut terminal = Terminal::spawn_with_ssh_trust(options, Arc::new(trust)).expect("guarded local fixture");
+        let completed = Arc::new(AtomicUsize::new(0));
+        if mode == 1 {
+            assert!(!terminal.wait_for_shutdown(Duration::ZERO));
+        }
+        if mode == 2 {
+            assert!(terminal.begin_async_join(&completed));
+        }
+        drop(terminal);
+        if mode != 0 {
+            assert!(path.exists());
+            assert_eq!(completed.load(Ordering::Relaxed), 0);
+            std::fs::write(&release, b"release").expect("release owned child");
+        }
+        await_removed(&path);
+        if mode == 2 {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while completed.load(Ordering::Relaxed) == 0 && Instant::now() < deadline {
+                std::thread::yield_now();
+            }
+            assert_eq!(completed.load(Ordering::Relaxed), 1);
+        }
+    }
+}
+
+#[test]
+fn failed_startup_and_concurrent_connections_release_only_their_own_trust() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let first = tempfile::NamedTempFile::new_in(directory.path()).expect("first");
+    let second = tempfile::NamedTempFile::new_in(directory.path()).expect("second");
+    let first_path = first.path().to_path_buf();
+    let second_path = second.path().to_path_buf();
+    let second_terminal =
+        Terminal::spawn_with_ssh_trust(local_options("read -r fixture"), Arc::new(second)).expect("second");
+    let mut options = local_options("exit 0");
+    options.program = directory.path().join("nonexistent").to_string_lossy().into_owned();
+    assert!(Terminal::spawn_with_ssh_trust(options, Arc::new(first)).is_err());
+    await_removed(&first_path);
+    assert!(second_path.exists());
+    drop(second_terminal);
+    await_removed(&second_path);
+}

--- a/crates/horizon-core/src/remote_panel_attachment/tests.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests.rs
@@ -190,14 +190,25 @@ fn running() -> RemotePanelStatus {
 
 #[test]
 fn fresh_running_and_exited_attempts_preserve_snapshots_and_never_promote_readiness() {
-    for status in [
+    for (status, phase) in [
         running(),
         RemotePanelStatus::Exited {
             pid: 123,
             exit_status: Some(7),
         },
-    ] {
+    ]
+    .into_iter()
+    .flat_map(|status| {
+        [RemoteRuntimePhase::Reconciling, RemoteRuntimePhase::Ready].map(|phase| (status.clone(), phase))
+    }) {
         let fixture = Fixture::new();
+        let original = fixture.current();
+        let mut state = original.workspace().state().clone();
+        state.runtime.as_mut().expect("runtime").phase = phase;
+        fixture
+            .store
+            .replace_remote_workspace(original.workspace(), &state)
+            .expect("phase");
         let before = fixture.current();
         let attempt = attach_with(
             &fixture.store,

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -1,9 +1,11 @@
 //! Crate-private pinned SSH command construction, not remote attachment authority.
 
 use crate::{
-    cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, remote_worker_status::RemotePanelStatusError as Error,
+    Terminal, cloud_run::CloudJobId, cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+    remote_ssh_identity::RemoteSshIdentity, remote_worker_status::RemotePanelStatusError as Error,
+    remote_workspace::valid_local_id, terminal::TerminalSpawnOptions,
 };
-use std::{path::Path, process::Command};
+use std::{io::Write, path::Path, process::Command, sync::Arc};
 
 pub(crate) const HOST_ALIAS: &str = "horizon-retained-worker";
 
@@ -12,11 +14,31 @@ pub(crate) fn prepared_command(
     known_hosts: &Path,
     endpoint: &InteractiveWorkerSshEndpoint,
 ) -> Result<Command, Error> {
+    command_for(identity, known_hosts, endpoint, Operation::Request)
+}
+
+#[derive(Clone, Copy)]
+enum Operation<'a> {
+    Request,
+    Attach { runtime: CloudJobId, panel: &'a str },
+}
+
+fn command_for(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+    operation: Operation<'_>,
+) -> Result<Command, Error> {
     if !endpoint.is_complete() {
         return Err(Error::WorkerUnavailable);
     }
     let mut command = Command::new("ssh");
-    command.args(["-F", "none", "-S", "none", "-T"]);
+    let terminal_mode = match operation {
+        Operation::Request => "-T",
+        Operation::Attach { panel, .. } if valid_local_id(panel) => "-tt",
+        Operation::Attach { .. } => return Err(Error::UnknownPanel),
+    };
+    command.args(["-F", "none", "-S", "none", terminal_mode]);
     for option in [
         "BatchMode=yes",
         "IdentitiesOnly=yes",
@@ -59,9 +81,62 @@ pub(crate) fn prepared_command(
         "--",
         &endpoint.host,
     ]);
-    command.arg("/usr/local/bin/horizon-panel-session request");
+    command.arg(match operation {
+        Operation::Request => "/usr/local/bin/horizon-panel-session request".into(),
+        Operation::Attach { runtime, panel } => {
+            format!("/usr/local/bin/horizon-panel-session attach -- {runtime} {panel}")
+        }
+    });
     command.env("SSH_ASKPASS_REQUIRE", "never");
     Ok(command)
+}
+
+pub(crate) fn known_hosts(
+    identity: &RemoteSshIdentity,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<tempfile::NamedTempFile, Error> {
+    // The recovered key's private parent avoids ambient temporary-directory trust.
+    let parent = identity.private_key_path().parent().ok_or(Error::UnsupportedPath)?;
+    let mut known_hosts = tempfile::NamedTempFile::new_in(parent).map_err(|_| Error::TrustStorage)?;
+    writeln!(known_hosts, "{HOST_ALIAS} {}", endpoint.host_key).map_err(|_| Error::TrustStorage)?;
+    Ok(known_hosts)
+}
+
+/// Private preparation must be consumed by the fresh admission boundary, never persisted.
+pub(crate) struct PreparedAttachment {
+    command: Command,
+    known_hosts: tempfile::NamedTempFile,
+}
+
+impl PreparedAttachment {
+    pub(crate) fn new(
+        identity: &RemoteSshIdentity,
+        endpoint: &InteractiveWorkerSshEndpoint,
+        runtime: CloudJobId,
+        panel: &str,
+    ) -> Result<Self, Error> {
+        let known_hosts = known_hosts(identity, endpoint)?;
+        let command = command_for(
+            identity.private_key_path(),
+            known_hosts.path(),
+            endpoint,
+            Operation::Attach { runtime, panel },
+        )?;
+        Ok(Self { command, known_hosts })
+    }
+
+    pub(crate) fn spawn(self, mut options: TerminalSpawnOptions) -> crate::Result<Terminal> {
+        options.program = "ssh".into();
+        options.args = self
+            .command
+            .get_args()
+            .map(|argument| argument.to_str().map(str::to_owned))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| crate::Error::State("protected SSH arguments are not supported".into()))?;
+        options.env.insert("SSH_ASKPASS_REQUIRE".into(), "never".into());
+        options.env.insert("TERM".into(), "xterm-256color".into());
+        Terminal::spawn_with_ssh_trust(options, Arc::new(self.known_hosts))
+    }
 }
 
 fn path_option(name: &str, path: &Path) -> Result<String, Error> {
@@ -75,4 +150,88 @@ fn path_option(name: &str, path: &Path) -> Result<String, Error> {
     // SSH applies its own configuration quoting and percent expansion after argv parsing.
     let escaped = path.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%");
     Ok(format!("{name}=\"{escaped}\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{HorizonHome, cloud_run::CloudWorkflowId, remote_ssh_identity::RemoteSshIdentityStore};
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn interactive_mode_shares_all_isolation_options_and_owns_unique_private_trust() {
+        let directory = tempfile::tempdir().expect("fixture");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+        let identities = RemoteSshIdentityStore::new(&HorizonHome::from_root(directory.path().join("home")));
+        let runtime = CloudJobId::new();
+        let identity = identities
+            .prepare_new(CloudWorkflowId::new(), runtime)
+            .expect("identity");
+        let endpoint = InteractiveWorkerSshEndpoint {
+            host: "127.0.0.1".into(),
+            port: 2222,
+            username: "horizon".into(),
+            host_key: identity.public_key().into(),
+        };
+        let first = PreparedAttachment::new(&identity, &endpoint, runtime, "-h").expect("first");
+        let second = PreparedAttachment::new(&identity, &endpoint, runtime, "terminal").expect("second");
+        let first_path = first.known_hosts.path().to_path_buf();
+        let second_path = second.known_hosts.path().to_path_buf();
+        assert_ne!(first_path, second_path);
+        assert_eq!(first_path.parent(), identity.private_key_path().parent());
+        assert_eq!(
+            first
+                .known_hosts
+                .as_file()
+                .metadata()
+                .expect("mode")
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
+        assert_eq!(
+            std::fs::read_to_string(&first_path).expect("pin"),
+            format!("{HOST_ALIAS} {}\n", endpoint.host_key)
+        );
+        let query = prepared_command(identity.private_key_path(), &first_path, &endpoint).expect("query");
+        let mut expected: Vec<_> = query.get_args().map(std::ffi::OsStr::to_os_string).collect();
+        expected[4] = "-tt".into();
+        *expected.last_mut().expect("helper") =
+            format!("/usr/local/bin/horizon-panel-session attach -- {runtime} -h").into();
+        assert_eq!(first.command.get_args().collect::<Vec<_>>(), expected);
+        assert_eq!(
+            first.command.get_envs().collect::<Vec<_>>(),
+            query.get_envs().collect::<Vec<_>>()
+        );
+        let parsed = Command::new("ssh")
+            .arg("-G")
+            .args(first.command.get_args())
+            .output()
+            .expect("SSH parser");
+        assert!(parsed.status.success());
+        assert!(
+            String::from_utf8(parsed.stdout)
+                .expect("config")
+                .lines()
+                .any(|line| line == "requesttty force")
+        );
+        for panel in ["", "../panel", "panel;start", "panel\nstart", "panel with spaces"] {
+            assert!(matches!(
+                PreparedAttachment::new(&identity, &endpoint, runtime, panel),
+                Err(Error::UnknownPanel)
+            ));
+        }
+        drop(first);
+        assert!(!first_path.exists());
+        assert!(second_path.exists());
+        drop(second);
+        assert!(!second_path.exists());
+        assert_eq!(
+            std::fs::read_dir(identity.private_key_path().parent().expect("parent"))
+                .expect("directory")
+                .count(),
+            1
+        );
+    }
 }

--- a/crates/horizon-core/src/remote_worker_status/ssh.rs
+++ b/crates/horizon-core/src/remote_worker_status/ssh.rs
@@ -2,9 +2,9 @@ use super::{RemotePanelStatusError as Error, command};
 use crate::{
     cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
     remote_ssh_identity::RemoteSshIdentity,
-    remote_worker_ssh::{HOST_ALIAS, prepared_command},
+    remote_worker_ssh::{known_hosts, prepared_command},
 };
-use std::{io::Write, time::Duration};
+use std::time::Duration;
 
 const DEADLINE: Duration = Duration::from_secs(10);
 
@@ -13,10 +13,7 @@ pub(super) fn request(
     endpoint: &InteractiveWorkerSshEndpoint,
     input: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    // The recovered key's private parent avoids ambient temporary-directory trust.
-    let parent = identity.private_key_path().parent().ok_or(Error::UnsupportedPath)?;
-    let mut known_hosts = tempfile::NamedTempFile::new_in(parent).map_err(|_| Error::TrustStorage)?;
-    writeln!(known_hosts, "{HOST_ALIAS} {}", endpoint.host_key).map_err(|_| Error::TrustStorage)?;
+    let known_hosts = known_hosts(identity, endpoint)?;
     let command = prepared_command(identity.private_key_path(), known_hosts.path(), endpoint)?;
     command::run(command, input, DEADLINE)
 }

--- a/crates/horizon-core/src/remote_workspace_recovery.rs
+++ b/crates/horizon-core/src/remote_workspace_recovery.rs
@@ -62,11 +62,13 @@ pub fn recover_remote_workspace<P: InteractiveWorkerProvider + ?Sized>(
     let allocation = store
         .load_remote_allocation(session_id, workspace_local_id)?
         .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
-    recover_remote_allocation(store, identities, provider, &allocation)
+    let mut recovered = inspect_remote_allocation(identities, provider, &allocation)?;
+    recovered.allocation = store.record_remote_worker_recovery(&allocation, recovered.observation.as_ref())?;
+    Ok(recovered)
 }
 
-pub(crate) fn recover_remote_allocation<P: InteractiveWorkerProvider + ?Sized>(
-    store: &CloudWorkflowStore,
+/// Shared read-only observation; callers retain separate snapshot and commit fences.
+pub(crate) fn inspect_remote_allocation<P: InteractiveWorkerProvider + ?Sized>(
     identities: &RemoteSshIdentityStore,
     provider: &P,
     allocation: &StoredRemoteAllocation,
@@ -87,9 +89,9 @@ pub(crate) fn recover_remote_allocation<P: InteractiveWorkerProvider + ?Sized>(
         None => provider.reconcile_worker(&request),
     }
     .map_err(|_| RemoteWorkspaceRecoveryError::ProviderUnavailable)?;
-    let allocation = store.record_remote_worker_recovery(allocation, observation.as_ref())?;
+    allocation.validate_worker_observation(observation.as_ref())?;
     Ok(RecoveredRemoteWorkspace {
-        allocation,
+        allocation: allocation.clone(),
         identity,
         observation,
     })

--- a/crates/horizon-core/src/remote_workspace_recovery.rs
+++ b/crates/horizon-core/src/remote_workspace_recovery.rs
@@ -62,6 +62,15 @@ pub fn recover_remote_workspace<P: InteractiveWorkerProvider + ?Sized>(
     let allocation = store
         .load_remote_allocation(session_id, workspace_local_id)?
         .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    recover_remote_allocation(store, identities, provider, &allocation)
+}
+
+pub(crate) fn recover_remote_allocation<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+) -> Result<RecoveredRemoteWorkspace, RemoteWorkspaceRecoveryError> {
     let request = allocation.recovery_request()?;
     if !request.is_valid_for(provider.provider()) {
         return Err(RemoteWorkspaceRecoveryError::ProviderMismatch);
@@ -78,7 +87,7 @@ pub fn recover_remote_workspace<P: InteractiveWorkerProvider + ?Sized>(
         None => provider.reconcile_worker(&request),
     }
     .map_err(|_| RemoteWorkspaceRecoveryError::ProviderUnavailable)?;
-    let allocation = store.record_remote_worker_recovery(&allocation, observation.as_ref())?;
+    let allocation = store.record_remote_worker_recovery(allocation, observation.as_ref())?;
     Ok(RecoveredRemoteWorkspace {
         allocation,
         identity,

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -136,6 +136,23 @@ impl RuntimeTitle {
 #[derive(Clone)]
 struct TerminalEventProxy {
     event_tx: mpsc::Sender<Event>,
+    // Both the grid and event loop retain trust through detached/asynchronous teardown.
+    _ssh_trust: TerminalSshTrust,
+}
+
+#[derive(Clone, Default)]
+struct TerminalSshTrust {
+    #[cfg(target_os = "linux")]
+    _file: Option<Arc<tempfile::NamedTempFile>>,
+}
+
+impl TerminalEventProxy {
+    fn new(event_tx: mpsc::Sender<Event>, ssh_trust: TerminalSshTrust) -> Self {
+        Self {
+            event_tx,
+            _ssh_trust: ssh_trust,
+        }
+    }
 }
 
 impl EventListener for TerminalEventProxy {
@@ -205,7 +222,7 @@ mod tests {
     use super::current_cwd_for_pid;
     use super::{
         AgentNotification, HorizonOscTitle, RuntimeTitle, Terminal, TerminalDimensions, TerminalEventProxy,
-        TerminalSpawnOptions, default_terminal_rgb, find_file_path_at_column, find_url_at_column,
+        TerminalSpawnOptions, TerminalSshTrust, default_terminal_rgb, find_file_path_at_column, find_url_at_column,
         queue_debounced_pty_resize, replay_terminal_bytes, should_debounce_pty_resize,
     };
     use alacritty_terminal::event::Event;
@@ -524,7 +541,7 @@ mod tests {
         Arc::new(FairMutex::new(Term::new(
             config,
             &dimensions,
-            TerminalEventProxy { event_tx },
+            TerminalEventProxy::new(event_tx, TerminalSshTrust::default()),
         )))
     }
 

--- a/crates/horizon-core/src/terminal/content.rs
+++ b/crates/horizon-core/src/terminal/content.rs
@@ -377,7 +377,7 @@ mod tests {
     use super::{
         append_cell_text, bottom_row_texts, hyperlink_uri_at_viewport_point, wrapped_line_chars_at_viewport_point,
     };
-    use crate::terminal::{TerminalDimensions, TerminalEventProxy, find_url_at_column};
+    use crate::terminal::{TerminalDimensions, TerminalEventProxy, TerminalSshTrust, find_url_at_column};
 
     fn reconstruct_line(cells: &[(usize, Cell)]) -> String {
         let mut line = String::new();
@@ -466,7 +466,11 @@ mod tests {
             ..term::Config::default()
         };
 
-        Term::new(config, &dimensions, TerminalEventProxy { event_tx })
+        Term::new(
+            config,
+            &dimensions,
+            TerminalEventProxy::new(event_tx, TerminalSshTrust::default()),
+        )
     }
 
     #[test]

--- a/crates/horizon-core/src/terminal/lifecycle.rs
+++ b/crates/horizon-core/src/terminal/lifecycle.rs
@@ -1,7 +1,7 @@
 use super::{
     Arc, AtomicUsize, Cow, Duration, Error, EventLoop, FairMutex, Msg, Ordering, PtyOptions, ReplayRestoreState,
-    Result, Shell, Term, Terminal, TerminalDimensions, TerminalEventProxy, TerminalSpawnOptions, WindowSize,
-    drain_replay_events, mpsc, replay_terminal_bytes, term, tty,
+    Result, Shell, Term, Terminal, TerminalDimensions, TerminalEventProxy, TerminalSpawnOptions, TerminalSshTrust,
+    WindowSize, drain_replay_events, mpsc, replay_terminal_bytes, term, tty,
 };
 
 impl Terminal {
@@ -11,6 +11,18 @@ impl Terminal {
     ///
     /// Returns an error if the PTY or event loop cannot be created.
     pub fn spawn(options: TerminalSpawnOptions) -> Result<Self> {
+        Self::spawn_guarded(options, TerminalSshTrust::default())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn spawn_with_ssh_trust(
+        options: TerminalSpawnOptions,
+        trust: Arc<tempfile::NamedTempFile>,
+    ) -> Result<Self> {
+        Self::spawn_guarded(options, TerminalSshTrust { _file: Some(trust) })
+    }
+
+    fn spawn_guarded(options: TerminalSpawnOptions, trust: TerminalSshTrust) -> Result<Self> {
         let rows = options.rows.max(1);
         let cols = options.cols.max(2);
         let scrollback_limit = options.scrollback_limit.max(1);
@@ -30,10 +42,8 @@ impl Terminal {
         };
         let replay_bytes = options.replay_bytes;
         let (event_tx, event_rx) = mpsc::channel();
-        let term_proxy = TerminalEventProxy {
-            event_tx: event_tx.clone(),
-        };
-        let event_loop_proxy = TerminalEventProxy { event_tx };
+        let event_loop_proxy = TerminalEventProxy::new(event_tx, trust);
+        let term_proxy = event_loop_proxy.clone();
 
         tty::setup_env();
 

--- a/crates/horizon-core/src/terminal/replay.rs
+++ b/crates/horizon-core/src/terminal/replay.rs
@@ -50,7 +50,7 @@ mod tests {
 
     use super::drain_replay_events;
     use crate::terminal::support::replay_terminal_bytes;
-    use crate::terminal::{TerminalDimensions, TerminalEventProxy};
+    use crate::terminal::{TerminalDimensions, TerminalEventProxy, TerminalSshTrust};
 
     #[test]
     fn replaying_device_status_queries_emits_side_effect_events() {
@@ -133,7 +133,7 @@ mod tests {
         let term = Arc::new(FairMutex::new(Term::new(
             config,
             &dimensions,
-            TerminalEventProxy { event_tx },
+            TerminalEventProxy::new(event_tx, TerminalSshTrust::default()),
         )));
 
         (term, event_rx)

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -139,9 +139,15 @@ back into large multi-purpose modules.
   literal argv plus the effective directory with the worker's retained intent;
   unresolved agent launch/handoff/resume semantics stay fail-closed.
 - `remote_worker_ssh.rs` centralizes crate-private pinned client options and SSH
-  path quoting without granting attachment authority. Status queries retain their
-  fixed noninteractive command, bounded I/O and public errors; the shared leaf does
-  not change general user-configured SSH or start an interactive connection.
+  path quoting without granting attachment authority. Typed query/attach modes
+  share isolation options; each owns private trust material. Status queries retain
+  bounded I/O, while interactive trust follows both terminal event proxies through
+  detached Drop and asynchronous join. General user-configured SSH is unchanged.
+- `remote_panel_attachment.rs` consumes explicit exact-allocation admission, fresh
+  non-creating recovery and saved-intent verification before a pinned local PTY.
+  Its target-bound attempt rechecks snapshots before input-capable handoff; it is
+  not authenticated attachment, saved Ready state or an atomic Stop/attach fence.
+  Board/UI admission and inert restore remain separate from this Linux-only API.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -144,7 +144,8 @@ back into large multi-purpose modules.
   bounded I/O, while interactive trust follows both terminal event proxies through
   detached Drop and asynchronous join. General user-configured SSH is unchanged.
 - `remote_panel_attachment.rs` consumes explicit exact-allocation admission, fresh
-  non-creating recovery and saved-intent verification before a pinned local PTY.
+  read-only identity/worker inspection and saved-intent verification before a pinned
+  local PTY. Only explicit recovery commits observations; attachment preserves saved phases.
   Its target-bound attempt rechecks snapshots before input-capable handoff; it is
   not authenticated attachment, saved Ready state or an atomic Stop/attach fence.
   Board/UI admission and inert restore remain separate from this Linux-only API.


### PR DESCRIPTION
## Purpose

Advance #383 with a Linux-only core API for explicitly connecting to an existing
persistent worker panel. The API inspects retained identity, verifies saved task
intent and exact owned snapshots, and starts only the worker's non-creating attach
command. It returns a connection attempt, not authenticated readiness.

## Behavior

- Use read-only worker/identity inspection, preserving saved phases and revisions.
  Explicit recovery retains its separate state-changing observation commit.
- Recheck exact allocation snapshots before/after local launch and before consuming
  the input-capable terminal. Reject stale, foreign, management-pending, unsupported
  or unavailable targets without task replay or replacement.
- Share existing isolated pinned SSH options with a fixed interactive command.
  Keep private trust material owned through local terminal shutdown, detached Drop
  and asynchronous joins; independent connections cannot remove each other's files.
- Preserve the short status-query deadline without limiting live connections to
  that duration. Use a worker-compatible terminal type only for this protected path.
- Leave generic SSH, inert restore, local Restart, Board/UI integration and saved
  Ready state unchanged. This is point-in-time admission, not an atomic Stop fence.
  Other platforms return unsupported before connection I/O. No cloud acceptance,
  automatic creation, management replay, repository certification or agent resume.

## Validation

- Full local matrix: formatting, maintainability, version synchronization, default
  and speech workspace tests, blocking/strict/advisory pedantic lint tiers.
  Source and exact committed candidate `69e3571a` both passed; worktree is clean.
- Focused regressions cover admission, argument isolation, exact-state races,
  missing identity, failed startup and trust lifetime through every teardown path.
  Running and exited tasks each cover saved Ready and Reconciling allocations.
- Independent local review completed. Real disposable retained-worker smoke passed
  two simultaneous pinned SSH PTYs, forwarded input, a connection longer than the
  query deadline, initial dimensions and live resize, same-PID reconnect after all
  clients exit and the original directory is renamed, and exited-pane inspection
  without replay. State revisions, client identity and retained task are unchanged.
  The full smoke was repeated successfully on the exact committed candidate from
  a saved Ready fixture, including unchanged saved phase and revisions.
- Client-local terminal definitions absent on the worker remain compatible. Missing
  tasks/keys and an injected wrong saved host pin reject without fallback. The pin
  fault lane exercises actual SSH preflight rejection, not a later handshake race.
- Disposable local worker and generated credentials cleaned up after exact ownership
  verification. No active user session or paid resource was used.

This focused change contains 10 source/test files and 970 changed source/test lines.
Open/Reconnect controls and remaining #383 acceptance work follow separately.
