### PR TITLE
Package the explicit repository helper in the remote worker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,5 @@ containers/remote-worker/**
 !containers/remote-worker/panel-session.py
 !containers/remote-worker/tmux.conf
 !containers/remote-worker/sshd_config
+**/.git
+**/.git/**

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,11 @@
 !crates/*/
 crates/*/**
 !crates/*/Cargo.toml
+!crates/horizon-browser/src/**/*.rs
+!crates/horizon-browser-protocol/src/**/*.rs
+!crates/horizon-core/src/**/*.rs
+!crates/horizon-repository/src/**/*.rs
+crates/*/src/**/*.rs/**
 !containers/
 !containers/remote-worker/
 containers/remote-worker/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
+  remote-worker-build-context:
+    name: Remote worker build context
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify source allowlist and excluded-file controls
+        run: python3 -B containers/remote-worker/test_repository_packaging.py --docker-host unix:///var/run/docker.sock
+
   remote-panel-sessions:
     name: Remote panel sessions
     runs-on: ubuntu-latest

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -9,6 +9,26 @@ RUN apt-get update \
 COPY containers/remote-worker/build-tmux.sh /tmp/build-tmux.sh
 RUN bash /tmp/build-tmux.sh /opt/horizon-tmux
 
+FROM ${WORKER_BASE_IMAGE} AS repository-builder
+ENV RUSTUP_TOOLCHAIN=1.95.0
+WORKDIR /opt/horizon-repository-build
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+# Only manifests leave this stage alongside the compiled helper. In particular,
+# never copy the widened source context into a final-image layer and delete it later.
+RUN mkdir -p crates/horizon-browser-cli/src crates/horizon-browser-mcp/src \
+        crates/horizon-cursor/src crates/horizon-ui/src /opt/horizon-manifests \
+    && touch crates/horizon-browser-cli/src/lib.rs crates/horizon-browser-cli/src/main.rs \
+        crates/horizon-browser-mcp/src/lib.rs crates/horizon-browser-mcp/src/main.rs \
+        crates/horizon-cursor/src/lib.rs crates/horizon-ui/src/main.rs \
+    && cp Cargo.toml Cargo.lock /opt/horizon-manifests/ \
+    && for manifest in crates/*/Cargo.toml; do \
+        mkdir -p "/opt/horizon-manifests/$(dirname "${manifest}")" \
+        && cp "${manifest}" "/opt/horizon-manifests/${manifest}" || exit 1; \
+    done \
+    && cargo build --locked --release --package horizon-repository \
+    && install -m 0755 target/release/horizon-repository /opt/horizon-repository
+
 FROM ${WORKER_BASE_IMAGE}
 
 ARG WORKER_BASE_IMAGE
@@ -123,8 +143,7 @@ RUN node --version \
     && tmux -V
 
 WORKDIR /opt/horizon-dependency-cache
-COPY Cargo.toml Cargo.lock ./
-COPY crates/ crates/
+COPY --from=repository-builder /opt/horizon-manifests/ ./
 RUN mkdir -p \
         crates/horizon-browser/src \
         crates/horizon-browser-cli/src \
@@ -150,6 +169,7 @@ RUN mkdir -p \
 
 WORKDIR /workspace/horizon
 
+COPY --from=repository-builder /opt/horizon-repository /usr/local/bin/horizon-repository
 COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entrypoint
 COPY containers/remote-worker/host-identity.py /usr/local/bin/horizon-worker-host-identity
 COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -9,7 +9,8 @@ not consequences of closing a panel, exiting Horizon, or powering off the
 client PC.
 
 The image contains the Rust toolchain, Horizon's Linux build dependencies,
-Git/Git LFS, GitHub CLI, rsync, tar, tmux, SSH, CA certificates, and the
+Git/Git LFS, GitHub CLI, rsync, tar, tmux, SSH, CA certificates, the explicit
+`horizon-repository` helper, and the
 supported coding-agent CLIs. Their versions and both base-image digests are
 pinned in `Dockerfile` and the checksum-verified `build-tmux.sh` helper. The
 worker and its CI tests use tmux 3.7c built without utmp integration; older
