### PR TITLE
Launch repository setup independently of request channels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ containers/remote-worker/**
 !containers/remote-worker/rust-path.sh
 !containers/remote-worker/session.sh
 !containers/remote-worker/panel-session.py
+!containers/remote-worker/setup-launch.py
 !containers/remote-worker/tmux.conf
 !containers/remote-worker/sshd_config
 **/.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+      - name: Verify detached setup handoff contract
+        run: python3 -B containers/remote-worker/test_setup_launch.py -v
       - name: Verify source allowlist and excluded-file controls
         run: python3 -B containers/remote-worker/test_repository_packaging.py --docker-host unix:///var/run/docker.sock
 

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -174,12 +174,14 @@ COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entryp
 COPY containers/remote-worker/host-identity.py /usr/local/bin/horizon-worker-host-identity
 COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session
 COPY containers/remote-worker/panel-session.py /usr/local/bin/horizon-panel-session
+COPY containers/remote-worker/setup-launch.py /usr/local/bin/horizon-setup-launch
 COPY containers/remote-worker/tmux.conf /etc/horizon/tmux.conf
 COPY containers/remote-worker/rust-path.sh /etc/profile.d/horizon-rust.sh
 COPY containers/remote-worker/sshd_config /etc/ssh/sshd_config.d/99-horizon-worker.conf
 
 RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-agent-session \
     /usr/local/bin/horizon-panel-session \
+    /usr/local/bin/horizon-setup-launch \
     /usr/local/bin/horizon-worker-host-identity \
     && chmod 0644 /etc/profile.d/horizon-rust.sh /etc/ssh/sshd_config.d/99-horizon-worker.conf \
     && git lfs install --system \

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -72,6 +72,10 @@ implicit. Missing replies are uncertain outcomes, not permission to retry.
 Retained `setup` uses one immutable claim and a fixed private setup child; repeated
 requests observe rather than replay. Status never creates state or proves liveness.
 The commands are synchronous and do not provide independent setup supervision.
