### PR TITLE
Add explicit worker repository materialization command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "horizon-repository"
+version = "0.2.7"
+dependencies = [
+ "horizon-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "horizon-ui"
 version = "0.2.7"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/horizon-browser-protocol",
     "crates/horizon-core",
     "crates/horizon-cursor",
+    "crates/horizon-repository",
     "crates/horizon-ui",
 ]
 

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -132,6 +132,7 @@ RUN mkdir -p \
         crates/horizon-browser-protocol/src \
         crates/horizon-core/src \
         crates/horizon-cursor/src \
+        crates/horizon-repository/src \
         crates/horizon-ui/src \
     && touch \
         crates/horizon-browser/src/lib.rs \
@@ -142,6 +143,7 @@ RUN mkdir -p \
         crates/horizon-browser-protocol/src/lib.rs \
         crates/horizon-core/src/lib.rs \
         crates/horizon-cursor/src/lib.rs \
+        crates/horizon-repository/src/main.rs \
         crates/horizon-ui/src/main.rs \
     && cargo fetch --locked \
     && rm -rf /opt/horizon-dependency-cache

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
@@ -1,4 +1,7 @@
-use super::{PreparedPrivateCheckout, PublicationError as Error, PublicationFailure, PublishedCheckout, walk};
+use super::{
+    PreparedPrivateCheckout, PublicationError as Error, PublicationFailure, PublishedCheckout, validate_sibling_name,
+    walk,
+};
 use crate::repository_overlay::{paths, reader::SelectedRepositoryReader};
 use rustix::fs::{
     CWD, Mode, OFlags, RenameFlags, ResolveFlags, fstatfs, major, minor, openat2, readlinkat_raw, renameat_with,
@@ -70,11 +73,8 @@ fn before_rename(
     storage: &impl Fn(&File) -> Result<(), Error>,
 ) -> Result<(), Error> {
     check_cancel(cancelled)?;
-    if sibling.len() > 255
-        || sibling.contains('/')
-        || paths::validate(sibling).is_err()
-        || checkout.path.file_name() == Some(std::ffi::OsStr::new(sibling))
-    {
+    validate_sibling_name(sibling)?;
+    if checkout.path.file_name() == Some(std::ffi::OsStr::new(sibling)) {
         return Err(Error::InvalidName);
     }
     verify_binding(checkout)?;

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
@@ -7,6 +7,7 @@ mod walk;
 
 use super::PreparedPrivateCheckout;
 use crate::cloud_run::ArtifactDigest;
+use crate::repository_overlay::paths;
 use git2::Oid;
 use std::{
     fmt,
@@ -78,6 +79,14 @@ pub enum PublicationError {
     Storage,
     #[error("checkout publication was cancelled")]
     Cancelled,
+}
+
+pub(crate) fn validate_sibling_name(sibling: &str) -> Result<(), PublicationError> {
+    if sibling.len() > 255 || sibling.contains('/') || paths::validate(sibling).is_err() {
+        Err(PublicationError::InvalidName)
+    } else {
+        Ok(())
+    }
 }
 
 /// Synchronize a prepared tree and rename it to an explicitly named fresh sibling.

--- a/crates/horizon-core/src/repository_overlay/materialize/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/materialize/mod.rs
@@ -1,0 +1,196 @@
+//! Explicit one-shot materialization, never task admission or an idempotent remote job.
+
+use super::{
+    bundle::store::BundleStoreError,
+    checkout::{
+        PrivateCheckoutFailure,
+        publication::{PublicationFailure, PublishedCheckout, validate_sibling_name},
+    },
+    namespace::NamespaceError,
+    seed::SeedError,
+};
+use crate::cloud_run::ArtifactDigest;
+use std::{
+    fmt,
+    path::{Component, Path, PathBuf},
+};
+
+/// Maximum UTF-8 bytes in each explicitly nominated request path.
+pub const MAX_REQUEST_PATH_BYTES: usize = 4096;
+
+/// Explicitly authorized complete base closure, verified overlay and fresh destination.
+/// Source/ancestry remain stable and scratch is exclusively controlled by the caller.
+pub struct MaterializationRequest<'a> {
+    pub objects_directory: &'a Path,
+    pub bundle_store: &'a Path,
+    pub bundle_manifest: &'a ArtifactDigest,
+    pub scratch_parent: &'a Path,
+    pub destination: &'a str,
+}
+
+/// Acknowledged publication plus retained source metadata. Drop never cleans either.
+pub struct MaterializedRepository {
+    metadata: PathBuf,
+    checkout: PublishedCheckout,
+}
+
+impl MaterializedRepository {
+    #[must_use]
+    pub fn source_metadata(&self) -> &Path {
+        &self.metadata
+    }
+    #[must_use]
+    pub fn checkout(&self) -> &PublishedCheckout {
+        &self.checkout
+    }
+}
+
+impl fmt::Debug for MaterializedRepository {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MaterializedRepository").finish_non_exhaustive()
+    }
+}
+
+/// All known state remains inspectable. No failure authorizes retry or cleanup.
+pub struct MaterializationFailure {
+    pub problem: MaterializationProblem,
+    metadata: Option<PathBuf>,
+}
+
+impl MaterializationFailure {
+    #[must_use]
+    pub fn source_metadata(&self) -> Option<&Path> {
+        self.metadata.as_deref()
+    }
+}
+
+impl fmt::Debug for MaterializationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.problem, f)
+    }
+}
+impl fmt::Display for MaterializationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.problem, f)
+    }
+}
+impl std::error::Error for MaterializationFailure {}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MaterializationProblem {
+    #[error("repository materialization requires explicit supported paths and a fresh destination name")]
+    InvalidRequest,
+    #[error(transparent)]
+    Bundle(#[from] BundleStoreError),
+    #[error(transparent)]
+    Source(#[from] SeedError),
+    #[error(transparent)]
+    Namespace(#[from] NamespaceError),
+    #[error(transparent)]
+    Preparation(#[from] PrivateCheckoutFailure),
+    #[error(transparent)]
+    Publication(#[from] Box<PublicationFailure>),
+}
+
+/// Load one expected private bundle and materialize/publish it through one isolated source.
+/// Requires the existing source, private-ancestry, trusted-tool and qualified-storage
+/// contracts of the component APIs. Default packed decoding ceilings apply. No source
+/// config/history transfer, transport, task start, retry or cleanup is performed.
+/// Run off the UI thread. Component I/O owns blocking latency. Lost response or abrupt
+/// process termination is an unknown observed outcome, not proof of a clean rollback.
+/// # Errors
+/// Rejects invalid/unsupported requests or component failures, retaining all known
+/// residues and exact publication state. Successful receipt Drop also retains data.
+pub fn materialize_repository(
+    request: &MaterializationRequest<'_>,
+    cancelled: impl Fn() -> bool,
+) -> Result<MaterializedRepository, MaterializationFailure> {
+    let validation = if cancelled() {
+        Err(SeedError::Cancelled.into())
+    } else if ![request.objects_directory, request.bundle_store, request.scratch_parent]
+        .into_iter()
+        .all(valid_path)
+        || validate_sibling_name(request.destination).is_err()
+    {
+        Err(MaterializationProblem::InvalidRequest)
+    } else {
+        Ok(())
+    };
+    validation.map_err(|problem| MaterializationFailure {
+        problem,
+        metadata: None,
+    })?;
+    #[cfg(target_os = "linux")]
+    {
+        run(request, &cancelled)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(MaterializationFailure {
+            problem: SeedError::Unsupported.into(),
+            metadata: None,
+        })
+    }
+}
+
+fn valid_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path
+            .to_str()
+            .is_some_and(|text| text.len() <= MAX_REQUEST_PATH_BYTES && !text.contains('\0'))
+        && path
+            .components()
+            .all(|part| matches!(part, Component::Prefix(_) | Component::RootDir | Component::Normal(_)))
+}
+
+#[cfg(target_os = "linux")]
+fn run(
+    request: &MaterializationRequest<'_>,
+    cancelled: &impl Fn() -> bool,
+) -> Result<MaterializedRepository, MaterializationFailure> {
+    use super::{
+        bundle::store::RepositoryBundleStore,
+        checkout::{prepare_private_checkout, publication::publish_sibling_checkout},
+        namespace::resolve_namespaces_from_source,
+        seed::packed::{PackedGitObjectSource, PackedSourceLimits},
+    };
+
+    let bundle = RepositoryBundleStore::open(request.bundle_store).and_then(|store| store.get(request.bundle_manifest));
+    if cancelled() {
+        return Err(MaterializationFailure {
+            problem: SeedError::Cancelled.into(),
+            metadata: None,
+        });
+    }
+    let bundle = bundle.map_err(|error| MaterializationFailure {
+        problem: error.into(),
+        metadata: None,
+    })?;
+    let mut source = PackedGitObjectSource::new(
+        request.scratch_parent,
+        request.objects_directory,
+        PackedSourceLimits::default(),
+        cancelled,
+    )
+    .map_err(|failure| MaterializationFailure {
+        metadata: failure.residue().map(std::path::Path::to_owned),
+        problem: failure.reason.into(),
+    })?;
+    let metadata = source.metadata_path().to_owned();
+    let result = (|| {
+        let resolved = resolve_namespaces_from_source(&mut source, bundle, cancelled)?;
+        let checkout = prepare_private_checkout(request.scratch_parent, &resolved, &mut source, cancelled)?;
+        publish_sibling_checkout(checkout, request.destination, cancelled)
+            .map_err(|failure| MaterializationProblem::Publication(Box::new(failure)))
+    })();
+    match result {
+        Ok(checkout) => Ok(MaterializedRepository { metadata, checkout }),
+        Err(problem) => Err(MaterializationFailure {
+            problem,
+            metadata: Some(metadata),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/materialize/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/materialize/tests.rs
@@ -1,0 +1,295 @@
+use super::*;
+
+#[test]
+fn invalid_request_and_early_cancellation_do_not_create_anything() {
+    let fixture = tempfile::tempdir().unwrap();
+    let missing = fixture.path().join("missing-private-marker");
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    let mut request = MaterializationRequest {
+        objects_directory: &missing,
+        bundle_store: &missing,
+        bundle_manifest: &digest,
+        scratch_parent: &missing,
+        destination: "valid",
+    };
+    let failure = materialize_repository(&request, || true).unwrap_err();
+    assert!(matches!(
+        failure.problem,
+        MaterializationProblem::Source(SeedError::Cancelled)
+    ));
+    assert!(failure.source_metadata().is_none());
+    for name in ["../escape", "", ".git", "two/names"] {
+        request.destination = name;
+        let failure = materialize_repository(&request, || false).unwrap_err();
+        assert!(matches!(failure.problem, MaterializationProblem::InvalidRequest));
+        assert!(failure.source_metadata().is_none());
+        assert!(!format!("{failure:?} {failure}").contains("private-marker"));
+    }
+    assert!(!missing.exists());
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_has_no_filesystem_effects() {
+    let fixture = tempfile::tempdir().unwrap();
+    let missing = fixture.path().join("missing");
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    let request = MaterializationRequest {
+        objects_directory: &missing,
+        bundle_store: &missing,
+        bundle_manifest: &digest,
+        scratch_parent: &missing,
+        destination: "valid",
+    };
+    let failure = materialize_repository(&request, || false).unwrap_err();
+    assert!(matches!(
+        failure.problem,
+        MaterializationProblem::Source(SeedError::Unsupported)
+    ));
+    assert!(failure.source_metadata().is_none());
+    assert!(!missing.exists());
+}
+
+#[cfg(target_os = "linux")]
+mod supported {
+    use super::*;
+    use crate::{
+        cloud_run::{GitCommitSha, GitSource},
+        repository_overlay::{
+            OverlayChange, OverlayContent, RepositoryOverlayPlan,
+            bundle::{RepositoryOverlayBundle, VerifiedOverlayBlob, store::RepositoryBundleStore},
+            checkout::{PrivateCheckoutError, publication::PublicationError},
+        },
+    };
+    use git2::{Oid, Repository, Signature};
+    use std::{cell::Cell, fs, os::unix::fs::PermissionsExt};
+
+    struct Fixture {
+        source: tempfile::TempDir,
+        store: tempfile::TempDir,
+        parent: tempfile::TempDir,
+        objects: PathBuf,
+        base: Oid,
+        digest: ArtifactDigest,
+    }
+
+    fn private() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .permissions(fs::Permissions::from_mode(0o700))
+            .tempdir()
+            .unwrap()
+    }
+
+    impl Fixture {
+        fn new(missing_base: bool) -> Self {
+            let source = private();
+            let repository = Repository::init(source.path()).unwrap();
+            let blob = repository.blob(b"base\0raw\xff").unwrap();
+            let mut tree = repository.treebuilder(None).unwrap();
+            tree.insert("file", blob, 0o100_644).unwrap();
+            let tree = repository.find_tree(tree.write().unwrap()).unwrap();
+            let signature = Signature::now("Fixture", "fixture@example.invalid").unwrap();
+            let base = repository
+                .commit(None, &signature, &signature, "base", &tree, &[])
+                .unwrap();
+            let staged = VerifiedOverlayBlob::new(b"staged\0raw".to_vec()).unwrap();
+            let working = VerifiedOverlayBlob::new(b"working\0raw\r\n".to_vec()).unwrap();
+            let change = |blob: &VerifiedOverlayBlob| {
+                OverlayChange::new(
+                    "file".into(),
+                    OverlayContent::File {
+                        sha256: blob.sha256().clone(),
+                        bytes: blob.bytes().len() as u64,
+                        executable: true,
+                    },
+                )
+                .unwrap()
+            };
+            let plan = RepositoryOverlayPlan::new(
+                GitSource {
+                    repository: "synthetic/project".into(),
+                    commit: GitCommitSha::parse(if missing_base { "a".repeat(40) } else { base.to_string() }).unwrap(),
+                    branch: None,
+                },
+                [change(&staged)],
+                [change(&working)],
+            )
+            .unwrap();
+            let bundle = RepositoryOverlayBundle::new(plan, [staged, working]).unwrap();
+            let store = private();
+            let digest = RepositoryBundleStore::open(store.path()).unwrap().put(&bundle).unwrap();
+            let objects = repository.path().join("objects");
+            Self {
+                source,
+                store,
+                parent: private(),
+                objects,
+                base,
+                digest,
+            }
+        }
+
+        fn request(&self) -> MaterializationRequest<'_> {
+            MaterializationRequest {
+                objects_directory: &self.objects,
+                bundle_store: self.store.path(),
+                bundle_manifest: &self.digest,
+                scratch_parent: self.parent.path(),
+                destination: "ready",
+            }
+        }
+    }
+
+    #[test]
+    fn absent_bundle_source_and_cancelled_read_have_no_new_residues() {
+        let fixture = Fixture::new(false);
+        let missing = ArtifactDigest::sha256(b"missing");
+        let mut request = fixture.request();
+        request.bundle_manifest = &missing;
+        let failure = materialize_repository(&request, || false).unwrap_err();
+        assert!(matches!(
+            failure.problem,
+            MaterializationProblem::Bundle(BundleStoreError::Missing)
+        ));
+        assert!(failure.source_metadata().is_none());
+        let calls = Cell::new(0);
+        let failure = materialize_repository(&request, || {
+            calls.set(calls.get() + 1);
+            calls.get() > 1
+        })
+        .unwrap_err();
+        assert_eq!(calls.get(), 2);
+        assert!(matches!(
+            failure.problem,
+            MaterializationProblem::Source(SeedError::Cancelled)
+        ));
+        request.bundle_manifest = &fixture.digest;
+        let absent = fixture.source.path().join("absent");
+        request.objects_directory = &absent;
+        let failure = materialize_repository(&request, || false).unwrap_err();
+        assert!(matches!(failure.problem, MaterializationProblem::Source(_)));
+        assert!(failure.source_metadata().is_none());
+        assert_eq!(fs::read_dir(fixture.parent.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn namespace_failure_retains_only_source_metadata_even_after_drop() {
+        let fixture = Fixture::new(true);
+        let failure = materialize_repository(&fixture.request(), || false).unwrap_err();
+        assert!(matches!(failure.problem, MaterializationProblem::Namespace(_)));
+        let metadata = failure.source_metadata().unwrap().to_owned();
+        assert!(!format!("{failure:?} {failure}").contains(metadata.to_str().unwrap()));
+        drop(failure);
+        assert!(metadata.join("HEAD").exists());
+        assert_eq!(fs::read_dir(fixture.parent.path()).unwrap().count(), 1);
+        assert!(!fixture.parent.path().join("ready").exists());
+    }
+
+    #[test]
+    fn preparation_cancellation_reports_both_retained_directories() {
+        let fixture = Fixture::new(false);
+        let failure = materialize_repository(&fixture.request(), || {
+            fs::read_dir(fixture.parent.path()).unwrap().count() >= 2
+        })
+        .unwrap_err();
+        let metadata = failure.source_metadata().unwrap().to_owned();
+        let MaterializationProblem::Preparation(preparation) = &failure.problem else {
+            panic!("unexpected failure: {failure}");
+        };
+        assert_eq!(preparation.reason, PrivateCheckoutError::Seed(SeedError::Cancelled));
+        let residue = preparation.residue().unwrap().to_owned();
+        assert_ne!(metadata, residue);
+        drop(failure);
+        assert!(metadata.exists() && residue.exists());
+        assert_eq!(fs::read_dir(fixture.parent.path()).unwrap().count(), 2);
+    }
+
+    #[test]
+    fn cancellation_after_actual_rename_retains_published_unsynchronized_receipt() {
+        let fixture = Fixture::new(false);
+        let destination = fixture.parent.path().join("ready");
+        let failure = materialize_repository(&fixture.request(), || destination.exists()).unwrap_err();
+        let metadata = failure.source_metadata().unwrap().to_owned();
+        let MaterializationProblem::Publication(publication) = &failure.problem else {
+            panic!("unexpected failure: {failure}");
+        };
+        if matches!(
+            publication.as_ref(),
+            PublicationFailure::Unpublished {
+                reason: PublicationError::Unsupported,
+                ..
+            }
+        ) {
+            eprintln!("SKIP post-rename cancellation: unqualified filesystem");
+            assert!(!destination.exists());
+            return;
+        }
+        let PublicationFailure::PublishedUnsynchronized { reason, checkout } = publication.as_ref() else {
+            panic!("wrong publication state: {failure}");
+        };
+        assert_eq!(*reason, PublicationError::Cancelled);
+        assert_eq!(checkout.path(), destination);
+        assert_eq!(checkout.base_commit(), fixture.base);
+        assert_eq!(checkout.manifest_sha256(), &fixture.digest);
+        drop(failure);
+        assert!(metadata.join("HEAD").exists() && destination.join(".git/HEAD").exists());
+        assert_eq!(fs::read_dir(fixture.parent.path()).unwrap().count(), 2);
+    }
+
+    #[test]
+    fn publication_receipts_retain_exact_layers_and_never_replace_existing_data() {
+        for existing in [false, true] {
+            let fixture = Fixture::new(false);
+            let destination = fixture.parent.path().join("ready");
+            if existing {
+                fs::write(&destination, b"sentinel").unwrap();
+            }
+            let result = materialize_repository(&fixture.request(), || false);
+            let (metadata, checkout) = match &result {
+                Ok(repository) => {
+                    assert!(!existing);
+                    assert_eq!(repository.checkout().path(), destination);
+                    assert_eq!(repository.checkout().base_commit(), fixture.base);
+                    assert_eq!(repository.checkout().manifest_sha256(), &fixture.digest);
+                    (repository.source_metadata(), repository.checkout().path())
+                }
+                Err(failure) => {
+                    let MaterializationProblem::Publication(publication) = &failure.problem else {
+                        panic!("unexpected failure: {failure}");
+                    };
+                    let PublicationFailure::Unpublished { reason, checkout } = publication.as_ref() else {
+                        panic!("unexpected publication state: {failure}");
+                    };
+                    // An unsupported CI filesystem is not successful durability proof.
+                    assert!(
+                        *reason == PublicationError::Unsupported
+                            || (existing && *reason == PublicationError::DestinationExists)
+                    );
+                    if *reason == PublicationError::Unsupported {
+                        eprintln!("SKIP synchronized publication: unqualified filesystem");
+                    }
+                    assert_eq!(checkout.base_commit(), fixture.base);
+                    assert_eq!(checkout.manifest_sha256(), &fixture.digest);
+                    (failure.source_metadata().unwrap(), checkout.path())
+                }
+            };
+            assert_eq!(fs::read(checkout.join("file")).unwrap(), b"working\0raw\r\n");
+            assert_ne!(
+                fs::metadata(checkout.join("file")).unwrap().permissions().mode() & 0o111,
+                0
+            );
+            let repository = Repository::open(checkout).unwrap();
+            assert_eq!(repository.head().unwrap().target(), Some(fixture.base));
+            let index = repository.index().unwrap();
+            let entry = index.get_path(Path::new("file"), 0).unwrap();
+            assert_eq!(entry.mode, 0o100_755);
+            assert_eq!(repository.find_blob(entry.id).unwrap().content(), b"staged\0raw");
+            let (metadata, checkout) = (metadata.to_owned(), checkout.to_owned());
+            drop(result);
+            assert!(metadata.join("HEAD").exists() && checkout.join(".git/HEAD").exists());
+            if existing {
+                assert_eq!(fs::read(destination).unwrap(), b"sentinel");
+            }
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -5,6 +5,7 @@
 pub mod bundle;
 pub mod capture;
 pub mod checkout;
+pub mod materialize;
 pub mod namespace;
 mod paths;
 pub mod reader;

--- a/crates/horizon-repository/Cargo.toml
+++ b/crates/horizon-repository/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "horizon-repository"
+publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Explicit headless repository materialization for Horizon workers"
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+horizon-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,0 +1,65 @@
+#![forbid(unsafe_code)]
+
+mod protocol;
+
+use std::{
+    io::{self, Read, Write},
+    process::ExitCode,
+};
+
+fn main() -> ExitCode {
+    let arguments: Vec<_> = std::env::args_os().skip(1).take(2).collect();
+    if arguments.len() != 1 || arguments[0] != "materialize" {
+        eprintln!("Usage: horizon-repository materialize < request.json");
+        return ExitCode::from(2);
+    }
+    run(&mut io::stdin().lock(), &mut io::stdout().lock())
+}
+
+fn run(input: &mut impl Read, output: &mut impl Write) -> ExitCode {
+    let request = protocol::read_request(input);
+    let result = request.as_ref().map(protocol::execute);
+    let response = match &result {
+        Ok(result) => protocol::Response::from_result(result),
+        Err(()) => protocol::Response::rejected(),
+    };
+    let bytes = serde_json::to_vec(&response)
+        .ok()
+        .filter(|bytes| bytes.len() < protocol::RESPONSE_LIMIT);
+    let written = bytes.is_some_and(|bytes| {
+        output
+            .write_all(&bytes)
+            .and_then(|()| output.write_all(b"\n"))
+            .and_then(|()| output.flush())
+            .is_ok()
+    });
+    if !written {
+        eprintln!("Could not write a complete response; retain data and inspect before any retry.");
+        return ExitCode::from(3);
+    }
+    ExitCode::from(response.exit_code())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejection_is_complete_json_and_failed_output_is_distinct() {
+        let mut bytes = Vec::new();
+        assert_eq!(
+            run(&mut b"private-invalid-input".as_slice(), &mut bytes),
+            ExitCode::from(2)
+        );
+        assert!(bytes.ends_with(b"\n"));
+        let response: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(response["version"], 1);
+        assert_eq!(response["status"], "rejected");
+        assert!(response["source_metadata"].is_null() && response["checkout"].is_null());
+        assert!(!String::from_utf8(bytes).unwrap().contains("private-invalid-input"));
+        assert_eq!(
+            run(&mut b"{}".as_slice(), &mut [0_u8; 0].as_mut_slice()),
+            ExitCode::from(3)
+        );
+    }
+}

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -10,13 +10,20 @@ use std::{
 fn main() -> ExitCode {
     let arguments: Vec<_> = std::env::args_os().skip(1).take(2).collect();
     if arguments.len() != 1 || arguments[0] != "materialize" {
-        eprintln!("Usage: horizon-repository materialize < request.json");
+        let _ = writeln!(
+            io::stderr().lock(),
+            "Usage: horizon-repository materialize < request.json"
+        );
         return ExitCode::from(2);
     }
-    run(&mut io::stdin().lock(), &mut io::stdout().lock())
+    run(
+        &mut io::stdin().lock(),
+        &mut io::stdout().lock(),
+        &mut io::stderr().lock(),
+    )
 }
 
-fn run(input: &mut impl Read, output: &mut impl Write) -> ExitCode {
+fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Write) -> ExitCode {
     let request = protocol::read_request(input);
     let result = request.as_ref().map(protocol::execute);
     let response = match &result {
@@ -34,7 +41,10 @@ fn run(input: &mut impl Read, output: &mut impl Write) -> ExitCode {
             .is_ok()
     });
     if !written {
-        eprintln!("Could not write a complete response; retain data and inspect before any retry.");
+        let _ = writeln!(
+            diagnostics,
+            "Could not write a complete response; retain data and inspect before any retry."
+        );
         return ExitCode::from(3);
     }
     ExitCode::from(response.exit_code())
@@ -48,7 +58,7 @@ mod tests {
     fn rejection_is_complete_json_and_failed_output_is_distinct() {
         let mut bytes = Vec::new();
         assert_eq!(
-            run(&mut b"private-invalid-input".as_slice(), &mut bytes),
+            run(&mut b"private-invalid-input".as_slice(), &mut bytes, &mut io::sink()),
             ExitCode::from(2)
         );
         assert!(bytes.ends_with(b"\n"));
@@ -58,7 +68,11 @@ mod tests {
         assert!(response["source_metadata"].is_null() && response["checkout"].is_null());
         assert!(!String::from_utf8(bytes).unwrap().contains("private-invalid-input"));
         assert_eq!(
-            run(&mut b"{}".as_slice(), &mut [0_u8; 0].as_mut_slice()),
+            run(
+                &mut b"{}".as_slice(),
+                &mut [0_u8; 0].as_mut_slice(),
+                &mut [0_u8; 0].as_mut_slice()
+            ),
             ExitCode::from(3)
         );
     }

--- a/crates/horizon-repository/src/protocol.rs
+++ b/crates/horizon-repository/src/protocol.rs
@@ -1,0 +1,266 @@
+use horizon_core::{
+    cloud_run::ArtifactDigest,
+    repository_overlay::{
+        checkout::publication::PublicationFailure,
+        materialize::{
+            MAX_REQUEST_PATH_BYTES, MaterializationFailure, MaterializationProblem, MaterializationRequest,
+            MaterializedRepository, materialize_repository,
+        },
+    },
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+const REQUEST_LIMIT: usize = 16 * 1024;
+// An uncertain rename reports three paths: allow six-byte JSON escaping, one
+// bounded child component per path, fixed metadata and the final newline.
+pub(super) const RESPONSE_LIMIT: usize = (3 * 6 * (MAX_REQUEST_PATH_BYTES + 256) + 4096 + 1).next_power_of_two();
+const VERSION: u32 = 1;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Request {
+    version: u32,
+    objects_directory: PathBuf,
+    bundle_store: PathBuf,
+    bundle_manifest: ArtifactDigest,
+    scratch_parent: PathBuf,
+    destination: String,
+}
+
+pub(super) fn read_request(input: &mut impl Read) -> Result<Request, ()> {
+    let mut bytes = Vec::new();
+    input
+        .take(REQUEST_LIMIT as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| ())?;
+    if bytes.len() > REQUEST_LIMIT {
+        return Err(());
+    }
+    let request: Request = serde_json::from_slice(&bytes).map_err(|_| ())?;
+    if request.version != VERSION {
+        return Err(());
+    }
+    Ok(request)
+}
+
+pub(super) fn execute(request: &Request) -> Result<MaterializedRepository, MaterializationFailure> {
+    materialize_repository(
+        &MaterializationRequest {
+            objects_directory: &request.objects_directory,
+            bundle_store: &request.bundle_store,
+            bundle_manifest: &request.bundle_manifest,
+            scratch_parent: &request.scratch_parent,
+            destination: &request.destination,
+        },
+        || false,
+    )
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Rejected,
+    Unpublished,
+    Published,
+    PublishedUnsynchronized,
+    RenameUnconfirmed,
+}
+
+#[derive(Serialize)]
+pub(super) struct Response<'a> {
+    version: u32,
+    status: Status,
+    reason: Option<String>,
+    source_metadata: Option<&'a Path>,
+    checkout: Option<&'a Path>,
+    possible_destination: Option<&'a Path>,
+    base_commit: Option<String>,
+    bundle_manifest: Option<&'a ArtifactDigest>,
+}
+
+impl<'a> Response<'a> {
+    pub(super) fn rejected() -> Self {
+        Self {
+            version: VERSION,
+            status: Status::Rejected,
+            reason: Some("invalid or unsupported materialization request".into()),
+            source_metadata: None,
+            checkout: None,
+            possible_destination: None,
+            base_commit: None,
+            bundle_manifest: None,
+        }
+    }
+
+    pub(super) fn exit_code(&self) -> u8 {
+        match self.status {
+            Status::Published => 0,
+            Status::Rejected => 2,
+            Status::Unpublished | Status::PublishedUnsynchronized | Status::RenameUnconfirmed => 1,
+        }
+    }
+
+    pub(super) fn from_result(result: &'a Result<MaterializedRepository, MaterializationFailure>) -> Self {
+        let mut response = Self::rejected();
+        match result {
+            Ok(repository) => {
+                response.status = Status::Published;
+                response.reason = None;
+                response.source_metadata = Some(repository.source_metadata());
+                response.checkout = Some(repository.checkout().path());
+                response.base_commit = Some(repository.checkout().base_commit().to_string());
+                response.bundle_manifest = Some(repository.checkout().manifest_sha256());
+            }
+            Err(failure) => {
+                response.status = Status::Unpublished;
+                response.reason = Some(failure.to_string());
+                response.source_metadata = failure.source_metadata();
+                match &failure.problem {
+                    MaterializationProblem::InvalidRequest => response.status = Status::Rejected,
+                    MaterializationProblem::Preparation(failure) => response.checkout = failure.residue(),
+                    MaterializationProblem::Publication(failure) => response.publication(failure),
+                    _ => {}
+                }
+            }
+        }
+        response
+    }
+
+    fn publication(&mut self, failure: &'a PublicationFailure) {
+        match failure {
+            PublicationFailure::Unpublished { checkout, .. } => {
+                self.checkout = Some(checkout.path());
+                self.base_commit = Some(checkout.base_commit().to_string());
+                self.bundle_manifest = Some(checkout.manifest_sha256());
+            }
+            PublicationFailure::PublishedUnsynchronized { checkout, .. } => {
+                self.status = Status::PublishedUnsynchronized;
+                self.checkout = Some(checkout.path());
+                self.base_commit = Some(checkout.base_commit().to_string());
+                self.bundle_manifest = Some(checkout.manifest_sha256());
+            }
+            PublicationFailure::RenameUnconfirmed { checkout, destination } => {
+                self.status = Status::RenameUnconfirmed;
+                self.checkout = Some(checkout.path());
+                self.possible_destination = Some(destination);
+                self.base_commit = Some(checkout.base_commit().to_string());
+                self.bundle_manifest = Some(checkout.manifest_sha256());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io;
+
+    fn request() -> serde_json::Value {
+        json!({"version":1,"objects_directory":"/synthetic/objects",
+            "bundle_store":"/synthetic/store","bundle_manifest":"a".repeat(64),
+            "scratch_parent":"/synthetic/private","destination":"ready"})
+    }
+
+    fn accepts(value: &serde_json::Value) -> bool {
+        read_request(&mut serde_json::to_vec(value).unwrap().as_slice()).is_ok()
+    }
+
+    #[test]
+    fn version_digest_fields_and_framing_are_strict_and_bounded() {
+        let original = request();
+        assert!(accepts(&original));
+        for key in original.as_object().unwrap().keys() {
+            let mut value = original.clone();
+            value.as_object_mut().unwrap().remove(key);
+            assert!(!accepts(&value));
+        }
+        for (key, value) in [
+            ("version", json!(2)),
+            ("version", json!(-1)),
+            ("version", json!(1.5)),
+            ("bundle_manifest", json!("secret-invalid-digest")),
+            ("bundle_manifest", json!("g".repeat(64))),
+            ("unknown", json!(true)),
+            ("destination", json!(null)),
+        ] {
+            let mut altered = original.clone();
+            altered[key] = value;
+            assert!(!accepts(&altered));
+        }
+        let encoded = serde_json::to_string(&original).unwrap();
+        for malformed in [
+            format!("{encoded}{{}}"),
+            encoded.replacen('{', "{\"version\":1,", 1),
+            String::new(),
+        ] {
+            assert!(read_request(&mut malformed.as_bytes()).is_err());
+        }
+        let mut exact = encoded.into_bytes();
+        exact.resize(REQUEST_LIMIT, b' ');
+        assert!(read_request(&mut exact.as_slice()).is_ok());
+        exact.push(b' ');
+        assert!(read_request(&mut exact.as_slice()).is_err());
+        let mut endless = io::repeat(b' ');
+        assert!(read_request(&mut endless).is_err());
+        // A finite wrapper independently measures bytes consumed from an oversized stream.
+        let bytes = vec![b' '; REQUEST_LIMIT * 2];
+        let mut cursor = io::Cursor::new(bytes);
+        assert!(read_request(&mut cursor).is_err());
+        assert_eq!(cursor.position(), REQUEST_LIMIT as u64 + 1);
+    }
+
+    #[test]
+    fn escaped_retained_paths_fit_the_complete_response_bound() {
+        let components: [String; 11] = std::array::from_fn(|_| "\u{1}".repeat(230));
+        let scratch = PathBuf::from(format!("/{}", components.join("/")));
+        let mut value = request();
+        value["scratch_parent"] = json!(scratch);
+        let encoded = serde_json::to_vec(&value).unwrap();
+        assert!(encoded.len() < REQUEST_LIMIT);
+        assert!(read_request(&mut encoded.as_slice()).is_ok());
+        // Pure receipt-format regression, not a claim that a rename was performed.
+        for parent in [
+            scratch,
+            PathBuf::from(format!("/{}", "\u{1}".repeat(MAX_REQUEST_PATH_BYTES - 1))),
+        ] {
+            let metadata = parent.join("m".repeat(255));
+            let checkout = parent.join("c".repeat(255));
+            let destination = parent.join("d".repeat(255));
+            let mut response = Response::rejected();
+            response.status = Status::RenameUnconfirmed;
+            response.source_metadata = Some(&metadata);
+            response.checkout = Some(&checkout);
+            response.possible_destination = Some(&destination);
+            response.base_commit = Some("a".repeat(40));
+            let digest = ArtifactDigest::sha256(b"synthetic");
+            response.bundle_manifest = Some(&digest);
+            let bytes = serde_json::to_vec(&response).unwrap();
+            assert!(bytes.len() > 32 * 1024);
+            assert!(bytes.len() < RESPONSE_LIMIT, "complete JSON plus newline must fit");
+        }
+    }
+
+    #[test]
+    fn relative_paths_and_unsafe_names_fail_before_io_and_response_is_redacted() {
+        let mut value = request();
+        value["objects_directory"] = json!("private-relative-marker");
+        let parsed = read_request(&mut serde_json::to_vec(&value).unwrap().as_slice()).unwrap();
+        let result = execute(&parsed);
+        let response = Response::from_result(&result);
+        assert_eq!(response.exit_code(), 2);
+        let bytes = serde_json::to_vec(&response).unwrap();
+        assert!(
+            !String::from_utf8(bytes.clone())
+                .unwrap()
+                .contains("private-relative-marker")
+        );
+        let response: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(response["status"], "rejected");
+        assert!(response["source_metadata"].is_null() && response["checkout"].is_null());
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -241,6 +241,13 @@ back into large multi-purpose modules.
   deletion or task launch occurs; healthy storage and unchanged, exclusively held
   private ancestry, trusted kernel metadata and stable mounts remain required.
   This is not cloud recovery or power-loss proof.
+  `materialize/` composes existing private bundle retrieval, isolated raw-object
+  resolution, checkout preparation and explicit publication into one worker-callable
+  operation. Its typed result preserves source metadata and every known checkout or
+  uncertain destination; no retry or cleanup is implied. `horizon-repository` owns
+  only the bounded versioned JSON command boundary and truthful response/exit status.
+  It does not install itself in worker images or create a retained remote job: lost
+  output/termination requires later observation, not automatic replay or task start.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in

--- a/docs/remote-repository-command.md
+++ b/docs/remote-repository-command.md
@@ -51,7 +51,8 @@ Ordinary diagnostics omit request contents and paths.
 
 Invalid command-line arguments print static usage on stderr and exit 2, without
 reading stdin. Exit 3 means a complete response could not be written, not that the
-operation was rolled back. Malformed, absent or lost output and abrupt termination
+operation was rolled back. Stderr diagnostics are best-effort; failure to write them
+does not replace the command's exit status. Malformed, absent or lost output and abrupt termination
 are unknown observed outcomes regardless of exit status. Stdin and storage I/O
 have no hard end-to-end deadline. A successful stdout write is not a remote
 acknowledgement, and no process destructor is guaranteed on abrupt termination.

--- a/docs/remote-repository-command.md
+++ b/docs/remote-repository-command.md
@@ -1,0 +1,62 @@
+# Explicit worker repository materialization
+
+`cargo build -p horizon-repository` builds a headless, one-shot helper. It is not
+automatically installed in worker images or included in Horizon release assets.
+No default invocation creates anything; the only command is:
+
+```sh
+horizon-repository materialize < request.json
+```
+
+Stdin must contain one JSON object followed by EOF, at most 16 KiB including
+whitespace. Unknown, duplicate or missing fields, trailing objects and unsupported
+versions are rejected. Paths must be absolute UTF-8 paths without parent traversal.
+
+```json
+{
+  "version": 1,
+  "objects_directory": "/worker/source.git/objects",
+  "bundle_store": "/worker/bundles",
+  "bundle_manifest": "<64 hexadecimal SHA-256 characters>",
+  "scratch_parent": "/worker/materialization",
+  "destination": "repository"
+}
+```
+
+The digest must identify an existing verified `RepositoryBundleStore` record.
+The caller must separately authorize the entire nominated base commit closure,
+both overlay layers and publication. Source/ancestry must remain stable; the
+existing private scratch parent must be exclusively controlled by the caller.
+Existing packed-source resource limits and trusted system Git/prlimit requirements
+apply. Publication requires qualified Linux journaled ext4 with barriers, stable
+mount configuration and healthy storage. Other platforms reject without writes;
+an unsupported Linux filesystem can retain an unpublished prepared checkout.
+This is neither export authorization nor cloud durability or power-loss proof.
+
+Stdout is one JSON response plus newline, bounded to 128 KiB including that newline.
+The ceiling covers three retained paths at their worst-case JSON-escaped sizes.
+Every response has
+`version`, `status`, `reason`, `source_metadata`, `checkout`,
+`possible_destination`, `base_commit`, and `bundle_manifest`; unavailable values
+are null. Paths intentionally identify retained state for the authorized caller.
+Ordinary diagnostics omit request contents and paths.
+
+| Status | Exit | Meaning |
+| --- | --- | --- |
+| `rejected` | 2 | Invalid command input; no materialization was begun. |
+| `unpublished` | 1 | No publication confirmed; retain all reported scratch/checkout paths. |
+| `published` | 0 | No-replace rename and required synchronization completed; checkout names the destination. |
+| `published_unsynchronized` | 1 | Rename completed, but later synchronization/checks did not; checkout names the destination. |
+| `rename_unconfirmed` | 1 | Rename outcome is uncertain; inspect both checkout and possible_destination. |
+
+Invalid command-line arguments print static usage on stderr and exit 2, without
+reading stdin. Exit 3 means a complete response could not be written, not that the
+operation was rolled back. Malformed, absent or lost output and abrupt termination
+are unknown observed outcomes regardless of exit status. Stdin and storage I/O
+have no hard end-to-end deadline. A successful stdout write is not a remote
+acknowledgement, and no process destructor is guaranteed on abrupt termination.
+
+Dropping any receipt never deletes data. Nothing overwrites existing destinations,
+starts tasks, fetches remotely, schedules checkpoints, retries or cleans residues.
+A later worker-retained operation layer must provide non-creating observation and
+recovery before wiring this helper into client reconnect/setup flows.


### PR DESCRIPTION
## Purpose

Add an explicit worker-callable repository materialization command and its core
orchestration boundary. Refs #383; this does not close the complete feature issue.

## Behavior

- `horizon-repository materialize` accepts one strict versioned JSON request, at
  most 16 KiB, naming an existing private bundle store, expected manifest, stable
  object source, exclusively owned scratch parent and fresh destination component.
- The core retrieves/revalidates that bundle, resolves namespaces and prepares
  raw Git/working contents through the same isolated packed source, then requests
  synchronized no-replace sibling publication.
- Typed and bounded JSON receipts retain known source metadata and distinguish
  unpublished, published, published-unsynchronized and uncertain-rename states.
  The 128 KiB response ceiling includes escaping and the final newline.
- No task start, transport, retry, cleanup, overwrite, UI/config change, image
  publication or release is included. Lost output/termination is an unknown
  observed outcome, never proof of rollback or permission to retry.
- Preserve the worker image's manifest-only dependency fetch by registering the
  new command placeholder; its filtered context still excludes application source.

## Validation

Candidate: `d83ba187`. Full exact-commit local validation and independent
source/committed-parity review passed. Format, maintainability, version alignment,
default and speech workspace tests, blocking/strict/advisory Clippy all passed in
the final worktree. Six core and four command-boundary regressions
cover early failure, retained state, cancellation including after actual rename,
raw staged/working layers, strict input, complete output and escaped response bounds.

The actual command smoke uses a synthetic packed 65 MiB-plus base, ordinary Git
checks and positive ambient configuration/template controls. It verifies exact
shallow HEAD/index/raw bytes/modes/links/LFS semantics, retained collision receipts,
unchanged source/existing destination and a complete retained publication after
broken stdout exits 3. The exact-commit smoke passed, including explicit cleanup
of only its disposable synthetic fixture after retained-state assertions.

Both usage and failed-response diagnostics are best-effort: unavailable stderr
does not turn the documented exit statuses into a panic. The original failure was
reproduced as exit 101; the corrected real-process smoke checks exit 2 for invalid
arguments and exit 3 after actual retained publication when both outputs fail.

The real filtered Docker context reproduces the missing-target failure without the
new placeholder and passes locked dependency fetch/target registration with it.
Application source and Git metadata remain excluded. This checks the dependency
step, not a new published worker image or a running worker installation.

## Runtime assumptions and limits

Linux uses the existing trusted Git/prlimit, stable source/private ancestry and
qualified journaled-ext4-with-barriers publication contracts. Unsupported platforms
reject without writes; unsupported Linux storage can retain an unpublished checkout.
Filesystem/stdio operations do not acquire a hard end-to-end deadline. No durability
claim is made for remote/overlay filesystems, power loss or a lost remote response.
This helper is not yet packaged into worker images or a retained remote operation;
production transfer, worker-owned observation/checkpoint/recovery and cloud/PC-off
acceptance remain. UI smoke is not applicable to this headless-only outcome.

Scope: ten source/config/test files, 878 changed lines, two documentation files and
generated local-package lock registration. No external dependency versions changed.
