### PR TITLE
Expose retained repository setup commands

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -57,8 +57,8 @@ dependency cache receives a manifest-only tree, never Horizon source in any laye
 ## Explicit repository helper
 
 The image installs `/usr/local/bin/horizon-repository`. Nothing invokes it during
-startup or starts a task after it finishes. Its only operation is an explicitly
-authorized `horizon-repository materialize` call with bounded JSON on stdin.
+startup or starts a task after it finishes. Explicitly authorized `materialize`,
+`setup` and read-only `setup-status` commands accept bounded JSON on stdin.
 See the [command protocol](../../docs/remote-repository-command.md) for the complete
 request, receipts, exit codes and retained-state rules.
 
@@ -69,8 +69,11 @@ container overlay storage is not sufficient. Unsupported storage fails closed an
 may leave an unpublished checkout. No permission repair, overwrite or cleanup is
 implicit. Missing replies are uncertain outcomes, not permission to retry.
 
-This packaging does not add object transport, worker-retained operation identity,
-client setup, recovery, checkpointing or task admission. Existing workers are not
+Retained `setup` uses one immutable claim and a fixed private setup child; repeated
+requests observe rather than replay. Status never creates state or proves liveness.
+The commands are synchronous and do not provide independent setup supervision.
+This packaging does not add object transport, client setup, recovery, checkpointing
+or task admission. Existing workers are not
 upgraded by rebuilding an image. Neither the helper nor a locally retained volume
 proves cloud durability or PC-off operation.
 
@@ -86,6 +89,9 @@ python3 -B containers/remote-worker/test_repository_packaging.py \
 
 The first checks large packed objects, raw index/worktree semantics, no-overwrite
 publication, retained data observed by a fresh container and overlay rejection.
+It also checks retained setup/status, intent conflicts, unknown claims without
+replay, unsafe result preflight and status after output loss. The claim-only case
+is a synthetic state fixture, not proof of surviving an actual interruption.
 It uses no network or credentials and removes only its owned containers/fixtures.
 The second checks the real Docker context filter with positive source controls and
 excluded synthetic files. Add `--image` and `--expected-binary-sha256` from a separate

--- a/containers/remote-worker/test_repository_image.py
+++ b/containers/remote-worker/test_repository_image.py
@@ -57,11 +57,14 @@ class ImageSmoke:
         assert value["Config"]["Labels"]["horizon.repository-image-smoke"] == self.label
         return value
 
-    def command(self, entrypoint, args, data=b"", overlay=False):
-        mounts = ["--mount", f"type=bind,src={self.root / 'source/objects'},dst=/objects,readonly",
-                  "--mount", f"type=bind,src={self.root / 'bundles'},dst=/bundles,readonly"]
+    def command(self, entrypoint, args, data=b"", overlay=False, writable_inputs=False, mount_inputs=True, retained_alias=None):
+        mode = "" if writable_inputs else ",readonly"
+        mounts = ["--mount", f"type=bind,src={self.root / 'source/objects'},dst=/objects{mode}",
+                  "--mount", f"type=bind,src={self.root / 'bundles'},dst=/bundles{mode}"] if mount_inputs else []
         if not overlay:
-            mounts += ["--mount", f"type=bind,src={self.root / 'retained'},dst=/retained"]
+            retained = self.root / "retained" if retained_alias is None else retained_alias
+            assert retained.resolve().is_relative_to(self.root.resolve())
+            mounts += ["--mount", f"type=bind,src={retained},dst=/retained"]
         command = self.docker + ["create", "--pull=never", "--network=none", "--interactive",
                                 "--user", self.user, "--label", f"horizon.repository-image-smoke={self.label}",
                                 "--entrypoint", entrypoint] + mounts + [self.image] + args
@@ -82,6 +85,126 @@ class ImageSmoke:
         receipt = json.loads(output.stdout)
         assert receipt["version"] == 1 and receipt["status"] == status
         return receipt
