### PR TITLE
Publish prepared checkouts without replacement

### DIFF
--- a/crates/horizon-core/src/repository_overlay/checkout/files.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/files.rs
@@ -19,6 +19,10 @@ const CONFINED: ResolveFlags = ResolveFlags::BENEATH
 pub(super) struct Root(File);
 
 impl Root {
+    pub(super) fn handle(&self) -> &File {
+        &self.0
+    }
+
     pub(super) fn open(path: &Path) -> Result<Self, Error> {
         let reader = SelectedRepositoryReader::open(path).map_err(|_| Error::UnsafeNode)?;
         let root = Self(reader.root.handle().try_clone().map_err(|_| Error::Storage)?);

--- a/crates/horizon-core/src/repository_overlay/checkout/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/linux.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::repository_overlay::{
     namespace::{NamespaceEntry, NamespaceFile},
+    reader::SelectedRepositoryReader,
     seed::prepare_git_seed,
 };
 use git2::{ObjectType, Oid};
@@ -15,12 +16,16 @@ pub(super) fn prepare(
     source: &mut impl GitObjectSource,
     cancelled: &impl Fn() -> bool,
 ) -> Result<PreparedPrivateCheckout, PrivateCheckoutFailure> {
+    let parent_handle = SelectedRepositoryReader::open(parent)
+        .map_err(|_| Error::UnsafeNode)
+        .and_then(|reader| reader.root.handle().try_clone().map_err(|_| Error::Storage))
+        .map_err(|reason| PrivateCheckoutFailure { reason, residue: None })?;
     let seed = prepare_git_seed(parent, resolved, source, cancelled).map_err(|failure| PrivateCheckoutFailure {
         reason: failure.reason.into(),
         residue: failure.residue().map(Path::to_path_buf),
     })?;
     let path = seed.path();
-    write(path, resolved, cancelled).map_err(|reason| PrivateCheckoutFailure {
+    let root = write(path, resolved, cancelled).map_err(|reason| PrivateCheckoutFailure {
         reason,
         residue: Some(path.to_owned()),
     })?;
@@ -28,6 +33,8 @@ pub(super) fn prepare(
         path: path.to_owned(),
         base_commit: seed.base_commit(),
         manifest_sha256: resolved.bundle().manifest_sha256().clone(),
+        root,
+        parent: parent_handle,
     })
 }
 
@@ -35,7 +42,7 @@ pub(super) fn write(
     path: &Path,
     resolved: &ResolvedRepositoryOverlay,
     cancelled: &impl Fn() -> bool,
-) -> Result<(), Error> {
+) -> Result<Root, Error> {
     check_cancel(cancelled)?;
     let root = Root::open(path)?;
     for directory in directories(resolved.working_tree().entries().map(|(path, _)| path), cancelled)? {
@@ -77,7 +84,8 @@ pub(super) fn write(
         }
     }
     check_cancel(cancelled)?;
-    root.verify(path)
+    root.verify(path)?;
+    Ok(root)
 }
 
 pub(super) fn directories<'a>(

--- a/crates/horizon-core/src/repository_overlay/checkout/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/mod.rs
@@ -1,4 +1,4 @@
-//! Complete private raw checkouts, without publication, durability or task authority.
+//! Private raw checkouts and separately requested publication, without task authority.
 
 #[cfg(target_os = "linux")]
 mod files;
@@ -6,6 +6,7 @@ mod files;
 mod linux;
 #[cfg(target_os = "linux")]
 mod loose;
+pub mod publication;
 
 use super::{
     namespace::ResolvedRepositoryOverlay,
@@ -25,6 +26,10 @@ pub struct PreparedPrivateCheckout {
     path: PathBuf,
     base_commit: Oid,
     manifest_sha256: ArtifactDigest,
+    #[cfg(target_os = "linux")]
+    root: files::Root,
+    #[cfg(target_os = "linux")]
+    parent: std::fs::File,
 }
 
 impl PreparedPrivateCheckout {

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
@@ -32,8 +32,9 @@ pub(super) fn publish(
     cancelled: &impl Fn() -> bool,
     sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
     rename: &mut impl FnMut(&PreparedPrivateCheckout, &str) -> rustix::io::Result<()>,
+    storage: &impl Fn(&File) -> Result<(), Error>,
 ) -> Result<PublishedCheckout, PublicationFailure> {
-    if let Err(reason) = before_rename(&checkout, sibling, cancelled, sync) {
+    if let Err(reason) = before_rename(&checkout, sibling, cancelled, sync, storage) {
         return Err(PublicationFailure::Unpublished { reason, checkout });
     }
     if let Err(error) = rename(&checkout, sibling) {
@@ -66,13 +67,18 @@ fn before_rename(
     sibling: &str,
     cancelled: &impl Fn() -> bool,
     sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+    storage: &impl Fn(&File) -> Result<(), Error>,
 ) -> Result<(), Error> {
     check_cancel(cancelled)?;
-    if sibling.len() > 255 || sibling.contains('/') || paths::validate(sibling).is_err() {
+    if sibling.len() > 255
+        || sibling.contains('/')
+        || paths::validate(sibling).is_err()
+        || checkout.path.file_name() == Some(std::ffi::OsStr::new(sibling))
+    {
         return Err(Error::InvalidName);
     }
     verify_binding(checkout)?;
-    supported_storage(&checkout.parent)?;
+    storage(&checkout.parent)?;
     walk::synchronize(checkout.root.handle(), cancelled, sync)?;
     check_cancel(cancelled)?;
     verify_binding(checkout)
@@ -157,7 +163,7 @@ fn identity(metadata: &Metadata) -> (u64, u64) {
     (metadata.dev(), metadata.ino())
 }
 
-fn supported_storage(parent: &File) -> Result<(), Error> {
+pub(super) fn supported_storage(parent: &File) -> Result<(), Error> {
     if fstatfs(parent).map_err(|_| Error::Storage)?.f_type != libc::EXT4_SUPER_MAGIC {
         return Err(Error::Unsupported);
     }

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
@@ -1,0 +1,209 @@
+use super::{PreparedPrivateCheckout, PublicationError as Error, PublicationFailure, PublishedCheckout, walk};
+use crate::repository_overlay::{paths, reader::SelectedRepositoryReader};
+use rustix::fs::{
+    CWD, Mode, OFlags, RenameFlags, ResolveFlags, fstatfs, major, minor, openat2, readlinkat_raw, renameat_with,
+};
+use std::{
+    fs::{File, Metadata, OpenOptions},
+    io::Read,
+    os::{
+        fd::AsRawFd,
+        unix::fs::{MetadataExt, OpenOptionsExt},
+    },
+    path::Path,
+};
+
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SyncPoint {
+    File,
+    Directory,
+    PublishedRoot,
+    Parent,
+}
+
+pub(super) fn publish(
+    mut checkout: PreparedPrivateCheckout,
+    sibling: &str,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+    rename: &mut impl FnMut(&PreparedPrivateCheckout, &str) -> rustix::io::Result<()>,
+) -> Result<PublishedCheckout, PublicationFailure> {
+    if let Err(reason) = before_rename(&checkout, sibling, cancelled, sync) {
+        return Err(PublicationFailure::Unpublished { reason, checkout });
+    }
+    if let Err(error) = rename(&checkout, sibling) {
+        let reason = match error {
+            rustix::io::Errno::EXIST | rustix::io::Errno::NOTEMPTY => Error::DestinationExists,
+            rustix::io::Errno::NOSYS => Error::Unsupported,
+            _ => {
+                return Err(PublicationFailure::RenameUnconfirmed {
+                    destination: checkout.path.with_file_name(sibling),
+                    checkout,
+                });
+            }
+        };
+        return Err(PublicationFailure::Unpublished { reason, checkout });
+    }
+    // No fallible operation may misreport a successful rename as an unpublished stage.
+    checkout.path.set_file_name(sibling);
+    let published = PublishedCheckout(checkout);
+    if let Err(reason) = after_rename(&published.0, cancelled, sync) {
+        return Err(PublicationFailure::PublishedUnsynchronized {
+            reason,
+            checkout: published,
+        });
+    }
+    Ok(published)
+}
+
+fn before_rename(
+    checkout: &PreparedPrivateCheckout,
+    sibling: &str,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
+    check_cancel(cancelled)?;
+    if sibling.len() > 255 || sibling.contains('/') || paths::validate(sibling).is_err() {
+        return Err(Error::InvalidName);
+    }
+    verify_binding(checkout)?;
+    supported_storage(&checkout.parent)?;
+    walk::synchronize(checkout.root.handle(), cancelled, sync)?;
+    check_cancel(cancelled)?;
+    verify_binding(checkout)
+}
+
+pub(super) fn rename(checkout: &PreparedPrivateCheckout, sibling: &str) -> rustix::io::Result<()> {
+    renameat_with(
+        &checkout.parent,
+        checkout.path.file_name().ok_or(rustix::io::Errno::INVAL)?,
+        &checkout.parent,
+        sibling,
+        RenameFlags::NOREPLACE,
+    )
+}
+
+fn after_rename(
+    checkout: &PreparedPrivateCheckout,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
+    for (point, handle) in [
+        (SyncPoint::PublishedRoot, checkout.root.handle()),
+        (SyncPoint::Parent, &checkout.parent),
+    ] {
+        check_cancel(cancelled)?;
+        sync(point, &reopen(handle)?)?;
+    }
+    check_cancel(cancelled)?;
+    verify_binding(checkout)
+}
+
+fn verify_binding(checkout: &PreparedPrivateCheckout) -> Result<(), Error> {
+    let parent_path = checkout.path.parent().ok_or(Error::UnsafeNode)?;
+    let current = SelectedRepositoryReader::open(parent_path).map_err(|_| Error::UnsafeNode)?;
+    let parent = checkout.parent.metadata().map_err(|_| Error::Storage)?;
+    let named_parent = current.root.handle().metadata().map_err(|_| Error::Storage)?;
+    let held = checkout.root.handle().metadata().map_err(|_| Error::Storage)?;
+    let named = pin(&checkout.parent, checkout.path.file_name().ok_or(Error::UnsafeNode)?)?
+        .metadata()
+        .map_err(|_| Error::Storage)?;
+    for metadata in [&parent, &named_parent, &held, &named] {
+        if !metadata.is_dir()
+            || metadata.mode() & 0o7777 != 0o700
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.nlink() == 0
+        {
+            return Err(Error::UnsafeNode);
+        }
+    }
+    if identity(&parent) != identity(&named_parent) || identity(&held) != identity(&named) || parent.dev() != held.dev()
+    {
+        return Err(Error::UnsafeNode);
+    }
+    Ok(())
+}
+
+pub(super) fn pin(root: &File, path: &std::ffi::OsStr) -> Result<File, Error> {
+    openat2(
+        root,
+        path,
+        OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+        CONFINED,
+    )
+    .map(File::from)
+    .map_err(|_| Error::UnsafeNode)
+}
+
+pub(super) fn reopen(file: &File) -> Result<File, Error> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(format!("/proc/self/fd/{}", file.as_raw_fd()))
+        .map_err(|_| Error::Storage)
+}
+
+pub(super) fn check_cancel(cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+    if cancelled() { Err(Error::Cancelled) } else { Ok(()) }
+}
+
+fn identity(metadata: &Metadata) -> (u64, u64) {
+    (metadata.dev(), metadata.ino())
+}
+
+fn supported_storage(parent: &File) -> Result<(), Error> {
+    if fstatfs(parent).map_err(|_| Error::Storage)?.f_type != libc::EXT4_SUPER_MAGIC {
+        return Err(Error::Unsupported);
+    }
+    let device = parent.metadata().map_err(|_| Error::Storage)?.dev();
+    let mut buffer = [0; 4097];
+    let length = readlinkat_raw(
+        CWD,
+        format!("/sys/dev/block/{}:{}", major(device), minor(device)),
+        &mut buffer[..],
+    )
+    .map_err(|_| Error::Unsupported)?;
+    if length == buffer.len() {
+        return Err(Error::Unsupported);
+    }
+    let target = std::str::from_utf8(&buffer[..length]).map_err(|_| Error::Unsupported)?;
+    let name = Path::new(target)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| name.len() <= 255 && paths::validate(name).is_ok())
+        .ok_or(Error::Unsupported)?;
+    let mut options = String::new();
+    File::open(format!("/proc/fs/ext4/{name}/options"))
+        .map_err(|_| Error::Unsupported)?
+        .take(4097)
+        .read_to_string(&mut options)
+        .map_err(|_| Error::Unsupported)?;
+    journaled_options(&options)
+}
+
+pub(super) fn journaled_options(options: &str) -> Result<(), Error> {
+    if options.len() > 4096 || !options.ends_with('\n') {
+        return Err(Error::Unsupported);
+    }
+    let lines: std::collections::BTreeSet<_> = options.split_terminator('\n').collect();
+    if lines.len() != options.split_terminator('\n').count()
+        || lines
+            .iter()
+            .any(|line| line.is_empty() || line.bytes().any(|b| b.is_ascii_control() || b == b' '))
+        || !lines.contains("rw")
+        || !lines.contains("barrier")
+        || lines.contains("ro")
+        || lines.contains("nobarrier")
+        || lines.iter().filter(|line| line.starts_with("data=")).count() != 1
+        || !(lines.contains("data=ordered") || lines.contains("data=journal"))
+    {
+        return Err(Error::Unsupported);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
@@ -109,6 +109,7 @@ pub fn publish_sibling_checkout(
             &cancelled,
             &mut |_, file| file.sync_all().map_err(|_| PublicationError::Storage),
             &mut linux::rename,
+            &linux::supported_storage,
         )
     }
     #[cfg(not(target_os = "linux"))]

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
@@ -1,0 +1,125 @@
+//! Explicit no-replace sibling publication; no task, transfer or cleanup authority.
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+mod walk;
+
+use super::PreparedPrivateCheckout;
+use crate::cloud_run::ArtifactDigest;
+use git2::Oid;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+/// The rename succeeded. The result containing this receipt states whether the
+/// subsequent synchronization was acknowledged. Dropping it never removes data.
+#[derive(Debug)]
+pub struct PublishedCheckout(PreparedPrivateCheckout);
+
+impl PublishedCheckout {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        self.0.path()
+    }
+
+    #[must_use]
+    pub fn base_commit(&self) -> Oid {
+        self.0.base_commit()
+    }
+
+    #[must_use]
+    pub fn manifest_sha256(&self) -> &ArtifactDigest {
+        self.0.manifest_sha256()
+    }
+}
+
+/// Pre-rename, confirmed-rename and uncertain-rename failures are different states.
+/// No receipt authorizes deletion; an uncertain rename requires inspecting both names.
+#[derive(thiserror::Error)]
+pub enum PublicationFailure {
+    #[error("checkout remains unpublished: {reason}")]
+    Unpublished {
+        reason: PublicationError,
+        checkout: PreparedPrivateCheckout,
+    },
+    #[error("checkout was published but synchronization is unconfirmed: {reason}")]
+    PublishedUnsynchronized {
+        reason: PublicationError,
+        checkout: PublishedCheckout,
+    },
+    #[error("rename outcome is uncertain; retain and inspect both names")]
+    RenameUnconfirmed {
+        checkout: PreparedPrivateCheckout,
+        destination: PathBuf,
+    },
+}
+
+impl fmt::Debug for PublicationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PublicationError {
+    #[error("checkout publication is unsupported on this platform or filesystem")]
+    Unsupported,
+    #[error("publication requires a fresh single-component sibling name")]
+    InvalidName,
+    #[error("publication destination already exists")]
+    DestinationExists,
+    #[error("checkout identity or node is unsafe or changed")]
+    UnsafeNode,
+    #[error("checkout exceeds a publication resource bound")]
+    Limit,
+    #[error("checkout storage synchronization or rename failed")]
+    Storage,
+    #[error("checkout publication was cancelled")]
+    Cancelled,
+}
+
+/// Synchronize a prepared tree and rename it to an explicitly named fresh sibling.
+/// The caller must keep the tree unchanged, ancestry stable and private parent under
+/// exclusive same-user control throughout preparation and publication. This is not
+/// confinement against concurrent same-user/privileged mutation or an export grant.
+/// Linux requires journaled ext4 with barriers, verified through bounded kernel
+/// metadata. Trusted proc/sysfs and unchanged mount configuration are prerequisites.
+/// No remote/overlay/nojournal filesystem, global sync or copy fallback is used.
+/// A successful result acknowledges file/directory synchronization on healthy storage;
+/// it cannot prove power-loss survival or exclude previously unobserved writeback errors.
+/// Run off the UI thread: cancellation is checked between calls, not during fsync.
+/// # Errors
+/// Pre-rename failures retain the private receipt. Once rename succeeds, every later
+/// failure/cancellation returns `PublishedUnsynchronized` with the destination receipt.
+/// An uncertain rename error returns `RenameUnconfirmed`; inspect both names, never
+/// assume the stage stayed in place or retry/clean up blindly.
+/// Nothing is rolled back, overwritten, auto-deleted or started, including on Drop.
+pub fn publish_sibling_checkout(
+    checkout: PreparedPrivateCheckout,
+    sibling: &str,
+    cancelled: impl Fn() -> bool,
+) -> Result<PublishedCheckout, PublicationFailure> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::publish(
+            checkout,
+            sibling,
+            &cancelled,
+            &mut |_, file| file.sync_all().map_err(|_| PublicationError::Storage),
+            &mut linux::rename,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (sibling, cancelled);
+        Err(PublicationFailure::Unpublished {
+            reason: PublicationError::Unsupported,
+            checkout,
+        })
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/tests.rs
@@ -1,0 +1,423 @@
+use super::super::tests::{Source, change, file, fixture, private, resolved};
+use super::*;
+use crate::repository_overlay::{OverlayContent, checkout::prepare_private_checkout};
+use git2::Repository;
+use linux::SyncPoint;
+use std::{
+    cell::Cell,
+    fs::{self, File},
+    os::unix::fs::{MetadataExt, PermissionsExt, symlink},
+};
+
+fn prepare(parent: &Path) -> PreparedPrivateCheckout {
+    let source = private();
+    let repository = Repository::init(source.path()).unwrap();
+    let base = fixture(
+        &[("base", repository.blob(b"base\0binary\xff").unwrap(), 0o100_644)],
+        &repository,
+    );
+    let (staged, staged_blob) = file("nested/tool", b"staged\0tool", true);
+    let (raw, raw_blob) = file("nested/tool", b"working\0tool\r\n", true);
+    let plan = resolved(
+        &repository,
+        base,
+        vec![staged],
+        vec![
+            raw,
+            change(
+                "link",
+                OverlayContent::Symlink {
+                    target: "long-dangling-target-".repeat(12),
+                },
+            ),
+        ],
+        vec![staged_blob, raw_blob],
+    );
+    prepare_private_checkout(parent, &plan, &mut Source(repository.odb().unwrap()), || false).unwrap()
+}
+
+fn sync(_: SyncPoint, file: &File) -> Result<(), PublicationError> {
+    file.sync_all().map_err(|_| PublicationError::Storage)
+}
+
+fn inject_sync(
+    stage: PreparedPrivateCheckout,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), PublicationError>,
+) -> Result<PublishedCheckout, PublicationFailure> {
+    linux::publish(stage, "ready", cancelled, sync, &mut linux::rename)
+}
+
+fn unpublished(failure: PublicationFailure, expected: PublicationError) -> PreparedPrivateCheckout {
+    assert!(!format!("{failure:?} {failure}").contains("/tmp/"));
+    let PublicationFailure::Unpublished { reason, checkout } = failure else {
+        panic!("wrong ownership state")
+    };
+    assert_eq!(reason, expected);
+    checkout
+}
+
+#[test]
+fn real_publication_preserves_inode_git_layers_bytes_modes_and_links() {
+    let parent = private();
+    let stage = prepare(parent.path());
+    let old = stage.path().to_owned();
+    let inode = fs::metadata(&old).unwrap().ino();
+    let base = stage.base_commit();
+    let digest = stage.manifest_sha256().clone();
+    let checkout = publish_sibling_checkout(stage, "ready", || false).unwrap();
+    assert!(!old.exists());
+    assert_eq!(checkout.path(), parent.path().join("ready"));
+    assert_eq!(fs::metadata(checkout.path()).unwrap().ino(), inode);
+    assert_eq!((checkout.base_commit(), checkout.manifest_sha256()), (base, &digest));
+    let repository = Repository::open(checkout.path()).unwrap();
+    assert!(repository.head_detached().unwrap() && repository.is_shallow());
+    assert_eq!(repository.head().unwrap().target(), Some(base));
+    let index = repository.index().unwrap();
+    let staged = index.get_path(Path::new("nested/tool"), 0).unwrap();
+    assert_eq!(repository.find_blob(staged.id).unwrap().content(), b"staged\0tool");
+    assert_eq!(staged.mode, 0o100_755);
+    assert_eq!(
+        fs::read(checkout.path().join("nested/tool")).unwrap(),
+        b"working\0tool\r\n"
+    );
+    assert_eq!(fs::read(checkout.path().join("base")).unwrap(), b"base\0binary\xff");
+    assert_eq!(
+        fs::metadata(checkout.path().join("nested/tool")).unwrap().mode() & 0o777,
+        0o755
+    );
+    assert_eq!(
+        fs::read_link(checkout.path().join("link")).unwrap(),
+        Path::new(&"long-dangling-target-".repeat(12))
+    );
+    assert!(!format!("{checkout:?}").contains("ready"));
+    drop(checkout);
+    assert!(parent.path().join("ready/.git/HEAD").exists());
+}
+
+#[test]
+fn existing_names_and_invalid_names_never_replace_or_remove_anything() {
+    let parent = private();
+    fs::write(parent.path().join("file"), b"sentinel").unwrap();
+    fs::create_dir(parent.path().join("directory")).unwrap();
+    symlink("missing", parent.path().join("symlink")).unwrap();
+    let mut stage = prepare(parent.path());
+    let old = stage.path().to_owned();
+    for name in ["file", "directory", "symlink"] {
+        stage = unpublished(
+            publish_sibling_checkout(stage, name, || false).unwrap_err(),
+            PublicationError::DestinationExists,
+        );
+        assert!(old.exists());
+    }
+    for name in [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "a/b",
+        "a\\b",
+        ".git",
+        "nul\0name",
+        "line\n",
+        "bad.",
+    ] {
+        stage = unpublished(
+            publish_sibling_checkout(stage, name, || false).unwrap_err(),
+            PublicationError::InvalidName,
+        );
+    }
+    drop(stage);
+    assert!(old.exists());
+    assert_eq!(fs::read(parent.path().join("file")).unwrap(), b"sentinel");
+    assert!(parent.path().join("directory").is_dir());
+    assert_eq!(
+        fs::read_link(parent.path().join("symlink")).unwrap(),
+        Path::new("missing")
+    );
+}
+
+#[test]
+fn actual_sync_order_and_failures_distinguish_pre_and_post_rename() {
+    for fail in [
+        None,
+        Some(SyncPoint::File),
+        Some(SyncPoint::Directory),
+        Some(SyncPoint::PublishedRoot),
+        Some(SyncPoint::Parent),
+    ] {
+        let parent = private();
+        let stage = prepare(parent.path());
+        let old = stage.path().to_owned();
+        let target = parent.path().join("ready");
+        let mut points = Vec::new();
+        let root_inode = fs::metadata(&old).unwrap().ino();
+        let nested_inode = fs::metadata(old.join("nested")).unwrap().ino();
+        let mut directories = Vec::new();
+        let result = inject_sync(stage, &|| false, &mut |point, file| {
+            points.push(point);
+            if point == SyncPoint::Directory {
+                directories.push(file.metadata().unwrap().ino());
+            }
+            assert_eq!(
+                target.exists(),
+                matches!(point, SyncPoint::PublishedRoot | SyncPoint::Parent)
+            );
+            if Some(point) == fail {
+                return Err(PublicationError::Storage);
+            }
+            sync(point, file)
+        });
+        match fail {
+            None => {
+                result.unwrap();
+            }
+            Some(SyncPoint::File | SyncPoint::Directory) => {
+                let receipt = unpublished(result.unwrap_err(), PublicationError::Storage);
+                assert_eq!(receipt.path(), old);
+                drop(receipt);
+                assert!(old.exists() && !target.exists());
+            }
+            Some(SyncPoint::PublishedRoot | SyncPoint::Parent) => {
+                let failure = result.unwrap_err();
+                assert!(!format!("{failure:?} {failure}").contains("/tmp/"));
+                let PublicationFailure::PublishedUnsynchronized { reason, checkout } = failure else {
+                    panic!("wrong state")
+                };
+                assert_eq!(reason, PublicationError::Storage);
+                assert_eq!(checkout.path(), target);
+                drop(checkout);
+                assert!(!old.exists() && target.join(".git/HEAD").exists());
+            }
+        }
+        let rank = |point| match point {
+            SyncPoint::File => 0,
+            SyncPoint::Directory => 1,
+            SyncPoint::PublishedRoot => 2,
+            SyncPoint::Parent => 3,
+        };
+        assert!(points.windows(2).all(|pair| rank(pair[0]) <= rank(pair[1])));
+        if fail.is_none() {
+            assert_eq!(points.last(), Some(&SyncPoint::Parent));
+            assert_eq!(directories.last(), Some(&root_inode));
+            assert!(directories.contains(&nested_inode));
+        }
+    }
+}
+
+#[test]
+fn cancellation_before_and_after_real_rename_retains_the_correct_name() {
+    for after in [false, true] {
+        let parent = private();
+        let stage = prepare(parent.path());
+        let old = stage.path().to_owned();
+        let target = parent.path().join("ready");
+        let before = Cell::new(false);
+        let root_inode = fs::metadata(&old).unwrap().ino();
+        let result = inject_sync(
+            stage,
+            &|| if after { target.exists() } else { before.get() },
+            &mut |point, file| {
+                sync(point, file)?;
+                if point == SyncPoint::Directory && file.metadata().unwrap().ino() == root_inode {
+                    before.set(true);
+                }
+                Ok(())
+            },
+        );
+        if after {
+            assert!(matches!(
+                result,
+                Err(PublicationFailure::PublishedUnsynchronized {
+                    reason: PublicationError::Cancelled,
+                    ..
+                })
+            ));
+            assert!(target.exists() && !old.exists());
+        } else {
+            unpublished(result.unwrap_err(), PublicationError::Cancelled);
+            assert!(old.exists() && !target.exists());
+        }
+    }
+}
+
+#[test]
+fn replaced_parent_or_stage_and_late_binding_changes_are_rejected() {
+    for replace_parent in [false, true] {
+        let outer = private();
+        let parent = outer.path().join("parent");
+        fs::create_dir(&parent).unwrap();
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o700)).unwrap();
+        let stage = prepare(&parent);
+        let old = if replace_parent {
+            parent.clone()
+        } else {
+            stage.path().to_owned()
+        };
+        let moved = outer.path().join("retained");
+        fs::rename(&old, &moved).unwrap();
+        fs::create_dir(&old).unwrap();
+        fs::set_permissions(&old, fs::Permissions::from_mode(0o700)).unwrap();
+        unpublished(
+            publish_sibling_checkout(stage, "ready", || false).unwrap_err(),
+            PublicationError::UnsafeNode,
+        );
+        assert!(moved.exists() && !parent.join("ready").exists());
+    }
+    let parent = private();
+    let stage = prepare(parent.path());
+    let old = stage.path().to_owned();
+    let changed = Cell::new(false);
+    let result = inject_sync(stage, &|| false, &mut |point, file| {
+        sync(point, file)?;
+        if point == SyncPoint::Directory && !changed.replace(true) {
+            fs::rename(&old, parent.path().join("retained")).unwrap();
+        }
+        Ok(())
+    });
+    unpublished(result.unwrap_err(), PublicationError::UnsafeNode);
+    assert!(parent.path().join("retained").exists() && !parent.path().join("ready").exists());
+}
+
+#[test]
+fn unsupported_nodes_metadata_links_and_oversized_sparse_files_fail_before_rename() {
+    for kind in 0..5 {
+        let parent = private();
+        let stage = prepare(parent.path());
+        let extra = stage.path().join("extra");
+        match kind {
+            0 => symlink("../escape", &extra).unwrap(),
+            1 => symlink("config", stage.path().join(".git/extra")).unwrap(),
+            2 => fs::hard_link(stage.path().join("base"), &extra).unwrap(),
+            3 => rustix::fs::mknodat(
+                rustix::fs::CWD,
+                &extra,
+                rustix::fs::FileType::Fifo,
+                rustix::fs::Mode::RUSR,
+                0,
+            )
+            .unwrap(),
+            _ => File::create(&extra).unwrap().set_len(walk::MAX_BYTES + 1).unwrap(),
+        }
+        let reason = if kind == 4 {
+            PublicationError::Limit
+        } else {
+            PublicationError::UnsafeNode
+        };
+        unpublished(publish_sibling_checkout(stage, "ready", || false).unwrap_err(), reason);
+        assert!(!parent.path().join("ready").exists());
+    }
+}
+
+#[test]
+fn walk_budgets_charge_before_growth_and_include_both_working_and_seed_bytes() {
+    let mut budget = walk::Budget::default();
+    budget
+        .charge(1, 0, crate::repository_overlay::MAX_CONTENT_BYTES)
+        .unwrap();
+    budget.charge(1, 0, crate::repository_overlay::seed::MAX_BYTES).unwrap();
+    assert_eq!(budget.charge(1, 0, u64::MAX), Err(PublicationError::Limit));
+    let mut full = walk::Budget {
+        nodes: walk::MAX_NODES,
+        ..walk::Budget::default()
+    };
+    assert_eq!(full.charge(1, 0, 0), Err(PublicationError::Limit));
+    assert_eq!(
+        walk::Budget::default().charge(usize::MAX, 1, 0),
+        Err(PublicationError::Limit)
+    );
+    let parent = private();
+    let stage = prepare(parent.path());
+    for n in 0..walk::MAX_NODES {
+        File::create(stage.path().join(format!("node-{n}"))).unwrap();
+    }
+    unpublished(
+        publish_sibling_checkout(stage, "ready", || false).unwrap_err(),
+        PublicationError::Limit,
+    );
+    assert!(!parent.path().join("ready").exists());
+}
+
+#[test]
+fn volatile_tmpfs_is_rejected_without_publishing_or_deleting_the_stage() {
+    let parent = tempfile::Builder::new()
+        .prefix("publication-test-")
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir_in("/dev/shm")
+        .unwrap();
+    let stage = prepare(parent.path());
+    let old = stage.path().to_owned();
+    let receipt = unpublished(
+        publish_sibling_checkout(stage, "ready", || false).unwrap_err(),
+        PublicationError::Unsupported,
+    );
+    drop(receipt);
+    assert!(old.join(".git/HEAD").exists() && !parent.path().join("ready").exists());
+    parent.close().unwrap();
+}
+
+#[test]
+fn mutation_during_final_directory_sync_prevents_publication() {
+    let parent = private();
+    let stage = prepare(parent.path());
+    let old = stage.path().to_owned();
+    let root_inode = fs::metadata(&old).unwrap().ino();
+    let result = inject_sync(stage, &|| false, &mut |point, file| {
+        sync(point, file)?;
+        if point == SyncPoint::Directory && file.metadata().unwrap().ino() == root_inode {
+            fs::write(old.join("base"), b"changed after file synchronization").unwrap();
+        }
+        Ok(())
+    });
+    unpublished(result.unwrap_err(), PublicationError::UnsafeNode);
+    assert_eq!(
+        fs::read(old.join("base")).unwrap(),
+        b"changed after file synchronization"
+    );
+    assert!(!parent.path().join("ready").exists());
+}
+
+#[test]
+fn rename_error_after_actual_rename_is_uncertain_and_retains_both_names_for_inspection() {
+    let parent = private();
+    let stage = prepare(parent.path());
+    let old = stage.path().to_owned();
+    let failure = linux::publish(stage, "ready", &|| false, &mut sync, &mut |stage, name| {
+        linux::rename(stage, name)?;
+        Err(rustix::io::Errno::IO)
+    })
+    .unwrap_err();
+    assert!(!format!("{failure:?} {failure}").contains("/tmp/"));
+    let PublicationFailure::RenameUnconfirmed { checkout, destination } = failure else {
+        panic!("wrong state")
+    };
+    assert_eq!(checkout.path(), old);
+    assert_eq!(destination, parent.path().join("ready"));
+    drop(checkout);
+    assert!(!old.exists() && destination.join(".git/HEAD").exists());
+}
+
+#[test]
+fn journal_contract_requires_exact_noncontradictory_bounded_kernel_options() {
+    for mode in ["ordered", "journal"] {
+        assert_eq!(linux::journaled_options(&format!("rw\nbarrier\ndata={mode}\n")), Ok(()));
+    }
+    for tail in [
+        "",
+        "data=writeback\n",
+        "data=ordered",
+        "data=ordered\r\n",
+        "data=ordered\nro\n",
+        "data=ordered\nnobarrier\n",
+        "data=ordered\nbarrier\n",
+        "data=ordered\ndata=journal\n",
+        "\n",
+    ] {
+        assert_eq!(
+            linux::journaled_options(&format!("rw\nbarrier\n{tail}")),
+            Err(PublicationError::Unsupported)
+        );
+    }
+    assert!(linux::journaled_options("rw\ndata=ordered\n").is_err());
+    assert!(linux::journaled_options(&"rw\nbarrier\ndata=ordered\n".repeat(200)).is_err());
+}

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/tests.rs
@@ -18,19 +18,14 @@ fn prepare(parent: &Path) -> PreparedPrivateCheckout {
     );
     let (staged, staged_blob) = file("nested/tool", b"staged\0tool", true);
     let (raw, raw_blob) = file("nested/tool", b"working\0tool\r\n", true);
+    let link = OverlayContent::Symlink {
+        target: "long-dangling-target-".repeat(12),
+    };
     let plan = resolved(
         &repository,
         base,
         vec![staged],
-        vec![
-            raw,
-            change(
-                "link",
-                OverlayContent::Symlink {
-                    target: "long-dangling-target-".repeat(12),
-                },
-            ),
-        ],
+        vec![raw, change("link", link)],
         vec![staged_blob, raw_blob],
     );
     prepare_private_checkout(parent, &plan, &mut Source(repository.odb().unwrap()), || false).unwrap()
@@ -45,7 +40,12 @@ fn inject_sync(
     cancelled: &impl Fn() -> bool,
     sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), PublicationError>,
 ) -> Result<PublishedCheckout, PublicationFailure> {
-    linux::publish(stage, "ready", cancelled, sync, &mut linux::rename)
+    linux::publish(stage, "ready", cancelled, sync, &mut linux::rename, &|_| Ok(()))
+}
+
+// State/identity tests exercise real files and rename, but make no durability claim.
+fn publish(stage: PreparedPrivateCheckout, name: &str) -> Result<PublishedCheckout, PublicationFailure> {
+    linux::publish(stage, name, &|| false, &mut sync, &mut linux::rename, &|_| Ok(()))
 }
 
 fn unpublished(failure: PublicationFailure, expected: PublicationError) -> PreparedPrivateCheckout {
@@ -58,9 +58,13 @@ fn unpublished(failure: PublicationFailure, expected: PublicationError) -> Prepa
 }
 
 #[test]
-fn real_publication_preserves_inode_git_layers_bytes_modes_and_links() {
+fn qualified_real_publication_preserves_inode_receipt_and_long_symlink() {
     let parent = private();
     let stage = prepare(parent.path());
+    if linux::supported_storage(&stage.parent) == Err(PublicationError::Unsupported) {
+        eprintln!("SKIP real publication: fixture is not qualified journaled ext4");
+        return;
+    }
     let old = stage.path().to_owned();
     let inode = fs::metadata(&old).unwrap().ino();
     let base = stage.base_commit();
@@ -70,22 +74,6 @@ fn real_publication_preserves_inode_git_layers_bytes_modes_and_links() {
     assert_eq!(checkout.path(), parent.path().join("ready"));
     assert_eq!(fs::metadata(checkout.path()).unwrap().ino(), inode);
     assert_eq!((checkout.base_commit(), checkout.manifest_sha256()), (base, &digest));
-    let repository = Repository::open(checkout.path()).unwrap();
-    assert!(repository.head_detached().unwrap() && repository.is_shallow());
-    assert_eq!(repository.head().unwrap().target(), Some(base));
-    let index = repository.index().unwrap();
-    let staged = index.get_path(Path::new("nested/tool"), 0).unwrap();
-    assert_eq!(repository.find_blob(staged.id).unwrap().content(), b"staged\0tool");
-    assert_eq!(staged.mode, 0o100_755);
-    assert_eq!(
-        fs::read(checkout.path().join("nested/tool")).unwrap(),
-        b"working\0tool\r\n"
-    );
-    assert_eq!(fs::read(checkout.path().join("base")).unwrap(), b"base\0binary\xff");
-    assert_eq!(
-        fs::metadata(checkout.path().join("nested/tool")).unwrap().mode() & 0o777,
-        0o755
-    );
     assert_eq!(
         fs::read_link(checkout.path().join("link")).unwrap(),
         Path::new(&"long-dangling-target-".repeat(12))
@@ -104,10 +92,7 @@ fn existing_names_and_invalid_names_never_replace_or_remove_anything() {
     let mut stage = prepare(parent.path());
     let old = stage.path().to_owned();
     for name in ["file", "directory", "symlink"] {
-        stage = unpublished(
-            publish_sibling_checkout(stage, name, || false).unwrap_err(),
-            PublicationError::DestinationExists,
-        );
+        stage = unpublished(publish(stage, name).unwrap_err(), PublicationError::DestinationExists);
         assert!(old.exists());
     }
     for name in [
@@ -121,11 +106,9 @@ fn existing_names_and_invalid_names_never_replace_or_remove_anything() {
         "nul\0name",
         "line\n",
         "bad.",
+        old.file_name().unwrap().to_str().unwrap(),
     ] {
-        stage = unpublished(
-            publish_sibling_checkout(stage, name, || false).unwrap_err(),
-            PublicationError::InvalidName,
-        );
+        stage = unpublished(publish(stage, name).unwrap_err(), PublicationError::InvalidName);
     }
     drop(stage);
     assert!(old.exists());
@@ -258,10 +241,7 @@ fn replaced_parent_or_stage_and_late_binding_changes_are_rejected() {
         fs::rename(&old, &moved).unwrap();
         fs::create_dir(&old).unwrap();
         fs::set_permissions(&old, fs::Permissions::from_mode(0o700)).unwrap();
-        unpublished(
-            publish_sibling_checkout(stage, "ready", || false).unwrap_err(),
-            PublicationError::UnsafeNode,
-        );
+        unpublished(publish(stage, "ready").unwrap_err(), PublicationError::UnsafeNode);
         assert!(moved.exists() && !parent.join("ready").exists());
     }
     let parent = private();
@@ -304,7 +284,7 @@ fn unsupported_nodes_metadata_links_and_oversized_sparse_files_fail_before_renam
         } else {
             PublicationError::UnsafeNode
         };
-        unpublished(publish_sibling_checkout(stage, "ready", || false).unwrap_err(), reason);
+        unpublished(publish(stage, "ready").unwrap_err(), reason);
         assert!(!parent.path().join("ready").exists());
     }
 }
@@ -331,20 +311,24 @@ fn walk_budgets_charge_before_growth_and_include_both_working_and_seed_bytes() {
     for n in 0..walk::MAX_NODES {
         File::create(stage.path().join(format!("node-{n}"))).unwrap();
     }
-    unpublished(
-        publish_sibling_checkout(stage, "ready", || false).unwrap_err(),
-        PublicationError::Limit,
-    );
+    unpublished(publish(stage, "ready").unwrap_err(), PublicationError::Limit);
     assert!(!parent.path().join("ready").exists());
 }
 
 #[test]
 fn volatile_tmpfs_is_rejected_without_publishing_or_deleting_the_stage() {
-    let parent = tempfile::Builder::new()
+    let Ok(parent) = tempfile::Builder::new()
         .prefix("publication-test-")
         .permissions(fs::Permissions::from_mode(0o700))
         .tempdir_in("/dev/shm")
-        .unwrap();
+    else {
+        eprintln!("SKIP volatile fixture: no writable shared-memory directory");
+        return;
+    };
+    if rustix::fs::fstatfs(File::open(parent.path()).unwrap()).unwrap().f_type != libc::TMPFS_MAGIC {
+        eprintln!("SKIP volatile fixture: shared-memory directory is not tmpfs");
+        return;
+    }
     let stage = prepare(parent.path());
     let old = stage.path().to_owned();
     let receipt = unpublished(
@@ -382,10 +366,17 @@ fn rename_error_after_actual_rename_is_uncertain_and_retains_both_names_for_insp
     let parent = private();
     let stage = prepare(parent.path());
     let old = stage.path().to_owned();
-    let failure = linux::publish(stage, "ready", &|| false, &mut sync, &mut |stage, name| {
-        linux::rename(stage, name)?;
-        Err(rustix::io::Errno::IO)
-    })
+    let failure = linux::publish(
+        stage,
+        "ready",
+        &|| false,
+        &mut sync,
+        &mut |stage, name| {
+            linux::rename(stage, name)?;
+            Err(rustix::io::Errno::IO)
+        },
+        &|_| Ok(()),
+    )
     .unwrap_err();
     assert!(!format!("{failure:?} {failure}").contains("/tmp/"));
     let PublicationFailure::RenameUnconfirmed { checkout, destination } = failure else {

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/walk.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/walk.rs
@@ -1,0 +1,181 @@
+use super::{
+    PublicationError as Error,
+    linux::{SyncPoint, check_cancel, pin, reopen},
+};
+use crate::repository_overlay::{
+    MAX_CHANGES, MAX_CONTENT_BYTES, MAX_METADATA_BYTES, checkout::files::same, paths, seed,
+};
+use rustix::fs::{Dir, readlinkat_raw};
+use std::{
+    ffi::OsStr,
+    fs::{File, Metadata},
+    os::unix::fs::MetadataExt,
+};
+
+// Working leaves/implicit directories, seed objects, 256 fan-out directories and
+// conservative fixed Git layout overhead, including the checkout root itself.
+pub(super) const MAX_NODES: usize = MAX_CHANGES + seed::MAX_OBJECTS + 256 + 64;
+const MAX_PATHS: usize = MAX_METADATA_BYTES + seed::MAX_OBJECTS * 53 + 64 * paths::MAX_PATH_BYTES;
+// Working bytes and compressed seed bytes are separate. Loose zlib overhead has
+// per-object slack as well as proportional slack; index/fixed metadata is additional.
+pub(super) const MAX_BYTES: u64 = MAX_CONTENT_BYTES
+    + seed::MAX_BYTES
+    + seed::MAX_BYTES / 100
+    + seed::MAX_OBJECTS as u64 * 65_536
+    + 2 * MAX_METADATA_BYTES as u64;
+
+#[derive(Default)]
+pub(super) struct Budget {
+    pub nodes: usize,
+    pub paths: usize,
+    pub bytes: u64,
+}
+
+impl Budget {
+    pub(super) fn charge(&mut self, path: usize, link: usize, bytes: u64) -> Result<(), Error> {
+        self.nodes = self
+            .nodes
+            .checked_add(1)
+            .filter(|n| *n <= MAX_NODES)
+            .ok_or(Error::Limit)?;
+        self.paths = self
+            .paths
+            .checked_add(path)
+            .and_then(|n| n.checked_add(link))
+            .filter(|n| *n <= MAX_PATHS)
+            .ok_or(Error::Limit)?;
+        self.bytes = self
+            .bytes
+            .checked_add(bytes)
+            .filter(|n| *n <= MAX_BYTES)
+            .ok_or(Error::Limit)?;
+        Ok(())
+    }
+}
+
+struct Node {
+    path: String,
+    metadata: Metadata,
+}
+
+pub(super) fn synchronize(
+    root: &File,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
+    let mut budget = Budget::default();
+    let first = node(root, ".", &mut budget)?;
+    let mut nodes = vec![first];
+    let mut cursor = 0;
+    while cursor < nodes.len() {
+        check_cancel(cancelled)?;
+        if nodes[cursor].metadata.is_dir() {
+            children(root, cursor, &mut nodes, &mut budget, cancelled)?;
+        }
+        cursor += 1;
+    }
+    for node in nodes.iter().filter(|node| node.metadata.is_file()) {
+        synchronize_node(root, node, SyncPoint::File, cancelled, sync)?;
+    }
+    // Breadth-first collection gives reverse parent order without sorting or recursion.
+    for node in nodes.iter().rev().filter(|node| node.metadata.is_dir()) {
+        synchronize_node(root, node, SyncPoint::Directory, cancelled, sync)?;
+    }
+    for node in &nodes {
+        check_cancel(cancelled)?;
+        verify(root, node)?;
+    }
+    Ok(())
+}
+
+fn children(
+    root: &File,
+    cursor: usize,
+    nodes: &mut Vec<Node>,
+    budget: &mut Budget,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), Error> {
+    let parent = &nodes[cursor];
+    let directory = reopen(&verify(root, parent)?)?;
+    let prefix = if cursor == 0 {
+        String::new()
+    } else {
+        format!("{}/", parent.path)
+    };
+    for entry in Dir::read_from(&directory).map_err(|_| Error::Storage)? {
+        check_cancel(cancelled)?;
+        let entry = entry.map_err(|_| Error::Storage)?;
+        let name = entry.file_name().to_str().map_err(|_| Error::UnsafeNode)?;
+        if matches!(name, "." | "..") {
+            continue;
+        }
+        let length = prefix.len().checked_add(name.len()).ok_or(Error::Limit)?;
+        if length > paths::MAX_PATH_BYTES
+            || budget.nodes >= MAX_NODES
+            || budget.paths.checked_add(length).is_none_or(|n| n > MAX_PATHS)
+        {
+            return Err(Error::Limit);
+        }
+        nodes.push(node(root, &format!("{prefix}{name}"), budget)?);
+    }
+    verify(root, &nodes[cursor])?;
+    Ok(())
+}
+
+fn node(root: &File, path: &str, budget: &mut Budget) -> Result<Node, Error> {
+    let file = pin(root, OsStr::new(path))?;
+    let metadata = file.metadata().map_err(|_| Error::Storage)?;
+    if metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.nlink() == 0
+        || !(metadata.is_file() || metadata.is_dir() || metadata.is_symlink())
+        || (!metadata.is_dir() && metadata.nlink() != 1)
+    {
+        return Err(Error::UnsafeNode);
+    }
+    let git = path == ".git" || path.starts_with(".git/");
+    if path != "." && !git {
+        paths::validate(path).map_err(|_| Error::UnsafeNode)?;
+    }
+    let link = if metadata.is_symlink() {
+        if git {
+            return Err(Error::UnsafeNode);
+        }
+        let mut buffer = [0; paths::MAX_PATH_BYTES + 1];
+        let bytes = readlinkat_raw(&file, "", &mut buffer[..]).map_err(|_| Error::Storage)?;
+        let target = std::str::from_utf8(&buffer[..bytes]).map_err(|_| Error::UnsafeNode)?;
+        paths::validate_link(path, target).map_err(|_| Error::UnsafeNode)?;
+        bytes
+    } else {
+        0
+    };
+    budget.charge(path.len(), link, if metadata.is_file() { metadata.len() } else { 0 })?;
+    Ok(Node {
+        path: path.to_owned(),
+        metadata,
+    })
+}
+
+fn verify(root: &File, node: &Node) -> Result<File, Error> {
+    let current = pin(root, OsStr::new(&node.path))?;
+    if !same(&node.metadata, &current.metadata().map_err(|_| Error::Storage)?) {
+        return Err(Error::UnsafeNode);
+    }
+    Ok(current)
+}
+
+fn synchronize_node(
+    root: &File,
+    node: &Node,
+    point: SyncPoint,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
+    check_cancel(cancelled)?;
+    let file = reopen(&verify(root, node)?)?;
+    if !same(&node.metadata, &file.metadata().map_err(|_| Error::Storage)?) {
+        return Err(Error::UnsafeNode);
+    }
+    sync(point, &file)?;
+    verify(root, node)?;
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/checkout/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/tests.rs
@@ -17,14 +17,14 @@ use std::{
     os::unix::fs::{MetadataExt, PermissionsExt, symlink},
 };
 
-fn private() -> tempfile::TempDir {
+pub(super) fn private() -> tempfile::TempDir {
     tempfile::Builder::new()
         .permissions(fs::Permissions::from_mode(0o700))
         .tempdir()
         .unwrap()
 }
 
-struct Source<'a>(Odb<'a>);
+pub(super) struct Source<'a>(pub(super) Odb<'a>);
 impl GitObjectSource for Source<'_> {
     fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
         // Synthetic fixture only; the production working writer never maps source objects.
@@ -37,7 +37,7 @@ impl GitObjectSource for Source<'_> {
     }
 }
 
-fn fixture(paths: &[(&str, Oid, u32)], repository: &Repository) -> Oid {
+pub(super) fn fixture(paths: &[(&str, Oid, u32)], repository: &Repository) -> Oid {
     let mut index = Index::new().unwrap();
     for (path, id, mode) in paths {
         index
@@ -71,7 +71,7 @@ fn fixture(paths: &[(&str, Oid, u32)], repository: &Repository) -> Oid {
         .unwrap()
 }
 
-fn resolved(
+pub(super) fn resolved(
     repository: &Repository,
     base: Oid,
     index: Vec<OverlayChange>,
@@ -90,7 +90,7 @@ fn resolved(
     .unwrap()
 }
 
-fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedOverlayBlob) {
+pub(super) fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedOverlayBlob) {
     let blob = VerifiedOverlayBlob::new(bytes.to_vec()).unwrap();
     (
         OverlayChange::new(
@@ -106,7 +106,7 @@ fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedO
     )
 }
 
-fn change(path: &str, content: OverlayContent) -> OverlayChange {
+pub(super) fn change(path: &str, content: OverlayContent) -> OverlayChange {
     OverlayChange::new(path.into(), content).unwrap()
 }
 
@@ -359,10 +359,10 @@ fn corrupt_base_identity_and_partial_write_never_succeed() {
     let object_path = seed.path().join(format!(".git/objects/{}/{}", &id[..2], &id[2..]));
     fs::set_permissions(&object_path, fs::Permissions::from_mode(0o600)).unwrap();
     fs::write(object_path, compressed(b"blob 3\0xyz")).unwrap();
-    assert_eq!(
+    assert!(matches!(
         linux::write(seed.path(), &plan, &|| false),
         Err(PrivateCheckoutError::Object)
-    );
+    ));
     assert_eq!(fs::read(seed.path().join("file")).unwrap(), b"xyz");
     let input = parent.path().join("input");
     fs::write(&input, compressed(b"blob 3\0abc")).unwrap();

--- a/crates/horizon-core/src/repository_overlay/seed/import.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/import.rs
@@ -1,15 +1,13 @@
-use super::{GitObjectSource, GitObjectStream, ResolvedRepositoryOverlay, SeedError as Error, staging::check_cancel};
-use crate::repository_overlay::{MAX_CHANGES, MAX_CONTENT_BYTES, MAX_METADATA_BYTES, bundle::MAX_BUNDLE_BYTES};
+use super::{
+    GitObjectSource, GitObjectStream, MAX_BYTES, MAX_OBJECTS, ResolvedRepositoryOverlay, SeedError as Error,
+    staging::check_cancel,
+};
+use crate::repository_overlay::{MAX_CHANGES, MAX_METADATA_BYTES};
 use git2::{ObjectType, Odb, Oid, Repository};
 use std::{
     collections::BTreeMap,
     io::{self, Read, Write},
 };
-
-// Base and replacement leaves, plus the base commit and its uncounted root tree.
-const MAX_OBJECTS: usize = MAX_CHANGES * 2 + 2;
-// Base links, staged links and raw Git metadata have independent byte allowances.
-const MAX_BYTES: u64 = MAX_CONTENT_BYTES + MAX_BUNDLE_BYTES as u64 + 3 * MAX_METADATA_BYTES as u64;
 
 pub(super) struct Importer<'a, 'repository, S, C> {
     database: &'a Odb<'repository>,

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -8,6 +8,11 @@ mod index;
 mod staging;
 
 use super::namespace::ResolvedRepositoryOverlay;
+#[cfg(target_os = "linux")]
+pub(super) const MAX_OBJECTS: usize = super::MAX_CHANGES * 2 + 2;
+#[cfg(target_os = "linux")]
+pub(super) const MAX_BYTES: u64 =
+    super::MAX_CONTENT_BYTES + super::bundle::MAX_BUNDLE_BYTES as u64 + 3 * super::MAX_METADATA_BYTES as u64;
 use git2::{ObjectType, Oid};
 use std::{
     fmt,

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -218,6 +218,15 @@ back into large multi-purpose modules.
   Literal links are created last. This private logical checkout retains failures;
   full synchronization, no-replace publication and task authorization remain separate.
   Its Linux compression dependency avoids whole compressed-object memory mappings.
+  `checkout/publication/` consumes a held private checkout identity for explicit
+  no-replace sibling publication on verified journaled ext4 storage. Its bounded
+  no-follow walk synchronizes files and then directories bottom-up; rename transfers
+  the receipt to the destination before final root/parent synchronization. Post-rename
+  failures retain an explicitly published, unsynchronized receipt; uncertain rename
+  errors retain both candidate names for inspection. No rollback,
+  deletion or task launch occurs; healthy storage and unchanged, exclusively held
+  private ancestry, trusted kernel metadata and stable mounts remain required.
+  This is not cloud recovery or power-loss proof.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Add explicitly requested no-replace sibling publication for prepared private
repository checkouts. Continues #383; does not close the overall feature.

## Behavior and boundaries

- Retain pinned checkout/parent identities, bound the complete no-follow traversal,
  synchronize all regular files and directories bottom-up, then use a no-replace rename.
- Distinguish an unpublished failure from a confirmed publication whose final sync
  is unconfirmed, and from an uncertain rename requiring inspection of both names.
  Existing work is never overwritten; no rollback, deletion or task launch occurs.
- Initial Linux support requires journaled ext4 with barriers, checked through
  bounded device-associated kernel metadata. Stable private ancestry, unchanged
  exclusively controlled content, trusted proc/sysfs and stable mounts are required.
  Successful synchronization assumes healthy storage honoring flushes; it is not
  power-loss, remote checkpoint, recovery or PC-off acceptance.
- No provider, UI, default configuration, dependency or release changes. Production
  packed-object acquisition and end-to-end transfer remain separate work.

## Validation

Exact candidate `8bb54802` passed formatting, maintainability/version checks,
the full default and speech workspace suites, blocking/strict/advisory Clippy,
independent full-diff review and committed-byte parity verification.

A separate public-API/ordinary-Git smoke passed with a restrictive child-only umask:
exact shallow HEAD, independent index and raw binary/executable/link/LFS semantics
remain intact after publication; the inode is retained, the private name disappears,
an existing destination and source repository are unchanged, and dropping receipts
does not delete data. Synthetic config/template/hook/filter sentinels did not run or
leak into the checkout. Disposable fixtures were explicitly cleaned up.

Eleven publication regressions cover long literal symlink content and retained inode,
existing file/directory/symlink targets and same-stage rejection, synchronization
ordering, pre/post-rename cancellation/failure, actual rename followed by injected I/O
error, replaced identities, late mutation, unsafe nodes, real excessive-entry/sparse
fixtures, volatile-filesystem rejection and strict journal-option parsing.

State/identity/fault tests use real filesystem operations independently of host storage
qualification; the public API always applies the actual storage check. A separate tmpfs
run passed all ten applicable cases and explicitly skipped the ext4-only positive case.
The real ext4/public-API smoke above supplies positive qualification evidence. The
volatile fixture probes both writability and filesystem type before running.
