### PR TITLE
Materialize private raw checkouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,12 +1465,13 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1985,6 +1986,7 @@ dependencies = [
  "atomicwrites",
  "base64 0.23.1",
  "comrak",
+ "flate2",
  "git2",
  "horizon-browser",
  "libc",
@@ -2628,6 +2630,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3367,7 +3379,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -6150,6 +6162,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ libc = "0.2.189"
 rustix = { version = "1.1.4", features = ["fs", "process"] }
 uuid = { version = "1.24.1", features = ["serde", "v4"] }
 git2 = { version = "0.21", default-features = false }
+flate2 = { version = "1.1.10", default-features = false, features = ["rust_backend"] }
 sha2 = { version = "0.11.0", default-features = false }
 regex = "1.13.1"
 arboard = "3.6.1"

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -37,6 +37,7 @@ regex.workspace = true
 atomicwrites.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+flate2.workspace = true
 rustix.workspace = true
 tempfile.workspace = true
 

--- a/crates/horizon-core/src/repository_overlay/checkout/files.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/files.rs
@@ -1,0 +1,198 @@
+use super::PrivateCheckoutError as Error;
+use crate::repository_overlay::reader::SelectedRepositoryReader;
+use git2::{ObjectType, Oid};
+use rustix::fs::{Mode, OFlags, ResolveFlags, mkdirat, openat2, readlinkat_raw, symlinkat};
+use std::{
+    fs::{self, File, Metadata, OpenOptions},
+    os::{
+        fd::AsRawFd,
+        unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
+    },
+    path::Path,
+};
+
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+pub(super) struct Root(File);
+
+impl Root {
+    pub(super) fn open(path: &Path) -> Result<Self, Error> {
+        let reader = SelectedRepositoryReader::open(path).map_err(|_| Error::UnsafeNode)?;
+        let root = Self(reader.root.handle().try_clone().map_err(|_| Error::Storage)?);
+        root.verify(path)?;
+        let mut entries = fs::read_dir(pinned(&root.0)).map_err(|_| Error::Storage)?;
+        let only = entries.next().ok_or(Error::UnsafeNode)?.map_err(|_| Error::Storage)?;
+        if only.file_name() != ".git" || entries.next().is_some() {
+            return Err(Error::UnsafeNode);
+        }
+        root.parent(".git")?;
+        Ok(root)
+    }
+
+    pub(super) fn verify(&self, path: &Path) -> Result<(), Error> {
+        let current = SelectedRepositoryReader::open(path).map_err(|_| Error::UnsafeNode)?;
+        let actual = current.root.handle().metadata().map_err(|_| Error::Storage)?;
+        let held = self.0.metadata().map_err(|_| Error::Storage)?;
+        if !actual.is_dir()
+            || actual.uid() != rustix::process::geteuid().as_raw()
+            || actual.mode() & 0o7777 != 0o700
+            || actual.nlink() == 0
+            || (actual.dev(), actual.ino()) != (held.dev(), held.ino())
+        {
+            return Err(Error::UnsafeNode);
+        }
+        Ok(())
+    }
+
+    fn parent(&self, path: &str) -> Result<File, Error> {
+        let fd = openat2(
+            &self.0,
+            path,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        )
+        .map_err(|_| Error::UnsafeNode)?;
+        Ok(File::from(fd))
+    }
+
+    fn split<'a>(&self, path: &'a str) -> Result<(File, &'a str), Error> {
+        let (parent, leaf) = path.rsplit_once('/').unwrap_or((".", path));
+        Ok((self.parent(parent)?, leaf))
+    }
+
+    pub(super) fn directory(&self, path: &str) -> Result<(), Error> {
+        let (parent, leaf) = self.split(path)?;
+        mkdirat(parent, leaf, Mode::RUSR | Mode::WUSR | Mode::XUSR).map_err(|_| Error::UnsafeNode)?;
+        let directory = self.parent(path)?;
+        let metadata = directory.metadata().map_err(|_| Error::Storage)?;
+        if metadata.mode() & 0o7777 != 0o700 || metadata.uid() != rustix::process::geteuid().as_raw() {
+            return Err(Error::UnsafeNode);
+        }
+        Ok(())
+    }
+
+    pub(super) fn create(&self, path: &str) -> Result<File, Error> {
+        let (parent, leaf) = self.split(path)?;
+        let fd = openat2(
+            parent,
+            leaf,
+            OFlags::RDWR | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::RUSR | Mode::WUSR,
+            CONFINED,
+        )
+        .map_err(|_| Error::UnsafeNode)?;
+        Ok(File::from(fd))
+    }
+
+    pub(super) fn read_regular(&self, path: &str) -> Result<File, Error> {
+        let file = self.pin(path)?;
+        let before = file.metadata().map_err(|_| Error::Storage)?;
+        regular(&before)?;
+        let input = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(pinned(&file))
+            .map_err(|_| Error::Storage)?;
+        if !same(&before, &input.metadata().map_err(|_| Error::Storage)?) {
+            return Err(Error::UnsafeNode);
+        }
+        Ok(input)
+    }
+
+    fn pin(&self, path: &str) -> Result<File, Error> {
+        openat2(
+            &self.0,
+            path,
+            OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        )
+        .map(File::from)
+        .map_err(|_| Error::UnsafeNode)
+    }
+
+    pub(super) fn verify_file(
+        &self,
+        path: &str,
+        file: &File,
+        bytes: u64,
+        executable: bool,
+        id: Oid,
+    ) -> Result<(), Error> {
+        let mode = if executable { 0o755 } else { 0o644 };
+        regular(&file.metadata().map_err(|_| Error::Storage)?)?;
+        file.set_permissions(fs::Permissions::from_mode(mode))
+            .map_err(|_| Error::Storage)?;
+        let before = file.metadata().map_err(|_| Error::Storage)?;
+        if before.len() != bytes || before.mode() & 0o7777 != mode {
+            return Err(Error::Object);
+        }
+        if Oid::hash_file(ObjectType::Blob, Path::new(&pinned(file))).map_err(|_| Error::Object)? != id {
+            return Err(Error::Object);
+        }
+        if !same(&before, &file.metadata().map_err(|_| Error::Storage)?)
+            || !same(&before, &self.pin(path)?.metadata().map_err(|_| Error::Storage)?)
+        {
+            return Err(Error::UnsafeNode);
+        }
+        Ok(())
+    }
+
+    pub(super) fn symlink(&self, path: &str, target: &str) -> Result<(), Error> {
+        let (parent, leaf) = self.split(path)?;
+        symlinkat(target, parent, leaf).map_err(|_| Error::UnsafeNode)?;
+        let link = self.pin(path)?;
+        let metadata = link.metadata().map_err(|_| Error::Storage)?;
+        if !metadata.is_symlink() || metadata.nlink() != 1 || metadata.uid() != rustix::process::geteuid().as_raw() {
+            return Err(Error::UnsafeNode);
+        }
+        let mut buffer = [0; 4097];
+        let length = readlinkat_raw(link, "", &mut buffer[..]).map_err(|_| Error::Storage)?;
+        if buffer[..length] != *target.as_bytes() {
+            return Err(Error::Object);
+        }
+        Ok(())
+    }
+}
+
+fn pinned(file: &File) -> String {
+    format!("/proc/self/fd/{}", file.as_raw_fd())
+}
+
+pub(super) fn regular(metadata: &Metadata) -> Result<(), Error> {
+    if !metadata.is_file() || metadata.nlink() != 1 || metadata.uid() != rustix::process::geteuid().as_raw() {
+        Err(Error::UnsafeNode)
+    } else {
+        Ok(())
+    }
+}
+
+pub(super) fn same(a: &Metadata, b: &Metadata) -> bool {
+    (
+        a.dev(),
+        a.ino(),
+        a.mode(),
+        a.uid(),
+        a.nlink(),
+        a.len(),
+        a.mtime(),
+        a.mtime_nsec(),
+        a.ctime(),
+        a.ctime_nsec(),
+    ) == (
+        b.dev(),
+        b.ino(),
+        b.mode(),
+        b.uid(),
+        b.nlink(),
+        b.len(),
+        b.mtime(),
+        b.mtime_nsec(),
+        b.ctime(),
+        b.ctime_nsec(),
+    )
+}