+The separate `horizon-setup-launch` command can submit setup independently of its
+request channel; it does not turn submission or a claim into proof of liveness.
+See [independent setup submission](../../docs/remote-repository-command.md#independent-setup-submission)
+for its bounded handoff, observation and recording limitations.
 This packaging does not add object transport, client setup, recovery, checkpointing
 or task admission. Existing workers are not
 upgraded by rebuilding an image. Neither the helper nor a locally retained volume
@@ -85,6 +89,7 @@ python3 -B containers/remote-worker/test_repository_image.py \
   --docker-host unix:///path/to/docker.sock --image horizon-remote-worker:0.1.0
 python3 -B containers/remote-worker/test_repository_packaging.py \
   --docker-host unix:///path/to/docker.sock
+python3 -B containers/remote-worker/test_setup_launch.py -v
 ```
 
 The first checks large packed objects, raw index/worktree semantics, no-overwrite
@@ -97,6 +102,23 @@ The second checks the real Docker context filter with positive source controls a
 excluded synthetic files. Add `--image` and `--expected-binary-sha256` from a separate
 `repository-builder` target to audit every final image layer and executable provenance.
 These tests retain images and fail, rather than claim success, on unsupported storage.
+
+To exercise independent setup through local SSH with a fresh synthetic client key,
+use local rootless Docker or a root host caller. The SSH worker runs as container
+root and must own the private host-created fixtures; the harness checks this
+precondition without changing ownership:
+
+```bash
+python3 -B containers/remote-worker/test_setup_launch_image.py \
+  --docker-host unix:///path/to/docker.sock --image horizon-remote-worker:0.1.0
+```
+
+This uses the real setup helper with a synthetic Git gate to keep admitted setup
+in progress while its request/output channel disappears. It then releases the
+gate, verifies the exact repository through a separate status channel, checks no
+claim replay and completed-child reaping, and runs an ungated submission. It binds
+only loopback SSH and removes its own containers, fixture and generated keypair.
+The gate is explicit test instrumentation, not cloud/PC-off or crash-durability proof.
 
 ## Runtime contract
 

--- a/containers/remote-worker/setup-launch.py
+++ b/containers/remote-worker/setup-launch.py
@@ -1,0 +1,180 @@
+#!/usr/bin/python3 -I
+"""Explicit detached setup submission; retained Rust state remains authoritative."""
+
+import io
+import json
+import os
+import selectors
+import subprocess
+import sys
+import time
+
+REQUEST_LIMIT = 128 * 1024
+OBSERVATION_LIMIT = 128 * 1024
+RESPONSE_LIMIT = 2 * OBSERVATION_LIMIT
+OBSERVE_SECONDS = 30
+HANDOFF_SECONDS = 15
+HELPER = '/usr/local/bin/horizon-repository'
+ENVIRONMENT = {'PATH': '/usr/bin:/bin', 'LC_ALL': 'C'}
+
+
+class LaunchError(Exception):
+    """Static diagnostics never include request content or process output."""
+
+
+def unique_fields(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise LaunchError('setup observation contains duplicate fields')
+        result[key] = value
+    return result
+
+
+def observe(request):
+    try:
+        result = subprocess.run([HELPER, 'setup-status'], input=request,
+            capture_output=True, check=False, timeout=OBSERVE_SECONDS,
+            cwd='/', env=ENVIRONMENT, close_fds=True)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise LaunchError('setup observation did not complete') from error
+    if (result.returncode not in (0, 1, 2, 4) or result.stderr
+            or len(result.stdout) > OBSERVATION_LIMIT or not result.stdout.endswith(b'\n')):
+        raise LaunchError('setup observation is unavailable')
+    try:
+        value = json.loads(result.stdout.decode('utf-8'), object_pairs_hook=unique_fields)
+    except (ValueError, RecursionError) as error:
+        raise LaunchError('setup observation is invalid') from error
+    if (not isinstance(value, dict) or set(value) != {'version', 'status', 'recording', 'reason', 'execution'}
+            or type(value['version']) is not int or value['version'] != 1
+            or value['status'] not in ('absent', 'claimed_unknown', 'completed', 'error', 'rejected')
+            or value['recording'] not in ('not_acknowledged', 'observed')
+            or value['reason'] is not None and not isinstance(value['reason'], str)
+            or value['execution'] is not None and not isinstance(value['execution'], dict)):
+        raise LaunchError('setup observation is invalid')
+    expected = {'absent': 0, 'claimed_unknown': 4, 'error': 1, 'rejected': 2}
+    if value['status'] == 'completed':
+        execution = value['execution']
+        states = {'published': 0, 'rejected': 2, 'unpublished': 1,
+                  'published_unsynchronized': 1, 'rename_unconfirmed': 1}
+        if (not isinstance(execution, dict) or not isinstance(execution.get('state'), str)
+                or execution['state'] not in states or value['recording'] != 'observed'
+                or value['reason'] is not None):
+            raise LaunchError('setup completion observation is invalid')
+        expected['completed'] = states[execution['state']]
+    elif value['execution'] is not None or value['recording'] != 'not_acknowledged':
+        raise LaunchError('setup observation recording is invalid')
+    if result.returncode != expected[value['status']]:
+        raise LaunchError('setup observation exit status is inconsistent')
+    if value['status'] == 'absent' and value != {
+        'version': 1, 'status': 'absent', 'recording': 'not_acknowledged', 'reason': None, 'execution': None
+    }:
+        raise LaunchError('setup absence was not established')
+    return value, result.returncode
+
+
+def handoff(request):
+    try:
+        process = subprocess.Popen([HELPER, 'setup'], stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, bufsize=0,
+            close_fds=True, start_new_session=True, cwd='/', env=ENVIRONMENT, umask=0o077)
+    except OSError as error:
+        raise LaunchError('independent setup could not be spawned') from error
+    complete = False
+    try:
+        descriptor = process.stdin.fileno()
+        os.set_blocking(descriptor, False)
+        remaining = memoryview(request)
+        deadline = time.monotonic() + HANDOFF_SECONDS
+        with selectors.DefaultSelector() as ready:
+            ready.register(descriptor, selectors.EVENT_WRITE)
+            while remaining:
+                timeout = deadline - time.monotonic()
+                if timeout <= 0 or not ready.select(timeout):
+                    break
+                try:
+                    written = os.write(descriptor, remaining)
+                except BlockingIOError:
+                    continue
+                if written <= 0:
+                    break
+                remaining = remaining[written:]
+            complete = not remaining
+    except (OSError, ValueError):
+        complete = False
+    finally:
+        try:
+            process.stdin.close()
+        except OSError:
+            complete = False
+        # Reap an already-exited child only. A running child transfers to worker PID1
+        # when this one-shot launcher exits; never wait, kill or infer its outcome.
+        process.poll()
+    return complete
+
+
+def execute(stream):
+    if stream is None:
+        return 'rejected', None, 2
+    try:
+        request = stream.read(REQUEST_LIMIT + 1)
+    except (OSError, ValueError):
+        return 'rejected', None, 2
+    if len(request) > REQUEST_LIMIT:
+        return 'rejected', None, 2
+    observation, code = observe(request)
+    if observation['status'] != 'absent':
+        return 'observed', observation, code
+    return ('submitted', None, 0) if handoff(request) else ('handoff_unconfirmed', None, 1)
+
+
+def run(stream, output, diagnostics):
+    try:
+        state, observation, code = execute(stream)
+    except LaunchError as error:
+        state, observation, code = 'error', None, 1
+        try:
+            diagnostics.write(str(error)+'\n')
+            diagnostics.flush()
+        except OSError:
+            pass
+    response = json.dumps({'version': 1, 'state': state, 'observation': observation},
+                          ensure_ascii=False, separators=(',', ':')).encode()+b'\n'
+    try:
+        if len(response) > RESPONSE_LIMIT or output.write(response) != len(response):
+            return 3
+        output.flush()
+    except OSError:
+        return 3
+    return code
+
+
+def main():
+    if sys.argv[1:]:
+        try:
+            if sys.stderr is not None:
+                os.write(sys.stderr.fileno(), b'Usage: horizon-setup-launch < setup-request.json\n')
+        except (OSError, ValueError):
+            pass
+        return 2
+    # Do not leave buffered output for interpreter shutdown to retry after exit 3.
+    if sys.stdout is None:
+        return 3
+    try:
+        output = io.FileIO(sys.stdout.fileno(), 'wb', closefd=False)
+    except (OSError, ValueError):
+        return 3
+    with output:
+        diagnostics = io.StringIO()
+        if sys.stderr is not None:
+            try:
+                diagnostics = io.TextIOWrapper(io.FileIO(sys.stderr.fileno(), 'wb', closefd=False),
+                                             encoding='utf-8', write_through=True)
+            except (OSError, ValueError):
+                pass
+        with diagnostics:
+            return run(sys.stdin.buffer if sys.stdin is not None else None, output, diagnostics)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/containers/remote-worker/test_repository_packaging.py
+++ b/containers/remote-worker/test_repository_packaging.py
@@ -13,7 +13,7 @@ import tempfile
 
 CRATES = ("horizon-repository", "horizon-core", "horizon-browser", "horizon-browser-protocol")
 WORKER_FILES = {"Dockerfile", "build-tmux.sh", "entrypoint.sh", "host-identity.py", "rust-path.sh",
-                "session.sh", "panel-session.py", "tmux.conf", "sshd_config"}
+                "session.sh", "panel-session.py", "setup-launch.py", "tmux.conf", "sshd_config"}
 
 
 def execute(argv, **kwargs):

--- a/containers/remote-worker/test_setup_launch.py
+++ b/containers/remote-worker/test_setup_launch.py
@@ -1,0 +1,256 @@
+"""Launcher protocol, mocked handoff faults, and response-only interpreter probes."""
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+SPEC = importlib.util.spec_from_file_location('setup_launch', Path(__file__).with_name('setup-launch.py'))
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def observation(status='absent', **changes):
+    return dict({'version': 1, 'status': status, 'recording': 'not_acknowledged',
+                 'reason': None, 'execution': None}, **changes)
+
+
+def result(value, code=0):
+    return subprocess.CompletedProcess([], code, json.dumps(value).encode()+b'\n', b'')
+
+
+class SetupLaunchTests(unittest.TestCase):
+    def setUp(self):
+        self.runner = self.enterContext(mock.patch.object(MODULE.subprocess, 'run'))
+        self.spawn = self.enterContext(mock.patch.object(MODULE.subprocess, 'Popen'))
+        self.runner.return_value = result(observation())
+
+    def run_request(self, request=b'private request', output=None, diagnostics=None):
+        if output is None:
+            output = io.BytesIO()
+        if diagnostics is None:
+            diagnostics = io.StringIO()
+        code = MODULE.run(io.BytesIO(request), output, diagnostics)
+        return code, json.loads(output.getvalue())
+
+    def test_observation_preserves_existing_results_without_launch(self):
+        cases = [('claimed_unknown', 4), ('error', 1), ('rejected', 2)]
+        for status, expected in cases:
+            value = observation(status, reason='static reason' if expected in (1, 2) else None)
+            self.runner.return_value = result(value, expected)
+            code, response = self.run_request()
+            self.assertEqual((code, response), (expected, {'version': 1, 'state': 'observed', 'observation': value}))
+        for state, expected in [('published', 0), ('rejected', 2), ('unpublished', 1),
+                                ('published_unsynchronized', 1), ('rename_unconfirmed', 1)]:
+            value = observation('completed', recording='observed', execution={'state': state})
+            self.runner.return_value = result(value, expected)
+            self.assertEqual(self.run_request(), (expected, {'version': 1, 'state': 'observed', 'observation': value}))
+        self.spawn.assert_not_called()
+        args, kwargs = self.runner.call_args
+        self.assertEqual(args, ([MODULE.HELPER, 'setup-status'],))
+        self.assertEqual(kwargs['input'], b'private request')
+        self.assertEqual(kwargs['env'], {'PATH': '/usr/bin:/bin', 'LC_ALL': 'C'})
+        self.assertTrue(kwargs['close_fds'] and kwargs['capture_output'])
+        self.assertEqual((kwargs['cwd'], kwargs['timeout']), ('/', 30))
+
+    def test_only_actual_absence_can_submit_and_handoff_is_not_completion(self):
+        with mock.patch.object(MODULE, 'handoff') as handoff:
+            for complete, state, expected in [(True, 'submitted', 0), (False, 'handoff_unconfirmed', 1)]:
+                handoff.return_value = complete
+                self.assertEqual(self.run_request(), (expected, {'version': 1, 'state': state, 'observation': None}))
+                handoff.assert_called_with(b'private request')
+            handoff.side_effect = MODULE.LaunchError('static failure')
+            diagnostics = io.StringIO()
+            self.assertEqual(self.run_request(diagnostics=diagnostics),
+                             (1, {'version': 1, 'state': 'error', 'observation': None}))
+            self.assertEqual(diagnostics.getvalue(), 'static failure\n')
+        self.spawn.assert_not_called()
+
+    def test_oversized_and_failed_reads_never_observe_or_launch(self):
+        self.assertEqual(self.run_request(b' '*(MODULE.REQUEST_LIMIT+1)),
+                         (2, {'version': 1, 'state': 'rejected', 'observation': None}))
+        stream = mock.Mock()
+        stream.read.side_effect = OSError('private path')
+        self.assertEqual(MODULE.execute(stream), ('rejected', None, 2))
+        stream.read.assert_called_once_with(MODULE.REQUEST_LIMIT+1)
+        self.runner.assert_not_called()
+        self.spawn.assert_not_called()
+
+    def test_invalid_observations_fail_closed_and_redact_output(self):
+        absent = json.dumps(observation()).encode()
+        invalid = [b'private output', b'\xff\n', b'{}\n', b'[]\n',
+                   b'{"version":1,'+absent[1:]+b'\n', b' '*MODULE.OBSERVATION_LIMIT+b'\n',
+                   absent+b'\n{}\n']
+        for raw in invalid:
+            with self.subTest(raw=raw[:40]):
+                self.runner.return_value = subprocess.CompletedProcess([], 0, raw, b'')
+                diagnostics = io.StringIO()
+                self.assertEqual(self.run_request(diagnostics=diagnostics)[0], 1)
+                self.assertNotIn('private', diagnostics.getvalue())
+        for value, code in [(observation(version=True), 0), (observation(version=2), 0),
+                            (observation(extra=True), 0), (observation(recording='acknowledged'), 0),
+                            (observation(execution={}), 0), (observation(reason='invalid'), 0),
+                            (observation(), 1), (observation('unknown'), 0),
+                            (observation('claimed_unknown'), 0),
+                            (observation('completed', recording='observed', execution={'state': 'future'}), 0),
+                            (observation('completed', recording='observed', execution={'state': []}), 0),
+                            (observation('completed', recording='observed', execution={'state': 'published'}), 1)]:
+            self.runner.return_value = result(value, code)
+            self.assertEqual(self.run_request()[0], 1)
+        for code, stderr in [(3, b''), (-9, b''), (0, b'private output')]:
+            self.runner.return_value = result(observation(), code)
+            self.runner.return_value.stderr = stderr
+            self.assertEqual(self.run_request()[0], 1)
+        self.spawn.assert_not_called()
+
+    def test_observer_timeout_and_spawn_errors_are_distinct_from_handoff(self):
+        for error in (OSError('private path'), subprocess.TimeoutExpired('private argv', 30)):
+            self.runner.side_effect = error
+            self.assertEqual(self.run_request(), (1, {'version': 1, 'state': 'error', 'observation': None}))
+        self.spawn.assert_not_called()
+        self.runner.side_effect = None
+        self.spawn.side_effect = OSError('private path')
+        diagnostics = io.StringIO()
+        self.assertEqual(self.run_request(diagnostics=diagnostics)[0], 1)
+        self.assertEqual(diagnostics.getvalue(), 'independent setup could not be spawned\n')
+
+    def handoff_mocks(self):
+        process = self.spawn.return_value
+        process.stdin.fileno.return_value = 29
+        blocking = self.enterContext(mock.patch.object(MODULE.os, 'set_blocking'))
+        write = self.enterContext(mock.patch.object(MODULE.os, 'write'))
+        select = self.enterContext(mock.patch.object(MODULE.selectors, 'DefaultSelector'))
+        ready = select.return_value.__enter__.return_value
+        ready.select.return_value = [(29, MODULE.selectors.EVENT_WRITE)]
+        return process, blocking, write, ready
+
+    def assert_not_terminated(self, process):
+        for name in ('kill', 'terminate', 'wait', 'communicate', '__enter__'):
+            getattr(process, name).assert_not_called()
+        process.poll.assert_called_once_with()
+        process.stdin.close.assert_called_once_with()
+
+    def test_detached_handoff_handles_partial_writes_and_would_block(self):
+        process, blocking, write, ready = self.handoff_mocks()
+        write.side_effect = [BlockingIOError(), 2, 3]
+        self.assertTrue(MODULE.handoff(b'hello'))
+        self.assertEqual([bytes(call.args[1]) for call in write.call_args_list], [b'hello', b'hello', b'llo'])
+        blocking.assert_called_once_with(29, False)
+        ready.register.assert_called_once_with(29, MODULE.selectors.EVENT_WRITE)
+        args, kwargs = self.spawn.call_args
+        self.assertEqual(args, ([MODULE.HELPER, 'setup'],))
+        self.assertEqual(kwargs, {'stdin': subprocess.PIPE, 'stdout': subprocess.DEVNULL,
+                                 'stderr': subprocess.DEVNULL, 'bufsize': 0, 'close_fds': True,
+                                 'start_new_session': True, 'cwd': '/', 'env': MODULE.ENVIRONMENT,
+                                 'umask': 0o077})
+        self.assert_not_terminated(process)
+
+    def test_partial_handoff_failure_or_deadline_never_kills_or_retries(self):
+        process, _, write, ready = self.handoff_mocks()
+        for fault in ('broken', 'zero', 'selector', 'deadline', 'close'):
+            with self.subTest(fault=fault):
+                process.reset_mock()
+                self.spawn.reset_mock()
+                process.stdin.close.side_effect = OSError() if fault == 'close' else None
+                write.side_effect = [2, BrokenPipeError()] if fault == 'broken' else None
+                write.return_value = 0 if fault == 'zero' else 5
+                ready.select.return_value = [] if fault == 'selector' else [(29, 2)]
+                with mock.patch.object(MODULE.time, 'monotonic', side_effect=[0, 16] if fault == 'deadline' else None,
+                                       return_value=0):
+                    self.assertFalse(MODULE.handoff(b'hello'))
+                self.spawn.assert_called_once()
+                self.assert_not_terminated(process)
+
+    def test_output_failure_after_submission_does_not_undo_handoff(self):
+        for failure in ('short', 'write', 'flush'):
+            with mock.patch.object(MODULE, 'handoff', return_value=True) as handoff:
+                output = mock.Mock()
+                output.write.return_value = 0
+                if failure == 'write':
+                    output.write.side_effect = BrokenPipeError()
+                if failure == 'flush':
+                    output.write.side_effect = len
+                    output.flush.side_effect = OSError()
+                self.assertEqual(MODULE.run(io.BytesIO(b'private request'), output, io.StringIO()), 3)
+                handoff.assert_called_once_with(b'private request')
+        self.spawn.assert_not_called()
+
+    def test_maximum_observation_fits_wrapped_response_bound(self):
+        value = observation('completed', recording='observed', execution={'state': 'rename_unconfirmed',
+            'source_metadata': '/'+('\x01'*4095), 'checkout': '/'+('\x02'*4095),
+            'possible_destination': '/'+('\x03'*4095)})
+        response = result(value, 1)
+        self.assertGreater(len(response.stdout), 64*1024)
+        self.assertLess(len(response.stdout), MODULE.OBSERVATION_LIMIT)
+        self.runner.return_value = response
+        output = io.BytesIO()
+        self.assertEqual(self.run_request(output=output)[0], 1)
+        self.assertLess(len(output.getvalue()), MODULE.RESPONSE_LIMIT)
+        self.assertTrue(output.getvalue().endswith(b'\n'))
+
+    def test_bad_arguments_do_not_read_stdin_even_when_usage_output_fails(self):
+        with mock.patch.object(MODULE.sys, 'argv', ['launcher', 'unexpected']), \
+                mock.patch.object(MODULE.os, 'write', side_effect=OSError()), \
+                mock.patch.object(MODULE, 'run') as run:
+            self.assertEqual(MODULE.main(), 2)
+            run.assert_not_called()
+        self.runner.assert_not_called()
+        self.spawn.assert_not_called()
+
+
+class MainProcessTests(unittest.TestCase):
+    PROGRAM = '''
+import importlib.util
+import sys
+spec = importlib.util.spec_from_file_location('launcher', sys.argv[1])
+launcher = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(launcher)
+mode = sys.argv[2]
+sys.argv = ['launcher', *sys.argv[3:]]
+def unexpected(*args, **kwargs):
+    raise AssertionError('response-only probe must not observe or launch a worker')
+launcher.observe = launcher.handoff = unexpected
+if mode == 'submitted':
+    launcher.execute = lambda stream: ('submitted', None, 0)
+elif mode == 'error':
+    def failure(stream):
+        raise launcher.LaunchError('static failure')
+    launcher.execute = failure
+sys.exit(launcher.main())
+'''
+
+    def probe(self, redirect, mode='unchanged', *args):
+        return subprocess.run(['/bin/sh', '-c', redirect+'; exec "$@"', 'launcher-probe',
+            sys.executable, '-I', '-B', '-c', self.PROGRAM, str(SPEC.origin), mode, *args],
+            input=b'', capture_output=True, timeout=10, check=False)
+
+    def test_closed_stdin_rejects_without_observing_or_launching(self):
+        result = self.probe('exec 0<&-')
+        self.assertEqual((result.returncode, result.stderr), (2, b''))
+        self.assertEqual(json.loads(result.stdout), {'version': 1, 'state': 'rejected', 'observation': None})
+
+    def test_closed_stdout_reports_output_loss_without_observing_or_launching(self):
+        result = self.probe('exec 1>&-')
+        self.assertEqual((result.returncode, result.stdout, result.stderr), (3, b'', b''))
+
+    def test_closed_stderr_does_not_break_usage_or_static_error_handling(self):
+        usage = self.probe('exec 2>&-', 'unchanged', 'unexpected')
+        self.assertEqual((usage.returncode, usage.stdout, usage.stderr), (2, b'', b''))
+        error = self.probe('exec 2>&-', 'error')
+        self.assertEqual((error.returncode, error.stderr), (1, b''))
+        self.assertEqual(json.loads(error.stdout), {'version': 1, 'state': 'error', 'observation': None})
+
+    def test_failed_stdout_does_not_retry_buffered_output_at_shutdown(self):
+        result = self.probe('exec 1>/dev/full', 'submitted')
+        self.assertEqual((result.returncode, result.stdout, result.stderr), (3, b'', b''))
+        diagnostics = self.probe('exec 2>/dev/full', 'error')
+        self.assertEqual((diagnostics.returncode, diagnostics.stderr), (1, b''))
+        self.assertEqual(json.loads(diagnostics.stdout)['state'], 'error')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/containers/remote-worker/test_setup_launch_image.py
+++ b/containers/remote-worker/test_setup_launch_image.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python3 -I
+"""Local worker proof with a synthetic Git gate around real repository setup."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+
+
+def wait_for(predicate, seconds=20):
+    deadline = time.monotonic()+seconds
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(0.1)
+    raise AssertionError('task-owned setup smoke did not settle')
+
+
+def git_gate():
+    root = Path('/probe-state')
+    if (root / 'enabled').exists():
+        with (root / 'entering').open('x') as output:
+            json.dump({'git': os.getpid(), 'setup': os.getppid(), 'sid': os.getsid(0)}, output)
+        (root / 'entering').rename(root / 'entered')
+        wait_for(lambda: (root / 'release').exists(), 15)
+    os.execv('/probe-git', ['/usr/bin/git', *sys.argv[1:]])
+
+
+class LauncherSmoke:
+    def __init__(self, smoke):
+        self.smoke = smoke
+        self.root = smoke.root
+        self.container = None
+        self.ssh = None
+        self.state = self.root / 'probe-state'
+
+    def execute(self, args, **kwargs):
+        return subprocess.run(args, check=True, capture_output=True, timeout=120, **kwargs).stdout
+
+    def worker(self, *args):
+        self.smoke.inspect(self.container)
+        return self.execute(self.smoke.docker + ['exec', self.container, *args])
+
+    def no_clients(self):
+        processes = self.worker('ps', '-eo', 'pid=,stat=,comm=').decode().splitlines()
+        return not any(parts[0] != '1' and parts[2].startswith('sshd') and not parts[1].startswith('Z')
+                       for line in processes if len(parts := line.split()) == 3)
+
+    def request(self, command, request, code):
+        output = subprocess.run(self.ssh+[command], input=json.dumps(request).encode(),
+                                capture_output=True, timeout=45, check=False)
+        assert output.returncode == code and not output.stderr, (output.returncode, output.stderr)
+        if code == 3:
+            assert not output.stdout
+            return None
+        assert output.stdout.endswith(b'\n') and len(output.stdout) <= 256*1024
+        return json.loads(output.stdout)
+
+    def start(self):
+        self.state.mkdir(mode=0o700)
+        gate = self.root / 'git-gate'
+        shutil.copyfile(__file__, gate)
+        gate.chmod(0o755)
+        self.smoke.command('/usr/bin/true', [])
+        original = self.root / 'git-original'
+        self.execute(self.smoke.docker + ['cp', self.smoke.containers[-1]+':/usr/bin/git', str(original)])
+        assert original.is_file() and not original.is_symlink()
+        original.chmod(0o755)
+        self.smoke.retire_completed()
+        key = self.root / 'client'
+        self.execute(['ssh-keygen', '-q', '-t', 'ed25519', '-N', '', '-f', str(key)])
+        mounts = [(self.root / 'source/objects', '/objects', True),
+                  (self.root / 'bundles', '/bundles', True), (self.root / 'retained', '/retained', False),
+                  (gate, '/usr/bin/git', True), (original, '/probe-git', True),
+                  (self.state, '/probe-state', False)]
+        arguments = self.smoke.docker + ['create', '--pull=never', '--publish', '127.0.0.1::22',
+            '--label', 'horizon.repository-image-smoke='+self.smoke.label,
+            '--env', 'HORIZON_SSH_PUBLIC_KEY='+key.with_suffix('.pub').read_text().strip()]
+        for source, target, readonly in mounts:
+            arguments += ['--mount', f'type=bind,src={source},dst={target}'+(',readonly' if readonly else '')]
+        self.container = self.execute(arguments+[self.smoke.image]).decode().strip()
+        self.smoke.containers.append(self.container)
+        self.smoke.inspect(self.container)
+        self.execute(self.smoke.docker + ['start', self.container])
+        ports = wait_for(lambda: self.smoke.inspect(self.container)['NetworkSettings']['Ports'].get('22/tcp'))
+        port = ports[0]['HostPort']
+        assert ports[0]['HostIp'] == '127.0.0.1' and port.isdecimal()
+
+        def scan():
+            result = subprocess.run(['ssh-keyscan', '-T', '1', '-p', port, '-t', 'ed25519', '127.0.0.1'],
+                                    capture_output=True, timeout=3, check=False)
+            return result.stdout if result.returncode == 0 and result.stdout else None
+
+        known = self.root / 'known-hosts'
+        known.write_bytes(wait_for(scan))
+        self.ssh = ['ssh', '-T', '-F', '/dev/null', '-i', str(key), '-o', 'BatchMode=yes',
+            '-o', 'IdentitiesOnly=yes', '-o', 'StrictHostKeyChecking=yes',
+            '-o', 'UserKnownHostsFile='+str(known), '-p', port, 'root@127.0.0.1']
+        wait_for(self.no_clients)
+
+    def test(self):
+        from test_repository_image import snapshot
+        before_inputs = snapshot(self.root / 'source'), snapshot(self.root / 'bundles')
+        self.start()
+        retained = self.root / 'retained' / 'detached'
+        retained.mkdir(mode=0o700)
+        expected = dict(self.smoke.request, retained_root='/retained/detached', workspace_local_id='workspace_1')
+        del expected['scratch_parent']
+        absent = self.request('/usr/local/bin/horizon-repository setup-status', expected, 0)
+        assert absent['status'] == 'absent' and not list(retained.iterdir())
+        rejected = self.request('/usr/local/bin/horizon-setup-launch', {}, 2)
+        assert rejected['state'] == 'observed' and rejected['observation']['status'] == 'rejected'
+        assert not list(retained.iterdir())
+        # This gate delays the real Git subprocess after the real setup child admitted.
+        # It changes no source bytes and later execs the image's original Git binary.
+        (self.state / 'enabled').touch()
+        self.request('/usr/local/bin/horizon-setup-launch > /dev/full', expected, 3)
+        wait_for(lambda: (self.state / 'entered').exists())
+        entered = json.loads((self.state / 'entered').read_text())
+        assert entered['setup'] == entered['sid'] and entered['git'] != entered['setup']
+        assert self.worker('readlink', f'/proc/{entered["setup"]}/exe').decode().strip() == '/usr/local/bin/horizon-repository'
+        wait_for(self.no_clients, 5)
+        claim = retained / 'setup-claim.json'
+        identity = claim.stat().st_dev, claim.stat().st_ino, claim.read_bytes()
+        assert not (retained / 'setup-result.json').exists()
+        observed = self.request('/usr/local/bin/horizon-setup-launch', expected, 4)
+        assert observed['state'] == 'observed' and observed['observation']['status'] == 'claimed_unknown'
+        wait_for(self.no_clients, 5)
+        assert not (retained / 'setup-result.json').exists()
+        # The original request channel is gone while admitted setup is still gated.
+        (self.state / 'enabled').unlink()
+        (self.state / 'release').touch()
+        wait_for(lambda: (retained / 'setup-result.json').exists(), 30)
+        assert self.no_clients() and self.smoke.inspect(self.container)['State']['Running']
+        self.smoke.verify_checkout(retained / 'setup-data/published')
+        finished = self.request('/usr/local/bin/horizon-repository setup-status', expected, 0)
+        assert finished['status'] == 'completed' and finished['recording'] == 'observed'
+        assert finished['execution']['state'] == 'published'
+        assert finished['execution']['base_commit'] == self.smoke.base
+        assert finished['execution']['bundle_manifest'] == self.smoke.manifest
+        retained_state = snapshot(retained)
+        again = self.request('/usr/local/bin/horizon-setup-launch', expected, 0)
+        assert again == {'version': 1, 'state': 'observed', 'observation': finished}
+        wrong = self.request('/usr/local/bin/horizon-setup-launch', dict(expected, workspace_local_id='different'), 1)
+        assert wrong['state'] == 'observed' and wrong['observation']['status'] == 'error'
+        assert (claim.stat().st_dev, claim.stat().st_ino, claim.read_bytes()) == identity
+        assert snapshot(retained) == retained_state
+        wait_for(lambda: subprocess.run(self.smoke.docker + ['exec', self.container, 'test', '!', '-e',
+            '/proc/'+str(entered['setup'])], capture_output=True, timeout=5, check=False).returncode == 0, 5)
+        # A separate ungated setup exercises normal submitted output on the same image.
+        ordinary = self.root / 'retained' / 'ordinary'
+        ordinary.mkdir(mode=0o700)
+        normal = dict(expected, retained_root='/retained/ordinary')
+        submitted = self.request('/usr/local/bin/horizon-setup-launch', normal, 0)
+        assert submitted == {'version': 1, 'state': 'submitted', 'observation': None}
+        wait_for(lambda: (ordinary / 'setup-result.json').exists(), 30)
+        self.smoke.verify_checkout(ordinary / 'setup-data/published')
+        assert before_inputs == (snapshot(self.root / 'source'), snapshot(self.root / 'bundles'))
+        print('PASS actual detached setup: admitted Git-gated execution outlives request/output loss; '
+              'separate status verifies exact repository; claimed/complete/conflicting requests never replay; '
+              'setup child reaped; ungated submission and exact checkout pass. '
+              'Git gate is synthetic, not cloud/PC-off or crash-durability proof.', flush=True)
+
+
+def main():
+    # Host invocation uses python3 explicitly; only the mounted Git gate uses -I.
+    from test_repository_image import ImageSmoke
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--image', required=True)
+    parser.add_argument('--docker-host', required=True)
+    parser.add_argument('--fixture-parent', default='/tmp')
+    smoke = ImageSmoke(parser.parse_args())
+    print(f'Task-owned setup fixture: {smoke.root}; label: {smoke.label}; image: {smoke.image}', flush=True)
+    try:
+        if smoke.user != '0:0':
+            raise SystemExit('SSH setup smoke requires local rootless Docker or a root host caller; '
+                             'the SSH worker runs as container root and must own its private fixtures')
+        smoke.fixture()
+        LauncherSmoke(smoke).test()
+    finally:
+        smoke.close()
+
+
+if __name__ == '__main__':
+    if Path(sys.argv[0]).name == 'git':
+        git_gate()
+    else:
+        main()

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -283,9 +283,16 @@ back into large multi-purpose modules.
   execution results, not unchecked deserialized snapshots. Setup/status distinguish
   fresh recording, historical observation, unknown claims and retained execution
   when recording fails. Status never creates or replays; the original materialize
-  protocol stays compatible. Image packaging installs the helper, but no command
-  detaches itself or creates independent remote supervision: lost output requires
-  later observation, not automatic replay or task start.
+  protocol stays compatible. These Rust commands remain synchronous.
+- `containers/remote-worker/setup-launch.py` owns the separate worker-only bounded
+  handoff: it delegates strict input/root observation to `setup-status`, returns
+  existing observations without launch, and passes only an absent intent through a
+  private pipe to the fixed `setup` child in an independent process session. The
+  child alone admits/consumes the core grant. Submission and handoff uncertainty
+  never prove current liveness, create replay authority or authorize a kill. The
+  launcher writes no request/log files; retained Rust completion remains the
+  recovery surface, not transient child output. Missing recording stays unknown.
+  It does not own task supervision, transport, provider lifetime or client wiring.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in

--- a/docs/remote-repository-command.md
+++ b/docs/remote-repository-command.md
@@ -144,5 +144,56 @@ liveness, current checkout contents, cleanup permission, cloud or power-loss pro
 
 These commands remain synchronous: they do not detach themselves from SSH, launch
 tasks, transfer source, create a supervisor or integrate the client. A worker-owned
-independent launcher must be added before claiming setup survives client loss.
+independent launcher is available separately below for submission across client loss.
 No invocation implicitly stops/deletes a workspace when a local view closes.
+
+## Independent setup submission
+
+The Linux worker image also installs a separate explicit launcher:
+
+```sh
+horizon-setup-launch < setup-request.json
+```
+
+It accepts the same complete immutable request as `setup`, bounded to 128 KiB
+and EOF, with no command-line arguments. It first delegates validation and
+qualified read-only observation to `horizon-repository setup-status`. A matching
+existing claim returns that observation without spawning setup. Invalid input,
+unsafe storage, mismatched intent or unavailable observation never means absent.
+
+Only after a verified absent observation does it spawn the fixed `setup` command,
+in a new process session, with a bounded private stdin pipe, no inherited client
+stdio, closed extra descriptors and a minimal environment. The launcher writes no
+request or log files. The detached child performs input separation and one-shot
+admission itself. Racing submitters cannot reconstruct or share its fresh grant.
+The worker's PID 1 must reap completed orphan children; the shipped SSH daemon
+provides that role. No PID is returned as liveness or recovery authority.
+
+The response is bounded JSON plus newline, at most 256 KiB to accommodate a full
+128 KiB observation and envelope. Its fields are `version`, `state`, `observation`:
+
+| State | Exit | Meaning |
+| --- | --- | --- |
+| `observed` | Original observation exit | Contains the unchanged parsed `setup-status` response; no child launched. |
+| `submitted` | 0 | Complete request handoff and EOF; not admission, current execution or completion. |
+| `handoff_unconfirmed` | 1 | Child spawned but complete handoff was not confirmed; retain state and observe. |
+| `rejected` | 2 | Oversized input or read failure before observation/spawn. |
+| `error` | 1 | Observation could not be safely consumed, or child spawn failed. |
+
+Only `observed` has a non-null observation. Exit 3 means the launcher response
+could not be completely written/flushed; it never kills or retries an already
+spawned child. Closing the SSH request channel after handoff does not terminate
+setup. Input, observation and handoff loss must remain unknown until separately
+observed. The 30-second observation and 15-second pipe handoff timeouts are best
+effort; input without EOF and uninterruptible OS I/O have no hard total deadline.
+
+Reconnect by calling `horizon-repository setup-status` with the same intent.
+Its retained result is the recovery surface; detached transient stdout/stderr is
+not an additional durable log. If recording failed, later observation may remain
+unknown/error and cannot reconstruct a transient unrecorded execution receipt.
+Claims and data remain retained, with no automatic cleanup or replay. A successful
+handoff does not strengthen storage guarantees or make failed recording successful.
+
+This provides independent setup submission, not source transfer, remote task/log
+supervision, client/provider integration, restart recovery or cloud/PC-off proof.
+No command implicitly stops/deletes an environment when a local view closes.


### PR DESCRIPTION
## Purpose and behavior

Refs #383 and #470. Add the separate worker-side `horizon-setup-launch` command so
explicit repository setup can continue independently of its request channel.

- Validate and observe with the existing bounded `setup-status` protocol; existing
  claims/results are returned without starting another setup.
- Hand an absent intent through a bounded private pipe to the fixed setup child in
  its own process session. The child alone owns one-shot admission.
- Distinguish submitted, uncertain handoff, observation, rejection and output loss.
  None implies current liveness or authorizes replay, termination or cleanup.
- Write no request/log files before admission. Retained completion remains the
  recovery surface; failed recording may remain unknown and does not become a
  successful durable receipt. Closing a local view never stops/deletes the worker.

This does not add source transfer, task/log supervision, client/provider wiring,
restart recovery, cloud/PC-off proof, image publication or a release. The worker
uses its existing Linux interpreter and SSH daemon child-reaping behavior.

## Validation

Candidate: `88f0ac431a3d84dc1c6495a519c145d2d3ceb234`.

- Full required matrix in the exact final worktree: formatting, maintainability,
  version sync, default and speech workspace tests, blocking and strict Clippy,
  plus the advisory pedantic lane.
- Fourteen protocol/interpreter regressions: exact-absence-only launch, strict
  framing, partial writes, deadlines, failed handoff, closed standard descriptors
  and output failure without shutdown retry or child termination.
- Actual worker-image setup smoke: delay the real Git subprocess after admission,
  lose the request/output channel, verify zero SSH clients while setup remains in
  progress, then observe the exact completed repository through a separate channel.
  Repeated/conflicting requests do not replay; completed child reaping and a second
  ungated submission pass. The Git gate is explicit synthetic instrumentation.
- Existing repository, packaging/layer provenance, security/disconnected-panel and
  retained-host-identity image lanes pass. The repository fixture includes a packed
  65 MiB-plus object, raw index/worktree differences, LFS, symlink and mode semantics.
- Independent local review completed. All smoke resources and keys are synthetic;
  cleanup targets only each test's own containers/fixtures, and images are retained.

The SSH setup harness requires local rootless Docker or a root host caller, plus
qualified journaled ext4 fixture storage. Local results are not cloud acceptance.

Scope: seven non-documentation files, 636 changed lines, plus three focused docs.

Final local image: `sha256:80bd5c2872607a5a941759f79ab24f319a4f9b29c4403bbb4ce98679d1440305`.
Installed launcher SHA-256: `35903eca32faa3f4f30c390ea8f6ead5ed0ec7d2ff49c71237ac2b77f4991059`,
equal to the committed script. Repository executable SHA-256:
`e9f871947114a271ca1582441af2b5528e0fd0d96c1dd9e5b1834a2701059e3e`,
independently checked against the builder stage and final-image layers.
