### PR TITLE
Make host initialization failure testing deterministic

### DIFF
--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -378,7 +378,7 @@ const fn backend_name(backend: BackendKind) -> &'static str {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use std::io::Read as _;
+    use std::os::fd::OwnedFd;
 
     use super::*;
 
@@ -407,25 +407,29 @@ mod tests {
 
     #[test]
     fn initialization_write_failure_reaps_the_child() {
-        let mut child = Command::new("/bin/sh")
-            .args(["-c", "exec 0<&-; printf ready; exec sleep 30"])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
+        let (read_end, _write_end) = io::pipe().unwrap_or_else(|error| panic!("create read-only stdin: {error}"));
+        // A pipe's read end rejects writes regardless of when other descriptors close.
+        let stdin = Some(ChildStdin::from(OwnedFd::from(read_end)));
+        let child = Command::new("/bin/sh")
+            .args(["-c", "exec sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
-            .unwrap_or_else(|error| panic!("start closed-stdin fixture: {error}"));
+            .unwrap_or_else(|error| panic!("start live cleanup fixture: {error}"));
         let child_id = child.id();
-        let mut ready = [0; 5];
-        child
-            .stdout
-            .take()
-            .unwrap_or_else(|| panic!("fixture stdout unavailable"))
-            .read_exact(&mut ready)
-            .unwrap_or_else(|error| panic!("wait for fixture readiness: {error}"));
-        assert_eq!(&ready, b"ready");
-        let stdin = child.stdin.take();
+        let mut host = OwnedHostProcess { child, stdin };
+        assert!(
+            host.child
+                .try_wait()
+                .unwrap_or_else(|error| panic!("inspect live cleanup fixture: {error}"))
+                .is_none()
+        );
 
-        let result = OwnedHostProcess { child, stdin }.initialize();
-        assert!(matches!(result, Err(StandaloneError::Startup(_))));
+        let result = host.initialize();
+        assert!(
+            matches!(result, Err(StandaloneError::Startup(message)) if message.starts_with("could not initialize browser host:"))
+        );
 
         let alive = Command::new("kill")
             .args(["-0", &child_id.to_string()])


### PR DESCRIPTION
## Purpose

Make the host-initialization write-failure cleanup test deterministic, unblocking
the post-merge validation of #454. Ref #383.

The Linux speech test job in [CI34133136815](https://github.com/peters/horizon/actions/runs/34133136815)
observed an unexpectedly successful initialization write from the old closed-stdin
fixture. Thirty local full-library repetitions passed, so the exact hosted
descriptor timing cause is not claimed proven.

## Behavior impact

Test-only: the fixture now supplies an owned read-end pipe as the deliberately
non-writable initialization endpoint. It still checks that a real child is live
before initialization, that initialization returns its specific startup error,
and that the child is reaped. This exercises write-error cleanup overall, not
forced cleanup independently of the drop fallback.

One test file; production code is byte-identical. No UI, browser session, provider,
configuration or remote task behavior changes.

## Validation

- Independent full-diff review: clear.
- Focused test and 200 repetitions with four concurrent disposable test processes: pass.
- Full source and exact-commit validation passed: format, maintainability, version
  sync, workspace tests with and without speech, blocking, strict and advisory lint.
- Exact committed-tree review: clear on `770976e3`.
- The original squash-commit Linux lane passed one retry; all post-merge checks
  and four platform artifact builds are now verified. This repair removes the
  test's dependence on the closed-reader timing assumption.
- No live browser or UI smoke applies to this test-fixture-only change.
