### PR TITLE
Share repository storage qualification

### DIFF
--- a/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/linux.rs
@@ -2,18 +2,14 @@ use super::{
     PreparedPrivateCheckout, PublicationError as Error, PublicationFailure, PublishedCheckout, validate_sibling_name,
     walk,
 };
-use crate::repository_overlay::{paths, reader::SelectedRepositoryReader};
-use rustix::fs::{
-    CWD, Mode, OFlags, RenameFlags, ResolveFlags, fstatfs, major, minor, openat2, readlinkat_raw, renameat_with,
-};
+use crate::repository_overlay::{reader::SelectedRepositoryReader, storage};
+use rustix::fs::{Mode, OFlags, RenameFlags, ResolveFlags, openat2, renameat_with};
 use std::{
     fs::{File, Metadata, OpenOptions},
-    io::Read,
     os::{
         fd::AsRawFd,
         unix::fs::{MetadataExt, OpenOptionsExt},
     },
-    path::Path,
 };
 
 const CONFINED: ResolveFlags = ResolveFlags::BENEATH
@@ -164,52 +160,8 @@ fn identity(metadata: &Metadata) -> (u64, u64) {
 }
 
 pub(super) fn supported_storage(parent: &File) -> Result<(), Error> {
-    if fstatfs(parent).map_err(|_| Error::Storage)?.f_type != libc::EXT4_SUPER_MAGIC {
-        return Err(Error::Unsupported);
-    }
-    let device = parent.metadata().map_err(|_| Error::Storage)?.dev();
-    let mut buffer = [0; 4097];
-    let length = readlinkat_raw(
-        CWD,
-        format!("/sys/dev/block/{}:{}", major(device), minor(device)),
-        &mut buffer[..],
-    )
-    .map_err(|_| Error::Unsupported)?;
-    if length == buffer.len() {
-        return Err(Error::Unsupported);
-    }
-    let target = std::str::from_utf8(&buffer[..length]).map_err(|_| Error::Unsupported)?;
-    let name = Path::new(target)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| name.len() <= 255 && paths::validate(name).is_ok())
-        .ok_or(Error::Unsupported)?;
-    let mut options = String::new();
-    File::open(format!("/proc/fs/ext4/{name}/options"))
-        .map_err(|_| Error::Unsupported)?
-        .take(4097)
-        .read_to_string(&mut options)
-        .map_err(|_| Error::Unsupported)?;
-    journaled_options(&options)
-}
-
-pub(super) fn journaled_options(options: &str) -> Result<(), Error> {
-    if options.len() > 4096 || !options.ends_with('\n') {
-        return Err(Error::Unsupported);
-    }
-    let lines: std::collections::BTreeSet<_> = options.split_terminator('\n').collect();
-    if lines.len() != options.split_terminator('\n').count()
-        || lines
-            .iter()
-            .any(|line| line.is_empty() || line.bytes().any(|b| b.is_ascii_control() || b == b' '))
-        || !lines.contains("rw")
-        || !lines.contains("barrier")
-        || lines.contains("ro")
-        || lines.contains("nobarrier")
-        || lines.iter().filter(|line| line.starts_with("data=")).count() != 1
-        || !(lines.contains("data=ordered") || lines.contains("data=journal"))
-    {
-        return Err(Error::Unsupported);
-    }
-    Ok(())
+    storage::qualify(parent).map_err(|error| match error {
+        storage::StorageQualificationError::Unsupported => Error::Unsupported,
+        storage::StorageQualificationError::Storage => Error::Storage,
+    })
 }

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/tests.rs
@@ -387,28 +387,3 @@ fn rename_error_after_actual_rename_is_uncertain_and_retains_both_names_for_insp
     drop(checkout);
     assert!(!old.exists() && destination.join(".git/HEAD").exists());
 }
-
-#[test]
-fn journal_contract_requires_exact_noncontradictory_bounded_kernel_options() {
-    for mode in ["ordered", "journal"] {
-        assert_eq!(linux::journaled_options(&format!("rw\nbarrier\ndata={mode}\n")), Ok(()));
-    }
-    for tail in [
-        "",
-        "data=writeback\n",
-        "data=ordered",
-        "data=ordered\r\n",
-        "data=ordered\nro\n",
-        "data=ordered\nnobarrier\n",
-        "data=ordered\nbarrier\n",
-        "data=ordered\ndata=journal\n",
-        "\n",
-    ] {
-        assert_eq!(
-            linux::journaled_options(&format!("rw\nbarrier\n{tail}")),
-            Err(PublicationError::Unsupported)
-        );
-    }
-    assert!(linux::journaled_options("rw\ndata=ordered\n").is_err());
-    assert!(linux::journaled_options(&"rw\nbarrier\ndata=ordered\n".repeat(200)).is_err());
-}

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -10,6 +10,8 @@ pub mod namespace;
 mod paths;
 pub mod reader;
 pub mod seed;
+#[cfg(target_os = "linux")]
+mod storage;
 
 use crate::cloud_run::{ArtifactDigest, GitSource};
 use std::{collections::BTreeMap, fmt};