--- a/crates/horizon-core/src/repository_overlay/checkout/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/linux.rs
@@ -1,0 +1,103 @@
+use super::{
+    GitObjectSource, PreparedPrivateCheckout, PrivateCheckoutError as Error, PrivateCheckoutFailure,
+    ResolvedRepositoryOverlay, files::Root, loose,
+};
+use crate::repository_overlay::{
+    namespace::{NamespaceEntry, NamespaceFile},
+    seed::prepare_git_seed,
+};
+use git2::{ObjectType, Oid};
+use std::{collections::BTreeSet, io::Write, path::Path};
+
+pub(super) fn prepare(
+    parent: &Path,
+    resolved: &ResolvedRepositoryOverlay,
+    source: &mut impl GitObjectSource,
+    cancelled: &impl Fn() -> bool,
+) -> Result<PreparedPrivateCheckout, PrivateCheckoutFailure> {
+    let seed = prepare_git_seed(parent, resolved, source, cancelled).map_err(|failure| PrivateCheckoutFailure {
+        reason: failure.reason.into(),
+        residue: failure.residue().map(Path::to_path_buf),
+    })?;
+    let path = seed.path();
+    write(path, resolved, cancelled).map_err(|reason| PrivateCheckoutFailure {
+        reason,
+        residue: Some(path.to_owned()),
+    })?;
+    Ok(PreparedPrivateCheckout {
+        path: path.to_owned(),
+        base_commit: seed.base_commit(),
+        manifest_sha256: resolved.bundle().manifest_sha256().clone(),
+    })
+}
+
+pub(super) fn write(
+    path: &Path,
+    resolved: &ResolvedRepositoryOverlay,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), Error> {
+    check_cancel(cancelled)?;
+    let root = Root::open(path)?;
+    for directory in directories(resolved.working_tree().entries().map(|(path, _)| path), cancelled)? {
+        check_cancel(cancelled)?;
+        root.directory(directory)?;
+    }
+    for (path, entry) in resolved.working_tree().entries() {
+        if let NamespaceEntry::File { source, executable } = entry {
+            check_cancel(cancelled)?;
+            let mut output = root.create(path)?;
+            let id = match source {
+                NamespaceFile::Base { object, bytes } => {
+                    let hex = object.to_string();
+                    let input = root.read_regular(&format!(".git/objects/{}/{}", &hex[..2], &hex[2..]))?;
+                    loose::copy(&input, *bytes, &mut output, cancelled)?;
+                    *object
+                }
+                NamespaceFile::Overlay { sha256, bytes } => {
+                    let payload = resolved
+                        .bundle()
+                        .blob(sha256)
+                        .filter(|data| data.len() as u64 == *bytes)
+                        .ok_or(Error::Object)?;
+                    for chunk in payload.chunks(16 * 1024) {
+                        check_cancel(cancelled)?;
+                        output.write_all(chunk).map_err(|_| Error::Storage)?;
+                    }
+                    Oid::hash_object(ObjectType::Blob, payload).map_err(|_| Error::Object)?
+                }
+            };
+            check_cancel(cancelled)?;
+            root.verify_file(path, &output, source.bytes(), *executable, id)?;
+        }
+    }
+    for (path, entry) in resolved.working_tree().entries() {
+        if let NamespaceEntry::Symlink { target } = entry {
+            check_cancel(cancelled)?;
+            root.symlink(path, target)?;
+        }
+    }
+    check_cancel(cancelled)?;
+    root.verify(path)
+}
+
+pub(super) fn directories<'a>(
+    paths: impl Iterator<Item = &'a str>,
+    cancelled: &impl Fn() -> bool,
+) -> Result<BTreeSet<&'a str>, Error> {
+    let mut directories = BTreeSet::new();
+    for mut path in paths {
+        check_cancel(cancelled)?;
+        while let Some((parent, _)) = path.rsplit_once('/') {
+            check_cancel(cancelled)?;
+            if !directories.insert(parent) {
+                break;
+            }
+            path = parent;
+        }
+    }
+    Ok(directories)
+}
+
+pub(super) fn check_cancel(cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+    if cancelled() { Err(Error::Cancelled) } else { Ok(()) }
+}

