### PR TITLE
Retain repository setup outcomes

### DIFF
--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
@@ -1,4 +1,4 @@
-use super::{SetupClaimError as Error, SetupIntent, SetupObservation, codec};
+use super::{SetupClaimError as Error, SetupCompletion, SetupIntent, SetupObservation, SetupRecordError, codec};
 use crate::repository_overlay::{
     reader::{
         RepositoryReadError, SelectedRepositoryReader,
@@ -15,6 +15,7 @@ use std::{
 };
 
 const CLAIM: &str = "setup-claim.json";
+mod outcome;
 mod scratch;
 pub(super) use scratch::Scratch;
 const CONFINED: ResolveFlags = ResolveFlags::BENEATH
@@ -34,6 +35,22 @@ pub(super) struct Directory {
 }
 
 impl Directory {
+    pub(super) fn completion(&self, intent: &SetupIntent) -> Result<Option<SetupCompletion>, SetupRecordError> {
+        outcome::read(self, intent)
+    }
+
+    pub(super) fn record(&self, intent: &SetupIntent, completion: &SetupCompletion) -> Result<(), SetupRecordError> {
+        self.qualify()?;
+        outcome::record(
+            self,
+            intent,
+            completion,
+            &mut |file, bytes| file.write_all(bytes),
+            &mut File::sync_all,
+            &mut outcome::link,
+        )
+    }
+
     pub(super) fn scratch(&self, intent: &SetupIntent) -> Result<Scratch, super::SetupBoundaryError> {
         self.qualify()?;
         if self.observe(intent)? != SetupObservation::ClaimedUnknown {

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/outcome.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/outcome.rs
@@ -1,0 +1,83 @@
+use super::super::{SetupBoundaryError, SetupCompletion, SetupRecordError, outcome::codec};
+use super::{Directory, RegularFileRead, RepositoryReadError, SetupIntent, SetupObservation, storage_error};
+use rustix::fs::{AtFlags, CWD, linkat};
+use std::{
+    fs::File,
+    io,
+    os::{fd::AsRawFd, unix::fs::MetadataExt},
+};
+
+const RESULT: &str = "setup-result.json";
+
+fn claimed(directory: &Directory, intent: &SetupIntent) -> Result<(), SetupRecordError> {
+    if directory.observe(intent)? != SetupObservation::ClaimedUnknown {
+        return Err(SetupBoundaryError::InvalidClaim.into());
+    }
+    Ok(())
+}
+
+pub(super) fn read(directory: &Directory, intent: &SetupIntent) -> Result<Option<SetupCompletion>, SetupRecordError> {
+    claimed(directory, intent)?;
+    let result = read_file(directory)?
+        .map(|record| codec::decode(&directory.path, intent, &record.bytes))
+        .transpose()?;
+    claimed(directory, intent)?;
+    Ok(result)
+}
+
+fn read_file(directory: &Directory) -> Result<Option<RegularFileRead>, SetupRecordError> {
+    match directory.reader.read_private_file(RESULT, codec::MAX_BYTES) {
+        Ok(record) => Ok(Some(record)),
+        Err(RepositoryReadError::Missing) => Ok(None),
+        Err(RepositoryReadError::Unsupported) => Err(SetupBoundaryError::Unsupported.into()),
+        Err(RepositoryReadError::TooLarge) => Err(SetupRecordError::InvalidRecord),
+        Err(_) => Err(SetupRecordError::Read),
+    }
+}
+
+pub(super) fn record(
+    directory: &Directory,
+    intent: &SetupIntent,
+    completion: &SetupCompletion,
+    write: &mut impl FnMut(&mut File, &[u8]) -> io::Result<()>,
+    sync: &mut impl FnMut(&File) -> io::Result<()>,
+    publish: &mut impl FnMut(&File, &File) -> Result<(), rustix::io::Errno>,
+) -> Result<(), SetupRecordError> {
+    if read(directory, intent)?.is_some() {
+        return Err(SetupRecordError::Existing);
+    }
+    let bytes = codec::encode(&directory.path, intent, completion)?;
+    let mut file = directory.anonymous()?;
+    write(&mut file, &bytes).map_err(|_| SetupRecordError::Storage)?;
+    sync(&file).map_err(|_| SetupRecordError::Storage)?;
+    claimed(directory, intent)?;
+    publish(&file, &directory.handle).map_err(|error| match error {
+        rustix::io::Errno::EXIST => SetupRecordError::Existing,
+        error => SetupRecordError::from(storage_error(error)),
+    })?;
+    sync(&file).map_err(|_| SetupRecordError::Storage)?;
+    sync(&directory.handle).map_err(|_| SetupRecordError::Storage)?;
+    claimed(directory, intent)?;
+    let actual = read_file(directory)?.ok_or(SetupRecordError::Read)?;
+    let observed = actual.file.metadata().map_err(|_| SetupRecordError::Read)?;
+    let expected = file.metadata().map_err(|_| SetupRecordError::Read)?;
+    if actual.bytes != bytes || (observed.dev(), observed.ino()) != (expected.dev(), expected.ino()) {
+        return Err(SetupRecordError::Read);
+    }
+    claimed(directory, intent)?;
+    Ok(())
+}
+
+pub(super) fn link(file: &File, directory: &File) -> Result<(), rustix::io::Errno> {
+    // Follow only the held anonymous inode, never the fixed no-replace destination.
+    linkat(
+        CWD,
+        format!("/proc/self/fd/{}", file.as_raw_fd()),
+        directory,
+        RESULT,
+        AtFlags::SYMLINK_FOLLOW,
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/outcome/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/outcome/tests.rs
@@ -1,0 +1,191 @@
+use super::super::super::{SetupCompletionState, outcome::tests::snapshot, tests::intent};
+use super::super::tests::{directory, private};
+use super::super::{Admission, CLAIM, Mode};
+use super::*;
+use std::{
+    fs,
+    io::Write,
+    os::unix::fs::{PermissionsExt, symlink},
+};
+
+fn fixture() -> (tempfile::TempDir, Directory, SetupIntent, SetupCompletion) {
+    let root = private();
+    let directory = directory(root.path());
+    let intent = intent();
+    assert!(matches!(
+        directory.admit_with(
+            &intent,
+            &mut |f, b| f.write_all(b),
+            &mut File::sync_all,
+            &mut super::super::link
+        ),
+        Ok(Admission::Fresh)
+    ));
+    let completion = snapshot(root.path(), &intent, SetupCompletionState::Rejected);
+    (root, directory, intent, completion)
+}
+
+// State-only faults use the existing unqualified test directory, never a production
+// qualification bypass. Real confined file operations do not prove power-loss survival.
+#[test]
+fn write_sync_and_link_faults_retain_named_results_and_never_replace_them() {
+    for fail in 0..6 {
+        let (root, directory, intent, completion) = fixture();
+        let mut syncs = 0;
+        let result = record(
+            &directory,
+            &intent,
+            &completion,
+            &mut |file, bytes| {
+                if fail == 0 {
+                    file.write_all(&bytes[..5])?;
+                    return Err(io::ErrorKind::Other.into());
+                }
+                file.write_all(bytes)
+            },
+            &mut |file| {
+                syncs += 1;
+                if syncs == fail {
+                    return Err(io::ErrorKind::Other.into());
+                }
+                file.sync_all()
+            },
+            &mut |file, parent| {
+                if fail == 4 {
+                    return Err(rustix::io::Errno::IO);
+                }
+                link(file, parent)?;
+                if fail == 5 {
+                    return Err(rustix::io::Errno::IO);
+                }
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        let named = matches!(fail, 2 | 3 | 5);
+        assert_eq!(root.path().join(RESULT).exists(), named);
+        assert_eq!(read(&directory, &intent).unwrap().is_some(), named);
+        assert_eq!(directory.observe(&intent), Ok(SetupObservation::ClaimedUnknown));
+        if named {
+            assert_eq!(
+                record(
+                    &directory,
+                    &intent,
+                    &completion,
+                    &mut |_, _| panic!("write"),
+                    &mut |_| panic!("sync"),
+                    &mut |_, _| panic!("link")
+                ),
+                Err(SetupRecordError::Existing)
+            );
+        }
+    }
+}
+
+#[test]
+fn correct_order_records_historical_result_without_observer_synchronization() {
+    let (root, directory, intent, completion) = fixture();
+    let mut syncs = 0;
+    record(
+        &directory,
+        &intent,
+        &completion,
+        &mut |file, bytes| file.write_all(bytes),
+        &mut |file| {
+            syncs += 1;
+            assert_eq!(file.metadata().unwrap().is_dir(), syncs == 3);
+            assert_eq!(read(&directory, &intent).unwrap().is_some(), syncs > 1);
+            file.sync_all()
+        },
+        &mut link,
+    )
+    .unwrap();
+    assert_eq!(syncs, 3);
+    assert_eq!(read(&directory, &intent).unwrap(), Some(completion));
+    drop(directory);
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 2);
+}
+
+#[test]
+fn existing_special_corrupt_and_conflicting_results_are_not_adopted() {
+    for kind in 0..7 {
+        let (root, directory, intent, completion) = fixture();
+        let path = root.path().join(RESULT);
+        match kind {
+            0 => fs::write(&path, b"invalid").unwrap(),
+            1 => fs::create_dir(&path).unwrap(),
+            2 => symlink("missing", &path).unwrap(),
+            3 => rustix::fs::mknodat(
+                &directory.handle,
+                RESULT,
+                rustix::fs::FileType::Fifo,
+                Mode::RUSR | Mode::WUSR,
+                0,
+            )
+            .unwrap(),
+            _ => {
+                let mut expected = intent.clone();
+                if kind == 6 {
+                    expected.workspace_local_id.push('2');
+                }
+                fs::write(&path, codec::encode(root.path(), &expected, &completion).unwrap()).unwrap();
+                fs::set_permissions(&path, fs::Permissions::from_mode(if kind == 4 { 0o644 } else { 0o600 })).unwrap();
+                if kind == 5 {
+                    fs::hard_link(&path, root.path().join("alias")).unwrap();
+                }
+            }
+        }
+        let before = fs::symlink_metadata(&path).unwrap().ino();
+        assert!(read(&directory, &intent).is_err());
+        assert!(
+            record(
+                &directory,
+                &intent,
+                &completion,
+                &mut |_, _| panic!("write"),
+                &mut |_| panic!("sync"),
+                &mut |_, _| panic!("link")
+            )
+            .is_err()
+        );
+        assert_eq!(fs::symlink_metadata(&path).unwrap().ino(), before);
+    }
+}
+
+#[test]
+fn claim_root_and_readback_changes_never_acknowledge_or_clean() {
+    for kind in 0..4 {
+        let (root, directory, intent, completion) = fixture();
+        let mut syncs = 0;
+        let result = record(
+            &directory,
+            &intent,
+            &completion,
+            &mut |file, bytes| file.write_all(bytes),
+            &mut |file| {
+                syncs += 1;
+                if syncs == 3 {
+                    match kind {
+                        0 => fs::write(root.path().join(CLAIM), b"invalid").unwrap(),
+                        1 => fs::set_permissions(root.path(), fs::Permissions::from_mode(0o755)).unwrap(),
+                        2 => fs::write(root.path().join(RESULT), b"invalid").unwrap(),
+                        _ => {
+                            fs::rename(root.path().join(RESULT), root.path().join("retained-original")).unwrap();
+                            fs::write(
+                                root.path().join(RESULT),
+                                codec::encode(root.path(), &intent, &completion).unwrap(),
+                            )
+                            .unwrap();
+                            fs::set_permissions(root.path().join(RESULT), fs::Permissions::from_mode(0o600)).unwrap();
+                        }
+                    }
+                }
+                file.sync_all()
+            },
+            &mut link,
+        );
+        assert!(result.is_err());
+        assert!(root.path().join(RESULT).exists());
+        assert!(root.path().join(CLAIM).exists());
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/tests.rs
@@ -7,7 +7,7 @@ use std::{
     thread,
 };
 
-fn private() -> tempfile::TempDir {
+pub(super) fn private() -> tempfile::TempDir {
     let root = tempfile::tempdir().unwrap();
     fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
     root
@@ -15,7 +15,7 @@ fn private() -> tempfile::TempDir {
 
 // Real confinement, private files, link and synchronization; these state tests
 // bypass only storage qualification and make no power-loss/durability claim.
-fn directory(path: &Path) -> Directory {
+pub(super) fn directory(path: &Path) -> Directory {
     Directory {
         reader: SelectedRepositoryReader::open(path).unwrap().root,
         handle: File::open(path).unwrap(),

--- a/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
@@ -8,9 +8,13 @@ mod execution;
 mod intent;
 #[cfg(target_os = "linux")]
 mod linux;
+mod outcome;
 
 pub use execution::{SetupBoundaryError, SetupExecutionError};
 pub use intent::SetupIntent;
+pub use outcome::{
+    SetupCompletion, SetupCompletionState, SetupMaterializationResult, SetupRecordError, SetupRecordingFailure,
+};
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
 use std::{fmt, path::Path};

--- a/crates/horizon-core/src/repository_overlay/retained_setup/outcome/codec.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/outcome/codec.rs
@@ -1,0 +1,113 @@
+use super::super::{SCRATCH_NAME, SetupIntent, codec as claim};
+use super::snapshot::CompletionData;
+use super::{SetupCompletion, SetupCompletionState as State, SetupRecordError as Error};
+use crate::{cloud_run::ArtifactDigest, repository_overlay::checkout::publication::validate_sibling_name};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+// Three escaped retained child paths plus canonical identity and a bounded reason.
+pub(in super::super) const MAX_BYTES: usize = 128 * 1024;
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Record {
+    version: u32,
+    claim_sha256: ArtifactDigest,
+    completion: CompletionData,
+}
+
+pub(in super::super) fn encode(
+    root: &Path,
+    intent: &SetupIntent,
+    completion: &SetupCompletion,
+) -> Result<Vec<u8>, Error> {
+    validate(root, intent, &completion.data)?;
+    let record = Record {
+        version: 1,
+        claim_sha256: ArtifactDigest::sha256(&claim::encode(intent)?),
+        completion: completion.data.clone(),
+    };
+    let bytes = serde_json::to_vec(&record).map_err(|_| Error::InvalidRecord)?;
+    if bytes.len() > MAX_BYTES {
+        return Err(Error::InvalidRecord);
+    }
+    Ok(bytes)
+}
+
+pub(in super::super) fn decode(root: &Path, intent: &SetupIntent, bytes: &[u8]) -> Result<SetupCompletion, Error> {
+    if bytes.len() > MAX_BYTES {
+        return Err(Error::InvalidRecord);
+    }
+    let record: Record = serde_json::from_slice(bytes).map_err(|_| Error::InvalidRecord)?;
+    let completion = SetupCompletion {
+        data: record.completion,
+    };
+    if record.version != 1
+        || record.claim_sha256 != ArtifactDigest::sha256(&claim::encode(intent)?)
+        || encode(root, intent, &completion)? != bytes
+    {
+        return Err(Error::InvalidRecord);
+    }
+    Ok(completion)
+}
+
+fn validate(root: &Path, intent: &SetupIntent, value: &CompletionData) -> Result<(), Error> {
+    let scratch = root.join(SCRATCH_NAME);
+    for path in [&value.source_metadata, &value.checkout, &value.possible_destination]
+        .into_iter()
+        .flatten()
+    {
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(Error::InvalidRecord)?;
+        if path.parent() != Some(scratch.as_path()) || validate_sibling_name(name).is_err() {
+            return Err(Error::InvalidRecord);
+        }
+    }
+    let identity = value.base_commit.is_some();
+    if identity != value.bundle_manifest.is_some()
+        || value
+            .bundle_manifest
+            .as_ref()
+            .is_some_and(|digest| digest != &intent.bundle_manifest)
+        || value
+            .base_commit
+            .as_ref()
+            .is_some_and(|base| !git2::Oid::from_str(base).is_ok_and(|oid| !oid.is_zero() && oid.to_string() == *base))
+        || (value.checkout.is_some() && value.source_metadata.is_none())
+        || (value.checkout.is_some() && value.checkout == value.source_metadata)
+        || (identity && value.checkout.is_none())
+        || value
+            .reason
+            .as_ref()
+            .is_some_and(|reason| reason.is_empty() || reason.len() > 1024 || reason.contains('\0'))
+    {
+        return Err(Error::InvalidRecord);
+    }
+    let complete = value.source_metadata.is_some() && value.checkout.is_some() && identity;
+    let destination = scratch.join(&intent.destination);
+    let valid = match value.state {
+        State::Rejected => {
+            value.reason.is_some()
+                && value.source_metadata.is_none()
+                && value.checkout.is_none()
+                && !identity
+                && value.possible_destination.is_none()
+        }
+        State::Unpublished => value.reason.is_some() && value.possible_destination.is_none(),
+        State::Published | State::PublishedUnsynchronized => {
+            complete
+                && value.checkout.as_ref() == Some(&destination)
+                && value.possible_destination.is_none()
+                && value.reason.is_none() == (value.state == State::Published)
+        }
+        State::RenameUnconfirmed => {
+            complete
+                && value.reason.is_some()
+                && value.possible_destination.as_ref() == Some(&destination)
+                && value.checkout != value.possible_destination
+        }
+    };
+    if valid { Ok(()) } else { Err(Error::InvalidRecord) }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/outcome/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/outcome/mod.rs
@@ -1,0 +1,119 @@
+//! Historical execution receipts, never liveness, replay or cleanup authority.
+
+#[cfg(any(target_os = "linux", test))]
+pub(super) mod codec;
+mod snapshot;
+
+use super::{RetainedSetup, SetupBoundaryError, SetupClaimError, SetupExecutionError, SetupGrant, SetupIntent};
+use crate::repository_overlay::materialize::MaterializedRepository;
+pub use snapshot::{SetupCompletion, SetupCompletionState};
+
+pub type SetupMaterializationResult = Result<MaterializedRepository, SetupExecutionError>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SetupRecordError {
+    #[error(transparent)]
+    Boundary(#[from] SetupBoundaryError),
+    #[error("retained setup result cannot be safely read")]
+    Read,
+    #[error("retained setup result is invalid, conflicting or exceeds its bound")]
+    InvalidRecord,
+    #[error("retained setup result already exists and cannot be replaced")]
+    Existing,
+    #[error("retained setup result synchronization is unconfirmed; retain all state")]
+    Storage,
+}
+
+impl From<SetupClaimError> for SetupRecordError {
+    fn from(error: SetupClaimError) -> Self {
+        Self::Boundary(error.into())
+    }
+}
+
+/// Recording uncertainty never discards an actual execution result or permits replay.
+#[derive(Debug, thiserror::Error)]
+#[error("{problem}")]
+pub struct SetupRecordingFailure {
+    pub problem: SetupRecordError,
+    execution: Option<SetupMaterializationResult>,
+}
+
+impl SetupRecordingFailure {
+    /// None means this invocation rejected recording preflight before execution.
+    #[must_use]
+    pub fn execution(&self) -> Option<&SetupMaterializationResult> {
+        self.execution.as_ref()
+    }
+
+    #[must_use]
+    pub fn into_execution(self) -> Option<SetupMaterializationResult> {
+        self.execution
+    }
+}
+
+impl RetainedSetup {
+    /// Read only the matching claim's historical result; never inspect its paths.
+    /// None means claimed but unknown, not unstarted, running or safe to replay.
+    /// Observation does not acknowledge this reader's synchronization or liveness.
+    /// Run off the UI thread; byte bounds do not bound filesystem I/O latency.
+    /// # Errors
+    /// Missing/conflicting claims and unsafe or malformed results are not absence.
+    pub fn completion(&self, intent: &SetupIntent) -> Result<Option<SetupCompletion>, SetupRecordError> {
+        #[cfg(target_os = "linux")]
+        return self.directory.completion(intent);
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = intent;
+            Err(SetupBoundaryError::Unsupported.into())
+        }
+    }
+}
+
+impl SetupGrant {
+    /// Consume one grant, materialize and record its result in the retained root.
+    /// An existing/unsafe result rejects execution; no record is adopted or replaced.
+    /// The outer Ok acknowledges result-file and parent synchronization on qualified
+    /// healthy storage; its inner result retains the materializer's exact outcome.
+    /// Requires the same stable private ancestry/mount/source contracts as materialize.
+    /// No supervisor, task launch, power-loss guarantee, replay or cleanup is provided.
+    /// # Errors
+    /// Record failures preserve an optional full execution result for inspection.
+    /// A missing record after interruption remains unknown, even if a checkout exists.
+    pub fn materialize_recorded(
+        self,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<SetupMaterializationResult, SetupRecordingFailure> {
+        #[cfg(target_os = "linux")]
+        {
+            let directory = std::sync::Arc::clone(&self.directory);
+            let intent = self.intent.clone();
+            let preflight = directory
+                .completion(&intent)
+                .and_then(|existing| existing.map_or(Ok(()), |_| Err(SetupRecordError::Existing)));
+            preflight.map_err(|problem| SetupRecordingFailure {
+                problem,
+                execution: None,
+            })?;
+            let execution = self.materialize(cancelled);
+            let completion = SetupCompletion::from_execution(&execution);
+            match directory.record(&intent, &completion) {
+                Ok(()) => Ok(execution),
+                Err(problem) => Err(SetupRecordingFailure {
+                    problem,
+                    execution: Some(execution),
+                }),
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = cancelled;
+            Err(SetupRecordingFailure {
+                problem: SetupBoundaryError::Unsupported.into(),
+                execution: None,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests;

--- a/crates/horizon-core/src/repository_overlay/retained_setup/outcome/snapshot.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/outcome/snapshot.rs
@@ -1,0 +1,143 @@
+use crate::cloud_run::ArtifactDigest;
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupCompletionState {
+    Rejected,
+    Unpublished,
+    Published,
+    PublishedUnsynchronized,
+    RenameUnconfirmed,
+}
+
+/// Historical returned execution state, not a current filesystem or task assertion.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SetupCompletion {
+    pub(super) data: CompletionData,
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CompletionData {
+    pub(super) state: SetupCompletionState,
+    pub(super) reason: Option<String>,
+    pub(super) source_metadata: Option<PathBuf>,
+    pub(super) checkout: Option<PathBuf>,
+    pub(super) possible_destination: Option<PathBuf>,
+    pub(super) base_commit: Option<String>,
+    pub(super) bundle_manifest: Option<ArtifactDigest>,
+}
+
+impl fmt::Debug for SetupCompletion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetupCompletion")
+            .field("state", &self.data.state)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SetupCompletion {
+    #[must_use]
+    pub fn state(&self) -> SetupCompletionState {
+        self.data.state
+    }
+    #[must_use]
+    pub fn reason(&self) -> Option<&str> {
+        self.data.reason.as_deref()
+    }
+    #[must_use]
+    pub fn source_metadata(&self) -> Option<&Path> {
+        self.data.source_metadata.as_deref()
+    }
+    #[must_use]
+    pub fn checkout(&self) -> Option<&Path> {
+        self.data.checkout.as_deref()
+    }
+    #[must_use]
+    pub fn possible_destination(&self) -> Option<&Path> {
+        self.data.possible_destination.as_deref()
+    }
+    #[must_use]
+    pub fn base_commit(&self) -> Option<&str> {
+        self.data.base_commit.as_deref()
+    }
+    #[must_use]
+    pub fn bundle_manifest(&self) -> Option<&ArtifactDigest> {
+        self.data.bundle_manifest.as_ref()
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(super) fn from_execution(result: &super::SetupMaterializationResult) -> Self {
+        use super::super::SetupExecutionError;
+        use crate::repository_overlay::{
+            checkout::publication::PublicationFailure, materialize::MaterializationProblem,
+        };
+        let mut snapshot = CompletionData {
+            state: SetupCompletionState::Rejected,
+            reason: None,
+            source_metadata: None,
+            checkout: None,
+            possible_destination: None,
+            base_commit: None,
+            bundle_manifest: None,
+        };
+        match result {
+            Ok(repository) => {
+                snapshot.state = SetupCompletionState::Published;
+                snapshot.source_metadata = Some(repository.source_metadata().to_owned());
+                let checkout = repository.checkout();
+                snapshot.repository(checkout.path(), checkout.base_commit(), checkout.manifest_sha256());
+            }
+            Err(error) => {
+                snapshot.reason = Some(error.to_string());
+                if let SetupExecutionError::Materialization(failure) = error {
+                    snapshot.source_metadata = failure.source_metadata().map(Path::to_owned);
+                    snapshot.state = SetupCompletionState::Unpublished;
+                    match &failure.problem {
+                        MaterializationProblem::InvalidRequest => snapshot.state = SetupCompletionState::Rejected,
+                        MaterializationProblem::Preparation(failure) => {
+                            snapshot.checkout = failure.residue().map(Path::to_owned);
+                        }
+                        MaterializationProblem::Publication(failure) => match failure.as_ref() {
+                            PublicationFailure::Unpublished { checkout: stage, .. } => {
+                                snapshot.repository(stage.path(), stage.base_commit(), stage.manifest_sha256());
+                            }
+                            PublicationFailure::PublishedUnsynchronized { checkout, .. } => {
+                                snapshot.state = SetupCompletionState::PublishedUnsynchronized;
+                                snapshot.repository(
+                                    checkout.path(),
+                                    checkout.base_commit(),
+                                    checkout.manifest_sha256(),
+                                );
+                            }
+                            PublicationFailure::RenameUnconfirmed {
+                                checkout: stage,
+                                destination,
+                            } => {
+                                snapshot.state = SetupCompletionState::RenameUnconfirmed;
+                                snapshot.repository(stage.path(), stage.base_commit(), stage.manifest_sha256());
+                                snapshot.possible_destination = Some(destination.clone());
+                            }
+                        },
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Self { data: snapshot }
+    }
+}
+
+impl CompletionData {
+    #[cfg(target_os = "linux")]
+    fn repository(&mut self, path: &Path, base: git2::Oid, manifest: &ArtifactDigest) {
+        self.checkout = Some(path.to_owned());
+        self.base_commit = Some(base.to_string());
+        self.bundle_manifest = Some(manifest.clone());
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/outcome/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/outcome/tests.rs
@@ -29,14 +29,18 @@ pub(in super::super) fn snapshot(root: &Path, intent: &SetupIntent, state: State
 #[test]
 fn canonical_states_round_trip_without_disclosing_paths_or_confusing_publication() {
     let root = std::env::temp_dir();
-    let intent = intent();
-    for state in [
-        State::Rejected,
-        State::Unpublished,
-        State::Published,
-        State::PublishedUnsynchronized,
-        State::RenameUnconfirmed,
+    for (state, destination) in [
+        (State::Rejected, "repository"),
+        (State::Unpublished, "repository"),
+        (State::Unpublished, "stage"),
+        (State::Unpublished, "metadata"),
+        (State::Published, "repository"),
+        (State::PublishedUnsynchronized, "repository"),
+        (State::RenameUnconfirmed, "repository"),
+        (State::RenameUnconfirmed, "metadata"),
     ] {
+        let mut intent = intent();
+        intent.destination = destination.into();
         let expected = snapshot(&root, &intent, state);
         let bytes = codec::encode(&root, &intent, &expected).unwrap();
         assert_eq!(codec::decode(&root, &intent, &bytes).unwrap(), expected);

--- a/crates/horizon-core/src/repository_overlay/retained_setup/outcome/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/outcome/tests.rs
@@ -1,0 +1,320 @@
+use super::super::{SCRATCH_NAME, tests::intent};
+use super::*;
+use SetupCompletionState as State;
+use serde_json::json;
+use std::path::Path;
+
+pub(in super::super) fn snapshot(root: &Path, intent: &SetupIntent, state: State) -> SetupCompletion {
+    let scratch = root.join(SCRATCH_NAME);
+    let published = state == State::Published;
+    let rejected = state == State::Rejected;
+    let checkout_name = if matches!(state, State::Published | State::PublishedUnsynchronized) {
+        &intent.destination
+    } else {
+        "stage"
+    };
+    SetupCompletion {
+        data: snapshot::CompletionData {
+            state,
+            reason: (!published).then(|| "synthetic redacted failure".into()),
+            source_metadata: (!rejected).then(|| scratch.join("metadata")),
+            checkout: (!rejected).then(|| scratch.join(checkout_name)),
+            possible_destination: (state == State::RenameUnconfirmed).then(|| scratch.join(&intent.destination)),
+            base_commit: (!rejected).then(|| "a".repeat(40)),
+            bundle_manifest: (!rejected).then(|| intent.bundle_manifest.clone()),
+        },
+    }
+}
+
+#[test]
+fn canonical_states_round_trip_without_disclosing_paths_or_confusing_publication() {
+    let root = std::env::temp_dir();
+    let intent = intent();
+    for state in [
+        State::Rejected,
+        State::Unpublished,
+        State::Published,
+        State::PublishedUnsynchronized,
+        State::RenameUnconfirmed,
+    ] {
+        let expected = snapshot(&root, &intent, state);
+        let bytes = codec::encode(&root, &intent, &expected).unwrap();
+        assert_eq!(codec::decode(&root, &intent, &bytes).unwrap(), expected);
+        assert!(!format!("{expected:?}").contains("metadata"));
+        let mut changed = intent.clone();
+        changed.workspace_local_id.push('2');
+        assert_eq!(
+            codec::decode(&root, &changed, &bytes),
+            Err(SetupRecordError::InvalidRecord)
+        );
+    }
+}
+
+#[test]
+fn corrupt_noncanonical_and_inconsistent_records_are_never_completion() {
+    let root = std::env::temp_dir();
+    let intent = intent();
+    let valid = codec::encode(&root, &intent, &snapshot(&root, &intent, State::Published)).unwrap();
+    let text = String::from_utf8(valid.clone()).unwrap();
+    for bad in [
+        String::new(),
+        "{}".into(),
+        format!("{text}\n"),
+        text.replace("\"version\":1", "\"version\":2"),
+        text.replace("\"version\":1", "\"version\":1,\"version\":1"),
+        text.replace("\"version\":1", "\"version\":1,\"extra\":0"),
+        text[..text.len() - 1].into(),
+        "x".repeat(codec::MAX_BYTES + 1),
+    ] {
+        assert_eq!(
+            codec::decode(&root, &intent, bad.as_bytes()),
+            Err(SetupRecordError::InvalidRecord)
+        );
+    }
+    for (field, replacement) in [
+        ("state", json!("unknown")),
+        ("reason", json!("false success")),
+        ("source_metadata", json!(null)),
+        ("base_commit", json!("invalid")),
+        ("base_commit", json!("A".repeat(40))),
+        ("bundle_manifest", json!("b".repeat(64))),
+        ("checkout", json!(root.join("outside"))),
+        ("possible_destination", json!(root.join(SCRATCH_NAME).join("other"))),
+        ("extra", json!(true)),
+    ] {
+        let mut value: serde_json::Value = serde_json::from_slice(&valid).unwrap();
+        value["completion"][field] = replacement;
+        if let Ok(data) = serde_json::from_value::<snapshot::CompletionData>(value["completion"].clone()) {
+            assert_eq!(
+                codec::encode(&root, &intent, &SetupCompletion { data }),
+                Err(SetupRecordError::InvalidRecord)
+            );
+        }
+        assert_eq!(
+            codec::decode(&root, &intent, &serde_json::to_vec(&value).unwrap()),
+            Err(SetupRecordError::InvalidRecord)
+        );
+    }
+    let mut largest = snapshot(&root, &intent, State::RenameUnconfirmed);
+    largest.data.reason = Some("x".repeat(1025));
+    assert_eq!(
+        codec::encode(&root, &intent, &largest),
+        Err(SetupRecordError::InvalidRecord)
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_cannot_observe_or_record() {
+    assert_eq!(
+        RetainedSetup {}.completion(&intent()),
+        Err(SetupBoundaryError::Unsupported.into())
+    );
+    let failure = SetupGrant { intent: intent() }
+        .materialize_recorded(|| false)
+        .unwrap_err();
+    assert_eq!(failure.problem, SetupBoundaryError::Unsupported.into());
+    assert!(failure.execution().is_none());
+}
+
+#[test]
+fn maximum_escaped_retained_paths_fit_the_bounded_record() {
+    // Serialization-only proof; no filesystem node with this component is created.
+    let root = std::env::temp_dir().join("\u{1}".repeat(4000));
+    let intent = intent();
+    let mut value = snapshot(&root, &intent, State::RenameUnconfirmed);
+    value.data.reason = Some("x".repeat(1024));
+    let bytes = codec::encode(&root, &intent, &value).unwrap();
+    assert!(bytes.len() > 64 * 1024 && bytes.len() < codec::MAX_BYTES);
+    assert_eq!(codec::decode(&root, &intent, &bytes).unwrap(), value);
+}
+
+#[cfg(target_os = "linux")]
+mod supported {
+    use super::*;
+    use crate::{
+        cloud_run::ArtifactDigest,
+        repository_overlay::{
+            checkout::publication::PublicationFailure,
+            materialize::{MaterializationProblem, tests::supported::Fixture},
+            retained_setup::{SetupAdmission, SetupObservation, codec as claim},
+        },
+    };
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    fn fixture(missing: bool) -> Option<(Fixture, RetainedSetup, SetupIntent)> {
+        let fixture = Fixture::new(missing);
+        let request = fixture.request();
+        let store = match RetainedSetup::open(request.scratch_parent) {
+            Err(SetupClaimError::Unsupported) => {
+                eprintln!("SKIP recorded setup: requires qualified journaled ext4");
+                return None;
+            }
+            other => other.unwrap(),
+        };
+        let intent = SetupIntent::new(
+            "workspace_1".into(),
+            request.objects_directory.to_owned(),
+            request.bundle_store.to_owned(),
+            request.bundle_manifest.clone(),
+            request.destination.into(),
+        )
+        .unwrap();
+        Some((fixture, store, intent))
+    }
+
+    fn grant(store: &RetainedSetup, intent: &SetupIntent) -> SetupGrant {
+        let SetupAdmission::Fresh(grant) = store.admit(intent.clone()).unwrap() else {
+            panic!("fresh grant");
+        };
+        grant
+    }
+
+    fn synthetic_rename(result: SetupMaterializationResult, destination: &Path) -> SetupCompletion {
+        // Projection-only uncertainty from a real unpublished receipt, not a rename.
+        let Err(SetupExecutionError::Materialization(mut failure)) = result else {
+            panic!("component failure");
+        };
+        let problem = std::mem::replace(&mut failure.problem, MaterializationProblem::InvalidRequest);
+        let MaterializationProblem::Publication(publication) = problem else {
+            panic!("publication failure");
+        };
+        let PublicationFailure::Unpublished { checkout, .. } = *publication else {
+            panic!("unpublished receipt");
+        };
+        failure.problem = MaterializationProblem::Publication(Box::new(PublicationFailure::RenameUnconfirmed {
+            checkout,
+            destination: destination.to_owned(),
+        }));
+        SetupCompletion::from_execution(&Err(SetupExecutionError::Materialization(failure)))
+    }
+
+    #[test]
+    fn qualified_success_and_failures_survive_process_reopen_without_replay() {
+        for kind in 0..6 {
+            let Some((fixture, store, mut intent)) = fixture(kind == 2) else {
+                return;
+            };
+            let root = fixture.request().scratch_parent;
+            if kind == 1 {
+                intent.bundle_manifest = ArtifactDigest::sha256(b"missing");
+            }
+            let destination = root.join(SCRATCH_NAME).join(&intent.destination);
+            let result = grant(&store, &intent)
+                .materialize_recorded(|| {
+                    if kind == 5 && destination.parent().unwrap().exists() && !destination.exists() {
+                        fs::write(&destination, b"sentinel").unwrap();
+                    }
+                    kind == 3 || (kind == 4 && destination.exists())
+                })
+                .unwrap();
+            let completion = store.completion(&intent).unwrap().unwrap();
+            assert_eq!(
+                completion.state(),
+                match kind {
+                    0 => State::Published,
+                    3 => State::Rejected,
+                    4 => State::PublishedUnsynchronized,
+                    _ => State::Unpublished,
+                }
+            );
+            assert_eq!(result.is_ok(), kind == 0);
+            assert_eq!(completion.source_metadata().is_some(), matches!(kind, 0 | 2 | 4 | 5));
+            assert_eq!(completion.checkout().is_some(), matches!(kind, 0 | 4 | 5));
+            if kind >= 4 {
+                assert_eq!(completion.base_commit(), Some(fixture.base.to_string().as_str()));
+                assert_eq!(completion.bundle_manifest(), Some(&intent.bundle_manifest));
+                assert!(completion.checkout().unwrap().join("file").exists());
+                assert!(completion.source_metadata().unwrap().join("HEAD").exists());
+            }
+            if let Ok(repository) = &result {
+                assert_eq!(completion.checkout(), Some(repository.checkout().path()));
+                assert_eq!(completion.base_commit(), Some(fixture.base.to_string().as_str()));
+                assert_eq!(
+                    fs::read(repository.checkout().path().join("file")).unwrap(),
+                    b"working\0raw\r\n"
+                );
+            }
+            if kind == 5 {
+                let projected = synthetic_rename(result, &destination);
+                assert_eq!(projected.state(), State::RenameUnconfirmed);
+                assert_eq!(projected.checkout(), completion.checkout());
+                assert_eq!(projected.possible_destination(), Some(destination.as_path()));
+                assert_eq!(projected.base_commit(), completion.base_commit());
+                assert_eq!(projected.bundle_manifest(), completion.bundle_manifest());
+                let bytes = codec::encode(root, &intent, &projected).unwrap();
+                assert_eq!(codec::decode(root, &intent, &bytes).unwrap(), projected);
+            } else {
+                drop(result);
+            }
+            let before = fs::read(root.join("setup-result.json")).unwrap();
+            drop(store);
+            let child = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "repository_overlay::retained_setup::outcome::tests::supported::reopen_child",
+                    "--nocapture",
+                ])
+                .env("HORIZON_SETUP_OUTCOME_FIXTURE", root)
+                .output()
+                .unwrap();
+            assert!(child.status.success(), "{}", String::from_utf8_lossy(&child.stderr));
+            assert!(String::from_utf8_lossy(&child.stdout).contains("RECORDED_SETUP_NO_REPLAY"));
+            assert_eq!(fs::read(root.join("setup-result.json")).unwrap(), before);
+            assert_eq!(
+                fs::metadata(root.join("setup-result.json"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o7777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn reopen_child() {
+        let Some(root) = std::env::var_os("HORIZON_SETUP_OUTCOME_FIXTURE") else {
+            return;
+        };
+        let root = Path::new(&root);
+        let intent = claim::decode(&fs::read(root.join("setup-claim.json")).unwrap()).unwrap();
+        let store = RetainedSetup::open(root).unwrap();
+        assert!(store.completion(&intent).unwrap().is_some());
+        assert_eq!(store.observe(&intent), Ok(SetupObservation::ClaimedUnknown));
+        assert!(matches!(store.admit(intent), Ok(SetupAdmission::Existing)));
+        println!("RECORDED_SETUP_NO_REPLAY");
+    }
+
+    #[test]
+    fn uncertain_recording_keeps_full_actual_execution_and_unsafe_preflight_never_runs() {
+        for preflight in [true, false] {
+            let Some((fixture, store, intent)) = fixture(false) else {
+                return;
+            };
+            let root = fixture.request().scratch_parent;
+            let grant = grant(&store, &intent);
+            let result_path = root.join("setup-result.json");
+            if preflight {
+                fs::write(&result_path, b"invalid").unwrap();
+            }
+            let result = grant
+                .materialize_recorded(|| {
+                    if !result_path.exists() {
+                        fs::write(&result_path, b"invalid").unwrap();
+                    }
+                    false
+                })
+                .unwrap_err();
+            assert_eq!(result.execution().is_some(), !preflight);
+            assert_eq!(root.join(SCRATCH_NAME).exists(), !preflight);
+            if let Some(result) = result.into_execution() {
+                let repository = result.unwrap();
+                assert!(repository.checkout().path().join("file").exists());
+                assert!(repository.source_metadata().join("HEAD").exists());
+            }
+            assert_eq!(fs::read(&result_path).unwrap(), b"invalid");
+            assert!(matches!(store.admit(intent), Ok(SetupAdmission::Existing)));
+        }
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -259,8 +259,17 @@ back into large multi-purpose modules.
   adopted or cleaned; cancellation, failed synchronization and component failures
   retain every named residue. Execution errors distinguish the consumed boundary
   from original admission and preserve typed materializer receipts. Observation
-  stays unknown; no independent runner, stored terminal receipt, recovery or
-  client/cloud integration is provided by this synchronous boundary.
+  stays unknown; the original synchronous method does not store its result.
+  `retained_setup/outcome/` owns the separate recorded-execution API, redacted
+  historical snapshot and bounded canonical intent-bound result schema. Its Linux
+  storage leaf privately reads or publishes one fixed no-replace result slot with
+  file/parent synchronization and read-back identity verification. Preflight errors
+  never execute; later recording errors retain the complete actual execution result.
+  Read-only completion never adopts the referenced paths, acknowledges its own
+  synchronization or establishes liveness. Missing results remain unknown; nothing
+  permits replay, cleanup or construction of another grant. Private wire types keep
+  deserialization separate from public validated snapshots. This is not independent
+  supervision, transport, cloud recovery or proof of power-loss durability.
   `materialize/` composes existing private bundle retrieval, isolated raw-object
   resolution, checkout preparation and explicit publication into one worker-callable
   operation. Its typed result preserves source metadata and every known checkout or


### PR DESCRIPTION
## Purpose

Retain the actual repository setup result for read-only inspection after its
producing process exits. This is the next bounded #470 outcome after #478.

## Behavior and boundaries

- Add a separate consuming recorded-materialization API; keep the original
  synchronous materialization API and one-shot admission semantics unchanged.
- Reject an existing, corrupt or unsafe result slot before execution. Never adopt,
  replace, repair, clean or replay any retained setup state.
- Preserve the full typed execution result if later recording fails, including
  known checkout/source metadata and publication or rename uncertainty.
- Record one bounded canonical, versioned result bound to the exact immutable
  claim. Use private wire types, strict field/state/path checks and redacted public
  snapshots; public callers cannot deserialize an unchecked validated snapshot.
- Publish a confined anonymous private file into a fixed no-replace result slot,
  synchronize file and parent, then verify the same bytes and inode.
- Observe historical rejected, unpublished, published, unsynchronized-publication
  or rename-unconfirmed results without opening/adopting their referenced paths.
  Missing results stay unknown; observation proves neither current liveness nor
  this reader's synchronization and never creates an execution grant.

Healthy qualified journaled ext4 and trusted stable private ancestry, mounts and
source remain required, with separately established remote ownership. This does
not establish power-loss or cloud/PC-off durability. State-only fault injection
and synthetic uncertain-rename receipt projection are explicitly not real crash
or ambiguous-rename proof.

No dependency, independent runner, task start, new CLI command, transport,
provider/client/UI integration, image publication or release change is included.

## Validation

Exact commit `1217fe6b` passed:

- Full local validation: formatting, maintainability, version synchronization,
  default and speech workspace tests, blocking and strict Clippy, and advisory
  pedantic Clippy.
- All 37 retained-setup tests on qualified native storage, without skips. Coverage
  includes canonical records, actual successful and failed setup, post-rename
  cancellation, retained paths/identities, process reopen without replay, fixed-slot
  conflicts, failed-publication destination aliases, and state-only
  write/link/synchronization faults.
- Complete diff review and independent local review, with exact committed-patch
  parity verified.

- Exact-commit runtime and builder images passed all four regression lanes:
  packaging, repository helper, disconnected-worker security, and retained identity.
  These are existing helper/session regression checks, not new setup-command or
  cloud/PC-off acceptance evidence.

Scope: nine source/test files, 1,000 changed source/test lines, plus a focused
architecture note. No UI smoke applies. Cross-platform compilation and tests
remain required in CI. Existing primary checkout and unrelated live work are
preserved. Ambiguous label/milestone/project metadata is not guessed.

Refs #383, #470.
