### PR TITLE
Validate complete repository overlay namespaces

### DIFF
--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod bundle;
 pub mod capture;
+pub mod namespace;
 mod paths;
 pub mod reader;
 

--- a/crates/horizon-core/src/repository_overlay/namespace/git.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/git.rs
@@ -1,0 +1,114 @@
+use super::{Budget, NamespaceEntry, NamespaceError as Error, NamespaceFile, RepositoryNamespace};
+use crate::repository_overlay::{MAX_METADATA_BYTES, paths, reader::MAX_READ_BYTES};
+use git2::{ObjectFormat, ObjectType, Odb, Oid, Repository};
+use std::collections::BTreeSet;
+
+pub(super) fn read(repository: &Repository, commit: Oid) -> Result<(Oid, RepositoryNamespace), Error> {
+    if repository.object_format() != ObjectFormat::Sha1 {
+        return Err(Error::Base);
+    }
+    let database = repository.odb().map_err(|_| Error::Base)?;
+    verify_metadata(&database, commit, ObjectType::Commit)?;
+    let commit = repository.find_commit(commit).map_err(|_| Error::Base)?;
+    let root = commit.tree_id();
+    let mut pending = vec![(String::new(), root)];
+    let mut namespace = RepositoryNamespace::default();
+    let mut budget = Budget::default();
+    let mut seen = BTreeSet::new();
+    while let Some((prefix, id)) = pending.pop() {
+        verify_metadata(&database, id, ObjectType::Tree)?;
+        let tree = repository.find_tree(id).map_err(|_| Error::Object)?;
+        if !prefix.is_empty() && tree.is_empty() {
+            return Err(Error::UnsupportedNode);
+        }
+        for entry in &tree {
+            let name = entry.name().map_err(|_| Error::UnsupportedNode)?;
+            if name.contains('/') {
+                return Err(Error::UnsupportedNode);
+            }
+            let path = if prefix.is_empty() {
+                name.to_owned()
+            } else {
+                format!("{prefix}/{name}")
+            };
+            paths::validate(&path)?;
+            if entry.filemode_raw() == 0o040_000 {
+                budget.add(&path, None, 0)?;
+                if !seen.insert(path.clone()) {
+                    return Err(Error::Topology);
+                }
+                pending.push((path, entry.id()));
+            } else {
+                let node = leaf(&database, entry.id(), entry.filemode_raw())?;
+                let (target, bytes) = match &node {
+                    NamespaceEntry::File { source, .. } => (None, source.bytes()),
+                    NamespaceEntry::Symlink { target } => (Some(target.as_str()), 0),
+                };
+                budget.add(&path, target, bytes)?;
+                if !seen.insert(path.clone()) {
+                    return Err(Error::Topology);
+                }
+                if namespace.entries.insert(path, node).is_some() {
+                    return Err(Error::Topology);
+                }
+            }
+        }
+    }
+    Ok((root, namespace))
+}
+
+fn verify_metadata(database: &Odb<'_>, id: Oid, kind: ObjectType) -> Result<(), Error> {
+    let (bytes, actual) = database.read_header(id).map_err(|_| Error::Base)?;
+    if bytes > MAX_METADATA_BYTES {
+        return Err(Error::Limit);
+    }
+    if actual != kind {
+        return Err(Error::Object);
+    }
+    let object = database.read(id).map_err(|_| Error::Object)?;
+    if object.kind() != kind
+        || object.len() != bytes
+        || Oid::hash_object(kind, object.data()).map_err(|_| Error::Object)? != id
+    {
+        return Err(Error::Object);
+    }
+    Ok(())
+}
+
+fn leaf(database: &Odb<'_>, object: Oid, mode: i32) -> Result<NamespaceEntry, Error> {
+    if !matches!(mode, 0o100_644 | 0o100_755 | 0o120_000) {
+        return Err(Error::UnsupportedNode);
+    }
+    let (bytes, kind) = database.read_header(object).map_err(|_| Error::Object)?;
+    if kind != ObjectType::Blob {
+        return Err(Error::Object);
+    }
+    if bytes > MAX_READ_BYTES {
+        return Err(Error::Limit);
+    }
+    if mode == 0o120_000 {
+        if bytes > paths::MAX_PATH_BYTES {
+            return Err(Error::Limit);
+        }
+        let blob = database.read(object).map_err(|_| Error::Object)?;
+        if blob.kind() != ObjectType::Blob
+            || blob.len() != bytes
+            || Oid::hash_object(ObjectType::Blob, blob.data()).map_err(|_| Error::Object)? != object
+        {
+            return Err(Error::Object);
+        }
+        Ok(NamespaceEntry::Symlink {
+            target: std::str::from_utf8(blob.data())
+                .map_err(|_| Error::UnsupportedNode)?
+                .to_owned(),
+        })
+    } else {
+        Ok(NamespaceEntry::File {
+            source: NamespaceFile::Base {
+                object,
+                bytes: u64::try_from(bytes).map_err(|_| Error::Limit)?,
+            },
+            executable: mode == 0o100_755,
+        })
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/git.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/git.rs
@@ -1,5 +1,5 @@
 use super::{Budget, NamespaceEntry, NamespaceError as Error, NamespaceFile, RepositoryNamespace};
-use crate::repository_overlay::{MAX_METADATA_BYTES, paths, reader::MAX_READ_BYTES};
+use crate::repository_overlay::{MAX_METADATA_BYTES, paths};
 use git2::{ObjectFormat, ObjectType, Odb, Oid, Repository};
 use std::collections::BTreeSet;
 
@@ -82,9 +82,6 @@ fn leaf(database: &Odb<'_>, object: Oid, mode: i32) -> Result<NamespaceEntry, Er
     let (bytes, kind) = database.read_header(object).map_err(|_| Error::Object)?;
     if kind != ObjectType::Blob {
         return Err(Error::Object);
-    }
-    if bytes > MAX_READ_BYTES {
-        return Err(Error::Limit);
     }
     if mode == 0o120_000 {
         if bytes > paths::MAX_PATH_BYTES {

--- a/crates/horizon-core/src/repository_overlay/namespace/links.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/links.rs
@@ -1,0 +1,78 @@
+use super::{MAX_METADATA_BYTES, NamespaceEntry, NamespaceError as Error, RepositoryNamespace};
+use crate::repository_overlay::paths::MAX_PATH_BYTES;
+use std::collections::VecDeque;
+
+const MAX_LINK_HOPS: usize = 40;
+const MAX_PENDING_COMPONENTS: usize = 8192;
+const MAX_LINK_WORK: usize = 8 * MAX_METADATA_BYTES;
+
+#[derive(Default)]
+pub(super) struct Work(usize);
+
+impl Work {
+    fn charge(&mut self, bytes: usize) -> Result<(), Error> {
+        self.0 = self
+            .0
+            .checked_add(bytes.max(1))
+            .filter(|total| *total <= MAX_LINK_WORK)
+            .ok_or(Error::Limit)?;
+        Ok(())
+    }
+}
+
+pub(super) fn validate(namespace: &RepositoryNamespace, work: &mut Work) -> Result<(), Error> {
+    for (path, entry) in &namespace.entries {
+        if matches!(entry, NamespaceEntry::Symlink { .. }) {
+            resolve(namespace, path, work)?;
+        }
+    }
+    Ok(())
+}
+
+fn resolve(namespace: &RepositoryNamespace, path: &str, work: &mut Work) -> Result<(), Error> {
+    let mut pending: VecDeque<_> = path.split('/').collect();
+    let mut resolved = String::with_capacity(MAX_PATH_BYTES);
+    let mut boundaries = Vec::new();
+    let mut hops = 0;
+    while let Some(component) = pending.pop_front() {
+        work.charge(component.len() + resolved.len())?;
+        match component {
+            "" | "." => continue,
+            ".." => {
+                resolved.truncate(boundaries.pop().ok_or(Error::Link)?);
+                continue;
+            }
+            _ => {}
+        }
+        let previous = resolved.len();
+        if previous + usize::from(previous != 0) + component.len() > MAX_PATH_BYTES {
+            return Err(Error::Limit);
+        }
+        if previous != 0 {
+            resolved.push('/');
+        }
+        resolved.push_str(component);
+        boundaries.push(previous);
+        match namespace.entries.get(&resolved) {
+            Some(NamespaceEntry::Symlink { target }) => {
+                hops += 1;
+                if hops > MAX_LINK_HOPS {
+                    return Err(Error::Link);
+                }
+                // Relative targets begin at the actual containing directory, after
+                // earlier links have resolved. Normalize `..` only while traversing.
+                resolved.truncate(boundaries.pop().ok_or(Error::Link)?);
+                for part in target.rsplit('/') {
+                    if pending.len() == MAX_PENDING_COMPONENTS {
+                        return Err(Error::Limit);
+                    }
+                    pending.push_front(part);
+                    work.charge(part.len())?;
+                }
+            }
+            Some(NamespaceEntry::File { .. }) if !pending.is_empty() => return Err(Error::Link),
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/mod.rs
@@ -1,0 +1,205 @@
+//! Compose exact-base, index and working-tree namespaces without applying or exporting them.
+
+mod git;
+mod links;
+mod tree;
+
+use super::{MAX_CHANGES, MAX_CONTENT_BYTES, MAX_METADATA_BYTES, OverlayPlanError, bundle::RepositoryOverlayBundle};
+use crate::cloud_run::ArtifactDigest;
+use git2::{Oid, Repository};
+use std::{collections::BTreeMap, fmt};
+
+/// A file reference, not a promise that base bytes have been read or exported.
+#[derive(Clone, Eq, PartialEq)]
+pub enum NamespaceFile {
+    Base { object: Oid, bytes: u64 },
+    Overlay { sha256: ArtifactDigest, bytes: u64 },
+}
+
+impl NamespaceFile {
+    #[must_use]
+    pub fn bytes(&self) -> u64 {
+        match self {
+            Self::Base { bytes, .. } | Self::Overlay { bytes, .. } => *bytes,
+        }
+    }
+}
+
+/// One final leaf. Directories are implicit; removals are never recursive nodes.
+#[derive(Clone, Eq, PartialEq)]
+pub enum NamespaceEntry {
+    File { source: NamespaceFile, executable: bool },
+    Symlink { target: String },
+}
+
+impl fmt::Debug for NamespaceEntry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::File { source, executable } => formatter
+                .debug_struct("File")
+                .field("bytes", &source.bytes())
+                .field("executable", executable)
+                .finish_non_exhaustive(),
+            Self::Symlink { .. } => formatter.debug_struct("Symlink").finish_non_exhaustive(),
+        }
+    }
+}
+
+/// Immutable ordered leaves with validated complete-tree topology and effective links.
+#[derive(Clone, Default)]
+pub struct RepositoryNamespace {
+    entries: BTreeMap<String, NamespaceEntry>,
+    logical_bytes: u64,
+}
+
+impl RepositoryNamespace {
+    #[must_use]
+    pub fn entry(&self, path: &str) -> Option<&NamespaceEntry> {
+        self.entries.get(path)
+    }
+
+    #[must_use]
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = (&str, &NamespaceEntry)> {
+        self.entries.iter().map(|(path, entry)| (path.as_str(), entry))
+    }
+
+    /// Sum of regular-file lengths at every path, including repeated blob references.
+    #[must_use]
+    pub fn logical_bytes(&self) -> u64 {
+        self.logical_bytes
+    }
+}
+
+/// Owns the original verified overlay and complete namespaces, without duplicating payloads.
+/// Only the resolver can construct this result. A later writer must revalidate base bytes
+/// against their Git IDs and use a separately authorized, confined fresh destination.
+pub struct ResolvedRepositoryOverlay {
+    bundle: RepositoryOverlayBundle,
+    base_commit: Oid,
+    base_tree: Oid,
+    base: RepositoryNamespace,
+    index: RepositoryNamespace,
+    working_tree: RepositoryNamespace,
+}
+
+impl ResolvedRepositoryOverlay {
+    #[must_use]
+    pub fn bundle(&self) -> &RepositoryOverlayBundle {
+        &self.bundle
+    }
+
+    #[must_use]
+    pub fn base_commit(&self) -> Oid {
+        self.base_commit
+    }
+
+    #[must_use]
+    pub fn base_tree(&self) -> Oid {
+        self.base_tree
+    }
+
+    #[must_use]
+    pub fn base(&self) -> &RepositoryNamespace {
+        &self.base
+    }
+
+    #[must_use]
+    pub fn index(&self) -> &RepositoryNamespace {
+        &self.index
+    }
+
+    #[must_use]
+    pub fn working_tree(&self) -> &RepositoryNamespace {
+        &self.working_tree
+    }
+}
+
+impl fmt::Debug for ResolvedRepositoryOverlay {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResolvedRepositoryOverlay")
+            .field("base_entries", &self.base.entries.len())
+            .field("index_entries", &self.index.entries.len())
+            .field("working_entries", &self.working_tree.entries.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Resolve the bundle's exact SHA-1 commit directly, independently of current HEAD/index.
+/// The caller supplies trusted Git metadata; this does not verify repository URL ownership
+/// or authorize capture/export. No worktree reads, writes, filters, hooks or transport occur.
+/// Regular base blobs remain references; only link payloads are read for topology validation.
+/// Run off the UI thread. Bounds cover expanded namespaces and link work, not filesystem
+/// latency or all native Git metadata allocations. No ready-checkout guarantee is returned.
+/// # Errors
+/// Rejects unsupported/corrupt base metadata, excluded paths, impossible topology, unsafe
+/// effective links and expanded entry, metadata, logical-byte or link-work limit excess.
+pub fn resolve_namespaces(
+    base: &Repository,
+    bundle: RepositoryOverlayBundle,
+) -> Result<ResolvedRepositoryOverlay, NamespaceError> {
+    let base_commit = Oid::from_str(bundle.plan().source().commit.as_str()).map_err(|_| NamespaceError::Base)?;
+    let (base_tree, mut original) = git::read(base, base_commit)?;
+    let mut link_work = links::Work::default();
+    tree::validate(&mut original, &mut link_work)?;
+    let index = tree::apply(&original, bundle.plan().index(), &mut link_work)?;
+    let working_tree = tree::apply(&index, bundle.plan().working_tree(), &mut link_work)?;
+    Ok(ResolvedRepositoryOverlay {
+        bundle,
+        base_commit,
+        base_tree,
+        base: original,
+        index,
+        working_tree,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum NamespaceError {
+    #[error("the exact supported repository base could not be read")]
+    Base,
+    #[error("repository object metadata is invalid or inconsistent")]
+    Object,
+    #[error("repository namespace contains an unsupported node")]
+    UnsupportedNode,
+    #[error("repository namespace has conflicting leaf and directory identities")]
+    Topology,
+    #[error("repository link resolution is unsafe or unsupported")]
+    Link,
+    #[error("expanded repository namespace exceeds a supported bound")]
+    Limit,
+    #[error(transparent)]
+    Policy(#[from] OverlayPlanError),
+}
+
+#[derive(Default)]
+struct Budget {
+    entries: usize,
+    metadata: usize,
+    logical: u64,
+}
+
+impl Budget {
+    fn add(&mut self, path: &str, target: Option<&str>, bytes: u64) -> Result<(), NamespaceError> {
+        self.entries = self
+            .entries
+            .checked_add(1)
+            .filter(|n| *n <= MAX_CHANGES)
+            .ok_or(NamespaceError::Limit)?;
+        self.metadata = self
+            .metadata
+            .checked_add(path.len())
+            .and_then(|n| n.checked_add(target.map_or(0, str::len)))
+            .filter(|n| *n <= MAX_METADATA_BYTES)
+            .ok_or(NamespaceError::Limit)?;
+        self.logical = self
+            .logical
+            .checked_add(bytes)
+            .filter(|n| *n <= MAX_CONTENT_BYTES)
+            .ok_or(NamespaceError::Limit)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/namespace/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/tests.rs
@@ -1,0 +1,460 @@
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{OverlayChange, OverlayContent, RepositoryOverlayPlan, bundle::VerifiedOverlayBlob},
+};
+use git2::{Index, IndexEntry, IndexTime, Signature};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    repository: Repository,
+    commit: Oid,
+}
+
+impl Fixture {
+    fn new(files: &[(&str, &[u8], u32)]) -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let repository = Repository::init(directory.path()).unwrap();
+        let mut index = Index::new().unwrap();
+        for (path, bytes, mode) in files {
+            index
+                .add(&IndexEntry {
+                    ctime: IndexTime::new(0, 0),
+                    mtime: IndexTime::new(0, 0),
+                    dev: 0,
+                    ino: 0,
+                    mode: *mode,
+                    uid: 0,
+                    gid: 0,
+                    file_size: u32::try_from(bytes.len()).unwrap(),
+                    id: repository.blob(bytes).unwrap(),
+                    flags: 0,
+                    flags_extended: 0,
+                    path: path.as_bytes().to_vec(),
+                })
+                .unwrap();
+        }
+        let tree = index.write_tree_to(&repository).unwrap();
+        let commit = commit(&repository, tree);
+        Self {
+            directory,
+            repository,
+            commit,
+        }
+    }
+
+    fn bundle(
+        &self,
+        index: Vec<OverlayChange>,
+        working: Vec<OverlayChange>,
+        blobs: Vec<VerifiedOverlayBlob>,
+    ) -> RepositoryOverlayBundle {
+        let source = GitSource {
+            repository: "synthetic/project".into(),
+            commit: GitCommitSha::parse(self.commit.to_string()).unwrap(),
+            branch: None,
+        };
+        RepositoryOverlayBundle::new(RepositoryOverlayPlan::new(source, index, working).unwrap(), blobs).unwrap()
+    }
+
+    fn resolve(
+        &self,
+        index: Vec<OverlayChange>,
+        working: Vec<OverlayChange>,
+        blobs: Vec<VerifiedOverlayBlob>,
+    ) -> Result<ResolvedRepositoryOverlay, NamespaceError> {
+        resolve_namespaces(&self.repository, self.bundle(index, working, blobs))
+    }
+}
+
+fn commit(repository: &Repository, tree: Oid) -> Oid {
+    let signature = Signature::now("Fixture", "fixture@example.invalid").unwrap();
+    repository
+        .commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "Synthetic base",
+            &repository.find_tree(tree).unwrap(),
+            &[],
+        )
+        .unwrap()
+}
+
+fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedOverlayBlob) {
+    let blob = VerifiedOverlayBlob::new(bytes.to_vec()).unwrap();
+    let change = OverlayChange::new(
+        path.into(),
+        OverlayContent::File {
+            sha256: blob.sha256().clone(),
+            bytes: bytes.len() as u64,
+            executable,
+        },
+    )
+    .unwrap();
+    (change, blob)
+}
+
+fn remove(path: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Remove).unwrap()
+}
+
+fn link(path: &str, target: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Symlink { target: target.into() }).unwrap()
+}
+
+fn contents(
+    fixture: &Fixture,
+    result: &ResolvedRepositoryOverlay,
+    tree: &RepositoryNamespace,
+    path: &str,
+) -> (Vec<u8>, bool) {
+    let NamespaceEntry::File { source, executable } = tree.entry(path).unwrap() else {
+        panic!("file expected")
+    };
+    let bytes = match source {
+        NamespaceFile::Base { object, .. } => fixture.repository.find_blob(*object).unwrap().content().to_vec(),
+        NamespaceFile::Overlay { sha256, .. } => result.bundle().blob(sha256).unwrap().to_vec(),
+    };
+    (bytes, *executable)
+}
+
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    let mut files = BTreeMap::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_dir() {
+                pending.push(entry.path());
+            } else {
+                files.insert(entry.path(), fs::read(entry.path()).unwrap());
+            }
+        }
+    }
+    files
+}
+
+#[test]
+fn exact_base_and_two_layers_preserve_independent_file_semantics_without_writes() {
+    let fixture = Fixture::new(&[
+        ("keep", b"base", 0o100_755),
+        ("nested/file", b"original", 0o100_644),
+        ("old-name", b"rename", 0o100_644),
+        ("delete-working", b"gone", 0o100_644),
+    ]);
+    let (staged, index_blob) = file("nested/file", b"staged\r\n", false);
+    let (working, working_blob) = file("nested/file", b"working\0\xff", true);
+    let (renamed, rename_blob) = file("new-name", b"rename", false);
+    let (untracked, untracked_blob) = file("untracked", b"local", false);
+    fs::write(fixture.directory.path().join("not-selected"), b"never read").unwrap();
+    let before = snapshot(fixture.directory.path());
+    let result = fixture
+        .resolve(
+            vec![staged, remove("old-name"), renamed, link("alias", "keep")],
+            vec![
+                working,
+                untracked,
+                remove("delete-working"),
+                link("alias", "nested/file"),
+            ],
+            vec![index_blob, working_blob, rename_blob, untracked_blob],
+        )
+        .unwrap();
+    assert_eq!(result.base_commit(), fixture.commit);
+    assert_eq!(
+        result.base_tree(),
+        fixture.repository.find_commit(fixture.commit).unwrap().tree_id()
+    );
+    assert_eq!(
+        contents(&fixture, &result, result.base(), "nested/file"),
+        (b"original".to_vec(), false)
+    );
+    assert_eq!(
+        contents(&fixture, &result, result.index(), "nested/file"),
+        (b"staged\r\n".to_vec(), false)
+    );
+    assert_eq!(
+        contents(&fixture, &result, result.working_tree(), "nested/file"),
+        (b"working\0\xff".to_vec(), true)
+    );
+    assert_eq!(
+        contents(&fixture, &result, result.working_tree(), "keep"),
+        (b"base".to_vec(), true)
+    );
+    assert!(result.base().entry("old-name").is_some() && result.index().entry("old-name").is_none());
+    assert!(
+        result.index().entry("delete-working").is_some() && result.working_tree().entry("delete-working").is_none()
+    );
+    assert!(result.index().entry("untracked").is_none() && result.working_tree().entry("untracked").is_some());
+    assert_eq!(
+        result.index().entry("alias"),
+        Some(&NamespaceEntry::Symlink { target: "keep".into() })
+    );
+    assert_eq!(
+        result.working_tree().entry("alias"),
+        Some(&NamespaceEntry::Symlink {
+            target: "nested/file".into()
+        })
+    );
+    assert!(result.working_tree().entry("not-selected").is_none());
+    assert_eq!(snapshot(fixture.directory.path()), before);
+}
+
+#[test]
+fn whole_layer_transitions_never_remove_unselected_descendants_recursively() {
+    let fixture = Fixture::new(&[("dir/a", b"a", 0o100_644), ("dir/b", b"b", 0o100_644)]);
+    assert!(matches!(
+        fixture.resolve(vec![remove("dir")], vec![], vec![]),
+        Err(NamespaceError::Topology)
+    ));
+    let (replacement, blob) = file("dir", b"replacement", false);
+    assert!(matches!(
+        fixture.resolve(vec![remove("dir/a"), replacement], vec![], vec![blob]),
+        Err(NamespaceError::Topology)
+    ));
+    let (replacement, blob) = file("dir", b"replacement", false);
+    let (child, child_blob) = file("dir/new/child", b"new", false);
+    let result = fixture
+        .resolve(
+            vec![remove("dir/a"), remove("dir/b"), replacement],
+            vec![remove("dir"), child],
+            vec![blob, child_blob],
+        )
+        .unwrap();
+    assert!(result.index().entry("dir").is_some() && result.index().entry("dir/a").is_none());
+    assert!(result.working_tree().entry("dir").is_none() && result.working_tree().entry("dir/new/child").is_some());
+    let fixture = Fixture::new(&[("file", b"base", 0o100_644)]);
+    let (child, blob) = file("file/child", b"new", false);
+    assert!(matches!(
+        fixture.resolve(vec![child], vec![], vec![blob]),
+        Err(NamespaceError::Topology)
+    ));
+}
+
+#[test]
+fn effective_links_reject_escapes_cycles_and_file_ancestors_in_every_namespace() {
+    for layers in [0, 1, 2] {
+        let files = if layers == 0 {
+            vec![
+                ("d/up", &b".."[..], 0o120_000),
+                ("escape", &b"d/up/../outside"[..], 0o120_000),
+            ]
+        } else {
+            vec![]
+        };
+        let fixture = Fixture::new(&files);
+        let bad = vec![link("d/up", ".."), link("escape", "d/up/../outside")];
+        let (index, working) = match layers {
+            0 => (vec![], vec![]),
+            1 => (bad, vec![]),
+            _ => (vec![], bad),
+        };
+        assert!(matches!(
+            fixture.resolve(index, working, vec![]),
+            Err(NamespaceError::Link)
+        ));
+    }
+    let fixture = Fixture::new(&[("ordinary", b"base", 0o100_644)]);
+    for changes in [
+        vec![link("a", "b"), link("b", "a")],
+        vec![link("a", "a")],
+        vec![link("a", "ordinary/child")],
+    ] {
+        assert!(matches!(
+            fixture.resolve(changes, vec![], vec![]),
+            Err(NamespaceError::Link)
+        ));
+    }
+    let result = fixture
+        .resolve(
+            vec![
+                link("nested/dangling", "../missing/leaf"),
+                link("root", "."),
+                link("alias", "root/ordinary"),
+            ],
+            vec![],
+            vec![],
+        )
+        .unwrap();
+    assert_eq!(result.index().entries().len(), 4);
+}
+
+#[test]
+fn exact_commit_is_independent_of_head_and_lfs_filters_do_not_run() {
+    let pointer = b"version https://git-lfs.github.com/spec/v1\noid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nsize 8\n";
+    let fixture = Fixture::new(&[
+        ("asset.bin", pointer, 0o100_644),
+        (".gitattributes", b"*.bin filter=synthetic\n", 0o100_644),
+    ]);
+    fixture.repository.set_head_detached(fixture.commit).unwrap();
+    fixture
+        .repository
+        .config()
+        .unwrap()
+        .set_str("filter.synthetic.smudge", "false")
+        .unwrap();
+    fixture
+        .repository
+        .config()
+        .unwrap()
+        .set_bool("filter.synthetic.required", true)
+        .unwrap();
+    fixture.repository.set_head("refs/heads/unborn-other-head").unwrap();
+    let (hydrated, blob) = file("asset.bin", b"hydrated", false);
+    let before = snapshot(fixture.directory.path());
+    let result = fixture.resolve(vec![], vec![hydrated], vec![blob]).unwrap();
+    assert_eq!(contents(&fixture, &result, result.index(), "asset.bin").0, pointer);
+    assert_eq!(
+        contents(&fixture, &result, result.working_tree(), "asset.bin").0,
+        b"hydrated"
+    );
+    assert_eq!(snapshot(fixture.directory.path()), before);
+}
+
+#[test]
+fn excluded_base_paths_and_missing_base_fail_with_redacted_diagnostics() {
+    let fixture = Fixture::new(&[(".env.private-marker", b"private-marker", 0o100_644)]);
+    let error = fixture.resolve(vec![], vec![], vec![]).unwrap_err();
+    assert!(matches!(error, NamespaceError::Policy(_)));
+    for text in [error.to_string(), format!("{error:?}")] {
+        assert!(!text.contains("private-marker"));
+    }
+    let empty = Fixture::new(&[]);
+    assert!(resolve_namespaces(&empty.repository, fixture.bundle(vec![], vec![], vec![])).is_err());
+    let result = empty.resolve(vec![], vec![], vec![]).unwrap();
+    assert!(!format!("{result:?}").contains("synthetic/project"));
+}
+
+#[test]
+fn expanded_budgets_count_paths_logical_bytes_and_shared_implicit_directories() {
+    let mut budget = Budget {
+        entries: MAX_CHANGES,
+        ..Budget::default()
+    };
+    assert_eq!(budget.add("next", None, 0), Err(NamespaceError::Limit));
+    let mut budget = Budget {
+        metadata: MAX_METADATA_BYTES,
+        ..Budget::default()
+    };
+    assert_eq!(budget.add("next", None, 0), Err(NamespaceError::Limit));
+    let mut budget = Budget {
+        logical: MAX_CONTENT_BYTES,
+        ..Budget::default()
+    };
+    assert_eq!(budget.add("next", None, 1), Err(NamespaceError::Limit));
+    let fixture = Fixture::new(&[("same/a", b"repeat", 0o100_644), ("same/b", b"repeat", 0o100_644)]);
+    let result = fixture.resolve(vec![], vec![], vec![]).unwrap();
+    assert_eq!(result.base().logical_bytes(), 12);
+    let mut namespace = RepositoryNamespace::default();
+    for n in 0..=(MAX_CHANGES / 2) {
+        namespace.entries.insert(
+            format!("d{n}/leaf"),
+            NamespaceEntry::File {
+                source: NamespaceFile::Base {
+                    object: fixture.commit,
+                    bytes: 0,
+                },
+                executable: false,
+            },
+        );
+    }
+    assert_eq!(
+        tree::validate(&mut namespace, &mut links::Work::default()),
+        Err(NamespaceError::Limit)
+    );
+    let leaf = namespace.entries.values().next().unwrap().clone();
+    namespace.entries.clear();
+    for n in 0..MAX_CHANGES - 1 {
+        namespace.entries.insert(format!("shared/{n}"), leaf.clone());
+    }
+    tree::validate(&mut namespace, &mut links::Work::default()).unwrap();
+    namespace.entries.insert("sibling".into(), leaf.clone());
+    assert_eq!(
+        tree::validate(&mut namespace, &mut links::Work::default()),
+        Err(NamespaceError::Limit)
+    );
+    let prefix = "d/".repeat(1000);
+    namespace.entries = (0..1000).map(|n| (format!("{prefix}{n}"), leaf.clone())).collect();
+    tree::validate(&mut namespace, &mut links::Work::default()).unwrap();
+}
+
+#[test]
+fn unsupported_and_inconsistent_raw_git_nodes_are_rejected() {
+    let mut fixture = Fixture::new(&[]);
+    let database = fixture.repository.odb().unwrap();
+    let blob = database.write(git2::ObjectType::Blob, b"literal").unwrap();
+    let empty = database.write(git2::ObjectType::Tree, b"").unwrap();
+    for (case, entries) in [
+        vec![("100644", &b"valid"[..], blob)],
+        vec![("40000", &b"empty-directory"[..], empty)],
+        vec![("160000", &b"module"[..], fixture.commit)],
+        vec![("100644", &b"wrong-kind"[..], empty)],
+        vec![("40000", &b"wrong-kind"[..], blob)],
+        vec![("100644", &b"invalid\xff"[..], blob)],
+        vec![("100644", &b"name/with-slash"[..], blob)],
+        vec![("100644", &b"same"[..], blob), ("100644", &b"same"[..], blob)],
+        vec![("40000", &b"same"[..], empty), ("40000", &b"same"[..], empty)],
+        vec![("100644", &b"same"[..], blob), ("40000", &b"same"[..], empty)],
+        vec![("100644", &b"missing"[..], Oid::ZERO_SHA1)],
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut bytes = Vec::new();
+        for (mode, name, object) in entries {
+            bytes.extend_from_slice(mode.as_bytes());
+            bytes.push(b' ');
+            bytes.extend_from_slice(name);
+            bytes.push(0);
+            bytes.extend_from_slice(object.as_bytes());
+        }
+        let tree = database.write(git2::ObjectType::Tree, &bytes).unwrap();
+        let raw_commit = format!(
+            "tree {tree}\nauthor Fixture <fixture@example.invalid> 1 +0000\ncommitter Fixture <fixture@example.invalid> 1 +0000\n\nSynthetic base\n"
+        );
+        fixture.commit = database.write(git2::ObjectType::Commit, raw_commit.as_bytes()).unwrap();
+        let result = fixture.resolve(vec![], vec![], vec![]);
+        if case == 0 {
+            let result = result.unwrap();
+            assert_eq!(result.base().entries().len(), 1);
+            assert_eq!(contents(&fixture, &result, result.base(), "valid").0, b"literal");
+        } else {
+            assert!(result.is_err());
+        }
+    }
+}
+
+#[test]
+fn link_hops_and_expanded_resolution_work_are_bounded() {
+    let fixture = Fixture::new(&[]);
+    let chain = |length: usize| {
+        (0..length)
+            .map(|n| link(&format!("link{n:02}"), &format!("link{:02}", n + 1)))
+            .collect()
+    };
+    fixture.resolve(chain(40), vec![], vec![]).unwrap();
+    assert!(matches!(
+        fixture.resolve(chain(41), vec![], vec![]),
+        Err(NamespaceError::Link)
+    ));
+    // Each target is bounded, but repeatedly traversing deep paths amplifies work.
+    let prefix = "d/".repeat(1000);
+    let mut namespace = RepositoryNamespace::default();
+    for n in 0..80 {
+        namespace.entries.insert(
+            format!("link{n}"),
+            NamespaceEntry::Symlink {
+                target: format!("{prefix}missing"),
+            },
+        );
+    }
+    assert_eq!(
+        tree::validate(&mut namespace, &mut links::Work::default()),
+        Err(NamespaceError::Limit)
+    );
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/tests.rs
@@ -458,3 +458,33 @@ fn link_hops_and_expanded_resolution_work_are_bounded() {
         Err(NamespaceError::Limit)
     );
 }
+
+#[test]
+fn large_base_references_use_expanded_logical_budget_not_capture_payload_limit() {
+    let bytes = vec![b'x'; crate::repository_overlay::reader::MAX_READ_BYTES + 1];
+    let length = bytes.len() as u64;
+    let fixture = Fixture::new(&[("large", &bytes, 0o100_755)]);
+    drop(bytes);
+    let before = snapshot(fixture.directory.path());
+    let result = fixture.resolve(vec![], vec![], vec![]).unwrap();
+    for namespace in [result.base(), result.index(), result.working_tree()] {
+        assert_eq!(namespace.logical_bytes(), length);
+        assert!(matches!(namespace.entry("large"), Some(NamespaceEntry::File {
+            source: NamespaceFile::Base { bytes, .. }, executable: true,
+        }) if *bytes == length));
+    }
+    assert_eq!(snapshot(fixture.directory.path()), before);
+    let leaf = result.base().entry("large").unwrap().clone();
+    let count = usize::try_from(MAX_CONTENT_BYTES / length).unwrap();
+    let mut expanded = RepositoryNamespace {
+        entries: (0..=count).map(|n| (format!("file{n}"), leaf.clone())).collect(),
+        ..RepositoryNamespace::default()
+    };
+    assert_eq!(
+        tree::validate(&mut expanded, &mut links::Work::default()),
+        Err(NamespaceError::Limit)
+    );
+    expanded.entries.remove(&format!("file{count}"));
+    tree::validate(&mut expanded, &mut links::Work::default()).unwrap();
+    assert_eq!(expanded.logical_bytes(), length * count as u64);
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/tree.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/tree.rs
@@ -1,0 +1,80 @@
+use super::{Budget, NamespaceEntry, NamespaceError as Error, NamespaceFile, RepositoryNamespace, links};
+use crate::repository_overlay::{OverlayChange, OverlayContent, paths};
+
+pub(super) fn apply(
+    previous: &RepositoryNamespace,
+    changes: &[OverlayChange],
+    work: &mut links::Work,
+) -> Result<RepositoryNamespace, Error> {
+    let mut next = previous.clone();
+    for change in changes {
+        if matches!(change.content(), OverlayContent::Remove) {
+            // Exact leaves only. A directory name never grants recursive removal.
+            if has_descendant(&previous.entries, change.path()) {
+                return Err(Error::Topology);
+            }
+            next.entries.remove(change.path());
+        }
+    }
+    for change in changes {
+        let entry = match change.content() {
+            OverlayContent::Remove => continue,
+            OverlayContent::File {
+                sha256,
+                bytes,
+                executable,
+            } => NamespaceEntry::File {
+                source: NamespaceFile::Overlay {
+                    sha256: sha256.clone(),
+                    bytes: *bytes,
+                },
+                executable: *executable,
+            },
+            OverlayContent::Symlink { target } => NamespaceEntry::Symlink { target: target.clone() },
+        };
+        next.entries.insert(change.path().to_owned(), entry);
+    }
+    validate(&mut next, work)?;
+    Ok(next)
+}
+
+pub(super) fn has_descendant(entries: &std::collections::BTreeMap<String, NamespaceEntry>, path: &str) -> bool {
+    let prefix = format!("{path}/");
+    entries
+        .range(prefix.clone()..)
+        .next()
+        .is_some_and(|(name, _)| name.starts_with(&prefix))
+}
+
+pub(super) fn validate(namespace: &mut RepositoryNamespace, work: &mut links::Work) -> Result<(), Error> {
+    let mut budget = Budget::default();
+    let mut previous = "";
+    for (path, entry) in &namespace.entries {
+        paths::validate(path)?;
+        let (target, bytes) = match entry {
+            NamespaceEntry::File { source, .. } => (None, source.bytes()),
+            NamespaceEntry::Symlink { target } => {
+                paths::validate_link(path, target)?;
+                (Some(target.as_str()), 0)
+            }
+        };
+        budget.add(path, target, bytes)?;
+        let shared = path.bytes().zip(previous.bytes()).take_while(|(a, b)| a == b).count();
+        for (boundary, _) in path.match_indices('/') {
+            let parent = &path[..boundary];
+            // Sorted leaves share contiguous directory prefixes. Charge each
+            // implicit directory and check its identity once, without allocating
+            // all ancestor strings or repeating shared-prefix tree lookups.
+            if boundary >= shared {
+                if namespace.entries.contains_key(parent) {
+                    return Err(Error::Topology);
+                }
+                budget.add(parent, None, 0)?;
+            }
+        }
+        previous = path;
+    }
+    links::validate(namespace, work)?;
+    namespace.logical_bytes = budget.logical;
+    Ok(())
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -203,6 +203,11 @@ back into large multi-purpose modules.
   verified bundle, preserving literal index and working bytes separately. It checks
   exact HEAD, selected index state and root association without filters or writes;
   coherent snapshots, selection/export approval and materialization remain separate.
+  `namespace/` composes exact-base Git leaves with both verified overlay layers into
+  ordered immutable namespaces. Whole-layer topology, effective link resolution
+  and expanded path/logical-byte budgets are checked before returning file references.
+  It does not read regular base payloads, write a checkout or authorize export;
+  the later confined writer must revalidate referenced base bytes independently.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Validate the complete exact-base, staged and working-tree file sets before adding
repository materialization. Refs #383; the full workspace feature remains open.

## Behavior

- Resolve the bundle's exact Git commit independently of current HEAD. Preserve
  staged-versus-working bytes, executable modes, removals, rename pairs and literal
  relative links while detecting conflicts with unchanged base files.
- Validate whole-layer topology and effective symlink traversal, including chained
  links followed by parent traversal. Reject unsupported nodes, empty non-root Git
  trees that cannot be represented as leaves, and expanded path,
  metadata, logical-byte or link-work limit excess.
- Return immutable ordered file references while retaining the original verified
  bundle. Regular base blobs remain object/length references, not copied payloads.
- No worktree reads or writes, filters, hooks, subprocesses, network, provider
  operations or implicit export authorization are introduced. Run off the UI thread.

## Validation

Full final-source and exact-commit validation passed on `5b79b4dc`: formatting,
maintainability, version sync, default/speech workspace tests and all three lint
tiers. Independent source and committed-tree review is clear.

- Nine namespace regressions cover base/index/working semantics, conflicts and
  non-recursive removals, safe/dangling/chained/cyclic links, exact-base lookup,
  literal LFS/binary bytes, redacted errors, malformed/unsupported Git nodes with a
  valid raw-object control, and expanded entry/byte/link-work budgets. A 64 MiB + 1
  byte untouched base file remains a metadata reference; repeated references still
  obey the aggregate logical budget. The regression failed before the correction;
  symlink and captured-payload bounds remain unchanged.
- An external Linux public-API smoke captures explicitly selected synthetic Git
  changes, encodes/decodes the bundle and resolves all three namespaces. It checks
  bytes, executable mode, rename, removal, selection boundaries and literal links,
  then verifies complete source-file bytes/modes are unchanged and removes only its
  generated fixture. No UI behavior changes; native UI smoke is not applicable.
  This and an added large-base-file lane passed again on the exact commit with
  every registry dependency matched to a repository-lock version (`7e56af1f`
  public-API binary SHA256 prefix).
- A deep-tree debug smoke resolves 1,000 leaves beneath 1,000 common directories.
  Five final repository-lock-aligned samples took 1,928–1,952ms. These are synthetic
  resolver measurements, not an application performance guarantee. Shared ancestors
  are checked once, and the deep shared-prefix case is also a regression.

## Boundaries

The caller supplies trusted Git metadata and separately authorizes selection and
export. This API does not verify repository URL ownership or create a ready checkout.
The later confined writer must revalidate referenced base bytes and use a fresh
destination with no-replace publication. Native Git metadata allocation and storage
latency are not completely bounded by these logical limits. Synthetic namespace
directory/file transitions do not extend the current capture API's supported nodes.
No UI change, remote allocation, cloud/PC-off acceptance or release is included.
