### PR TITLE
feat(remote): bind panel reconnection to the configured profile

### DIFF
--- a/crates/horizon-core/src/remote_panel_attachment.rs
+++ b/crates/horizon-core/src/remote_panel_attachment.rs
@@ -1,5 +1,11 @@
 //! Explicit, non-creating attachment to one retained panel. Run off the render thread.
 
+mod configured;
+
+pub use configured::{
+    ConfiguredRemotePanelAttachError, ConfiguredRemotePanelAttachRequest, attach_configured_remote_panel,
+};
+
 use crate::{
     Terminal,
     cloud_run::{

--- a/crates/horizon-core/src/remote_panel_attachment/configured.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/configured.rs
@@ -1,0 +1,83 @@
+//! Explicit current-client and exact-profile admission; no ambient provider fallback.
+
+use super::{RemotePanelAttachError, RemotePanelAttachRequest, RemotePanelConnectionAttempt, RemotePanelTerminalSize};
+use crate::{
+    cloud_run::{CloudProvider, CloudWorkflowStore, local_docker::LocalDockerInteractiveWorkerProvider},
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace::RemoteEnvironmentSummary,
+    remote_workspace_recovery::RemoteWorkspaceRecoveryError,
+};
+
+#[derive(Clone, Copy)]
+pub struct ConfiguredRemotePanelAttachRequest<'a> {
+    pub expected: &'a RemoteEnvironmentSummary,
+    /// Actual resolved active client session, never copied from an environment or view claim.
+    pub client_session_id: &'a str,
+    pub panel_id: &'a str,
+    pub terminal: RemotePanelTerminalSize,
+}
+
+/// Explicitly connect one existing panel through its exact configured local profile.
+/// Run all storage, retained-key, provider and SSH work off the render thread.
+/// The actual active session must own the selected environment; copied references
+/// and global inventory access alone do not admit a connection. The caller must
+/// additionally bind the request/result to the exact client view and config/request
+/// generation. Same-owner admission does not implement cross-session Open.
+/// No identity creation, task startup/replay, worker allocation, Stop, Delete or
+/// provider/profile fallback occurs. Saved state is unchanged; this returns a local
+/// transport attempt, not authenticated connection or workspace readiness.
+/// # Errors
+/// Rejects unsupported providers, stale or foreign selections, missing profiles or
+/// owned allocations, and attachment failures without exposing private payloads.
+pub fn attach_configured_remote_panel(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    config: &RemoteProviderConfig,
+    request: ConfiguredRemotePanelAttachRequest<'_>,
+) -> Result<RemotePanelConnectionAttempt, ConfiguredRemotePanelAttachError> {
+    if request.expected.provider != CloudProvider::LocalDocker {
+        return Err(ConfiguredRemotePanelAttachError::UnsupportedProvider);
+    }
+    if request.client_session_id != request.expected.owning_session_id {
+        return Err(ConfiguredRemotePanelAttachError::ClientSessionMismatch);
+    }
+    let profile = config.local_docker_profile(&request.expected.profile)?;
+    let allocation = store
+        .load_remote_allocation(request.client_session_id, &request.expected.workspace_local_id)
+        .map_err(RemoteWorkspaceRecoveryError::from)?
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    if allocation.workspace().environment_summary() != *request.expected {
+        return Err(RemoteWorkspaceRecoveryError::StateChanged.into());
+    }
+    let provider = LocalDockerInteractiveWorkerProvider::new(profile.clone(), store.clone())
+        .map_err(|_| RemoteWorkspaceRecoveryError::ProviderUnavailable)?;
+    Ok(super::attach_remote_panel(
+        store,
+        identities,
+        &provider,
+        RemotePanelAttachRequest {
+            allocation: &allocation,
+            panel_id: request.panel_id,
+            terminal: request.terminal,
+        },
+    )?)
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum ConfiguredRemotePanelAttachError {
+    #[error("panel reconnection is not yet supported for this environment's provider")]
+    UnsupportedProvider,
+    #[error("the active client session does not own the selected environment")]
+    ClientSessionMismatch,
+    #[error(transparent)]
+    Configuration(#[from] RemoteProviderConfigError),
+    #[error(transparent)]
+    Attachment(#[from] RemotePanelAttachError),
+}
+
+impl From<RemoteWorkspaceRecoveryError> for ConfiguredRemotePanelAttachError {
+    fn from(error: RemoteWorkspaceRecoveryError) -> Self {
+        Self::Attachment(error.into())
+    }
+}

--- a/crates/horizon-core/src/remote_panel_attachment/tests.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests.rs
@@ -11,6 +11,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+mod configured;
+
 const OWNER: &str = "00000000-0000-4000-8000-000000000001";
 
 struct Fixture {
@@ -26,6 +28,10 @@ impl Fixture {
     }
 
     fn with_lifetime(lifetime: WorkerLifetime) -> Self {
+        Self::with_resource_id(lifetime, "synthetic-worker")
+    }
+
+    fn with_resource_id(lifetime: WorkerLifetime, resource_id: &str) -> Self {
         let directory = tempfile::tempdir().expect("fixture");
         std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
         let home = HorizonHome::from_root(directory.path().join("home"));
@@ -68,7 +74,7 @@ impl Fixture {
                         provider: request.target.provider,
                         workflow_id: request.workflow_id,
                         job_id: request.job_id,
-                        resource_id: "synthetic-worker".into(),
+                        resource_id: resource_id.into(),
                     },
                     target: request.target,
                     ssh_public_key: request.ssh_public_key,

--- a/crates/horizon-core/src/remote_panel_attachment/tests/configured.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests/configured.rs
@@ -1,0 +1,190 @@
+use super::*;
+use crate::{
+    cloud_run::local_docker::LocalDockerProfile,
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_workspace::RemoteEnvironmentSummary,
+};
+
+fn config() -> RemoteProviderConfig {
+    RemoteProviderConfig {
+        local_docker: vec![LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///nonexistent-panel-attachment-fixture/docker.sock".into(),
+        }],
+    }
+}
+
+fn connect(
+    fixture: &Fixture,
+    config: &RemoteProviderConfig,
+    expected: &RemoteEnvironmentSummary,
+    owner: &str,
+    panel: &str,
+) -> ConfiguredRemotePanelAttachError {
+    attach_configured_remote_panel(
+        &fixture.store,
+        &fixture.identities,
+        config,
+        ConfiguredRemotePanelAttachRequest {
+            expected,
+            client_session_id: owner,
+            panel_id: panel,
+            terminal: terminal_size(),
+        },
+    )
+    .expect_err("synthetic fixture cannot admit an interactive connection")
+}
+
+#[test]
+fn actual_owner_and_supported_provider_are_required_before_profile_access() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let mut expected = before.workspace().environment_summary();
+    assert_eq!(
+        connect(
+            &fixture,
+            &RemoteProviderConfig::default(),
+            &expected,
+            "copied-session",
+            "terminal"
+        ),
+        ConfiguredRemotePanelAttachError::ClientSessionMismatch
+    );
+    for provider in [CloudProvider::Azure, CloudProvider::RunPod] {
+        expected.provider = provider;
+        assert_eq!(
+            connect(&fixture, &RemoteProviderConfig::default(), &expected, OWNER, "terminal"),
+            ConfiguredRemotePanelAttachError::UnsupportedProvider
+        );
+    }
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn exact_valid_profile_is_required_without_ambient_fallback_or_diagnostic_leakage() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let expected = before.workspace().environment_summary();
+    let missing = ConfiguredRemotePanelAttachError::Configuration(RemoteProviderConfigError::UnconfiguredLocalProfile);
+    assert_eq!(
+        connect(&fixture, &RemoteProviderConfig::default(), &expected, OWNER, "terminal"),
+        missing
+    );
+    let mut profiles = config();
+    profiles.local_docker[0].name = "Development".into();
+    assert_eq!(connect(&fixture, &profiles, &expected, OWNER, "terminal"), missing);
+    let mut profiles = config();
+    profiles.local_docker.push(profiles.local_docker[0].clone());
+    assert_eq!(
+        connect(&fixture, &profiles, &expected, OWNER, "terminal"),
+        ConfiguredRemotePanelAttachError::Configuration(RemoteProviderConfigError::DuplicateLocalProfile { index: 1 })
+    );
+    profiles.local_docker.pop();
+    profiles.local_docker[0].docker_host = "tcp://private-endpoint-marker:2375".into();
+    let error = connect(&fixture, &profiles, &expected, OWNER, "terminal");
+    assert!(matches!(error, ConfiguredRemotePanelAttachError::Configuration(_)));
+    assert!(!format!("{error:?} {error}").contains("private-endpoint-marker"));
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn every_stale_summary_or_foreign_owner_rejects_before_provider_access() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let expected = before.workspace().environment_summary();
+    let mut changed = vec![expected.clone(); 5];
+    changed[0].revision += 1;
+    changed[1].generation += 1;
+    changed[2].repository = "different/repository".into();
+    changed[3].panel_count += 1;
+    changed[4].saved_phase = Some(RemoteRuntimePhase::Failed);
+    for selection in changed {
+        assert_eq!(
+            connect(&fixture, &config(), &selection, OWNER, "terminal"),
+            RemoteWorkspaceRecoveryError::StateChanged.into()
+        );
+    }
+    let mut foreign = expected;
+    foreign.owning_session_id = "00000000-0000-4000-8000-000000000002".into();
+    assert_eq!(
+        connect(&fixture, &config(), &foreign, OWNER, "terminal"),
+        ConfiguredRemotePanelAttachError::ClientSessionMismatch
+    );
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn missing_allocation_or_unknown_panel_never_starts_a_replacement() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let expected = before.workspace().environment_summary();
+    assert_eq!(
+        connect(&fixture, &config(), &expected, OWNER, "missing-panel"),
+        ConfiguredRemotePanelAttachError::Attachment(RemotePanelStatusError::UnknownPanel.into())
+    );
+    let mut unallocated = before.workspace().state().clone();
+    unallocated.spec.workspace_local_id = "unallocated-workspace".into();
+    unallocated.spec.generation = 0;
+    unallocated.runtime = None;
+    let saved = fixture
+        .store
+        .create_remote_workspace(OWNER, &unallocated)
+        .expect("unallocated fixture");
+    assert_eq!(
+        connect(&fixture, &config(), &saved.environment_summary(), OWNER, "terminal"),
+        RemoteWorkspaceRecoveryError::MissingAllocation.into()
+    );
+    assert_eq!(fixture.current(), before);
+    assert_eq!(
+        fixture
+            .store
+            .load_remote_workspace(OWNER, "unallocated-workspace")
+            .expect("load"),
+        Some(saved)
+    );
+}
+
+#[test]
+fn timed_execution_is_rejected_before_provider_access() {
+    let fixture = Fixture::with_lifetime(WorkerLifetime::TimeLimited { seconds: 300 });
+    let before = fixture.current();
+    assert_eq!(
+        connect(
+            &fixture,
+            &config(),
+            &before.workspace().environment_summary(),
+            OWNER,
+            "terminal"
+        ),
+        RemotePanelAttachError::UnsupportedLifetime.into()
+    );
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn unavailable_explicit_endpoint_preserves_allocation_and_retained_key() {
+    let fixture = Fixture::with_resource_id(WorkerLifetime::Persistent, &"a".repeat(64));
+    let before = fixture.current();
+    let runtime = before.workspace().state().runtime.as_ref().expect("runtime");
+    let identity = fixture
+        .identities
+        .recover(
+            runtime.workflow_id,
+            runtime.job_id,
+            runtime.ssh_public_key.as_deref().expect("public key"),
+        )
+        .expect("retained key");
+    let bytes = std::fs::read(identity.private_key_path()).expect("original key");
+    assert_eq!(
+        connect(
+            &fixture,
+            &config(),
+            &before.workspace().environment_summary(),
+            OWNER,
+            "terminal"
+        ),
+        RemoteWorkspaceRecoveryError::ProviderUnavailable.into()
+    );
+    assert_eq!(fixture.current(), before);
+    assert_eq!(std::fs::read(identity.private_key_path()).expect("retained key"), bytes);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -149,6 +149,10 @@ back into large multi-purpose modules.
   Its target-bound attempt rechecks snapshots before input-capable handoff; it is
   not authenticated attachment, saved Ready state or an atomic Stop/attach fence.
   Board/UI admission and inert restore remain separate from this Linux-only API.
+- `remote_panel_attachment/configured.rs` admits only the actual owner session,
+  exact saved selection and explicitly named local provider profile before calling
+  non-creating attachment. It does not infer authority from inventory visibility or
+  copied client references, and has no ambient provider or profile fallback.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply


### PR DESCRIPTION
## Purpose

Bind explicit panel reconnection to the actual active client session and the exact configured local worker profile. This is a focused prerequisite for the reconnect controls in #383, not completion of that issue.

## Behavior

- Require actual session ownership and an exact saved environment summary before attaching an existing panel.
- Resolve the saved profile explicitly; missing, invalid or case-mismatched profiles cannot fall back to ambient daemon/context settings.
- Reuse the existing non-creating, pinned-identity attachment path. No allocation, key creation, task startup/replay, Stop/Delete, saved-state mutation or readiness promotion.
- Keep all storage/provider/SSH work off the render thread. The caller must still bind asynchronous results to its current view, selection and config.
- Local worker support only on the already-supported platform; other providers remain explicitly unsupported. This does not add UI or cross-session Open.

## Evidence

Candidate `cef84562d9c65f3c80b2964879116895b83b84f4`, tree `36fbf0c43143cc3aa562d791f674a58691fd28ee`, integrates actual main `4ddd70adf966161476f8b482e0dbce9879085d94`. Four source/test files, 287 changed lines, plus four architecture lines.

- Independent full source, staged integration and committed-tree review: clear.
- Full locked validation on final source and exact commit: formatting, maintainability, version sync, workspace tests with and without speech, blocking and strict lint, and advisory pedantic lint passed. Lockfile remained unchanged at every gate.
- Six focused admission regressions cover owner/provider, exact/invalid profile, stale summary, missing allocation/panel, unsupported lifetime and unavailable explicit endpoint without state/key changes.
- Actual configured-provider SSH smoke on the exact candidate passed two concurrent pinned PTYs, input, a connection beyond ten seconds, initial/live resize and independent client teardown. After every client disconnected and the original working directory was renamed, new clients reached the same running PID and retained exit-7 pane without replay.
- Hostile ambient daemon/context settings were ignored. Foreign/stale selection, absent/case-mismatched profile, unavailable explicit endpoint, absent task, missing retained key and provider-observed host-pin mismatch rejected without creation or fallback. The pin lane is provider-observation rejection, not an additional SSH-preflight claim.
- The complete saved allocation database, Ready snapshot/revisions and key bytes remained unchanged. Cleanup removed only the exact identity/label/image-verified disposable local worker and generated test state.

No paid cloud resources, pre-existing processes or user resources were changed. No release is requested.