--- a/crates/horizon-core/src/repository_overlay/checkout/loose.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/loose.rs
@@ -1,0 +1,64 @@
+use super::{PrivateCheckoutError as Error, files, linux::check_cancel};
+use crate::repository_overlay::MAX_CONTENT_BYTES;
+use flate2::{Decompress, FlushDecompress, Status};
+use std::{
+    fs::File,
+    io::{BufRead, BufReader, Read, Write},
+};
+
+/// Only standard loose blobs emitted by the fresh seed writer are supported.
+pub(super) fn copy(
+    input: &File,
+    bytes: u64,
+    output: &mut impl Write,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), Error> {
+    let metadata = input.metadata().map_err(|_| Error::Storage)?;
+    files::regular(&metadata)?;
+    if bytes > MAX_CONTENT_BYTES || metadata.len() > bytes + bytes / 100 + 65_536 {
+        return Err(Error::Object);
+    }
+    let mut reader = BufReader::with_capacity(16 * 1024, input.take(metadata.len()));
+    let header = format!("blob {bytes}\0");
+    let mut header_read = 0;
+    let mut remaining = bytes;
+    let mut decoder = Decompress::new(true);
+    let mut buffer = [0u8; 16 * 1024];
+    loop {
+        check_cancel(cancelled)?;
+        let before_in = decoder.total_in();
+        let before_out = decoder.total_out();
+        let status = decoder
+            .decompress(
+                reader.fill_buf().map_err(|_| Error::Storage)?,
+                &mut buffer,
+                FlushDecompress::None,
+            )
+            .map_err(|_| Error::Object)?;
+        let consumed = usize::try_from(decoder.total_in() - before_in).map_err(|_| Error::Object)?;
+        let produced = usize::try_from(decoder.total_out() - before_out).map_err(|_| Error::Object)?;
+        reader.consume(consumed);
+        let prefix = produced.min(header.len() - header_read);
+        if buffer[..prefix] != header.as_bytes()[header_read..header_read + prefix] {
+            return Err(Error::Object);
+        }
+        header_read += prefix;
+        let payload = &buffer[prefix..produced];
+        remaining = remaining.checked_sub(payload.len() as u64).ok_or(Error::Object)?;
+        output.write_all(payload).map_err(|_| Error::Storage)?;
+        if status == Status::StreamEnd {
+            if remaining != 0 || header_read != header.len() || decoder.total_in() != metadata.len() {
+                return Err(Error::Object);
+            }
+            break;
+        }
+        if consumed == 0 && produced == 0 {
+            return Err(Error::Object);
+        }
+    }
+    check_cancel(cancelled)?;
+    if !files::same(&metadata, &input.metadata().map_err(|_| Error::Storage)?) {
+        return Err(Error::UnsafeNode);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/checkout/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/mod.rs
@@ -1,0 +1,134 @@
+//! Complete private raw checkouts, without publication, durability or task authority.
+
+#[cfg(target_os = "linux")]
+mod files;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+mod loose;
+
+use super::{
+    namespace::ResolvedRepositoryOverlay,
+    seed::{GitObjectSource, SeedError},
+};
+use crate::cloud_run::ArtifactDigest;
+use git2::Oid;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+/// Exact logical HEAD, independent index and raw working files in a private stage.
+/// The caller must retain exclusive control. This is neither durable nor published;
+/// it does not authorize export or task launch. Dropping it never deletes anything.
+pub struct PreparedPrivateCheckout {
+    path: PathBuf,
+    base_commit: Oid,
+    manifest_sha256: ArtifactDigest,
+}
+
+impl PreparedPrivateCheckout {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn base_commit(&self) -> Oid {
+        self.base_commit
+    }
+
+    #[must_use]
+    pub fn manifest_sha256(&self) -> &ArtifactDigest {
+        &self.manifest_sha256
+    }
+}
+
+impl fmt::Debug for PreparedPrivateCheckout {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedPrivateCheckout")
+            .finish_non_exhaustive()
+    }
+}
+
+/// A redacted failure with an explicitly inspectable private residue, never auto-cleaned.
+pub struct PrivateCheckoutFailure {
+    pub reason: PrivateCheckoutError,
+    residue: Option<PathBuf>,
+}
+
+impl PrivateCheckoutFailure {
+    #[must_use]
+    pub fn residue(&self) -> Option<&Path> {
+        self.residue.as_deref()
+    }
+}
+
+impl fmt::Debug for PrivateCheckoutFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PrivateCheckoutFailure")
+            .field("reason", &self.reason)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PrivateCheckoutFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.reason.fmt(formatter)
+    }
+}
+
+impl std::error::Error for PrivateCheckoutFailure {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PrivateCheckoutError {
+    #[error(transparent)]
+    Seed(#[from] SeedError),
+    #[error("private checkout storage failed")]
+    Storage,
+    #[error("private checkout node or identity is unsafe or changed")]
+    UnsafeNode,
+    #[error("private checkout object bytes are inconsistent")]
+    Object,
+    #[error("private checkout preparation was cancelled")]
+    Cancelled,
+}
+
+/// Prepare a fresh seed and materialize the same immutable resolved working namespace.
+/// No independently supplied seed can be paired with a different overlay. The caller
+/// authorizes the complete base closure and guarantees stable ancestry/exclusive
+/// same-user ownership of the private parent throughout seed creation and writing.
+/// Linux confines working writes through pinned no-follow parents and creates links last;
+/// libgit2's seed metadata pathname operations retain their documented trust premise.
+/// Raw base bytes are incrementally decoded from this operation's own fresh loose store,
+/// never through filters, hooks, packed-object fallback or whole-object mappings.
+/// Run off the UI thread. Cancellation is checked between chunks/operations, but native
+/// raw-file hashing and individual filesystem calls have no in-call cancellation bound.
+/// No synchronization, publication, existing-checkout mutation or task launch occurs.
+/// # Errors
+/// Rejects unsupported platforms, unsafe nodes, inconsistent objects, I/O failures and
+/// cancellation. Partial private stages remain available through the failure receipt.
+pub fn prepare_private_checkout(
+    parent: &Path,
+    resolved: &ResolvedRepositoryOverlay,
+    source: &mut impl GitObjectSource,
+    cancelled: impl Fn() -> bool,
+) -> Result<PreparedPrivateCheckout, PrivateCheckoutFailure> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::prepare(parent, resolved, source, &cancelled)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (parent, resolved, source, cancelled);
+        Err(PrivateCheckoutFailure {
+            reason: SeedError::Unsupported.into(),
+            residue: None,
+        })
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/checkout/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/tests.rs
@@ -1,0 +1,455 @@
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{
+        OverlayChange, OverlayContent, RepositoryOverlayPlan,
+        bundle::{RepositoryOverlayBundle, VerifiedOverlayBlob},
+        namespace::resolve_namespaces,
+        seed::{GitObjectStream, prepare_git_seed},
+    },
+};
+use flate2::{Compression, write::ZlibEncoder};
+use git2::{Index, IndexEntry, IndexTime, ObjectType, Odb, Repository, Signature};
+use std::{
+    cell::Cell,
+    fs::{self, File},
+    io::{self, Write},
+    os::unix::fs::{MetadataExt, PermissionsExt, symlink},
+};
+
+fn private() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir()
+        .unwrap()
+}
+
+struct Source<'a>(Odb<'a>);
+impl GitObjectSource for Source<'_> {
+    fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        // Synthetic fixture only; the production working writer never maps source objects.
+        let (reader, bytes, kind) = self.0.reader(object).map_err(|_| SeedError::Source)?;
+        Ok(GitObjectStream {
+            reader: Box::new(reader),
+            bytes: bytes as u64,
+            kind,
+        })
+    }
+}
+
+fn fixture(paths: &[(&str, Oid, u32)], repository: &Repository) -> Oid {
+    let mut index = Index::new().unwrap();
+    for (path, id, mode) in paths {
+        index
+            .add(&IndexEntry {
+                ctime: IndexTime::new(0, 0),
+                mtime: IndexTime::new(0, 0),
+                dev: 0,
+                ino: 0,
+                mode: *mode,
+                uid: 0,
+                gid: 0,
+                file_size: 0,
+                id: *id,
+                flags: 0,
+                flags_extended: 0,
+                path: path.as_bytes().to_vec(),
+            })
+            .unwrap();
+    }
+    let tree = index.write_tree_to(repository).unwrap();
+    let signature = Signature::now("Fixture", "fixture@example.invalid").unwrap();
+    repository
+        .commit(
+            None,
+            &signature,
+            &signature,
+            "Synthetic base",
+            &repository.find_tree(tree).unwrap(),
+            &[],
+        )
+        .unwrap()
+}
+
+fn resolved(
+    repository: &Repository,
+    base: Oid,
+    index: Vec<OverlayChange>,
+    working: Vec<OverlayChange>,
+    blobs: Vec<VerifiedOverlayBlob>,
+) -> ResolvedRepositoryOverlay {
+    let source = GitSource {
+        repository: "synthetic/project".into(),
+        commit: GitCommitSha::parse(base.to_string()).unwrap(),
+        branch: None,
+    };
+    resolve_namespaces(
+        repository,
+        RepositoryOverlayBundle::new(RepositoryOverlayPlan::new(source, index, working).unwrap(), blobs).unwrap(),
+    )
+    .unwrap()
+}
+
+fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedOverlayBlob) {
+    let blob = VerifiedOverlayBlob::new(bytes.to_vec()).unwrap();
+    (
+        OverlayChange::new(
+            path.into(),
+            OverlayContent::File {
+                sha256: blob.sha256().clone(),
+                bytes: bytes.len() as u64,
+                executable,
+            },
+        )
+        .unwrap(),
+        blob,
+    )
+}
+
+fn change(path: &str, content: OverlayContent) -> OverlayChange {
+    OverlayChange::new(path.into(), content).unwrap()
+}
+
+#[test]
+fn private_checkout_preserves_independent_layers_raw_bytes_links_and_source() {
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let raw = b"base\0binary\xff\r\n";
+    let pointer = b"version https://git-lfs.github.com/spec/v1\noid sha256:synthetic\nsize 42\n";
+    let blob = repository.blob(raw).unwrap();
+    let base = fixture(
+        &[
+            ("kept", blob, 0o100_644),
+            ("removed", blob, 0o100_644),
+            ("from-file", blob, 0o100_644),
+            ("from-dir/leaf", blob, 0o100_644),
+            ("asset", repository.blob(pointer).unwrap(), 0o100_644),
+        ],
+        &repository,
+    );
+    let source_index = fs::read(repository.path().join("config")).unwrap();
+    fs::write(source.path().join("sentinel"), raw).unwrap();
+    let (staged, staged_blob) = file("nested/tool", b"staged\0tool", true);
+    let (working, working_blob) = file("asset", b"hydrated\0asset", false);
+    let (child, child_blob) = file("from-file/child", b"new child", false);
+    let (flat, flat_blob) = file("from-dir", b"flat", false);
+    let plan = resolved(
+        &repository,
+        base,
+        vec![staged, change("removed", OverlayContent::Remove)],
+        vec![
+            working,
+            change("from-file", OverlayContent::Remove),
+            child,
+            change("from-dir/leaf", OverlayContent::Remove),
+            flat,
+            change(
+                "link",
+                OverlayContent::Symlink {
+                    target: "nested/tool".into(),
+                },
+            ),
+            change(
+                "dangling",
+                OverlayContent::Symlink {
+                    target: "missing".into(),
+                },
+            ),
+        ],
+        vec![staged_blob, working_blob, child_blob, flat_blob],
+    );
+    let destination = private();
+    fs::write(destination.path().join("existing"), b"preserve").unwrap();
+    let checkout = prepare_private_checkout(
+        destination.path(),
+        &plan,
+        &mut Source(repository.odb().unwrap()),
+        || false,
+    )
+    .unwrap();
+    let path = checkout.path().to_owned();
+    assert_eq!(checkout.base_commit(), base);
+    assert_eq!(checkout.manifest_sha256(), plan.bundle().manifest_sha256());
+    let actual = Repository::open(&path).unwrap();
+    assert!(actual.head_detached().unwrap() && actual.is_shallow());
+    assert_eq!(actual.head().unwrap().target(), Some(base));
+    let index = actual.index().unwrap();
+    assert_eq!(
+        actual
+            .find_blob(index.get_path(Path::new("asset"), 0).unwrap().id)
+            .unwrap()
+            .content(),
+        pointer
+    );
+    assert_eq!(index.get_path(Path::new("nested/tool"), 0).unwrap().mode, 0o100_755);
+    assert!(index.get_path(Path::new("from-file"), 0).is_some());
+    assert_eq!(fs::read(path.join("kept")).unwrap(), raw);
+    assert_eq!(fs::read(path.join("asset")).unwrap(), b"hydrated\0asset");
+    assert_eq!(fs::read(path.join("nested/tool")).unwrap(), b"staged\0tool");
+    assert_eq!(fs::read(path.join("from-file/child")).unwrap(), b"new child");
+    assert_eq!(fs::read(path.join("from-dir")).unwrap(), b"flat");
+    assert!(!path.join("removed").exists());
+    assert_eq!(fs::read_link(path.join("link")).unwrap(), Path::new("nested/tool"));
+    assert_eq!(fs::read_link(path.join("dangling")).unwrap(), Path::new("missing"));
+    assert_eq!(fs::metadata(path.join("nested/tool")).unwrap().mode() & 0o7777, 0o755);
+    assert_eq!(fs::metadata(path.join("asset")).unwrap().mode() & 0o7777, 0o644);
+    assert_eq!(fs::read(destination.path().join("existing")).unwrap(), b"preserve");
+    assert_eq!(fs::read(source.path().join("sentinel")).unwrap(), raw);
+    assert_eq!(fs::read(repository.path().join("config")).unwrap(), source_index);
+    assert!(!format!("{checkout:?}").contains(path.to_str().unwrap()));
+    drop(checkout);
+    assert!(path.join("asset").exists());
+}
+
+#[test]
+fn identical_base_and_index_cannot_mix_different_working_overlays() {
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let base = fixture(&[], &repository);
+    let parent = private();
+    let mut identities = Vec::new();
+    for bytes in [b"first".as_slice(), b"second".as_slice()] {
+        let (change, blob) = file("working", bytes, false);
+        let plan = resolved(&repository, base, vec![], vec![change], vec![blob]);
+        let checkout =
+            prepare_private_checkout(parent.path(), &plan, &mut Source(repository.odb().unwrap()), || false).unwrap();
+        assert_eq!(fs::read(checkout.path().join("working")).unwrap(), bytes);
+        assert!(Repository::open(checkout.path()).unwrap().index().unwrap().is_empty());
+        identities.push(checkout.manifest_sha256().clone());
+    }
+    assert_ne!(identities[0], identities[1]);
+}
+
+fn compressed(bytes: &[u8]) -> Vec<u8> {
+    let mut writer = ZlibEncoder::new(Vec::new(), Compression::default());
+    writer.write_all(bytes).unwrap();
+    writer.finish().unwrap()
+}
+
+#[test]
+fn loose_decoder_rejects_wrong_headers_corruption_truncation_and_trailing_bytes() {
+    let good = compressed(b"blob 3\0abc");
+    let mut trailing = good.clone();
+    trailing.push(0);
+    let mut damaged = good.clone();
+    *damaged.last_mut().unwrap() ^= 1;
+    for encoded in [
+        compressed(b"tree 3\0abc"),
+        compressed(b"blob 2\0ab"),
+        compressed(b"blob 4\0abcd"),
+        good[..good.len() - 1].to_vec(),
+        trailing,
+        damaged,
+        compressed(b"blob 3\0ab"),
+        compressed(b"blob 3\0abcd"),
+    ] {
+        let directory = private();
+        let path = directory.path().join("object");
+        fs::write(&path, encoded).unwrap();
+        assert_eq!(
+            loose::copy(&File::open(path).unwrap(), 3, &mut Vec::new(), &|| false),
+            Err(PrivateCheckoutError::Object)
+        );
+    }
+    let directory = private();
+    let path = directory.path().join("object");
+    fs::write(&path, good).unwrap();
+    let mut output = Vec::new();
+    loose::copy(&File::open(path).unwrap(), 3, &mut output, &|| false).unwrap();
+    assert_eq!(output, b"abc");
+}
+
+#[test]
+fn exclusive_writes_reject_collisions_escape_links_and_replaced_names() {
+    let directory = private();
+    fs::create_dir(directory.path().join(".git")).unwrap();
+    let root = files::Root::open(directory.path()).unwrap();
+    let outside = private();
+    fs::write(outside.path().join("sentinel"), b"safe").unwrap();
+    symlink(outside.path(), directory.path().join("escape")).unwrap();
+    assert!(root.create("escape/sentinel").is_err());
+    assert!(root.create("../outside").is_err());
+    fs::hard_link(outside.path().join("sentinel"), directory.path().join("hard")).unwrap();
+    assert!(root.create("hard").is_err());
+    assert!(root.read_regular("hard").is_err());
+    assert!(root.read_regular("escape").is_err());
+    fs::create_dir(directory.path().join("collision")).unwrap();
+    assert!(root.create("collision").is_err());
+    let mut file = root.create("new").unwrap();
+    file.write_all(b"original").unwrap();
+    assert!(root.create("new").is_err());
+    fs::rename(directory.path().join("new"), directory.path().join("moved")).unwrap();
+    fs::write(directory.path().join("new"), b"replacement").unwrap();
+    let id = Oid::hash_object(ObjectType::Blob, b"original").unwrap();
+    assert_eq!(
+        root.verify_file("new", &file, 8, false, id),
+        Err(PrivateCheckoutError::UnsafeNode)
+    );
+    assert_eq!(fs::read(directory.path().join("new")).unwrap(), b"replacement");
+    assert_eq!(fs::read(outside.path().join("sentinel")).unwrap(), b"safe");
+    assert!(root.symlink("hard", "missing").is_err());
+    assert!(files::Root::open(directory.path()).is_err());
+}
+
+#[test]
+fn cancellation_during_working_writes_retains_private_residue_without_links() {
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let base = fixture(&[], &repository);
+    let (change, blob) = file("large", &vec![9; 48 * 1024], false);
+    let plan = resolved(
+        &repository,
+        base,
+        vec![],
+        vec![
+            change,
+            self::change("link", OverlayContent::Symlink { target: "large".into() }),
+        ],
+        vec![blob],
+    );
+    let parent = private();
+    let failure = prepare_private_checkout(parent.path(), &plan, &mut Source(repository.odb().unwrap()), || {
+        fs::read_dir(parent.path()).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .path()
+                .join("large")
+                .metadata()
+                .is_ok_and(|m| m.len() >= 16 * 1024)
+        })
+    })
+    .unwrap_err();
+    assert_eq!(failure.reason, PrivateCheckoutError::Cancelled);
+    let residue = failure.residue().unwrap().to_owned();
+    assert_eq!(fs::metadata(residue.join("large")).unwrap().len(), 16 * 1024);
+    assert!(!residue.join("link").exists());
+    assert!(!format!("{failure:?} {failure}").contains(residue.to_str().unwrap()));
+    drop(failure);
+    assert!(residue.join(".git/HEAD").exists());
+    let early =
+        prepare_private_checkout(parent.path(), &plan, &mut Source(repository.odb().unwrap()), || true).unwrap_err();
+    assert_eq!(early.reason, PrivateCheckoutError::Seed(SeedError::Cancelled));
+    assert!(early.residue().is_none());
+}
+
+#[test]
+fn corrupt_base_identity_and_partial_write_never_succeed() {
+    struct FailingWriter(bool);
+    impl Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            if self.0 {
+                Err(io::Error::other("private sentinel"))
+            } else {
+                self.0 = true;
+                Ok(1)
+            }
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let blob = repository.blob(b"abc").unwrap();
+    let base = fixture(&[("file", blob, 0o100_644)], &repository);
+    let plan = resolved(&repository, base, vec![], vec![], vec![]);
+    let parent = private();
+    let seed = prepare_git_seed(parent.path(), &plan, &mut Source(repository.odb().unwrap()), || false).unwrap();
+    let id = blob.to_string();
+    let object_path = seed.path().join(format!(".git/objects/{}/{}", &id[..2], &id[2..]));
+    fs::set_permissions(&object_path, fs::Permissions::from_mode(0o600)).unwrap();
+    fs::write(object_path, compressed(b"blob 3\0xyz")).unwrap();
+    assert_eq!(
+        linux::write(seed.path(), &plan, &|| false),
+        Err(PrivateCheckoutError::Object)
+    );
+    assert_eq!(fs::read(seed.path().join("file")).unwrap(), b"xyz");
+    let input = parent.path().join("input");
+    fs::write(&input, compressed(b"blob 3\0abc")).unwrap();
+    assert_eq!(
+        loose::copy(&File::open(input).unwrap(), 3, &mut FailingWriter(false), &|| false),
+        Err(PrivateCheckoutError::Storage)
+    );
+}
+
+#[test]
+fn large_incompressible_base_streams_to_repeated_working_files() {
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let bytes = 64 * 1024 * 1024 + 1;
+    let database = repository.odb().unwrap();
+    let mut writer = database.writer(bytes, ObjectType::Blob).unwrap();
+    let mut state = 0x1234_5678_u32;
+    let mut chunk = [0; 16 * 1024];
+    let mut remaining = bytes;
+    while remaining > 0 {
+        let count = remaining.min(chunk.len());
+        for byte in &mut chunk[..count] {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            *byte = state.to_le_bytes()[0];
+        }
+        writer.write_all(&chunk[..count]).unwrap();
+        remaining -= count;
+    }
+    let blob = writer.finalize().unwrap();
+    drop(writer);
+    let base = fixture(&[("one", blob, 0o100_644), ("two", blob, 0o100_755)], &repository);
+    let plan = resolved(&repository, base, vec![], vec![], vec![]);
+    let parent = private();
+    let checks = Cell::new(0);
+    let checkout = prepare_private_checkout(parent.path(), &plan, &mut Source(database), || {
+        checks.set(checks.get() + 1);
+        false
+    })
+    .unwrap();
+    for name in ["one", "two"] {
+        let path = checkout.path().join(name);
+        assert_eq!(fs::metadata(&path).unwrap().len(), bytes as u64);
+        assert_eq!(Oid::hash_file(ObjectType::Blob, &path).unwrap(), blob);
+    }
+    assert!(checks.get() > 8_000);
+}
+
+#[test]
+fn deep_directories_empty_payloads_and_special_nodes_remain_bounded() {
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let base = fixture(&[], &repository);
+    let path = format!("{}leaf", "nested/".repeat(120));
+    let (entry, blob) = file(&path, b"", true);
+    let plan = resolved(&repository, base, vec![], vec![entry], vec![blob]);
+    let parent = private();
+    let checkout =
+        prepare_private_checkout(parent.path(), &plan, &mut Source(repository.odb().unwrap()), || false).unwrap();
+    let metadata = fs::metadata(checkout.path().join(path)).unwrap();
+    assert_eq!(
+        (metadata.len(), metadata.mode() & 0o7777, metadata.nlink()),
+        (0, 0o755, 1)
+    );
+    let directory = private();
+    fs::create_dir(directory.path().join(".git")).unwrap();
+    let root = files::Root::open(directory.path()).unwrap();
+    rustix::fs::mkfifoat(rustix::fs::CWD, directory.path().join("fifo"), rustix::fs::Mode::RUSR).unwrap();
+    assert!(root.create("fifo").is_err());
+    assert!(root.read_regular("fifo").is_err());
+}
+
+#[test]
+fn shared_directory_prefixes_are_collected_once_with_bounded_cancellation_gaps() {
+    let prefix = "a/".repeat(1_000);
+    let paths: Vec<_> = (0..1_000).map(|index| format!("{prefix}leaf{index}")).collect();
+    let checks = Cell::new(0);
+    let directories = linux::directories(paths.iter().map(String::as_str), &|| {
+        checks.set(checks.get() + 1);
+        false
+    })
+    .unwrap();
+    assert_eq!(directories.len(), 1_000);
+    assert_eq!(checks.get(), 2_999);
+    assert_eq!(
+        linux::directories(paths.iter().map(String::as_str), &|| true),
+        Err(PrivateCheckoutError::Cancelled)
+    );
+}

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod bundle;
 pub mod capture;
