### PR TITLE
fix(build): align the lockfile with the declared dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # Rust surface is identical to `speech` (they only toggle native
       # backends). cpal needs the ALSA headers on Linux.
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
-      - run: cargo clippy --all-targets --features speech,trace-profiling -- -D warnings
+      - run: cargo clippy --locked --all-targets --features speech,trace-profiling -- -D warnings
 
   clippy-strict:
     name: Clippy (strict)
@@ -94,7 +94,7 @@ jobs:
       # `--features speech` so the unwrap/expect ban also covers the speech
       # runtime code (needs the ALSA headers to build cpal on Linux).
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
-      - run: cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
+      - run: cargo clippy --locked --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
 
   clippy-pedantic:
     name: Clippy (pedantic — advisory)
@@ -109,7 +109,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - name: Run pedantic audit (non-blocking)
         run: |
-          cargo clippy --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic || {
+          cargo clippy --locked --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic || {
             echo "::warning::Pedantic lint debt detected (non-blocking advisory job)."
           }
 
@@ -140,14 +140,14 @@ jobs:
       - name: Link the Swift runtime in macOS test binaries
         if: startsWith(matrix.os, 'macos-')
         run: echo "RUSTFLAGS=${RUSTFLAGS} -C link-arg=-Wl,-rpath,/usr/lib/swift" >> "$GITHUB_ENV"
-      - run: cargo test --workspace
+      - run: cargo test --locked --workspace
       # Speech tests (resampler, GGUF reader, shortcut matchers, engine
       # state machine) run on every OS in the matrix so the native audio
       # linkage (ALSA / CoreAudio) is exercised on each supported target;
       # the no-mic and real-model paths stay env-gated off.
       - if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
-      - run: cargo test --workspace --features speech
+      - run: cargo test --locked --workspace --features speech
 
   windows-smoke:
     name: Windows test build
@@ -160,13 +160,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: windows-test-build
-      - run: cargo test --workspace --no-run
+      - run: cargo test --locked --workspace --no-run
       - name: Execute durable publication regression
-        run: cargo test -p horizon-browser-cli --test cli run_publishes_a_complete_relative_job_when_home_is_unset -- --exact
+        run: cargo test --locked -p horizon-browser-cli --test cli run_publishes_a_complete_relative_job_when_home_is_unset -- --exact
       # The speech feature is advertised on Windows too (WASAPI capture via
       # cpal); build it so a Windows-only break cannot pass CI. Compiling the
       # vendored C++ tree here is the point — tests are not run.
-      - run: cargo test --workspace --features speech --no-run
+      - run: cargo test --locked --workspace --features speech --no-run
 
   snap-build-inputs:
     name: Snap Build Inputs
@@ -270,7 +270,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.cache_key }}
-      - run: cargo build --release
+      - run: cargo build --locked --release
       - name: Package release asset
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,15 +2751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,16 +3031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,17 +3074,6 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2 0.6.4",
- "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3558,15 +3528,6 @@ name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -4427,7 +4388,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "surge-core"
 version = "1.0.0"
-source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.61#27c22c1dfb8c73df8d3bd7f5f24f82f82d674c04"
+source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.55#83f22fcec5956d81f8752e8720b157e21f7271f5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -4436,22 +4397,19 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
- "libc",
  "nix",
  "percent-encoding",
- "quick-xml 0.42.0",
+ "quick-xml",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
- "sysinfo",
  "tar",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "uuid",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -4496,21 +4454,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.39.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "objc2-open-directory",
- "windows",
 ]
 
 [[package]]
@@ -5369,7 +5312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.41.0",
+ "quick-xml",
  "quote",
 ]
 


### PR DESCRIPTION
## Purpose

Restore reproducible dependency resolution after #444, unblocking exact-tree validation for #383. The manifest still declares the previous Git tag, while the merged lockfile records a different tag. A normal workspace test run consequently rewrites that lockfile.

## Behavior

- Keep the manifest and the dependency version already selected by normal builds unchanged.
- Correct only the inconsistent lock entries and remove dependencies exclusive to the undeclared version. Preserve unrelated package versions and dependency edges.
- Make all nine CI test, lint and build commands use locked resolution, so a future mismatch fails instead of silently changing the validated dependency tree. Platforms, features, advisory handling and conditional jobs stay unchanged.
- No application source, UI, configuration, installer or release changes. An upgrade of the declared library version remains separate work.

The patch changes one generated lockfile (three additions and sixty deletions) and nine workflow commands. The lock repair is byte-identical to Cargo's minimal automatic resolution of the current manifest.

## Validation

- Independent full-diff review and canonical-tree verification passed.
- Full exact-source validation passed with locked resolution and an unchanged lockfile fingerprint after each gate: formatting, maintainability, version synchronization, default/speech tests and blocking/strict/advisory Clippy.
- Full exact-commit validation passed with the same locked-resolution and per-gate fingerprint checks.

The CI-guard correction passed independent full-diff and committed-tree review plus the full source and exact-commit matrices. A disposable exact-base reproduction confirmed that locked testing rejects the inconsistent lockfile before compilation.

Candidate: `05ea1bf0595d1b8382153e887c2ec32a87a3bebd`, tree `25e0d2e7f772f4e96de059e1aad1aed72b4eb49c`, base `eb4cab477160ee0b56cd3c3854005896a5a4d7bd`.
