### PR TITLE
Retain one-shot repository setup claims

### DIFF
--- a/crates/horizon-core/src/repository_overlay/materialize/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/materialize/mod.rs
@@ -133,7 +133,7 @@ pub fn materialize_repository(
     }
 }
 
-fn valid_path(path: &Path) -> bool {
+pub(super) fn valid_path(path: &Path) -> bool {
     path.is_absolute()
         && path
             .to_str()

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -9,6 +9,7 @@ pub mod materialize;
 pub mod namespace;
 mod paths;
 pub mod reader;
+pub mod retained_setup;
 pub mod seed;
 #[cfg(target_os = "linux")]
 mod storage;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/codec.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/codec.rs
@@ -1,0 +1,55 @@
+use super::{SetupClaimError as Error, SetupIntent};
+use crate::cloud_run::ArtifactDigest;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub(super) const MAX_RECORD_BYTES: usize = 64 * 1024;
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Record {
+    version: u32,
+    workspace_local_id: String,
+    objects_directory: PathBuf,
+    bundle_store: PathBuf,
+    bundle_manifest: ArtifactDigest,
+    destination: String,
+}
+
+pub(super) fn encode(intent: &SetupIntent) -> Result<Vec<u8>, Error> {
+    let record = Record {
+        version: 1,
+        workspace_local_id: intent.workspace_local_id.clone(),
+        objects_directory: intent.objects_directory.clone(),
+        bundle_store: intent.bundle_store.clone(),
+        bundle_manifest: intent.bundle_manifest.clone(),
+        destination: intent.destination.clone(),
+    };
+    let bytes = serde_json::to_vec(&record).map_err(|_| Error::InvalidRecord)?;
+    if bytes.len() > MAX_RECORD_BYTES {
+        return Err(Error::InvalidRecord);
+    }
+    Ok(bytes)
+}
+
+pub(super) fn decode(bytes: &[u8]) -> Result<SetupIntent, Error> {
+    if bytes.len() > MAX_RECORD_BYTES {
+        return Err(Error::InvalidRecord);
+    }
+    let record: Record = serde_json::from_slice(bytes).map_err(|_| Error::InvalidRecord)?;
+    if record.version != 1 {
+        return Err(Error::InvalidRecord);
+    }
+    let intent = SetupIntent::new(
+        record.workspace_local_id,
+        record.objects_directory,
+        record.bundle_store,
+        record.bundle_manifest,
+        record.destination,
+    )
+    .map_err(|_| Error::InvalidRecord)?;
+    if encode(&intent)? != bytes {
+        return Err(Error::InvalidRecord);
+    }
+    Ok(intent)
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/intent.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/intent.rs
@@ -1,0 +1,53 @@
+use super::SetupClaimError;
+use crate::{
+    cloud_run::ArtifactDigest,
+    remote_workspace::valid_local_id,
+    repository_overlay::{checkout::publication::validate_sibling_name, materialize::valid_path},
+};
+use std::{fmt, path::PathBuf};
+
+/// Complete immutable setup intent. The retained root determines the scratch slot;
+/// a client-supplied retry ID or runtime generation never selects a new claim slot.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SetupIntent {
+    pub(super) workspace_local_id: String,
+    pub(super) objects_directory: PathBuf,
+    pub(super) bundle_store: PathBuf,
+    pub(super) bundle_manifest: ArtifactDigest,
+    pub(super) destination: String,
+}
+
+impl SetupIntent {
+    /// Validate without filesystem access or authorization to transfer any source.
+    /// Paths use the existing materialization request policy, not alias inference.
+    /// # Errors
+    /// Rejects invalid workspace identity, unsupported paths or destination names.
+    pub fn new(
+        workspace_local_id: String,
+        objects_directory: PathBuf,
+        bundle_store: PathBuf,
+        bundle_manifest: ArtifactDigest,
+        destination: String,
+    ) -> Result<Self, SetupClaimError> {
+        if !valid_local_id(&workspace_local_id)
+            || !valid_path(&objects_directory)
+            || !valid_path(&bundle_store)
+            || validate_sibling_name(&destination).is_err()
+        {
+            return Err(SetupClaimError::InvalidIntent);
+        }
+        Ok(Self {
+            workspace_local_id,
+            objects_directory,
+            bundle_store,
+            bundle_manifest,
+            destination,
+        })
+    }
+}
+
+impl fmt::Debug for SetupIntent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetupIntent").finish_non_exhaustive()
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
@@ -33,9 +33,7 @@ pub(super) struct Directory {
 
 impl Directory {
     pub(super) fn open(path: &Path) -> Result<Self, Error> {
-        let reader = SelectedRepositoryReader::open(path)
-            .map_err(|_| Error::UnsafeRoot)?
-            .root;
+        let reader = SelectedRepositoryReader::open(path).map_err(root_error)?.root;
         let directory = File::from(
             openat2(
                 reader.handle(),
@@ -72,7 +70,7 @@ impl Directory {
         {
             return Err(Error::UnsafeRoot);
         }
-        let current = SelectedRepositoryReader::open(&self.path).map_err(|_| Error::UnsafeRoot)?;
+        let current = SelectedRepositoryReader::open(&self.path).map_err(root_error)?;
         let bound = current.root.handle().metadata().map_err(|_| Error::UnsafeRoot)?;
         if (metadata.dev(), metadata.ino()) != (bound.dev(), bound.ino()) {
             return Err(Error::UnsafeRoot);
@@ -88,7 +86,7 @@ impl Directory {
                 Ok(Some(record))
             }
             Err(RepositoryReadError::Missing) => Ok(None),
-            Err(_) => Err(Error::Read),
+            Err(error) => Err(read_error(error)),
         }
     }
 
@@ -179,6 +177,21 @@ fn link(file: &File, directory: &File) -> Result<(), rustix::io::Errno> {
         CLAIM,
         AtFlags::SYMLINK_FOLLOW,
     )
+}
+
+fn root_error(error: RepositoryReadError) -> Error {
+    match error {
+        RepositoryReadError::Unsupported => Error::Unsupported,
+        _ => Error::UnsafeRoot,
+    }
+}
+
+fn read_error(error: RepositoryReadError) -> Error {
+    match error {
+        RepositoryReadError::Unsupported => Error::Unsupported,
+        RepositoryReadError::TooLarge => Error::InvalidRecord,
+        _ => Error::Read,
+    }
 }
 
 fn storage_error(error: rustix::io::Errno) -> Error {

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
@@ -1,0 +1,192 @@
+use super::{SetupClaimError as Error, SetupIntent, SetupObservation, codec};
+use crate::repository_overlay::{
+    reader::{
+        RepositoryReadError, SelectedRepositoryReader,
+        linux::{RegularFileRead, Root},
+    },
+    storage,
+};
+use rustix::fs::{AtFlags, CWD, Mode, OFlags, ResolveFlags, linkat, openat2};
+use std::{
+    fs::File,
+    io::{self, Write},
+    os::{fd::AsRawFd, unix::fs::MetadataExt},
+    path::{Path, PathBuf},
+};
+
+const CLAIM: &str = "setup-claim.json";
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+pub(super) enum Admission {
+    Fresh,
+    Existing,
+}
+
+pub(super) struct Directory {
+    reader: Root,
+    handle: File,
+    path: PathBuf,
+}
+
+impl Directory {
+    pub(super) fn open(path: &Path) -> Result<Self, Error> {
+        let reader = SelectedRepositoryReader::open(path)
+            .map_err(|_| Error::UnsafeRoot)?
+            .root;
+        let directory = File::from(
+            openat2(
+                reader.handle(),
+                ".",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            )
+            .map_err(storage_error)?,
+        );
+        let result = Self {
+            reader,
+            handle: directory,
+            path: path.to_owned(),
+        };
+        result.verify()?;
+        result.qualify()?;
+        Ok(result)
+    }
+
+    fn qualify(&self) -> Result<(), Error> {
+        storage::qualify(&self.handle).map_err(|error| match error {
+            storage::StorageQualificationError::Unsupported => Error::Unsupported,
+            storage::StorageQualificationError::Storage => Error::Storage,
+        })
+    }
+
+    fn verify(&self) -> Result<(), Error> {
+        let metadata = self.handle.metadata().map_err(|_| Error::UnsafeRoot)?;
+        if !metadata.is_dir()
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o700
+            || metadata.nlink() == 0
+        {
+            return Err(Error::UnsafeRoot);
+        }
+        let current = SelectedRepositoryReader::open(&self.path).map_err(|_| Error::UnsafeRoot)?;
+        let bound = current.root.handle().metadata().map_err(|_| Error::UnsafeRoot)?;
+        if (metadata.dev(), metadata.ino()) != (bound.dev(), bound.ino()) {
+            return Err(Error::UnsafeRoot);
+        }
+        Ok(())
+    }
+
+    fn read(&self) -> Result<Option<RegularFileRead>, Error> {
+        self.verify()?;
+        match self.reader.read_private_file(CLAIM, codec::MAX_RECORD_BYTES) {
+            Ok(record) => {
+                codec::decode(&record.bytes)?;
+                Ok(Some(record))
+            }
+            Err(RepositoryReadError::Missing) => Ok(None),
+            Err(_) => Err(Error::Read),
+        }
+    }
+
+    pub(super) fn observe(&self, intent: &SetupIntent) -> Result<SetupObservation, Error> {
+        match self.read()? {
+            None => Ok(SetupObservation::Absent),
+            Some(record) if record.bytes == codec::encode(intent)? => Ok(SetupObservation::ClaimedUnknown),
+            Some(_) => Err(Error::Conflict),
+        }
+    }
+
+    pub(super) fn admit(&self, intent: &SetupIntent) -> Result<Admission, Error> {
+        self.qualify()?;
+        self.admit_with(
+            intent,
+            &mut |file, bytes| file.write_all(bytes),
+            &mut File::sync_all,
+            &mut link,
+        )
+    }
+
+    fn admit_with(
+        &self,
+        intent: &SetupIntent,
+        write: &mut impl FnMut(&mut File, &[u8]) -> io::Result<()>,
+        sync: &mut impl FnMut(&File) -> io::Result<()>,
+        publish: &mut impl FnMut(&File, &File) -> Result<(), rustix::io::Errno>,
+    ) -> Result<Admission, Error> {
+        if self.observe(intent)? == SetupObservation::ClaimedUnknown {
+            return Ok(Admission::Existing);
+        }
+        let bytes = codec::encode(intent)?;
+        let mut file = self.anonymous()?;
+        write(&mut file, &bytes).map_err(|_| Error::Storage)?;
+        sync(&file).map_err(|_| Error::Storage)?;
+        self.verify()?;
+        match publish(&file, &self.handle) {
+            Ok(()) => {
+                sync(&file).map_err(|_| Error::Storage)?;
+                sync(&self.handle).map_err(|_| Error::Storage)?;
+                let record = self.read()?.ok_or(Error::Read)?;
+                let actual = record.file.metadata().map_err(|_| Error::Read)?;
+                let expected = file.metadata().map_err(|_| Error::Read)?;
+                if record.bytes != bytes || (actual.dev(), actual.ino()) != (expected.dev(), expected.ino()) {
+                    return Err(Error::Read);
+                }
+                Ok(Admission::Fresh)
+            }
+            Err(rustix::io::Errno::EXIST) => match self.observe(intent)? {
+                SetupObservation::ClaimedUnknown => Ok(Admission::Existing),
+                SetupObservation::Absent => Err(Error::Read),
+            },
+            Err(error) => Err(storage_error(error)),
+        }
+    }
+
+    fn anonymous(&self) -> Result<File, Error> {
+        self.verify()?;
+        let file = File::from(
+            openat2(
+                &self.handle,
+                ".",
+                OFlags::TMPFILE | OFlags::RDWR | OFlags::CLOEXEC,
+                Mode::RUSR | Mode::WUSR,
+                CONFINED,
+            )
+            .map_err(storage_error)?,
+        );
+        let metadata = file.metadata().map_err(|_| Error::Storage)?;
+        if !metadata.is_file()
+            || metadata.nlink() != 0
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o600
+        {
+            return Err(Error::Storage);
+        }
+        Ok(file)
+    }
+}
+
+fn link(file: &File, directory: &File) -> Result<(), rustix::io::Errno> {
+    // Only this held anonymous regular inode is followed; the fixed destination
+    // is never replaced. A post-link failure must retain that replay barrier.
+    linkat(
+        CWD,
+        format!("/proc/self/fd/{}", file.as_raw_fd()),
+        directory,
+        CLAIM,
+        AtFlags::SYMLINK_FOLLOW,
+    )
+}
+
+fn storage_error(error: rustix::io::Errno) -> Error {
+    match error {
+        rustix::io::Errno::NOSYS | rustix::io::Errno::INVAL | rustix::io::Errno::OPNOTSUPP => Error::Unsupported,
+        _ => Error::Storage,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/tests.rs
@@ -1,0 +1,318 @@
+use super::super::{RetainedSetup, SetupAdmission, tests::intent};
+use super::*;
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+    sync::{Arc, Barrier},
+    thread,
+};
+
+fn private() -> tempfile::TempDir {
+    let root = tempfile::tempdir().unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    root
+}
+
+// Real confinement, private files, link and synchronization; these state tests
+// bypass only storage qualification and make no power-loss/durability claim.
+fn directory(path: &Path) -> Directory {
+    Directory {
+        reader: SelectedRepositoryReader::open(path).unwrap().root,
+        handle: File::open(path).unwrap(),
+        path: path.to_owned(),
+    }
+}
+
+fn admit(directory: &Directory, intent: &SetupIntent) -> Result<Admission, Error> {
+    directory.admit_with(
+        intent,
+        &mut |file, bytes| file.write_all(bytes),
+        &mut File::sync_all,
+        &mut link,
+    )
+}
+
+fn claim(path: &Path, bytes: &[u8]) {
+    fs::write(path.join(CLAIM), bytes).unwrap();
+    fs::set_permissions(path.join(CLAIM), fs::Permissions::from_mode(0o600)).unwrap();
+}
+
+#[test]
+fn observations_and_identical_retries_never_write_sync_or_replay() {
+    let root = private();
+    let directory = directory(root.path());
+    let intent = intent();
+    assert_eq!(directory.observe(&intent), Ok(SetupObservation::Absent));
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 0);
+    assert!(matches!(admit(&directory, &intent), Ok(Admission::Fresh)));
+    let before = fs::read(root.path().join(CLAIM)).unwrap();
+    let metadata = fs::metadata(root.path().join(CLAIM)).unwrap();
+    assert_eq!(metadata.mode() & 0o7777, 0o600);
+    for _ in 0..3 {
+        assert_eq!(directory.observe(&intent), Ok(SetupObservation::ClaimedUnknown));
+        assert!(matches!(
+            directory.admit_with(
+                &intent,
+                &mut |_, _| panic!("write"),
+                &mut |_| panic!("sync"),
+                &mut |_, _| panic!("link")
+            ),
+            Ok(Admission::Existing)
+        ));
+    }
+    assert_eq!(fs::read(root.path().join(CLAIM)).unwrap(), before);
+    assert_eq!(fs::metadata(root.path().join(CLAIM)).unwrap().ino(), metadata.ino());
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+    assert!(!root.path().join(super::super::SCRATCH_NAME).exists());
+}
+
+#[test]
+fn concurrent_identical_and_conflicting_admissions_have_at_most_one_winner() {
+    for conflict in [false, true] {
+        let root = private();
+        let barrier = Arc::new(Barrier::new(8));
+        let directory = Arc::new(directory(root.path()));
+        let handles: Vec<_> = (0..8)
+            .map(|index| {
+                let directory = Arc::clone(&directory);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let mut expected = intent();
+                    if conflict {
+                        expected.workspace_local_id.push_str(&index.to_string());
+                    }
+                    barrier.wait();
+                    admit(&directory, &expected)
+                })
+            })
+            .collect();
+        let outcomes: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        assert_eq!(outcomes.iter().filter(|r| matches!(r, Ok(Admission::Fresh))).count(), 1);
+        assert!(
+            outcomes
+                .iter()
+                .all(|r| matches!(r, Ok(Admission::Fresh | Admission::Existing) | Err(Error::Conflict)))
+        );
+        if conflict {
+            assert_eq!(outcomes.iter().filter(|r| matches!(r, Err(Error::Conflict))).count(), 7);
+        }
+        assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+}
+
+#[test]
+fn changed_fields_conflict_after_reopen_instead_of_selecting_another_slot() {
+    let root = private();
+    let expected = intent();
+    assert!(matches!(
+        admit(&directory(root.path()), &expected),
+        Ok(Admission::Fresh)
+    ));
+    for field in 0..5 {
+        let mut changed = expected.clone();
+        match field {
+            0 => changed.workspace_local_id.push('2'),
+            1 => changed.objects_directory.push("different"),
+            2 => changed.bundle_store.push("different"),
+            3 => changed.bundle_manifest = crate::cloud_run::ArtifactDigest::sha256(b"different"),
+            _ => changed.destination.push('2'),
+        }
+        let reopened = directory(root.path());
+        assert_eq!(reopened.observe(&changed), Err(Error::Conflict));
+        assert!(matches!(admit(&reopened, &changed), Err(Error::Conflict)));
+    }
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+}
+
+#[test]
+fn write_and_sync_faults_never_grant_and_post_link_claims_block_replay() {
+    for fail in 0..4 {
+        let root = private();
+        let directory = directory(root.path());
+        let mut syncs = 0;
+        let result = directory.admit_with(
+            &intent(),
+            &mut |file, bytes| {
+                if fail == 0 {
+                    file.write_all(&bytes[..5])?;
+                    return Err(io::ErrorKind::Other.into());
+                }
+                file.write_all(bytes)
+            },
+            &mut |file| {
+                syncs += 1;
+                if syncs == fail {
+                    return Err(io::ErrorKind::Other.into());
+                }
+                file.sync_all()
+            },
+            &mut link,
+        );
+        assert!(matches!(result, Err(Error::Storage)));
+        let named = fail >= 2;
+        assert_eq!(root.path().join(CLAIM).exists(), named);
+        assert_eq!(
+            directory.observe(&intent()).unwrap(),
+            if named {
+                SetupObservation::ClaimedUnknown
+            } else {
+                SetupObservation::Absent
+            }
+        );
+        if named {
+            assert!(matches!(admit(&directory, &intent()), Ok(Admission::Existing)));
+        }
+    }
+}
+
+#[test]
+fn link_error_after_real_link_is_uncertain_and_cannot_grant_on_retry() {
+    for actual_link in [false, true] {
+        let root = private();
+        let directory = directory(root.path());
+        let result = directory.admit_with(
+            &intent(),
+            &mut |file, bytes| file.write_all(bytes),
+            &mut File::sync_all,
+            &mut |file, parent| {
+                if actual_link {
+                    link(file, parent)?;
+                }
+                Err(rustix::io::Errno::IO)
+            },
+        );
+        assert!(matches!(result, Err(Error::Storage)));
+        assert_eq!(root.path().join(CLAIM).exists(), actual_link);
+        if actual_link {
+            assert!(matches!(admit(&directory, &intent()), Ok(Admission::Existing)));
+        }
+    }
+}
+
+#[test]
+fn synchronization_order_exposes_only_unknown_before_fresh_acknowledgement() {
+    let root = private();
+    let directory = directory(root.path());
+    let mut syncs = 0;
+    let result = directory.admit_with(
+        &intent(),
+        &mut |file, bytes| file.write_all(bytes),
+        &mut |file| {
+            syncs += 1;
+            assert_eq!(
+                directory.observe(&intent()).unwrap(),
+                if syncs == 1 {
+                    SetupObservation::Absent
+                } else {
+                    SetupObservation::ClaimedUnknown
+                }
+            );
+            assert_eq!(file.metadata().unwrap().is_dir(), syncs == 3);
+            file.sync_all()
+        },
+        &mut link,
+    );
+    assert!(matches!(result, Ok(Admission::Fresh)));
+    assert_eq!(syncs, 3);
+}
+
+#[test]
+fn malformed_and_unsafe_claims_fail_closed_without_repair() {
+    for kind in 0..7 {
+        let root = private();
+        let expected = intent();
+        match kind {
+            0 => claim(root.path(), b""),
+            1 => claim(root.path(), b"{\"version\":1"),
+            2 => claim(root.path(), &vec![b'x'; codec::MAX_RECORD_BYTES + 1]),
+            3 => {
+                claim(root.path(), &codec::encode(&expected).unwrap());
+                fs::set_permissions(root.path().join(CLAIM), fs::Permissions::from_mode(0o644)).unwrap();
+            }
+            4 => {
+                claim(root.path(), &codec::encode(&expected).unwrap());
+                fs::hard_link(root.path().join(CLAIM), root.path().join("alias")).unwrap();
+            }
+            5 => symlink("missing", root.path().join(CLAIM)).unwrap(),
+            _ => fs::create_dir(root.path().join(CLAIM)).unwrap(),
+        }
+        let directory = directory(root.path());
+        assert!(directory.observe(&expected).is_err());
+        assert!(admit(&directory, &expected).is_err());
+        assert!(fs::symlink_metadata(root.path().join(CLAIM)).is_ok());
+    }
+}
+
+#[test]
+fn missing_insecure_removed_and_replaced_roots_never_become_absent_claims() {
+    let outer = private();
+    let missing = outer.path().join("missing");
+    assert!(matches!(RetainedSetup::open(&missing), Err(Error::UnsafeRoot)));
+    assert!(!missing.exists());
+    for remove in [false, true] {
+        let root = outer.path().join(if remove { "removed" } else { "replaced" });
+        fs::create_dir(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let directory = directory(&root);
+        if remove {
+            fs::remove_dir(&root).unwrap();
+        } else {
+            fs::rename(&root, outer.path().join("old")).unwrap();
+            fs::create_dir(&root).unwrap();
+        }
+        assert_eq!(directory.observe(&intent()), Err(Error::UnsafeRoot));
+        assert!(matches!(admit(&directory, &intent()), Err(Error::UnsafeRoot)));
+    }
+    fs::set_permissions(outer.path(), fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(matches!(RetainedSetup::open(outer.path()), Err(Error::UnsafeRoot)));
+}
+
+#[test]
+fn qualified_public_admission_grant_drop_and_process_reopen_never_replay() {
+    let root = private();
+    let store = match RetainedSetup::open(root.path()) {
+        Err(Error::Unsupported) => {
+            eprintln!("SKIP real claim: requires qualified journaled ext4");
+            return;
+        }
+        other => other.unwrap(),
+    };
+    let SetupAdmission::Fresh(grant) = store.admit(intent()).unwrap() else {
+        panic!("fresh grant");
+    };
+    assert_eq!(grant.intent(), &intent());
+    assert_eq!(format!("{grant:?}"), "SetupGrant { .. }");
+    drop(grant);
+    drop(store);
+    let child = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "repository_overlay::retained_setup::linux::tests::reopen_child",
+            "--nocapture",
+        ])
+        .env("HORIZON_SETUP_CLAIM_FIXTURE", root.path())
+        .output()
+        .unwrap();
+    assert!(child.status.success(), "{}", String::from_utf8_lossy(&child.stderr));
+    assert!(String::from_utf8_lossy(&child.stdout).contains("REOPEN_NO_REPLAY"));
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+}
+
+#[test]
+fn reopen_child() {
+    let Some(root) = std::env::var_os("HORIZON_SETUP_CLAIM_FIXTURE") else {
+        return;
+    };
+    let store = RetainedSetup::open(Path::new(&root)).unwrap();
+    assert_eq!(store.observe(&intent()), Ok(SetupObservation::ClaimedUnknown));
+    assert!(matches!(store.admit(intent()), Ok(SetupAdmission::Existing)));
+    println!("REOPEN_NO_REPLAY");
+}
+
+#[test]
+fn volatile_storage_is_rejected_without_claim_or_root_creation() {
+    let root = tempfile::tempdir_in("/dev/shm").unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(matches!(RetainedSetup::open(root.path()), Err(Error::Unsupported)));
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 0);
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/tests.rs
@@ -237,9 +237,28 @@ fn malformed_and_unsafe_claims_fail_closed_without_repair() {
             _ => fs::create_dir(root.path().join(CLAIM)).unwrap(),
         }
         let directory = directory(root.path());
-        assert!(directory.observe(&expected).is_err());
-        assert!(admit(&directory, &expected).is_err());
+        let error = if kind <= 2 { Error::InvalidRecord } else { Error::Read };
+        assert_eq!(directory.observe(&expected), Err(error));
+        assert!(matches!(admit(&directory, &expected), Err(actual) if actual == error));
         assert!(fs::symlink_metadata(root.path().join(CLAIM)).is_ok());
+    }
+}
+
+#[test]
+fn reader_errors_preserve_unsupported_confinement_and_invalid_records() {
+    assert_eq!(root_error(RepositoryReadError::Unsupported), Error::Unsupported);
+    assert_eq!(read_error(RepositoryReadError::Unsupported), Error::Unsupported);
+    assert_eq!(read_error(RepositoryReadError::TooLarge), Error::InvalidRecord);
+    for error in [
+        RepositoryReadError::InvalidRoot,
+        RepositoryReadError::Missing,
+        RepositoryReadError::UnsafePath,
+        RepositoryReadError::UnsupportedNode,
+        RepositoryReadError::Changed,
+        RepositoryReadError::ReadFailed,
+    ] {
+        assert_eq!(root_error(error), Error::UnsafeRoot);
+        assert_eq!(read_error(error), Error::Read);
     }
 }
 

--- a/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
@@ -1,0 +1,129 @@
+//! Worker-owned setup admission, not a runner, retry policy or completion receipt.
+//! The nominated root must be retained independently of runtime/client generations.
+//! Its private ancestry and mount configuration must remain trusted and stable.
+
+#[cfg(any(target_os = "linux", test))]
+mod codec;
+mod intent;
+#[cfg(target_os = "linux")]
+mod linux;
+
+pub use intent::SetupIntent;
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+use std::{fmt, path::Path};
+
+const SCRATCH_NAME: &str = "setup-data";
+
+/// One fixed claim slot in an existing, privately owned retained workspace root.
+pub struct RetainedSetup {
+    #[cfg(target_os = "linux")]
+    directory: Arc<linux::Directory>,
+}
+
+/// Read-only observation cannot establish synchronization, liveness or completion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupObservation {
+    Absent,
+    ClaimedUnknown,
+}
+
+#[derive(Debug)]
+pub enum SetupAdmission {
+    Fresh(SetupGrant),
+    Existing,
+}
+
+/// Only a freshly synchronized admission can construct this non-cloneable grant.
+/// Dropping it retains the claim. It cannot be reconstructed from stored bytes.
+pub struct SetupGrant {
+    intent: SetupIntent,
+    #[cfg(target_os = "linux")]
+    _directory: Arc<linux::Directory>,
+}
+
+impl SetupGrant {
+    #[must_use]
+    pub fn intent(&self) -> &SetupIntent {
+        &self.intent
+    }
+}
+
+impl fmt::Debug for SetupGrant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetupGrant").finish_non_exhaustive()
+    }
+}
+
+impl RetainedSetup {
+    /// Open existing private, qualified storage; never create or repair it.
+    /// Run off the UI thread; filesystem byte bounds do not bound I/O latency.
+    /// # Errors
+    /// Rejects missing, unsupported, untrusted or invalid roots without fallback.
+    pub fn open(root: &Path) -> Result<Self, SetupClaimError> {
+        if !super::materialize::valid_path(&root.join(SCRATCH_NAME)) {
+            return Err(SetupClaimError::InvalidIntent);
+        }
+        #[cfg(target_os = "linux")]
+        return Ok(Self {
+            directory: Arc::new(linux::Directory::open(root)?),
+        });
+        #[cfg(not(target_os = "linux"))]
+        Err(SetupClaimError::Unsupported)
+    }
+
+    /// Observe only: no creation, synchronization, expiry, repair or execution.
+    /// # Errors
+    /// Read/parse failures never mean absence; changed intent is a conflict.
+    pub fn observe(&self, intent: &SetupIntent) -> Result<SetupObservation, SetupClaimError> {
+        #[cfg(target_os = "linux")]
+        return self.directory.observe(intent);
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = intent;
+            Err(SetupClaimError::Unsupported)
+        }
+    }
+
+    /// Admit at most once per retained root, independent of retry/client identity.
+    /// Existing identical claims never receive a new grant, even without a result.
+    /// # Errors
+    /// Any uncertain publication or synchronization returns no grant. Retain the
+    /// root for inspection: an error is not permission to delete it or replay setup.
+    pub fn admit(&self, intent: SetupIntent) -> Result<SetupAdmission, SetupClaimError> {
+        #[cfg(target_os = "linux")]
+        return match self.directory.admit(&intent)? {
+            linux::Admission::Fresh => Ok(SetupAdmission::Fresh(SetupGrant {
+                intent,
+                _directory: Arc::clone(&self.directory),
+            })),
+            linux::Admission::Existing => Ok(SetupAdmission::Existing),
+        };
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = intent;
+            Err(SetupClaimError::Unsupported)
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SetupClaimError {
+    #[error("retained setup requires a valid immutable intent")]
+    InvalidIntent,
+    #[error("retained setup requires supported journaled storage and confinement")]
+    Unsupported,
+    #[error("retained setup root is missing, changed or not privately owned")]
+    UnsafeRoot,
+    #[error("retained setup claim cannot be safely read")]
+    Read,
+    #[error("retained setup claim is invalid or exceeds its bound")]
+    InvalidRecord,
+    #[error("retained setup intent conflicts with the existing claim")]
+    Conflict,
+    #[error("retained setup storage operation failed; no execution grant was issued")]
+    Storage,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/tests.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::cloud_run::ArtifactDigest;
+
+pub(super) fn intent() -> SetupIntent {
+    let root = std::env::temp_dir();
+    SetupIntent::new(
+        "workspace_1".into(),
+        root.join("source-objects"),
+        root.join("bundle-store"),
+        ArtifactDigest::sha256(b"manifest"),
+        "repository".into(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn strict_bounded_record_round_trip_and_redacted_debug() {
+    let expected = intent();
+    let bytes = codec::encode(&expected).unwrap();
+    assert_eq!(codec::decode(&bytes).unwrap(), expected);
+    assert!(bytes.len() < codec::MAX_RECORD_BYTES);
+    assert_eq!(format!("{expected:?}"), "SetupIntent { .. }");
+    for error in [
+        SetupClaimError::InvalidIntent,
+        SetupClaimError::Unsupported,
+        SetupClaimError::UnsafeRoot,
+        SetupClaimError::Read,
+        SetupClaimError::InvalidRecord,
+        SetupClaimError::Conflict,
+        SetupClaimError::Storage,
+    ] {
+        assert!(!format!("{error:?} {error}").contains("source-objects"));
+    }
+}
+
+#[test]
+fn corrupt_newer_duplicate_unknown_and_noncanonical_records_are_rejected() {
+    let valid = String::from_utf8(codec::encode(&intent()).unwrap()).unwrap();
+    for invalid in [
+        String::new(),
+        "{}".into(),
+        format!("{valid}\n"),
+        valid.replace("\"version\":1", "\"version\":2"),
+        valid.replace("\"version\":1", "\"version\":1,\"version\":1"),
+        valid.replace("\"version\":1", "\"version\":1,\"extra\":0"),
+        valid.replace("workspace_1", "../bad"),
+        valid.replace("repository", "../bad"),
+        valid[..valid.len() - 1].to_owned(),
+        "x".repeat(codec::MAX_RECORD_BYTES + 1),
+    ] {
+        assert_eq!(codec::decode(invalid.as_bytes()), Err(SetupClaimError::InvalidRecord));
+    }
+    assert_eq!(codec::decode(b"\xff"), Err(SetupClaimError::InvalidRecord));
+}
+
+#[test]
+fn invalid_intents_share_existing_workspace_and_materialization_policy() {
+    let original = intent();
+    for id in [String::new(), "../bad".into(), "space id".into(), "a".repeat(129)] {
+        assert!(
+            SetupIntent::new(
+                id,
+                original.objects_directory.clone(),
+                original.bundle_store.clone(),
+                original.bundle_manifest.clone(),
+                original.destination.clone()
+            )
+            .is_err()
+        );
+    }
+    for path in [
+        std::path::PathBuf::from("relative"),
+        std::env::temp_dir().join("../escape"),
+        std::env::temp_dir().join("a".repeat(4097)),
+        std::env::temp_dir().join("nul\0path"),
+    ] {
+        assert!(
+            SetupIntent::new(
+                "valid".into(),
+                path.clone(),
+                original.bundle_store.clone(),
+                original.bundle_manifest.clone(),
+                original.destination.clone()
+            )
+            .is_err()
+        );
+        assert!(
+            SetupIntent::new(
+                "valid".into(),
+                original.objects_directory.clone(),
+                path,
+                original.bundle_manifest.clone(),
+                original.destination.clone()
+            )
+            .is_err()
+        );
+    }
+    for destination in ["", ".git", "../bad", "a/b", "a\\b", "line\n"] {
+        assert!(
+            SetupIntent::new(
+                "valid".into(),
+                original.objects_directory.clone(),
+                original.bundle_store.clone(),
+                original.bundle_manifest.clone(),
+                destination.into()
+            )
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn every_immutable_field_changes_the_claim_bytes() {
+    let original = intent();
+    let bytes = codec::encode(&original).unwrap();
+    for field in 0..5 {
+        let mut changed = original.clone();
+        match field {
+            0 => changed.workspace_local_id.push('2'),
+            1 => changed.objects_directory.push("different"),
+            2 => changed.bundle_store.push("different"),
+            3 => changed.bundle_manifest = ArtifactDigest::sha256(b"different"),
+            _ => changed.destination.push('2'),
+        }
+        let changed_bytes = codec::encode(&changed).unwrap();
+        assert_ne!(changed_bytes, bytes);
+        assert_eq!(codec::decode(&changed_bytes).unwrap(), changed);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_never_creates_or_grants() {
+    let root = tempfile::tempdir().unwrap();
+    assert!(matches!(
+        RetainedSetup::open(root.path()),
+        Err(SetupClaimError::Unsupported)
+    ));
+    let store = RetainedSetup {};
+    assert_eq!(store.observe(&intent()), Err(SetupClaimError::Unsupported));
+    assert!(matches!(store.admit(intent()), Err(SetupClaimError::Unsupported)));
+    assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 0);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -244,6 +244,15 @@ back into large multi-purpose modules.
   Linux `storage.rs` owns the shared, read-only journaled-filesystem qualification
   and bounded kernel-option validation. Publication maps its errors to the existing
   receipt contract; qualification alone does not synchronize, write or grant execution.
+  `retained_setup/` owns one immutable setup claim per existing private retained
+  workspace root. Constructor-checked intent and bounded canonical records are
+  separate from Linux confined storage. Only fresh no-replace publication followed
+  by file/directory synchronization creates a non-cloneable grant. Observation,
+  identical retries and grant Drop never execute, repair, expire or remove a claim.
+  A claim means unknown outcome, not running/completed; trusted stable private
+  ancestry, healthy qualified storage and separately verified remote ownership
+  remain prerequisites. No runner, scratch creation, terminal receipt, recovery or
+  client/cloud integration is provided by this admission boundary.
   `materialize/` composes existing private bundle retrieval, isolated raw-object
   resolution, checkout preparation and explicit publication into one worker-callable
   operation. Its typed result preserves source metadata and every known checkout or


### PR DESCRIPTION
## Purpose

Add worker-retained admission for one repository setup attempt per existing private
workspace root. This is a focused prerequisite for the independent setup runner
and production client integration tracked by #470 and parent #383.

## Behavior and boundaries

- Bind complete immutable intent to one fixed claim slot; a changed retry/client
  identity, runtime generation or intent digest cannot select another slot.
- Observe only absent or claimed/unknown. Existing identical claims never grant
  execution again; changed intent, malformed records and unsafe nodes fail closed.
- Issue a non-cloneable, non-serializable fresh grant only after anonymous write,
  file synchronization, no-replace link, linked-file and parent synchronization,
  and exact record/inode verification. Post-link uncertainty retains the claim.
- Reuse existing workspace/path validators, confined private-file reads and the
  shared journaled-filesystem qualifier. Records are strict, canonical and bounded
  to 64 KiB; errors/debug output are redacted. Unsupported platforms fail closed.
- No runner, scratch creation, task start, terminal receipt, retry/recovery policy,
  transport, UI, provider behavior, dependency, image publication or release change.

The caller must nominate the same trusted, stable private worker-owned retained
root across reconnects/runtime replacement and separately verify remote ownership.
Healthy qualified journaled ext4, trusted kernel metadata and unchanged mounts are
required. Storage rollback, malicious same-user mutation, remote replication and
cloud/PC-off durability are not proved by this component. A claim alone is never
reported as a running or completed task. Dropping a grant never cleans the claim.

## Validation

- Exact commit `de499728`: full eight-lane local matrix passed, including default and
  speech workspace tests plus blocking, strict and pedantic lint tiers.
- Sixteen focused tests cover concurrent identical/conflicting admission, all
  immutable fields, strict/oversized/corrupt records, unsafe files and roots,
  write/link/synchronization faults, actual-link-then-error uncertainty, observation
  without mutation, and no replay after reopening in a separate process.
- Preserve unsupported-confinement and invalid-record classifications, including
  exact assertions for oversized and malformed retained claims.
- Qualified ext4 admission/drop/reopen and volatile tmpfs rejection ran without
  a skip. State-only fault tests do not claim power-loss durability.
- Independent local review is clear on the exact committed tree and full patch.
- Exact-commit worker image passed all four regression lanes: build-context/layer
  audit and independent executable hash; packed 65 MiB-plus repository checkout and
  retained failure state; disconnected task progress; retained identity, workspace
  bytes and task claims after runtime replacement. These validate existing helper
  and session behavior, not a setup-runner integration (none is added here).

Scope: eight source/test files, 925 changed source/test lines, plus one focused
architecture note. No UI smoke is applicable. Cross-platform compile/tests remain
required in CI. Existing primary checkout, unrelated work and live resources are
preserved. Assignee follows repository convention; ambiguous label/milestone/project
metadata is intentionally not guessed.

Refs #383, #470.
