### PR TITLE
feat(remote): hand off retained connections to board views

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -2,10 +2,12 @@ mod agent_status;
 mod arrangement;
 mod attention;
 mod geometry;
+mod remote;
 mod shutdown;
 mod workspaces;
 
 pub use arrangement::WorkspaceAlignment;
+pub use remote::RemotePanelHandoffError;
 use shutdown::FORCED_BROWSER_SHUTDOWN_WAIT;
 pub use shutdown::{ForcedBrowserShutdownStatus, ShutdownProgress};
 

--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -7,7 +7,7 @@ mod shutdown;
 mod workspaces;
 
 pub use arrangement::WorkspaceAlignment;
-pub use remote::RemotePanelHandoffError;
+pub use remote::{PreparedRemotePanelHandoff, RemotePanelHandoffError};
 use shutdown::FORCED_BROWSER_SHUTDOWN_WAIT;
 pub use shutdown::{ForcedBrowserShutdownStatus, ShutdownProgress};
 

--- a/crates/horizon-core/src/board/remote.rs
+++ b/crates/horizon-core/src/board/remote.rs
@@ -2,11 +2,60 @@
 
 use super::Board;
 use crate::{
-    PanelContent, PanelId, SshConnectionStatus,
+    PanelContent, PanelId, SshConnectionStatus, Terminal,
     cloud_run::CloudWorkflowStore,
     remote_panel_attachment::{RemotePanelAttachError, RemotePanelConnectionAttempt},
     runtime_state::RemoteWorkspaceReference,
 };