@@ -45,9 +46,51 @@ Version tags make development builds understandable, but provider profiles must
 use a registry digest after publication. This slice does not publish an image
 or change any provider configuration.
 
-Only workspace manifests and the lockfile enter the dependency-cache build
-stage. Horizon source, local configuration, SSH material, tokens, and registry
-credentials are excluded from the build context and final image.
+The helper is compiled with the pinned Rust toolchain in a separate build stage.
+The context admits workspace manifests, the lockfile, reviewed worker scripts and
+only Rust source under the repository, core, browser and browser-protocol crates.
+Build from a trusted clean checkout: the source allowlist is not a secret scanner.
+Unrelated application source, local configuration, SSH material and credentials
+remain excluded. Only the executable crosses into the final runtime; the existing
+dependency cache receives a manifest-only tree, never Horizon source in any layer.
+
+## Explicit repository helper
+
+The image installs `/usr/local/bin/horizon-repository`. Nothing invokes it during
+startup or starts a task after it finishes. Its only operation is an explicitly
+authorized `horizon-repository materialize` call with bounded JSON on stdin.
+See the [command protocol](../../docs/remote-repository-command.md) for the complete
+request, receipts, exit codes and retained-state rules.
+
+Supply stable, authorized Git objects and an existing verified bundle store,
+plus a separately prepared private scratch parent on retained storage. Publication
+requires Linux journaled ext4 with barriers and readable kernel storage metadata;
+container overlay storage is not sufficient. Unsupported storage fails closed and
+may leave an unpublished checkout. No permission repair, overwrite or cleanup is
+implicit. Missing replies are uncertain outcomes, not permission to retry.
+
+This packaging does not add object transport, worker-retained operation identity,
+client setup, recovery, checkpointing or task admission. Existing workers are not
+upgraded by rebuilding an image. Neither the helper nor a locally retained volume
+proves cloud durability or PC-off operation.
+
+After building, run the synthetic image smoke against an explicit local Docker
+socket and a trusted journaled ext4 fixture parent:
+
+```bash
+python3 -B containers/remote-worker/test_repository_image.py \
+  --docker-host unix:///path/to/docker.sock --image horizon-remote-worker:0.1.0
+python3 -B containers/remote-worker/test_repository_packaging.py \
+  --docker-host unix:///path/to/docker.sock
+```
+
+The first checks large packed objects, raw index/worktree semantics, no-overwrite
+publication, retained data observed by a fresh container and overlay rejection.
+It uses no network or credentials and removes only its owned containers/fixtures.
+The second checks the real Docker context filter with positive source controls and
+excluded synthetic files. Add `--image` and `--expected-binary-sha256` from a separate
+`repository-builder` target to audit every final image layer and executable provenance.
+These tests retain images and fail, rather than claim success, on unsupported storage.
 
 ## Runtime contract
 

