### PR TITLE
Materialize repositories from retained setup grants

### DIFF
--- a/crates/horizon-core/src/repository_overlay/materialize/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/materialize/mod.rs
@@ -193,4 +193,4 @@ fn run(
 }
 
 #[cfg(test)]
-mod tests;
+pub(super) mod tests;

--- a/crates/horizon-core/src/repository_overlay/materialize/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/materialize/tests.rs
@@ -51,7 +51,7 @@ fn unsupported_platform_has_no_filesystem_effects() {
 }
 
 #[cfg(target_os = "linux")]
-mod supported {
+pub(in crate::repository_overlay) mod supported {
     use super::*;
     use crate::{
         cloud_run::{GitCommitSha, GitSource},
@@ -64,12 +64,12 @@ mod supported {
     use git2::{Oid, Repository, Signature};
     use std::{cell::Cell, fs, os::unix::fs::PermissionsExt};
 
-    struct Fixture {
+    pub(in crate::repository_overlay) struct Fixture {
         source: tempfile::TempDir,
         store: tempfile::TempDir,
         parent: tempfile::TempDir,
         objects: PathBuf,
-        base: Oid,
+        pub(in crate::repository_overlay) base: Oid,
         digest: ArtifactDigest,
     }
 
@@ -81,7 +81,7 @@ mod supported {
     }
 
     impl Fixture {
-        fn new(missing_base: bool) -> Self {
+        pub(in crate::repository_overlay) fn new(missing_base: bool) -> Self {
             let source = private();
             let repository = Repository::init(source.path()).unwrap();
             let blob = repository.blob(b"base\0raw\xff").unwrap();
@@ -129,7 +129,7 @@ mod supported {
             }
         }
 
-        fn request(&self) -> MaterializationRequest<'_> {
+        pub(in crate::repository_overlay) fn request(&self) -> MaterializationRequest<'_> {
             MaterializationRequest {
                 objects_directory: &self.objects,
                 bundle_store: self.store.path(),

--- a/crates/horizon-core/src/repository_overlay/retained_setup/execution.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/execution.rs
@@ -1,0 +1,83 @@
+use super::{SetupClaimError, SetupGrant};
+use crate::repository_overlay::materialize::{MaterializationFailure, MaterializedRepository};
+
+/// Consuming a grant never authorizes a retry, cleanup or a task start.
+#[derive(Debug, thiserror::Error)]
+pub enum SetupExecutionError {
+    #[error(transparent)]
+    Boundary(#[from] SetupBoundaryError),
+    #[error(transparent)]
+    Materialization(Box<MaterializationFailure>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SetupBoundaryError {
+    #[error("retained setup execution was cancelled; existing state is retained")]
+    Cancelled,
+    #[error("retained setup execution requires supported storage and confinement")]
+    Unsupported,
+    #[error("retained setup root is missing, changed or not privately owned")]
+    UnsafeRoot,
+    #[error("retained setup claim cannot be safely read")]
+    ClaimRead,
+    #[error("retained setup claim is missing, invalid or conflicts with the admitted intent")]
+    InvalidClaim,
+    #[error("retained setup scratch slot already exists and cannot be reused")]
+    ExistingScratch,
+    #[error("retained setup storage operation failed; retain all state for inspection")]
+    Storage,
+}
+
+impl From<SetupClaimError> for SetupBoundaryError {
+    fn from(error: SetupClaimError) -> Self {
+        match error {
+            SetupClaimError::Unsupported => Self::Unsupported,
+            SetupClaimError::UnsafeRoot => Self::UnsafeRoot,
+            SetupClaimError::Read => Self::ClaimRead,
+            SetupClaimError::InvalidIntent | SetupClaimError::InvalidRecord | SetupClaimError::Conflict => {
+                Self::InvalidClaim
+            }
+            SetupClaimError::Storage => Self::Storage,
+        }
+    }
+}
+
+impl SetupGrant {
+    /// Consume admission for one materialization into the fixed retained scratch slot.
+    /// Intent and scratch cannot be replaced by the caller. Requires stable, trusted
+    /// private ancestry, mounts and source throughout the existing materializer's I/O.
+    /// Keep execution off the UI thread; cancellation cannot bound blocked filesystem
+    /// latency. Drop retains the claim, scratch and all component residues.
+    /// This synchronous receipt is not remote supervision or a stored terminal result.
+    /// # Errors
+    /// Boundary failures never run the materializer. Component failures preserve its
+    /// typed retention/publication receipts. Lost results never authorize another grant.
+    pub fn materialize(self, cancelled: impl Fn() -> bool) -> Result<MaterializedRepository, SetupExecutionError> {
+        if cancelled() {
+            return Err(SetupBoundaryError::Cancelled.into());
+        }
+        #[cfg(target_os = "linux")]
+        {
+            use crate::repository_overlay::materialize::{MaterializationRequest, materialize_repository};
+
+            let scratch = self.directory.scratch(&self.intent)?;
+            if cancelled() {
+                return Err(SetupBoundaryError::Cancelled.into());
+            }
+            let request = MaterializationRequest {
+                objects_directory: &self.intent.objects_directory,
+                bundle_store: &self.intent.bundle_store,
+                bundle_manifest: &self.intent.bundle_manifest,
+                scratch_parent: scratch.path(),
+                destination: &self.intent.destination,
+            };
+            materialize_repository(&request, cancelled)
+                .map_err(|error| SetupExecutionError::Materialization(Box::new(error)))
+        }
+        #[cfg(not(target_os = "linux"))]
+        Err(SetupBoundaryError::Unsupported.into())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/execution/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/execution/tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+#[test]
+fn claim_errors_keep_execution_specific_classification_and_redacted_messages() {
+    for (claim, boundary) in [
+        (SetupClaimError::Unsupported, SetupBoundaryError::Unsupported),
+        (SetupClaimError::UnsafeRoot, SetupBoundaryError::UnsafeRoot),
+        (SetupClaimError::Read, SetupBoundaryError::ClaimRead),
+        (SetupClaimError::InvalidIntent, SetupBoundaryError::InvalidClaim),
+        (SetupClaimError::InvalidRecord, SetupBoundaryError::InvalidClaim),
+        (SetupClaimError::Conflict, SetupBoundaryError::InvalidClaim),
+        (SetupClaimError::Storage, SetupBoundaryError::Storage),
+    ] {
+        assert_eq!(SetupBoundaryError::from(claim), boundary);
+        let error = SetupExecutionError::from(boundary);
+        assert!(!format!("{error:?} {error}").contains("no execution grant was issued"));
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_execution_does_not_fall_back_to_materialization() {
+    let grant = SetupGrant {
+        intent: super::super::tests::intent(),
+    };
+    assert!(matches!(
+        grant.materialize(|| false),
+        Err(SetupExecutionError::Boundary(SetupBoundaryError::Unsupported))
+    ));
+}
+
+#[cfg(target_os = "linux")]
+mod supported {
+    use super::*;
+    use crate::{
+        cloud_run::ArtifactDigest,
+        repository_overlay::{
+            materialize::{MaterializationProblem, tests::supported::Fixture},
+            retained_setup::{RetainedSetup, SCRATCH_NAME, SetupAdmission, SetupIntent, SetupObservation, codec},
+        },
+    };
+    use git2::Repository;
+    use std::{fs, os::unix::fs::PermissionsExt, path::Path};
+
+    fn intent(fixture: &Fixture) -> SetupIntent {
+        let request = fixture.request();
+        SetupIntent::new(
+            "workspace_1".into(),
+            request.objects_directory.to_owned(),
+            request.bundle_store.to_owned(),
+            request.bundle_manifest.clone(),
+            request.destination.into(),
+        )
+        .unwrap()
+    }
+
+    fn store(path: &Path) -> Option<RetainedSetup> {
+        match RetainedSetup::open(path) {
+            Err(SetupClaimError::Unsupported) => {
+                eprintln!("SKIP real execution: requires qualified journaled ext4");
+                None
+            }
+            other => Some(other.unwrap()),
+        }
+    }
+
+    fn grant(store: &RetainedSetup, expected: &SetupIntent) -> SetupGrant {
+        let SetupAdmission::Fresh(grant) = store.admit(expected.clone()).unwrap() else {
+            panic!("fresh grant");
+        };
+        grant
+    }
+
+    fn assert_layers(path: &Path) {
+        assert_eq!(fs::read(path.join("file")).unwrap(), b"working\0raw\r\n");
+        assert_ne!(fs::metadata(path.join("file")).unwrap().permissions().mode() & 0o111, 0);
+        let repository = Repository::open(path).unwrap();
+        let index = repository.index().unwrap();
+        let entry = index.get_path(Path::new("file"), 0).unwrap();
+        assert_eq!(entry.mode, 0o100_755);
+        assert_eq!(repository.find_blob(entry.id).unwrap().content(), b"staged\0raw");
+    }
+
+    #[test]
+    fn qualified_consumption_retains_exact_layers_and_process_reopen_cannot_replay() {
+        let fixture = Fixture::new(false);
+        let root = fixture.request().scratch_parent.to_owned();
+        let Some(store) = store(&root) else {
+            return;
+        };
+        let expected = intent(&fixture);
+        let grant = grant(&store, &expected);
+        drop(store);
+        let result = grant.materialize(|| false).unwrap();
+        let checkout = root.join(SCRATCH_NAME).join("ready");
+        assert_eq!(result.checkout().path(), checkout);
+        assert_eq!(result.checkout().base_commit(), fixture.base);
+        assert_eq!(result.checkout().manifest_sha256(), &expected.bundle_manifest);
+        assert_eq!(
+            result.source_metadata().parent(),
+            Some(root.join(SCRATCH_NAME).as_path())
+        );
+        assert_layers(&checkout);
+        let metadata = result.source_metadata().to_owned();
+        drop(result);
+        assert!(metadata.join("HEAD").exists());
+        let child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "repository_overlay::retained_setup::execution::tests::supported::reopen_child",
+                "--nocapture",
+            ])
+            .env("HORIZON_SETUP_MATERIALIZATION_FIXTURE", &root)
+            .output()
+            .unwrap();
+        assert!(child.status.success(), "{}", String::from_utf8_lossy(&child.stderr));
+        assert!(String::from_utf8_lossy(&child.stdout).contains("MATERIALIZATION_REOPEN_NO_REPLAY"));
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+        assert_eq!(fs::read_dir(root.join(SCRATCH_NAME)).unwrap().count(), 2);
+        assert_layers(&checkout);
+    }
+
+    #[test]
+    fn reopen_child() {
+        let Some(root) = std::env::var_os("HORIZON_SETUP_MATERIALIZATION_FIXTURE") else {
+            return;
+        };
+        let root = Path::new(&root);
+        let expected = codec::decode(&fs::read(root.join("setup-claim.json")).unwrap()).unwrap();
+        let store = RetainedSetup::open(root).unwrap();
+        assert_eq!(store.observe(&expected), Ok(SetupObservation::ClaimedUnknown));
+        assert!(matches!(store.admit(expected), Ok(SetupAdmission::Existing)));
+        assert_layers(&root.join(SCRATCH_NAME).join("ready"));
+        println!("MATERIALIZATION_REOPEN_NO_REPLAY");
+    }
+
+    #[test]
+    fn cancellation_before_and_after_scratch_creation_consumes_without_replay() {
+        for after_create in [false, true] {
+            let fixture = Fixture::new(false);
+            let root = fixture.request().scratch_parent;
+            let Some(store) = store(root) else {
+                return;
+            };
+            let expected = intent(&fixture);
+            let scratch = root.join(SCRATCH_NAME);
+            let result = grant(&store, &expected).materialize(|| !after_create || scratch.exists());
+            assert!(matches!(
+                result,
+                Err(SetupExecutionError::Boundary(SetupBoundaryError::Cancelled))
+            ));
+            assert_eq!(scratch.exists(), after_create);
+            if after_create {
+                assert_eq!(fs::read_dir(scratch).unwrap().count(), 0);
+            }
+            assert!(matches!(store.admit(expected), Ok(SetupAdmission::Existing)));
+        }
+    }
+
+    #[test]
+    fn missing_bundle_and_namespace_failure_keep_typed_receipts_and_residues() {
+        for missing_base in [false, true] {
+            let fixture = Fixture::new(missing_base);
+            let root = fixture.request().scratch_parent;
+            let Some(store) = store(root) else {
+                return;
+            };
+            let mut expected = intent(&fixture);
+            if !missing_base {
+                expected.bundle_manifest = ArtifactDigest::sha256(b"missing");
+            }
+            let result = grant(&store, &expected).materialize(|| false);
+            let Err(SetupExecutionError::Materialization(failure)) = result else {
+                panic!("component failure");
+            };
+            if missing_base {
+                assert!(matches!(failure.problem, MaterializationProblem::Namespace(_)));
+            } else {
+                assert!(matches!(failure.problem, MaterializationProblem::Bundle(_)));
+            }
+            let metadata = failure.source_metadata().map(Path::to_owned);
+            assert_eq!(metadata.is_some(), missing_base);
+            assert!(!format!("{failure:?} {failure}").contains(root.to_str().unwrap()));
+            drop(failure);
+            if let Some(metadata) = metadata {
+                assert!(metadata.join("HEAD").exists());
+            }
+            assert_eq!(
+                fs::read_dir(root.join(SCRATCH_NAME)).unwrap().count(),
+                usize::from(missing_base)
+            );
+            assert!(matches!(store.admit(expected), Ok(SetupAdmission::Existing)));
+        }
+    }
+
+    #[test]
+    fn changed_claim_root_and_preexisting_scratch_never_start_materialization() {
+        for kind in 0..5 {
+            let fixture = Fixture::new(false);
+            let root = fixture.request().scratch_parent;
+            let Some(store) = store(root) else {
+                return;
+            };
+            let expected = intent(&fixture);
+            let grant = grant(&store, &expected);
+            let claim = root.join("setup-claim.json");
+            let scratch = root.join(SCRATCH_NAME);
+            let error = match kind {
+                0 => {
+                    fs::remove_file(&claim).unwrap();
+                    SetupBoundaryError::InvalidClaim
+                }
+                1 => {
+                    fs::write(&claim, b"invalid").unwrap();
+                    SetupBoundaryError::InvalidClaim
+                }
+                2 => {
+                    fs::set_permissions(&claim, fs::Permissions::from_mode(0o644)).unwrap();
+                    SetupBoundaryError::ClaimRead
+                }
+                3 => {
+                    fs::set_permissions(root, fs::Permissions::from_mode(0o755)).unwrap();
+                    SetupBoundaryError::UnsafeRoot
+                }
+                _ => {
+                    fs::create_dir(&scratch).unwrap();
+                    SetupBoundaryError::ExistingScratch
+                }
+            };
+            let result = grant.materialize(|| false);
+            assert!(matches!(result, Err(SetupExecutionError::Boundary(actual)) if actual == error));
+            assert_eq!(scratch.exists(), kind == 4);
+            if kind == 4 {
+                assert_eq!(fs::read_dir(scratch).unwrap().count(), 0);
+            }
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
@@ -15,6 +15,8 @@ use std::{
 };
 
 const CLAIM: &str = "setup-claim.json";
+mod scratch;
+pub(super) use scratch::Scratch;
 const CONFINED: ResolveFlags = ResolveFlags::BENEATH
     .union(ResolveFlags::NO_SYMLINKS)
     .union(ResolveFlags::NO_MAGICLINKS)
@@ -32,6 +34,14 @@ pub(super) struct Directory {
 }
 
 impl Directory {
+    pub(super) fn scratch(&self, intent: &SetupIntent) -> Result<Scratch, super::SetupBoundaryError> {
+        self.qualify()?;
+        if self.observe(intent)? != SetupObservation::ClaimedUnknown {
+            return Err(super::SetupBoundaryError::InvalidClaim);
+        }
+        scratch::create(self)
+    }
+
     pub(super) fn open(path: &Path) -> Result<Self, Error> {
         let reader = SelectedRepositoryReader::open(path).map_err(root_error)?.root;
         let directory = File::from(

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/scratch.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/scratch.rs
@@ -1,0 +1,89 @@
+use super::{CONFINED, Directory, root_error};
+use crate::repository_overlay::{
+    reader::SelectedRepositoryReader,
+    retained_setup::{SCRATCH_NAME, SetupBoundaryError as Error},
+};
+use rustix::fs::{Mode, OFlags, mkdirat, openat2};
+use std::{
+    fs::File,
+    io,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+/// Both descriptors remain held during the path-based materializer's execution.
+pub(in crate::repository_overlay::retained_setup) struct Scratch {
+    handle: File,
+    path: PathBuf,
+}
+
+impl Scratch {
+    pub(in crate::repository_overlay::retained_setup) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn verify(&self, parent: &Directory) -> Result<(), Error> {
+        parent.verify()?;
+        let held = self.handle.metadata().map_err(|_| Error::Storage)?;
+        let current = SelectedRepositoryReader::open(&self.path).map_err(root_error)?;
+        let actual = current.root.handle().metadata().map_err(|_| Error::Storage)?;
+        if !held.is_dir()
+            || held.uid() != rustix::process::geteuid().as_raw()
+            || held.mode() & 0o7777 != 0o700
+            || held.nlink() == 0
+            || (held.dev(), held.ino()) != (actual.dev(), actual.ino())
+        {
+            return Err(Error::UnsafeRoot);
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn create(parent: &Directory) -> Result<Scratch, Error> {
+    create_with(parent, &mut reserve, &mut open, &mut File::sync_all)
+}
+
+fn create_with(
+    parent: &Directory,
+    reserve: &mut impl FnMut(&File) -> Result<(), rustix::io::Errno>,
+    open: &mut impl FnMut(&File) -> Result<File, rustix::io::Errno>,
+    sync: &mut impl FnMut(&File) -> io::Result<()>,
+) -> Result<Scratch, Error> {
+    parent.verify()?;
+    reserve(&parent.handle).map_err(storage_error)?;
+    let scratch = Scratch {
+        handle: open(&parent.handle).map_err(storage_error)?,
+        path: parent.path.join(SCRATCH_NAME),
+    };
+    scratch.verify(parent)?;
+    sync(&scratch.handle).map_err(|_| Error::Storage)?;
+    sync(&parent.handle).map_err(|_| Error::Storage)?;
+    scratch.verify(parent)?;
+    Ok(scratch)
+}
+
+fn reserve(parent: &File) -> Result<(), rustix::io::Errno> {
+    mkdirat(parent, SCRATCH_NAME, Mode::RUSR | Mode::WUSR | Mode::XUSR)
+}
+
+fn open(parent: &File) -> Result<File, rustix::io::Errno> {
+    openat2(
+        parent,
+        SCRATCH_NAME,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+        CONFINED,
+    )
+    .map(File::from)
+}
+
+fn storage_error(error: rustix::io::Errno) -> Error {
+    if error == rustix::io::Errno::EXIST {
+        Error::ExistingScratch
+    } else {
+        super::storage_error(error).into()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/scratch/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/scratch/tests.rs
@@ -1,0 +1,145 @@
+use super::*;
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+};
+
+// Real confined I/O and synchronization, but deliberately no filesystem qualifier:
+// these are state/fault tests, not power-loss or durable-admission evidence.
+fn parent() -> (tempfile::TempDir, Directory) {
+    let fixture = tempfile::tempdir().unwrap();
+    let path = fixture.path().join("root");
+    fs::create_dir(&path).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    let directory = Directory {
+        reader: SelectedRepositoryReader::open(&path).unwrap().root,
+        handle: File::open(&path).unwrap(),
+        path,
+    };
+    (fixture, directory)
+}
+
+#[test]
+fn fresh_scratch_syncs_child_then_parent_and_drop_retains_it() {
+    let (_fixture, parent) = parent();
+    let mut calls = 0;
+    let scratch = create_with(&parent, &mut reserve, &mut open, &mut |file| {
+        calls += 1;
+        let expected = if calls == 1 {
+            parent.path.join(SCRATCH_NAME)
+        } else {
+            parent.path.clone()
+        };
+        assert_eq!(file.metadata()?.ino(), fs::metadata(expected)?.ino());
+        file.sync_all()
+    })
+    .unwrap();
+    assert_eq!(calls, 2);
+    assert_eq!(fs::metadata(scratch.path()).unwrap().mode() & 0o7777, 0o700);
+    assert_eq!(fs::read_dir(scratch.path()).unwrap().count(), 0);
+    drop(scratch);
+    assert!(parent.path.join(SCRATCH_NAME).is_dir());
+}
+
+#[test]
+fn existing_nodes_are_never_opened_adopted_or_replaced() {
+    for kind in 0..4 {
+        let (fixture, parent) = parent();
+        let path = parent.path.join(SCRATCH_NAME);
+        let sentinel = fixture.path().join("sentinel");
+        fs::write(&sentinel, b"unchanged").unwrap();
+        match kind {
+            0 => fs::write(&path, b"existing").unwrap(),
+            1 => fs::create_dir(&path).unwrap(),
+            2 => symlink(&sentinel, &path).unwrap(),
+            _ => rustix::fs::mkfifoat(&parent.handle, SCRATCH_NAME, Mode::RUSR | Mode::WUSR).unwrap(),
+        }
+        let inode = fs::symlink_metadata(&path).unwrap().ino();
+        let result = create_with(&parent, &mut reserve, &mut |_| panic!("open existing"), &mut |_| {
+            panic!("sync existing")
+        });
+        assert!(matches!(result, Err(Error::ExistingScratch)));
+        assert_eq!(fs::symlink_metadata(path).unwrap().ino(), inode);
+        assert_eq!(fs::read(sentinel).unwrap(), b"unchanged");
+    }
+}
+
+#[test]
+fn create_open_and_sync_faults_retain_every_named_residue() {
+    for fail in 0..5 {
+        let (_fixture, parent) = parent();
+        let mut syncs = 0;
+        let result = create_with(
+            &parent,
+            &mut |file| {
+                if fail == 0 {
+                    return Err(rustix::io::Errno::IO);
+                }
+                reserve(file)?;
+                if fail == 1 {
+                    return Err(rustix::io::Errno::IO);
+                }
+                Ok(())
+            },
+            &mut |file| {
+                if fail == 2 {
+                    return Err(rustix::io::Errno::IO);
+                }
+                open(file)
+            },
+            &mut |file| {
+                syncs += 1;
+                if fail == syncs + 2 {
+                    return Err(io::ErrorKind::Other.into());
+                }
+                file.sync_all()
+            },
+        );
+        assert!(matches!(result, Err(Error::Storage)));
+        assert_eq!(parent.path.join(SCRATCH_NAME).exists(), fail != 0);
+        assert_eq!(syncs, if fail < 3 { 0 } else { fail - 2 });
+    }
+}
+
+#[test]
+fn root_replacement_after_creation_keeps_residue_in_original_root() {
+    let (fixture, parent) = parent();
+    let moved = fixture.path().join("original");
+    let result = create_with(
+        &parent,
+        &mut reserve,
+        &mut |file| {
+            let child = open(file)?;
+            fs::rename(&parent.path, &moved).unwrap();
+            fs::create_dir(&parent.path).unwrap();
+            fs::set_permissions(&parent.path, fs::Permissions::from_mode(0o700)).unwrap();
+            Ok(child)
+        },
+        &mut |_| panic!("sync rebound root"),
+    );
+    assert!(matches!(result, Err(Error::UnsafeRoot)));
+    assert!(moved.join(SCRATCH_NAME).is_dir());
+    assert!(!parent.path.join(SCRATCH_NAME).exists());
+}
+
+#[test]
+fn insecure_or_replaced_scratch_never_acknowledges_execution() {
+    for replace in [false, true] {
+        let (_fixture, parent) = parent();
+        let path = parent.path.join(SCRATCH_NAME);
+        let result = create_with(&parent, &mut reserve, &mut open, &mut |file| {
+            file.sync_all()?;
+            if file.metadata()?.ino() != parent.handle.metadata()?.ino() {
+                if replace {
+                    fs::rename(&path, parent.path.join("original-scratch"))?;
+                    fs::create_dir(&path)?;
+                }
+                fs::set_permissions(&path, fs::Permissions::from_mode(if replace { 0o700 } else { 0o755 }))?;
+            }
+            Ok(())
+        });
+        assert!(matches!(result, Err(Error::UnsafeRoot)));
+        assert!(path.is_dir());
+        assert_eq!(parent.path.join("original-scratch").exists(), replace);
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
@@ -1,13 +1,15 @@
-//! Worker-owned setup admission, not a runner, retry policy or completion receipt.
+//! Worker-owned setup admission/materialization, not independent task supervision.
 //! The nominated root must be retained independently of runtime/client generations.
 //! Its private ancestry and mount configuration must remain trusted and stable.
 
 #[cfg(any(target_os = "linux", test))]
 mod codec;
+mod execution;
 mod intent;
 #[cfg(target_os = "linux")]
 mod linux;
 
+pub use execution::{SetupBoundaryError, SetupExecutionError};
 pub use intent::SetupIntent;
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
@@ -39,7 +41,7 @@ pub enum SetupAdmission {
 pub struct SetupGrant {
     intent: SetupIntent,
     #[cfg(target_os = "linux")]
-    _directory: Arc<linux::Directory>,
+    directory: Arc<linux::Directory>,
 }
 
 impl SetupGrant {
@@ -95,7 +97,7 @@ impl RetainedSetup {
         return match self.directory.admit(&intent)? {
             linux::Admission::Fresh => Ok(SetupAdmission::Fresh(SetupGrant {
                 intent,
-                _directory: Arc::clone(&self.directory),
+                directory: Arc::clone(&self.directory),
             })),
             linux::Admission::Existing => Ok(SetupAdmission::Existing),
         };

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -251,8 +251,16 @@ back into large multi-purpose modules.
   identical retries and grant Drop never execute, repair, expire or remove a claim.
   A claim means unknown outcome, not running/completed; trusted stable private
   ancestry, healthy qualified storage and separately verified remote ownership
-  remain prerequisites. No runner, scratch creation, terminal receipt, recovery or
-  client/cloud integration is provided by this admission boundary.
+  remain prerequisites. Admission alone never creates scratch or runs setup.
+  `retained_setup/execution.rs` consumes the in-process grant and its immutable
+  intent for one materialization. Linux `scratch.rs` creates one fixed private
+  child without replacement and synchronizes it and its retained parent before
+  handing the held subtree to the existing materializer. Existing nodes are never
+  adopted or cleaned; cancellation, failed synchronization and component failures
+  retain every named residue. Execution errors distinguish the consumed boundary
+  from original admission and preserve typed materializer receipts. Observation
+  stays unknown; no independent runner, stored terminal receipt, recovery or
+  client/cloud integration is provided by this synchronous boundary.
   `materialize/` composes existing private bundle retrieval, isolated raw-object
   resolution, checkout preparation and explicit publication into one worker-callable
   operation. Its typed result preserves source metadata and every known checkout or


### PR DESCRIPTION
## Purpose

Consume a fresh retained setup grant for one repository materialization inside
its fixed worker-owned scratch directory. This is the next bounded #470 outcome
after #477, not an independent worker supervisor or production client integration.

## Behavior and boundaries

- Derive the complete request from the admitted immutable intent; callers cannot
  substitute another intent, source or scratch path when consuming the grant.
- Recheck qualified storage and the retained claim before creating `setup-data`.
  Create the private child without replacement, pin and verify it, synchronize
  the child and parent, and recheck identity before materialization.
- Hold retained-root and scratch descriptors through the existing path-based
  materializer. Reuse its typed source-metadata and publication/failure receipts.
- Never adopt an existing scratch node or clean any claim, directory or residue
  on cancellation, failed I/O, uncertain synchronization or Drop. No failed or
  lost result grants replay; read-only observation remains claimed/unknown.
- Keep execution-specific errors redacted and preserve unsupported-confinement,
  invalid-claim and component-failure distinctions.
- Reuse existing validators, filesystem qualification/confinement/error policy,
  materializer and test fixture. No dependency or mechanical module move.

Healthy qualified journaled ext4, trusted stable private ancestry/mounts/source
and separately verified remote ownership remain caller requirements. A held
descriptor does not protect path-based components from malicious same-user
changes or storage rollback. This synchronous return is not a stored terminal
result, proof of ongoing supervision or cloud/PC-off durability.

No task start, independent runner, transport, provider behavior, UI, retry/recovery,
image publication or release change is included.

## Validation

Validated exact commit `9eea2bc2`:

- Full eight-lane local validation passed: formatting, maintainability, version
  synchronization, default and speech workspace tests, blocking and strict
  Clippy, and advisory pedantic Clippy.
- All 27 retained-setup tests passed on qualified native storage, with no skips.
  Coverage includes exact base/index/working content and modes, cancellation,
  retained materializer failures, reopen without replay, fixed-scratch conflicts,
  namespace changes and state-only I/O fault injection.
- Exact-commit runtime and builder images passed packaging, repository,
  security/disconnected-worker, and retained-identity smoke lanes. These exercise
  existing helper/session regressions, not a new setup CLI or cloud durability.
- Full-diff self-review and independent local review completed; the discovered
  non-Linux test-module path error was fixed before final validation.

Scope: eight source/test files, 585 changed source/test lines, plus a focused
architecture note. No UI smoke is applicable. Cross-platform compilation and
tests remain required in CI. Existing primary checkout, unrelated work and live
resources are preserved. Assignee follows repository convention; ambiguous
label/milestone/project metadata is intentionally not guessed.

Refs #383, #470.
