### PR TITLE
Resolve repository namespaces through isolated raw objects

### DIFF
--- a/crates/horizon-core/src/repository_overlay/namespace/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/mod.rs
@@ -2,8 +2,10 @@
 
 mod git;
 mod links;
+mod source;
 mod tree;
 
+use super::seed::{GitObjectInspector, SeedError};
 use super::{MAX_CHANGES, MAX_CONTENT_BYTES, MAX_METADATA_BYTES, OverlayPlanError, bundle::RepositoryOverlayBundle};
 use crate::cloud_run::ArtifactDigest;
 use git2::{Oid, Repository};
@@ -139,11 +141,46 @@ pub fn resolve_namespaces(
     bundle: RepositoryOverlayBundle,
 ) -> Result<ResolvedRepositoryOverlay, NamespaceError> {
     let base_commit = Oid::from_str(bundle.plan().source().commit.as_str()).map_err(|_| NamespaceError::Base)?;
-    let (base_tree, mut original) = git::read(base, base_commit)?;
+    compose(bundle, base_commit, git::read(base, base_commit)?, &|| false)
+}
+
+/// Resolve the exact base through an explicitly authorized raw-object inspector.
+/// Regular blobs remain header-only references; commit, tree and link bytes are
+/// length/type/hash verified within aggregate metadata and expanded namespace bounds.
+/// Read metadata work, including repeated tree expansion, is capped at 8 MiB; a valid
+/// repository can exceed this supported subset. Native source decoding needs its own caps.
+/// Only supported SHA-1 record shapes are accepted; signatures are not authenticated.
+/// The seed importer must still parse the complete commit before preparation succeeds.
+/// No repository metadata configuration, worktree I/O, writes or export authority.
+/// Source calls own their blocking/resource policy. Run off the UI thread; cancellation
+/// is checked between object operations, chunks, tree records and composition phases.
+/// # Errors
+/// Rejects invalid or unsupported metadata, unsafe topology/links, bounded-resource
+/// excess, cancellation and redacted source failures. No ready checkout is returned.
+pub fn resolve_namespaces_from_source(
+    source: &mut impl GitObjectInspector,
+    bundle: RepositoryOverlayBundle,
+    cancelled: impl Fn() -> bool,
+) -> Result<ResolvedRepositoryOverlay, NamespaceError> {
+    let base_commit = Oid::from_str(bundle.plan().source().commit.as_str()).map_err(|_| NamespaceError::Base)?;
+    let original = source::read(source, base_commit, &cancelled)?;
+    compose(bundle, base_commit, original, &cancelled)
+}
+
+fn compose(
+    bundle: RepositoryOverlayBundle,
+    base_commit: Oid,
+    (base_tree, mut original): (Oid, RepositoryNamespace),
+    cancelled: &impl Fn() -> bool,
+) -> Result<ResolvedRepositoryOverlay, NamespaceError> {
+    source::check_cancel(cancelled)?;
     let mut link_work = links::Work::default();
     tree::validate(&mut original, &mut link_work)?;
+    source::check_cancel(cancelled)?;
     let index = tree::apply(&original, bundle.plan().index(), &mut link_work)?;
+    source::check_cancel(cancelled)?;
     let working_tree = tree::apply(&index, bundle.plan().working_tree(), &mut link_work)?;
+    source::check_cancel(cancelled)?;
     Ok(ResolvedRepositoryOverlay {
         bundle,
         base_commit,
@@ -170,6 +207,8 @@ pub enum NamespaceError {
     Limit,
     #[error(transparent)]
     Policy(#[from] OverlayPlanError),
+    #[error(transparent)]
+    Source(#[from] SeedError),
 }
 
 #[derive(Default)]

--- a/crates/horizon-core/src/repository_overlay/namespace/source/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/source/mod.rs
@@ -1,0 +1,97 @@
+mod objects;
+mod records;
+
+use super::{Budget, NamespaceEntry, NamespaceError as Error, NamespaceFile, RepositoryNamespace};
+use crate::repository_overlay::{
+    MAX_METADATA_BYTES, paths,
+    seed::{GitObjectInspector, SeedError},
+};
+use git2::{ObjectType, Oid};
+use std::collections::BTreeSet;
+
+pub(super) fn check_cancel(cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+    if cancelled() {
+        Err(SeedError::Cancelled.into())
+    } else {
+        Ok(())
+    }
+}
+
+pub(super) fn read(
+    source: &mut impl GitObjectInspector,
+    commit: Oid,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(Oid, RepositoryNamespace), Error> {
+    let mut objects = objects::Objects::new(source, cancelled);
+    let root = records::commit_tree(&objects.read(commit, ObjectType::Commit, MAX_METADATA_BYTES)?)?;
+    let mut pending = vec![(String::new(), root)];
+    let mut namespace = RepositoryNamespace::default();
+    let mut budget = Budget::default();
+    let mut seen = BTreeSet::new();
+    while let Some((prefix, id)) = pending.pop() {
+        let bytes = objects.read(id, ObjectType::Tree, MAX_METADATA_BYTES)?;
+        if !prefix.is_empty() && bytes.is_empty() {
+            return Err(Error::UnsupportedNode);
+        }
+        let mut records = records::Tree::new(&bytes);
+        while let Some(entry) = records.next()? {
+            check_cancel(cancelled)?;
+            let length = prefix.len() + usize::from(!prefix.is_empty()) + entry.name.len();
+            if length > paths::MAX_PATH_BYTES {
+                return Err(Error::Limit);
+            }
+            let path = if prefix.is_empty() {
+                entry.name.to_owned()
+            } else {
+                format!("{prefix}/{}", entry.name)
+            };
+            paths::validate(&path)?;
+            if entry.kind == records::Kind::Directory {
+                budget.add(&path, None, 0)?;
+                if !seen.insert(path.clone()) {
+                    return Err(Error::Topology);
+                }
+                pending.push((path, entry.object));
+            } else {
+                let node = leaf(&mut objects, entry.object, entry.kind)?;
+                let (target, bytes) = match &node {
+                    NamespaceEntry::File { source, .. } => (None, source.bytes()),
+                    NamespaceEntry::Symlink { target } => (Some(target.as_str()), 0),
+                };
+                budget.add(&path, target, bytes)?;
+                if !seen.insert(path.clone()) || namespace.entries.insert(path, node).is_some() {
+                    return Err(Error::Topology);
+                }
+            }
+        }
+    }
+    Ok((root, namespace))
+}
+
+fn leaf<S: GitObjectInspector, C: Fn() -> bool>(
+    objects: &mut objects::Objects<'_, S, C>,
+    object: Oid,
+    kind: records::Kind,
+) -> Result<NamespaceEntry, Error> {
+    if kind == records::Kind::Link {
+        let bytes = objects.read(object, ObjectType::Blob, paths::MAX_PATH_BYTES)?;
+        Ok(NamespaceEntry::Symlink {
+            target: String::from_utf8(bytes).map_err(|_| Error::UnsupportedNode)?,
+        })
+    } else {
+        let metadata = objects.inspect(object)?;
+        if metadata.kind != ObjectType::Blob {
+            return Err(Error::Object);
+        }
+        Ok(NamespaceEntry::File {
+            source: NamespaceFile::Base {
+                object,
+                bytes: metadata.bytes,
+            },
+            executable: kind == records::Kind::Executable,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/namespace/source/objects.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/source/objects.rs
@@ -1,0 +1,79 @@
+use super::{Error, GitObjectInspector, MAX_METADATA_BYTES, SeedError, check_cancel};
+use crate::repository_overlay::seed::GitObjectMetadata;
+use git2::{ObjectType, Oid};
+use std::io::{self, Read};
+
+pub(super) struct Objects<'a, S, C> {
+    source: &'a mut S,
+    cancelled: &'a C,
+    metadata: usize,
+}
+
+impl<'a, S: GitObjectInspector, C: Fn() -> bool> Objects<'a, S, C> {
+    pub(super) fn new(source: &'a mut S, cancelled: &'a C) -> Self {
+        Self {
+            source,
+            cancelled,
+            metadata: 0,
+        }
+    }
+
+    pub(super) fn inspect(&mut self, object: Oid) -> Result<GitObjectMetadata, Error> {
+        check_cancel(self.cancelled)?;
+        let result = self.source.inspect(object);
+        check_cancel(self.cancelled)?;
+        result.map_err(Error::from)
+    }
+
+    pub(super) fn read(&mut self, object: Oid, kind: ObjectType, limit: usize) -> Result<Vec<u8>, Error> {
+        check_cancel(self.cancelled)?;
+        let stream = self.source.open(object);
+        check_cancel(self.cancelled)?;
+        let mut stream = stream?;
+        if stream.kind != kind {
+            return Err(Error::Object);
+        }
+        let length = usize::try_from(stream.bytes).map_err(|_| Error::Limit)?;
+        if length > limit {
+            return Err(Error::Limit);
+        }
+        self.metadata = self
+            .metadata
+            .checked_add(length)
+            .filter(|n| *n <= MAX_METADATA_BYTES)
+            .ok_or(Error::Limit)?;
+        let mut bytes = Vec::new();
+        bytes.try_reserve_exact(length).map_err(|_| Error::Limit)?;
+        bytes.resize(length, 0);
+        for chunk in bytes.chunks_mut(16 * 1024) {
+            let mut offset = 0;
+            while offset < chunk.len() {
+                let count = read_chunk(&mut *stream.reader, &mut chunk[offset..], self.cancelled)?;
+                if count == 0 {
+                    return Err(Error::Object);
+                }
+                offset += count;
+            }
+        }
+        if read_chunk(&mut *stream.reader, &mut [0], self.cancelled)? != 0
+            || Oid::hash_object(kind, &bytes).map_err(|_| Error::Object)? != object
+        {
+            return Err(Error::Object);
+        }
+        check_cancel(self.cancelled)?;
+        Ok(bytes)
+    }
+}
+
+fn read_chunk(reader: &mut dyn Read, bytes: &mut [u8], cancelled: &impl Fn() -> bool) -> Result<usize, Error> {
+    loop {
+        check_cancel(cancelled)?;
+        let result = reader.read(bytes);
+        check_cancel(cancelled)?;
+        match result {
+            Ok(count) => return Ok(count),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(_) => return Err(SeedError::Source.into()),
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/source/records.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/source/records.rs
@@ -1,0 +1,127 @@
+use super::Error;
+use git2::Oid;
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) enum Kind {
+    Directory,
+    File,
+    Executable,
+    Link,
+}
+
+pub(super) struct Entry<'a> {
+    pub name: &'a str,
+    pub object: Oid,
+    pub kind: Kind,
+}
+
+pub(super) struct Tree<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Tree<'a> {
+    pub(super) fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    pub(super) fn next(&mut self) -> Result<Option<Entry<'a>>, Error> {
+        if self.remaining.is_empty() {
+            return Ok(None);
+        }
+        let space = self.remaining.iter().position(|b| *b == b' ').ok_or(Error::Object)?;
+        let kind = match &self.remaining[..space] {
+            b"40000" | b"040000" => Kind::Directory,
+            b"100644" => Kind::File,
+            b"100755" => Kind::Executable,
+            b"120000" => Kind::Link,
+            _ => return Err(Error::UnsupportedNode),
+        };
+        let rest = &self.remaining[space + 1..];
+        let nul = rest.iter().position(|b| *b == 0).ok_or(Error::Object)?;
+        let name = std::str::from_utf8(&rest[..nul]).map_err(|_| Error::UnsupportedNode)?;
+        if name.is_empty() || name.contains('/') {
+            return Err(Error::UnsupportedNode);
+        }
+        let tail = &rest[nul + 1..];
+        let object = Oid::from_bytes(tail.get(..20).ok_or(Error::Object)?).map_err(|_| Error::Object)?;
+        self.remaining = &tail[20..];
+        Ok(Some(Entry { name, object, kind }))
+    }
+}
+
+pub(super) fn commit_tree(bytes: &[u8]) -> Result<Oid, Error> {
+    let boundary = bytes.windows(2).position(|pair| pair == b"\n\n").ok_or(Error::Object)?;
+    let mut lines = bytes[..boundary].split(|b| *b == b'\n');
+    let tree = oid_line(lines.next().ok_or(Error::Object)?, b"tree ")?;
+    let mut line = lines.next().ok_or(Error::Object)?;
+    while line.starts_with(b"parent ") {
+        oid_line(line, b"parent ")?;
+        line = lines.next().ok_or(Error::Object)?;
+    }
+    signature(line, b"author ")?;
+    line = lines.next().ok_or(Error::Object)?;
+    while line.starts_with(b"author ") {
+        signature(line, b"author ")?;
+        line = lines.next().ok_or(Error::Object)?;
+    }
+    signature(line, b"committer ")?;
+    let mut extra = false;
+    for line in lines {
+        if line.contains(&0) {
+            return Err(Error::Object);
+        }
+        if line.starts_with(b" ") {
+            if !extra {
+                return Err(Error::Object);
+            }
+        } else {
+            let space = line.iter().position(|b| *b == b' ').ok_or(Error::Object)?;
+            let key = &line[..space];
+            if key.is_empty()
+                || !key.iter().all(|b| b.is_ascii_alphanumeric() || *b == b'-')
+                || matches!(key, b"tree" | b"parent" | b"author" | b"committer")
+            {
+                return Err(Error::Object);
+            }
+            extra = true;
+        }
+    }
+    Ok(tree)
+}
+
+fn oid_line(line: &[u8], prefix: &[u8]) -> Result<Oid, Error> {
+    let hex = line
+        .strip_prefix(prefix)
+        .filter(|hex| hex.len() == 40)
+        .ok_or(Error::Object)?;
+    let text = std::str::from_utf8(hex).map_err(|_| Error::Object)?;
+    Oid::from_str(text).map_err(|_| Error::Object)
+}
+
+fn signature(line: &[u8], prefix: &[u8]) -> Result<(), Error> {
+    let value = line.strip_prefix(prefix).ok_or(Error::Object)?;
+    if value.contains(&0) {
+        return Err(Error::Object);
+    }
+    let close = value.iter().rposition(|b| *b == b'>').ok_or(Error::Object)?;
+    let open = value[..close].iter().position(|b| *b == b'<').ok_or(Error::Object)?;
+    if open == 0 || value[open - 1] != b' ' || value[open + 1..close].contains(&b'<') {
+        return Err(Error::Object);
+    }
+    let suffix = std::str::from_utf8(&value[close + 1..]).map_err(|_| Error::Object)?;
+    let mut fields = suffix.strip_prefix(' ').ok_or(Error::Object)?.split(' ');
+    fields
+        .next()
+        .ok_or(Error::Object)?
+        .parse::<i64>()
+        .map_err(|_| Error::Object)?;
+    let zone = fields.next().ok_or(Error::Object)?.as_bytes();
+    if zone.len() != 5
+        || !matches!(zone[0], b'+' | b'-')
+        || !zone[1..].iter().all(u8::is_ascii_digit)
+        || fields.next().is_some()
+    {
+        return Err(Error::Object);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/source/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/source/tests.rs
@@ -1,0 +1,315 @@
+use super::*;
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{
+        RepositoryOverlayPlan,
+        bundle::RepositoryOverlayBundle,
+        namespace::resolve_namespaces_from_source,
+        seed::{GitObjectMetadata, GitObjectSource, GitObjectStream},
+    },
+};
+use std::{
+    cell::Cell,
+    collections::BTreeMap,
+    io::{self, Read},
+    rc::Rc,
+};
+
+#[derive(Clone)]
+struct Record {
+    kind: ObjectType,
+    length: u64,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+struct Source {
+    records: BTreeMap<Oid, Record>,
+    opened: Vec<Oid>,
+    inspected: Vec<Oid>,
+    reads: Rc<Cell<usize>>,
+    fail: bool,
+    cancel: Option<Rc<Cell<bool>>>,
+}
+
+impl Source {
+    fn add(&mut self, kind: ObjectType, bytes: &[u8]) -> Oid {
+        let id = Oid::hash_object(kind, bytes).unwrap();
+        self.records.insert(
+            id,
+            Record {
+                kind,
+                length: bytes.len() as u64,
+                bytes: bytes.to_vec(),
+            },
+        );
+        id
+    }
+    fn commit(&mut self, tree: Oid) -> Oid {
+        self.add(ObjectType::Commit, &commit_bytes(tree))
+    }
+    fn resolve(&mut self, commit: Oid) -> Result<super::super::ResolvedRepositoryOverlay, Error> {
+        let plan = RepositoryOverlayPlan::new(
+            GitSource {
+                repository: "synthetic/project".into(),
+                commit: GitCommitSha::parse(commit.to_string()).unwrap(),
+                branch: None,
+            },
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        resolve_namespaces_from_source(self, RepositoryOverlayBundle::new(plan, vec![]).unwrap(), || false)
+    }
+}
+
+impl GitObjectSource for Source {
+    fn open(&mut self, id: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        self.opened.push(id);
+        let record = self.records.get(&id).ok_or(SeedError::Source)?;
+        Ok(GitObjectStream {
+            kind: record.kind,
+            bytes: record.length,
+            reader: Box::new(Reader {
+                bytes: io::Cursor::new(record.bytes.clone()),
+                reads: self.reads.clone(),
+                fail: self.fail,
+                cancel: self.cancel.clone(),
+            }),
+        })
+    }
+}
+
+impl GitObjectInspector for Source {
+    fn inspect(&mut self, id: Oid) -> Result<GitObjectMetadata, SeedError> {
+        self.inspected.push(id);
+        let record = self.records.get(&id).ok_or(SeedError::Source)?;
+        Ok(GitObjectMetadata {
+            kind: record.kind,
+            bytes: record.length,
+        })
+    }
+}
+
+struct Reader {
+    bytes: io::Cursor<Vec<u8>>,
+    reads: Rc<Cell<usize>>,
+    fail: bool,
+    cancel: Option<Rc<Cell<bool>>>,
+}
+
+impl Read for Reader {
+    fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+        self.reads.set(self.reads.get() + 1);
+        if let Some(cancel) = &self.cancel {
+            cancel.set(true);
+        }
+        if self.fail {
+            return Err(io::Error::other("private-fixture-marker"));
+        }
+        let limit = bytes.len().min(37);
+        self.bytes.read(&mut bytes[..limit])
+    }
+}
+
+fn commit_bytes(tree: Oid) -> Vec<u8> {
+    format!("tree {tree}\nauthor Fixture <fixture@example.invalid> 1 +0000\ncommitter Fixture <fixture@example.invalid> 1 +0000\n\nSynthetic\n").into_bytes()
+}
+
+fn tree_bytes(entries: &[(&str, &[u8], Oid)]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for (mode, name, id) in entries {
+        bytes.extend_from_slice(mode.as_bytes());
+        bytes.push(b' ');
+        bytes.extend_from_slice(name);
+        bytes.push(0);
+        bytes.extend_from_slice(id.as_bytes());
+    }
+    bytes
+}
+
+#[test]
+fn namespace_inspects_large_files_but_only_reads_commit_tree_and_literal_links() {
+    let mut source = Source::default();
+    let blob = source.add(ObjectType::Blob, b"unread bytes");
+    let length = 65 * 1024 * 1024 + 1;
+    source.records.get_mut(&blob).unwrap().length = length;
+    let link = source.add(ObjectType::Blob, b"large");
+    let tree = source.add(
+        ObjectType::Tree,
+        &tree_bytes(&[("100755", b"large", blob), ("120000", b"alias", link)]),
+    );
+    let commit = source.commit(tree);
+    let result = source.resolve(commit).unwrap();
+    assert_eq!(result.base().logical_bytes(), length);
+    assert!(matches!(
+        result.base().entry("large"),
+        Some(NamespaceEntry::File { executable: true, .. })
+    ));
+    assert_eq!(
+        result.base().entry("alias"),
+        Some(&NamespaceEntry::Symlink { target: "large".into() })
+    );
+    assert_eq!(source.opened, [commit, tree, link]);
+    assert_eq!(source.inspected, [blob]);
+}
+
+#[test]
+fn exact_metadata_reader_rejects_wrong_kind_size_hash_truncation_and_extra_bytes() {
+    for case in 0..5 {
+        let mut source = Source::default();
+        let id = source.add(ObjectType::Tree, b"literal");
+        let record = source.records.get_mut(&id).unwrap();
+        match case {
+            0 => record.kind = ObjectType::Blob,
+            1 => record.length += 1,
+            2 => record.bytes[0] ^= 1,
+            3 => {
+                record.bytes.pop();
+            }
+            _ => record.bytes.push(0),
+        }
+        let mut objects = objects::Objects::new(&mut source, &|| false);
+        assert_eq!(objects.read(id, ObjectType::Tree, 100), Err(Error::Object));
+        if case > 0 {
+            assert!(source.reads.get() > 0);
+        }
+    }
+}
+
+#[test]
+fn metadata_bounds_reject_headers_before_reads_and_charge_actual_aggregate_work() {
+    let mut source = Source::default();
+    let blob = source.add(ObjectType::Blob, b"unread");
+    source.records.get_mut(&blob).unwrap().length = u64::MAX;
+    assert_eq!(
+        objects::Objects::new(&mut source, &|| false).read(blob, ObjectType::Blob, 4096),
+        Err(Error::Limit)
+    );
+    assert_eq!(source.reads.get(), 0);
+
+    let tree = source.add(ObjectType::Tree, &tree_bytes(&[("100644", b"file", blob)]));
+    let mut bytes = commit_bytes(tree);
+    bytes.resize(MAX_METADATA_BYTES, b'x');
+    let commit = source.add(ObjectType::Commit, &bytes);
+    assert!(matches!(source.resolve(commit), Err(Error::Limit)));
+    assert_eq!(source.opened, [blob, commit, tree]);
+    assert!(source.inspected.is_empty());
+    assert!(source.reads.get() > MAX_METADATA_BYTES / 37);
+}
+
+#[test]
+fn malformed_tree_records_and_unsupported_modes_never_return_a_namespace() {
+    let oid = Oid::hash_object(ObjectType::Blob, b"literal").unwrap();
+    for raw in [
+        b"100644 name".to_vec(),
+        b"100644 name\0short".to_vec(),
+        tree_bytes(&[("100644", b"", oid)]),
+        tree_bytes(&[("100644", b"bad\xff", oid)]),
+        tree_bytes(&[("100644", b"a/b", oid)]),
+        tree_bytes(&[("160000", b"module", oid)]),
+        tree_bytes(&[("999999", b"mode", oid)]),
+    ] {
+        let mut source = Source::default();
+        let tree = source.add(ObjectType::Tree, &raw);
+        let commit = source.commit(tree);
+        assert!(source.resolve(commit).is_err());
+        assert!(source.inspected.is_empty());
+    }
+}
+
+#[test]
+fn repeated_tree_expansion_charges_real_pending_directories_and_each_leaf() {
+    use crate::repository_overlay::MAX_CHANGES;
+    for count in [MAX_CHANGES / 2, MAX_CHANGES / 2 + 1] {
+        let mut source = Source::default();
+        let blob = source.add(ObjectType::Blob, b"x");
+        let shared = source.add(ObjectType::Tree, &tree_bytes(&[("100644", b"file", blob)]));
+        let names: Vec<_> = (0..count).map(|n| format!("d{n}")).collect();
+        let entries: Vec<_> = names.iter().map(|name| ("40000", name.as_bytes(), shared)).collect();
+        let root = source.add(ObjectType::Tree, &tree_bytes(&entries));
+        let commit = source.commit(root);
+        let result = source.resolve(commit);
+        if count == MAX_CHANGES / 2 {
+            let result = result.unwrap();
+            assert_eq!(result.base().entries().len(), count);
+            assert_eq!(result.base().logical_bytes(), count as u64);
+            assert_eq!(source.opened.len(), count + 2);
+            assert_eq!(source.inspected.len(), count);
+        } else {
+            assert!(matches!(result, Err(Error::Limit)));
+            assert_eq!(source.inspected.len(), MAX_CHANGES - count + 1);
+        }
+        assert!(!source.opened.contains(&blob));
+    }
+}
+
+#[test]
+fn bounded_commit_structure_keeps_signed_headers_non_utf8_message_and_parent_ids() {
+    let tree = Oid::hash_object(ObjectType::Tree, b"").unwrap();
+    let mut valid = commit_bytes(tree);
+    let extras = format!(
+        "tree {tree}\nparent {tree}\nauthor Fixture <fixture@example.invalid> -1 +0130\nauthor Second <second@example.invalid> 1 -0200\ncommitter Fixture <fixture@example.invalid> 1 +0000\ngpgsig-sha256 synthetic\n continuation\nencoding synthetic\n\n"
+    );
+    assert_eq!(
+        records::commit_tree(&[extras.as_bytes(), b"message\xff\0"].concat()),
+        Ok(tree)
+    );
+    assert_eq!(records::commit_tree(&valid), Ok(tree));
+    for raw in [
+        b"tree short\n\n".to_vec(),
+        format!("tree {tree}\n\n").into_bytes(),
+        extras.replace("parent ", "parent invalid").into_bytes(),
+        extras.replace("committer ", "missing ").into_bytes(),
+        extras.replace("1 +0000", "invalid +0000").into_bytes(),
+        extras.replace("+0130", "0130").into_bytes(),
+        extras
+            .replace("gpgsig-sha256 synthetic", &format!("tree {tree}"))
+            .into_bytes(),
+        extras.replace("gpgsig-sha256 synthetic\n", "").into_bytes(),
+        extras
+            .replace("encoding synthetic", "encoding\0 synthetic")
+            .into_bytes(),
+    ] {
+        assert_eq!(records::commit_tree(&raw), Err(Error::Object));
+    }
+    let boundary = valid.windows(2).position(|p| p == b"\n\n").unwrap();
+    valid.truncate(boundary + 1);
+    assert_eq!(records::commit_tree(&valid), Err(Error::Object));
+}
+
+#[test]
+fn actual_payload_and_framing_failures_preserve_caller_cancel_and_redact_source_errors() {
+    for length in [0, 1] {
+        for cancellation in [false, true] {
+            let cancelled = Rc::new(Cell::new(false));
+            let mut source = Source {
+                fail: true,
+                cancel: cancellation.then(|| cancelled.clone()),
+                ..Source::default()
+            };
+            let id = source.add(ObjectType::Blob, &vec![0; length]);
+            let check = || cancelled.get();
+            let error = objects::Objects::new(&mut source, &check)
+                .read(id, ObjectType::Blob, 100)
+                .unwrap_err();
+            assert_eq!(source.reads.get(), 1);
+            assert_eq!(
+                error,
+                Error::Source(if cancellation {
+                    SeedError::Cancelled
+                } else {
+                    SeedError::Source
+                })
+            );
+            assert!(!format!("{error:?} {error}").contains("private-fixture-marker"));
+        }
+    }
+    let mut source = Source::default();
+    let id = source.add(ObjectType::Blob, b"unread");
+    assert_eq!(
+        objects::Objects::new(&mut source, &|| true).read(id, ObjectType::Blob, 100),
+        Err(Error::Source(SeedError::Cancelled))
+    );
+    assert!(source.opened.is_empty());
+}

--- a/crates/horizon-core/src/repository_overlay/namespace/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/namespace/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::repository_overlay::seed::{
+    GitObjectInspector, GitObjectMetadata, GitObjectSource, GitObjectStream, SeedError,
+};
 use crate::{
     cloud_run::{GitCommitSha, GitSource},
     repository_overlay::{OverlayChange, OverlayContent, RepositoryOverlayPlan, bundle::VerifiedOverlayBlob},
@@ -67,7 +70,61 @@ impl Fixture {
         working: Vec<OverlayChange>,
         blobs: Vec<VerifiedOverlayBlob>,
     ) -> Result<ResolvedRepositoryOverlay, NamespaceError> {
-        resolve_namespaces(&self.repository, self.bundle(index, working, blobs))
+        let copied = blobs
+            .iter()
+            .map(|blob| VerifiedOverlayBlob::new(blob.bytes().to_vec()).unwrap())
+            .collect();
+        let streamed = resolve_namespaces_from_source(
+            &mut RepositorySource(&self.repository),
+            self.bundle(index.clone(), working.clone(), copied),
+            || false,
+        );
+        let result = resolve_namespaces(&self.repository, self.bundle(index, working, blobs));
+        match (&result, &streamed) {
+            (Ok(left), Ok(right)) => {
+                assert_eq!(left.base_commit(), right.base_commit());
+                assert_eq!(left.base_tree(), right.base_tree());
+                for (a, b) in [
+                    (left.base(), right.base()),
+                    (left.index(), right.index()),
+                    (left.working_tree(), right.working_tree()),
+                ] {
+                    assert_eq!(a.entries().collect::<Vec<_>>(), b.entries().collect::<Vec<_>>());
+                    assert_eq!(a.logical_bytes(), b.logical_bytes());
+                }
+            }
+            (Err(_), Err(_)) => {}
+            _ => panic!("resolver parity mismatch: {result:?} / {streamed:?}"),
+        }
+        result
+    }
+}
+
+struct RepositorySource<'a>(&'a Repository);
+
+impl GitObjectSource for RepositorySource<'_> {
+    fn open(&mut self, id: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        let database = self.0.odb().map_err(|_| SeedError::Source)?;
+        let object = database.read(id).map_err(|_| SeedError::Source)?;
+        Ok(GitObjectStream {
+            kind: object.kind(),
+            bytes: object.len() as u64,
+            reader: Box::new(std::io::Cursor::new(object.data().to_vec())),
+        })
+    }
+}
+
+impl GitObjectInspector for RepositorySource<'_> {
+    fn inspect(&mut self, id: Oid) -> Result<GitObjectMetadata, SeedError> {
+        let (bytes, kind) = self
+            .0
+            .odb()
+            .and_then(|odb| odb.read_header(id))
+            .map_err(|_| SeedError::Source)?;
+        Ok(GitObjectMetadata {
+            kind,
+            bytes: bytes as u64,
+        })
     }
 }
 

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -39,6 +39,21 @@ pub trait GitObjectSource {
     fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError>;
 }
 
+/// Header claims only; consumers must verify payload identity when reading contents.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitObjectMetadata {
+    pub kind: ObjectType,
+    pub bytes: u64,
+}
+
+/// A source that can inspect objects without opening or abandoning payload streams.
+/// Inspection follows the source's existing resource, cancellation and trust policy.
+pub trait GitObjectInspector: GitObjectSource {
+    /// # Errors
+    /// Return a redacted failure without silently restarting a failed source session.
+    fn inspect(&mut self, object: Oid) -> Result<GitObjectMetadata, SeedError>;
+}
+
 /// Logically verified private Git seed. No working files, publication or durability proof.
 /// The path and its ancestry must remain exclusively controlled until later preparation
 /// and publication. Dropping this receipt never deletes data.

--- a/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
@@ -4,7 +4,7 @@ mod process;
 mod protocol;
 mod view;
 
-use super::{GitObjectSource, GitObjectStream, SeedError, SeedFailure, staging};
+use super::{GitObjectInspector, GitObjectMetadata, GitObjectSource, GitObjectStream, SeedError, SeedFailure, staging};
 use git2::Oid;
 use std::{
     fmt,
@@ -96,17 +96,31 @@ impl<'a> PackedGitObjectSource<'a> {
     pub fn metadata_path(&self) -> &Path {
         &self.metadata
     }
+
+    fn header(&mut self, object: Oid) -> Result<protocol::Header, SeedError> {
+        match self.session.info(object) {
+            Ok(header) => Ok(header),
+            Err(error) => {
+                self.session.poison();
+                Err(error)
+            }
+        }
+    }
+}
+
+impl GitObjectInspector for PackedGitObjectSource<'_> {
+    fn inspect(&mut self, object: Oid) -> Result<GitObjectMetadata, SeedError> {
+        let header = self.header(object)?;
+        Ok(GitObjectMetadata {
+            kind: header.kind,
+            bytes: header.bytes,
+        })
+    }
 }
 
 impl GitObjectSource for PackedGitObjectSource<'_> {
     fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
-        let header = match self.session.info(object) {
-            Ok(header) => header,
-            Err(error) => {
-                self.session.poison();
-                return Err(error);
-            }
-        };
+        let header = self.header(object)?;
         Ok(GitObjectStream {
             kind: header.kind,
             bytes: header.bytes,

--- a/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
@@ -2,7 +2,9 @@ use super::super::tests::{commit, private_fixture, snapshot};
 use super::*;
 use crate::{
     cloud_run::{GitCommitSha, GitSource},
-    repository_overlay::{RepositoryOverlayPlan, bundle::RepositoryOverlayBundle, namespace::resolve_namespaces},
+    repository_overlay::{
+        RepositoryOverlayPlan, bundle::RepositoryOverlayBundle, namespace::resolve_namespaces_from_source,
+    },
 };
 use git2::{ObjectType, Repository};
 use std::{
@@ -83,6 +85,16 @@ fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source()
     assert!(listing.lines().any(|line| line.split_whitespace().count() == 7));
     let before = snapshot(&path);
     let mut source = packed(parent.path(), &repository);
+    for _ in 0..3 {
+        assert_eq!(
+            source.inspect(second).unwrap(),
+            GitObjectMetadata {
+                kind: ObjectType::Blob,
+                bytes: bytes.len() as u64
+            }
+        );
+        assert_eq!(source.inspect(base).unwrap().kind, ObjectType::Commit);
+    }
     assert_eq!(raw(&mut source, second), bytes);
     let plan = RepositoryOverlayPlan::new(
         GitSource {
@@ -94,7 +106,11 @@ fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source()
         vec![],
     )
     .unwrap();
-    let resolved = resolve_namespaces(&repository, RepositoryOverlayBundle::new(plan, vec![]).unwrap()).unwrap();
+    let resolved =
+        resolve_namespaces_from_source(&mut source, RepositoryOverlayBundle::new(plan, vec![]).unwrap(), || {
+            false
+        })
+        .unwrap();
     let seed = super::super::prepare_git_seed(parent.path(), &resolved, &mut source, || false).unwrap();
     let seeded = Repository::open(seed.path()).unwrap();
     assert_eq!(seeded.find_blob(second).unwrap().content(), bytes);
@@ -103,6 +119,19 @@ fn real_loose_packed_delta_and_seed_consumer_preserve_exact_objects_and_source()
     drop(source);
     assert!(metadata.join("HEAD").exists());
     assert_eq!(snapshot(&path), before);
+}
+
+#[test]
+fn failed_header_inspection_poisoning_is_not_a_payload_open_or_restart() {
+    let fixture = private_fixture();
+    let repository = Repository::init(fixture.path()).unwrap();
+    let oid = repository.blob(b"known").unwrap();
+    let parent = private_fixture();
+    let mut source = packed(parent.path(), &repository);
+    let missing = Oid::hash_object(ObjectType::Blob, b"absent").unwrap();
+    assert_eq!(source.inspect(missing), Err(SeedError::Source));
+    assert_eq!(source.inspect(oid), Err(SeedError::Source));
+    assert!(matches!(source.open(oid), Err(SeedError::Source)));
 }
 
 #[test]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -208,6 +208,13 @@ back into large multi-purpose modules.
   and expanded path/logical-byte budgets are checked before returning file references.
   It does not read regular base payloads, write a checkout or authorize export;
   the later confined writer must revalidate referenced base bytes independently.
+  `namespace/source/` resolves the same immutable result through an explicit raw-object
+  inspector: bounded payload reads, supported SHA-1 commit/tree records and streamed
+  traversal stay separate. Regular base blobs are inspected without payload reads;
+  aggregate metadata work counts repeated expansion. The existing trusted-repository
+  resolver remains available and shares the whole-layer composition path. Header-only
+  inspection is additive to `seed/` object streaming, without abandoning lazy payloads;
+  the packed adapter shares one strict failure/poison path for both operations.
   `seed/` streams verified exact-base objects into an internally fresh private Git
   repository and constructs its detached HEAD, shallow boundary and independent
   staged index. Source adapters own their I/O behavior; private Git pathname writes


### PR DESCRIPTION
## Purpose

Connect repository namespace resolution to the isolated raw-object source used for
private checkout preparation. Continues #383; does not close it.

## Behavior and boundaries

- Add header-only object inspection without opening or abandoning lazy payloads.
  The packed source shares its existing strict framing/failure path for inspection
  and streaming; a failed session is never silently restarted.
- Resolve exact base, staged and working namespaces through this source. Regular
  base files remain header-only references, including files above the capture limit.
  Commit, tree and literal-link payloads are type/length/EOF/hash verified before use.
- Bound aggregate metadata work to 8 MiB, including repeated tree expansion, and
  retain existing expanded entry/path/logical/link rules. The parser supports ordinary
  SHA-1 commit/tree record shapes, preserves extra/signed headers and message bytes,
  and does not authenticate signatures. Full commit parsing remains a prerequisite
  for subsequent private seed preparation; resolution alone is not a ready checkout.
- Preserve the existing trusted-repository resolver and existing streaming-source
  implementations. Both resolvers share whole-layer composition. Source adapters
  retain their own memory, blocking and cancellation policy; the packed adapter's
  Linux/trusted-tool/stable-source premises still apply.
- No source mutations, export authorization, transfer, task startup, provider,
  UI, configuration, dependency or release changes. Complete workspace setup,
  remote checkpoint/recovery and cloud/PC-off acceptance remain.

## Validation

Exact candidate `eac45a30` passed the full local validation matrix:
formatting, maintainability/version checks, default and speech workspace tests,
and blocking/strict/advisory Clippy. Full independent local review and committed
parity verification completed.

All 151 repository-overlay regressions passed, including 16 namespace tests and
packed inspection/stream reuse. Shared fixtures compare both resolver outcomes and
all successful base/index/working entries. Counted sources prove header-only regular
files, exact payload corruption/framing rejection, pre-read limits, cancellation
after actual payload/framing failures, and real repeated-tree expansion at the
16,384-node boundary and beyond. The inherited casefold probe is conditional;
unavailable host support is not counted as positive casefold evidence.

A real public-API/ordinary-Git smoke resolved namespaces through the candidate API
and used the SAME packed source session for private seed, raw checkout and qualified
no-replace publication. A packed incompressible 65 MiB-plus base file, repeated header
inspection, independent staged index, raw binary/executable/link/LFS behavior and
exact shallow HEAD all passed. Positive synthetic ambient configuration controls
remained isolated; source bytes/modes and an existing destination were unchanged.
Only owned synthetic fixtures were explicitly cleaned up after receipt/source drop.
This is not power-loss, remote checkpointing or cloud/PC-off proof.