+pub mod checkout;
 pub mod namespace;
 mod paths;
 pub mod reader;

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -213,6 +213,11 @@ back into large multi-purpose modules.
   staged index. Source adapters own their I/O behavior; private Git pathname writes
   require stable ancestry and exclusive same-user ownership. Failed residues remain
   explicit. Working files, packed-object acquisition and publication are separate.
+  `checkout/` prepares the seed and raw working namespace together, using exclusive
+  descriptor-relative writes, incremental loose decoding and pinned-file verification.
+  Literal links are created last. This private logical checkout retains failures;
+  full synchronization, no-replace publication and task authorization remain separate.
+  Its Linux compression dependency avoids whole compressed-object memory mappings.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose and behavior

Refs #383. Complete the next repository-preparation boundary: a fresh private raw
checkout with exact detached HEAD, an independently staged index and the resolved
working files. Seed creation and working-file materialization use the same immutable
overlay in one operation; callers cannot pair an unrelated seed with another overlay.

- Create new directories/files through pinned, no-follow parents with exclusive
  creation. Never reuse or overwrite an existing checkout; create literal links last.
- Incrementally decode base blobs from this operation's fresh loose store. Check
  canonical headers, declared lengths, compression completion/checksum and trailing
  bytes, then hash each completed pinned file and verify its mode and pathname identity.
