### PR TITLE
Stream isolated packed repository objects

### DIFF
--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -5,6 +5,8 @@ mod import;
 #[cfg(target_os = "linux")]
 mod index;
 #[cfg(target_os = "linux")]
+pub mod packed;
+#[cfg(target_os = "linux")]
 mod staging;
 
 use super::namespace::ResolvedRepositoryOverlay;

--- a/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
@@ -1,0 +1,117 @@
+//! Bounded raw objects from an explicitly authorized, stable Linux object store.
+
+mod process;
+mod protocol;
+mod view;
+
+use super::{GitObjectSource, GitObjectStream, SeedError, SeedFailure, staging};
+use git2::Oid;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+/// Native decoding can materialize delta objects; these limits may reject valid packs.
+/// CPU time accumulates over the complete session. Pipe deadlines exclude blocking
+/// filesystem calls, process creation and kill/reap latency.
+#[derive(Clone, Copy, Debug)]
+pub struct PackedSourceLimits {
+    pub address_space_bytes: u64,
+    pub cpu_seconds: u32,
+    pub object_timeout: Duration,
+}
+
+impl Default for PackedSourceLimits {
+    fn default() -> Self {
+        Self {
+            address_space_bytes: 1024 * 1024 * 1024,
+            cpu_seconds: 60,
+            object_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl PackedSourceLimits {
+    fn validate(self) -> Result<(), SeedError> {
+        if !(64 * 1024 * 1024..=16 * 1024 * 1024 * 1024).contains(&self.address_space_bytes)
+            || !(1..=3600).contains(&self.cpu_seconds)
+            || self.object_timeout.is_zero()
+            || self.object_timeout > Duration::from_secs(300)
+        {
+            return Err(SeedError::Limit);
+        }
+        Ok(())
+    }
+}
+
+/// A fresh isolated metadata view and one owned, resource-limited Git child.
+/// Only full object IDs are requested; no source config, refs, filters, hooks or
+/// recursive alternates are inherited. The importer still verifies destination OIDs.
+/// Drop terminates only this child and retains the private metadata directory.
+pub struct PackedGitObjectSource<'a> {
+    session: process::Session<'a>,
+    metadata: PathBuf,
+}
+
+impl fmt::Debug for PackedGitObjectSource<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PackedGitObjectSource").finish_non_exhaustive()
+    }
+}
+
+impl<'a> PackedGitObjectSource<'a> {
+    /// The caller authorizes the object store and keeps its topology/content and
+    /// ancestry stable, with the private scratch parent exclusively controlled.
+    /// No-follow validation is not confinement against concurrent same-user changes.
+    /// Requires trusted `/usr/bin/git` (batch-command support) and `/usr/bin/prlimit`.
+    /// No installation, fallback, source mutation or export authority is provided.
+    /// # Errors
+    /// Reject unsafe topology, invalid bounds, missing tools, cancellation or storage
+    /// failure. A failed private metadata directory is reported and never auto-deleted.
+    pub fn new(
+        parent: &Path,
+        objects: &Path,
+        limits: PackedSourceLimits,
+        cancelled: impl Fn() -> bool + 'a,
+    ) -> Result<Self, SeedFailure> {
+        let preflight = limits.validate().and_then(|()| view::validate(objects, &cancelled));
+        preflight.map_err(|reason| SeedFailure { reason, residue: None })?;
+        let metadata = staging::reserve(parent, &cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
+        let result = view::command(&metadata, objects, limits)
+            .and_then(|command| process::Session::spawn(command, limits.object_timeout, Box::new(cancelled)));
+        match result {
+            Ok(session) => Ok(Self { session, metadata }),
+            Err(reason) => Err(SeedFailure {
+                reason,
+                residue: Some(metadata),
+            }),
+        }
+    }
+
+    /// Retained scratch metadata, not a checkout or a cleanup authorization.
+    #[must_use]
+    pub fn metadata_path(&self) -> &Path {
+        &self.metadata
+    }
+}
+
+impl GitObjectSource for PackedGitObjectSource<'_> {
+    fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        let header = match self.session.info(object) {
+            Ok(header) => header,
+            Err(error) => {
+                self.session.poison();
+                return Err(error);
+            }
+        };
+        Ok(GitObjectStream {
+            kind: header.kind,
+            bytes: header.bytes,
+            reader: Box::new(protocol::ObjectReader::new(&mut self.session, header)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
@@ -75,7 +75,9 @@ impl<'a> PackedGitObjectSource<'a> {
         limits: PackedSourceLimits,
         cancelled: impl Fn() -> bool + 'a,
     ) -> Result<Self, SeedFailure> {
-        let preflight = limits.validate().and_then(|()| view::validate(objects, &cancelled));
+        let preflight = limits
+            .validate()
+            .and_then(|()| view::validate(objects, parent, &cancelled));
         preflight.map_err(|reason| SeedFailure { reason, residue: None })?;
         let metadata = staging::reserve(parent, &cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
         let result = view::command(&metadata, objects, limits)

--- a/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
@@ -51,12 +51,12 @@ impl<'a> Session<'a> {
 
     pub(super) fn info(&mut self, oid: Oid) -> Result<Header, SeedError> {
         self.deadline = Instant::now() + self.timeout;
-        if (self.cancelled)() {
-            return Err(SeedError::Cancelled);
-        }
         self.request("info", oid)
             .and_then(|()| self.header(oid))
-            .map_err(|_| SeedError::Source)
+            .map_err(|error| match error.kind() {
+                io::ErrorKind::ConnectionAborted => SeedError::Cancelled,
+                _ => SeedError::Source,
+            })
     }
 
     pub(super) fn request(&mut self, command: &str, oid: Oid) -> io::Result<()> {
@@ -108,8 +108,17 @@ impl<'a> Session<'a> {
     }
 
     fn check(&self) -> io::Result<()> {
-        if self.child.is_none() || (self.cancelled)() || Instant::now() >= self.deadline {
+        if (self.cancelled)() {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "raw object source cancelled",
+            ));
+        }
+        if self.child.is_none() {
             return Err(failed());
+        }
+        if Instant::now() >= self.deadline {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "raw object source timed out"));
         }
         Ok(())
     }

--- a/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
@@ -1,0 +1,149 @@
+use super::{SeedError, protocol::Header};
+use git2::Oid;
+use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+use std::{
+    io::{self, Read, Write},
+    os::fd::AsFd,
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+pub(super) struct Session<'a> {
+    child: Option<OwnedChild>,
+    input: ChildStdin,
+    output: ChildStdout,
+    cancelled: Box<dyn Fn() -> bool + 'a>,
+    timeout: Duration,
+    deadline: Instant,
+}
+
+impl<'a> Session<'a> {
+    pub(super) fn spawn(
+        mut command: Command,
+        timeout: Duration,
+        cancelled: Box<dyn Fn() -> bool + 'a>,
+    ) -> Result<Self, SeedError> {
+        if cancelled() {
+            return Err(SeedError::Cancelled);
+        }
+        let mut child = OwnedChild(
+            command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .spawn()
+                .map_err(|_| SeedError::Source)?,
+        );
+        let input = child.0.stdin.take().ok_or(SeedError::Source)?;
+        let output = child.0.stdout.take().ok_or(SeedError::Source)?;
+        nonblocking(&input)?;
+        nonblocking(&output)?;
+        Ok(Self {
+            child: Some(child),
+            input,
+            output,
+            cancelled,
+            timeout,
+            deadline: Instant::now(),
+        })
+    }
+
+    pub(super) fn info(&mut self, oid: Oid) -> Result<Header, SeedError> {
+        self.deadline = Instant::now() + self.timeout;
+        if (self.cancelled)() {
+            return Err(SeedError::Cancelled);
+        }
+        self.request("info", oid)
+            .and_then(|()| self.header(oid))
+            .map_err(|_| SeedError::Source)
+    }
+
+    pub(super) fn request(&mut self, command: &str, oid: Oid) -> io::Result<()> {
+        let request = format!("{command} {oid}\n");
+        let mut pending = request.as_bytes();
+        while !pending.is_empty() {
+            self.check()?;
+            match self.input.write(pending) {
+                Ok(0) => return Err(failed()),
+                Ok(n) => pending = &pending[n..],
+                Err(e) if retry(&e) => self.pause(),
+                Err(_) => return Err(failed()),
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn header(&mut self, oid: Oid) -> io::Result<Header> {
+        let mut line = [0; 80];
+        for n in 0..line.len() {
+            self.exact(&mut line[n..=n])?;
+            if line[n] == b'\n' {
+                return Header::parse(&line[..n], oid).ok_or_else(failed);
+            }
+        }
+        Err(failed())
+    }
+
+    pub(super) fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        loop {
+            self.check()?;
+            match self.output.read(buffer) {
+                Ok(n) => return Ok(n),
+                Err(e) if retry(&e) => self.pause(),
+                Err(_) => return Err(failed()),
+            }
+        }
+    }
+
+    pub(super) fn exact(&mut self, mut buffer: &mut [u8]) -> io::Result<()> {
+        while !buffer.is_empty() {
+            let n = self.read(buffer)?;
+            if n == 0 {
+                return Err(failed());
+            }
+            buffer = &mut buffer[n..];
+        }
+        Ok(())
+    }
+
+    fn check(&self) -> io::Result<()> {
+        if self.child.is_none() || (self.cancelled)() || Instant::now() >= self.deadline {
+            return Err(failed());
+        }
+        Ok(())
+    }
+
+    fn pause(&self) {
+        thread::sleep(Duration::from_millis(2).min(self.deadline.saturating_duration_since(Instant::now())));
+    }
+
+    pub(super) fn poison(&mut self) {
+        self.child.take();
+    }
+
+    #[cfg(test)]
+    pub(super) fn id(&self) -> Option<u32> {
+        self.child.as_ref().map(|child| child.0.id())
+    }
+}
+
+pub(super) fn failed() -> io::Error {
+    io::Error::other("raw object source failed")
+}
+fn retry(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock)
+}
+fn nonblocking(fd: &impl AsFd) -> Result<(), SeedError> {
+    let flags = fcntl_getfl(fd).map_err(|_| SeedError::Source)?;
+    fcntl_setfl(fd, flags | OFlags::NONBLOCK).map_err(|_| SeedError::Source)
+}
+struct OwnedChild(Child);
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        if !matches!(self.0.try_wait(), Ok(Some(_))) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/seed/packed/protocol.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/protocol.rs
@@ -1,0 +1,102 @@
+use super::process::{Session, failed};
+use git2::{ObjectType, Oid};
+use std::io::{self, Read};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct Header {
+    pub oid: Oid,
+    pub kind: ObjectType,
+    pub bytes: u64,
+}
+impl Header {
+    pub(super) fn parse(line: &[u8], oid: Oid) -> Option<Self> {
+        let text = std::str::from_utf8(line).ok()?;
+        let mut fields = text.split(' ');
+        if fields.next()? != oid.to_string() {
+            return None;
+        }
+        let kind = match fields.next()? {
+            "blob" => ObjectType::Blob,
+            "tree" => ObjectType::Tree,
+            "commit" => ObjectType::Commit,
+            "tag" => ObjectType::Tag,
+            _ => return None,
+        };
+        let size = fields.next()?;
+        if size.is_empty()
+            || !size.bytes().all(|b| b.is_ascii_digit())
+            || (size.len() > 1 && size.starts_with('0'))
+            || fields.next().is_some()
+        {
+            return None;
+        }
+        Some(Self {
+            oid,
+            kind,
+            bytes: size.parse().ok()?,
+        })
+    }
+}
+
+pub(super) struct ObjectReader<'s, 'a> {
+    session: &'s mut Session<'a>,
+    header: Header,
+    remaining: u64,
+    started: bool,
+    complete: bool,
+}
+impl<'s, 'a> ObjectReader<'s, 'a> {
+    pub(super) fn new(session: &'s mut Session<'a>, header: Header) -> Self {
+        Self {
+            session,
+            header,
+            remaining: header.bytes,
+            started: false,
+            complete: false,
+        }
+    }
+    fn read_payload(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if !self.started {
+            self.session.request("contents", self.header.oid)?;
+            if self.session.header(self.header.oid)? != self.header {
+                return Err(failed());
+            }
+            self.started = true;
+        }
+        if self.remaining == 0 {
+            let mut delimiter = [0];
+            self.session.exact(&mut delimiter)?;
+            if delimiter != *b"\n" {
+                return Err(failed());
+            }
+            self.complete = true;
+            return Ok(0);
+        }
+        let limit = usize::try_from(self.remaining.min(buffer.len() as u64)).map_err(|_| failed())?;
+        let n = self.session.read(&mut buffer[..limit])?;
+        if n == 0 {
+            return Err(failed());
+        }
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
+impl Read for ObjectReader<'_, '_> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() || self.complete {
+            return Ok(0);
+        }
+        let result = self.read_payload(buffer);
+        if result.is_err() {
+            self.session.poison();
+        }
+        result
+    }
+}
+impl Drop for ObjectReader<'_, '_> {
+    fn drop(&mut self) {
+        if !self.complete {
+            self.session.poison();
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
@@ -8,7 +8,7 @@ use git2::{ObjectType, Repository};
 use std::{
     cell::Cell,
     fs,
-    io::Read,
+    io::{self, Read},
     os::unix::fs::{PermissionsExt, symlink},
     process::Command,
 };
@@ -38,6 +38,21 @@ fn raw(source: &mut impl GitObjectSource, oid: Oid) -> Vec<u8> {
     bytes
 }
 
+fn validate(objects: &Path, cancelled: impl Fn() -> bool) -> Result<(), SeedError> {
+    let parent = private_fixture();
+    view::validate(objects, parent.path(), &cancelled)
+}
+
+fn packed(parent: &Path, repository: &Repository) -> PackedGitObjectSource<'static> {
+    PackedGitObjectSource::new(
+        parent,
+        &repository.path().join("objects"),
+        PackedSourceLimits::default(),
+        || false,
+    )
+    .unwrap()
+}
+
 #[test]
 fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source() {
     let fixture = private_fixture();
@@ -54,13 +69,7 @@ fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source()
     );
     let parent = private_fixture();
     {
-        let mut source = PackedGitObjectSource::new(
-            parent.path(),
-            &repository.path().join("objects"),
-            PackedSourceLimits::default(),
-            || false,
-        )
-        .unwrap();
+        let mut source = packed(parent.path(), &repository);
         assert_eq!(raw(&mut source, second), bytes);
     }
     git(&path, &["repack", "-ad", "--window=20", "--depth=20"]);
@@ -73,13 +82,7 @@ fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source()
     let listing = git(&path, &["verify-pack", "-v", index.to_str().unwrap()]);
     assert!(listing.lines().any(|line| line.split_whitespace().count() == 7));
     let before = snapshot(&path);
-    let mut source = PackedGitObjectSource::new(
-        parent.path(),
-        &repository.path().join("objects"),
-        PackedSourceLimits::default(),
-        || false,
-    )
-    .unwrap();
+    let mut source = packed(parent.path(), &repository);
     assert_eq!(raw(&mut source, second), bytes);
     let plan = RepositoryOverlayPlan::new(
         GitSource {
@@ -93,14 +96,8 @@ fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source()
     .unwrap();
     let resolved = resolve_namespaces(&repository, RepositoryOverlayBundle::new(plan, vec![]).unwrap()).unwrap();
     let seed = super::super::prepare_git_seed(parent.path(), &resolved, &mut source, || false).unwrap();
-    assert_eq!(
-        Repository::open(seed.path())
-            .unwrap()
-            .find_blob(second)
-            .unwrap()
-            .content(),
-        bytes
-    );
+    let seeded = Repository::open(seed.path()).unwrap();
+    assert_eq!(seeded.find_blob(second).unwrap().content(), bytes);
     let metadata = source.metadata_path().to_owned();
     assert!(!format!("{source:?}").contains(metadata.to_str().unwrap()));
     drop(source);
@@ -223,36 +220,44 @@ fn unsafe_alternates_links_special_nodes_ancestry_and_limits_are_rejected() {
                 symlink("actual", &objects).unwrap();
             }
         }
-        assert_eq!(view::validate(&objects, &|| false), Err(SeedError::UnsafeParent));
+        assert_eq!(validate(&objects, || false), Err(SeedError::UnsafeParent));
     }
-    assert!(
+    for limits in [
         PackedSourceLimits {
             cpu_seconds: 0,
             ..PackedSourceLimits::default()
-        }
-        .validate()
-        .is_err()
-    );
-    assert!(
+        },
         PackedSourceLimits {
             address_space_bytes: u64::MAX,
             ..PackedSourceLimits::default()
-        }
-        .validate()
-        .is_err()
-    );
-    assert!(
+        },
         PackedSourceLimits {
             object_timeout: Duration::ZERO,
             ..PackedSourceLimits::default()
-        }
-        .validate()
-        .is_err()
-    );
+        },
+    ] {
+        assert_eq!(limits.validate(), Err(SeedError::Limit));
+    }
     let fixture = private_fixture();
-    assert_eq!(view::validate(fixture.path(), &|| true), Err(SeedError::Cancelled));
+    assert_eq!(validate(fixture.path(), || true), Err(SeedError::Cancelled));
     fs::create_dir_all(fixture.path().join("a/b/c/d")).unwrap();
-    assert_eq!(view::validate(fixture.path(), &|| false), Err(SeedError::Limit));
+    assert_eq!(validate(fixture.path(), || false), Err(SeedError::Limit));
+}
+
+#[test]
+fn scratch_inside_source_is_rejected_before_reservation_without_source_changes() {
+    let fixture = private_fixture();
+    let nested = fixture.path().join("scratch");
+    fs::create_dir(&nested).unwrap();
+    fs::set_permissions(&nested, fs::Permissions::from_mode(0o700)).unwrap();
+    let before = snapshot(fixture.path());
+    for parent in [fixture.path(), nested.as_path()] {
+        let failure =
+            PackedGitObjectSource::new(parent, fixture.path(), PackedSourceLimits::default(), || false).unwrap_err();
+        assert_eq!(failure.reason, SeedError::UnsafeParent);
+        assert!(failure.residue().is_none());
+        assert_eq!(snapshot(fixture.path()), before);
+    }
 }
 
 fn peer(script: &str, timeout: Duration) -> process::Session<'static> {
@@ -337,6 +342,7 @@ fn stalled_owned_child_times_out_and_midstream_cancellation_poisons_source() {
     let process = PathBuf::from(format!("/proc/{}", session.id().unwrap()));
     let started = std::time::Instant::now();
     assert!(session.info(Oid::ZERO_SHA1).is_err());
+    assert_eq!(session.read(&mut [0]).unwrap_err().kind(), io::ErrorKind::TimedOut);
     session.poison();
     assert!(!process.exists());
     assert!(started.elapsed() < Duration::from_secs(2));
@@ -351,9 +357,30 @@ fn stalled_owned_child_times_out_and_midstream_cancellation_poisons_source() {
     let header = session.info(Oid::ZERO_SHA1).unwrap();
     let mut reader = protocol::ObjectReader::new(&mut session, header);
     cancelled.set(true);
-    assert!(reader.read(&mut [0]).is_err());
+    assert_eq!(
+        reader.read(&mut [0]).unwrap_err().kind(),
+        io::ErrorKind::ConnectionAborted
+    );
     drop(reader);
     assert!(session.info(Oid::ZERO_SHA1).is_err());
+    let calls = Cell::new(0);
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", "read a oid; read again"]).env_clear();
+    let mut session = process::Session::spawn(
+        command,
+        Duration::from_secs(2),
+        Box::new(|| {
+            calls.set(calls.get() + 1);
+            calls.get() >= 3
+        }),
+    )
+    .unwrap();
+    assert_eq!(session.info(Oid::ZERO_SHA1), Err(SeedError::Cancelled));
+    assert_eq!(
+        calls.get(),
+        3,
+        "cancellation must occur inside header I/O, not its entry preflight"
+    );
 }
 
 #[test]
@@ -411,7 +438,7 @@ fn casefold_alternate_alias_is_rejected_when_fixture_capability_is_available() {
     fs::create_dir(fixture.path().join("INFO")).unwrap();
     fs::write(fixture.path().join("INFO/ALTERNATES"), b"/unauthorized\n").unwrap();
     assert!(fixture.path().join("info/alternates").exists());
-    assert_eq!(view::validate(fixture.path(), &|| false), Err(SeedError::UnsafeParent));
+    assert_eq!(validate(fixture.path(), || false), Err(SeedError::UnsafeParent));
 }
 
 #[test]
@@ -421,6 +448,6 @@ fn actual_source_enumeration_charges_node_and_path_limits_before_growth() {
         for number in 0..entries {
             fs::File::create(fixture.path().join(format!("{number:0width$}"))).unwrap();
         }
-        assert_eq!(view::validate(fixture.path(), &|| false), Err(SeedError::Limit));
+        assert_eq!(validate(fixture.path(), || false), Err(SeedError::Limit));
     }
 }

--- a/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
@@ -1,0 +1,426 @@
+use super::super::tests::{commit, private_fixture, snapshot};
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{RepositoryOverlayPlan, bundle::RepositoryOverlayBundle, namespace::resolve_namespaces},
+};
+use git2::{ObjectType, Repository};
+use std::{
+    cell::Cell,
+    fs,
+    io::Read,
+    os::unix::fs::{PermissionsExt, symlink},
+    process::Command,
+};
+
+fn git(path: &Path, arguments: &[&str]) -> String {
+    let output = Command::new("/usr/bin/git")
+        .current_dir(path)
+        .args(arguments)
+        .env_clear()
+        .envs([
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("LC_ALL", "C"),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn raw(source: &mut impl GitObjectSource, oid: Oid) -> Vec<u8> {
+    let mut stream = source.open(oid).unwrap();
+    let mut bytes = Vec::new();
+    stream.reader.read_to_end(&mut bytes).unwrap();
+    assert_eq!(stream.bytes, bytes.len() as u64);
+    assert_eq!(Oid::hash_object(stream.kind, &bytes).unwrap(), oid);
+    bytes
+}
+
+#[test]
+fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source() {
+    let fixture = private_fixture();
+    let path = fixture.path().join("source : quoted\" and \\ path æøå");
+    let repository = Repository::init(&path).unwrap();
+    let mut bytes = vec![b'a'; 2 * 1024 * 1024];
+    let first = repository.blob(&bytes).unwrap();
+    bytes[1234] = b'z';
+    let second = repository.blob(&bytes).unwrap();
+    let base = commit(
+        &repository,
+        &[("one", first, 0o100_644), ("two", second, 0o100_755)],
+        &[],
+    );
+    let parent = private_fixture();
+    {
+        let mut source = PackedGitObjectSource::new(
+            parent.path(),
+            &repository.path().join("objects"),
+            PackedSourceLimits::default(),
+            || false,
+        )
+        .unwrap();
+        assert_eq!(raw(&mut source, second), bytes);
+    }
+    git(&path, &["repack", "-ad", "--window=20", "--depth=20"]);
+    let index = fs::read_dir(repository.path().join("objects/pack"))
+        .unwrap()
+        .map(Result::unwrap)
+        .map(|entry| entry.path())
+        .find(|p| p.extension().is_some_and(|e| e == "idx"))
+        .unwrap();
+    let listing = git(&path, &["verify-pack", "-v", index.to_str().unwrap()]);
+    assert!(listing.lines().any(|line| line.split_whitespace().count() == 7));
+    let before = snapshot(&path);
+    let mut source = PackedGitObjectSource::new(
+        parent.path(),
+        &repository.path().join("objects"),
+        PackedSourceLimits::default(),
+        || false,
+    )
+    .unwrap();
+    assert_eq!(raw(&mut source, second), bytes);
+    let plan = RepositoryOverlayPlan::new(
+        GitSource {
+            repository: "synthetic/project".into(),
+            commit: GitCommitSha::parse(base.to_string()).unwrap(),
+            branch: None,
+        },
+        vec![],
+        vec![],
+    )
+    .unwrap();
+    let resolved = resolve_namespaces(&repository, RepositoryOverlayBundle::new(plan, vec![]).unwrap()).unwrap();
+    let seed = super::super::prepare_git_seed(parent.path(), &resolved, &mut source, || false).unwrap();
+    assert_eq!(
+        Repository::open(seed.path())
+            .unwrap()
+            .find_blob(second)
+            .unwrap()
+            .content(),
+        bytes
+    );
+    let metadata = source.metadata_path().to_owned();
+    assert!(!format!("{source:?}").contains(metadata.to_str().unwrap()));
+    drop(source);
+    assert!(metadata.join("HEAD").exists());
+    assert_eq!(snapshot(&path), before);
+}
+
+#[test]
+fn isolated_command_discards_source_configuration_and_missing_promisors() {
+    let fixture = private_fixture();
+    let repository = Repository::init(fixture.path()).unwrap();
+    let oid = repository.blob(b"literal raw object").unwrap();
+    let marker = fixture.path().join("helper-ran");
+    let helper = fixture.path().join("helper");
+    fs::write(&helper, format!("#!/bin/sh\nprintf ran > '{}'\n", marker.display())).unwrap();
+    fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+    let mut config = repository.config().unwrap();
+    config
+        .set_str("remote.synthetic.url", &format!("ext::{}", helper.display()))
+        .unwrap();
+    config.set_bool("remote.synthetic.promisor", true).unwrap();
+    config.set_i32("core.repositoryformatversion", 1).unwrap();
+    config.set_str("extensions.partialClone", "synthetic").unwrap();
+    config.set_str("core.hooksPath", helper.to_str().unwrap()).unwrap();
+    config
+        .set_str("filter.synthetic.smudge", helper.to_str().unwrap())
+        .unwrap();
+    config
+        .set_str("include.path", fixture.path().join("missing-include").to_str().unwrap())
+        .unwrap();
+    let objects = repository.path().join("objects");
+    fs::write(
+        objects.join("pack/multi-pack-index"),
+        b"malicious MIDX must not be parsed",
+    )
+    .unwrap();
+    fs::write(
+        objects.join("pack/pack-0000000000000000000000000000000000000000.promisor"),
+        b"",
+    )
+    .unwrap();
+    let before = snapshot(fixture.path());
+    let parent = private_fixture();
+    let mut source =
+        PackedGitObjectSource::new(parent.path(), &objects, PackedSourceLimits::default(), || false).unwrap();
+    assert_eq!(raw(&mut source, oid), b"literal raw object");
+    let missing = Oid::hash_object(ObjectType::Blob, b"absent nonzero promisor probe").unwrap();
+    assert!(!repository.odb().unwrap().exists(missing));
+    assert!(source.open(missing).is_err());
+    assert!(source.open(oid).is_err());
+    assert!(!marker.exists());
+    assert_eq!(snapshot(fixture.path()), before);
+    let control = Command::new("/usr/bin/git")
+        .current_dir(fixture.path())
+        .args([
+            "-c",
+            "core.multiPackIndex=false",
+            "cat-file",
+            "-p",
+            &missing.to_string(),
+        ])
+        .env_clear()
+        .envs([
+            ("GIT_ALLOW_PROTOCOL", "ext"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_TERMINAL_PROMPT", "0"),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !control.status.success() && marker.exists(),
+        "local helper positive control did not run: {}",
+        String::from_utf8_lossy(&control.stderr)
+    );
+    let command = view::command(
+        &staging::reserve(parent.path(), &|| false).unwrap(),
+        &objects,
+        PackedSourceLimits::default(),
+    )
+    .unwrap();
+    let environment: std::collections::BTreeMap<_, _> = command.get_envs().collect();
+    let arguments: Vec<_> = command.get_args().collect();
+    assert!(arguments.contains(&std::ffi::OsStr::new("core.multiPackIndex=false")));
+    assert!(arguments.contains(&std::ffi::OsStr::new("core.commitGraph=false")));
+    assert_eq!(
+        environment.get(std::ffi::OsStr::new("GIT_CONFIG_GLOBAL")),
+        Some(&Some(std::ffi::OsStr::new("/dev/null")))
+    );
+    assert_eq!(
+        environment.get(std::ffi::OsStr::new("GIT_ALLOW_PROTOCOL")),
+        Some(&Some(std::ffi::OsStr::new("")))
+    );
+}
+
+#[test]
+fn unsafe_alternates_links_special_nodes_ancestry_and_limits_are_rejected() {
+    for kind in 0..5 {
+        let fixture = private_fixture();
+        let objects = fixture.path().join("objects");
+        fs::create_dir(&objects).unwrap();
+        fs::create_dir(objects.join("info")).unwrap();
+        match kind {
+            0 => fs::write(objects.join("info/alternates"), b"/unauthorized\n").unwrap(),
+            1 => symlink("/dev/null", objects.join("object")).unwrap(),
+            2 => rustix::fs::mknodat(
+                rustix::fs::CWD,
+                objects.join("fifo"),
+                rustix::fs::FileType::Fifo,
+                rustix::fs::Mode::RUSR,
+                0,
+            )
+            .unwrap(),
+            3 => {
+                fs::write(objects.join("one"), b"hardlink").unwrap();
+                fs::hard_link(objects.join("one"), objects.join("two")).unwrap();
+            }
+            _ => {
+                fs::rename(&objects, fixture.path().join("actual")).unwrap();
+                symlink("actual", &objects).unwrap();
+            }
+        }
+        assert_eq!(view::validate(&objects, &|| false), Err(SeedError::UnsafeParent));
+    }
+    assert!(
+        PackedSourceLimits {
+            cpu_seconds: 0,
+            ..PackedSourceLimits::default()
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        PackedSourceLimits {
+            address_space_bytes: u64::MAX,
+            ..PackedSourceLimits::default()
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        PackedSourceLimits {
+            object_timeout: Duration::ZERO,
+            ..PackedSourceLimits::default()
+        }
+        .validate()
+        .is_err()
+    );
+    let fixture = private_fixture();
+    assert_eq!(view::validate(fixture.path(), &|| true), Err(SeedError::Cancelled));
+    fs::create_dir_all(fixture.path().join("a/b/c/d")).unwrap();
+    assert_eq!(view::validate(fixture.path(), &|| false), Err(SeedError::Limit));
+}
+
+fn peer(script: &str, timeout: Duration) -> process::Session<'static> {
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", script]).env_clear();
+    process::Session::spawn(command, timeout, Box::new(|| false)).unwrap()
+}
+
+#[test]
+fn strict_headers_accept_only_exact_oid_type_canonical_length_and_field_count() {
+    let oid = Oid::ZERO_SHA1;
+    for suffix in ["blob 0", "tree 123", "commit 456", "tag 1"] {
+        assert!(protocol::Header::parse(format!("{oid} {suffix}").as_bytes(), oid).is_some());
+    }
+    for suffix in [
+        "missing",
+        "blob +1",
+        "blob -1",
+        "blob 01",
+        "blob 18446744073709551616",
+        "blob 1 extra",
+        "blob 1\r",
+        "blob ",
+        "blob  1",
+        "other 1",
+    ] {
+        assert!(protocol::Header::parse(format!("{oid} {suffix}").as_bytes(), oid).is_none());
+    }
+    assert!(protocol::Header::parse(format!("{} blob 1", "1".repeat(40)).as_bytes(), oid).is_none());
+}
+
+#[test]
+fn protocol_rejects_bad_second_header_truncation_delimiter_and_oversized_header() {
+    for response in [
+        "blob 3\nabc!",
+        "blob 3\nab",
+        "tree 3\nabc\n",
+        "blob 4\nabc\n",
+        "blob 3\nabc",
+        "blob 3 extra\nabc\n",
+    ] {
+        let script = format!("read a oid; printf '%s blob 3\\n' \"$oid\"; read a oid; printf '%s {response}' \"$oid\"");
+        let mut session = peer(&script, Duration::from_secs(2));
+        let header = session.info(Oid::ZERO_SHA1).unwrap();
+        let mut reader = protocol::ObjectReader::new(&mut session, header);
+        assert!(reader.read_to_end(&mut Vec::new()).is_err());
+        drop(reader);
+        assert!(session.info(Oid::ZERO_SHA1).is_err());
+    }
+    let mut session = peer("read a oid; printf '%090d' 0", Duration::from_secs(2));
+    assert!(session.info(Oid::ZERO_SHA1).is_err());
+}
+
+#[test]
+fn delayed_contents_empty_reads_zero_payload_and_early_drop_obey_framing() {
+    let fixture = private_fixture();
+    let marker = fixture.path().join("contents-requested");
+    let script = format!(
+        "read a oid; printf '%s blob 0\\n' \"$oid\"; read a oid; printf yes > '{}'; printf '%s blob 0\\n\\n' \"$oid\"",
+        marker.display()
+    );
+    let mut session = peer(&script, Duration::from_secs(2));
+    let header = session.info(Oid::ZERO_SHA1).unwrap();
+    let mut reader = protocol::ObjectReader::new(&mut session, header);
+    assert_eq!(reader.read(&mut []).unwrap(), 0);
+    assert!(!marker.exists());
+    assert_eq!(reader.read(&mut [0]).unwrap(), 0);
+    assert!(marker.exists());
+    drop(reader);
+    let mut session = peer(
+        "read a oid; printf '%s blob 100\\n' \"$oid\"; read a oid",
+        Duration::from_secs(2),
+    );
+    let header = session.info(Oid::ZERO_SHA1).unwrap();
+    drop(protocol::ObjectReader::new(&mut session, header));
+    assert!(session.info(Oid::ZERO_SHA1).is_err());
+}
+
+#[test]
+fn stalled_owned_child_times_out_and_midstream_cancellation_poisons_source() {
+    let mut session = peer("read a oid; read again", Duration::from_millis(50));
+    let process = PathBuf::from(format!("/proc/{}", session.id().unwrap()));
+    let started = std::time::Instant::now();
+    assert!(session.info(Oid::ZERO_SHA1).is_err());
+    session.poison();
+    assert!(!process.exists());
+    assert!(started.elapsed() < Duration::from_secs(2));
+    let cancelled = Cell::new(false);
+    let mut command = Command::new("/bin/sh");
+    command.env_clear();
+    command.args([
+        "-c",
+        "read a oid; printf '%s blob 3\\n' \"$oid\"; read a oid; printf '%s blob 3\\nabc\\n' \"$oid\"",
+    ]);
+    let mut session = process::Session::spawn(command, Duration::from_secs(2), Box::new(|| cancelled.get())).unwrap();
+    let header = session.info(Oid::ZERO_SHA1).unwrap();
+    let mut reader = protocol::ObjectReader::new(&mut session, header);
+    cancelled.set(true);
+    assert!(reader.read(&mut [0]).is_err());
+    drop(reader);
+    assert!(session.info(Oid::ZERO_SHA1).is_err());
+}
+
+#[test]
+fn native_resource_limits_apply_before_git_and_limit_termination_is_reported() {
+    let fixture = private_fixture();
+    let repository = Repository::init(fixture.path()).unwrap();
+    let oid = repository.blob(b"limits probe").unwrap();
+    let parent = private_fixture();
+    let limits = PackedSourceLimits::default();
+    let mut source =
+        PackedGitObjectSource::new(parent.path(), &repository.path().join("objects"), limits, || false).unwrap();
+    raw(&mut source, oid);
+    let process = PathBuf::from(format!("/proc/{}", source.session.id().unwrap()));
+    let actual = fs::read_to_string(process.join("limits")).unwrap();
+    for (label, value) in [
+        ("Max address space", limits.address_space_bytes),
+        ("Max cpu time", u64::from(limits.cpu_seconds)),
+        ("Max open files", 64),
+        ("Max core file size", 0),
+    ] {
+        let fields: Vec<_> = actual
+            .lines()
+            .find_map(|line| line.strip_prefix(label))
+            .unwrap()
+            .split_whitespace()
+            .collect();
+        assert_eq!(fields[..2], [value.to_string(), value.to_string()]);
+    }
+    drop(source);
+    assert!(!process.exists());
+    let mut command = Command::new("/usr/bin/prlimit");
+    command
+        .args(["--cpu=1:1", "--core=0:0", "--", "/bin/sh", "-c", "while :; do :; done"])
+        .env_clear();
+    let mut session = process::Session::spawn(command, Duration::from_secs(5), Box::new(|| false)).unwrap();
+    let process = PathBuf::from(format!("/proc/{}", session.id().unwrap()));
+    let started = std::time::Instant::now();
+    assert!(session.info(Oid::ZERO_SHA1).is_err());
+    assert!(
+        started.elapsed() < Duration::from_secs(4),
+        "pipe timeout is not proof of CPU-limit termination"
+    );
+    session.poison();
+    assert!(!process.exists());
+}
+
+#[test]
+fn casefold_alternate_alias_is_rejected_when_fixture_capability_is_available() {
+    let fixture = private_fixture();
+    let enabled = Command::new("/usr/bin/chattr").arg("+F").arg(fixture.path()).output();
+    if !enabled.is_ok_and(|output| output.status.success()) {
+        eprintln!("SKIP casefold fixture: per-directory casefold is unavailable");
+        return;
+    }
+    fs::create_dir(fixture.path().join("INFO")).unwrap();
+    fs::write(fixture.path().join("INFO/ALTERNATES"), b"/unauthorized\n").unwrap();
+    assert!(fixture.path().join("info/alternates").exists());
+    assert_eq!(view::validate(fixture.path(), &|| false), Err(SeedError::UnsafeParent));
+}
+
+#[test]
+fn actual_source_enumeration_charges_node_and_path_limits_before_growth() {
+    for (entries, width) in [(view::MAX_NODES + 1, 0), (view::MAX_PATH_BYTES / 200 + 1, 200)] {
+        let fixture = private_fixture();
+        for number in 0..entries {
+            fs::File::create(fixture.path().join(format!("{number:0width$}"))).unwrap();
+        }
+        assert_eq!(view::validate(fixture.path(), &|| false), Err(SeedError::Limit));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
@@ -15,12 +15,14 @@ use std::{
 pub(super) const MAX_NODES: usize = 262_144;
 pub(super) const MAX_PATH_BYTES: usize = 16 * 1024 * 1024;
 
-pub(super) fn validate(objects: &Path, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+pub(super) fn validate(objects: &Path, parent: &Path, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
     staging::check_cancel(cancelled)?;
     if !objects.is_absolute() {
         return Err(Error::UnsafeParent);
     }
     let root = SelectedRepositoryReader::open(objects).map_err(|_| Error::UnsafeParent)?;
+    let scratch = SelectedRepositoryReader::open(parent).map_err(|_| Error::UnsafeParent)?;
+    let scratch = scratch.root.handle().metadata().map_err(|_| Error::UnsafeParent)?;
     // Probe Git's actual lookup, including aliases on casefold filesystems.
     match rustix::fs::openat2(
         root.root.handle(),
@@ -50,6 +52,10 @@ pub(super) fn validate(objects: &Path, cancelled: &impl Fn() -> bool) -> Result<
             return Err(Error::UnsafeParent);
         }
         if metadata.is_dir() {
+            // Compare identities, not spelling: scratch must never modify the source.
+            if metadata.dev() == scratch.dev() && metadata.ino() == scratch.ino() {
+                return Err(Error::UnsafeParent);
+            }
             if relative.components().count() >= 4 {
                 return Err(Error::Limit);
             }

--- a/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
@@ -1,0 +1,138 @@
+use super::{PackedSourceLimits, SeedError as Error, staging};
+use crate::repository_overlay::reader::SelectedRepositoryReader;
+use std::{
+    fmt::Write as _,
+    fs::{self, OpenOptions},
+    io::Write,
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{MetadataExt, OpenOptionsExt},
+    },
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub(super) const MAX_NODES: usize = 262_144;
+pub(super) const MAX_PATH_BYTES: usize = 16 * 1024 * 1024;
+
+pub(super) fn validate(objects: &Path, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+    staging::check_cancel(cancelled)?;
+    if !objects.is_absolute() {
+        return Err(Error::UnsafeParent);
+    }
+    let root = SelectedRepositoryReader::open(objects).map_err(|_| Error::UnsafeParent)?;
+    // Probe Git's actual lookup, including aliases on casefold filesystems.
+    match rustix::fs::openat2(
+        root.root.handle(),
+        "info/alternates",
+        rustix::fs::OFlags::PATH | rustix::fs::OFlags::NOFOLLOW | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+        rustix::fs::ResolveFlags::BENEATH
+            | rustix::fs::ResolveFlags::NO_SYMLINKS
+            | rustix::fs::ResolveFlags::NO_MAGICLINKS
+            | rustix::fs::ResolveFlags::NO_XDEV,
+    ) {
+        Err(rustix::io::Errno::NOENT) => {}
+        _ => return Err(Error::UnsafeParent),
+    }
+    let device = root.root.handle().metadata().map_err(|_| Error::Source)?.dev();
+    let mut pending = vec![PathBuf::new()];
+    let (mut nodes, mut paths) = (0usize, 0usize);
+    while let Some(relative) = pending.pop() {
+        staging::check_cancel(cancelled)?;
+        let path = objects.join(&relative);
+        let metadata = fs::symlink_metadata(&path).map_err(|_| Error::Source)?;
+        if metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.dev() != device
+            || metadata.nlink() == 0
+            || !(metadata.is_dir() || (metadata.is_file() && metadata.nlink() == 1))
+        {
+            return Err(Error::UnsafeParent);
+        }
+        if metadata.is_dir() {
+            if relative.components().count() >= 4 {
+                return Err(Error::Limit);
+            }
+            for entry in fs::read_dir(path).map_err(|_| Error::Source)? {
+                staging::check_cancel(cancelled)?;
+                let child = relative.join(entry.map_err(|_| Error::Source)?.file_name());
+                nodes = nodes.checked_add(1).filter(|n| *n <= MAX_NODES).ok_or(Error::Limit)?;
+                paths = paths
+                    .checked_add(child.as_os_str().len())
+                    .filter(|n| *n <= MAX_PATH_BYTES)
+                    .ok_or(Error::Limit)?;
+                pending.push(child);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn command(path: &Path, objects: &Path, limits: PackedSourceLimits) -> Result<Command, Error> {
+    for directory in ["objects", "objects/info", "objects/pack", "refs"] {
+        fs::create_dir(path.join(directory)).map_err(|_| Error::Storage)?;
+    }
+    for (name, contents) in [
+        ("HEAD", "ref: refs/heads/isolated\n"),
+        ("config", "[core]\nrepositoryformatversion = 0\nbare = true\n"),
+    ] {
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path.join(name))
+            .and_then(|mut file| file.write_all(contents.as_bytes()))
+            .map_err(|_| Error::Storage)?;
+    }
+    let mut quoted = String::from("\"");
+    for &byte in objects.as_os_str().as_bytes() {
+        match byte {
+            b'"' | b'\\' => {
+                quoted.push('\\');
+                quoted.push(char::from(byte));
+            }
+            0x20..=0x7e => quoted.push(char::from(byte)),
+            _ => write!(quoted, "\\{byte:03o}").map_err(|_| Error::Source)?,
+        }
+    }
+    quoted.push('"');
+    let mut command = Command::new("/usr/bin/prlimit");
+    command
+        .args([
+            format!("--as={0}:{0}", limits.address_space_bytes),
+            format!("--cpu={0}:{0}", limits.cpu_seconds),
+            "--nofile=64:64".into(),
+            "--core=0:0".into(),
+        ])
+        .args(["--", "/usr/bin/git", "--no-replace-objects", "--git-dir"])
+        .arg(path)
+        .args([
+            "-c",
+            "core.multiPackIndex=false",
+            "-c",
+            "core.commitGraph=false",
+            "-c",
+            "core.packedGitLimit=64m",
+            "-c",
+            "core.packedGitWindowSize=16m",
+            "-c",
+            "core.deltaBaseCacheLimit=16m",
+            "-c",
+            "core.bigFileThreshold=1m",
+            "cat-file",
+            "--batch-command",
+        ])
+        .current_dir(path)
+        .env_clear()
+        .envs([
+            ("LC_ALL", "C"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("GIT_CONFIG_SYSTEM", "/dev/null"),
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_ALLOW_PROTOCOL", ""),
+            ("GIT_OPTIONAL_LOCKS", "0"),
+            ("GIT_TERMINAL_PROMPT", "0"),
+        ])
+        .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", quoted);
+    Ok(command)
+}

--- a/crates/horizon-core/src/repository_overlay/seed/staging.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/staging.rs
@@ -30,7 +30,7 @@ pub(super) fn prepare(
     }
 }
 
-fn reserve(parent: &Path, cancelled: &impl Fn() -> bool) -> Result<std::path::PathBuf, Error> {
+pub(super) fn reserve(parent: &Path, cancelled: &impl Fn() -> bool) -> Result<std::path::PathBuf, Error> {
     check_cancel(cancelled)?;
     if !parent.is_absolute() {
         return Err(Error::UnsafeParent);

--- a/crates/horizon-core/src/repository_overlay/seed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/tests.rs
@@ -26,7 +26,7 @@ struct Fixture {
     base_blob: Oid,
 }
 
-fn private_fixture() -> tempfile::TempDir {
+pub(super) fn private_fixture() -> tempfile::TempDir {
     tempfile::Builder::new()
         .permissions(fs::Permissions::from_mode(0o700))
         .tempdir()
@@ -118,7 +118,7 @@ fn entry(path: &str, id: Oid, mode: u32) -> IndexEntry {
     }
 }
 
-fn commit(repository: &Repository, files: &[(&str, Oid, u32)], parents: &[Oid]) -> Oid {
+pub(super) fn commit(repository: &Repository, files: &[(&str, Oid, u32)], parents: &[Oid]) -> Oid {
     let mut index = Index::new().unwrap();
     for (path, id, mode) in files {
         index.add(&entry(path, *id, *mode)).unwrap();
@@ -157,7 +157,7 @@ fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedO
     )
 }
 
-fn snapshot(root: &Path) -> BTreeMap<PathBuf, (Vec<u8>, u32)> {
+pub(super) fn snapshot(root: &Path) -> BTreeMap<PathBuf, (Vec<u8>, u32)> {
     let mut files = BTreeMap::new();
     let mut pending = vec![root.to_path_buf()];
     while let Some(path) = pending.pop() {

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -212,7 +212,14 @@ back into large multi-purpose modules.
   repository and constructs its detached HEAD, shallow boundary and independent
   staged index. Source adapters own their I/O behavior; private Git pathname writes
   require stable ancestry and exclusive same-user ownership. Failed residues remain
-  explicit. Working files, packed-object acquisition and publication are separate.
+  explicit. Working files and publication are separate. Linux `seed/packed/` owns
+  explicit stable-object-store validation, isolated bare metadata, resource-limited
+  native Git acquisition and strict lazy batch framing. It needs trusted system Git
+  and prlimit executables; native delta allocations remain subject to those ceilings.
+  No source config, recursive alternates, hooks, filters or network transports are
+  inherited. Cancellation/failure or an unfinished stream terminates only its owned
+  child; private metadata remains explicit. Stable source/ancestry and exclusive
+  scratch ownership are prerequisites, not confinement against concurrent mutation.
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;


### PR DESCRIPTION
## Purpose

Add a production raw-object source for the existing private Git seed importer,
including packed and delta-compressed objects. Continues #383; does not close it.

## Behavior and boundaries

- Read full object IDs through an owned, resource-limited Git batch process and a
  fresh private metadata view. Source refs, configuration, templates, hooks,
  filters and recursive alternates are not inherited. MIDX/commit-graph paths
  are disabled; source object-store topology is bounded and checked without
  following links or crossing devices.
- Validate exact headers, object types and canonical lengths before requesting
  contents lazily. Bound headers and pipe waits, check cancellation, consume exact
  payload framing, and poison/reap only the owned child on failure or early drop.
  The importer continues to verify destination object IDs and aggregate budgets.
- Keep private scratch metadata on success, failure and drop for explicit cleanup.
  Reject scratch parents within the source object store before reserving anything,
  using held directory identities. Do not mutate the source, grant export authority,
  launch tasks or contact a provider.
- Preserve cancellation during metadata requests and report distinct stream
  cancellation/timeout error kinds. The shared import read-error prerequisite #465
  is merged and included in the base.
- Linux only; requires trusted Git with batch-command support and the resource-limit
  launcher at their documented absolute paths. Tested with Git 2.43.0 and util-linux
  2.39.3. The caller must hold source content/topology/ancestry stable and exclusively
  control private scratch. This is not confinement against concurrent hostile
  same-user mutation or a vulnerable trusted executable.
- Native delta decoding can materialize objects: address-space/CPU caps can reject
  otherwise valid packs. CPU time accumulates across the session; pipe deadlines
  do not bound filesystem calls, process creation or kill/reap latency.
- No UI, default configuration, dependency, provider or release changes. Production
  transfer, workspace setup, remote checkpointing and PC-off acceptance remain.

## Validation

Exact candidate `024ae635` passed the full local validation matrix: formatting,
maintainability/version checks, default and speech workspace tests, and
blocking/strict/advisory Clippy. Independent full-diff review and exact committed
parity verification cleared the candidate.

Eleven regressions cover real packed/delta objects and exact shallow import; source
configuration isolation with a nonzero missing-object test and controlled local
helper positive control; unsafe topology and alternates; strict headers and payload
framing; lazy and early-drop behavior; timeout/cancellation and exact owned-child
cleanup; actual process limits and CPU exhaustion; real node/path-budget overflow;
and source-overlapping scratch rejection without source changes or failure residue.
The casefold-specific fixture probes host support and explicitly skips when absent;
this host did not provide that capability, so no executed casefold smoke is claimed.

A separate actual-public-API/ordinary-Git smoke passed with a restrictive child-only
umask and synthetic global configuration: a packed incompressible object exceeding
65 MiB, special/UTF-8 source paths, private seed, raw checkout and qualified no-replace
publication. Exact shallow HEAD, independent index, binary/executable/link and LFS
pointer-versus-hydrated bytes remained correct. Source bytes/modes and an existing
destination stayed unchanged; sentinels did not execute or leak into the checkout;
an absent nonzero object poisoned the source; scratch remained until explicit
fixture cleanup. No paid cloud resources or release operations were involved.
