### PR TITLE
Isolate renderability tests from interactive shells

### DIFF
--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -323,12 +323,14 @@ mod tests {
         let mut board = Board::new();
         let attached = board.create_workspace("attached");
         let detached = board.create_workspace("detached");
-        let attached_panel = board
-            .create_panel(PanelOptions::default(), attached)
-            .expect("attached panel");
-        let detached_panel = board
-            .create_panel(PanelOptions::default(), detached)
-            .expect("detached panel");
+        // Renderability depends on board membership, not an interactive PTY.
+        let options = || PanelOptions {
+            kind: PanelKind::Editor,
+            ..PanelOptions::default()
+        };
+        let attached_panel = board.create_panel(options(), attached).expect("attached panel");
+        let detached_panel = board.create_panel(options(), detached).expect("detached panel");
+        assert!(board.panels.iter().all(|panel| panel.terminal().is_none()));
         let detached_local_id = board.workspace(detached).expect("detached workspace").local_id.clone();
 
         let detached_workspaces = BTreeMap::from([(

--- a/crates/horizon-ui/src/app/actions.rs
+++ b/crates/horizon-ui/src/app/actions.rs
@@ -357,7 +357,7 @@ mod tests {
         let (board, _, detached_panel, detached_workspaces) = board_with_detached_workspace();
 
         // The detached window paints this panel in its own viewport; allowing it
-        // to also go fullscreen in the root window renders one PTY twice a frame.
+        // to also go fullscreen in the root window renders one panel twice a frame.
         assert!(!fullscreen_panel_is_renderable(
             &board,
             &detached_workspaces,


### PR DESCRIPTION
## Purpose

Make the three fullscreen renderability tests independent of interactive shell
startup and PTY cleanup. This is a focused CI unblocker for the ongoing #383 work.

The macOS x64 retry of [post-merge CI](https://github.com/peters/horizon/actions/runs/34216888512/attempts/2)
finished compilation in 2m 53s, then left
`fullscreen_panel_is_not_renderable_once_the_panel_is_closed` unfinished until
the job was cancelled at its 15-minute limit. The other UI tests had finished.
An earlier attempt instead timed out while compiling the speech tier. The retry
log establishes an unfinished test, not a diagnosed terminal deadlock.

## Behavior and scope

- Use two scratch editor panels in the shared renderability fixture, with no file
  path, shell or PTY. Assert that neither panel contains a terminal.
- Keep all three existing assertions and the real board create/close membership
  operations unchanged. The predicate does not depend on panel content type.
- Change only this test fixture and its explanation: nine additions and seven
  deletions in one file.
  No production code, workflow timeout, test exclusion or assertion is changed.

This removes an unnecessary process-lifecycle dependency from membership tests.
It does not claim to fix a runtime shutdown bug. Investigating the underlying
platform-specific shell behavior would require separate runtime evidence.

## Validation

All local evidence below passed on exact commit `c8046024`.

- Full eight-lane repository matrix, including both test feature sets and all
  lint tiers, passed on the final committed head.
- One hundred independently bounded test processes, each running all three
  renderability tests in parallel: all 300 passed on the final committed head.
- Independent local review of the complete test-only diff, comment correction and
  committed parity is clear. The review correction changes no behavior/assertion.

Runtime/UI behavior and container inputs are unchanged, so no interactive UI or
container smoke is applicable. Cross-platform tests on the PR and resulting main
commit remain required. The previous cancelled run is not reported as successful;
the repair must supply new successful CI evidence on its descendant commit.

Refs #383.