+
+    def setup(self, command, request, status, code, **options):
+        output = self.command("/usr/local/bin/horizon-repository", [command], encoded(request), **options)
+        assert output.returncode == code, (output.returncode, output.stdout, output.stderr)
+        assert not output.stderr and output.stdout.endswith(b"\n") and len(output.stdout) <= 128 * 1024
+        receipt = json.loads(output.stdout)
+        assert receipt["version"] == 1 and receipt["status"] == status, (receipt["status"], status)
+        return receipt
+
+    def test_setup(self):
+        def private(name):
+            root = self.root / "retained" / name
+            root.mkdir(mode=0o700)
+            return root
+
+        def request(name):
+            value = dict(self.request, workspace_local_id="workspace_1", retained_root="/retained/" + name)
+            del value["scratch_parent"]
+            return value
+
+        def state(root):
+            return snapshot(root), sorted(str(path.relative_to(root)) for path in root.rglob("*"))
+
+        root = private("setup-success")
+        expected = request(root.name)
+        initial = state(root)
+        absent = self.setup("setup-status", expected, "absent", 0, mount_inputs=False)
+        assert absent["recording"] == "not_acknowledged" and absent["execution"] is None
+        assert state(root) == initial
+        receipt = self.setup("setup", expected, "completed", 0)
+        assert receipt["recording"] == "acknowledged" and receipt["reason"] is None
+        execution = receipt["execution"]
+        assert execution["state"] == "published" and execution["base_commit"] == self.base
+        assert execution["bundle_manifest"] == self.manifest
+        assert execution["checkout"] == "/retained/setup-success/setup-data/published"
+        self.verify_checkout(root / "setup-data/published")
+        self.retire_completed()
+        retained = state(root)
+        for command in ("setup-status", "setup"):
+            observed = self.setup(command, expected, "completed", 0, mount_inputs=False)
+            assert observed["recording"] == "observed" and observed["execution"] == execution
+            assert state(root) == retained
+            conflict = self.setup(command, dict(expected, workspace_local_id="workspace_2"), "error", 1)
+            assert "conflicts" in conflict["reason"] and conflict["execution"] is None
+            assert state(root) == retained
+
+        # Synthetic interrupted-claim shape; this is not a real interruption test.
+        unknown = private("setup-unknown")
+        claim = unknown / "setup-claim.json"
+        claim.write_bytes((root / "setup-claim.json").read_bytes())
+        claim.chmod(0o600)
+        before = state(unknown)
+        for command in ("setup-status", "setup"):
+            result = self.setup(command, request(unknown.name), "claimed_unknown", 4)
+            assert result["execution"] is None and result["recording"] == "not_acknowledged"
+            assert state(unknown) == before and not (unknown / "setup-data").exists()
+
+        for command in ("setup-status", "setup"):
+            missing = self.setup(command, request("missing-setup-root"), "error", 1)
+            assert missing["execution"] is None and not (self.root / "retained/missing-setup-root").exists()
+        unsafe = self.root / "retained/setup-symlink"
+        unsafe.symlink_to(root.name)
+        for command in ("setup-status", "setup"):
+            self.setup(command, request(unsafe.name), "error", 1)
+        assert state(root) == retained
+
+        rejected = private("setup-unsafe-result")
+        result_path = rejected / "setup-result.json"
+        result_path.write_bytes(b"corrupt")
+        result_path.chmod(0o600)
+        result = self.setup("setup", request(rejected.name), "recording_unconfirmed", 1)
+        assert result["execution"] is None and result["recording"] == "not_acknowledged"
+        assert result_path.read_bytes() == b"corrupt" and not (rejected / "setup-data").exists()
+        assert (rejected / "setup-claim.json").is_file()
+        self.setup("setup-status", request(rejected.name), "error", 1)
+
+        failed = private("setup-missing-bundle")
+        failed_request = dict(request(failed.name), bundle_manifest="0" * 64)
+        failure = self.setup("setup", failed_request, "completed", 1)
+        assert failure["recording"] == "acknowledged" and failure["execution"]["state"] == "unpublished"
+        before = state(failed)
+        observed = self.setup("setup-status", failed_request, "completed", 1)
+        assert observed["recording"] == "observed" and observed["execution"] == failure["execution"]
+        assert state(failed) == before
+
+        lost = private("setup-output-loss")
+        output_loss = self.command("/usr/bin/python3", ["-c",
+            "import subprocess,sys; "
+            "out=open('/dev/full','wb'); "
+            "r=subprocess.run(['/usr/local/bin/horizon-repository','setup'],"
+            "input=sys.stdin.buffer.read(),stdout=out,stderr=subprocess.PIPE); "
+            "sys.stderr.buffer.write(r.stderr); sys.exit(r.returncode)"], encoded(request(lost.name)))
+        assert output_loss.returncode == 3 and not output_loss.stdout
+        assert b"Could not write a complete response" in output_loss.stderr
+        self.retire_completed()
+        before = state(lost)
+        observed = self.setup("setup-status", request(lost.name), "completed", 0)
+        assert observed["recording"] == "observed" and observed["execution"]["state"] == "published"
+        self.setup("setup", request(lost.name), "completed", 0)
+        assert state(lost) == before
+        self.verify_checkout(lost / "setup-data/published")
+        # Writable synthetic inputs ensure mount permissions cannot mask admission-order bugs.
+        for container_path, host_path in [("/objects", self.root / "source/objects"), ("/bundles", self.root / "bundles")]:
+            host_path.chmod(0o700)
+            nested = host_path / "setup-overlap"
+            nested.mkdir(mode=0o700)
+            for suffix in ("", "/setup-overlap"):
+                before = state(host_path)
+                overlap = dict(expected, retained_root=container_path + suffix)
+                result = self.setup("setup", overlap, "error", 1, writable_inputs=True)
+                assert result["recording"] == "not_acknowledged" and result["execution"] is None
+                assert state(host_path) == before
+                alias_root = host_path if not suffix else nested
+                aliased = dict(expected, retained_root="/retained")
+                self.setup("setup", aliased, "error", 1, writable_inputs=True, retained_alias=alias_root)
+                assert state(host_path) == before
+        print("PASS retained setup commands: non-creating status, real recorded setup and failures, "
+              "fresh-container observation, conflict rejection, synthetic claim-only no replay, "
+              "unsafe/overlapping input preflight, missing-input observation and output-loss retention; "
+              "no independent-launch claim", flush=True)
 
     def retire_completed(self):
         while self.containers:
@@ -196,6 +319,7 @@ class ImageSmoke:
         assert overlay.returncode == 1, (overlay.returncode, overlay.stdout, overlay.stderr)
         rejected = json.loads(overlay.stdout)
         assert rejected["status"] == "unpublished" and "unsupported" in rejected["reason"]
