### PR TITLE
Reopen closed remote views from the overview

### DIFF
--- a/crates/horizon-core/src/board/remote_views.rs
+++ b/crates/horizon-core/src/board/remote_views.rs
@@ -46,6 +46,21 @@ impl RemoteViewCatalog {
     pub fn panel_ids(&self) -> &[String] {
         &self.panels
     }
+
+    /// Whether this saved identity has a local view of the same remote environment.
+    /// Presentation only: a matching view does not grant connection authority or readiness.
+    /// The panel's execution reference is independent of its visual workspace placement.
+    #[must_use]
+    pub fn view_is_present(&self, board: &Board, panel_local_id: &str) -> bool {
+        self.panels.iter().any(|id| id == panel_local_id)
+            && board.panels.iter().any(|panel| {
+                panel.local_id == panel_local_id
+                    && panel.remote_workspace().is_some_and(|reference| {
+                        reference.owner_session_id() == self.expected.owning_session_id
+                            && reference.workspace_local_id() == self.expected.workspace_local_id
+                    })
+            })
+    }
 }
 
 /// An unreserved local insertion proposal. Board changes may invalidate it.

--- a/crates/horizon-core/src/board/remote_views/tests.rs
+++ b/crates/horizon-core/src/board/remote_views/tests.rs
@@ -90,6 +90,50 @@ fn matching_workspace(board: &mut Board) -> WorkspaceId {
 }
 
 #[test]