+use std::time::{Duration, Instant};
+
+const MAX_HANDOFF_AGE: Duration = Duration::from_secs(1);
+
+/// One short-lived, non-serializable local handoff, not remote execution authority.
+/// Prepare off the render thread and deliver promptly. The UI must also discard
+/// responses after a request, selection, configuration or active-session change.
+pub struct PreparedRemotePanelHandoff {
+    owner_session_id: String,
+    workspace_local_id: String,
+    panel_local_id: String,
+    terminal: Terminal,
+    admitted_at: Instant,
+}
+
+impl PreparedRemotePanelHandoff {
+    /// Recheck the owned allocation and consume its transport off the render thread.
+    /// Adoption rejects handoffs older than one second and closes only that local
+    /// connection. Holding or dropping a handoff never expires, stops or deletes the remote task.
+    /// Admission is point-in-time, not continuous revocation or an atomic Stop fence.
+    /// # Errors
+    /// Rejects allocation drift or failed storage reads without touching the view.
+    pub fn prepare(
+        store: &CloudWorkflowStore,
+        attempt: RemotePanelConnectionAttempt,
+    ) -> Result<Self, RemotePanelHandoffError> {
+        let workspace = attempt.allocation().workspace();
+        let owner_session_id = workspace.session_id().into();
+        let workspace_local_id = workspace.state().spec.workspace_local_id.clone();
+        let panel_local_id = attempt.panel_id().into();
+        let admitted_at = Instant::now();
+        let terminal = attempt.into_terminal(store)?;
+        Ok(Self {
+            owner_session_id,
+            workspace_local_id,
+            panel_local_id,
+            terminal,
+            admitted_at,
+        })
+    }
+}
+
+impl std::fmt::Debug for PreparedRemotePanelHandoff {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedRemotePanelHandoff")
+            .finish_non_exhaustive()
+    }
+}
 
 impl Board {
     /// Install one explicit connection attempt into its exact disconnected client view.
@@ -14,28 +63,28 @@ impl Board {
     /// never from the view's copied owner claim. Cross-session Open needs separate
     /// admission and is not authorized by this same-owner handoff.
     ///
-    /// Preserves view identity, layout, launch metadata and focus. Performs one owned
-    /// store check, but no provider I/O, task replay, Stop, Delete or saved-state write.
+    /// Preserves view identity, layout, launch metadata and focus. Performs no storage
+    /// or provider I/O, task replay, Stop, Delete or saved-state write.
+    /// Rechecks client/view identity, not durable allocation: a later Stop or store
+    /// change may remain undetected. The short local age limit is not revocation.
     /// Success means local transport was installed, not authenticated readiness.
     /// # Errors
-    /// Rejects mismatched sessions/targets, live existing transport or stale allocation.
+    /// Rejects mismatched sessions/targets, live existing transport or expired admission.
     /// A rejected attempt closes only its own local transport, not the target view.
     pub fn adopt_remote_panel_connection(
         &mut self,
-        store: &CloudWorkflowStore,
         client_session_id: &str,
         panel_id: PanelId,
-        attempt: RemotePanelConnectionAttempt,
+        handoff: PreparedRemotePanelHandoff,
     ) -> Result<(), RemotePanelHandoffError> {
-        let workspace = attempt.allocation().workspace();
-        if client_session_id != workspace.session_id() {
+        if client_session_id != handoff.owner_session_id {
             return Err(RemotePanelHandoffError::ClientSessionMismatch);
         }
         let panel = self.panel(panel_id).ok_or(RemotePanelHandoffError::TargetChanged)?;
         let reference = panel.remote_workspace().ok_or(RemotePanelHandoffError::TargetChanged)?;
         if reference.owner_session_id() != client_session_id
-            || reference.workspace_local_id() != workspace.state().spec.workspace_local_id
-            || panel.local_id != attempt.panel_id()
+            || reference.workspace_local_id() != handoff.workspace_local_id
+            || panel.local_id != handoff.panel_local_id
         {
             return Err(RemotePanelHandoffError::TargetChanged);
         }
@@ -61,9 +110,11 @@ impl Board {
         if panel.ssh_status() != Some(SshConnectionStatus::Disconnected) || !old_terminal.child_exited() {
             return Err(RemotePanelHandoffError::AlreadyConnected);
         }
-        let terminal = attempt.into_terminal(store)?;
+        if handoff.admitted_at.elapsed() > MAX_HANDOFF_AGE {
+            return Err(RemotePanelHandoffError::Expired);
+        }
         let panel = self.panel_mut(panel_id).ok_or(RemotePanelHandoffError::TargetChanged)?;
-        panel.content = PanelContent::Terminal(terminal);
+        panel.content = PanelContent::Terminal(handoff.terminal);
         panel.terminal_title.clear();
         panel.had_recent_output = false;
         // Generic SSH promotes Connecting on any output; that is not attachment proof.
@@ -80,6 +131,11 @@ pub enum RemotePanelHandoffError {
     TargetChanged,
     #[error("the remote view still has a local connection; it was not replaced")]
     AlreadyConnected,
+    #[error("the local connection handoff expired; retry without restarting the remote task")]
+    Expired,
     #[error(transparent)]
     Attachment(#[from] RemotePanelAttachError),
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/board/remote.rs
+++ b/crates/horizon-core/src/board/remote.rs
@@ -24,8 +24,11 @@ pub struct PreparedRemotePanelHandoff {
 
 impl PreparedRemotePanelHandoff {
     /// Recheck the owned allocation and consume its transport off the render thread.
-    /// Adoption rejects handoffs older than one second and closes only that local
+    /// Adoption rejects handoffs more than one second after the final store read
+    /// started, including time spent in that read, and closes only that local
     /// connection. Holding or dropping a handoff never expires, stops or deletes the remote task.
+    /// Slow reads can exhaust the budget before delivery; there is no guaranteed
+    /// one-second delivery window after preparation and no automatic remote cleanup.
     /// Admission is point-in-time, not continuous revocation or an atomic Stop fence.
     /// # Errors
     /// Rejects allocation drift or failed storage reads without touching the view.
@@ -37,6 +40,7 @@ impl PreparedRemotePanelHandoff {
         let owner_session_id = workspace.session_id().into();
         let workspace_local_id = workspace.state().spec.workspace_local_id.clone();
         let panel_local_id = attempt.panel_id().into();
+        // Count fence latency so a slow read or scheduling pause cannot refresh stale admission.
         let admitted_at = Instant::now();
         let terminal = attempt.into_terminal(store)?;
         Ok(Self {
@@ -75,7 +79,7 @@ impl Board {
         &mut self,
         client_session_id: &str,
         panel_id: PanelId,
-        handoff: PreparedRemotePanelHandoff,
+        mut handoff: PreparedRemotePanelHandoff,
     ) -> Result<(), RemotePanelHandoffError> {
         if client_session_id != handoff.owner_session_id {
             return Err(RemotePanelHandoffError::ClientSessionMismatch);
@@ -113,6 +117,7 @@ impl Board {
         if handoff.admitted_at.elapsed() > MAX_HANDOFF_AGE {
             return Err(RemotePanelHandoffError::Expired);
         }
+        handoff.terminal.resize_to_match(old_terminal);
         let panel = self.panel_mut(panel_id).ok_or(RemotePanelHandoffError::TargetChanged)?;
         panel.content = PanelContent::Terminal(handoff.terminal);
         panel.terminal_title.clear();

--- a/crates/horizon-core/src/board/remote.rs
+++ b/crates/horizon-core/src/board/remote.rs
@@ -1,0 +1,85 @@
+//! Consuming handoff into an existing disconnected remote view, never a task launch.
+
+use super::Board;
+use crate::{
+    PanelContent, PanelId, SshConnectionStatus,
+    cloud_run::CloudWorkflowStore,
+    remote_panel_attachment::{RemotePanelAttachError, RemotePanelConnectionAttempt},
+    runtime_state::RemoteWorkspaceReference,
+};
+
+impl Board {
+    /// Install one explicit connection attempt into its exact disconnected client view.
+    /// `client_session_id` must come from the actual resolved active client session,
+    /// never from the view's copied owner claim. Cross-session Open needs separate
+    /// admission and is not authorized by this same-owner handoff.
+    ///
+    /// Preserves view identity, layout, launch metadata and focus. Performs one owned
+    /// store check, but no provider I/O, task replay, Stop, Delete or saved-state write.
+    /// Success means local transport was installed, not authenticated readiness.
+    /// # Errors
+    /// Rejects mismatched sessions/targets, live existing transport or stale allocation.
+    /// A rejected attempt closes only its own local transport, not the target view.
+    pub fn adopt_remote_panel_connection(
+        &mut self,
+        store: &CloudWorkflowStore,
+        client_session_id: &str,
+        panel_id: PanelId,
+        attempt: RemotePanelConnectionAttempt,
+    ) -> Result<(), RemotePanelHandoffError> {
+        let workspace = attempt.allocation().workspace();
+        if client_session_id != workspace.session_id() {
+            return Err(RemotePanelHandoffError::ClientSessionMismatch);
+        }
+        let panel = self.panel(panel_id).ok_or(RemotePanelHandoffError::TargetChanged)?;
+        let reference = panel.remote_workspace().ok_or(RemotePanelHandoffError::TargetChanged)?;
+        if reference.owner_session_id() != client_session_id
+            || reference.workspace_local_id() != workspace.state().spec.workspace_local_id
+            || panel.local_id != attempt.panel_id()
+        {
+            return Err(RemotePanelHandoffError::TargetChanged);
+        }
+        RemoteWorkspaceReference::validate_client_panel(
+            &panel.local_id,
+            panel.kind,
+            &panel.resume,
+            panel.session_binding.as_ref(),
+        )
+        .map_err(|_| RemotePanelHandoffError::TargetChanged)?;
+        let visual_workspace = self
+            .workspace_for_panel(panel_id)
+            .ok_or(RemotePanelHandoffError::TargetChanged)?;
+        if !visual_workspace.panels.contains(&panel_id)
+            || visual_workspace
+                .remote_workspace
+                .as_ref()
+                .is_some_and(|visual_reference| visual_reference != reference)
+        {
+            return Err(RemotePanelHandoffError::TargetChanged);
+        }
+        let old_terminal = panel.terminal().ok_or(RemotePanelHandoffError::TargetChanged)?;
+        if panel.ssh_status() != Some(SshConnectionStatus::Disconnected) || !old_terminal.child_exited() {
+            return Err(RemotePanelHandoffError::AlreadyConnected);
+        }
+        let terminal = attempt.into_terminal(store)?;
+        let panel = self.panel_mut(panel_id).ok_or(RemotePanelHandoffError::TargetChanged)?;
+        panel.content = PanelContent::Terminal(terminal);
+        panel.terminal_title.clear();
+        panel.had_recent_output = false;
+        // Generic SSH promotes Connecting on any output; that is not attachment proof.
+        panel.ssh_status = None;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemotePanelHandoffError {
+    #[error("the active client session does not own this remote connection attempt")]
+    ClientSessionMismatch,
+    #[error("the disconnected remote view changed; discard the connection attempt")]
+    TargetChanged,
+    #[error("the remote view still has a local connection; it was not replaced")]
+    AlreadyConnected,
+    #[error(transparent)]
+    Attachment(#[from] RemotePanelAttachError),
+}

--- a/crates/horizon-core/src/board/remote/tests.rs
+++ b/crates/horizon-core/src/board/remote/tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn handoff_can_be_delivered_from_a_background_thread() {
+    fn assert_send<T: Send>() {}
+    assert_send::<PreparedRemotePanelHandoff>();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn expired_handoff_preserves_the_disconnected_view() {
+    use crate::{CanvasViewState, PanelKind, PanelState, RuntimeState, WindowConfig, WorkspaceState};
+
+    let owner = "00000000-0000-4000-8000-000000000001";
+    let reference = RemoteWorkspaceReference::new(owner.into(), "workspace".into()).expect("reference");
+    let state = RuntimeState {
+        workspaces: vec![WorkspaceState {
+            local_id: "visual-workspace".into(),
+            remote_workspace: Some(reference.clone()),
+            panels: vec![PanelState {
+                local_id: "terminal".into(),
+                kind: PanelKind::Ssh,
+                remote_workspace: Some(reference),
+                ..PanelState::default()
+            }],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    };
+    let mut board = Board::from_runtime_state(&state).expect("inert view");
+    assert!(board.panels[0].wait_for_shutdown(Duration::from_secs(2)));
+    board.panels[0].process_output();
+    let panel_id = board.panels[0].id;
+    let before = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    let handoff = PreparedRemotePanelHandoff {
+        owner_session_id: owner.into(),
+        workspace_local_id: "workspace".into(),
+        panel_local_id: "terminal".into(),
+        terminal: Terminal::spawn(crate::terminal::TerminalSpawnOptions {
+            program: "/bin/sh".into(),
+            args: vec!["-c".into(), "exit 0".into()],
+            cwd: None,
+            rows: 24,
+            cols: 80,
+            cell_width: 8,
+            cell_height: 16,
+            scrollback_limit: 100,
+            window_id: 0,
+            replay_bytes: Vec::new(),
+            env: std::collections::HashMap::new(),
+            kitty_keyboard: false,
+        })
+        .expect("owned transport"),
+        admitted_at: Instant::now()
+            .checked_sub(MAX_HANDOFF_AGE + Duration::from_secs(1))
+            .expect("expired fixture instant"),
+    };
+    let debug = format!("{handoff:?}");
+    assert!(!debug.contains(owner) && !debug.contains("workspace") && !debug.contains("terminal"));
+    assert_eq!(
+        board.adopt_remote_panel_connection(owner, panel_id, handoff),
+        Err(RemotePanelHandoffError::Expired)
+    );
+    let after = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    assert_eq!(after.to_yaml().expect("after"), before.to_yaml().expect("before"));
+    assert!(board.panels[0].terminal().expect("inert view").child_exited());
+}

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -54,7 +54,8 @@ pub use alacritty_terminal::index::Side as TerminalSide;
 pub use alacritty_terminal::selection::SelectionType;
 pub use attention::{AttentionId, AttentionItem, AttentionSeverity, AttentionState};
 pub use board::{
-    Board, ForcedBrowserShutdownStatus, ShutdownProgress, WorkspaceAlignment, WorkspaceDockSide, WorkspaceLayout,
+    Board, ForcedBrowserShutdownStatus, RemotePanelHandoffError, ShutdownProgress, WorkspaceAlignment,
+    WorkspaceDockSide, WorkspaceLayout,
 };
 pub use config::{
     AppearanceConfig, AppearanceTheme, Config, FeaturesConfig, OverlaysConfig, PresetConfig, ShortcutsConfig,

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -54,8 +54,8 @@ pub use alacritty_terminal::index::Side as TerminalSide;
 pub use alacritty_terminal::selection::SelectionType;
 pub use attention::{AttentionId, AttentionItem, AttentionSeverity, AttentionState};
 pub use board::{
-    Board, ForcedBrowserShutdownStatus, RemotePanelHandoffError, ShutdownProgress, WorkspaceAlignment,
-    WorkspaceDockSide, WorkspaceLayout,
+    Board, ForcedBrowserShutdownStatus, PreparedRemotePanelHandoff, RemotePanelHandoffError, ShutdownProgress,
+    WorkspaceAlignment, WorkspaceDockSide, WorkspaceLayout,
 };
 pub use config::{
     AppearanceConfig, AppearanceTheme, Config, FeaturesConfig, OverlaysConfig, PresetConfig, ShortcutsConfig,

--- a/crates/horizon-core/src/remote_panel_attachment/tests.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests.rs
@@ -11,10 +11,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+mod board;
+
 const OWNER: &str = "00000000-0000-4000-8000-000000000001";
 
 struct Fixture {
-    _directory: tempfile::TempDir,
+    directory: tempfile::TempDir,
     store: CloudWorkflowStore,
     identities: RemoteSshIdentityStore,
     provider: Provider,
@@ -90,7 +92,7 @@ impl Fixture {
             .expect("recovery");
         *provider.calls.lock().expect("calls") = 0;
         Self {
-            _directory: directory,
+            directory,
             store,
             identities,
             provider,

--- a/crates/horizon-core/src/remote_panel_attachment/tests/board.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests/board.rs
@@ -1,0 +1,290 @@
+use super::{Fixture, OWNER, invalidate, local_options, running};
+use crate::{
+    Board, CanvasViewState, PanelId, PanelKind, PanelResume, RemotePanelHandoffError, SshConnectionStatus,
+    remote_panel_attachment::{RemotePanelAttachError, RemotePanelConnectionAttempt},
+    runtime_state::{PanelState, RemoteWorkspaceReference, RuntimeState, WorkspaceState},
+};
+use std::time::{Duration, Instant};
+
+fn board(fixture: &Fixture) -> Board {
+    let reference = RemoteWorkspaceReference::new(OWNER.into(), "workspace".into()).expect("reference");
+    let marker = fixture.directory.path().join("never-start-locally");
+    let state = RuntimeState {
+        workspaces: vec![WorkspaceState {
+            local_id: "remote-view".into(),
+            name: "Retained remote view".into(),
+            remote_workspace: Some(reference.clone()),
+            panels: vec![PanelState {
+                local_id: "terminal".into(),
+                name: "Custom remote task".into(),
+                kind: PanelKind::Ssh,
+                remote_workspace: Some(reference),
+                command: Some("/bin/sh".into()),
+                args: vec![
+                    "-c".into(),
+                    ": > \"$1\"".into(),
+                    "fixture".into(),
+                    marker.to_string_lossy().into_owned(),
+                ],
+                ..PanelState::default()
+            }],
+            ..WorkspaceState::default()
+        }],
+        ..RuntimeState::default()
+    };
+    let mut board = Board::from_runtime_state(&state).expect("inert remote view");
+    let panel = &mut board.panels[0];
+    assert!(panel.wait_for_shutdown(Duration::from_secs(2)));
+    panel.process_output();
+    assert!(panel.terminal().expect("placeholder").child_exited());
+    assert!(!marker.exists());
+    board
+}
+
+fn attempt(fixture: &Fixture, script: &str) -> RemotePanelConnectionAttempt {
+    RemotePanelConnectionAttempt {
+        allocation: fixture.current(),
+        panel_id: "terminal".into(),
+        observed_status: running(),
+        terminal: crate::Terminal::spawn(local_options(script)).expect("owned local transport fixture"),
+    }
+}
+
+fn saved_view(board: &Board) -> String {
+    RuntimeState::from_board(
+        board,
+        crate::config::WindowConfig::default(),
+        CanvasViewState::default(),
+    )
+    .to_yaml()
+    .expect("saved view")
+}
+
+fn await_output(board: &mut Board, panel_id: PanelId, marker: &str) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let panel = board.panel_mut(panel_id).expect("view");
+        panel.process_output();
+        if panel.terminal().expect("terminal").last_lines_text(24).contains(marker) {
+            return;
+        }
+        assert!(Instant::now() < deadline, "local output deadline");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn handoff_preserves_view_and_store_without_promoting_arbitrary_output() {
+    let fixture = Fixture::new();
+    let mut board = board(&fixture);
+    let before_view = saved_view(&board);
+    let before_store = fixture.current();
+    let panel_id = board.panels[0].id;
+    let focus = (board.focused, board.active_workspace);
+    board
+        .adopt_remote_panel_connection(
+            &fixture.store,
+            OWNER,
+            panel_id,
+            attempt(&fixture, "printf 'unverified-transport-output\\n'; read -r fixture"),
+        )
+        .expect("handoff");
+    await_output(&mut board, panel_id, "unverified-transport-output");
+    assert_eq!(board.panel(panel_id).expect("view").ssh_status(), None);
+    assert_eq!(saved_view(&board), before_view);
+    assert_eq!((board.focused, board.active_workspace), focus);
+    assert_eq!(fixture.current(), before_store);
+    assert!(board.restart_panel(panel_id).is_err());
+    assert!(!fixture.directory.path().join("never-start-locally").exists());
+    board.shutdown_terminal_panels();
+    assert_eq!(fixture.current(), before_store);
+}
+
+#[test]
+fn copied_references_and_changed_view_identity_do_not_authorize_handoff() {
+    for fault in 0..7 {
+        let fixture = Fixture::new();
+        let mut board = board(&fixture);
+        let panel_id = board.panels[0].id;
+        let mut current_session = OWNER;
+        match fault {
+            0 => current_session = "00000000-0000-4000-8000-000000000002",
+            1 => board.panels[0].local_id = "different-panel".into(),
+            2 => board.panels[0].kind = PanelKind::Shell,
+            3 => board.panels[0].resume = PanelResume::Last,
+            4 => board.workspaces[0].panels.clear(),
+            5 => {
+                board.workspaces[0].remote_workspace =
+                    Some(RemoteWorkspaceReference::new(OWNER.into(), "different-workspace".into()).expect("reference"));
+            }
+            6 => board.panels[0].workspace_id = crate::WorkspaceId(u64::MAX),
+            _ => unreachable!(),
+        }
+        let before = fixture.current();
+        let original_content = board.panels[0].terminal().expect("placeholder").last_lines_text(24);
+        let result =
+            board.adopt_remote_panel_connection(&fixture.store, current_session, panel_id, attempt(&fixture, "exit 0"));
+        assert_eq!(
+            result,
+            Err(if fault == 0 {
+                RemotePanelHandoffError::ClientSessionMismatch
+            } else {
+                RemotePanelHandoffError::TargetChanged
+            })
+        );
+        assert_eq!(
+            board.panels[0].terminal().expect("placeholder").last_lines_text(24),
+            original_content
+        );
+        assert_eq!(fixture.current(), before);
+    }
+}
+
+#[test]
+fn missing_or_local_panel_cannot_receive_a_remote_connection() {
+    let fixture = Fixture::new();
+    let mut board = board(&fixture);
+    let before = saved_view(&board);
+    assert_eq!(
+        board.adopt_remote_panel_connection(&fixture.store, OWNER, PanelId(u64::MAX), attempt(&fixture, "exit 0")),
+        Err(RemotePanelHandoffError::TargetChanged)
+    );
+    assert_eq!(saved_view(&board), before);
+    let local_workspace = board.create_workspace("Local");
+    let local = board
+        .create_panel(
+            crate::PanelOptions {
+                kind: PanelKind::Ssh,
+                command: Some("/bin/sh".into()),
+                args: vec!["-c".into(), "exit 0".into()],
+                ..crate::PanelOptions::default()
+            },
+            local_workspace,
+        )
+        .expect("local view");
+    let before = saved_view(&board);
+    assert_eq!(
+        board.adopt_remote_panel_connection(&fixture.store, OWNER, local, attempt(&fixture, "exit 0")),
+        Err(RemotePanelHandoffError::TargetChanged)
+    );
+    assert_eq!(saved_view(&board), before);
+    board.shutdown_terminal_panels();
+}
+
+#[test]
+fn moved_remote_view_keeps_its_execution_identity_during_handoff() {
+    let fixture = Fixture::new();
+    let mut board = board(&fixture);
+    let panel_id = board.panels[0].id;
+    let local_workspace = board.create_workspace("Local visual container");
+    board.assign_panel_to_workspace(panel_id, local_workspace);
+    let before = saved_view(&board);
+    board
+        .adopt_remote_panel_connection(&fixture.store, OWNER, panel_id, attempt(&fixture, "read -r fixture"))
+        .expect("explicit connection to moved remote view");
+    assert_eq!(saved_view(&board), before);
+    assert_eq!(board.panel_workspace_id(panel_id), Some(local_workspace));
+    board.shutdown_terminal_panels();
+}
+
+#[test]
+fn stale_allocation_or_second_attempt_never_replaces_the_target_transport() {
+    let fixture = Fixture::new();
+    let mut board = board(&fixture);
+    let panel_id = board.panels[0].id;
+    let stale = attempt(&fixture, "exit 0");
+    invalidate(&fixture.store);
+    let before = saved_view(&board);
+    assert_eq!(
+        board.adopt_remote_panel_connection(&fixture.store, OWNER, panel_id, stale),
+        Err(RemotePanelHandoffError::Attachment(
+            RemotePanelAttachError::StateChanged
+        ))
+    );
+    assert_eq!(saved_view(&board), before);
+    board
+        .adopt_remote_panel_connection(
+            &fixture.store,
+            OWNER,
+            panel_id,
+            attempt(
+                &fixture,
+                "printf 'first-connection\\n'; read -r fixture; printf 'original-still-live\\n'; read -r fixture",
+            ),
+        )
+        .expect("first handoff");
+    await_output(&mut board, panel_id, "first-connection");
+    assert_eq!(
+        board.adopt_remote_panel_connection(&fixture.store, OWNER, panel_id, attempt(&fixture, "exit 0")),
+        Err(RemotePanelHandoffError::AlreadyConnected)
+    );
+    board
+        .panel(panel_id)
+        .expect("view")
+        .terminal()
+        .expect("transport")
+        .write_input(b"fixture\n");
+    await_output(&mut board, panel_id, "original-still-live");
+    board.shutdown_terminal_panels();
+}
+
+#[test]
+fn disconnected_transport_accepts_fresh_handoff_but_saved_restore_remains_inert() {
+    let fixture = Fixture::new();
+    let mut board = board(&fixture);
+    let panel_id = board.panels[0].id;
+    let before_store = fixture.current();
+    board
+        .adopt_remote_panel_connection(
+            &fixture.store,
+            OWNER,
+            panel_id,
+            attempt(&fixture, "printf 'transport-ended\\n'"),
+        )
+        .expect("first handoff");
+    assert!(
+        board
+            .panel_mut(panel_id)
+            .expect("panel")
+            .wait_for_shutdown(Duration::from_secs(2))
+    );
+    board.panel_mut(panel_id).expect("panel").process_output();
+    assert_eq!(
+        board.panel(panel_id).expect("panel").ssh_status(),
+        Some(SshConnectionStatus::Disconnected)
+    );
+    board
+        .adopt_remote_panel_connection(
+            &fixture.store,
+            OWNER,
+            panel_id,
+            attempt(&fixture, "printf 'reconnected-view\\n'; read -r fixture"),
+        )
+        .expect("fresh handoff after local exit");
+    await_output(&mut board, panel_id, "reconnected-view");
+    let state = RuntimeState::from_board(
+        &board,
+        crate::config::WindowConfig::default(),
+        CanvasViewState::default(),
+    );
+    board.close_panel(panel_id);
+    assert!(board.panel(panel_id).is_none());
+    assert!(
+        !board.workspaces.is_empty(),
+        "remote workspace remains after its last local view closes"
+    );
+    assert_eq!(fixture.current(), before_store);
+    let mut restored = Board::from_runtime_state(&state).expect("inert reopened view");
+    assert!(restored.panels[0].wait_for_shutdown(Duration::from_secs(2)));
+    restored.panels[0].process_output();
+    assert!(
+        restored.panels[0]
+            .terminal()
+            .expect("placeholder")
+            .last_lines_text(24)
+            .contains("Remote connection pending")
+    );
+    assert!(restored.restart_panel(restored.panels[0].id).is_err());
+    assert!(!fixture.directory.path().join("never-start-locally").exists());
+    assert_eq!(fixture.current(), before_store);
+}

--- a/crates/horizon-core/src/remote_panel_attachment/tests/board.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests/board.rs
@@ -1,6 +1,7 @@
 use super::{Fixture, OWNER, invalidate, local_options, running};
 use crate::{
-    Board, CanvasViewState, PanelId, PanelKind, PanelResume, RemotePanelHandoffError, SshConnectionStatus,
+    Board, CanvasViewState, PanelId, PanelKind, PanelResume, PreparedRemotePanelHandoff, RemotePanelHandoffError,
+    SshConnectionStatus,
     remote_panel_attachment::{RemotePanelAttachError, RemotePanelConnectionAttempt},
     runtime_state::{PanelState, RemoteWorkspaceReference, RuntimeState, WorkspaceState},
 };
@@ -50,6 +51,10 @@ fn attempt(fixture: &Fixture, script: &str) -> RemotePanelConnectionAttempt {
     }
 }
 
+fn handoff(fixture: &Fixture, script: &str) -> PreparedRemotePanelHandoff {
+    PreparedRemotePanelHandoff::prepare(&fixture.store, attempt(fixture, script)).expect("fresh handoff")
+}
+
 fn saved_view(board: &Board) -> String {
     RuntimeState::from_board(
         board,
@@ -83,10 +88,9 @@ fn handoff_preserves_view_and_store_without_promoting_arbitrary_output() {
     let focus = (board.focused, board.active_workspace);
     board
         .adopt_remote_panel_connection(
-            &fixture.store,
             OWNER,
             panel_id,
-            attempt(&fixture, "printf 'unverified-transport-output\\n'; read -r fixture"),
+            handoff(&fixture, "printf 'unverified-transport-output\\n'; read -r fixture"),
         )
         .expect("handoff");
     await_output(&mut board, panel_id, "unverified-transport-output");
@@ -122,8 +126,7 @@ fn copied_references_and_changed_view_identity_do_not_authorize_handoff() {
         }
         let before = fixture.current();
         let original_content = board.panels[0].terminal().expect("placeholder").last_lines_text(24);
-        let result =
-            board.adopt_remote_panel_connection(&fixture.store, current_session, panel_id, attempt(&fixture, "exit 0"));
+        let result = board.adopt_remote_panel_connection(current_session, panel_id, handoff(&fixture, "exit 0"));
         assert_eq!(
             result,
             Err(if fault == 0 {
@@ -146,7 +149,7 @@ fn missing_or_local_panel_cannot_receive_a_remote_connection() {
     let mut board = board(&fixture);
     let before = saved_view(&board);
     assert_eq!(
-        board.adopt_remote_panel_connection(&fixture.store, OWNER, PanelId(u64::MAX), attempt(&fixture, "exit 0")),
+        board.adopt_remote_panel_connection(OWNER, PanelId(u64::MAX), handoff(&fixture, "exit 0")),
         Err(RemotePanelHandoffError::TargetChanged)
     );
     assert_eq!(saved_view(&board), before);
@@ -164,7 +167,7 @@ fn missing_or_local_panel_cannot_receive_a_remote_connection() {
         .expect("local view");
     let before = saved_view(&board);
     assert_eq!(
-        board.adopt_remote_panel_connection(&fixture.store, OWNER, local, attempt(&fixture, "exit 0")),
+        board.adopt_remote_panel_connection(OWNER, local, handoff(&fixture, "exit 0")),
         Err(RemotePanelHandoffError::TargetChanged)
     );
     assert_eq!(saved_view(&board), before);
@@ -180,7 +183,7 @@ fn moved_remote_view_keeps_its_execution_identity_during_handoff() {
     board.assign_panel_to_workspace(panel_id, local_workspace);
     let before = saved_view(&board);
     board
-        .adopt_remote_panel_connection(&fixture.store, OWNER, panel_id, attempt(&fixture, "read -r fixture"))
+        .adopt_remote_panel_connection(OWNER, panel_id, handoff(&fixture, "read -r fixture"))
         .expect("explicit connection to moved remote view");
     assert_eq!(saved_view(&board), before);
     assert_eq!(board.panel_workspace_id(panel_id), Some(local_workspace));
@@ -196,18 +199,15 @@ fn stale_allocation_or_second_attempt_never_replaces_the_target_transport() {
     invalidate(&fixture.store);
     let before = saved_view(&board);
     assert_eq!(
-        board.adopt_remote_panel_connection(&fixture.store, OWNER, panel_id, stale),
-        Err(RemotePanelHandoffError::Attachment(
-            RemotePanelAttachError::StateChanged
-        ))
+        PreparedRemotePanelHandoff::prepare(&fixture.store, stale).expect_err("stale allocation"),
+        RemotePanelHandoffError::Attachment(RemotePanelAttachError::StateChanged)
     );
     assert_eq!(saved_view(&board), before);
     board
         .adopt_remote_panel_connection(
-            &fixture.store,
             OWNER,
             panel_id,
-            attempt(
+            handoff(
                 &fixture,
                 "printf 'first-connection\\n'; read -r fixture; printf 'original-still-live\\n'; read -r fixture",
             ),
@@ -215,7 +215,7 @@ fn stale_allocation_or_second_attempt_never_replaces_the_target_transport() {
         .expect("first handoff");
     await_output(&mut board, panel_id, "first-connection");
     assert_eq!(
-        board.adopt_remote_panel_connection(&fixture.store, OWNER, panel_id, attempt(&fixture, "exit 0")),
+        board.adopt_remote_panel_connection(OWNER, panel_id, handoff(&fixture, "exit 0")),
         Err(RemotePanelHandoffError::AlreadyConnected)
     );
     board
@@ -235,12 +235,7 @@ fn disconnected_transport_accepts_fresh_handoff_but_saved_restore_remains_inert(
     let panel_id = board.panels[0].id;
     let before_store = fixture.current();
     board
-        .adopt_remote_panel_connection(
-            &fixture.store,
-            OWNER,
-            panel_id,
-            attempt(&fixture, "printf 'transport-ended\\n'"),
-        )
+        .adopt_remote_panel_connection(OWNER, panel_id, handoff(&fixture, "printf 'transport-ended\\n'"))
         .expect("first handoff");
     assert!(
         board
@@ -255,10 +250,9 @@ fn disconnected_transport_accepts_fresh_handoff_but_saved_restore_remains_inert(
     );
     board
         .adopt_remote_panel_connection(
-            &fixture.store,
             OWNER,
             panel_id,
-            attempt(&fixture, "printf 'reconnected-view\\n'; read -r fixture"),
+            handoff(&fixture, "printf 'reconnected-view\\n'; read -r fixture"),
         )
         .expect("fresh handoff after local exit");
     await_output(&mut board, panel_id, "reconnected-view");

--- a/crates/horizon-core/src/remote_panel_attachment/tests/board.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests/board.rs
@@ -144,6 +144,32 @@ fn copied_references_and_changed_view_identity_do_not_authorize_handoff() {
 }
 
 #[test]
+fn handoff_uses_current_view_geometry_even_when_resized_during_preparation() {
+    let fixture = Fixture::new();
+    let mut board = board(&fixture);
+    let panel_id = board.panels[0].id;
+    board.panels[0]
+        .terminal_mut()
+        .expect("view")
+        .resize_immediately(31, 99, 10, 18);
+    let prepared = handoff(&fixture, "read -r fixture; stty size; read -r fixture");
+    board.panels[0]
+        .terminal_mut()
+        .expect("view")
+        .resize_immediately(48, 120, 11, 19);
+    let before = saved_view(&board);
+    board
+        .adopt_remote_panel_connection(OWNER, panel_id, prepared)
+        .expect("geometry-preserving handoff");
+    assert_eq!(saved_view(&board), before);
+    let terminal = board.panels[0].terminal().expect("connection");
+    assert_eq!((terminal.rows(), terminal.cols()), (48, 120));
+    terminal.write_input(b"check-current-geometry\n");
+    await_output(&mut board, panel_id, "48 120");
+    board.shutdown_terminal_panels();
+}
+
+#[test]
 fn missing_or_local_panel_cannot_receive_a_remote_connection() {
     let fixture = Fixture::new();
     let mut board = board(&fixture);

--- a/crates/horizon-core/src/terminal/resize.rs
+++ b/crates/horizon-core/src/terminal/resize.rs
@@ -20,6 +20,10 @@ impl Terminal {
         self.resize_with_policy(rows, cols, cell_width, cell_height, true);
     }
 
+    pub(crate) fn resize_to_match(&mut self, other: &Self) {
+        self.resize_immediately(other.rows, other.cols, other.cell_width, other.cell_height);
+    }
+
     fn resize_with_policy(&mut self, rows: u16, cols: u16, cell_width: u16, cell_height: u16, immediate: bool) {
         let rows = rows.max(1);
         let cols = cols.max(2);

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -149,11 +149,13 @@ back into large multi-purpose modules.
   Its target-bound attempt rechecks snapshots before input-capable handoff; it is
   not authenticated attachment, saved Ready state or an atomic Stop/attach fence.
   Board/UI admission and inert restore remain separate from this Linux-only API.
-- `board/remote.rs` consumes a protected attempt into one disconnected same-owner
-  remote view, comparing the actual client session and current view identity before
-  the final store fence. Visual rehoming preserves execution identity. Handoff does
-  not persist transport arguments, promote readiness or enable implicit restore;
-  global cross-session Open and asynchronous UI orchestration remain separate.
+- `board/remote.rs` prepares a protected, short-lived local handoff after the final
+  off-thread store fence, then consumes it into one disconnected same-owner view
+  without I/O. The actual client session and current view identity must match;
+  queued admission expires without affecting remote task lifetime. Visual rehoming
+  preserves execution identity. It does not persist transport arguments, promote
+  readiness or enable implicit restore. UI request/config/session invalidation and
+  global cross-session Open remain separate; admission is not continuous revocation.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -156,6 +156,8 @@ back into large multi-purpose modules.
   preserves execution identity. It does not persist transport arguments, promote
   readiness or enable implicit restore. UI request/config/session invalidation and
   global cross-session Open remain separate; admission is not continuous revocation.
+  Handoff synchronizes terminal grid and PTY geometry to the current view, not the
+  earlier asynchronous request. Its age bound conservatively includes store latency.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -149,6 +149,11 @@ back into large multi-purpose modules.
   Its target-bound attempt rechecks snapshots before input-capable handoff; it is
   not authenticated attachment, saved Ready state or an atomic Stop/attach fence.
   Board/UI admission and inert restore remain separate from this Linux-only API.
+- `board/remote.rs` consumes a protected attempt into one disconnected same-owner
+  remote view, comparing the actual client session and current view identity before
+  the final store fence. Visual rehoming preserves execution identity. Handoff does
+  not persist transport arguments, promote readiness or enable implicit restore;
+  global cross-session Open and asynchronous UI orchestration remain separate.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply


### PR DESCRIPTION
## Purpose

Advance #383 by handing a protected existing-session connection into its exact disconnected Board view. This is a focused core prerequisite for Open/Reconnect, not completion of the remote-workspace feature.

## Behavior

- Prepare an opaque, consuming handoff off the render thread, preserving the attachment API's final owned-allocation check. Board adoption performs no storage or provider I/O.
- Require the actual active owner session, exact current execution identity and a disconnected view; preserve layout, launch metadata, focus and saved state. Reject old local admission after one second without stopping the remote task. The conservative age bound includes the final store read; it does not promise a fresh one-second delivery window afterward.
- Synchronize the incoming terminal grid and PTY dimensions with the view's current geometry, including changes made while preparation was pending.
- Keep arbitrary transport output unverified. Generic Restart and saved restore remain inert; panel close and Board teardown disconnect only the local view.
- Admission is point-in-time: later durable changes are not continuously revoked or atomically fenced against Stop. UI request/config/session invalidation and cross-session Open remain separate requirements.

Seven source/test files, 538 changed lines, plus nine architecture lines. No UI controls, provider creation, task replay, dependency/configuration changes or release.

## Validation

- Independent full-diff review and final committed-tree ratification passed.
- Focused ownership/target drift, stale preparation, duplicate handoff, moved views, inert restore, expiry, thread-delivery and resize-during-preparation tests passed. The geometry regression verifies both the terminal grid and the child-reported PTY size.
- Full final-source and exact-commit validation passed: formatting, maintainability, version sync, default and speech workspace tests, blocking/strict/advisory Clippy. The repaired-main repeat uses locked resolution and verifies the lockfile fingerprint after each gate.
- Real disposable retained-worker smoke passed simultaneous pinned SSH clients, input, exact initial/live PTY dimensions, same-PID reconnect after all clients exit and directory rename, and retained exit-status inspection without replay.
- Verified panel close, Board Drop, and independently completed Board shutdown: the Board remained alive while the exact remote client disappeared and the same task continued progressing. Persisted views, allocation snapshots/revisions and retained keys stayed unchanged; only verified task-owned fixtures were removed.
- Missing task/key and wrong-pin preflight reject without fallback. No cloud/PC-off, native UI or authenticated-readiness acceptance is claimed.

Refreshed onto the actual repaired main from #451; the feature diff is unchanged. Independent integration/committed-tree review, the complete source/exact-commit matrices and the strengthened real-worker repeat passed on this candidate.

Candidate: `2c0558dc2328402d66653c79b76be02dc3a51199`, tree `dd2d506b4d043d11cb29df78d165a92b7c2e1da9`, based on `6c00b81ef1a263ba68916d932152de76b0ec9360`.