- Preserve raw binary and executable content, staged LFS pointers versus hydrated
  working bytes, file/directory transitions, removals and untracked files.
- Retain failed private stages with redacted errors and explicit residue access.
  Dropping success/failure receipts never recursively deletes data.
- Collect shared directory prefixes once with cancellation checks throughout.

## Boundaries and dependency

Linux only; other platforms fail explicitly without a weaker writing fallback.
The caller must guarantee private, stable ancestry and exclusive same-user control,
including the existing seed API's native Git metadata pathname operations. Working
decoding uses bounded chunks, not whole compressed-object mappings; the supplied
object source still owns its memory/I/O policy. Native file hashing and individual
filesystem calls cannot be cancelled mid-call. Run preparation off the UI thread.

Add a direct Linux `flate2` dependency to decode incrementally and require explicit
stream completion. Checked the official registry's current stable, non-yanked
version, 1.1.10. Its required backend updates are included; unrelated lockfile
dependency selections are preserved.

This is a logically complete **private** checkout, not a durability or publication
guarantee. Full synchronization, no-replace publication, production packed-source
acquisition, export/task authorization and cloud/PC-off integration remain separate.
No UI, provider, user configuration, release or existing resource is changed.

## Validation

Completed on exact commit `32df1f3e`: full local matrix (format, maintainability,
version sync, default and speech workspace tests, blocking/strict/pedantic Clippy),
independent source and committed-parity review, and fresh public-API/Git smoke.
The smoke also passes under a restrictive child-only `umask 077`.

- Nine focused regressions cover raw HEAD/index/working semantics, different
  working-only overlays on the same base/index, deep/shared prefixes, empty files,
  safe/dangling links, exclusive-write collisions, hardlinks/FIFOs, replaced paths,
  cancellation, retained residues, corruption and partial writes.
- A real incompressible 64 MiB + 1 base blob is materialized at two working paths
  with independent mode checks and exact Git hashes.
- Public-API/ordinary-Git smoke checks strict fsck, shallow detached HEAD, raw
  staged bytes and complete working files under synthetic global template/hook/filter
  sentinels. Source data remains unchanged; disposable fixtures close explicitly.
  Packed acquisition in this smoke is a bounded-small-fixture adapter, not a
  production packed-source implementation.
