### PR TITLE
Preserve cancellation during seed import read failures

### DIFF
--- a/crates/horizon-core/src/repository_overlay/seed/import.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/import.rs
@@ -142,7 +142,7 @@ pub(super) fn charge(
     Ok(())
 }
 
-fn copy(
+pub(super) fn copy(
     database: &Odb<'_>,
     mut stream: GitObjectStream<'_>,
     id: Oid,
@@ -159,7 +159,10 @@ fn copy(
             Ok(0) => return Err(Error::Object),
             Ok(count) => count,
             Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
-            Err(_) => return Err(Error::Source),
+            Err(_) => {
+                check_cancel(cancelled)?;
+                return Err(Error::Source);
+            }
         };
         writer.write_all(&buffer[..count]).map_err(|_| Error::Storage)?;
         remaining -= count as u64;
@@ -172,7 +175,10 @@ fn copy(
             Ok(0) => break,
             Ok(_) => return Err(Error::Object),
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
-            Err(_) => return Err(Error::Source),
+            Err(_) => {
+                check_cancel(cancelled)?;
+                return Err(Error::Source);
+            }
         }
     }
     if writer.finalize().map_err(|_| Error::Storage)? != id {

--- a/crates/horizon-core/src/repository_overlay/seed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/tests.rs
@@ -520,3 +520,36 @@ fn transfer_read_errors_are_redacted() {
     assert_eq!(error.reason, SeedError::Source);
     assert!(!format!("{error:?}").contains("private source detail"));
 }
+
+#[test]
+fn read_failures_recheck_cancellation_during_payload_and_final_framing() {
+    struct CountedFailure<'a>(&'a Cell<usize>);
+    impl Read for CountedFailure<'_> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            self.0.set(self.0.get() + 1);
+            FailedRead.read(bytes)
+        }
+    }
+    let fixture = private_fixture();
+    let repository = Repository::init_bare(fixture.path().join("git")).unwrap();
+    let database = repository.odb().unwrap();
+    for bytes in [0, 1] {
+        for expected in [SeedError::Source, SeedError::Cancelled] {
+            let calls = Cell::new(0);
+            let reads = Cell::new(0);
+            let checks = if bytes == 0 { 3 } else { 2 };
+            let stream = GitObjectStream {
+                kind: ObjectType::Blob,
+                bytes,
+                reader: Box::new(CountedFailure(&reads)),
+            };
+            let result = import::copy(&database, stream, Oid::ZERO_SHA1, &|| {
+                calls.set(calls.get() + 1);
+                expected == SeedError::Cancelled && calls.get() >= checks
+            });
+            assert_eq!(result, Err(expected));
+            assert_eq!(calls.get(), checks);
+            assert_eq!(reads.get(), 1, "all four cases must actually reach the failing read");
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Preserve caller cancellation when a private Git seed import fails during a payload
or final-framing read. This shared-importer correction is a small prerequisite for
the packed-source work in #463 and does not close the overall feature in #383.

## Behavior

Previously a source read could fail after the last cancellation check, and the
importer returned `Source` even when cancellation was now requested. Both read-error
arms now recheck the caller's cancellation callback before returning that generic
failure. Non-cancelled failures still return the same redacted source error; arbitrary
transport error kinds do not grant cancellation authority.

No public API, successful-import, cleanup, provider, UI, default configuration,
dependency or release changes. Failed private stages remain retained by the existing
error path; this does not add interruption of blocking source operations.

## Validation

Exact candidate `826bec5c` passed formatting, maintainability/version checks, default
and speech workspace tests, and blocking/strict/advisory Clippy. Independent full-diff
review and exact committed-byte parity verification cleared the change.

A deterministic regression exercises both the payload and final-framing error arms,
with cancellation requested and absent. It asserts that all four cases actually
perform one failing read before the cancellation recheck, preserving `Source` for
ordinary failures and returning `Cancelled` only when the caller requests it.
The existing public seed tests also cover cancellation residue retention and
redaction of source error details.