+fn catalog_presence_requires_both_saved_identity_and_execution_reference() {
+    let fixture = Fixture::new();
+    let catalog = fixture.catalog();
+    assert!(!catalog.view_is_present(&Board::new(), "alpha"));
+    for (owner, workspace, present) in [
+        (None, "remote-workspace", false),
+        (Some(FOREIGN), "remote-workspace", false),
+        (Some(OWNER), "other-environment", false),
+        (Some(OWNER), "remote-workspace", true),
+    ] {
+        let reference =
+            owner.map(|owner| RemoteWorkspaceReference::new(owner.into(), workspace.into()).expect("reference"));
+        let mut board = Board::from_runtime_state(&RuntimeState {
+            workspaces: vec![crate::WorkspaceState {
+                local_id: "visual".into(),
+                remote_workspace: reference.clone(),
+                panels: vec![crate::PanelState {
+                    local_id: "alpha".into(),
+                    kind: if reference.is_some() {
+                        PanelKind::Ssh
+                    } else {
+                        PanelKind::Editor
+                    },
+                    remote_workspace: reference,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        })
+        .expect("inert board");
+        assert_eq!(catalog.view_is_present(&board, "alpha"), present);
+        assert!(!catalog.view_is_present(&board, "unknown"));
+        if present {
+            let id = board.panels[0].id;
+            let destination = board.create_workspace("Other placement");
+            board.assign_panel_to_workspace(id, destination);
+            assert!(catalog.view_is_present(&board, "alpha"));
+        }
+    }
+    fixture.assert_unchanged();
+}
+
+#[test]
 fn reopening_is_inert_copy_safe_and_persistable_after_all_views_close() {
     let fixture = Fixture::new();
     let mut board = Board::new();

--- a/crates/horizon-ui/src/app/remote_environments.rs
+++ b/crates/horizon-ui/src/app/remote_environments.rs
@@ -3,6 +3,7 @@
 mod observation;
 mod paint;
 mod reconnect;
+mod reopen;
 mod stop;
 
 use std::sync::mpsc::{self, Receiver, TryRecvError};
@@ -24,6 +25,7 @@ pub(super) struct RemoteEnvironments {
     observation: observation::ObservationState,
     stop: stop::StopState,
     reconnect: reconnect::ReconnectState,
+    reopen: reopen::ReopenState,
     refresh_after_stop: bool,
 }
 
@@ -66,6 +68,8 @@ enum InventoryAction {
     CancelStop,
     ListReconnectViews,
     Reconnect(horizon_core::PanelId),
+    ListReopenPanels,
+    ReopenView(usize),
 }
 
 struct WakeOnDrop(Context);
@@ -83,6 +87,7 @@ impl RemoteEnvironments {
 
     pub(super) fn invalidate_session_views(&mut self) {
         self.reconnect.invalidate();
+        self.reopen.invalidate();
     }
 
     pub(super) fn open(&mut self, home: &HorizonHome, ctx: &Context) {
@@ -90,7 +95,7 @@ impl RemoteEnvironments {
             return;
         }
         self.open = true;
-        self.reconnect.invalidate();
+        self.invalidate_session_views();
         self.page = None;
         self.page_cursor = None;
         self.selected = None;
@@ -108,7 +113,7 @@ impl RemoteEnvironments {
 
     fn close(&mut self) {
         self.open = false;
-        self.reconnect.invalidate();
+        self.invalidate_session_views();
         self.observation.invalidate();
         self.stop.invalidate();
         self.refresh_after_stop = false;
@@ -122,7 +127,7 @@ impl RemoteEnvironments {
         if !self.open || self.pending.is_some() {
             return;
         }
-        self.reconnect.invalidate();
+        self.invalidate_session_views();
         self.observation.invalidate();
         self.stop.cancel_confirmation();
         let (tx, rx) = mpsc::sync_channel(1);
@@ -167,7 +172,7 @@ impl RemoteEnvironments {
     }
 
     fn accept_result(&mut self, cursor: Option<String>, result: Result<InventoryPage, LoadError>) {
-        self.reconnect.invalidate();
+        self.invalidate_session_views();
         self.observation.invalidate();
         self.stop.cancel_confirmation();
         match result {
@@ -205,14 +210,14 @@ impl RemoteEnvironments {
             InventoryAction::None
             | InventoryAction::Observe
             | InventoryAction::RequestStop
-            | InventoryAction::ConfirmStop
-            | InventoryAction::ListReconnectViews
-            | InventoryAction::Reconnect(_) => {}
+            | InventoryAction::ConfirmStop => {}
+            InventoryAction::ListReconnectViews | InventoryAction::Reconnect(_) => self.reopen.invalidate(),
+            InventoryAction::ListReopenPanels | InventoryAction::ReopenView(_) => self.reconnect.invalidate(),
             InventoryAction::CancelStop => self.stop.cancel_confirmation(),
             InventoryAction::Close => self.close(),
             InventoryAction::Select(index) => {
                 if self.selected != Some(index) && self.page.as_ref().is_some_and(|page| index < page.rows.len()) {
-                    self.reconnect.invalidate();
+                    self.invalidate_session_views();
                     self.observation.invalidate();
                     self.stop.invalidate();
                     self.selected = Some(index);
@@ -234,7 +239,7 @@ impl RemoteEnvironments {
     }
 
     pub(super) fn invalidate_provider_state(&mut self) {
-        self.reconnect.invalidate();
+        self.invalidate_session_views();
         self.observation.invalidate();
         self.stop.invalidate();
     }
@@ -277,11 +282,11 @@ impl RemoteEnvironments {
         };
         match action {
             InventoryAction::RequestStop => {
-                self.reconnect.invalidate();
+                self.invalidate_session_views();
                 self.stop.prepare(&summary, config, ctx);
             }
             InventoryAction::ConfirmStop if self.stop.start(home, config, &summary, ctx) => {
-                self.reconnect.invalidate();
+                self.invalidate_session_views();
                 self.observation.invalidate();
             }
             _ => {}
@@ -348,11 +353,13 @@ impl HorizonApp {
             }
             self.remote_environments.apply(action, self.session_store.home(), ctx);
             self.remote_reconnect_action(action, ctx);
+            self.remote_reopen_action(action, ctx);
             let modal_input = ctx.input(Clone::clone);
             self.suppress_root_viewport_interaction(ctx);
             return Some(modal_input);
         }
         self.remote_reconnect_action(InventoryAction::None, ctx);
+        self.remote_reopen_action(InventoryAction::None, ctx);
         None
     }
 

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -196,10 +196,17 @@ fn render_content(ui: &mut egui::Ui, state: &RemoteEnvironments, action: &mut In
     }
     if let Some(row) = state.selected.and_then(|index| page.rows.get(index)) {
         render_observation(ui, state, action);
+        let views_enabled = state.pending.is_none() && !state.observation.is_pending() && !state.stop.is_pending();
+        super::reopen::show(
+            ui,
+            &state.reopen,
+            views_enabled && !state.reconnect.is_pending(),
+            action,
+        );
         super::reconnect::show(
             ui,
             &state.reconnect,
-            state.pending.is_none() && !state.observation.is_pending() && !state.stop.is_pending(),
+            views_enabled && !state.reopen.is_pending(),
             action,
         );
         super::stop::show(

--- a/crates/horizon-ui/src/app/remote_environments/reconnect.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reconnect.rs
@@ -37,6 +37,10 @@ struct ClientContext<'a> {
 }
 
 impl ReconnectState {
+    pub(super) fn is_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+
     pub(super) fn invalidate(&mut self) {
         let changed = self.views.take().is_some()
             | self.notice.take().is_some()
@@ -248,7 +252,12 @@ impl super::HorizonApp {
                 .filter(|session| session.persistent)
                 .map(|session| session.session_id.as_str()),
         };
-        if state.open && state.pending.is_none() && !state.observation.is_pending() && !state.stop.is_pending() {
+        if state.open
+            && state.pending.is_none()
+            && !state.observation.is_pending()
+            && !state.stop.is_pending()
+            && !state.reopen.is_pending()
+        {
             match action {
                 InventoryAction::ListReconnectViews => {
                     state.stop.cancel_confirmation();

--- a/crates/horizon-ui/src/app/remote_environments/reconnect/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reconnect/tests.rs
@@ -191,11 +191,14 @@ fn navigation_refresh_stop_and_provider_reload_invalidate_pending_results() {
         InventoryAction::Select(1),
         InventoryAction::Refresh,
         InventoryAction::RequestStop,
+        InventoryAction::ListReopenPanels,
+        InventoryAction::ReopenView(0),
     ] {
         let (_temp, mut app) = test_app();
         let expected = summary("00000000-0000-4000-8000-000000000001");
         app.remote_environments = inventory(&expected);
         let tx = pending(&mut app.remote_environments.reconnect, &expected);
+        tx.send(Err("discarded-result".into())).expect("queued send");
         let ctx = Context::default();
         if matches!(action, InventoryAction::RequestStop) {
             app.remote_environments
@@ -210,7 +213,6 @@ fn navigation_refresh_stop_and_provider_reload_invalidate_pending_results() {
                 .expect("slot")
                 .discard
         );
-        tx.send(Err("discarded-result".into())).expect("send");
         app.remote_reconnect_action(InventoryAction::None, &ctx);
         assert!(app.remote_environments.reconnect.pending.is_none());
         assert!(app.remote_environments.reconnect.notice.is_none());

--- a/crates/horizon-ui/src/app/remote_environments/reopen.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen.rs
@@ -216,7 +216,7 @@ impl ReopenState {
                         .iter()
                         .map(|id| SavedView {
                             id: id.clone(),
-                            present: board.panel_id_by_local_id(id).is_some(),
+                            present: catalog.view_is_present(board, id),
                         })
                         .collect(),
                     catalog,
@@ -228,7 +228,7 @@ impl ReopenState {
                 Ok(id) => {
                     if let Some(cached) = &mut self.catalog {
                         for row in &mut cached.rows {
-                            row.present = board.panel_id_by_local_id(&row.id).is_some();
+                            row.present = cached.catalog.view_is_present(board, &row.id);
                         }
                     }
                     self.notice =

--- a/crates/horizon-ui/src/app/remote_environments/reopen.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen.rs
@@ -1,0 +1,299 @@
+//! Explicit saved-view loading and inert reopening, never remote task startup.
+
+mod paint;
+
+use super::{Context, HorizonHome, InventoryAction, RemoteEnvironmentSummary, WakeOnDrop};
+use horizon_core::{
+    Board, PanelId, PreparedRemoteViewReopen, RemoteViewCatalog, cloud_run::CloudWorkflowStore,
+    remote_provider_config::RemoteProviderConfig,
+};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+
+#[derive(Default)]
+pub(super) struct ReopenState {
+    catalog: Option<CachedCatalog>,
+    pending: Option<PendingReopen>,
+    notice: Option<String>,
+    repaint_context: Option<Context>,
+}
+
+struct CachedCatalog {
+    catalog: RemoteViewCatalog,
+    scope: RequestScope,
+    rows: Vec<SavedView>,
+}
+
+struct SavedView {
+    id: String,
+    present: bool,
+}
+
+struct PendingReopen {
+    rx: Receiver<Result<Completion, String>>,
+    scope: RequestScope,
+    discard: bool,
+}
+
+enum Completion {
+    Catalog(Box<RemoteViewCatalog>),
+    View(Box<PreparedRemoteViewReopen>),
+}
+
+#[derive(Clone)]
+struct RequestScope {
+    expected: RemoteEnvironmentSummary,
+    owner: String,
+    config: RemoteProviderConfig,
+}
+
+struct ClientContext<'a> {
+    home: &'a HorizonHome,
+    config: &'a RemoteProviderConfig,
+    selected: Option<&'a RemoteEnvironmentSummary>,
+    owner: Option<&'a str>,
+}
+
+impl RequestScope {
+    fn current(client: &ClientContext<'_>) -> Result<Self, &'static str> {
+        let owner = client
+            .owner
+            .ok_or("Open the owning persistent session before reopening its views.")?;
+        let expected = client.selected.ok_or("Select a saved environment first.")?;
+        if owner != expected.owning_session_id {
+            return Err("This environment belongs to another session. Open that session before reopening its views.");
+        }
+        Ok(Self {
+            expected: expected.clone(),
+            owner: owner.into(),
+            config: client.config.clone(),
+        })
+    }
+
+    fn matches(&self, client: &ClientContext<'_>) -> bool {
+        client.owner == Some(self.owner.as_str())
+            && client.selected == Some(&self.expected)
+            && *client.config == self.config
+    }
+}
+
+impl ReopenState {
+    pub(super) fn is_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+
+    pub(super) fn invalidate(&mut self) {
+        let changed = self.catalog.take().is_some()
+            | self.notice.take().is_some()
+            | self.pending.as_ref().is_some_and(|pending| !pending.discard);
+        if let Some(pending) = &mut self.pending {
+            pending.discard = true;
+        }
+        if changed && let Some(ctx) = &self.repaint_context {
+            ctx.request_repaint();
+        }
+    }
+
+    fn set_notice(&mut self, message: impl Into<String>, ctx: &Context) {
+        self.notice = Some(message.into());
+        self.repaint_context = Some(ctx.clone());
+        ctx.request_repaint();
+    }
+
+    fn load(&mut self, client: &ClientContext<'_>, ctx: &Context) {
+        if self.is_pending() {
+            return;
+        }
+        let scope = match RequestScope::current(client) {
+            Ok(scope) => scope,
+            Err(message) => {
+                self.catalog = None;
+                self.set_notice(message, ctx);
+                return;
+            }
+        };
+        let expected = scope.expected.clone();
+        let owner = scope.owner.clone();
+        self.catalog = None;
+        self.spawn(client.home, scope, ctx, move |store| {
+            RemoteViewCatalog::load(store, &owner, &expected)
+                .map(Box::new)
+                .map(Completion::Catalog)
+                .map_err(|error| error.to_string())
+        });
+    }
+
+    fn reopen(&mut self, client: &ClientContext<'_>, board: &Board, index: usize, ctx: &Context) {
+        if self.is_pending() {
+            return;
+        }
+        let Some(cached) = &self.catalog else {
+            return;
+        };
+        if !cached.scope.matches(client) {
+            self.invalidate();
+            self.set_notice("The session or saved selection changed. Show saved panels again.", ctx);
+            return;
+        }
+        let Some(row) = cached.rows.get(index) else {
+            return;
+        };
+        let request = match board.request_remote_view_reopen(&cached.scope.owner, &cached.catalog, &row.id) {
+            Ok(request) => request,
+            Err(error) => {
+                self.set_notice(error.to_string(), ctx);
+                return;
+            }
+        };
+        let scope = cached.scope.clone();
+        self.spawn(client.home, scope, ctx, move |store| {
+            request
+                .prepare(store)
+                .map(Box::new)
+                .map(Completion::View)
+                .map_err(|error| error.to_string())
+        });
+    }
+
+    fn spawn(
+        &mut self,
+        home: &HorizonHome,
+        scope: RequestScope,
+        ctx: &Context,
+        work: impl FnOnce(&CloudWorkflowStore) -> Result<Completion, String> + Send + 'static,
+    ) {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let home = home.clone();
+        let wake = WakeOnDrop(ctx.clone());
+        let worker = std::thread::Builder::new()
+            .name("remote-view-reopening".into())
+            .spawn(move || {
+                let _wake = wake;
+                let result = CloudWorkflowStore::open(&home)
+                    .map_err(|_| "The saved environment could not be safely read. Refresh and retry.".to_string())
+                    .and_then(|store| work(&store));
+                let _ = tx.send(result);
+            });
+        self.notice = None;
+        self.repaint_context = Some(ctx.clone());
+        match worker {
+            Ok(_) => {
+                self.pending = Some(PendingReopen {
+                    rx,
+                    scope,
+                    discard: false,
+                });
+            }
+            Err(_) => self.notice = Some(worker_failure().into()),
+        }
+        ctx.request_repaint();
+    }
+
+    fn drain(&mut self, client: &ClientContext<'_>, board: &mut Board, ctx: &Context) -> Option<PanelId> {
+        let pending = self.pending.take()?;
+        let result = match pending.rx.try_recv() {
+            Ok(result) => result,
+            Err(TryRecvError::Empty) => {
+                self.pending = Some(pending);
+                return None;
+            }
+            Err(TryRecvError::Disconnected) => Err(worker_failure().into()),
+        };
+        ctx.request_repaint();
+        if pending.discard || !pending.scope.matches(client) {
+            tracing::debug!(
+                prepared = matches!(&result, Ok(Completion::View(_))),
+                catalog_loaded = matches!(&result, Ok(Completion::Catalog(_))),
+                "Discarding a stale remote view reopening result"
+            );
+            return None;
+        }
+        match result {
+            Ok(Completion::Catalog(catalog)) => {
+                let catalog = *catalog;
+                self.catalog = Some(CachedCatalog {
+                    rows: catalog
+                        .panel_ids()
+                        .iter()
+                        .map(|id| SavedView {
+                            id: id.clone(),
+                            present: board.panel_id_by_local_id(id).is_some(),
+                        })
+                        .collect(),
+                    catalog,
+                    scope: pending.scope,
+                });
+                self.notice = None;
+            }
+            Ok(Completion::View(prepared)) => match board.adopt_reopened_remote_view(&pending.scope.owner, *prepared) {
+                Ok(id) => {
+                    if let Some(cached) = &mut self.catalog {
+                        for row in &mut cached.rows {
+                            row.present = board.panel_id_by_local_id(&row.id).is_some();
+                        }
+                    }
+                    self.notice =
+                        Some("View reopened and disconnected. Use Show session panels, then Reconnect.".into());
+                    return Some(id);
+                }
+                Err(error) => self.notice = Some(error.to_string()),
+            },
+            Err(message) => self.notice = Some(message),
+        }
+        None
+    }
+}
+
+fn worker_failure() -> &'static str {
+    "The saved-view worker could not start or finish. Show saved panels to retry."
+}
+
+pub(super) fn show(ui: &mut egui::Ui, state: &ReopenState, enabled: bool, action: &mut InventoryAction) {
+    paint::show(ui, state, enabled, action);
+}
+
+impl super::HorizonApp {
+    pub(super) fn remote_reopen_action(&mut self, action: InventoryAction, ctx: &Context) {
+        let state = &mut self.remote_environments;
+        let selected = state
+            .page
+            .as_ref()
+            .filter(|_| state.open)
+            .and_then(|page| state.selected.and_then(|index| page.rows.get(index)))
+            .map(|row| &row.summary);
+        let client = ClientContext {
+            home: self.session_store.home(),
+            config: &self.template_config.remote,
+            selected,
+            owner: self
+                .active_session
+                .as_ref()
+                .filter(|session| session.persistent)
+                .map(|session| session.session_id.as_str()),
+        };
+        if state.open
+            && state.pending.is_none()
+            && !state.observation.is_pending()
+            && !state.stop.is_pending()
+            && !state.reconnect.is_pending()
+        {
+            match action {
+                InventoryAction::ListReopenPanels => {
+                    state.stop.cancel_confirmation();
+                    state.reopen.load(&client, ctx);
+                }
+                InventoryAction::ReopenView(index) => {
+                    state.stop.cancel_confirmation();
+                    state.reopen.reopen(&client, &self.board, index, ctx);
+                }
+                _ => {}
+            }
+        }
+        if state.reopen.drain(&client, &mut self.board, ctx).is_some() {
+            state.reconnect.invalidate();
+            self.mark_runtime_dirty();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-ui/src/app/remote_environments/reopen/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/paint.rs
@@ -1,0 +1,43 @@
+use super::{InventoryAction, ReopenState};
+
+pub(super) fn show(ui: &mut egui::Ui, state: &ReopenState, enabled: bool, action: &mut InventoryAction) {
+    ui.separator();
+    ui.strong("Reopen closed views");
+    ui.label("Restore local views in their owning session. They stay disconnected; remote tasks are unchanged.");
+    if ui
+        .add_enabled(enabled && !state.is_pending(), egui::Button::new("Show saved panels"))
+        .clicked()
+    {
+        *action = InventoryAction::ListReopenPanels;
+    }
+    if let Some(pending) = &state.pending {
+        ui.label(if pending.discard {
+            "Waiting for the discarded saved-view request to finish…"
+        } else {
+            "Preparing saved local views…"
+        });
+    }
+    if let Some(cached) = &state.catalog {
+        if cached.rows.is_empty() {
+            ui.label("No saved panel identities in this environment.");
+        }
+        for (index, row) in cached.rows.iter().enumerate() {
+            ui.push_id((&row.id, "reopen"), |ui| {
+                ui.horizontal_wrapped(|ui| {
+                    ui.label(&row.id);
+                    if row.present {
+                        ui.label("View already open");
+                    } else if ui
+                        .add_enabled(enabled && !state.is_pending(), egui::Button::new("Reopen view"))
+                        .clicked()
+                    {
+                        *action = InventoryAction::ReopenView(index);
+                    }
+                });
+            });
+        }
+    }
+    if let Some(notice) = &state.notice {
+        ui.label(notice);
+    }
+}

--- a/crates/horizon-ui/src/app/remote_environments/reopen/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/tests.rs
@@ -103,26 +103,13 @@ fn foreign_and_ephemeral_clients_are_rejected_before_opening_storage() {
 fn explicit_load_and_reopen_are_inert_persistable_and_revalidate_cached_presence() {
     let temp = tempfile::tempdir().expect("fixture");
     let home = HorizonHome::from_root(temp.path().join("state"));
-    let (store, expected) = seed(&home, OWNER, 2);
+    let (store, expected) = seed(&home, OWNER, 3);
     let original = store.load_remote_workspace(OWNER, "environment").expect("record");
     let scope = scope(&expected);
     let client = client(&home, &scope);
     let ctx = Context::default();
     let mut board = Board::new();
     let mut state = ReopenState::default();
-    state.load(&client, &ctx);
-    settle(&mut state, &client, &mut board, &ctx);
-    assert_eq!(state.catalog.as_ref().expect("catalog").rows.len(), 2);
-    state.reopen(&client, &board, 0, &ctx);
-    settle(&mut state, &client, &mut board, &ctx);
-    assert_eq!(board.panels.len(), 1);
-    assert!(board.panels[0].terminal().expect("inert terminal").child_exited());
-    assert!(state.catalog.as_ref().expect("catalog").rows[0].present);
-    state.reopen(&client, &board, 0, &ctx);
-    assert!(!state.is_pending() && board.panels.len() == 1);
-    let saved = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
-    saved.validate_remote_references().expect("persistable");
-    assert!(!saved.to_yaml().expect("yaml").contains("private-"));
     let unrelated = board.create_workspace("Local");
     board
         .create_panel(
@@ -134,8 +121,45 @@ fn explicit_load_and_reopen_are_inert_persistable_and_revalidate_cached_presence
             unrelated,
         )
         .expect("editor");
+    state.load(&client, &ctx);
+    settle(&mut state, &client, &mut board, &ctx);
+    assert_eq!(state.catalog.as_ref().expect("catalog").rows.len(), 3);
+    assert!(!state.catalog.as_ref().expect("catalog").rows[1].present);
     state.reopen(&client, &board, 1, &ctx);
+    assert!(!state.is_pending() && board.panels.len() == 1);
+    assert_eq!(
+        state.notice.as_deref(),
+        Some(
+            horizon_core::RemoteViewReopenError::ViewAlreadyPresent
+                .to_string()
+                .as_str()
+        )
+    );
+    state.reopen(&client, &board, 0, &ctx);
+    settle(&mut state, &client, &mut board, &ctx);
+    assert_eq!(board.panels.len(), 2);
+    assert!(board.panels[1].terminal().expect("inert terminal").child_exited());
+    assert!(state.catalog.as_ref().expect("catalog").rows[0].present);
+    assert!(!state.catalog.as_ref().expect("catalog").rows[1].present);
+    state.reopen(&client, &board, 0, &ctx);
     assert!(!state.is_pending() && board.panels.len() == 2);
+    let saved = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    saved.validate_remote_references().expect("persistable");
+    assert!(!saved.to_yaml().expect("yaml").contains("private-"));
+    board
+        .create_panel(
+            PanelOptions {
+                kind: PanelKind::Editor,
+                local_id: Some("task-2".into()),
+                ..Default::default()
+            },
+            unrelated,
+        )
+        .expect("late conflicting editor");
+    state.reopen(&client, &board, 2, &ctx);
+    assert!(!state.is_pending() && board.panels.len() == 3);
+    state.reopen(&client, &board, 1, &ctx);
+    assert!(!state.is_pending() && board.panels.len() == 3);
     assert_eq!(
         store.load_remote_workspace(OWNER, "environment").expect("record"),
         original

--- a/crates/horizon-ui/src/app/remote_environments/reopen/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/tests.rs
@@ -1,0 +1,401 @@
+use super::super::{InventoryPage, RemoteEnvironments, paint::InventoryRow};
+use super::*;
+use crate::app::test_support::{raw_input, test_app};
+use crate::test_egui::DiscardTextures;
+use horizon_core::{CanvasViewState, PanelKind, PanelOptions, RuntimeState, WindowConfig};
+use std::time::{Duration, Instant};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+const FOREIGN: &str = "00000000-0000-4000-8000-000000000002";
+
+fn seed(home: &HorizonHome, owner: &str, count: usize) -> (CloudWorkflowStore, RemoteEnvironmentSummary) {
+    let store = CloudWorkflowStore::open(home).expect("store");
+    let panels: Vec<_> = (0..count)
+        .map(|index| {
+            serde_json::json!({
+                "panel_local_id":format!("task-{index}"), "kind":"command",
+                "command":{"program":"private-must-not-execute", "args":["private-argument"]}
+            })
+        })
+        .collect();
+    let state = serde_json::from_value(serde_json::json!({"version":1,"spec":{
+        "workspace_local_id":"environment","working_directory":".","generation":0,
+        "target":{"provider":"local_docker","profile":"development","disk_gib":20,
+            "lifetime":"persistent","image":format!("example/worker@sha256:{}", "a".repeat(64))},
+        "repository":{"repository":"example/project","commit":"b".repeat(40)},"panels":panels
+    }}))
+    .expect("state");
+    let record = store.create_remote_workspace(owner, &state).expect("record");
+    (store, record.environment_summary())
+}
+
+fn scope(expected: &RemoteEnvironmentSummary) -> RequestScope {
+    RequestScope {
+        expected: expected.clone(),
+        owner: expected.owning_session_id.clone(),
+        config: RemoteProviderConfig::default(),
+    }
+}
+
+fn client<'a>(home: &'a HorizonHome, scope: &'a RequestScope) -> ClientContext<'a> {
+    ClientContext {
+        home,
+        config: &scope.config,
+        selected: Some(&scope.expected),
+        owner: Some(&scope.owner),
+    }
+}
+
+fn pending(
+    state: &mut ReopenState,
+    scope: &RequestScope,
+    ctx: &Context,
+) -> mpsc::SyncSender<Result<Completion, String>> {
+    let (tx, rx) = mpsc::sync_channel(1);
+    state.pending = Some(PendingReopen {
+        rx,
+        scope: scope.clone(),
+        discard: false,
+    });
+    state.repaint_context = Some(ctx.clone());
+    tx
+}
+
+fn prepared(store: &CloudWorkflowStore, scope: &RequestScope, board: &Board) -> Box<PreparedRemoteViewReopen> {
+    let catalog = RemoteViewCatalog::load(store, &scope.owner, &scope.expected).expect("catalog");
+    let request = board
+        .request_remote_view_reopen(&scope.owner, &catalog, "task-0")
+        .expect("request");
+    let store = store.clone();
+    std::thread::spawn(move || request.prepare(&store).map(Box::new))
+        .join()
+        .expect("worker")
+        .expect("prepared")
+}
+
+fn settle(state: &mut ReopenState, client: &ClientContext<'_>, board: &mut Board, ctx: &Context) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while state.is_pending() {
+        state.drain(client, board, ctx);
+        assert!(Instant::now() < deadline, "bounded local worker");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn foreign_and_ephemeral_clients_are_rejected_before_opening_storage() {
+    let temp = tempfile::tempdir().expect("fixture");
+    let (_, expected) = seed(&HorizonHome::from_root(temp.path().join("seed")), OWNER, 1);
+    let home = HorizonHome::from_root(temp.path().join("unused"));
+    let scope = scope(&expected);
+    let ctx = Context::default();
+    let mut state = ReopenState::default();
+    for owner in [None, Some(FOREIGN)] {
+        let mut client = client(&home, &scope);
+        client.owner = owner;
+        state.load(&client, &ctx);
+        assert!(!state.is_pending() && state.catalog.is_none() && state.notice.is_some());
+    }
+    assert!(!home.root().exists());
+}
+
+#[test]
+fn explicit_load_and_reopen_are_inert_persistable_and_revalidate_cached_presence() {
+    let temp = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(temp.path().join("state"));
+    let (store, expected) = seed(&home, OWNER, 2);
+    let original = store.load_remote_workspace(OWNER, "environment").expect("record");
+    let scope = scope(&expected);
+    let client = client(&home, &scope);
+    let ctx = Context::default();
+    let mut board = Board::new();
+    let mut state = ReopenState::default();
+    state.load(&client, &ctx);
+    settle(&mut state, &client, &mut board, &ctx);
+    assert_eq!(state.catalog.as_ref().expect("catalog").rows.len(), 2);
+    state.reopen(&client, &board, 0, &ctx);
+    settle(&mut state, &client, &mut board, &ctx);
+    assert_eq!(board.panels.len(), 1);
+    assert!(board.panels[0].terminal().expect("inert terminal").child_exited());
+    assert!(state.catalog.as_ref().expect("catalog").rows[0].present);
+    state.reopen(&client, &board, 0, &ctx);
+    assert!(!state.is_pending() && board.panels.len() == 1);
+    let saved = RuntimeState::from_board(&board, WindowConfig::default(), CanvasViewState::default());
+    saved.validate_remote_references().expect("persistable");
+    assert!(!saved.to_yaml().expect("yaml").contains("private-"));
+    let unrelated = board.create_workspace("Local");
+    board
+        .create_panel(
+            PanelOptions {
+                kind: PanelKind::Editor,
+                local_id: Some("task-1".into()),
+                ..Default::default()
+            },
+            unrelated,
+        )
+        .expect("editor");
+    state.reopen(&client, &board, 1, &ctx);
+    assert!(!state.is_pending() && board.panels.len() == 2);
+    assert_eq!(
+        store.load_remote_workspace(OWNER, "environment").expect("record"),
+        original
+    );
+}
+
+#[test]
+fn invalidation_retains_one_worker_until_discard_and_explicit_retry() {
+    let temp = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(temp.path().join("state"));
+    let (store, expected) = seed(&home, OWNER, 0);
+    let scope = scope(&expected);
+    let client = client(&home, &scope);
+    let ctx = Context::default();
+    let mut board = Board::new();
+    let mut state = ReopenState::default();
+    let tx = pending(&mut state, &scope, &ctx);
+    for _ in 0..100 {
+        state.invalidate();
+        state.load(&client, &ctx);
+        state.reopen(&client, &board, 0, &ctx);
+        assert!(state.pending.as_ref().expect("slot").discard);
+    }
+    let catalog = RemoteViewCatalog::load(&store, OWNER, &expected).expect("catalog");
+    assert!(tx.send(Ok(Completion::Catalog(Box::new(catalog)))).is_ok());
+    assert_eq!(state.drain(&client, &mut board, &ctx), None);
+    assert!(!state.is_pending() && state.catalog.is_none() && state.notice.is_none());
+    state.load(&client, &ctx);
+    settle(&mut state, &client, &mut board, &ctx);
+    assert!(state.catalog.as_ref().expect("empty catalog").rows.is_empty());
+    drop(pending(&mut state, &scope, &ctx));
+    state.drain(&client, &mut board, &ctx);
+    assert_eq!(state.notice.as_deref(), Some(worker_failure()));
+}
+
+#[test]
+fn missing_and_invalid_storage_errors_leave_an_explicit_retry_without_board_changes() {
+    let temp = tempfile::tempdir().expect("fixture");
+    let (_, expected) = seed(&HorizonHome::from_root(temp.path().join("seed")), OWNER, 1);
+    let scope = scope(&expected);
+    let ctx = Context::default();
+    for malformed in [false, true] {
+        let home = HorizonHome::from_root(temp.path().join(if malformed { "invalid" } else { "missing" }));
+        if malformed {
+            std::fs::write(home.root(), b"not a directory").expect("invalid storage fixture");
+        }
+        let mut board = Board::new();
+        let mut state = ReopenState::default();
+        for _ in 0..2 {
+            state.load(&client(&home, &scope), &ctx);
+            settle(&mut state, &client(&home, &scope), &mut board, &ctx);
+            assert!(state.catalog.is_none() && state.notice.is_some());
+            assert!(board.panels.is_empty() && board.workspaces.is_empty());
+        }
+    }
+}
+
+#[test]
+fn queued_preparation_rechecks_owner_selection_config_and_explicit_discard() {
+    let temp = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(temp.path().join("state"));
+    let (store, expected) = seed(&home, OWNER, 1);
+    let original = scope(&expected);
+    let ctx = Context::default();
+    for fault in 0..4 {
+        let mut board = Board::new();
+        let mut state = ReopenState::default();
+        let tx = pending(&mut state, &original, &ctx);
+        assert!(
+            tx.send(Ok(Completion::View(prepared(&store, &original, &board))))
+                .is_ok()
+        );
+        let mut changed = original.clone();
+        match fault {
+            0 => changed.owner = FOREIGN.into(),
+            1 => changed.expected.revision += 1,
+            2 => changed
+                .config
+                .local_docker
+                .push(horizon_core::cloud_run::local_docker::LocalDockerProfile {
+                    name: "changed".into(),
+                    docker_host: "unix:///unused/socket".into(),
+                }),
+            _ => state.invalidate(),
+        }
+        assert_eq!(state.drain(&client(&home, &changed), &mut board, &ctx), None);
+        assert!(board.panels.is_empty() && board.workspaces.is_empty() && state.notice.is_none());
+    }
+}
+
+fn app_fixture() -> (
+    tempfile::TempDir,
+    crate::app::HorizonApp,
+    CloudWorkflowStore,
+    RequestScope,
+) {
+    let (temp, mut app) = test_app();
+    let session = app
+        .session_store
+        .create_session_from_runtime(RuntimeState::default())
+        .expect("session");
+    app.activate_persistent_session(&session);
+    let (store, expected) = seed(app.session_store.home(), &session.session_id, 1);
+    app.remote_environments = RemoteEnvironments {
+        open: true,
+        selected: Some(0),
+        page: Some(InventoryPage {
+            rows: vec![InventoryRow::new(expected.clone())],
+            next_cursor: None,
+        }),
+        ..Default::default()
+    };
+    (temp, app, store, scope(&expected))
+}
+
+#[test]
+fn application_adoption_marks_dirty_and_retries_blocked_persistence() {
+    let (_temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    let tx = pending(&mut app.remote_environments.reopen, &scope, &ctx);
+    assert!(
+        tx.send(Ok(Completion::View(prepared(&store, &scope, &app.board))))
+            .is_ok()
+    );
+    app.remote_reopen_action(InventoryAction::None, &ctx);
+    assert!(app.runtime_dirty_since.is_some() && app.board.panels.len() == 1);
+    app.pending_startup_runtime_state = Some(RuntimeState::default());
+    app.runtime_dirty_since = Some(Instant::now().checked_sub(Duration::from_secs(1)).expect("test clock"));
+    app.flush_runtime_if_dirty();
+    assert!(app.runtime_dirty_since.is_some());
+    assert!(
+        app.session_store
+            .resume_session(&scope.owner)
+            .expect("saved")
+            .runtime_state
+            .workspaces
+            .is_empty()
+    );
+    app.pending_startup_runtime_state = None;
+    app.root_viewport_stabilizer = None;
+    app.runtime_dirty_since = Some(Instant::now().checked_sub(Duration::from_secs(1)).expect("test clock"));
+    app.flush_runtime_if_dirty();
+    assert!(app.runtime_dirty_since.is_none());
+    let saved = app
+        .session_store
+        .resume_session(&scope.owner)
+        .expect("saved")
+        .runtime_state;
+    assert_eq!(saved.workspaces[0].panels[0].local_id, "task-0");
+    assert!(!saved.to_yaml().expect("yaml").contains("private-"));
+}
+
+#[test]
+fn escape_discards_a_success_already_queued_before_the_modal_frame() {
+    let (_temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    let _ = ctx
+        .run_ui(raw_input([900.0, 700.0], None), |ui| {
+            let _ = app.render_remote_environments(ui);
+        })
+        .discard_textures();
+    let tx = pending(&mut app.remote_environments.reopen, &scope, &ctx);
+    assert!(
+        tx.send(Ok(Completion::View(prepared(&store, &scope, &app.board))))
+            .is_ok()
+    );
+    let mut input = raw_input([900.0, 700.0], None);
+    input.events.push(egui::Event::Key {
+        key: egui::Key::Escape,
+        physical_key: None,
+        pressed: true,
+        repeat: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    let _ = ctx
+        .run_ui(input, |ui| {
+            let _ = app.render_remote_environments(ui);
+        })
+        .discard_textures();
+    assert!(!app.remote_environments.open && app.board.panels.is_empty());
+    assert!(!app.remote_environments.reopen.is_pending() && app.remote_environments.reopen.notice.is_none());
+}
+
+#[test]
+fn same_owner_board_replacement_and_competing_reconnect_discard_prepared_views() {
+    for replace_board in [false, true] {
+        let (_temp, mut app, store, scope) = app_fixture();
+        let ctx = Context::default();
+        let tx = pending(&mut app.remote_environments.reopen, &scope, &ctx);
+        assert!(
+            tx.send(Ok(Completion::View(prepared(&store, &scope, &app.board))))
+                .is_ok()
+        );
+        if replace_board {
+            app.apply_runtime_state(&RuntimeState::default());
+        } else {
+            app.remote_environments
+                .apply(InventoryAction::ListReconnectViews, app.session_store.home(), &ctx);
+            app.remote_reconnect_action(InventoryAction::ListReconnectViews, &ctx);
+        }
+        assert!(
+            app.remote_environments
+                .reopen
+                .pending
+                .as_ref()
+                .expect("retained slot")
+                .discard
+        );
+        app.remote_reopen_action(InventoryAction::None, &ctx);
+        assert!(app.board.panels.is_empty() && app.remote_environments.reopen.notice.is_none());
+    }
+}
+
+#[test]
+fn post_paint_config_invalidation_wakes_a_completed_catalog_once_without_polling() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    let (_temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    let tx = pending(&mut app.remote_environments.reopen, &scope, &ctx);
+    let catalog = RemoteViewCatalog::load(&store, &scope.owner, &scope.expected).expect("catalog");
+    assert!(tx.send(Ok(Completion::Catalog(Box::new(catalog)))).is_ok());
+    for frame in 0..30 {
+        let mut input = raw_input([900.0, 700.0], None);
+        input.time = Some(f64::from(frame) * 0.1);
+        let _ = ctx
+            .run_ui(input, |ui| {
+                let _ = app.render_remote_environments(ui);
+            })
+            .discard_textures();
+        if !ctx.has_requested_repaint() {
+            break;
+        }
+    }
+    assert!(app.board.panels.is_empty() && app.remote_environments.reopen.catalog.is_some());
+    assert!(!ctx.has_requested_repaint(), "completed catalog must not poll");
+    let requests = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&requests);
+    ctx.set_request_repaint_callback(move |_| {
+        observed.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut config = app.template_config.clone();
+    app.apply_runtime_config(&config);
+    assert_eq!(requests.load(Ordering::Relaxed), 0);
+    config
+        .remote
+        .local_docker
+        .push(horizon_core::cloud_run::local_docker::LocalDockerProfile {
+            name: "changed".into(),
+            docker_host: "unix:///unused/socket".into(),
+        });
+    app.apply_runtime_config(&config);
+    assert_eq!(requests.load(Ordering::Relaxed), 1);
+    assert!(app.remote_environments.reopen.catalog.is_none());
+    app.remote_environments.invalidate_provider_state();
+    assert_eq!(
+        requests.load(Ordering::Relaxed),
+        1,
+        "repeated invalidation must not loop"
+    );
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -175,6 +175,10 @@ back into large multi-purpose modules.
   Its single-flight worker prepares connections off-thread; lifecycle and modal
   actions invalidate before queued handoff adoption. Pending discarded receivers
   retain the slot until completion. Same-owner views do not implement global Open.
+- UI `remote_environments/reopen/` explicitly loads saved panel identities and
+  prepares inert missing views off-thread. It shares lifecycle invalidation with
+  reconnect; competing actions discard queued results before either handoff drains.
+  Adoption marks reference-only runtime state dirty without starting remote tasks.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply


### PR DESCRIPTION
## Purpose

Reopen a closed remote panel view from Remote Environments without restarting its
task. This delivers the UI for the core API in #456. Refs #383; the full remote
workspace feature remains open.

## Behavior

- Explicit **Show saved panels** loads identities for the selected environment.
  **Reopen view** restores a missing local view in its actual owning persistent
  session. Existing views cannot be replaced or duplicated.
- Reopened views stay disconnected. The existing **Show session panels** and
  **Reconnect** actions remain the separate transport operation.
- Preparation runs off the render thread. Session/board replacement, selection,
  refresh, dismissal, provider-config changes and competing actions discard stale
  results before adoption. Invalidated workers retain their single-flight slot.
- Successful adoption uses normal reference-only persistence. It does not load
  saved task commands into local runtime state or create/stop/delete remote work.

## Validation

- Full source and exact-commit matrix passed on `abb827fc`: formatting,
  maintainability, version sync, default/speech workspace tests and all three lint
  tiers. Independent source and committed-tree reviews passed.
- Nine new UI state tests and a core identity regression cover ownership, malformed/missing records, duplicates,
  blocked-save retry, actual prepared results queued before cancellation,
  same-frame competing actions and changed-state-only repaint.
- Native Linux/X11 checks used isolated state, software rendering, a cached local
  worker image and two running synthetic tasks plus one retained exit with status 7.
  Explicit reopening produced three disconnected reference-only views. Explicit
  reconnect reached original task identities; input stayed isolated. Close-one,
  close-all, reopening, client exit and relaunch preserved tasks, repository bytes,
  allocation records and client identity. No input was replayed.
- Light/dark, 800x600 minimum size, scrolling and Fit screenshots were inspected.
  Deterministic state tests cover stale-result races; no cloud or physical PC-off
  acceptance is claimed. Temporary smoke instructions are removed after validation;
  private evidence is retained.
- The exact committed build is byte-identical to its reviewed source build
  (`1400e26f` SHA256 prefix). All affected native lanes were repeated on that binary
  using a fresh owning-session fixture after the hosted-review correction.
- Collision regression: the previous head falsely marked an unrelated local
  editor as an existing remote view. The corrected catalog checks both saved ID
  and execution reference; clicking Reopen shows the core conflict error without
  replacing the editor or connecting a task. Native before/after proof and core/UI
  regressions cover this, including cached and late-arriving conflicts.

### Matched redraw measurements

Debug trace build; three six-second samples per workload, identical disconnected
three-panel layout and input coordinates, no concurrent builds. This paired run
compares the previous UI head `4a6b3938` with corrected head `abb827fc`; the complete
saved layout matched exactly, as did every paired post-interaction screenshot.
Values below are CPU percentages of one core, weighted by elapsed time.

| Workload | Baseline | Candidate |
| --- | ---: | ---: |
| Idle | 13.59 | 13.20 |
| Empty-canvas pointer | 366.08 | 357.94 |
| Panel-chrome pointer | 361.53 | 356.28 |
| Overview pointer | 419.05 | 405.81 |

CPU was similar. Normalized render-span costs varied by up to 7.6%; this is not a
speedup claim. The presence correction executes only during explicit catalog or
adoption completion, not pointer frames. No periodic store/provider polling is
introduced. The original feature also had a separate pre-correction comparison
against its merged-core baseline; those older measurements are not new-head proof.

## Boundaries

This does not implement global session Open, workspace setup/materialization,
cloud-provider management, checkpoint recovery or separate Delete. No release,
cloud allocation or changes to pre-existing sessions/resources are included.
