### PR TITLE
Prepare verified private Git seeds

### DIFF
--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -7,6 +7,7 @@ pub mod capture;
 pub mod namespace;
 mod paths;
 pub mod reader;
+pub mod seed;
 
 use crate::cloud_run::{ArtifactDigest, GitSource};
 use std::{collections::BTreeMap, fmt};

--- a/crates/horizon-core/src/repository_overlay/seed/import.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/import.rs
@@ -1,0 +1,182 @@
+use super::{GitObjectSource, GitObjectStream, ResolvedRepositoryOverlay, SeedError as Error, staging::check_cancel};
+use crate::repository_overlay::{MAX_CHANGES, MAX_CONTENT_BYTES, MAX_METADATA_BYTES, bundle::MAX_BUNDLE_BYTES};
+use git2::{ObjectType, Odb, Oid, Repository};
+use std::{
+    collections::BTreeMap,
+    io::{self, Read, Write},
+};
+
+const MAX_OBJECTS: usize = MAX_CHANGES * 2 + 1;
+const MAX_BYTES: u64 = MAX_CONTENT_BYTES + MAX_BUNDLE_BYTES as u64 + MAX_METADATA_BYTES as u64;
+
+pub(super) struct Importer<'a, 'repository, S, C> {
+    database: &'a Odb<'repository>,
+    source: &'a mut S,
+    cancelled: &'a C,
+    seen: BTreeMap<Oid, (ObjectType, u64)>,
+    metadata: u64,
+    bytes: u64,
+}
+
+impl<'a, 'repository, S: GitObjectSource, C: Fn() -> bool> Importer<'a, 'repository, S, C> {
+    pub(super) fn new(database: &'a Odb<'repository>, source: &'a mut S, cancelled: &'a C) -> Self {
+        Self {
+            database,
+            source,
+            cancelled,
+            seen: BTreeMap::new(),
+            metadata: 0,
+            bytes: 0,
+        }
+    }
+
+    pub(super) fn objects(&self) -> usize {
+        self.seen.len()
+    }
+
+    pub(super) fn base(&mut self, repository: &Repository, resolved: &ResolvedRepositoryOverlay) -> Result<(), Error> {
+        self.object(resolved.base_commit(), ObjectType::Commit, None)?;
+        let commit = repository
+            .find_commit(resolved.base_commit())
+            .map_err(|_| Error::Object)?;
+        if commit.tree_id() != resolved.base_tree() {
+            return Err(Error::Object);
+        }
+        let mut pending = vec![commit.tree_id()];
+        while let Some(id) = pending.pop() {
+            let fresh = !self.seen.contains_key(&id);
+            self.object(id, ObjectType::Tree, None)?;
+            if !fresh {
+                continue;
+            }
+            let tree = repository.find_tree(id).map_err(|_| Error::Object)?;
+            for entry in &tree {
+                match entry.filemode_raw() {
+                    0o040_000 => pending.push(entry.id()),
+                    0o100_644 | 0o100_755 | 0o120_000 => {
+                        self.object(entry.id(), ObjectType::Blob, None)?;
+                    }
+                    _ => return Err(Error::Object),
+                }
+            }
+            if pending.len() > MAX_CHANGES {
+                return Err(Error::Limit);
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn object(&mut self, id: Oid, kind: ObjectType, bytes: Option<u64>) -> Result<Oid, Error> {
+        check_cancel(self.cancelled)?;
+        if let Some((actual, length)) = self.seen.get(&id) {
+            return if *actual == kind && bytes.is_none_or(|bytes| bytes == *length) {
+                Ok(id)
+            } else {
+                Err(Error::Object)
+            };
+        }
+        let stream = self.source.open(id)?;
+        if stream.kind != kind || bytes.is_some_and(|bytes| bytes != stream.bytes) {
+            return Err(Error::Object);
+        }
+        let length = stream.bytes;
+        charge(self.seen.len(), &mut self.bytes, &mut self.metadata, kind, length)?;
+        copy(self.database, stream, id, self.cancelled)?;
+        self.seen.insert(id, (kind, length));
+        Ok(id)
+    }
+
+    pub(super) fn blob(&mut self, bytes: &[u8]) -> Result<Oid, Error> {
+        check_cancel(self.cancelled)?;
+        let id = Oid::hash_object(ObjectType::Blob, bytes).map_err(|_| Error::Object)?;
+        if let Some((kind, length)) = self.seen.get(&id) {
+            return if *kind == ObjectType::Blob && *length == bytes.len() as u64 {
+                Ok(id)
+            } else {
+                Err(Error::Object)
+            };
+        }
+        let length = bytes.len() as u64;
+        charge(
+            self.seen.len(),
+            &mut self.bytes,
+            &mut self.metadata,
+            ObjectType::Blob,
+            length,
+        )?;
+        copy(
+            self.database,
+            GitObjectStream {
+                kind: ObjectType::Blob,
+                bytes: length,
+                reader: Box::new(bytes),
+            },
+            id,
+            self.cancelled,
+        )?;
+        self.seen.insert(id, (ObjectType::Blob, length));
+        Ok(id)
+    }
+}
+
+pub(super) fn charge(
+    objects: usize,
+    total: &mut u64,
+    metadata: &mut u64,
+    kind: ObjectType,
+    bytes: u64,
+) -> Result<(), Error> {
+    if objects >= MAX_OBJECTS {
+        return Err(Error::Limit);
+    }
+    *total = total
+        .checked_add(bytes)
+        .filter(|n| *n <= MAX_BYTES)
+        .ok_or(Error::Limit)?;
+    if matches!(kind, ObjectType::Commit | ObjectType::Tree) {
+        *metadata = metadata
+            .checked_add(bytes)
+            .filter(|n| *n <= MAX_METADATA_BYTES as u64)
+            .ok_or(Error::Limit)?;
+    }
+    Ok(())
+}
+
+fn copy(
+    database: &Odb<'_>,
+    mut stream: GitObjectStream<'_>,
+    id: Oid,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), Error> {
+    let length = usize::try_from(stream.bytes).map_err(|_| Error::Limit)?;
+    let mut writer = database.writer(length, stream.kind).map_err(|_| Error::Storage)?;
+    let mut remaining = stream.bytes;
+    let mut buffer = [0u8; 16 * 1024];
+    while remaining > 0 {
+        check_cancel(cancelled)?;
+        let limit = usize::try_from(remaining.min(buffer.len() as u64)).map_err(|_| Error::Limit)?;
+        let count = match stream.reader.read(&mut buffer[..limit]) {
+            Ok(0) => return Err(Error::Object),
+            Ok(count) => count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => return Err(Error::Source),
+        };
+        writer.write_all(&buffer[..count]).map_err(|_| Error::Storage)?;
+        remaining -= count as u64;
+    }
+    check_cancel(cancelled)?;
+    let mut tail = [0];
+    loop {
+        check_cancel(cancelled)?;
+        match stream.reader.read(&mut tail) {
+            Ok(0) => break,
+            Ok(_) => return Err(Error::Object),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(_) => return Err(Error::Source),
+        }
+    }
+    if writer.finalize().map_err(|_| Error::Storage)? != id {
+        return Err(Error::Object);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/seed/import.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/import.rs
@@ -6,8 +6,10 @@ use std::{
     io::{self, Read, Write},
 };
 
-const MAX_OBJECTS: usize = MAX_CHANGES * 2 + 1;
-const MAX_BYTES: u64 = MAX_CONTENT_BYTES + MAX_BUNDLE_BYTES as u64 + MAX_METADATA_BYTES as u64;
+// Base and replacement leaves, plus the base commit and its uncounted root tree.
+const MAX_OBJECTS: usize = MAX_CHANGES * 2 + 2;
+// Base links, staged links and raw Git metadata have independent byte allowances.
+const MAX_BYTES: u64 = MAX_CONTENT_BYTES + MAX_BUNDLE_BYTES as u64 + 3 * MAX_METADATA_BYTES as u64;
 
 pub(super) struct Importer<'a, 'repository, S, C> {
     database: &'a Odb<'repository>,

--- a/crates/horizon-core/src/repository_overlay/seed/index.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/index.rs
@@ -1,0 +1,48 @@
+use super::{GitObjectSource, ResolvedRepositoryOverlay, SeedError as Error, import::Importer};
+use crate::repository_overlay::namespace::{NamespaceEntry, NamespaceFile};
+use git2::{IndexEntry, IndexTime, ObjectType, Repository};
+
+pub(super) fn write<S: GitObjectSource, C: Fn() -> bool>(
+    repository: &Repository,
+    resolved: &ResolvedRepositoryOverlay,
+    importer: &mut Importer<'_, '_, S, C>,
+) -> Result<(), Error> {
+    let mut index = repository.index().map_err(|_| Error::Storage)?;
+    if !index.is_empty() {
+        return Err(Error::Storage);
+    }
+    for (path, entry) in resolved.index().entries() {
+        let (id, mode) = match entry {
+            NamespaceEntry::File { source, executable } => {
+                let id = match source {
+                    NamespaceFile::Base { object, bytes } => {
+                        importer.object(*object, ObjectType::Blob, Some(*bytes))?
+                    }
+                    NamespaceFile::Overlay { sha256, .. } => {
+                        importer.blob(resolved.bundle().blob(sha256).ok_or(Error::Object)?)?
+                    }
+                };
+                (id, if *executable { 0o100_755 } else { 0o100_644 })
+            }
+            NamespaceEntry::Symlink { target } => (importer.blob(target.as_bytes())?, 0o120_000),
+        };
+        index
+            .add(&IndexEntry {
+                ctime: IndexTime::new(0, 0),
+                mtime: IndexTime::new(0, 0),
+                dev: 0,
+                ino: 0,
+                mode,
+                uid: 0,
+                gid: 0,
+                file_size: 0,
+                id,
+                flags: 0,
+                flags_extended: 0,
+                path: path.as_bytes().to_vec(),
+            })
+            .map_err(|_| Error::Storage)?;
+    }
+    index.write().map_err(|_| Error::Storage)?;
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -1,0 +1,152 @@
+//! Unpublished exact-base Git material; never a ready checkout or export authority.
+
+#[cfg(target_os = "linux")]
+mod import;
+#[cfg(target_os = "linux")]
+mod index;
+#[cfg(target_os = "linux")]
+mod staging;
+
+use super::namespace::ResolvedRepositoryOverlay;
+use git2::{ObjectType, Oid};
+use std::{
+    fmt,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+/// One raw Git object stream, without Git's type/length hash prefix.
+/// The importer checks kind, exact length and the destination-computed object ID.
+pub struct GitObjectStream<'a> {
+    pub kind: ObjectType,
+    pub bytes: u64,
+    pub reader: Box<dyn Read + 'a>,
+}
+
+/// Explicitly authorized source of raw objects, independent of their storage format.
+/// Implementations own their memory, blocking, cancellation and transport policy.
+/// The importer does not provide an unbounded buffered or loose-only Git adapter.
+pub trait GitObjectSource {
+    /// # Errors
+    /// Return a redacted failure when the requested object cannot be streamed.
+    fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError>;
+}
+
+/// Logically verified private Git seed. No working files, publication or durability proof.
+/// The path and its ancestry must remain exclusively controlled until later preparation
+/// and publication. Dropping this receipt never deletes data.
+pub struct PreparedGitSeed {
+    path: PathBuf,
+    base_commit: Oid,
+    objects: usize,
+}
+
+impl PreparedGitSeed {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn base_commit(&self) -> Oid {
+        self.base_commit
+    }
+
+    #[must_use]
+    pub fn imported_objects(&self) -> usize {
+        self.objects
+    }
+}
+
+impl fmt::Debug for PreparedGitSeed {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedGitSeed")
+            .field("objects", &self.objects)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Failure with an optional private residue. No cleanup is implicit; the caller must
+/// prove ownership before removing a residue. Display and Debug redact the path.
+pub struct SeedFailure {
+    pub reason: SeedError,
+    residue: Option<PathBuf>,
+}
+
+impl SeedFailure {
+    #[must_use]
+    pub fn residue(&self) -> Option<&Path> {
+        self.residue.as_deref()
+    }
+}
+
+impl fmt::Debug for SeedFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SeedFailure")
+            .field("reason", &self.reason)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for SeedFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.reason.fmt(formatter)
+    }
+}
+
+impl std::error::Error for SeedFailure {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SeedError {
+    #[error("private Git seed preparation is unsupported on this platform")]
+    Unsupported,
+    #[error("Git seed preparation requires a trusted private directory")]
+    UnsafeParent,
+    #[error("private Git seed storage failed")]
+    Storage,
+    #[error("repository object source failed")]
+    Source,
+    #[error("repository object identity, type or length is inconsistent")]
+    Object,
+    #[error("Git seed preparation exceeds a supported bound")]
+    Limit,
+    #[error("Git seed preparation was cancelled")]
+    Cancelled,
+}
+
+/// Create a fresh private repository with exact detached HEAD, shallow boundary and
+/// independently constructed stage-zero index. No working files or tasks are created.
+/// The caller authorizes the complete base closure, including removed files and exact
+/// commit metadata, and guarantees stable ancestry/exclusive ownership of `parent`.
+/// Linux checks private ownership and rejects symlink ancestry; libgit2 pathname writes
+/// are not confined against concurrent same-user/privileged mutation. No hooks, filters,
+/// repository configuration, parent history, refs or alternates are imported.
+/// Run off the UI thread. Cancellation is checked between source operations/chunks;
+/// a blocking source call and native Git/storage work need their own latency controls.
+/// # Errors
+/// Rejects unsafe parents, inconsistent source objects, bounded-resource excess and
+/// cancellation. Failed private stages are retained and reported, never auto-deleted.
+pub fn prepare_git_seed(
+    parent: &Path,
+    resolved: &ResolvedRepositoryOverlay,
+    source: &mut impl GitObjectSource,
+    cancelled: impl Fn() -> bool,
+) -> Result<PreparedGitSeed, SeedFailure> {
+    #[cfg(target_os = "linux")]
+    {
+        staging::prepare(parent, resolved, source, &cancelled)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (parent, resolved, source, cancelled);
+        Err(SeedFailure {
+            reason: SeedError::Unsupported,
+            residue: None,
+        })
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/staging.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/staging.rs
@@ -1,0 +1,91 @@
+use super::{
+    GitObjectSource, PreparedGitSeed, ResolvedRepositoryOverlay, SeedError as Error, SeedFailure, import, index,
+};
+use crate::repository_overlay::reader::SelectedRepositoryReader;
+use git2::{Config, Repository, RepositoryInitOptions};
+use std::{
+    fs,
+    os::unix::fs::{MetadataExt, PermissionsExt},
+    path::Path,
+};
+
+pub(super) fn prepare(
+    parent: &Path,
+    resolved: &ResolvedRepositoryOverlay,
+    source: &mut impl GitObjectSource,
+    cancelled: &impl Fn() -> bool,
+) -> Result<PreparedGitSeed, SeedFailure> {
+    let reservation = reserve(parent, cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
+    let result = populate(&reservation, resolved, source, cancelled);
+    match result {
+        Ok(objects) => Ok(PreparedGitSeed {
+            path: reservation,
+            base_commit: resolved.base_commit(),
+            objects,
+        }),
+        Err(reason) => Err(SeedFailure {
+            reason,
+            residue: Some(reservation),
+        }),
+    }
+}
+
+fn reserve(parent: &Path, cancelled: &impl Fn() -> bool) -> Result<std::path::PathBuf, Error> {
+    check_cancel(cancelled)?;
+    if !parent.is_absolute() {
+        return Err(Error::UnsafeParent);
+    }
+    let reader = SelectedRepositoryReader::open(parent).map_err(|_| Error::UnsafeParent)?;
+    let metadata = reader.root.handle().metadata().map_err(|_| Error::UnsafeParent)?;
+    if metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.mode() & 0o7777 != 0o700
+        || !metadata.is_dir()
+        || metadata.nlink() == 0
+    {
+        return Err(Error::UnsafeParent);
+    }
+    // Stable ancestry and exclusive same-user ownership are caller preconditions.
+    // Keep immediately: a failed seed is evidence, never an automatic recursive delete.
+    tempfile::Builder::new()
+        .prefix("repository-seed-")
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir_in(parent)
+        .map(tempfile::TempDir::keep)
+        .map_err(|_| Error::Storage)
+}
+
+fn populate(
+    path: &Path,
+    resolved: &ResolvedRepositoryOverlay,
+    source: &mut impl GitObjectSource,
+    cancelled: &impl Fn() -> bool,
+) -> Result<usize, Error> {
+    check_cancel(cancelled)?;
+    let mut options = RepositoryInitOptions::new();
+    options.no_reinit(true).external_template(false).initial_head("seed");
+    let repository = Repository::init_opts(path, &options).map_err(|_| Error::Storage)?;
+    let mut config = Config::open(&repository.path().join("config")).map_err(|_| Error::Storage)?;
+    config.set_bool("core.ignorecase", false).map_err(|_| Error::Storage)?;
+    config.set_bool("core.filemode", true).map_err(|_| Error::Storage)?;
+    repository.set_config(&config).map_err(|_| Error::Storage)?;
+    let database = repository.odb().map_err(|_| Error::Storage)?;
+    let mut importer = import::Importer::new(&database, source, cancelled);
+    importer.base(&repository, resolved)?;
+    index::write(&repository, resolved, &mut importer)?;
+    check_cancel(cancelled)?;
+    let commit = format!("{}\n", resolved.base_commit());
+    fs::write(repository.path().join("shallow"), &commit).map_err(|_| Error::Storage)?;
+    fs::write(repository.path().join("HEAD"), &commit).map_err(|_| Error::Storage)?;
+    let reopened = Repository::open(path).map_err(|_| Error::Storage)?;
+    if !reopened.head_detached().map_err(|_| Error::Storage)?
+        || !reopened.is_shallow()
+        || reopened.head().map_err(|_| Error::Storage)?.target() != Some(resolved.base_commit())
+    {
+        return Err(Error::Object);
+    }
+    Ok(importer.objects())
+}
+
+pub(super) fn check_cancel(cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+    if cancelled() { Err(Error::Cancelled) } else { Ok(()) }
+}

--- a/crates/horizon-core/src/repository_overlay/seed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/tests.rs
@@ -1,0 +1,485 @@
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{
+        OverlayChange, OverlayContent, RepositoryOverlayPlan,
+        bundle::{RepositoryOverlayBundle, VerifiedOverlayBlob},
+        namespace::resolve_namespaces,
+    },
+};
+use git2::{Index, IndexEntry, IndexTime, Odb, Repository, Signature};
+use std::{
+    cell::Cell,
+    collections::BTreeMap,
+    fs,
+    io::{self, Cursor, Write},
+    os::unix::fs::{PermissionsExt, symlink},
+};
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    repository: Repository,
+    commit: Oid,
+    ancestor: Oid,
+    private_blob: Oid,
+    base_blob: Oid,
+}
+
+fn private_fixture() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir()
+        .unwrap()
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = private_fixture();
+        let repository = Repository::init(directory.path()).unwrap();
+        let private_blob = repository.blob(b"unrelated older private data").unwrap();
+        let base_blob = repository.blob(b"base\0literal\xff").unwrap();
+        let ancestor = commit(&repository, &[("old", private_blob, 0o100_644)], &[]);
+        let commit = commit(
+            &repository,
+            &[("kept", base_blob, 0o100_644), ("removed", base_blob, 0o100_644)],
+            &[ancestor],
+        );
+        repository
+            .config()
+            .unwrap()
+            .set_str("remote.private.url", "synthetic-private-remote")
+            .unwrap();
+        Self {
+            directory,
+            repository,
+            commit,
+            ancestor,
+            private_blob,
+            base_blob,
+        }
+    }
+
+    fn resolve(
+        &self,
+        changes: Vec<OverlayChange>,
+        working: Vec<OverlayChange>,
+        blobs: Vec<VerifiedOverlayBlob>,
+    ) -> ResolvedRepositoryOverlay {
+        let source = GitSource {
+            repository: "synthetic/project".into(),
+            commit: GitCommitSha::parse(self.commit.to_string()).unwrap(),
+            branch: None,
+        };
+        let bundle =
+            RepositoryOverlayBundle::new(RepositoryOverlayPlan::new(source, changes, working).unwrap(), blobs).unwrap();
+        resolve_namespaces(&self.repository, bundle).unwrap()
+    }
+
+    fn source(&self) -> LooseFixtureSource<'_> {
+        LooseFixtureSource {
+            database: self.repository.odb().unwrap(),
+            calls: BTreeMap::new(),
+        }
+    }
+}
+
+// Fixture-only adapter: production does not mistake libgit2 loose streaming for packed support.
+struct LooseFixtureSource<'a> {
+    database: Odb<'a>,
+    calls: BTreeMap<Oid, usize>,
+}
+impl GitObjectSource for LooseFixtureSource<'_> {
+    fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        *self.calls.entry(object).or_default() += 1;
+        let (reader, bytes, kind) = self.database.reader(object).map_err(|_| SeedError::Source)?;
+        Ok(GitObjectStream {
+            kind,
+            bytes: bytes as u64,
+            reader: Box::new(reader),
+        })
+    }
+}
+
+fn entry(path: &str, id: Oid, mode: u32) -> IndexEntry {
+    IndexEntry {
+        ctime: IndexTime::new(0, 0),
+        mtime: IndexTime::new(0, 0),
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        file_size: 0,
+        id,
+        flags: 0,
+        flags_extended: 0,
+        path: path.as_bytes().to_vec(),
+    }
+}
+
+fn commit(repository: &Repository, files: &[(&str, Oid, u32)], parents: &[Oid]) -> Oid {
+    let mut index = Index::new().unwrap();
+    for (path, id, mode) in files {
+        index.add(&entry(path, *id, *mode)).unwrap();
+    }
+    let tree = index.write_tree_to(repository).unwrap();
+    let signature = Signature::now("Fixture", "fixture@example.invalid").unwrap();
+    let parents: Vec<_> = parents.iter().map(|id| repository.find_commit(*id).unwrap()).collect();
+    repository
+        .commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "Synthetic base",
+            &repository.find_tree(tree).unwrap(),
+            &parents.iter().collect::<Vec<_>>(),
+        )
+        .unwrap()
+}
+
+fn change(path: &str, content: OverlayContent) -> OverlayChange {
+    OverlayChange::new(path.into(), content).unwrap()
+}
+
+fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedOverlayBlob) {
+    let blob = VerifiedOverlayBlob::new(bytes.to_vec()).unwrap();
+    (
+        change(
+            path,
+            OverlayContent::File {
+                sha256: blob.sha256().clone(),
+                bytes: bytes.len() as u64,
+                executable,
+            },
+        ),
+        blob,
+    )
+}
+
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, (Vec<u8>, u32)> {
+    let mut files = BTreeMap::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        for entry in fs::read_dir(path).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_dir() {
+                pending.push(entry.path());
+            } else {
+                files.insert(
+                    entry.path(),
+                    (
+                        fs::read(entry.path()).unwrap(),
+                        entry.metadata().unwrap().permissions().mode(),
+                    ),
+                );
+            }
+        }
+    }
+    files
+}
+
+#[test]
+fn seed_preserves_exact_base_and_independent_index_without_worktree_or_private_history() {
+    let fixture = Fixture::new();
+    let before = snapshot(fixture.directory.path());
+    let parent = private_fixture();
+    let (staged, staged_blob) = file("nested/staged", b"staged\0\xff", true);
+    let (working, working_blob) = file("nested/staged", b"working-only", false);
+    let working_id = Oid::hash_object(ObjectType::Blob, working_blob.bytes()).unwrap();
+    let resolved = fixture.resolve(
+        vec![
+            staged,
+            change("removed", OverlayContent::Remove),
+            change(
+                "link",
+                OverlayContent::Symlink {
+                    target: "nested/staged".into(),
+                },
+            ),
+        ],
+        vec![working],
+        vec![staged_blob, working_blob],
+    );
+    let mut source = fixture.source();
+    let seed = prepare_git_seed(parent.path(), &resolved, &mut source, || false).unwrap();
+    let repository = Repository::open(seed.path()).unwrap();
+    assert_eq!(fs::metadata(seed.path()).unwrap().permissions().mode() & 0o7777, 0o700);
+    assert_eq!(seed.base_commit(), fixture.commit);
+    assert_eq!(repository.head().unwrap().target(), Some(fixture.commit));
+    assert!(repository.head_detached().unwrap());
+    assert!(repository.is_shallow());
+    assert_eq!(repository.references().unwrap().count(), 0);
+    let database = repository.odb().unwrap();
+    assert!(!database.exists(fixture.ancestor));
+    assert!(!database.exists(fixture.private_blob));
+    assert!(!database.exists(working_id));
+    assert!(database.exists(fixture.base_blob));
+    let base = repository.find_commit(fixture.commit).unwrap().tree().unwrap();
+    assert_eq!(base.get_name("removed").unwrap().id(), fixture.base_blob);
+    assert_eq!(
+        database.read(fixture.commit).unwrap().data(),
+        fixture.repository.odb().unwrap().read(fixture.commit).unwrap().data()
+    );
+    let index = repository.index().unwrap();
+    assert_eq!(index.len(), 3);
+    assert!(index.get_path(Path::new("removed"), 0).is_none());
+    let staged = index.get_path(Path::new("nested/staged"), 0).unwrap();
+    assert_eq!(staged.mode, 0o100_755);
+    assert_eq!(repository.find_blob(staged.id).unwrap().content(), b"staged\0\xff");
+    let link = index.get_path(Path::new("link"), 0).unwrap();
+    assert_eq!(link.mode, 0o120_000);
+    assert_eq!(repository.find_blob(link.id).unwrap().content(), b"nested/staged");
+    assert!(!index.has_conflicts());
+    assert_eq!(fs::read_dir(seed.path()).unwrap().count(), 1);
+    assert!(!repository.path().join("objects/info/alternates").exists());
+    assert!(!repository.path().join("logs").exists());
+    assert!(
+        !fs::read_to_string(repository.path().join("config"))
+            .unwrap()
+            .contains("private")
+    );
+    assert!(source.calls.values().all(|count| *count == 1));
+    assert_eq!(snapshot(fixture.directory.path()), before);
+    assert!(!format!("{seed:?}").contains(seed.path().to_str().unwrap()));
+    let retained = seed.path().to_path_buf();
+    drop(seed);
+    assert!(retained.exists());
+}
+
+#[test]
+fn streams_large_removed_base_blob_without_the_capture_limit() {
+    let mut fixture = Fixture::new();
+    let size = 64 * 1024 * 1024 + 1;
+    let database = fixture.repository.odb().unwrap();
+    let mut writer = database.writer(size, ObjectType::Blob).unwrap();
+    let buffer = [19u8; 16 * 1024];
+    for _ in 0..4096 {
+        writer.write_all(&buffer).unwrap();
+    }
+    writer.write_all(&[19]).unwrap();
+    let id = writer.finalize().unwrap();
+    drop(writer);
+    drop(database);
+    fixture.commit = commit(&fixture.repository, &[("large", id, 0o100_644)], &[fixture.commit]);
+    let resolved = fixture.resolve(vec![change("large", OverlayContent::Remove)], vec![], vec![]);
+    let parent = private_fixture();
+    let mut source = fixture.source();
+    let seed = prepare_git_seed(parent.path(), &resolved, &mut source, || false).unwrap();
+    let repository = Repository::open(seed.path()).unwrap();
+    assert!(repository.index().unwrap().is_empty());
+    assert_eq!(
+        repository.odb().unwrap().read_header(id).unwrap(),
+        (size, ObjectType::Blob)
+    );
+    assert_eq!(source.calls.get(&id), Some(&1));
+    assert_eq!(seed.imported_objects(), 3);
+}
+
+struct BrokenSource {
+    kind: ObjectType,
+    declared: u64,
+    data: Vec<u8>,
+    fail: bool,
+}
+impl GitObjectSource for BrokenSource {
+    fn open(&mut self, _: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        if self.fail {
+            return Err(SeedError::Source);
+        }
+        Ok(GitObjectStream {
+            kind: self.kind,
+            bytes: self.declared,
+            reader: Box::new(Cursor::new(&self.data)),
+        })
+    }
+}
+
+#[test]
+fn inconsistent_sources_retain_only_private_unready_residues() {
+    let fixture = Fixture::new();
+    let resolved = fixture.resolve(vec![], vec![], vec![]);
+    let raw = fixture
+        .repository
+        .odb()
+        .unwrap()
+        .read(fixture.commit)
+        .unwrap()
+        .data()
+        .to_vec();
+    for (kind, declared, data, fail, expected) in [
+        (
+            ObjectType::Blob,
+            raw.len() as u64,
+            raw.clone(),
+            false,
+            SeedError::Object,
+        ),
+        (
+            ObjectType::Commit,
+            raw.len() as u64 + 1,
+            raw.clone(),
+            false,
+            SeedError::Object,
+        ),
+        (
+            ObjectType::Commit,
+            raw.len() as u64 - 1,
+            raw.clone(),
+            false,
+            SeedError::Object,
+        ),
+        (ObjectType::Commit, 3, b"bad".to_vec(), false, SeedError::Object),
+        (
+            ObjectType::Commit,
+            super::super::MAX_METADATA_BYTES as u64 + 1,
+            vec![],
+            false,
+            SeedError::Limit,
+        ),
+        (ObjectType::Commit, 0, vec![], true, SeedError::Source),
+    ] {
+        let parent = private_fixture();
+        fs::write(parent.path().join("existing"), b"preserve").unwrap();
+        let failure = prepare_git_seed(
+            parent.path(),
+            &resolved,
+            &mut BrokenSource {
+                kind,
+                declared,
+                data,
+                fail,
+            },
+            || false,
+        )
+        .unwrap_err();
+        assert_eq!(failure.reason, expected);
+        let residue = failure.residue().unwrap().to_path_buf();
+        assert_eq!(residue.parent(), Some(parent.path()));
+        assert_eq!(fs::read(parent.path().join("existing")).unwrap(), b"preserve");
+        assert!(!format!("{failure:?}: {failure}").contains(residue.to_str().unwrap()));
+        assert!(!Repository::open(&residue).unwrap().head_detached().unwrap());
+        drop(failure);
+        assert!(residue.is_dir());
+    }
+}
+
+#[test]
+fn unsafe_parents_and_early_cancellation_do_not_create_residues_or_read_source() {
+    let fixture = Fixture::new();
+    let resolved = fixture.resolve(vec![], vec![], vec![]);
+    let parent = private_fixture();
+    let target = private_fixture();
+    symlink(target.path(), parent.path().join("alias")).unwrap();
+    let mut source = fixture.source();
+    for path in [
+        parent.path().join("alias"),
+        PathBuf::from("relative"),
+        parent.path().join("../missing"),
+    ] {
+        let error = prepare_git_seed(&path, &resolved, &mut source, || false).unwrap_err();
+        assert_eq!(error.reason, SeedError::UnsafeParent);
+        assert!(error.residue().is_none());
+    }
+    fs::set_permissions(target.path(), fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(
+        prepare_git_seed(target.path(), &resolved, &mut source, || false)
+            .unwrap_err()
+            .reason,
+        SeedError::UnsafeParent
+    );
+    let error = prepare_git_seed(parent.path(), &resolved, &mut source, || true).unwrap_err();
+    assert_eq!(error.reason, SeedError::Cancelled);
+    assert!(error.residue().is_none());
+    assert!(source.calls.is_empty());
+    assert_eq!(fs::read_dir(target.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn cancellation_after_reservation_or_first_stream_chunk_keeps_an_unready_directory() {
+    let fixture = Fixture::new();
+    let resolved = fixture.resolve(vec![], vec![], vec![]);
+    for cancel_at in [2, 5] {
+        let parent = private_fixture();
+        let calls = Cell::new(0);
+        let mut source = fixture.source();
+        let error = prepare_git_seed(parent.path(), &resolved, &mut source, || {
+            calls.set(calls.get() + 1);
+            calls.get() >= cancel_at
+        })
+        .unwrap_err();
+        assert_eq!(error.reason, SeedError::Cancelled);
+        if cancel_at == 2 {
+            assert_eq!(fs::read_dir(error.residue().unwrap()).unwrap().count(), 0);
+            assert!(source.calls.is_empty());
+        } else {
+            assert_eq!(source.calls.len(), 1);
+            assert!(
+                !Repository::open(error.residue().unwrap())
+                    .unwrap()
+                    .head_detached()
+                    .unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn importer_budgets_exact_boundaries_and_rejects_overflow() {
+    let mut bytes = 0;
+    let mut metadata = 0;
+    assert!(
+        import::charge(
+            0,
+            &mut bytes,
+            &mut metadata,
+            ObjectType::Commit,
+            super::super::MAX_METADATA_BYTES as u64
+        )
+        .is_ok()
+    );
+    assert_eq!(
+        import::charge(1, &mut bytes, &mut metadata, ObjectType::Tree, 1),
+        Err(SeedError::Limit)
+    );
+    bytes = u64::MAX;
+    assert_eq!(
+        import::charge(0, &mut bytes, &mut metadata, ObjectType::Blob, 1),
+        Err(SeedError::Limit)
+    );
+    assert_eq!(
+        import::charge(super::super::MAX_CHANGES * 2 + 1, &mut 0, &mut 0, ObjectType::Blob, 0),
+        Err(SeedError::Limit)
+    );
+}
+
+struct FailedRead;
+impl Read for FailedRead {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::other("private source detail"))
+    }
+}
+
+#[test]
+fn transfer_read_errors_are_redacted() {
+    struct Source;
+    impl GitObjectSource for Source {
+        fn open(&mut self, _: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+            Ok(GitObjectStream {
+                kind: ObjectType::Commit,
+                bytes: 1,
+                reader: Box::new(FailedRead),
+            })
+        }
+    }
+    let fixture = Fixture::new();
+    let parent = private_fixture();
+    let error = prepare_git_seed(
+        parent.path(),
+        &fixture.resolve(vec![], vec![], vec![]),
+        &mut Source,
+        || false,
+    )
+    .unwrap_err();
+    assert_eq!(error.reason, SeedError::Source);
+    assert!(!format!("{error:?}").contains("private source detail"));
+}

--- a/crates/horizon-core/src/repository_overlay/seed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/tests.rs
@@ -1,3 +1,4 @@
+use super::super::{MAX_CHANGES, MAX_CONTENT_BYTES, MAX_METADATA_BYTES, bundle::MAX_BUNDLE_BYTES};
 use super::*;
 use crate::{
     cloud_run::{GitCommitSha, GitSource},
@@ -427,16 +428,8 @@ fn cancellation_after_reservation_or_first_stream_chunk_keeps_an_unready_directo
 fn importer_budgets_exact_boundaries_and_rejects_overflow() {
     let mut bytes = 0;
     let mut metadata = 0;
-    assert!(
-        import::charge(
-            0,
-            &mut bytes,
-            &mut metadata,
-            ObjectType::Commit,
-            super::super::MAX_METADATA_BYTES as u64
-        )
-        .is_ok()
-    );
+    let metadata_limit = MAX_METADATA_BYTES as u64;
+    assert!(import::charge(0, &mut bytes, &mut metadata, ObjectType::Commit, metadata_limit).is_ok());
     assert_eq!(
         import::charge(1, &mut bytes, &mut metadata, ObjectType::Tree, 1),
         Err(SeedError::Limit)
@@ -446,9 +439,53 @@ fn importer_budgets_exact_boundaries_and_rejects_overflow() {
         import::charge(0, &mut bytes, &mut metadata, ObjectType::Blob, 1),
         Err(SeedError::Limit)
     );
+    let object_limit = MAX_CHANGES * 2 + 2;
+    assert!(import::charge(object_limit - 1, &mut 0, &mut 0, ObjectType::Blob, 0).is_ok());
     assert_eq!(
-        import::charge(super::super::MAX_CHANGES * 2 + 1, &mut 0, &mut 0, ObjectType::Blob, 0),
+        import::charge(object_limit, &mut 0, &mut 0, ObjectType::Blob, 0),
         Err(SeedError::Limit)
+    );
+    bytes = MAX_CONTENT_BYTES + MAX_BUNDLE_BYTES as u64;
+    metadata = 0;
+    assert!(import::charge(0, &mut bytes, &mut metadata, ObjectType::Blob, metadata_limit * 2).is_ok());
+    assert!(import::charge(1, &mut bytes, &mut metadata, ObjectType::Commit, metadata_limit).is_ok());
+    assert_eq!(
+        import::charge(2, &mut bytes, &mut metadata, ObjectType::Blob, 1),
+        Err(SeedError::Limit)
+    );
+}
+
+#[test]
+fn maximum_base_and_staged_replacement_objects_fit_the_import_budget() {
+    let mut fixture = Fixture::new();
+    let files: Vec<_> = (0..MAX_CHANGES)
+        .map(|n| {
+            (
+                format!("file{n}"),
+                fixture.repository.blob(&n.to_le_bytes()).unwrap(),
+                0o100_644,
+            )
+        })
+        .collect();
+    let entries: Vec<_> = files
+        .iter()
+        .map(|(path, id, mode)| (path.as_str(), *id, *mode))
+        .collect();
+    fixture.commit = commit(&fixture.repository, &entries, &[fixture.commit]);
+    let (changes, blobs): (Vec<_>, Vec<_>) = files
+        .iter()
+        .map(|(path, id, _)| file(path, id.as_bytes(), false))
+        .unzip();
+    let resolved = fixture.resolve(changes, vec![], blobs);
+    let parent = private_fixture();
+    let mut source = fixture.source();
+    let seed = prepare_git_seed(parent.path(), &resolved, &mut source, || false).unwrap();
+    assert_eq!(seed.imported_objects(), MAX_CHANGES * 2 + 2);
+    assert_eq!(source.calls.len(), MAX_CHANGES + 2);
+    assert!(source.calls.values().all(|count| *count == 1));
+    assert_eq!(
+        Repository::open(seed.path()).unwrap().index().unwrap().len(),
+        MAX_CHANGES
     );
 }
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -208,6 +208,11 @@ back into large multi-purpose modules.
   and expanded path/logical-byte budgets are checked before returning file references.
   It does not read regular base payloads, write a checkout or authorize export;
   the later confined writer must revalidate referenced base bytes independently.
+  `seed/` streams verified exact-base objects into an internally fresh private Git
+  repository and constructs its detached HEAD, shallow boundary and independent
+  staged index. Source adapters own their I/O behavior; private Git pathname writes
+  require stable ancestry and exclusive same-user ownership. Failed residues remain
+  explicit. Working files, packed-object acquisition and publication are separate.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Part of #383. Prepare useful Git material for a future fresh checkout: the exact
base commit and complete tree/blob closure, detached HEAD, shallow boundary and
an independently constructed stage-zero index. The seed remains private and
unpublished; it is not a ready checkout.

## Behavior and boundaries

- Read raw objects through an explicit source interface. Enforce declared type,
  exact length and destination-computed Git ID, with deduplication, aggregate
  budgets and a 16 KiB transfer buffer. Large unchanged base files do not inherit
  the selected-capture payload cap.
- Retain base objects for files removed by the overlay, but do not traverse commit
  parents or copy source packs, refs, configuration, alternates or credentials.
  Exact commit metadata, including parent IDs, remains in the exact commit bytes.
- Construct staged entries from verified IDs and modes without path-based filters.
  Working-only overlay bytes are not imported into the seed's index.
- Internally reserve a fresh private Linux directory under an owned `0700` parent.
  Stable ancestry and exclusive same-user ownership are caller requirements for
  Git library pathname writes; this is not confinement against same-user/root races.
  Disable external templates and use local-only configuration for index construction.
- Report cancellation/errors with a redacted reason and explicit residue accessor.
  Failed stages and dropped seed receipts never trigger recursive deletion.

The source implementation owns its allocation, blocking and transport behavior.
This does not add production packed-object acquisition, worktree writing, atomic
publication, durability, export approval, task launch, UI or cloud/PC-off acceptance.
Unsupported platforms fail explicitly. Run preparation off the UI thread.

## Validation

- Exact commit `87f0d25d`: formatting, maintainability, version sync, warning-as-error
  default/speech workspace tests, blocking and strict Clippy, and pedantic Clippy pass.
- Eight focused regressions pass: full base/index semantics, streamed 64 MiB + 1
  removed base blob, type/hash/short/excess-byte failures, bounds, unsafe parents,
  cancellation before/after the first payload chunk, and retained redacted failures.
  The actual maximum base plus distinct staged replacements imports all 32,770
  objects; separate counter checks accept the complete file/link/metadata allowance
  and reject the next object or byte. The object-count failure was reproduced before
  its correction; the independent raw-metadata limit is unchanged.
- Independent local review and committed-tree parity are clear.
- Exact-commit public-API smoke uses repository-lock-matched dependencies and real
  Git 2.43 checks: strict fsck, single-commit shallow history, exact HEAD and index
  binary/LFS-pointer/symlink bytes and executable mode. Ambient config/template
  positive controls are present in the source, absent from the generated local
  configuration/template/hooks; no hook/filter sentinel executes. Source bytes and
  modes remain unchanged, and generated smoke fixtures are explicitly removed.
- The synthetic packed fixture uses a smoke-only bounded small-object adapter;
  this is not a production packed-source implementation. No UI changes or native
  UI smoke apply to this core-only API slice.
