### PR TITLE
Reopen closed remote views without starting tasks

### DIFF
--- a/crates/horizon-core/src/board.rs
+++ b/crates/horizon-core/src/board.rs
@@ -3,11 +3,13 @@ mod arrangement;
 mod attention;
 mod geometry;
 mod remote;
+mod remote_views;
 mod shutdown;
 mod workspaces;
 
 pub use arrangement::WorkspaceAlignment;
 pub use remote::{PreparedRemotePanelHandoff, RemotePanelHandoffError};
+pub use remote_views::{PreparedRemoteViewReopen, RemoteViewCatalog, RemoteViewReopenError, RemoteViewReopenRequest};
 use shutdown::FORCED_BROWSER_SHUTDOWN_WAIT;
 pub use shutdown::{ForcedBrowserShutdownStatus, ShutdownProgress};
 

--- a/crates/horizon-core/src/board/remote_views.rs
+++ b/crates/horizon-core/src/board/remote_views.rs
@@ -1,0 +1,229 @@
+//! Explicit reopening of inert client views, never execution or connection authority.
+
+mod target;
+
+use super::Board;
+use crate::{
+    Panel, PanelId, PanelKind, PanelOptions, RemoteWorkspaceReference, SshConnectionStatus,
+    cloud_run::{CloudWorkflowStore, StoredRemoteWorkspace},
+    remote_workspace::RemoteEnvironmentSummary,
+};
+use std::time::Duration;
+use target::ViewTarget;
+
+/// Bounded saved panel identities without commands, task context or credentials.
+/// Loading this catalog does not observe a provider or certify that tasks exist.
+pub struct RemoteViewCatalog {
+    expected: RemoteEnvironmentSummary,
+    panels: Vec<String>,
+}
+
+impl RemoteViewCatalog {
+    /// Read only the actual client's owned record, off the render thread.
+    /// `client_session_id` must come from the actual resolved persistent session,
+    /// never from a copied view or inventory owner claim.
+    /// # Errors
+    /// Rejects foreign, stale, missing or unreadable saved environments.
+    pub fn load(
+        store: &CloudWorkflowStore,
+        client_session_id: &str,
+        expected: &RemoteEnvironmentSummary,
+    ) -> Result<Self, RemoteViewReopenError> {
+        let record = load_current(store, client_session_id, expected)?;
+        Ok(Self {
+            expected: expected.clone(),
+            panels: record
+                .state()
+                .spec
+                .panels
+                .iter()
+                .map(|panel| panel.panel_local_id.clone())
+                .collect(),
+        })
+    }
+
+    #[must_use]
+    pub fn panel_ids(&self) -> &[String] {
+        &self.panels
+    }
+}
+
+/// An unreserved local insertion proposal. Board changes may invalidate it.
+pub struct RemoteViewReopenRequest {
+    expected: RemoteEnvironmentSummary,
+    reference: RemoteWorkspaceReference,
+    local_id: String,
+    panel_id: PanelId,
+    target: ViewTarget,
+}
+
+/// One fully prepared disconnected snapshot. Dropping it never touches remote work.
+pub struct PreparedRemoteViewReopen {
+    request: RemoteViewReopenRequest,
+    panel: Panel,
+}
+
+impl RemoteViewReopenRequest {
+    /// Prepare only an inert local snapshot, off the render thread.
+    /// No SSH key, provider, command, task handoff, agent identity or remote cwd
+    /// enters the client panel. The snapshot's fixed exit process is already gone
+    /// before this method returns. Store freshness is point-in-time, not revocation.
+    /// # Errors
+    /// Rejects record drift, missing panel intent or failed snapshot preparation.
+    pub fn prepare(self, store: &CloudWorkflowStore) -> Result<PreparedRemoteViewReopen, RemoteViewReopenError> {
+        self.check_record(store)?;
+        let mut panel = Panel::spawn(
+            self.panel_id,
+            self.target.id(),
+            PanelOptions {
+                name: Some(format!("Remote · {}", self.local_id)),
+                kind: PanelKind::Ssh,
+                local_id: Some(self.local_id.clone()),
+                remote_workspace: Some(self.reference.clone()),
+                ..PanelOptions::default()
+            },
+        )
+        .map_err(|_| RemoteViewReopenError::PreparationFailed)?;
+        let completed = panel.wait_for_shutdown(Duration::from_secs(2));
+        panel.process_output();
+        if !completed
+            || panel.ssh_status() != Some(SshConnectionStatus::Disconnected)
+            || !panel.terminal().is_some_and(|terminal| {
+                terminal.child_exited() && terminal.child_exit_status().is_some_and(|status| status.success())
+            })
+        {
+            return Err(RemoteViewReopenError::PreparationFailed);
+        }
+        self.check_record(store)?;
+        Ok(PreparedRemoteViewReopen { request: self, panel })
+    }
+
+    fn check_record(&self, store: &CloudWorkflowStore) -> Result<(), RemoteViewReopenError> {
+        let record = load_current(store, self.reference.owner_session_id(), &self.expected)?;
+        if !record
+            .state()
+            .spec
+            .panels
+            .iter()
+            .any(|panel| panel.panel_local_id == self.local_id)
+        {
+            return Err(RemoteViewReopenError::MissingPanel);
+        }
+        Ok(())
+    }
+
+    fn check_board(&self, board: &Board, client_session_id: &str) -> Result<(), RemoteViewReopenError> {
+        if client_session_id != self.reference.owner_session_id() {
+            return Err(RemoteViewReopenError::ClientSessionMismatch);
+        }
+        if board.next_panel_id != self.panel_id.0 || board.next_panel_id == u64::MAX {
+            return Err(RemoteViewReopenError::TargetChanged);
+        }
+        if board.panels.iter().any(|panel| panel.local_id == self.local_id) {
+            return Err(RemoteViewReopenError::ViewAlreadyPresent);
+        }
+        self.target.check(board, &self.reference, &self.local_id)
+    }
+}
+
+impl Board {
+    /// Propose reopening exactly one missing saved panel in its owning session.
+    /// Performs only metadata checks; neither reserves ids nor changes the board.
+    /// # Errors
+    /// Rejects foreign clients, unknown panels, identity conflicts or ambiguous workspaces.
+    pub fn request_remote_view_reopen(
+        &self,
+        client_session_id: &str,
+        catalog: &RemoteViewCatalog,
+        panel_local_id: &str,
+    ) -> Result<RemoteViewReopenRequest, RemoteViewReopenError> {
+        if client_session_id != catalog.expected.owning_session_id {
+            return Err(RemoteViewReopenError::ClientSessionMismatch);
+        }
+        if !catalog.panels.iter().any(|id| id == panel_local_id) {
+            return Err(RemoteViewReopenError::MissingPanel);
+        }
+        let reference =
+            RemoteWorkspaceReference::new(client_session_id.into(), catalog.expected.workspace_local_id.clone())
+                .map_err(|_| RemoteViewReopenError::TargetChanged)?;
+        let request = RemoteViewReopenRequest {
+            expected: catalog.expected.clone(),
+            target: ViewTarget::select(self, &reference)?,
+            reference,
+            local_id: panel_local_id.into(),
+            panel_id: PanelId(self.next_panel_id),
+        };
+        request.check_board(self, client_session_id)?;
+        Ok(request)
+    }
+
+    /// Consume a prepared snapshot into the exact still-valid local board target.
+    /// Performs no I/O, process startup, provider action, transport or saved-state write.
+    /// Caller must invalidate results on session/board replacement (even same-owner
+    /// reused ids), selection/config changes and dismissal before calling this method.
+    /// A reopened view is not a connection; later reconnect must obtain fresh admission.
+    /// # Errors
+    /// Rejects stale owner/target/identity proposals before changing counters or layout.
+    pub fn adopt_reopened_remote_view(
+        &mut self,
+        client_session_id: &str,
+        prepared: PreparedRemoteViewReopen,
+    ) -> Result<PanelId, RemoteViewReopenError> {
+        let PreparedRemoteViewReopen { request, panel } = prepared;
+        request.check_board(self, client_session_id)?;
+        let workspace = request
+            .target
+            .install(self, &request.reference, &request.expected.repository);
+        // Preflight verified the reference; the insertion callback cannot fail or spawn.
+        self.create_panel_with(
+            PanelOptions {
+                remote_workspace: Some(request.reference),
+                ..PanelOptions::default()
+            },
+            workspace,
+            |_, _, _| Ok(panel),
+        )
+        .map_err(|_| RemoteViewReopenError::TargetChanged)
+    }
+}
+
+fn load_current(
+    store: &CloudWorkflowStore,
+    client_session_id: &str,
+    expected: &RemoteEnvironmentSummary,
+) -> Result<StoredRemoteWorkspace, RemoteViewReopenError> {
+    if client_session_id != expected.owning_session_id {
+        return Err(RemoteViewReopenError::ClientSessionMismatch);
+    }
+    let record = store
+        .load_remote_workspace(client_session_id, &expected.workspace_local_id)
+        .map_err(|_| RemoteViewReopenError::StorageUnavailable)?
+        .ok_or(RemoteViewReopenError::StateChanged)?;
+    if record.environment_summary() != *expected {
+        return Err(RemoteViewReopenError::StateChanged);
+    }
+    Ok(record)
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteViewReopenError {
+    #[error("the active client session does not own this saved environment")]
+    ClientSessionMismatch,
+    #[error("the saved environment changed; refresh before reopening its views")]
+    StateChanged,
+    #[error("the saved environment could not be safely read")]
+    StorageUnavailable,
+    #[error("the selected panel is not in this saved environment")]
+    MissingPanel,
+    #[error("a local view already uses this panel identity; it was not replaced")]
+    ViewAlreadyPresent,
+    #[error("more than one local workspace matches this environment")]
+    AmbiguousWorkspace,
+    #[error("the local board target or persistence identities changed; retry reopening")]
+    TargetChanged,
+    #[error("the disconnected local view could not be prepared")]
+    PreparationFailed,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/board/remote_views/target.rs
+++ b/crates/horizon-core/src/board/remote_views/target.rs
@@ -1,0 +1,133 @@
+//! Metadata-only target selection and persistence checks; no terminal cwd reads.
+
+use super::{Board, PanelKind, RemoteViewReopenError as Error, RemoteWorkspaceReference};
+use crate::{PanelState, RuntimeState, WorkspaceId, WorkspaceState, new_local_id};
+use std::collections::HashSet;
+
+pub(super) enum ViewTarget {
+    Existing { id: WorkspaceId, local_id: String },
+    New { id: WorkspaceId, local_id: String },
+}
+
+impl ViewTarget {
+    pub(super) fn select(board: &Board, reference: &RemoteWorkspaceReference) -> Result<Self, Error> {
+        let mut matching = board
+            .workspaces
+            .iter()
+            .filter(|workspace| workspace.remote_workspace.as_ref() == Some(reference));
+        let first = matching.next();
+        if matching.next().is_some() {
+            return Err(Error::AmbiguousWorkspace);
+        }
+        Ok(first.map_or_else(
+            || Self::New {
+                id: WorkspaceId(board.next_workspace_id),
+                local_id: new_local_id(),
+            },
+            |workspace| Self::Existing {
+                id: workspace.id,
+                local_id: workspace.local_id.clone(),
+            },
+        ))
+    }
+
+    pub(super) fn id(&self) -> WorkspaceId {
+        match self {
+            Self::Existing { id, .. } | Self::New { id, .. } => *id,
+        }
+    }
+
+    pub(super) fn check(
+        &self,
+        board: &Board,
+        reference: &RemoteWorkspaceReference,
+        panel_id: &str,
+    ) -> Result<(), Error> {
+        match (self, Self::select(board, reference)?) {
+            (
+                Self::Existing { id, local_id },
+                Self::Existing {
+                    id: current,
+                    local_id: current_local,
+                },
+            ) if *id == current && *local_id == current_local => {}
+            (Self::New { id, .. }, Self::New { id: current, .. }) if *id == current && id.0 != u64::MAX => {}
+            _ => return Err(Error::TargetChanged),
+        }
+        let mut numeric_workspaces = HashSet::new();
+        let mut numeric_panels = HashSet::new();
+        let mut state = RuntimeState::default();
+        for workspace in &board.workspaces {
+            if !numeric_workspaces.insert(workspace.id) {
+                return Err(Error::TargetChanged);
+            }
+            let mut saved = WorkspaceState {
+                local_id: workspace.local_id.clone(),
+                remote_workspace: workspace.remote_workspace.clone(),
+                ..WorkspaceState::default()
+            };
+            for id in &workspace.panels {
+                let panel = board.panel(*id).ok_or(Error::TargetChanged)?;
+                if !numeric_panels.insert(*id) || panel.workspace_id != workspace.id {
+                    return Err(Error::TargetChanged);
+                }
+                saved.panels.push(PanelState {
+                    local_id: panel.local_id.clone(),
+                    kind: panel.kind,
+                    resume: panel.resume.clone(),
+                    session_binding: panel.session_binding.clone(),
+                    remote_workspace: panel.remote_workspace().cloned(),
+                    ..PanelState::default()
+                });
+            }
+            state.workspaces.push(saved);
+        }
+        if numeric_panels.len() != board.panels.len() || numeric_panels.contains(&crate::PanelId(board.next_panel_id)) {
+            return Err(Error::TargetChanged);
+        }
+        let index = match self {
+            Self::Existing { id, .. } => board
+                .workspaces
+                .iter()
+                .position(|workspace| workspace.id == *id)
+                .ok_or(Error::TargetChanged)?,
+            Self::New { id, local_id } => {
+                if numeric_workspaces.contains(id) {
+                    return Err(Error::TargetChanged);
+                }
+                state.workspaces.push(WorkspaceState {
+                    local_id: local_id.clone(),
+                    remote_workspace: Some(reference.clone()),
+                    ..WorkspaceState::default()
+                });
+                state.workspaces.len() - 1
+            }
+        };
+        state.workspaces[index].panels.push(PanelState {
+            local_id: panel_id.into(),
+            kind: PanelKind::Ssh,
+            remote_workspace: Some(reference.clone()),
+            ..PanelState::default()
+        });
+        state.validate_remote_references().map_err(|_| Error::TargetChanged)
+    }
+
+    pub(super) fn install(
+        self,
+        board: &mut Board,
+        reference: &RemoteWorkspaceReference,
+        repository: &str,
+    ) -> WorkspaceId {
+        match self {
+            Self::Existing { id, .. } => id,
+            Self::New { id, local_id } => {
+                let created = board.create_workspace(repository);
+                if let Some(workspace) = board.workspace_mut(created) {
+                    workspace.local_id = local_id;
+                    workspace.remote_workspace = Some(reference.clone());
+                }
+                id
+            }
+        }
+    }
+}

--- a/crates/horizon-core/src/board/remote_views/tests.rs
+++ b/crates/horizon-core/src/board/remote_views/tests.rs
@@ -1,0 +1,390 @@
+use super::*;
+use crate::board::vec2_eq;
+use crate::{CanvasViewState, PanelResume, RuntimeState, WindowConfig, WorkspaceId};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+const FOREIGN: &str = "00000000-0000-4000-8000-000000000002";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    record: StoredRemoteWorkspace,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("private/state.sqlite3")).expect("store");
+        let state = serde_json::from_value(serde_json::json!({
+            "version": 1, "spec": {
+                "workspace_local_id": "remote-workspace", "working_directory": "nested", "generation": 0,
+                "target": {"provider": "local_docker", "profile": "development", "disk_gib": 20,
+                    "lifetime": "persistent", "image": format!("example/worker@sha256:{}", "a".repeat(64))},
+                "repository": {"repository": "example/project", "commit": "b".repeat(40)},
+                "panels": [
+                    {"panel_local_id": "alpha", "kind": "command", "working_directory": "nested",
+                     "command": {"program": "must-not-execute-private-marker", "args": ["private-argument"]},
+                     "task_handoff": "private-task"},
+                    {"panel_local_id": "bravo", "kind": "claude", "agent_session_id": "private-agent-session"}
+                ]
+            }
+        }))
+        .expect("saved intent");
+        let record = store.create_remote_workspace(OWNER, &state).expect("record");
+        Self {
+            _directory: directory,
+            store,
+            record,
+        }
+    }
+
+    fn catalog(&self) -> RemoteViewCatalog {
+        RemoteViewCatalog::load(&self.store, OWNER, &self.record.environment_summary()).expect("catalog")
+    }
+
+    fn prepare(&self, board: &Board, id: &str) -> PreparedRemoteViewReopen {
+        let request = board
+            .request_remote_view_reopen(OWNER, &self.catalog(), id)
+            .expect("request");
+        let store = self.store.clone();
+        std::thread::spawn(move || request.prepare(&store))
+            .join()
+            .expect("worker")
+            .expect("prepared view")
+    }
+
+    fn assert_unchanged(&self) {
+        assert_eq!(
+            self.store
+                .load_remote_workspace(OWNER, "remote-workspace")
+                .expect("read"),
+            Some(self.record.clone())
+        );
+        assert!(
+            self.store
+                .load_remote_allocation(OWNER, "remote-workspace")
+                .expect("allocation")
+                .is_none()
+        );
+    }
+}
+
+fn snapshot(board: &Board) -> (String, u64, u64) {
+    (
+        serde_json::to_string(&RuntimeState::from_board(
+            board,
+            WindowConfig::default(),
+            CanvasViewState::default(),
+        ))
+        .expect("snapshot"),
+        board.next_panel_id,
+        board.next_workspace_id,
+    )
+}
+
+fn matching_workspace(board: &mut Board) -> WorkspaceId {
+    let id = board.create_workspace("Existing remote views");
+    board.workspace_mut(id).expect("workspace").remote_workspace =
+        Some(RemoteWorkspaceReference::new(OWNER.into(), "remote-workspace".into()).expect("reference"));
+    id
+}
+
+#[test]
+fn reopening_is_inert_copy_safe_and_persistable_after_all_views_close() {
+    let fixture = Fixture::new();
+    let mut board = Board::new();
+    assert_eq!(fixture.catalog().panel_ids(), &["alpha", "bravo"]);
+    let before = snapshot(&board);
+    let prepared = fixture.prepare(&board, "alpha");
+    assert_eq!(snapshot(&board), before);
+    assert_eq!(
+        board.adopt_reopened_remote_view(FOREIGN, prepared),
+        Err(RemoteViewReopenError::ClientSessionMismatch)
+    );
+    assert_eq!(snapshot(&board), before);
+    let prepared = fixture.prepare(&board, "alpha");
+    let alpha = board
+        .adopt_reopened_remote_view(OWNER, prepared)
+        .expect("reopened alpha");
+    let workspace = board.panels[0].workspace_id;
+    let prepared = fixture.prepare(&board, "bravo");
+    let bravo = board
+        .adopt_reopened_remote_view(OWNER, prepared)
+        .expect("reopened bravo");
+    assert_eq!(board.workspaces.len(), 1);
+    for panel in &board.panels {
+        assert_eq!(panel.workspace_id, workspace);
+        assert_eq!(panel.kind, PanelKind::Ssh);
+        assert_eq!(panel.resume, PanelResume::Fresh);
+        assert_eq!(panel.ssh_status(), Some(SshConnectionStatus::Disconnected));
+        assert!(panel.terminal().expect("terminal").child_exited());
+        assert!(panel.launch_command.is_none() && panel.launch_args.is_empty() && panel.launch_cwd.is_none());
+        assert!(panel.ssh_connection.is_none() && panel.session_binding.is_none() && panel.template.is_none());
+    }
+    assert!(board.panel_mut(alpha).expect("alpha").restart().is_err());
+    let saved = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    saved.validate_remote_references().expect("persistable");
+    assert!(!saved.to_yaml().expect("yaml").contains("private-"));
+    let restored = Board::from_runtime_state(&saved).expect("inert restoration");
+    assert_eq!(restored.panels[0].local_id, "alpha");
+    assert_eq!(restored.panels[1].local_id, "bravo");
+    board.close_panel(alpha);
+    assert_eq!(board.panels.len(), 1);
+    board.close_panel(bravo);
+    assert!(board.panels.is_empty());
+    let prepared = fixture.prepare(&board, "alpha");
+    board
+        .adopt_reopened_remote_view(OWNER, prepared)
+        .expect("reopened after final close");
+    assert_eq!(board.panels[0].workspace_id, workspace);
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn admission_rejects_foreign_stale_missing_and_corrupt_records() {
+    let fixture = Fixture::new();
+    let summary = fixture.record.environment_summary();
+    assert!(matches!(
+        RemoteViewCatalog::load(&fixture.store, FOREIGN, &summary),
+        Err(RemoteViewReopenError::ClientSessionMismatch)
+    ));
+    let mut foreign_claim = summary.clone();
+    foreign_claim.owning_session_id = FOREIGN.into();
+    assert!(RemoteViewCatalog::load(&fixture.store, FOREIGN, &foreign_claim).is_err());
+    let board = Board::new();
+    assert!(matches!(
+        board.request_remote_view_reopen(FOREIGN, &fixture.catalog(), "alpha"),
+        Err(RemoteViewReopenError::ClientSessionMismatch)
+    ));
+    assert!(matches!(
+        board.request_remote_view_reopen(OWNER, &fixture.catalog(), "unknown"),
+        Err(RemoteViewReopenError::MissingPanel)
+    ));
+    let request = board
+        .request_remote_view_reopen(OWNER, &fixture.catalog(), "alpha")
+        .expect("request");
+    let mut changed = fixture.record.state().clone();
+    changed.spec.working_directory = "another-directory".into();
+    fixture
+        .store
+        .replace_remote_workspace(&fixture.record, &changed)
+        .expect("change");
+    assert!(matches!(
+        request.prepare(&fixture.store),
+        Err(RemoteViewReopenError::StateChanged)
+    ));
+    assert!(matches!(
+        RemoteViewCatalog::load(&fixture.store, OWNER, &summary),
+        Err(RemoteViewReopenError::StateChanged)
+    ));
+    let database = rusqlite::Connection::open(fixture.store.path()).expect("fixture connection");
+    database
+        .execute(
+            "UPDATE remote_workspaces SET snapshot = ?1",
+            [b"invalid-fixture".as_slice()],
+        )
+        .expect("corrupt fixture");
+    assert!(matches!(
+        RemoteViewCatalog::load(&fixture.store, OWNER, &summary),
+        Err(RemoteViewReopenError::StorageUnavailable)
+    ));
+    database
+        .execute("DELETE FROM remote_workspaces", [])
+        .expect("remove fixture row");
+    assert!(matches!(
+        RemoteViewCatalog::load(&fixture.store, OWNER, &summary),
+        Err(RemoteViewReopenError::StateChanged)
+    ));
+}
+
+#[test]
+fn adoption_reuses_the_exact_workspace_and_allows_visual_movement() {
+    let fixture = Fixture::new();
+    let mut board = Board::new();
+    let workspace = matching_workspace(&mut board);
+    let before = snapshot(&board);
+    let prepared = fixture.prepare(&board, "alpha");
+    assert_eq!(snapshot(&board), before);
+    board.workspace_mut(workspace).expect("workspace").position = [700.0, 800.0];
+    let id = board.adopt_reopened_remote_view(OWNER, prepared).expect("reopened");
+    assert_eq!(board.panel(id).expect("panel").workspace_id, workspace);
+    assert!(vec2_eq(
+        board.workspace(workspace).expect("workspace").position,
+        [700.0, 800.0]
+    ));
+    let before = snapshot(&board);
+    assert!(matches!(
+        board.request_remote_view_reopen(OWNER, &fixture.catalog(), "alpha"),
+        Err(RemoteViewReopenError::ViewAlreadyPresent)
+    ));
+    assert_eq!(snapshot(&board), before);
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn changed_existing_targets_and_new_ambiguity_reject_without_board_mutation() {
+    let fixture = Fixture::new();
+    for change in ["local-id", "reference", "ambiguity", "next-panel", "invalid-unrelated"] {
+        let mut board = Board::new();
+        let workspace = matching_workspace(&mut board);
+        let prepared = fixture.prepare(&board, "alpha");
+        match change {
+            "local-id" => board.workspace_mut(workspace).expect("workspace").local_id = "replacement".into(),
+            "reference" => board.workspace_mut(workspace).expect("workspace").remote_workspace = None,
+            "ambiguity" => {
+                matching_workspace(&mut board);
+            }
+            "next-panel" => board.next_panel_id += 1,
+            "invalid-unrelated" => {
+                let unrelated = board.create_workspace("Unrelated");
+                board.workspace_mut(unrelated).expect("workspace").local_id.clear();
+            }
+            _ => unreachable!(),
+        }
+        let before = snapshot(&board);
+        assert!(board.adopt_reopened_remote_view(OWNER, prepared).is_err(), "{change}");
+        assert_eq!(snapshot(&board), before, "{change}");
+    }
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn changed_new_workspace_proposals_and_competing_reopens_are_inert() {
+    let fixture = Fixture::new();
+    for becomes_matching in [false, true] {
+        let mut board = Board::new();
+        let prepared = fixture.prepare(&board, "alpha");
+        if becomes_matching {
+            matching_workspace(&mut board);
+        } else {
+            let _ = board.create_workspace("Unrelated new workspace");
+        }
+        let before = snapshot(&board);
+        assert_eq!(
+            board.adopt_reopened_remote_view(OWNER, prepared),
+            Err(RemoteViewReopenError::TargetChanged)
+        );
+        assert_eq!(snapshot(&board), before);
+    }
+    let mut board = Board::new();
+    let first = fixture.prepare(&board, "alpha");
+    let second = fixture.prepare(&board, "bravo");
+    board.adopt_reopened_remote_view(OWNER, first).expect("first proposal");
+    let before = snapshot(&board);
+    assert_eq!(
+        board.adopt_reopened_remote_view(OWNER, second),
+        Err(RemoteViewReopenError::TargetChanged)
+    );
+    assert_eq!(snapshot(&board), before);
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn the_first_remote_view_requires_valid_unrelated_persistence_identities() {
+    let fixture = Fixture::new();
+    for change in [
+        "invalid-workspace",
+        "duplicate-workspace",
+        "duplicate-numeric",
+        "exhausted-workspace",
+        "exhausted-panel",
+    ] {
+        let mut board = Board::new();
+        let first = board.create_workspace("Local one");
+        let second = board.create_workspace("Local two");
+        match change {
+            "invalid-workspace" => board.workspace_mut(first).expect("workspace").local_id = "invalid/id".into(),
+            "duplicate-workspace" => {
+                let duplicate = board.workspace(first).expect("workspace").local_id.clone();
+                board.workspace_mut(second).expect("workspace").local_id = duplicate;
+            }
+            "duplicate-numeric" => board.workspace_mut(second).expect("workspace").id = first,
+            "exhausted-workspace" => board.next_workspace_id = u64::MAX,
+            "exhausted-panel" => board.next_panel_id = u64::MAX,
+            _ => unreachable!(),
+        }
+        let before = snapshot(&board);
+        assert!(
+            matches!(
+                board.request_remote_view_reopen(OWNER, &fixture.catalog(), "alpha"),
+                Err(RemoteViewReopenError::TargetChanged)
+            ),
+            "{change}"
+        );
+        assert_eq!(snapshot(&board), before, "{change}");
+    }
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn foreign_local_panel_identity_is_not_replaced_or_treated_as_ownership() {
+    let fixture = Fixture::new();
+    let mut board = Board::new();
+    let workspace = board.create_workspace("Foreign copied reference");
+    let reference = RemoteWorkspaceReference::new(FOREIGN.into(), "another-environment".into()).expect("reference");
+    let id = board
+        .create_panel(
+            PanelOptions {
+                kind: PanelKind::Ssh,
+                local_id: Some("alpha".into()),
+                remote_workspace: Some(reference),
+                ..PanelOptions::default()
+            },
+            workspace,
+        )
+        .expect("foreign inert view");
+    assert!(
+        board
+            .panel_mut(id)
+            .expect("panel")
+            .wait_for_shutdown(Duration::from_secs(2))
+    );
+    board.panel_mut(id).expect("panel").process_output();
+    let before = snapshot(&board);
+    assert!(matches!(
+        board.request_remote_view_reopen(OWNER, &fixture.catalog(), "alpha"),
+        Err(RemoteViewReopenError::ViewAlreadyPresent)
+    ));
+    assert_eq!(snapshot(&board), before);
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn unrelated_panel_identity_and_membership_fail_closed() {
+    let fixture = Fixture::new();
+    for change in ["invalid-id", "duplicate-id", "orphan", "numeric-collision"] {
+        let mut board = Board::new();
+        let workspace = board.create_workspace("Local editor views");
+        for local_id in ["local-one", "local-two"] {
+            board
+                .create_panel(
+                    PanelOptions {
+                        kind: PanelKind::Editor,
+                        local_id: Some(local_id.into()),
+                        ..PanelOptions::default()
+                    },
+                    workspace,
+                )
+                .expect("local editor");
+        }
+        match change {
+            "invalid-id" => board.panels[0].local_id = "invalid/id".into(),
+            "duplicate-id" => board.panels[1].local_id = board.panels[0].local_id.clone(),
+            "orphan" => {
+                board.workspace_mut(workspace).expect("workspace").panels.pop();
+            }
+            "numeric-collision" => board.next_panel_id = board.panels[0].id.0,
+            _ => unreachable!(),
+        }
+        let before = snapshot(&board);
+        assert!(
+            matches!(
+                board.request_remote_view_reopen(OWNER, &fixture.catalog(), "alpha"),
+                Err(RemoteViewReopenError::TargetChanged)
+            ),
+            "{change}"
+        );
+        assert_eq!(snapshot(&board), before, "{change}");
+    }
+    fixture.assert_unchanged();
+}

--- a/crates/horizon-core/src/board/workspaces.rs
+++ b/crates/horizon-core/src/board/workspaces.rs
@@ -75,7 +75,7 @@ impl Board {
         })
     }
 
-    fn create_panel_with(
+    pub(super) fn create_panel_with(
         &mut self,
         mut opts: PanelOptions,
         workspace: WorkspaceId,

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -54,8 +54,9 @@ pub use alacritty_terminal::index::Side as TerminalSide;
 pub use alacritty_terminal::selection::SelectionType;
 pub use attention::{AttentionId, AttentionItem, AttentionSeverity, AttentionState};
 pub use board::{
-    Board, ForcedBrowserShutdownStatus, PreparedRemotePanelHandoff, RemotePanelHandoffError, ShutdownProgress,
-    WorkspaceAlignment, WorkspaceDockSide, WorkspaceLayout,
+    Board, ForcedBrowserShutdownStatus, PreparedRemotePanelHandoff, PreparedRemoteViewReopen, RemotePanelHandoffError,
+    RemoteViewCatalog, RemoteViewReopenError, RemoteViewReopenRequest, ShutdownProgress, WorkspaceAlignment,
+    WorkspaceDockSide, WorkspaceLayout,
 };
 pub use config::{
     AppearanceConfig, AppearanceTheme, Config, FeaturesConfig, OverlaysConfig, PresetConfig, ShortcutsConfig,

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -166,6 +166,11 @@ back into large multi-purpose modules.
   exact saved selection and explicitly named local provider profile before calling
   non-creating attachment. It does not infer authority from inventory visibility or
   copied client references, and has no ambient provider or profile fallback.
+- `board/remote_views/` separates metadata-only reopen target/persistence checks
+  from off-thread owned-record lookup and inert snapshot preparation. Consuming
+  adoption uses the existing insertion/layout path without starting a process or
+  connecting. Reopening never copies executable intent or grants remote authority;
+  current-client/request invalidation and later fresh reconnect remain mandatory.
 - UI `remote_environments/reconnect/` caches view labels on explicit interaction.
   Its single-flight worker prepares connections off-thread; lifecycle and modal
   actions invalidate before queued handoff adoption. Pending discarded receivers


### PR DESCRIPTION
## Purpose

Part of #383: add an explicit core API to reopen a closed local remote-panel view
from its durable saved panel identity, including when its former visual workspace
is absent. This is a core-only prerequisite; the overview UI will follow separately.

## Behavior

- Requires the actual persistent client owner and exact saved selection. Rejects
  copied foreign references, duplicate local identities, ambiguous workspaces,
  malformed persistence metadata and stale insertion proposals without mutation.
- Prepares only an inert disconnected snapshot off-thread. Copies no executable
  command, task context, agent binding, remote directory or connection credentials.
- Consuming adoption uses the existing board insertion/layout path with no process
  startup or provider, transport, storage or task mutation. Reopening does not
  connect, create, restart, stop or delete remote work.
- Later explicit reconnect still requires fresh admission. Callers must invalidate
  pending results on session/board replacement, selection/config changes or dismissal.

No global Open, cross-session takeover, new workspace setup or cloud/PC-off
acceptance is claimed. No UI entry point, release or dependency changes.

## Validation

- Eight focused core tests cover inert restore/persistence, exact workspace reuse,
  actual ownership, stale/missing/corrupt records, ambiguous/replaced targets,
  competing requests and unrelated identity/membership conflicts.
- Full source and exact-commit validation passed: format, maintainability, version synchronization,
  default and speech workspace tests, blocking/strict/advisory lint tiers.
- Independent full source and exact-commit reviews passed on `c184d330`.
- Isolated Linux retained-worker smoke passed before and after commit: reopen
  without connecting; explicitly reconnect three original tasks; close/reopen one
  view; close all views; recreate an absent visual workspace; save, reload and
  reconstruct populated reference-only views. Original task identities, exit
  status, live progress, repository bytes, complete allocation-store content and
  key material remained unchanged. Input reached each intended live task once.
- Exact local client-session sets were checked at every checkpoint. Exited status
  was visible in the client; earlier exited output remained in remote scrollback.
  All test clients exited and only the disposable workers/generated state were removed.
- No UI/app-relaunch or real cloud/PC-off acceptance is claimed by this core smoke.

Runtime assumptions: inert snapshot preparation uses the existing platform-local
short-lived exit process off-thread. Saved intent does not certify remote readiness
or task existence. This API provides point-in-time validation, not continuous revocation.