--- a/containers/remote-worker/test_repository_image.py
+++ b/containers/remote-worker/test_repository_image.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Exercise an existing local image against disposable synthetic retained storage."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import random
+import shutil
+import stat
+import struct
+import subprocess
+import tempfile
+import uuid
+
+
+def execute(argv, **kwargs):
+    return subprocess.run(argv, check=True, capture_output=True, timeout=300, **kwargs).stdout
+
+
+def encoded(value):
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def snapshot(root):
+    return {str(path.relative_to(root)): (digest(path.read_bytes()), stat.S_IMODE(path.stat().st_mode))
+            for path in root.rglob("*") if path.is_file()}
+
+
+class ImageSmoke:
+    def __init__(self, options):
+        if not options.docker_host.startswith("unix:///"):
+            raise ValueError("an explicit local Unix Docker socket is required")
+        self.docker = ["docker", "--host", options.docker_host]
+        self.image = json.loads(execute(self.docker + ["image", "inspect", options.image]))[0]["Id"]
+        security = json.loads(execute(self.docker + ["info", "--format", "{{json .SecurityOptions}}"] ))
+        self.user = "0:0" if "name=rootless" in security else f"{os.geteuid()}:{os.getegid()}"
+        self.label = str(uuid.uuid4())
+        self.containers = []
+        self.root = Path(tempfile.mkdtemp(prefix="horizon-repository-image-", dir=options.fixture_parent))
+        self.identity = self.root.stat().st_dev, self.root.stat().st_ino
+        self.environment = {"PATH": "/usr/bin:/bin", "LC_ALL": "C", "GIT_CONFIG_NOSYSTEM": "1",
+                            "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+                            "GIT_ALLOW_PROTOCOL": "", "GIT_TERMINAL_PROMPT": "0",
+                            "GIT_AUTHOR_NAME": "Fixture", "GIT_AUTHOR_EMAIL": "fixture@example.invalid",
+                            "GIT_COMMITTER_NAME": "Fixture", "GIT_COMMITTER_EMAIL": "fixture@example.invalid",
+                            "GIT_AUTHOR_DATE": "2000-01-01T00:00:00Z", "GIT_COMMITTER_DATE": "2000-01-01T00:00:00Z"}
+
+    def inspect(self, container):
+        value = json.loads(execute(self.docker + ["container", "inspect", container]))[0]
+        assert value["Id"] == container and value["Image"] == self.image
+        assert value["Config"]["Labels"]["horizon.repository-image-smoke"] == self.label
+        return value
+
+    def command(self, entrypoint, args, data=b"", overlay=False):
+        mounts = ["--mount", f"type=bind,src={self.root / 'source/objects'},dst=/objects,readonly",
+                  "--mount", f"type=bind,src={self.root / 'bundles'},dst=/bundles,readonly"]
+        if not overlay:
+            mounts += ["--mount", f"type=bind,src={self.root / 'retained'},dst=/retained"]
+        command = self.docker + ["create", "--pull=never", "--network=none", "--interactive",
+                                "--user", self.user, "--label", f"horizon.repository-image-smoke={self.label}",
+                                "--entrypoint", entrypoint] + mounts + [self.image] + args
+        container = execute(command).decode().strip()
+        self.containers.append(container)
+        self.inspect(container)
+        output = subprocess.run(self.docker + ["start", "--attach", "--interactive", container],
+                                input=data, capture_output=True, timeout=300, check=False)
+        observed = self.inspect(container)
+        assert not observed["State"]["Running"] and not observed["State"]["OOMKilled"]
+        assert output.returncode == observed["State"]["ExitCode"]
+        return output
+
+    def materialize(self, request, status, code):
+        output = self.command("/usr/local/bin/horizon-repository", ["materialize"], request)
+        assert output.returncode == code, (output.returncode, output.stdout, output.stderr)
+        assert not output.stderr and output.stdout.endswith(b"\n") and len(output.stdout) <= 128 * 1024
+        receipt = json.loads(output.stdout)
+        assert receipt["version"] == 1 and receipt["status"] == status
+        return receipt
+
+    def retire_completed(self):
+        while self.containers:
+            container = self.containers[-1]
+            assert not self.inspect(container)["State"]["Running"]
+            execute(self.docker + ["container", "rm", container])
+            self.containers.pop()
+
+    def git(self, root, *args, data=None, check=True):
+        return subprocess.run(["/usr/bin/git", "--no-replace-objects", "-C", str(root), *args],
+                              input=data, env=self.environment, capture_output=True, timeout=120, check=check)
+
+    def fixture(self):
+        for name in ("source", "bundles", "retained"):
+            (self.root / name).mkdir(mode=0o700)
+        source = self.root / "source"
+        self.git(source, "init", "--bare", "--template=", "--object-format=sha1")
+        old_blob = self.git(source, "hash-object", "-w", "--stdin", data=b"unrelated old bytes").stdout.strip()
+        old_tree = self.git(source, "mktree", data=b"100644 blob " + old_blob + b"\told\n").stdout.strip()
+        ancestor = self.git(source, "commit-tree", old_tree.decode(), data=b"old\n").stdout.strip()
+        self.large = random.Random(383).randbytes(65 * 1024 * 1024 + 1)
+        self.pointer = b"version https://git-lfs.github.com/spec/v1\noid sha256:synthetic\nsize 99\n"
+        files = {".gitattributes": b"* filter=lfs\n", "asset": self.pointer,
+                 "kept": b"unchanged", "large": self.large, "removed": b"remove this"}
+        records = []
+        for name, content in sorted(files.items()):
+            oid = self.git(source, "hash-object", "-w", "--stdin", data=content).stdout.strip()
+            records.append(b"100644 blob " + oid + b"\t" + name.encode() + b"\n")
+        tree = self.git(source, "mktree", data=b"".join(records)).stdout.strip()
+        self.base = self.git(source, "commit-tree", tree.decode(), "-p", ancestor.decode(), data=b"base\n").stdout.decode().strip()
+        self.git(source, "update-ref", "refs/heads/main", self.base)
+        self.git(source, "repack", "-ad")
+        assert list((source / "objects/pack").glob("*.pack"))
+        self.ancestor = ancestor.decode()
+        self.staged = b"staged\0binary\xff"
+        working = b"working-only hydrated bytes"
+        blobs = {digest(self.staged): self.staged, digest(working): working}
+        metadata = encoded({"domain": "horizon.repository-overlay", "version": 1,
+                            "repository": "synthetic/project", "commit": self.base, "branch": None,
+                            "index": [{"path": "link", "kind": "symlink", "target": "staged"},
+                                      {"path": "removed", "kind": "remove"},
+                                      {"path": "staged", "kind": "file", "sha256": digest(self.staged),
+                                       "bytes": len(self.staged), "executable": True}],
+                            "working_tree": [{"path": "asset", "kind": "file", "sha256": digest(working),
+                                              "bytes": len(working), "executable": False}]})
+        self.manifest = digest(metadata)
+        bundle = b"HZOVLY\0\x01" + struct.pack("<I", len(metadata)) + metadata + struct.pack("<I", len(blobs))
+        for key, value in sorted(blobs.items()):
+            bundle += key.encode() + struct.pack("<Q", len(value)) + value
+        path = self.root / "bundles" / (self.manifest + ".hzov")
+        path.write_bytes(bundle)
+        path.chmod(0o600)
+        self.request = {"version": 1, "objects_directory": "/objects", "bundle_store": "/bundles",
+                        "bundle_manifest": self.manifest, "scratch_parent": "/retained", "destination": "published"}
+
+    def verify_checkout(self, path):
+        assert self.git(path, "rev-parse", "HEAD").stdout.decode().strip() == self.base
+        assert self.git(path, "rev-list", "--count", "HEAD").stdout == b"1\n"
+        assert self.git(path, "rev-parse", "--is-shallow-repository").stdout == b"true\n"
+        assert not self.git(path, "fsck", "--full", "--strict").stdout
+        assert self.git(path, "cat-file", "-e", self.ancestor, check=False).returncode != 0
+        assert self.git(path, "show", ":asset").stdout == self.pointer
+        assert self.git(path, "show", ":staged").stdout == self.staged
+        assert self.git(path, "show", ":link").stdout == b"staged"
+        index = self.git(path, "ls-files", "--stage").stdout.decode().splitlines()
+        assert any(line.startswith("100755 ") and line.endswith("\tstaged") for line in index)
+        assert any(line.startswith("120000 ") and line.endswith("\tlink") for line in index)
+        assert not any(line.endswith("\tremoved") for line in index)
+        assert (path / "asset").read_bytes() == b"working-only hydrated bytes"
+        assert (path / "staged").read_bytes() == self.staged
+        assert stat.S_IMODE((path / "staged").stat().st_mode) == 0o755
+        assert (path / "link").readlink() == Path("staged")
+        assert (path / "large").read_bytes() == self.large
+        assert (path / "kept").read_bytes() == b"unchanged" and not (path / "removed").exists()
+
+    def test(self):
+        self.fixture()
+        before = snapshot(self.root / "source"), snapshot(self.root / "bundles")
+        for args in ([], ["unknown"], ["materialize", "extra"]):
+            result = self.command("/usr/local/bin/horizon-repository", args)
+            assert result.returncode == 2 and not result.stdout
+        for invalid in (b"{}", b"private-input-marker", b" " * 16385):
+            receipt = self.materialize(invalid, "rejected", 2)
+            assert "private-input-marker" not in str(receipt)
+        missing = dict(self.request, bundle_manifest="0" * 64)
+        self.materialize(encoded(missing), "unpublished", 1)
+        assert not list((self.root / "retained").iterdir())
+        receipt = self.materialize(encoded(self.request), "published", 0)
+        assert receipt["checkout"] == "/retained/published" and receipt["base_commit"] == self.base
+        assert receipt["bundle_manifest"] == self.manifest and receipt["possible_destination"] is None
+        assert receipt["reason"] is None
+        metadata = Path(receipt["source_metadata"])
+        assert metadata.parent == Path("/retained")
+        assert (self.root / "retained" / metadata.name / "HEAD").is_file()
+        self.verify_checkout(self.root / "retained/published")
+        collision = self.materialize(encoded(self.request), "unpublished", 1)
+        assert "destination already exists" in collision["reason"]
+        retained = Path(collision["checkout"])
+        assert retained.parent == Path("/retained") and retained.name != "published"
+        self.verify_checkout(self.root / "retained" / retained.name)
+        self.verify_checkout(self.root / "retained/published")
+        self.retire_completed()
+        # A fresh, non-creating observer proves data outlives container removal.
+        observation = self.command("/usr/bin/sha256sum", ["/retained/published/large"])
+        assert observation.returncode == 0 and observation.stdout.decode().split()[0] == digest(self.large)
+        # A private directory on the container's writable overlay is not qualified storage.
+        overlay = self.command("/usr/bin/python3", ["-c",
+            "import os,subprocess,sys; os.mkdir('/tmp/private-smoke',0o700); "
+            "r=subprocess.run(['/usr/local/bin/horizon-repository','materialize'],input=sys.stdin.buffer.read(),capture_output=True); "
+            "sys.stdout.buffer.write(r.stdout); sys.stderr.buffer.write(r.stderr); sys.exit(r.returncode)"],
+            encoded(dict(self.request, scratch_parent="/tmp/private-smoke")), overlay=True)
+        assert overlay.returncode == 1, (overlay.returncode, overlay.stdout, overlay.stderr)
+        rejected = json.loads(overlay.stdout)
+        assert rejected["status"] == "unpublished" and "unsupported" in rejected["reason"]
+        assert before == (snapshot(self.root / "source"), snapshot(self.root / "bundles"))
+        print("PASS image helper: strict input, packed 65 MiB-plus raw checkout, shallow HEAD/index/LFS/link/modes, "
+              "qualified publication, no overwrite, retained unpublished checkout, fresh-container observation, "
+              "unqualified overlay rejection and unchanged read-only inputs", flush=True)
+
+    def close(self):
+        for container in self.containers:
+            self.inspect(container)
+            execute(self.docker + ["container", "rm", "--force", container])
+        assert self.identity == (self.root.stat().st_dev, self.root.stat().st_ino)
+        shutil.rmtree(self.root)
+        print("Removed only this smoke's exact containers and synthetic fixture; image retained", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--docker-host", required=True, help="explicit local unix:///path/to/docker.sock")
+    parser.add_argument("--fixture-parent", default="/tmp", help="trusted local journaled ext4 parent")
+    options = parser.parse_args()
+    smoke = ImageSmoke(options)
+    print(f"Task-owned fixture: {smoke.root}; label: {smoke.label}; image: {smoke.image}", flush=True)
+    try:
+        smoke.test()
+    finally:
+        smoke.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/remote-worker/test_repository_packaging.py
+++ b/containers/remote-worker/test_repository_packaging.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Audit the actual Docker context filter and optional final image layers."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+import tempfile
+
+
+CRATES = ("horizon-repository", "horizon-core", "horizon-browser", "horizon-browser-protocol")
+WORKER_FILES = {"Dockerfile", "build-tmux.sh", "entrypoint.sh", "host-identity.py", "rust-path.sh",
+                "session.sh", "panel-session.py", "tmux.conf", "sshd_config"}
+
+
+def execute(argv, **kwargs):
+    return subprocess.run(argv, check=True, capture_output=True, timeout=600, **kwargs).stdout
+
+
+def admitted(path):
+    parts = path.parts
+    return (str(path) in ("Cargo.toml", "Cargo.lock")
+            or len(parts) == 3 and parts[0] == "crates" and parts[2] == "Cargo.toml"
+            or len(parts) >= 4 and parts[0] == "crates" and parts[1] in CRATES
+            and parts[2] == "src" and path.suffix == ".rs"
+            or len(parts) == 3 and parts[:2] == ("containers", "remote-worker") and parts[2] in WORKER_FILES)
+
+
+def context_test(docker, root, fixture):
+    context, exported = fixture / "context", fixture / "exported"
+    context.mkdir()
+    tracked = [Path(p.decode()) for p in execute(["git", "-C", str(root), "ls-files", "-z"]).split(b"\0") if p]
+    expected = {}
+    for path in tracked:
+        # Include unrelated Rust source as a negative control without copying LFS assets.
+        if admitted(path) or path.suffix == ".rs" or str(path) == ".dockerignore":
+            target = context / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(root / path, target)
+            if admitted(path):
+                expected[str(path)] = hashlib.sha256(target.read_bytes()).hexdigest()
+    for name in (".env", ".git/config", ".cargo/config.toml", ".ssh/id_ed25519", "target/fixture.rs",
+                 "crates/horizon-core/src/fixture.env", "crates/horizon-core/src/private/key.pem",
+                 "crates/horizon-core/src/fixture.rs/private.env", "crates/horizon-core/src/fixture.rs/nested/key.pem",
+                 "crates/horizon-core/src/fixture.rs/nested/source.rs",
+                 "crates/horizon-ui/src/untracked.rs", "containers/remote-worker/fixture-token"):
+        sentinel = context / name
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text("synthetic excluded marker\n")
+    execute(docker + ["build", "--file", "-", "--output", f"type=local,dest={exported}", str(context)],
+            input=b"FROM scratch\nCOPY . /\n")
+    observed = {str(path.relative_to(exported)): hashlib.sha256(path.read_bytes()).hexdigest()
+                for path in exported.rglob("*") if path.is_file()}
+    assert observed == expected, (observed.keys() - expected.keys(), expected.keys() - observed.keys())
+    assert all(any(name.startswith(f"crates/{crate}/src/") for name in observed) for crate in CRATES)
+    print(f"PASS actual Docker filter: {len(observed)} exact source/manifest/worker inputs; unrelated source and sentinels excluded", flush=True)
+
+
+def image_test(docker, image, fixture, expected_binary):
+    identity = json.loads(execute(docker + ["image", "inspect", image]))[0]["Id"]
+    archive = fixture / "image.tar"
+    execute(docker + ["image", "save", "--output", str(archive), identity])
+    binary_hashes = []
+    layers = 0
+    with tarfile.open(archive) as outer:
+        manifests = json.load(outer.extractfile("manifest.json"))
+        assert len(manifests) == 1
+        for layer_name in manifests[0]["Layers"]:
+            with tarfile.open(fileobj=outer.extractfile(layer_name), mode="r|*") as layer:
+                for item in layer:
+                    name = item.name.removeprefix("./")
+                    assert not name.startswith("opt/horizon-repository-build/"), name
+                    assert not name.startswith("opt/horizon-manifests/"), name
+                    if name.startswith("opt/horizon-dependency-cache/crates/"):
+                        assert not item.isfile() or name.endswith("/Cargo.toml"), name
+                    if name == "usr/local/bin/horizon-repository":
+                        assert item.isfile() and item.mode & 0o111
+                        binary_hashes.append(hashlib.sha256(layer.extractfile(item).read()).hexdigest())
+            layers += 1
+    assert binary_hashes == [expected_binary], binary_hashes
+    print(f"PASS {layers} final image layers: no Horizon build/source tree; exactly the expected executable hash", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--docker-host", required=True)
+    parser.add_argument("--image")
+    parser.add_argument("--expected-binary-sha256")
+    options = parser.parse_args()
+    if not options.docker_host.startswith("unix:///"):
+        parser.error("an explicit local Unix Docker socket is required")
+    if options.image and (not options.expected_binary_sha256 or len(options.expected_binary_sha256) != 64):
+        parser.error("image audit requires the separately observed build-stage binary SHA-256")
+    docker = ["docker", "--host", options.docker_host]
+    root = Path(__file__).resolve().parents[2]
+    with tempfile.TemporaryDirectory(prefix="horizon-repository-packaging-") as temporary:
+        fixture = Path(temporary)
+        context_test(docker, root, fixture)
+        if options.image:
+            image_test(docker, options.image, fixture, options.expected_binary_sha256)
+    print("Removed only temporary audit context, export and archive; images unchanged", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/remote-worker/test_repository_packaging.py
+++ b/containers/remote-worker/test_repository_packaging.py
@@ -46,6 +46,8 @@ def context_test(docker, root, fixture):
                  "crates/horizon-core/src/fixture.env", "crates/horizon-core/src/private/key.pem",
                  "crates/horizon-core/src/fixture.rs/private.env", "crates/horizon-core/src/fixture.rs/nested/key.pem",
                  "crates/horizon-core/src/fixture.rs/nested/source.rs",
+                 "crates/horizon-core/src/.git/hooks/fixture.rs",
+                 "crates/horizon-browser/src/nested/.git/hooks/fixture.rs",
                  "crates/horizon-ui/src/untracked.rs", "containers/remote-worker/fixture-token"):
         sentinel = context / name
         sentinel.parent.mkdir(parents=True, exist_ok=True)

--- a/docs/remote-repository-command.md
+++ b/docs/remote-repository-command.md
@@ -1,7 +1,9 @@
 # Explicit worker repository materialization
 
-`cargo build -p horizon-repository` builds a headless, one-shot helper. It is not
-automatically installed in worker images or included in Horizon release assets.
+`cargo build -p horizon-repository` builds a headless, one-shot helper. The
+[remote worker image](../containers/remote-worker/README.md#explicit-repository-helper)
+installs it from a separate pinned-toolchain build stage. It is not included in
+Horizon release assets, and existing running workers are not automatically upgraded.
 No default invocation creates anything; the only command is:
 
 ```sh


### PR DESCRIPTION
## Purpose and behavior

Refs #383. Install the existing explicit `horizon-repository materialize` command
in the remote worker image. Compile it with the pinned Rust toolchain in a separate
stage, transfer only its executable to the runtime, and preserve the existing
manifest-only dependency cache. Admit only required Rust source and worker inputs.

The entrypoint and task lifecycle are unchanged: no automatic materialization,
task start, retries, cleanup, image publication or release. Existing running workers
are not upgraded. Object transport, worker-retained operation identity, client
setup, checkpoints and cloud/PC-off acceptance remain separate work.

## Validation

Candidate `6618a15c`; seven files, including two documentation files. No dependency
versions or Rust behavior changed.

All applicable exact-commit local checks and image smoke lanes passed.

- Full exact-commit local matrix: format, maintainability/version sync, default
  and speech workspace tests, blocking/strict/pedantic lint tiers.
- Actual pinned-toolchain image build and separately observed helper digest;
  required runtime libraries and Git/process-limiter tools available.
- Actual Docker context: 328 exact inputs; excluded config/key/output/unrelated
  source controls, including nested Git metadata and descendants of directories
  named like Rust files.
  This lightweight regression also runs in CI.
- All 30 final image layers audited: no Horizon source/build tree and exactly the
  expected helper executable. Build from a trusted clean checkout; the allowlist
  is not a secret scanner.
- Real container command: packed 65 MiB-plus base, exact shallow HEAD/index,
  working-tree divergence, raw LFS pointers, executable/symlink modes, verified
  publication, no-overwrite collisions and retained unpublished checkout. Data
  remains after invocation containers are removed and is observed by a fresh
  non-creating container. Source/bundle mounts are read-only and unchanged.
- Existing worker security, disconnected progress, same-task reconnect, explicit
  data-preserving Stop, retained host identity and non-replayed task claims after
  container filesystem replacement.
- Independent local full-diff and committed-head parity review.

All smoke resources are synthetic and task-owned; no registry publication or
cloud resources are used. Publication tests require qualified journaled Linux ext4
with barriers and readable kernel metadata; unqualified container overlay storage
is explicitly rejected. Local container retention is not cloud durability or
power-loss proof. The optional workflow linter reports only the unchanged,
deliberately disabled Snap condition on both base and candidate.