--- a/crates/horizon-core/src/repository_overlay/storage.rs
+++ b/crates/horizon-core/src/repository_overlay/storage.rs
@@ -1,0 +1,97 @@
+//! Shared Linux storage qualification, without synchronization or write authority.
+
+use super::paths;
+use rustix::fs::{CWD, fstatfs, major, minor, readlinkat_raw};
+use std::{fs::File, io::Read, os::unix::fs::MetadataExt, path::Path};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub(super) enum StorageQualificationError {
+    #[error("repository storage is not a supported journaled filesystem")]
+    Unsupported,
+    #[error("repository storage qualification failed")]
+    Storage,
+}
+
+use StorageQualificationError as Error;
+
+/// Requires trusted kernel metadata and an unchanged mount configuration.
+pub(super) fn qualify(parent: &File) -> Result<(), Error> {
+    if fstatfs(parent).map_err(|_| Error::Storage)?.f_type != libc::EXT4_SUPER_MAGIC {
+        return Err(Error::Unsupported);
+    }
+    let device = parent.metadata().map_err(|_| Error::Storage)?.dev();
+    let mut buffer = [0; 4097];
+    let length = readlinkat_raw(
+        CWD,
+        format!("/sys/dev/block/{}:{}", major(device), minor(device)),
+        &mut buffer[..],
+    )
+    .map_err(|_| Error::Unsupported)?;
+    if length == buffer.len() {
+        return Err(Error::Unsupported);
+    }
+    let target = std::str::from_utf8(&buffer[..length]).map_err(|_| Error::Unsupported)?;
+    let name = Path::new(target)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| name.len() <= 255 && paths::validate(name).is_ok())
+        .ok_or(Error::Unsupported)?;
+    let mut options = String::new();
+    File::open(format!("/proc/fs/ext4/{name}/options"))
+        .map_err(|_| Error::Unsupported)?
+        .take(4097)
+        .read_to_string(&mut options)
+        .map_err(|_| Error::Unsupported)?;
+    journaled_options(&options)
+}
+
+fn journaled_options(options: &str) -> Result<(), Error> {
+    if options.len() > 4096 || !options.ends_with('\n') {
+        return Err(Error::Unsupported);
+    }
+    let lines: std::collections::BTreeSet<_> = options.split_terminator('\n').collect();
+    if lines.len() != options.split_terminator('\n').count()
+        || lines
+            .iter()
+            .any(|line| line.is_empty() || line.bytes().any(|b| b.is_ascii_control() || b == b' '))
+        || !lines.contains("rw")
+        || !lines.contains("barrier")
+        || lines.contains("ro")
+        || lines.contains("nobarrier")
+        || lines.iter().filter(|line| line.starts_with("data=")).count() != 1
+        || !(lines.contains("data=ordered") || lines.contains("data=journal"))
+    {
+        return Err(Error::Unsupported);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_contract_requires_exact_noncontradictory_bounded_kernel_options() {
+        for mode in ["ordered", "journal"] {
+            assert_eq!(journaled_options(&format!("rw\nbarrier\ndata={mode}\n")), Ok(()));
+        }
+        for tail in [
+            "",
+            "data=writeback\n",
+            "data=ordered",
+            "data=ordered\r\n",
+            "data=ordered\nro\n",
+            "data=ordered\nnobarrier\n",
+            "data=ordered\nbarrier\n",
+            "data=ordered\ndata=journal\n",
+            "\n",
+        ] {
+            assert_eq!(
+                journaled_options(&format!("rw\nbarrier\n{tail}")),
+                Err(Error::Unsupported)
+            );
+        }
+        assert!(journaled_options("rw\ndata=ordered\n").is_err());
+        assert!(journaled_options(&"rw\nbarrier\ndata=ordered\n".repeat(200)).is_err());
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -241,6 +241,9 @@ back into large multi-purpose modules.
   deletion or task launch occurs; healthy storage and unchanged, exclusively held
   private ancestry, trusted kernel metadata and stable mounts remain required.
   This is not cloud recovery or power-loss proof.
+  Linux `storage.rs` owns the shared, read-only journaled-filesystem qualification
+  and bounded kernel-option validation. Publication maps its errors to the existing
+  receipt contract; qualification alone does not synchronize, write or grant execution.
   `materialize/` composes existing private bundle retrieval, isolated raw-object
   resolution, checkout preparation and explicit publication into one worker-callable
   operation. Its typed result preserves source metadata and every known checkout or


### PR DESCRIPTION
## Purpose and behavior

Refs #383. Extract the existing Linux journaled-filesystem qualifier into a shared
repository-overlay module before adding retained setup admission. Move its bounded
kernel-option test with it and document the module boundary.

This is a focused structural prerequisite. Qualification policy, syscall order,
public publication errors, retained receipts and synchronization behavior are
unchanged. No setup claim, runner, retry, cleanup, transfer, UI, provider or release
behavior is added. No dependencies, versions or configuration defaults change.

## Validation

Candidate `410f2669`; four source/test files and one architecture note.
All applicable exact-commit local checks and image smoke lanes passed.

- Direct base/candidate comparison verifies identical qualifier and option-test
  bodies after only names, visibility and indentation are normalized.
- Full exact-commit local matrix: format, maintainability/version sync, default
  and speech workspace tests, blocking/strict/pedantic lint tiers.
- Explicit no-skip tests prove real qualified publication and unchanged
  data-preserving rejection of volatile storage.
- Actual pinned-toolchain worker image rebuild, independently observed helper
  digest, exact 329-input context audit and all 30 runtime layers audited.
- Actual packed 65 MiB-plus image materialization, exact shallow HEAD/index and
  raw working-file semantics, no overwrite, retained failed checkout, read-only
  input integrity, and fresh-container observation after invocation removal.
- Existing worker security, disconnected progress, data-preserving explicit Stop,
  retained host identity and non-replayed task claims after container replacement.
- Independent full-diff and committed-head parity review.

Smoke uses only disposable synthetic local containers and storage. Qualified Linux
ext4, trusted kernel metadata, stable mounts and healthy storage remain explicit
preconditions. This is not cloud durability, power-loss acceptance or an image
publication. There are no UI changes requiring native desktop interaction.