+        self.test_setup()
         assert before == (snapshot(self.root / "source"), snapshot(self.root / "bundles"))
         print("PASS image helper: strict input, packed 65 MiB-plus raw checkout, shallow HEAD/index/LFS/link/modes, "
               "qualified publication, no overwrite, retained unpublished checkout, fresh-container observation, "

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 const CLAIM: &str = "setup-claim.json";
+mod inputs;
 mod outcome;
 mod scratch;
 pub(super) use scratch::Scratch;
@@ -35,6 +36,12 @@ pub(super) struct Directory {
 }
 
 impl Directory {
+    pub(super) fn check_inputs(&self, intent: &SetupIntent) -> Result<(), super::SetupInputError> {
+        self.verify()?;
+        inputs::validate(&self.handle, intent)?;
+        Ok(self.verify()?)
+    }
+
     pub(super) fn completion(&self, intent: &SetupIntent) -> Result<Option<SetupCompletion>, SetupRecordError> {
         outcome::read(self, intent)
     }

--- a/crates/horizon-core/src/repository_overlay/retained_setup/linux/inputs.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/linux/inputs.rs
@@ -1,0 +1,130 @@
+use super::super::SetupInputError as Error;
+use super::{CONFINED, File, Mode, OFlags, SelectedRepositoryReader, SetupIntent, openat2};
+use rustix::fs::Dir;
+use std::{
+    fs::Metadata,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const MAX_NODES: usize = 262_144;
+const MAX_PATH_BYTES: usize = 16 * 1024 * 1024;
+
+pub(super) fn validate(retained: &File, intent: &SetupIntent) -> Result<(), Error> {
+    let identity = retained.metadata().map_err(|_| Error::Unverified)?;
+    for source in [&intent.objects_directory, &intent.bundle_store] {
+        separate(source, &identity, MAX_NODES)?;
+    }
+    Ok(())
+}
+
+fn same(left: &Metadata, right: &Metadata) -> bool {
+    (left.dev(), left.ino()) == (right.dev(), right.ino())
+}
+
+fn separate(source: &Path, retained: &Metadata, limit: usize) -> Result<(), Error> {
+    let reader = SelectedRepositoryReader::open(source).map_err(|_| Error::Unverified)?;
+    let identity = reader.root.handle().metadata().map_err(|_| Error::Unverified)?;
+    let mut pending = vec![PathBuf::from(".")];
+    let (mut nodes, mut bytes) = (1usize, 1usize);
+    while let Some(relative) = pending.pop() {
+        if nodes > limit || relative.components().count() > 64 {
+            return Err(Error::Unverified);
+        }
+        let node = File::from(
+            openat2(
+                reader.root.handle(),
+                &relative,
+                OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            )
+            .map_err(|_| Error::Unverified)?,
+        );
+        let metadata = node.metadata().map_err(|_| Error::Unverified)?;
+        if metadata.nlink() == 0 || !(metadata.is_file() || metadata.is_dir()) || same(&metadata, retained) {
+            return Err(Error::Unverified);
+        }
+        if !metadata.is_dir() {
+            continue;
+        }
+        let directory = File::from(
+            openat2(
+                &node,
+                ".",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            )
+            .map_err(|_| Error::Unverified)?,
+        );
+        for entry in Dir::read_from(&directory).map_err(|_| Error::Unverified)? {
+            let entry = entry.map_err(|_| Error::Unverified)?;
+            let name = entry.file_name().to_str().map_err(|_| Error::Unverified)?;
+            if matches!(name, "." | "..") {
+                continue;
+            }
+            let child = relative.join(name);
+            nodes = nodes
+                .checked_add(1)
+                .filter(|count| *count <= limit)
+                .ok_or(Error::Unverified)?;
+            bytes = bytes
+                .checked_add(child.as_os_str().len())
+                .filter(|count| *count <= MAX_PATH_BYTES)
+                .ok_or(Error::Unverified)?;
+            pending.push(child);
+        }
+    }
+    let current = SelectedRepositoryReader::open(source).map_err(|_| Error::Unverified)?;
+    if !same(
+        &identity,
+        &current.root.handle().metadata().map_err(|_| Error::Unverified)?,
+    ) {
+        return Err(Error::Unverified);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{directory, private};
+    use super::*;
+    use crate::repository_overlay::retained_setup::tests::intent;
+    use std::{
+        fs,
+        os::unix::fs::{PermissionsExt, symlink},
+    };
+
+    #[test]
+    fn exact_nested_alias_and_unsafe_input_roots_are_read_only_rejections() {
+        let source = private();
+        let other = private();
+        fs::write(source.path().join("sentinel"), b"unchanged").unwrap();
+        let nested = source.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::set_permissions(&nested, fs::Permissions::from_mode(0o700)).unwrap();
+        for root in [source.path(), &nested] {
+            for bundle in [false, true] {
+                let mut expected = intent();
+                expected.objects_directory = if bundle { other.path() } else { source.path() }.into();
+                expected.bundle_store = if bundle { source.path() } else { other.path() }.into();
+                assert_eq!(directory(root).check_inputs(&expected), Err(Error::Unverified));
+                assert!(!root.join("setup-claim.json").exists() && !root.join("setup-data").exists());
+            }
+        }
+        let retained = File::open(other.path()).unwrap().metadata().unwrap();
+        assert_eq!(separate(source.path(), &retained, MAX_NODES), Ok(()));
+        assert_eq!(separate(source.path(), &retained, 0), Err(Error::Unverified));
+        let alias = other.path().join("alias");
+        symlink(source.path(), &alias).unwrap();
+        assert_eq!(separate(&alias, &retained, MAX_NODES), Err(Error::Unverified));
+        assert_eq!(
+            separate(&source.path().join("missing"), &retained, MAX_NODES),
+            Err(Error::Unverified)
+        );
+        assert_eq!(fs::read(source.path().join("sentinel")).unwrap(), b"unchanged");
+        assert_eq!(fs::read_dir(source.path()).unwrap().count(), 2);
+        assert_eq!(fs::read_dir(nested).unwrap().count(), 0);
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
@@ -62,6 +62,24 @@ impl fmt::Debug for SetupGrant {
 }
 
 impl RetainedSetup {
+    /// Admit setup only after read-only input-tree separation checks, unless already claimed.
+    /// Existing matching claims do not require the original source inputs to remain available.
+    /// Trusted stable input topology, ancestry and mounts must remain unchanged through execution.
+    /// # Errors
+    /// Fails closed on unavailable/unsafe/overlapping inputs or bounded traversal exhaustion,
+    /// without writing a fresh claim. Existing admission/uncertainty rules still apply.
+    pub fn admit_materialization(&self, intent: SetupIntent) -> Result<SetupAdmission, SetupInputError> {
+        if self.observe(&intent)? == SetupObservation::ClaimedUnknown {
+            return Ok(SetupAdmission::Existing);
+        }
+        #[cfg(target_os = "linux")]
+        self.directory.check_inputs(&intent)?;
+        #[cfg(not(target_os = "linux"))]
+        return Err(SetupClaimError::Unsupported.into());
+        #[cfg(target_os = "linux")]
+        Ok(self.admit(intent)?)
+    }
+
     /// Open existing private, qualified storage; never create or repair it.
     /// Run off the UI thread; filesystem byte bounds do not bound I/O latency.
     /// # Errors
@@ -111,6 +129,14 @@ impl RetainedSetup {
             Err(SetupClaimError::Unsupported)
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SetupInputError {
+    #[error(transparent)]
+    Claim(#[from] SetupClaimError),
+    #[error("retained setup inputs could not be verified as bounded, safe and separate from its write root")]
+    Unverified,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]

--- a/crates/horizon-core/src/repository_overlay/retained_setup/outcome/snapshot.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/outcome/snapshot.rs
@@ -71,8 +71,10 @@ impl SetupCompletion {
         self.data.bundle_manifest.as_ref()
     }
 
-    #[cfg(target_os = "linux")]
-    pub(super) fn from_execution(result: &super::SetupMaterializationResult) -> Self {
+    /// Project a typed execution result without observing or changing the filesystem.
+    /// This does not establish recording, synchronization, liveness or replay authority.
+    #[must_use]
+    pub fn from_execution(result: &super::SetupMaterializationResult) -> Self {
         use super::super::SetupExecutionError;
         use crate::repository_overlay::{
             checkout::publication::PublicationFailure, materialize::MaterializationProblem,
@@ -134,7 +136,6 @@ impl SetupCompletion {
 }
 
 impl CompletionData {
-    #[cfg(target_os = "linux")]
     fn repository(&mut self, path: &Path, base: git2::Oid, manifest: &ArtifactDigest) {
         self.checkout = Some(path.to_owned());
         self.base_commit = Some(base.to_string());

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod protocol;
+mod setup;
 
 use std::{
     io::{self, Read, Write},
@@ -9,18 +10,22 @@ use std::{
 
 fn main() -> ExitCode {
     let arguments: Vec<_> = std::env::args_os().skip(1).take(2).collect();
-    if arguments.len() != 1 || arguments[0] != "materialize" {
+    let command = arguments.first().and_then(|argument| argument.to_str());
+    if arguments.len() != 1 || !matches!(command, Some("materialize" | "setup" | "setup-status")) {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize < request.json"
+            "Usage: horizon-repository materialize|setup|setup-status < request.json"
         );
         return ExitCode::from(2);
     }
-    run(
-        &mut io::stdin().lock(),
-        &mut io::stdout().lock(),
-        &mut io::stderr().lock(),
-    )
+    let mut input = io::stdin().lock();
+    let mut output = io::stdout().lock();
+    let mut diagnostics = io::stderr().lock();
+    match command {
+        Some("setup") => setup::run(setup::Command::Execute, &mut input, &mut output, &mut diagnostics),
+        Some("setup-status") => setup::run(setup::Command::Observe, &mut input, &mut output, &mut diagnostics),
+        _ => run(&mut input, &mut output, &mut diagnostics),
+    }
 }
 
 fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Write) -> ExitCode {
@@ -30,9 +35,23 @@ fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Wr
         Ok(result) => protocol::Response::from_result(result),
         Err(()) => protocol::Response::rejected(),
     };
-    let bytes = serde_json::to_vec(&response)
-        .ok()
-        .filter(|bytes| bytes.len() < protocol::RESPONSE_LIMIT);
+    write_response(
+        &response,
+        response.exit_code(),
+        protocol::RESPONSE_LIMIT,
+        output,
+        diagnostics,
+    )
+}
+
+fn write_response(
+    response: &impl serde::Serialize,
+    exit_code: u8,
+    limit: usize,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    let bytes = serde_json::to_vec(response).ok().filter(|bytes| bytes.len() < limit);
     let written = bytes.is_some_and(|bytes| {
         output
             .write_all(&bytes)
@@ -47,7 +66,7 @@ fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Wr
         );
         return ExitCode::from(3);
     }
-    ExitCode::from(response.exit_code())
+    ExitCode::from(exit_code)
 }
 
 #[cfg(test)]

--- a/crates/horizon-repository/src/setup/mod.rs
+++ b/crates/horizon-repository/src/setup/mod.rs
@@ -1,0 +1,92 @@
+mod request;
+mod response;
+
+use horizon_core::repository_overlay::retained_setup::{
+    RetainedSetup, SetupAdmission, SetupCompletion, SetupIntent, SetupObservation,
+};
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+const VERSION: u32 = 1;
+
+#[derive(Clone, Copy)]
+pub(super) enum Command {
+    Execute,
+    Observe,
+}
+
+enum Outcome {
+    Rejected,
+    Error(String),
+    Absent,
+    ClaimedUnknown,
+    Completed {
+        receipt: SetupCompletion,
+        observed: bool,
+    },
+    RecordingUnconfirmed {
+        reason: String,
+        execution: Option<SetupCompletion>,
+    },
+}
+
+pub(super) fn run(
+    command: Command,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    let outcome = request::read(input).map_or(Outcome::Rejected, |request| execute(&request, command));
+    let response = response::Response::from_outcome(&outcome);
+    super::write_response(
+        &response,
+        response.exit_code(),
+        request::RESPONSE_LIMIT,
+        output,
+        diagnostics,
+    )
+}
+
+fn execute(request: &request::Request, command: Command) -> Outcome {
+    let store = match RetainedSetup::open(&request.retained_root) {
+        Ok(store) => store,
+        Err(error) => return Outcome::Error(error.to_string()),
+    };
+    if matches!(command, Command::Observe) {
+        return match store.observe(&request.intent) {
+            Ok(SetupObservation::Absent) => Outcome::Absent,
+            Ok(SetupObservation::ClaimedUnknown) => observe(&store, &request.intent),
+            Err(error) => Outcome::Error(error.to_string()),
+        };
+    }
+    match store.admit_materialization(request.intent.clone()) {
+        Ok(SetupAdmission::Existing) => observe(&store, &request.intent),
+        Ok(SetupAdmission::Fresh(grant)) => match grant.materialize_recorded(|| false) {
+            Ok(execution) => Outcome::Completed {
+                receipt: SetupCompletion::from_execution(&execution),
+                observed: false,
+            },
+            Err(error) => Outcome::RecordingUnconfirmed {
+                reason: error.to_string(),
+                execution: error.execution().map(SetupCompletion::from_execution),
+            },
+        },
+        Err(error) => Outcome::Error(error.to_string()),
+    }
+}
+
+fn observe(store: &RetainedSetup, intent: &SetupIntent) -> Outcome {
+    match store.completion(intent) {
+        Ok(Some(receipt)) => Outcome::Completed {
+            receipt,
+            observed: true,
+        },
+        Ok(None) => Outcome::ClaimedUnknown,
+        Err(error) => Outcome::Error(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/setup/request.rs
+++ b/crates/horizon-repository/src/setup/request.rs
@@ -1,0 +1,54 @@
+use horizon_core::{
+    cloud_run::ArtifactDigest,
+    repository_overlay::{materialize::MAX_REQUEST_PATH_BYTES, retained_setup::SetupIntent},
+};
+use serde::Deserialize;
+use std::{io::Read, path::PathBuf};
+
+// Three supported paths may each need six-byte JSON escaping, plus identity/name fields.
+pub(super) const REQUEST_LIMIT: usize = (3 * 6 * MAX_REQUEST_PATH_BYTES + 8192).next_power_of_two();
+pub(super) const RESPONSE_LIMIT: usize = (3 * 6 * (MAX_REQUEST_PATH_BYTES + 256) + 8193).next_power_of_two();
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireRequest {
+    version: u32,
+    retained_root: PathBuf,
+    workspace_local_id: String,
+    objects_directory: PathBuf,
+    bundle_store: PathBuf,
+    bundle_manifest: ArtifactDigest,
+    destination: String,
+}
+
+pub(super) struct Request {
+    pub(super) retained_root: PathBuf,
+    pub(super) intent: SetupIntent,
+}
+
+pub(super) fn read(input: &mut impl Read) -> Result<Request, ()> {
+    let mut bytes = Vec::new();
+    input
+        .take(REQUEST_LIMIT as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| ())?;
+    if bytes.len() > REQUEST_LIMIT {
+        return Err(());
+    }
+    let wire: WireRequest = serde_json::from_slice(&bytes).map_err(|_| ())?;
+    if wire.version != super::VERSION {
+        return Err(());
+    }
+    let intent = SetupIntent::new(
+        wire.workspace_local_id,
+        wire.objects_directory,
+        wire.bundle_store,
+        wire.bundle_manifest,
+        wire.destination,
+    )
+    .map_err(|_| ())?;
+    Ok(Request {
+        retained_root: wire.retained_root,
+        intent,
+    })
+}

--- a/crates/horizon-repository/src/setup/response.rs
+++ b/crates/horizon-repository/src/setup/response.rs
@@ -1,0 +1,147 @@
+use super::{Outcome, VERSION};
+use horizon_core::{
+    cloud_run::ArtifactDigest,
+    repository_overlay::retained_setup::{SetupCompletion, SetupCompletionState},
+};
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Rejected,
+    Error,
+    Absent,
+    ClaimedUnknown,
+    Completed,
+    RecordingUnconfirmed,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Recording {
+    NotAcknowledged,
+    Acknowledged,
+    Observed,
+}
+
+#[derive(Serialize)]
+pub(super) struct Response<'a> {
+    version: u32,
+    status: Status,
+    recording: Recording,
+    reason: Option<&'a str>,
+    execution: Option<Execution<'a>>,
+}
+
+#[derive(Serialize)]
+struct Execution<'a> {
+    state: SetupCompletionState,
+    reason: Option<&'a str>,
+    source_metadata: Option<&'a Path>,
+    checkout: Option<&'a Path>,
+    possible_destination: Option<&'a Path>,
+    base_commit: Option<&'a str>,
+    bundle_manifest: Option<&'a ArtifactDigest>,
+}
+
+impl<'a> From<&'a SetupCompletion> for Execution<'a> {
+    fn from(receipt: &'a SetupCompletion) -> Self {
+        Self {
+            state: receipt.state(),
+            reason: receipt.reason(),
+            source_metadata: receipt.source_metadata(),
+            checkout: receipt.checkout(),
+            possible_destination: receipt.possible_destination(),
+            base_commit: receipt.base_commit(),
+            bundle_manifest: receipt.bundle_manifest(),
+        }
+    }
+}
+
+impl<'a> Response<'a> {
+    pub(super) fn from_outcome(outcome: &'a Outcome) -> Self {
+        let mut response = Self {
+            version: VERSION,
+            status: Status::Rejected,
+            recording: Recording::NotAcknowledged,
+            reason: None,
+            execution: None,
+        };
+        match outcome {
+            Outcome::Rejected => response.reason = Some("invalid or unsupported setup request"),
+            Outcome::Error(reason) => {
+                response.status = Status::Error;
+                response.reason = Some(reason);
+            }
+            Outcome::Absent => response.status = Status::Absent,
+            Outcome::ClaimedUnknown => response.status = Status::ClaimedUnknown,
+            Outcome::Completed { receipt, observed } => {
+                response.status = Status::Completed;
+                response.recording = if *observed {
+                    Recording::Observed
+                } else {
+                    Recording::Acknowledged
+                };
+                response.execution = Some(receipt.into());
+            }
+            Outcome::RecordingUnconfirmed { reason, execution } => {
+                response.status = Status::RecordingUnconfirmed;
+                response.reason = Some(reason);
+                response.execution = execution.as_ref().map(Into::into);
+            }
+        }
+        response
+    }
+
+    pub(super) fn exit_code(&self) -> u8 {
+        match self.status {
+            Status::Absent => 0,
+            Status::Rejected => 2,
+            Status::ClaimedUnknown => 4,
+            Status::Completed => match self.execution.as_ref().map(|receipt| receipt.state) {
+                Some(SetupCompletionState::Published) => 0,
+                Some(SetupCompletionState::Rejected) => 2,
+                _ => 1,
+            },
+            Status::Error | Status::RecordingUnconfirmed => 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup::request::RESPONSE_LIMIT;
+    use horizon_core::repository_overlay::materialize::MAX_REQUEST_PATH_BYTES;
+    use std::path::PathBuf;
+
+    #[test]
+    fn maximum_escaped_uncertain_receipt_fits_complete_response() {
+        // Synthetic wire-format coverage, not a filesystem or rename claim.
+        let root = PathBuf::from(format!("/{}", "\u{1}".repeat(MAX_REQUEST_PATH_BYTES - 1)));
+        let metadata = root.join("m".repeat(255));
+        let checkout = root.join("c".repeat(255));
+        let destination = root.join("d".repeat(255));
+        let digest = ArtifactDigest::sha256(b"synthetic");
+        let base = "a".repeat(40);
+        let response = Response {
+            version: VERSION,
+            status: Status::RecordingUnconfirmed,
+            recording: Recording::NotAcknowledged,
+            reason: Some("recording unconfirmed"),
+            execution: Some(Execution {
+                state: SetupCompletionState::RenameUnconfirmed,
+                reason: Some("rename unconfirmed"),
+                source_metadata: Some(&metadata),
+                checkout: Some(&checkout),
+                possible_destination: Some(&destination),
+                base_commit: Some(&base),
+                bundle_manifest: Some(&digest),
+            }),
+        };
+        let bytes = serde_json::to_vec(&response).unwrap();
+        assert!(bytes.len() > 64 * 1024 && bytes.len() < RESPONSE_LIMIT);
+        assert_eq!(response.exit_code(), 1);
+    }
+}

--- a/crates/horizon-repository/src/setup/tests.rs
+++ b/crates/horizon-repository/src/setup/tests.rs
@@ -1,0 +1,181 @@
+use super::*;
+use horizon_core::repository_overlay::retained_setup::{SetupBoundaryError, SetupExecutionError};
+use serde_json::{Value, json};
+use std::io;
+
+fn request() -> Value {
+    let root = std::env::temp_dir();
+    json!({"version":1, "retained_root":root.join("synthetic-private-root"),
+        "workspace_local_id":"workspace_1", "objects_directory":root.join("synthetic-objects"),
+        "bundle_store":root.join("synthetic-bundles"), "bundle_manifest":"a".repeat(64),
+        "destination":"ready"})
+}
+
+fn accepts(value: &Value) -> bool {
+    request::read(&mut serde_json::to_vec(value).unwrap().as_slice()).is_ok()
+}
+
+#[test]
+fn immutable_intent_input_is_strict_bounded_and_validated_before_io() {
+    let original = request();
+    assert!(accepts(&original));
+    for key in original.as_object().unwrap().keys() {
+        let mut changed = original.clone();
+        changed.as_object_mut().unwrap().remove(key);
+        assert!(!accepts(&changed));
+    }
+    for (key, value) in [
+        ("version", json!(2)),
+        ("version", json!(-1)),
+        ("version", json!(1.5)),
+        ("workspace_local_id", json!("../private-marker")),
+        ("objects_directory", json!("relative")),
+        ("bundle_store", json!("relative")),
+        ("bundle_manifest", json!("G".repeat(64))),
+        ("destination", json!(".git")),
+        ("destination", json!("../escape")),
+        ("extra", json!(true)),
+    ] {
+        let mut changed = original.clone();
+        changed[key] = value;
+        assert!(!accepts(&changed));
+    }
+    let encoded = serde_json::to_string(&original).unwrap();
+    for malformed in [
+        String::new(),
+        format!("{encoded}{{}}"),
+        encoded.replacen('{', "{\"version\":1,", 1),
+    ] {
+        assert!(request::read(&mut malformed.as_bytes()).is_err());
+    }
+    assert!(request::read(&mut b"\xff".as_slice()).is_err());
+    let mut exact = encoded.into_bytes();
+    exact.resize(request::REQUEST_LIMIT, b' ');
+    assert!(request::read(&mut exact.as_slice()).is_ok());
+    exact.push(b' ');
+    assert!(request::read(&mut exact.as_slice()).is_err());
+    let mut oversized = io::repeat(b' ');
+    assert!(request::read(&mut oversized).is_err());
+    let mut measured = io::Cursor::new(vec![b' '; request::REQUEST_LIMIT * 2]);
+    assert!(request::read(&mut measured).is_err());
+    assert_eq!(measured.position(), request::REQUEST_LIMIT as u64 + 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn three_maximum_escaped_paths_fit_request_bounds() {
+    use horizon_core::repository_overlay::materialize::MAX_REQUEST_PATH_BYTES;
+    let path = format!("/{}", "\u{1}".repeat(MAX_REQUEST_PATH_BYTES - 1));
+    let mut value = request();
+    for key in ["retained_root", "objects_directory", "bundle_store"] {
+        value[key] = json!(path);
+    }
+    let encoded = serde_json::to_vec(&value).unwrap();
+    assert!(encoded.len() > 64 * 1024 && encoded.len() < request::REQUEST_LIMIT);
+    assert!(request::read(&mut encoded.as_slice()).is_ok());
+}
+
+#[test]
+fn command_states_never_conflate_observation_recording_and_execution() {
+    let execution = Err(SetupExecutionError::Boundary(SetupBoundaryError::Cancelled));
+    let receipt = SetupCompletion::from_execution(&execution);
+    for (outcome, state, recording, code) in [
+        (Outcome::Rejected, "rejected", "not_acknowledged", 2),
+        (
+            Outcome::Error("redacted storage failure".into()),
+            "error",
+            "not_acknowledged",
+            1,
+        ),
+        (Outcome::Absent, "absent", "not_acknowledged", 0),
+        (Outcome::ClaimedUnknown, "claimed_unknown", "not_acknowledged", 4),
+        (
+            Outcome::Completed {
+                receipt: receipt.clone(),
+                observed: false,
+            },
+            "completed",
+            "acknowledged",
+            2,
+        ),
+        (
+            Outcome::Completed {
+                receipt: receipt.clone(),
+                observed: true,
+            },
+            "completed",
+            "observed",
+            2,
+        ),
+        (
+            Outcome::RecordingUnconfirmed {
+                reason: "redacted".into(),
+                execution: None,
+            },
+            "recording_unconfirmed",
+            "not_acknowledged",
+            1,
+        ),
+        (
+            Outcome::RecordingUnconfirmed {
+                reason: "redacted".into(),
+                execution: Some(receipt.clone()),
+            },
+            "recording_unconfirmed",
+            "not_acknowledged",
+            1,
+        ),
+    ] {
+        let response = response::Response::from_outcome(&outcome);
+        assert_eq!(response.exit_code(), code);
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["status"], state);
+        assert_eq!(value["recording"], recording);
+        assert_eq!(value["version"], 1);
+        let has_execution = matches!(
+            outcome,
+            Outcome::Completed { .. } | Outcome::RecordingUnconfirmed { execution: Some(_), .. }
+        );
+        assert_eq!(!value["execution"].is_null(), has_execution);
+        if !value["execution"].is_null() {
+            assert_eq!(value["execution"]["state"], "rejected");
+            assert!(value["execution"]["checkout"].is_null());
+        }
+    }
+}
+
+#[test]
+fn rejection_output_and_flush_failure_remain_redacted_and_distinct() {
+    struct FlushFailure;
+    impl Write for FlushFailure {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::ErrorKind::BrokenPipe.into())
+        }
+    }
+    for command in [Command::Execute, Command::Observe] {
+        let mut output = Vec::new();
+        assert_eq!(
+            run(command, &mut b"private-marker".as_slice(), &mut output, &mut io::sink()),
+            ExitCode::from(2)
+        );
+        assert!(output.ends_with(b"\n"));
+        assert!(!String::from_utf8(output.clone()).unwrap().contains("private-marker"));
+        assert_eq!(serde_json::from_slice::<Value>(&output).unwrap()["status"], "rejected");
+        assert_eq!(
+            run(
+                command,
+                &mut b"{}".as_slice(),
+                &mut [0_u8; 0].as_mut_slice(),
+                &mut io::sink()
+            ),
+            ExitCode::from(3)
+        );
+        assert_eq!(
+            run(command, &mut b"{}".as_slice(), &mut FlushFailure, &mut io::sink()),
+            ExitCode::from(3)
+        );
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -275,8 +275,17 @@ back into large multi-purpose modules.
   operation. Its typed result preserves source metadata and every known checkout or
   uncertain destination; no retry or cleanup is implied. `horizon-repository` owns
   only the bounded versioned JSON command boundary and truthful response/exit status.
-  It does not install itself in worker images or create a retained remote job: lost
-  output/termination requires later observation, not automatic replay or task start.
+  Its `setup/` tree separates immutable input validation, one-shot core API
+  orchestration and response projection. Core `admit_materialization` performs
+  bounded read-only input-tree identity separation before fresh admission; existing
+  claims skip that preflight so missing inputs cannot prevent observation. The
+  original claim-only admission API is unchanged. Public core projection accepts only typed
+  execution results, not unchecked deserialized snapshots. Setup/status distinguish
+  fresh recording, historical observation, unknown claims and retained execution
+  when recording fails. Status never creates or replays; the original materialize
+  protocol stays compatible. Image packaging installs the helper, but no command
+  detaches itself or creates independent remote supervision: lost output requires
+  later observation, not automatic replay or task start.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in

--- a/docs/remote-repository-command.md
+++ b/docs/remote-repository-command.md
@@ -4,7 +4,7 @@
 [remote worker image](../containers/remote-worker/README.md#explicit-repository-helper)
 installs it from a separate pinned-toolchain build stage. It is not included in
 Horizon release assets, and existing running workers are not automatically upgraded.
-No default invocation creates anything; the only command is:
+No default invocation creates anything. The original synchronous command is:
 
 ```sh
 horizon-repository materialize < request.json
@@ -61,5 +61,88 @@ acknowledgement, and no process destructor is guaranteed on abrupt termination.
 
 Dropping any receipt never deletes data. Nothing overwrites existing destinations,
 starts tasks, fetches remotely, schedules checkpoints, retries or cleans residues.
-A later worker-retained operation layer must provide non-creating observation and
-recovery before wiring this helper into client reconnect/setup flows.
+Use the retained setup commands below when one-shot admission and subsequent
+read-only observation are required. Independent supervision, recovery and client
+integration are separate; the original `materialize` command remains unchanged.
+
+## Retained setup commands
+
+```sh
+horizon-repository setup < setup-request.json
+horizon-repository setup-status < setup-request.json
+```
+
+Both accept one strict versioned JSON object followed by EOF, bounded to 128 KiB
+including whitespace. The larger input bound accommodates three supported paths
+with worst-case JSON escaping. Unknown, duplicate, missing and malformed fields
+are rejected. Provide the same complete immutable intent on every observation.
+
+```json
+{
+  "version": 1,
+  "retained_root": "/worker/retained-workspace",
+  "workspace_local_id": "workspace_1",
+  "objects_directory": "/worker/source.git/objects",
+  "bundle_store": "/worker/bundles",
+  "bundle_manifest": "<64 hexadecimal SHA-256 characters>",
+  "destination": "repository"
+}
+```
+
+The retained root must already exist, be privately owned, and satisfy the core
+storage/confinement requirements. Neither command creates or repairs it. Its
+ancestry, mount configuration and authorized source must remain trusted and stable.
+The root and claim must outlive client connections and runtime generations; a retry
+ID or new request does not select another slot. Remote ownership must be established
+separately. Setup materializes under the fixed `setup-data` child; the example
+checkout is `/worker/retained-workspace/setup-data/repository`.
+
+Only `setup` can admit and consume a fresh in-process grant. An existing matching
+claim observes the result instead, even when no result exists. A conflicting intent
+fails without modifying the existing claim. `setup-status` only opens/reads: it
+never creates, synchronizes, adopts, repairs, replays or cleans any retained state.
+
+Before fresh admission, a read-only identity scan rejects a retained write root
+inside either input tree, including aliases; it does not rely on read-only mounts
+or path spelling. Each input scan is confined without symlink/mount traversal and
+bounded to 262,144 nodes, 16 MiB of aggregate relative paths and depth 64. Missing,
+unsafe or excessive inputs fail closed before a claim is written. Existing-claim
+and status observation bypass source validation so saved results remain observable
+when the original inputs are unavailable. These checks still require stable trusted
+topology through execution, not concurrent same-user namespace changes.
+
+Responses are complete JSON plus newline, bounded to 128 KiB. They contain
+`version`, `status`, `recording`, `reason` and `execution`. A non-null `execution`
+contains `state`, `reason`, `source_metadata`, `checkout`, `possible_destination`,
+`base_commit` and `bundle_manifest`, with the historical receipt meanings described
+above. Paths are intentionally returned only to the authorized caller; diagnostics
+remain redacted. A requested destination alias in a failed receipt does not prove
+that publication occurred.
+
+| Command status | Exit | Meaning |
+| --- | --- | --- |
+| `absent` | 0 | Status observed no claim in the qualified root; not authorization to bypass admission. |
+| `claimed_unknown` | 4 | Matching claim, no recorded result; not unstarted, running, successful or safe to replay. |
+| `completed` | 0/1/2 | Receipt exists: published exits 0, rejected exits 2, other execution states exit 1. |
+| `recording_unconfirmed` | 1 | Recording was not acknowledged; retain all state and inspect any known execution. |
+| `error` | 1 | Storage, identity, claim or result could not be safely observed/admitted; never treat as absence. |
+| `rejected` | 2 | Invalid command request, before admission. |
+
+`recording: "acknowledged"` means this invocation freshly recorded and verified its
+execution result on qualified healthy storage. `"observed"` means read-only access
+to a historical record, not this reader's synchronization or current liveness.
+`"not_acknowledged"` provides no recording guarantee. On `recording_unconfirmed`,
+`execution: null` means preflight rejected before execution; otherwise the known
+execution result is preserved even though recording was not acknowledged. In both
+cases admission may already have consumed the one-shot claim.
+
+Exit 3 retains the same output-failure meaning as `materialize`. Output loss never
+rolls back setup, removes its claim, or authorizes replay. A fresh status request
+can read a previously recorded result after the producer exits. Missing/corrupt
+output remains unknown until safely observed. No response establishes current task
+liveness, current checkout contents, cleanup permission, cloud or power-loss proof.
+
+These commands remain synchronous: they do not detach themselves from SSH, launch
+tasks, transfer source, create a supervisor or integrate the client. A worker-owned
+independent launcher must be added before claiming setup survives client loss.
+No invocation implicitly stops/deletes a workspace when a local view closes.


### PR DESCRIPTION
## Purpose

Expose bounded worker-side `setup` and read-only `setup-status` commands using
the merged retained-setup APIs. This is one independently testable #470 outcome.

## Behavior and boundaries

- Preserve the original `materialize` command and wire protocol.
- Validate strict versioned requests, immutable setup intent and complete bounded
  responses. Diagnostics do not include request contents or paths.
- Distinguish freshly acknowledged recording, historical observation, absent or
  unknown claims, input/storage errors and recording uncertainty with any known
  execution result. Existing claims never grant another execution.
- Reject a retained write root inside either input tree before fresh admission,
  using bounded read-only identity checks, including bind aliases. Existing-claim
  and status observation still work when original input mounts are absent.
- Preserve retained state on response-write failure. Reconnecting callers can
  observe the stored result without replay; lost output does not imply rollback.

Healthy qualified Linux journaled ext4, stable trusted ancestry/mounts/source and
separately established remote ownership remain required. The commands are still
synchronous: independent launch, transfer, task start and client integration are
the next separate outcomes. No cloud/PC-off or power-loss acceptance is claimed.
No dependency, UI, provider, image publication or release change is included.

## Validation

Exact commit `a0064b49`:

- Passed the full exact-commit local validation matrix, including both workspace test
  suites, blocking/strict Clippy and the advisory pedantic lane.
- Passed nine focused command tests and 38 native retained-setup tests, no skips.
- Passed independent local review with exact committed-patch parity.
- Passed exact-commit runtime and builder images and all four smoke lanes:
  packaging, repository commands, disconnected panel sessions and retained identity.

Repository image coverage includes real publication of the existing 65 MiB packed
fixture and exact base/index/raw/LFS/mode/symlink checks; status before admission;
fresh-container observation without original inputs; no replay and conflicting
intent; retained corrupt/missing-result cases; actual response loss through a full
output device; and writable input-overlap/bind-alias rejection without mutations.
A copied claim-only fixture characterizes unknown state, not a real interruption.
Disconnected panel-session regression proof is not independent setup-launch proof.

An earlier full run hit an unchanged browser deadline test; its exact-binary
focused rerun and subsequent complete suites passed. The original timeout cause
remains unproven. A new Clippy ownership warning was corrected without suppression.

Scope: ten source/test files, 817 changed source/test lines, plus three focused
docs. No UI smoke applies. Cross-platform checks remain required in CI. Existing
primary checkout and unrelated work are preserved. Ambiguous label, milestone and
project metadata is not guessed.

Refs #383, #470.
