### PR TITLE
fix(remote): keep connection trust anonymous across client exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,15 +2751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,16 +3031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,17 +3074,6 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2 0.6.4",
- "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3558,15 +3528,6 @@ name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -4427,7 +4388,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "surge-core"
 version = "1.0.0"
-source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.61#27c22c1dfb8c73df8d3bd7f5f24f82f82d674c04"
+source = "git+https://github.com/fintermobilityas/surge.git?tag=v1.0.0-beta.55#83f22fcec5956d81f8752e8720b157e21f7271f5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -4436,22 +4397,19 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
- "libc",
  "nix",
  "percent-encoding",
- "quick-xml 0.42.0",
+ "quick-xml",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
- "sysinfo",
  "tar",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "uuid",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -4496,21 +4454,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.39.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "objc2-open-directory",
- "windows",
 ]
 
 [[package]]
@@ -5369,7 +5312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.41.0",
+ "quick-xml",
  "quote",
 ]
 

--- a/crates/horizon-core/src/remote_panel_attachment/tests.rs
+++ b/crates/horizon-core/src/remote_panel_attachment/tests.rs
@@ -431,12 +431,52 @@ fn drift_after_local_start_or_before_consumption_discards_the_attempt() {
     }
 }
 
-fn await_removed(path: &std::path::Path) {
+struct TrustProbe {
+    path: std::path::PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl TrustProbe {
+    fn is_retained(&self) -> bool {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(&self.path)
+            .is_ok_and(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode)
+    }
+}
+
+fn await_removed(probe: &TrustProbe) {
     let deadline = Instant::now() + Duration::from_secs(5);
-    while path.exists() && Instant::now() < deadline {
+    while probe.is_retained() && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(10));
     }
-    assert!(!path.exists(), "owned trust must be released after local teardown");
+    assert!(
+        !probe.is_retained(),
+        "owned trust must be released after local teardown"
+    );
+}
+
+fn anonymous_trust(directory: &std::path::Path) -> (std::fs::File, TrustProbe) {
+    use rustix::fs::{Mode, OFlags, open};
+    use std::os::{fd::AsRawFd, unix::fs::MetadataExt};
+    let file = std::fs::File::from(
+        open(
+            directory,
+            OFlags::TMPFILE | OFlags::RDWR | OFlags::CLOEXEC,
+            Mode::RUSR | Mode::WUSR,
+        )
+        .expect("anonymous trust"),
+    );
+    let path = format!("/proc/{}/fd/{}", std::process::id(), file.as_raw_fd()).into();
+    let metadata = file.metadata().expect("inode");
+    (
+        file,
+        TrustProbe {
+            path,
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        },
+    )
 }
 
 #[test]
@@ -444,8 +484,7 @@ fn private_trust_survives_immediate_drop_timeout_and_async_join_until_owned_tear
     use std::sync::atomic::{AtomicUsize, Ordering};
     for mode in 0..3 {
         let directory = tempfile::tempdir().expect("fixture");
-        let trust = tempfile::NamedTempFile::new_in(directory.path()).expect("trust");
-        let path = trust.path().to_path_buf();
+        let (trust, path) = anonymous_trust(directory.path());
         let release = directory.path().join("release");
         let mut options =
             local_options("i=0; while [ ! -f \"$1\" ] && [ \"$i\" -lt 200 ]; do i=$((i+1)); sleep 0.01; done");
@@ -462,7 +501,7 @@ fn private_trust_survives_immediate_drop_timeout_and_async_join_until_owned_tear
         }
         drop(terminal);
         if mode != 0 {
-            assert!(path.exists());
+            assert!(path.is_retained());
             assert_eq!(completed.load(Ordering::Relaxed), 0);
             std::fs::write(&release, b"release").expect("release owned child");
         }
@@ -480,17 +519,15 @@ fn private_trust_survives_immediate_drop_timeout_and_async_join_until_owned_tear
 #[test]
 fn failed_startup_and_concurrent_connections_release_only_their_own_trust() {
     let directory = tempfile::tempdir().expect("fixture");
-    let first = tempfile::NamedTempFile::new_in(directory.path()).expect("first");
-    let second = tempfile::NamedTempFile::new_in(directory.path()).expect("second");
-    let first_path = first.path().to_path_buf();
-    let second_path = second.path().to_path_buf();
+    let (first, first_path) = anonymous_trust(directory.path());
+    let (second, second_path) = anonymous_trust(directory.path());
     let second_terminal =
         Terminal::spawn_with_ssh_trust(local_options("read -r fixture"), Arc::new(second)).expect("second");
     let mut options = local_options("exit 0");
     options.program = directory.path().join("nonexistent").to_string_lossy().into_owned();
     assert!(Terminal::spawn_with_ssh_trust(options, Arc::new(first)).is_err());
     await_removed(&first_path);
-    assert!(second_path.exists());
+    assert!(second_path.is_retained());
     drop(second_terminal);
     await_removed(&second_path);
 }

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -1,11 +1,16 @@
 //! Crate-private pinned SSH command construction, not remote attachment authority.
 
+mod trust;
+
+use trust::KnownHosts;
+pub(crate) use trust::known_hosts;
+
 use crate::{
     Terminal, cloud_run::CloudJobId, cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
     remote_ssh_identity::RemoteSshIdentity, remote_worker_status::RemotePanelStatusError as Error,
     remote_workspace::valid_local_id, terminal::TerminalSpawnOptions,
 };
-use std::{io::Write, path::Path, process::Command, sync::Arc};
+use std::{path::Path, process::Command, sync::Arc};
 
 pub(crate) const HOST_ALIAS: &str = "horizon-retained-worker";
 
@@ -91,21 +96,10 @@ fn command_for(
     Ok(command)
 }
 
-pub(crate) fn known_hosts(
-    identity: &RemoteSshIdentity,
-    endpoint: &InteractiveWorkerSshEndpoint,
-) -> Result<tempfile::NamedTempFile, Error> {
-    // The recovered key's private parent avoids ambient temporary-directory trust.
-    let parent = identity.private_key_path().parent().ok_or(Error::UnsupportedPath)?;
-    let mut known_hosts = tempfile::NamedTempFile::new_in(parent).map_err(|_| Error::TrustStorage)?;
-    writeln!(known_hosts, "{HOST_ALIAS} {}", endpoint.host_key).map_err(|_| Error::TrustStorage)?;
-    Ok(known_hosts)
-}
-
 /// Private preparation must be consumed by the fresh admission boundary, never persisted.
 pub(crate) struct PreparedAttachment {
     command: Command,
-    known_hosts: tempfile::NamedTempFile,
+    known_hosts: KnownHosts,
 }
 
 impl PreparedAttachment {
@@ -135,7 +129,7 @@ impl PreparedAttachment {
             .ok_or_else(|| crate::Error::State("protected SSH arguments are not supported".into()))?;
         options.env.insert("SSH_ASKPASS_REQUIRE".into(), "never".into());
         options.env.insert("TERM".into(), "xterm-256color".into());
-        Terminal::spawn_with_ssh_trust(options, Arc::new(self.known_hosts))
+        Terminal::spawn_with_ssh_trust(options, Arc::new(self.known_hosts.into_file()))
     }
 }
 
@@ -156,7 +150,7 @@ fn path_option(name: &str, path: &Path) -> Result<String, Error> {
 mod tests {
     use super::*;
     use crate::{HorizonHome, cloud_run::CloudWorkflowId, remote_ssh_identity::RemoteSshIdentityStore};
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     #[test]
     fn interactive_mode_shares_all_isolation_options_and_owns_unique_private_trust() {
@@ -177,17 +171,16 @@ mod tests {
         let second = PreparedAttachment::new(&identity, &endpoint, runtime, "terminal").expect("second");
         let first_path = first.known_hosts.path().to_path_buf();
         let second_path = second.known_hosts.path().to_path_buf();
+        let first_inode = std::fs::metadata(&first_path).expect("first inode");
+        let second_inode = std::fs::metadata(&second_path).expect("second inode");
         assert_ne!(first_path, second_path);
-        assert_eq!(first_path.parent(), identity.private_key_path().parent());
         assert_eq!(
-            first
-                .known_hosts
-                .as_file()
-                .metadata()
-                .expect("mode")
-                .permissions()
-                .mode()
-                & 0o077,
+            first_path.parent(),
+            Some(Path::new(&format!("/proc/{}/fd", std::process::id())))
+        );
+        assert_eq!(std::fs::metadata(&first_path).expect("anonymous inode").nlink(), 0);
+        assert_eq!(
+            std::fs::metadata(&first_path).expect("mode").permissions().mode() & 0o077,
             0
         );
         assert_eq!(
@@ -223,10 +216,16 @@ mod tests {
             ));
         }
         drop(first);
-        assert!(!first_path.exists());
+        assert!(
+            !std::fs::metadata(&first_path)
+                .is_ok_and(|metadata| { metadata.dev() == first_inode.dev() && metadata.ino() == first_inode.ino() })
+        );
         assert!(second_path.exists());
         drop(second);
-        assert!(!second_path.exists());
+        assert!(
+            !std::fs::metadata(&second_path)
+                .is_ok_and(|metadata| { metadata.dev() == second_inode.dev() && metadata.ino() == second_inode.ino() })
+        );
         assert_eq!(
             std::fs::read_dir(identity.private_key_path().parent().expect("parent"))
                 .expect("directory")

--- a/crates/horizon-core/src/remote_worker_ssh/trust.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/trust.rs
@@ -1,0 +1,77 @@
+use super::{Error, HOST_ALIAS, InteractiveWorkerSshEndpoint, RemoteSshIdentity};
+use rustix::fs::{CWD, Mode, OFlags, ResolveFlags, openat2};
+use std::{
+    fs::File,
+    io::Write,
+    os::{fd::AsRawFd, unix::fs::MetadataExt},
+    path::{Path, PathBuf},
+};
+
+/// The argument names this exact held descriptor in the owning process, not the SSH child.
+/// No directory entry is created, including on failure or process exit without destructors.
+pub(crate) struct KnownHosts {
+    file: File,
+    path: PathBuf,
+}
+
+impl KnownHosts {
+    fn create(parent: &Path, host_key: &str) -> Result<Self, Error> {
+        let directory = File::from(
+            openat2(
+                CWD,
+                parent,
+                OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS,
+            )
+            .map_err(|_| Error::TrustStorage)?,
+        );
+        let metadata = directory.metadata().map_err(|_| Error::TrustStorage)?;
+        let uid = rustix::process::geteuid().as_raw();
+        if !metadata.is_dir() || metadata.uid() != uid || metadata.mode() & 0o7777 != 0o700 || metadata.nlink() == 0 {
+            return Err(Error::TrustStorage);
+        }
+        // A named fallback would restore the process::exit leak this guard prevents.
+        let mut file = File::from(
+            openat2(
+                &directory,
+                ".",
+                OFlags::TMPFILE | OFlags::RDWR | OFlags::CLOEXEC | OFlags::EXCL,
+                Mode::RUSR | Mode::WUSR,
+                ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS,
+            )
+            .map_err(|_| Error::TrustStorage)?,
+        );
+        let metadata = file.metadata().map_err(|_| Error::TrustStorage)?;
+        if !metadata.is_file() || metadata.uid() != uid || metadata.mode() & 0o7777 != 0o600 || metadata.nlink() != 0 {
+            return Err(Error::TrustStorage);
+        }
+        writeln!(file, "{HOST_ALIAS} {host_key}").map_err(|_| Error::TrustStorage)?;
+        let path = PathBuf::from(format!("/proc/{}/fd/{}", std::process::id(), file.as_raw_fd()));
+        // Restricted procfs access must reject preparation, never choose alternate trust.
+        let visible = std::fs::metadata(&path).map_err(|_| Error::TrustStorage)?;
+        if visible.dev() != metadata.dev() || visible.ino() != metadata.ino() {
+            return Err(Error::TrustStorage);
+        }
+        Ok(Self { file, path })
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn into_file(self) -> File {
+        self.file
+    }
+}
+
+pub(crate) fn known_hosts(
+    identity: &RemoteSshIdentity,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<KnownHosts, Error> {
+    let parent = identity.private_key_path().parent().ok_or(Error::UnsupportedPath)?;
+    KnownHosts::create(parent, &endpoint.host_key)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_worker_ssh/trust/tests.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/trust/tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+use rustix::io::{FdFlags, fcntl_getfd};
+use std::{os::unix::fs::PermissionsExt, process::Command};
+
+const EXIT_DIRECTORY: &str = "HORIZON_TEST_ANONYMOUS_TRUST_DIRECTORY";
+
+fn private_directory() -> tempfile::TempDir {
+    let directory = tempfile::tempdir().expect("fixture");
+    std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+    directory
+}
+
+fn snapshot(path: &Path) -> Vec<(std::ffi::OsString, Vec<u8>)> {
+    let mut files: Vec<_> = std::fs::read_dir(path)
+        .expect("directory")
+        .map(|entry| {
+            let entry = entry.expect("entry");
+            (entry.file_name(), std::fs::read(entry.path()).expect("file"))
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn exact_owner_descriptor_is_anonymous_private_and_readable_by_a_child() {
+    let directory = private_directory();
+    std::fs::write(directory.path().join("identity"), b"synthetic identity sentinel").expect("sentinel");
+    let before = snapshot(directory.path());
+    let first = KnownHosts::create(directory.path(), "synthetic first pin").expect("first");
+    let second = KnownHosts::create(directory.path(), "synthetic second pin").expect("second");
+    assert_ne!(first.path(), second.path());
+    assert_eq!(fcntl_getfd(&first.file).expect("descriptor flags"), FdFlags::CLOEXEC);
+    for guard in [&first, &second] {
+        let metadata = std::fs::metadata(guard.path()).expect("held inode");
+        assert!(metadata.is_file());
+        assert_eq!(metadata.nlink(), 0);
+        assert_eq!(metadata.uid(), rustix::process::geteuid().as_raw());
+        assert_eq!(metadata.mode() & 0o7777, 0o600);
+        assert_eq!(
+            guard.path(),
+            Path::new(&format!("/proc/{}/fd/{}", std::process::id(), guard.file.as_raw_fd()))
+        );
+    }
+    let output = Command::new("/bin/cat")
+        .arg(first.path())
+        .output()
+        .expect("child reader");
+    assert!(output.status.success());
+    assert_eq!(output.stdout, format!("{HOST_ALIAS} synthetic first pin\n").as_bytes());
+    drop(first);
+    assert_eq!(
+        std::fs::read_to_string(second.path()).expect("independent reader"),
+        format!("{HOST_ALIAS} synthetic second pin\n")
+    );
+    assert_eq!(snapshot(directory.path()), before);
+    drop(second);
+    assert_eq!(snapshot(directory.path()), before);
+}
+
+#[test]
+fn unsafe_or_unavailable_parent_rejects_without_a_named_fallback() {
+    let directory = private_directory();
+    let alias = directory.path().join("alias");
+    std::os::unix::fs::symlink(directory.path(), &alias).expect("fixture link");
+    assert!(matches!(KnownHosts::create(&alias, "pin"), Err(Error::TrustStorage)));
+    assert!(matches!(
+        KnownHosts::create(&directory.path().join("missing"), "pin"),
+        Err(Error::TrustStorage)
+    ));
+    std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o755)).expect("insecure");
+    let failure = KnownHosts::create(directory.path(), "pin");
+    assert!(matches!(failure, Err(Error::TrustStorage)));
+    assert_eq!(std::fs::read_dir(directory.path()).expect("no fallback").count(), 1);
+}
+
+#[test]
+fn process_exit_without_destructors_leaves_no_named_pin_or_identity_change() {
+    let directory = private_directory();
+    std::fs::write(directory.path().join("identity"), b"synthetic identity sentinel").expect("sentinel");
+    let before = snapshot(directory.path());
+    let output = Command::new(std::env::current_exe().expect("test executable"))
+        .args([
+            "--exact",
+            "remote_worker_ssh::trust::tests::process_exit_fixture",
+            "--nocapture",
+        ])
+        .env(EXIT_DIRECTORY, directory.path())
+        .output()
+        .expect("owned exit fixture");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("anonymous trust held before exit"));
+    assert_eq!(snapshot(directory.path()), before);
+}
+
+#[test]
+fn process_exit_fixture() {
+    let Some(directory) = std::env::var_os(EXIT_DIRECTORY) else {
+        return;
+    };
+    let guard = KnownHosts::create(Path::new(&directory), "synthetic exit pin").expect("anonymous trust");
+    assert_eq!(std::fs::metadata(guard.path()).expect("held").nlink(), 0);
+    assert_eq!(std::fs::read_dir(directory).expect("no named pin").count(), 1);
+    println!("anonymous trust held before exit");
+    std::process::exit(0);
+}

--- a/crates/horizon-core/src/terminal.rs
+++ b/crates/horizon-core/src/terminal.rs
@@ -143,7 +143,7 @@ struct TerminalEventProxy {
 #[derive(Clone, Default)]
 struct TerminalSshTrust {
     #[cfg(target_os = "linux")]
-    _file: Option<Arc<tempfile::NamedTempFile>>,
+    _file: Option<Arc<std::fs::File>>,
 }
 
 impl TerminalEventProxy {

--- a/crates/horizon-core/src/terminal/lifecycle.rs
+++ b/crates/horizon-core/src/terminal/lifecycle.rs
@@ -15,10 +15,7 @@ impl Terminal {
     }
 
     #[cfg(target_os = "linux")]
-    pub(crate) fn spawn_with_ssh_trust(
-        options: TerminalSpawnOptions,
-        trust: Arc<tempfile::NamedTempFile>,
-    ) -> Result<Self> {
+    pub(crate) fn spawn_with_ssh_trust(options: TerminalSpawnOptions, trust: Arc<std::fs::File>) -> Result<Self> {
         Self::spawn_guarded(options, TerminalSshTrust { _file: Some(trust) })
     }
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -143,6 +143,10 @@ back into large multi-purpose modules.
   share isolation options; each owns private trust material. Status queries retain
   bounded I/O, while interactive trust follows both terminal event proxies through
   detached Drop and asynchronous join. General user-configured SSH is unchanged.
+  Its Linux `trust.rs` leaf uses strict anonymous private inodes and an owner-PID
+  descriptor path for both modes, with no named-file fallback. Holding the exact
+  descriptor preserves each pin through local teardown; process exit cannot leave
+  a named trust file, even when normal shutdown bypasses Rust destructors.
 - `remote_panel_attachment.rs` consumes explicit exact-allocation admission, fresh
   read-only identity/worker inspection and saved-intent verification before a pinned
   local PTY. Only explicit recovery commits observations; attachment preserves saved phases.


### PR DESCRIPTION
## Purpose

Prevent connection-specific SSH trust files from leaving named residue when a client exits without running destructors. This is a focused reconnect prerequisite for #383, not completion of the feature.

## Behavior

- Create a private anonymous inode in the validated identity directory using strict Linux temporary-file flags. There is no named-file fallback.
- Verify directory ownership/mode and anonymous file ownership/mode/link count, then expose the retained descriptor through the owning process's procfs path. Query and interactive attachment use the same trust factory.
- Retain that exact file through both terminal event proxies. Existing delayed teardown, failed-spawn and independent-client lifetimes remain intact; normal app shutdown does not gain blocking waits.
- Unsupported filesystem/kernel/procfs conditions fail closed. This is a Linux-specific implementation on the existing supported attachment path, using the existing dependency.
- No retained-key replacement, worker/task Stop/Delete, allocation replay, saved-state mutation or readiness promotion. General SSH behavior is unchanged.

## Reproduction

The former named temporary-file guard depended on destructor execution. A client using immediate process exit could leave its generated known-host pin pathname behind, even though closing the local connection must not affect remote task lifetime. The anonymous inode has no pathname to leave behind.

## Evidence

Candidate `bca3ced935e85d52c3c45b3a9a3d4e09e6eb92ce`, tree `17ca0bc69ef0c416c6821bc0c2fb0a2acd08f630`, integrates actual main `89bd3a101922c4b3970b4ded021ae2f84fce49e6`. Six source/test files, 300 changed lines, plus four architecture lines.

- Independent full source, final integration and committed-tree reviews: clear.
- Full locked source and exact-commit matrices passed: formatting, maintainability/version checks, focused trust/attachment tests, workspace tests with and without speech, blocking/strict lint and advisory pedantic lint. Lockfile unchanged.
- Five new trust tests cover private anonymous storage, actual child reading, insecure/missing/symlinked directories and subprocess exit without destructors. Existing lifecycle tests verify independent descriptor identity, delayed teardown, timeout/async joins and failed spawn. Twenty additional parallel rounds covered 260 direct trust/lifecycle cases on the unchanged implementation.
- Final-source and exact-commit real pinned-SSH repeats passed concurrent clients, input, a connection beyond ten seconds, initial/live PTY resize, reconnect to the same running PID after all clients closed and the original directory was renamed, and retained exit-7 output without replay.
- A live SSH client exited without destructors after independently verified input. Its local client disappeared, no named pin remained, and the same remote PID kept progressing. Saved allocation database, Ready snapshot/revisions and retained key bytes were unchanged.
- Actual SSH rejected wrong or unreadable pins without alternate trust. Matched private-namespace controls proved usable procfs permits attachment and absent procfs rejects preparation. Missing task/key also rejected without recreation or replay.
- Every smoke removed only its full-identity/label/image-verified disposable local worker and generated private state. The final driver uses matching native core dependency resolution.

This proves no named trust residue, not universal orphan-process cleanup or an enduring procfs capability. Native reconnect UI and real cloud/PC-off acceptance remain separate. No paid resources, pre-existing processes or user resources were changed; no release is requested.
