### PR TITLE
Receive and observe verified remote overlay bundles

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -76,8 +76,12 @@ The separate `horizon-setup-launch` command can submit setup independently of it
 request channel; it does not turn submission or a claim into proof of liveness.
 See [independent setup submission](../../docs/remote-repository-command.md#independent-setup-submission)
 for its bounded handoff, observation and recording limitations.
-This packaging does not add object transport, client setup, recovery, checkpointing
-or task admission. Existing workers are not
+The same helper can explicitly receive a canonical overlay bundle into an existing
+private bundle store and inspect a lost acknowledgement without writing. See
+[worker overlay receipt](../../docs/remote-overlay-transfer.md) for the framed
+input and storage limits. No local files are captured/exported automatically.
+This packaging does not add Git-object transport, client setup, worker-loss recovery,
+checkpointing or task admission. Existing workers are not
 upgraded by rebuilding an image. Neither the helper nor a locally retained volume
 proves cloud durability or PC-off operation.
 
@@ -119,6 +123,18 @@ gate, verifies the exact repository through a separate status channel, checks no
 claim replay and completed-child reaping, and runs an ungated submission. It binds
 only loopback SSH and removes its own containers, fixture and generated keypair.
 The gate is explicit test instrumentation, not cloud/PC-off or crash-durability proof.
+
+To check framed overlay receipt and fresh-process observation with synthetic data:
+
+```bash
+python3 -B containers/remote-worker/test_overlay_receive_image.py \
+  --docker-host unix:///path/to/docker.sock --image horizon-remote-worker:0.1.0
+```
+
+This covers exact small and 65 MiB-plus multi-file bundles, immutable retries,
+malformed frames, conflicting/unsafe records, missing roots and acknowledgement
+loss. It uses no network or credentials, changes only its private input stores,
+and removes only its own containers/fixtures. It is not cloud/checkpoint proof.
 
 ## Runtime contract
 

--- a/containers/remote-worker/test_overlay_receive_image.py
+++ b/containers/remote-worker/test_overlay_receive_image.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Synthetic framed overlay receipt and fresh-process acknowledgement recovery."""
+
+import argparse
+import json
+import stat
+import struct
+
+from test_repository_image import ImageSmoke, digest, encoded, snapshot
+
+
+def frame(request, payload):
+    header = encoded(dict(request, encoded_bytes=len(payload)))
+    return struct.pack('<I', len(header))+header+payload
+
+
+def identity(path):
+    value = path.lstat()
+    return value.st_dev, value.st_ino, value.st_nlink, value.st_mtime_ns, stat.S_IMODE(value.st_mode)
+
+
+def large_bundle(smoke):
+    payloads = [smoke.large[:33*1024*1024], smoke.large[33*1024*1024:]]
+    changes = [{'path': name, 'kind': 'file', 'sha256': digest(payload), 'bytes': len(payload),
+                'executable': False} for name, payload in zip(('transfer-a', 'transfer-b'), payloads)]
+    metadata = encoded({'domain': 'horizon.repository-overlay', 'version': 1,
+        'repository': 'synthetic/project', 'commit': smoke.base, 'branch': None,
+        'index': [], 'working_tree': changes})
+    result = bytearray(b'HZOVLY\0\x01'+struct.pack('<I', len(metadata))+metadata+struct.pack('<I', 2))
+    for key, payload in sorted((digest(payload), payload) for payload in payloads):
+        result.extend(key.encode()+struct.pack('<Q', len(payload)))
+        result.extend(payload)
+    return digest(metadata), bytes(result)
+
+
+def test(smoke):
+    smoke.fixture()
+    before = snapshot(smoke.root / 'source'), snapshot(smoke.root / 'bundles')
+    payload = (smoke.root / 'bundles' / (smoke.manifest+'.hzov')).read_bytes()
+
+    def private(name):
+        root = smoke.root / 'retained' / name
+        root.mkdir(mode=0o700)
+        return root, {'version': 1, 'bundle_store': '/retained/'+name, 'bundle_manifest': smoke.manifest}
+
+    def invoke(command, data, state, code):
+        output = smoke.command('/usr/local/bin/horizon-repository', [command], data, mount_inputs=False)
+        assert output.returncode == code and not output.stderr, (output.returncode, output.stderr)
+        assert output.stdout.endswith(b'\n') and len(output.stdout) <= 1024
+        response = json.loads(output.stdout)
+        assert response['version'] == 1 and response['status'] == state, response
+        assert set(response) == {'version', 'status', 'bundle_manifest', 'reason'}
+        assert 'private-input-marker' not in str(response)
+        smoke.retire_completed()
+        return response
+
+    root, request = private('receiver')
+    invoke('overlay-status', encoded(request), 'missing', 4)
+    assert not list(root.iterdir())
+    for malformed in (frame(request, payload)[:-1], frame(request, payload)+b'extra',
+                      frame(dict(request, bundle_manifest='a'*64), payload), b'private-input-marker'):
+        invoke('receive-overlay', malformed, 'rejected', 2)
+        assert not list(root.iterdir())
+    receipt = invoke('receive-overlay', frame(request, payload), 'acknowledged', 0)
+    assert receipt['bundle_manifest'] == smoke.manifest and receipt['reason'] is None
+    record = root / (smoke.manifest+'.hzov')
+    original = identity(record)
+    assert original[2] == 1 and original[4] == 0o600 and record.read_bytes() == payload
+    observed = invoke('overlay-status', encoded(request), 'observed', 0)
+    assert observed['bundle_manifest'] == smoke.manifest and identity(record) == original
+    invoke('receive-overlay', frame(request, payload), 'acknowledged', 0)
+    assert identity(record) == original and record.read_bytes() == payload and len(list(root.iterdir())) == 1
+
+    for name in ('conflict', 'hardlink', 'symlink'):
+        unsafe, expected = private(name)
+        destination = unsafe / (smoke.manifest+'.hzov')
+        if name == 'symlink':
+            destination.symlink_to(record)
+        elif name == 'hardlink':
+            other = unsafe / 'other'
+            other.write_bytes(payload)
+            other.chmod(0o600)
+            destination.hardlink_to(other)
+        else:
+            destination.write_bytes(b'private-input-marker')
+            destination.chmod(0o600)
+        retained = identity(destination), snapshot(unsafe)
+        invoke('receive-overlay', frame(expected, payload), 'write_unconfirmed', 1)
+        invoke('overlay-status', encoded(expected), 'error', 1)
+        assert retained == (identity(destination), snapshot(unsafe))
+        assert identity(record) == original and record.read_bytes() == payload
+
+    missing = dict(request, bundle_store='/retained/missing')
+    invoke('overlay-status', encoded(missing), 'error', 1)
+    invoke('receive-overlay', frame(missing, payload), 'error', 1)
+    assert not (smoke.root / 'retained/missing').exists()
+    lost, expected = private('lost-output')
+    output = smoke.command('/bin/sh', ['-c', 'exec /usr/local/bin/horizon-repository receive-overlay > /dev/full'],
+                           frame(expected, payload), mount_inputs=False)
+    assert output.returncode == 3 and not output.stdout
+    assert output.stderr == b'Could not write a complete response; retain data and inspect before any retry.\n'
+    lost_record = lost / (smoke.manifest+'.hzov')
+    saved = identity(lost_record)
+    assert lost_record.read_bytes() == payload
+    smoke.retire_completed()
+    invoke('overlay-status', encoded(expected), 'observed', 0)
+    assert identity(lost_record) == saved
+
+    large, expected = private('large')
+    manifest, contents = large_bundle(smoke)
+    assert len(contents) > 65*1024*1024
+    expected['bundle_manifest'] = manifest
+    invoke('receive-overlay', frame(expected, contents), 'acknowledged', 0)
+    large_record = large / (manifest+'.hzov')
+    saved = identity(large_record)
+    assert large_record.read_bytes() == contents
+    invoke('overlay-status', encoded(expected), 'observed', 0)
+    invoke('receive-overlay', frame(expected, contents), 'acknowledged', 0)
+    assert identity(large_record) == saved and large_record.read_bytes() == contents
+    assert before == (snapshot(smoke.root / 'source'), snapshot(smoke.root / 'bundles'))
+    assert not list((smoke.root / 'retained').rglob('setup-claim.json'))
+    print('PASS overlay receiver: exact small and 65 MiB-plus multi-blob records, fresh-process '
+          'observation, immutable retries, strict malformed input, no root creation, unsafe/conflicting '
+          'records retained and output-loss recovery; source inputs unchanged and no setup started. '
+          'Synthetic local storage proof, not client export or cloud/checkpoint durability.', flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--image', required=True)
+    parser.add_argument('--docker-host', required=True)
+    parser.add_argument('--fixture-parent', default='/tmp')
+    smoke = ImageSmoke(parser.parse_args())
+    print(f'Task-owned overlay fixture: {smoke.root}; label: {smoke.label}; image: {smoke.image}', flush=True)
+    try:
+        test(smoke)
+    finally:
+        smoke.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod protocol;
+mod receive;
 mod setup;
 
 use std::{
@@ -11,10 +12,15 @@ use std::{
 fn main() -> ExitCode {
     let arguments: Vec<_> = std::env::args_os().skip(1).take(2).collect();
     let command = arguments.first().and_then(|argument| argument.to_str());
-    if arguments.len() != 1 || !matches!(command, Some("materialize" | "setup" | "setup-status")) {
+    if arguments.len() != 1
+        || !matches!(
+            command,
+            Some("materialize" | "setup" | "setup-status" | "receive-overlay" | "overlay-status")
+        )
+    {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status < request.json"
+            "Usage: horizon-repository materialize|setup|setup-status|receive-overlay|overlay-status < request"
         );
         return ExitCode::from(2);
     }
@@ -24,6 +30,8 @@ fn main() -> ExitCode {
     match command {
         Some("setup") => setup::run(setup::Command::Execute, &mut input, &mut output, &mut diagnostics),
         Some("setup-status") => setup::run(setup::Command::Observe, &mut input, &mut output, &mut diagnostics),
+        Some("receive-overlay") => receive::run(receive::Command::Receive, &mut input, &mut output, &mut diagnostics),
+        Some("overlay-status") => receive::run(receive::Command::Observe, &mut input, &mut output, &mut diagnostics),
         _ => run(&mut input, &mut output, &mut diagnostics),
     }
 }

--- a/crates/horizon-repository/src/receive/mod.rs
+++ b/crates/horizon-repository/src/receive/mod.rs
@@ -1,0 +1,110 @@
+//! Explicit overlay receipt and read-only observation, not capture/export or setup authority.
+
+mod request;
+
+use horizon_core::{
+    cloud_run::ArtifactDigest,
+    repository_overlay::bundle::store::{BundleStoreError, RepositoryBundleStore},
+};
+use request::Operation;
+use serde::Serialize;
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+const VERSION: u32 = 1;
+const RESPONSE_LIMIT: usize = 1024;
+
+#[derive(Clone, Copy)]
+pub(super) enum Command {
+    Receive,
+    Observe,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Acknowledged,
+    Observed,
+    Missing,
+    Rejected,
+    Error,
+    WriteUnconfirmed,
+}
+
+#[derive(Serialize)]
+struct Response {
+    version: u32,
+    status: Status,
+    bundle_manifest: Option<ArtifactDigest>,
+    reason: Option<&'static str>,
+}
+
+impl Response {
+    fn new(status: Status, manifest: Option<ArtifactDigest>, reason: Option<&'static str>) -> Self {
+        Self {
+            version: VERSION,
+            status,
+            bundle_manifest: manifest,
+            reason,
+        }
+    }
+
+    fn exit_code(&self) -> u8 {
+        match self.status {
+            Status::Acknowledged | Status::Observed => 0,
+            Status::Rejected => 2,
+            Status::Missing => 4,
+            Status::Error | Status::WriteUnconfirmed => 1,
+        }
+    }
+}
+
+pub(super) fn run(
+    command: Command,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    run_with(command, input, output, diagnostics, execute)
+}
+
+fn run_with(
+    command: Command,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+    execute: impl FnOnce(&Operation) -> Response,
+) -> ExitCode {
+    let response = match request::read(command, input) {
+        Ok(operation) => execute(&operation),
+        Err(()) => Response::new(Status::Rejected, None, Some("invalid or unsupported overlay request")),
+    };
+    super::write_response(&response, response.exit_code(), RESPONSE_LIMIT, output, diagnostics)
+}
+
+fn execute(operation: &Operation) -> Response {
+    let request = operation.request();
+    let Ok(store) = RepositoryBundleStore::open(&request.bundle_store) else {
+        return Response::new(Status::Error, None, Some("overlay storage could not be safely opened"));
+    };
+    match operation {
+        Operation::Receive { bundle, .. } => match store.put(bundle) {
+            Ok(digest) => Response::new(Status::Acknowledged, Some(digest), None),
+            Err(_) => Response::new(
+                Status::WriteUnconfirmed,
+                None,
+                Some("overlay publication was not acknowledged; retain and observe existing data"),
+            ),
+        },
+        Operation::Observe(_) => match store.get(&request.bundle_manifest) {
+            Ok(bundle) => Response::new(Status::Observed, Some(bundle.manifest_sha256().clone()), None),
+            Err(BundleStoreError::Missing) => Response::new(Status::Missing, None, None),
+            Err(_) => Response::new(Status::Error, None, Some("overlay data could not be safely observed")),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/receive/request.rs
+++ b/crates/horizon-repository/src/receive/request.rs
@@ -1,0 +1,136 @@
+use super::{Command, VERSION};
+use horizon_core::{
+    cloud_run::ArtifactDigest,
+    repository_overlay::{
+        bundle::{RepositoryOverlayBundle, codec},
+        materialize::MAX_REQUEST_PATH_BYTES,
+    },
+};
+use serde::Deserialize;
+use std::{
+    io::{self, Read},
+    path::{Component, PathBuf},
+};
+
+// One maximum escaped path, digest and fixed framing fields; no payload in JSON.
+pub(super) const HEADER_LIMIT: usize = (6 * MAX_REQUEST_PATH_BYTES + 4096).next_power_of_two();
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ObservationRequest {
+    version: u32,
+    bundle_store: PathBuf,
+    bundle_manifest: ArtifactDigest,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReceiveHeader {
+    version: u32,
+    bundle_store: PathBuf,
+    bundle_manifest: ArtifactDigest,
+    encoded_bytes: usize,
+}
+
+pub(super) struct Request {
+    pub(super) bundle_store: PathBuf,
+    pub(super) bundle_manifest: ArtifactDigest,
+}
+
+impl Request {
+    fn new(version: u32, bundle_store: PathBuf, bundle_manifest: ArtifactDigest) -> Result<Self, ()> {
+        if version != VERSION
+            || !bundle_store.is_absolute()
+            || bundle_store.parent().is_none()
+            || bundle_store.components().any(|part| part == Component::ParentDir)
+            || !bundle_store
+                .to_str()
+                .is_some_and(|path| path.len() <= MAX_REQUEST_PATH_BYTES && !path.contains('\0'))
+        {
+            return Err(());
+        }
+        Ok(Self {
+            bundle_store,
+            bundle_manifest,
+        })
+    }
+}
+
+pub(super) enum Operation {
+    Receive {
+        request: Request,
+        bundle: Box<RepositoryOverlayBundle>,
+    },
+    Observe(Request),
+}
+
+impl Operation {
+    pub(super) fn request(&self) -> &Request {
+        match self {
+            Self::Receive { request, .. } | Self::Observe(request) => request,
+        }
+    }
+}
+
+pub(super) fn read(command: Command, input: &mut impl Read) -> Result<Operation, ()> {
+    match command {
+        Command::Observe => {
+            let mut bytes = Vec::new();
+            input
+                .take(HEADER_LIMIT as u64 + 1)
+                .read_to_end(&mut bytes)
+                .map_err(|_| ())?;
+            if bytes.len() > HEADER_LIMIT {
+                return Err(());
+            }
+            let wire: ObservationRequest = serde_json::from_slice(&bytes).map_err(|_| ())?;
+            Request::new(wire.version, wire.bundle_store, wire.bundle_manifest).map(Operation::Observe)
+        }
+        Command::Receive => receive(input),
+    }
+}
+
+fn receive(input: &mut impl Read) -> Result<Operation, ()> {
+    let mut prefix = [0; 4];
+    input.read_exact(&mut prefix).map_err(|_| ())?;
+    let length = usize::try_from(u32::from_le_bytes(prefix)).map_err(|_| ())?;
+    if length == 0 || length > HEADER_LIMIT {
+        return Err(());
+    }
+    let header = read_exact_bytes(input, length)?;
+    let wire: ReceiveHeader = serde_json::from_slice(&header).map_err(|_| ())?;
+    let request = Request::new(wire.version, wire.bundle_store, wire.bundle_manifest)?;
+    if wire.encoded_bytes == 0 || wire.encoded_bytes > codec::MAX_ENCODED_BUNDLE_BYTES {
+        return Err(());
+    }
+    let encoded = read_exact_bytes(input, wire.encoded_bytes)?;
+    require_eof(input)?;
+    let bundle = codec::decode(&encoded).map_err(|_| ())?;
+    if bundle.manifest_sha256() != &request.bundle_manifest {
+        return Err(());
+    }
+    // The input buffer drops before storage re-encodes/verifies any existing record.
+    Ok(Operation::Receive {
+        request,
+        bundle: Box::new(bundle),
+    })
+}
+
+fn read_exact_bytes(input: &mut impl Read, length: usize) -> Result<Vec<u8>, ()> {
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(length).map_err(|_| ())?;
+    bytes.resize(length, 0);
+    input.read_exact(&mut bytes).map_err(|_| ())?;
+    Ok(bytes)
+}
+
+fn require_eof(input: &mut impl Read) -> Result<(), ()> {
+    let mut extra = [0];
+    loop {
+        match input.read(&mut extra) {
+            Ok(0) => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            _ => return Err(()),
+        }
+    }
+}

--- a/crates/horizon-repository/src/receive/tests.rs
+++ b/crates/horizon-repository/src/receive/tests.rs
@@ -1,0 +1,286 @@
+use super::*;
+use horizon_core::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{
+        OverlayChange, OverlayContent, RepositoryOverlayPlan,
+        bundle::{RepositoryOverlayBundle, VerifiedOverlayBlob, codec},
+    },
+};
+use serde_json::{Value, json};
+use std::io;
+
+fn bundle() -> RepositoryOverlayBundle {
+    let blob = VerifiedOverlayBlob::new(b"synthetic\0raw\xff".to_vec()).unwrap();
+    let change = OverlayChange::new(
+        "selected".into(),
+        OverlayContent::File {
+            sha256: blob.sha256().clone(),
+            bytes: blob.bytes().len() as u64,
+            executable: true,
+        },
+    )
+    .unwrap();
+    let plan = RepositoryOverlayPlan::new(
+        GitSource {
+            repository: "synthetic/project".into(),
+            commit: GitCommitSha::parse("a".repeat(40)).unwrap(),
+            branch: None,
+        },
+        [change],
+        [],
+    )
+    .unwrap();
+    RepositoryOverlayBundle::new(plan, [blob]).unwrap()
+}
+
+fn request() -> Value {
+    json!({"version":1, "bundle_store":std::env::temp_dir().join("synthetic-private-receiver"),
+        "bundle_manifest":bundle().manifest_sha256()})
+}
+
+fn header() -> Value {
+    let mut value = request();
+    value["encoded_bytes"] = json!(codec::encode(&bundle()).unwrap().len());
+    value
+}
+
+fn frame(header: &[u8], payload: &[u8]) -> Vec<u8> {
+    let mut bytes = u32::try_from(header.len()).unwrap().to_le_bytes().to_vec();
+    bytes.extend_from_slice(header);
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn assert_rejected(command: Command, mut input: &[u8]) {
+    let mut output = Vec::new();
+    let mut diagnostics = Vec::new();
+    let code = run_with(command, &mut input, &mut output, &mut diagnostics, |_| {
+        panic!("invalid input must not reach storage")
+    });
+    assert_eq!(code, ExitCode::from(2));
+    assert!(diagnostics.is_empty() && output.ends_with(b"\n") && output.len() <= RESPONSE_LIMIT);
+    let response: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(response["status"], "rejected");
+    assert!(response["bundle_manifest"].is_null());
+    assert!(!String::from_utf8(output).unwrap().contains("private"));
+}
+
+#[test]
+fn exact_framed_bundle_and_status_preserve_only_verified_intent() {
+    let expected = bundle();
+    let payload = codec::encode(&expected).unwrap();
+    let input = frame(&serde_json::to_vec(&header()).unwrap(), &payload);
+    let operation = request::read(Command::Receive, &mut input.as_slice()).unwrap();
+    let Operation::Receive {
+        request: received,
+        bundle,
+    } = operation
+    else {
+        panic!("receive operation")
+    };
+    assert_eq!(*bundle, expected);
+    assert_eq!(received.bundle_manifest, *expected.manifest_sha256());
+    assert_eq!(
+        received.bundle_store,
+        std::env::temp_dir().join("synthetic-private-receiver")
+    );
+    let observed = request::read(
+        Command::Observe,
+        &mut serde_json::to_vec(&request()).unwrap().as_slice(),
+    )
+    .unwrap();
+    assert!(matches!(observed, Operation::Observe(_)));
+    assert_eq!(observed.request().bundle_manifest, received.bundle_manifest);
+}
+
+#[test]
+fn malformed_headers_never_open_storage_for_either_command() {
+    let payload = codec::encode(&bundle()).unwrap();
+    for (command, original) in [(Command::Receive, header()), (Command::Observe, request())] {
+        let check = |encoded: &[u8]| match command {
+            Command::Receive => assert_rejected(command, &frame(encoded, &payload)),
+            Command::Observe => assert_rejected(command, encoded),
+        };
+        for key in original.as_object().unwrap().keys() {
+            let mut changed = original.clone();
+            changed.as_object_mut().unwrap().remove(key);
+            check(&serde_json::to_vec(&changed).unwrap());
+        }
+        for (key, value) in [
+            ("version", json!(true)),
+            ("version", json!(2)),
+            ("version", json!(-1)),
+            ("bundle_store", json!("relative-private-marker")),
+            ("bundle_store", json!(std::env::temp_dir().join("../private-marker"))),
+            ("bundle_store", json!("\0private-marker")),
+            ("bundle_manifest", json!("G".repeat(64))),
+            ("bundle_manifest", json!("a".repeat(63))),
+            ("extra", json!(true)),
+        ] {
+            let mut changed = original.clone();
+            changed[key] = value;
+            check(&serde_json::to_vec(&changed).unwrap());
+        }
+        let encoded = serde_json::to_string(&original).unwrap();
+        for invalid in [
+            b"\xff".to_vec(),
+            b"{}".to_vec(),
+            b"[]".to_vec(),
+            format!("{encoded}{{}}").into_bytes(),
+            encoded.replacen('{', "{\"version\":1,", 1).into_bytes(),
+        ] {
+            check(&invalid);
+        }
+    }
+    assert_rejected(Command::Observe, &serde_json::to_vec(&header()).unwrap());
+}
+
+#[test]
+fn framing_truncation_trailing_bytes_and_unverified_payload_never_reach_storage() {
+    let payload = codec::encode(&bundle()).unwrap();
+    let encoded = serde_json::to_vec(&header()).unwrap();
+    let valid = frame(&encoded, &payload);
+    for length in [0, 1, 3, 4, 4 + encoded.len() - 1, valid.len() - 1] {
+        assert_rejected(Command::Receive, &valid[..length]);
+    }
+    let mut trailing = valid.clone();
+    trailing.extend_from_slice(b"private-trailing-bytes");
+    let mut measured = io::Cursor::new(trailing);
+    assert!(request::read(Command::Receive, &mut measured).is_err());
+    assert_eq!(measured.position(), valid.len() as u64 + 1);
+    let mut corrupted = valid;
+    *corrupted.last_mut().unwrap() ^= 1;
+    assert_rejected(Command::Receive, &corrupted);
+    for (key, value) in [
+        ("bundle_manifest", json!("b".repeat(64))),
+        ("encoded_bytes", json!(0)),
+        ("encoded_bytes", json!(-1)),
+        ("encoded_bytes", json!(payload.len() - 1)),
+        ("encoded_bytes", json!(payload.len() + 1)),
+        ("encoded_bytes", json!(codec::MAX_ENCODED_BUNDLE_BYTES + 1)),
+    ] {
+        let mut changed = header();
+        changed[key] = value;
+        assert_rejected(
+            Command::Receive,
+            &frame(&serde_json::to_vec(&changed).unwrap(), &payload),
+        );
+    }
+}
+
+#[test]
+fn header_limits_bound_reads_and_allow_exact_supported_frames() {
+    let payload = codec::encode(&bundle()).unwrap();
+    let mut encoded = serde_json::to_vec(&header()).unwrap();
+    encoded.resize(request::HEADER_LIMIT, b' ');
+    assert!(request::read(Command::Receive, &mut frame(&encoded, &payload).as_slice()).is_ok());
+    encoded.push(b' ');
+    let mut measured = io::Cursor::new(frame(&encoded, &payload));
+    assert!(request::read(Command::Receive, &mut measured).is_err());
+    assert_eq!(measured.position(), 4);
+    assert_rejected(Command::Receive, &0_u32.to_le_bytes());
+    let mut status = serde_json::to_vec(&request()).unwrap();
+    status.resize(request::HEADER_LIMIT, b' ');
+    assert!(request::read(Command::Observe, &mut status.as_slice()).is_ok());
+    status.extend_from_slice(b"  ");
+    let mut measured = io::Cursor::new(status);
+    assert!(request::read(Command::Observe, &mut measured).is_err());
+    assert_eq!(measured.position(), request::HEADER_LIMIT as u64 + 1);
+}
+
+#[test]
+fn read_failures_are_rejections_and_interrupted_eof_can_retry() {
+    struct Failed;
+    impl Read for Failed {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("private-read-failure"))
+        }
+    }
+    struct InterruptEof<'a>(&'a [u8], bool);
+    impl Read for InterruptEof<'_> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            if self.0.is_empty() && !self.1 {
+                self.1 = true;
+                return Err(io::ErrorKind::Interrupted.into());
+            }
+            self.0.read(bytes)
+        }
+    }
+    for command in [Command::Receive, Command::Observe] {
+        assert!(request::read(command, &mut Failed).is_err());
+    }
+    let payload = codec::encode(&bundle()).unwrap();
+    let input = frame(&serde_json::to_vec(&header()).unwrap(), &payload);
+    assert!(request::read(Command::Receive, &mut InterruptEof(&input, false)).is_ok());
+}
+
+#[cfg(unix)]
+#[test]
+fn maximum_escaped_root_fits_but_oversized_or_nul_roots_never_reach_storage() {
+    use horizon_core::repository_overlay::materialize::MAX_REQUEST_PATH_BYTES;
+    let payload = codec::encode(&bundle()).unwrap();
+    let mut value = header();
+    value["bundle_store"] = json!(format!("/{}", "\u{1}".repeat(MAX_REQUEST_PATH_BYTES - 1)));
+    let encoded = serde_json::to_vec(&value).unwrap();
+    assert!(encoded.len() > 24 * 1024 && encoded.len() < request::HEADER_LIMIT);
+    assert!(request::read(Command::Receive, &mut frame(&encoded, &payload).as_slice()).is_ok());
+    for path in [
+        "/".into(),
+        "/private\0marker".into(),
+        format!("/{}", "x".repeat(MAX_REQUEST_PATH_BYTES)),
+    ] {
+        value["bundle_store"] = json!(path);
+        assert_rejected(Command::Receive, &frame(&serde_json::to_vec(&value).unwrap(), &payload));
+    }
+}
+
+#[test]
+fn a_valid_empty_overlay_is_not_confused_with_an_empty_encoding() {
+    let plan = RepositoryOverlayPlan::new(bundle().plan().source().clone(), [], []).unwrap();
+    let empty = RepositoryOverlayBundle::new(plan, []).unwrap();
+    let payload = codec::encode(&empty).unwrap();
+    assert!(!payload.is_empty());
+    let mut value = header();
+    value["bundle_manifest"] = json!(empty.manifest_sha256());
+    value["encoded_bytes"] = json!(payload.len());
+    assert!(
+        request::read(
+            Command::Receive,
+            &mut frame(&serde_json::to_vec(&value).unwrap(), &payload).as_slice()
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn response_states_and_lost_output_do_not_repeat_storage_operations() {
+    for (status, expected) in [
+        (Status::Acknowledged, 0),
+        (Status::Observed, 0),
+        (Status::Missing, 4),
+        (Status::Rejected, 2),
+        (Status::Error, 1),
+        (Status::WriteUnconfirmed, 1),
+    ] {
+        assert_eq!(Response::new(status, None, None).exit_code(), expected);
+    }
+    let payload = codec::encode(&bundle()).unwrap();
+    let input = frame(&serde_json::to_vec(&header()).unwrap(), &payload);
+    let mut calls = 0;
+    let code = run_with(
+        Command::Receive,
+        &mut input.as_slice(),
+        &mut [0_u8; 0].as_mut_slice(),
+        &mut io::sink(),
+        |operation| {
+            calls += 1;
+            Response::new(
+                Status::Acknowledged,
+                Some(operation.request().bundle_manifest.clone()),
+                None,
+            )
+        },
+    );
+    assert_eq!(code, ExitCode::from(3));
+    assert_eq!(calls, 1);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -274,7 +274,7 @@ back into large multi-purpose modules.
   resolution, checkout preparation and explicit publication into one worker-callable
   operation. Its typed result preserves source metadata and every known checkout or
   uncertain destination; no retry or cleanup is implied. `horizon-repository` owns
-  only the bounded versioned JSON command boundary and truthful response/exit status.
+  only the bounded versioned command boundaries and truthful response/exit status.
   Its `setup/` tree separates immutable input validation, one-shot core API
   orchestration and response projection. Core `admit_materialization` performs
   bounded read-only input-tree identity separation before fresh admission; existing
@@ -284,6 +284,12 @@ back into large multi-purpose modules.
   fresh recording, historical observation, unknown claims and retained execution
   when recording fails. Status never creates or replays; the original materialize
   protocol stays compatible. These Rust commands remain synchronous.
+  Its separate `receive/` tree validates a bounded framed header and complete
+  canonical overlay bundle before any store access. `receive-overlay` reuses the
+  immutable bundle store; `overlay-status` reads only and never acknowledges new
+  synchronization. Lost output/write acknowledgement retains possible publication
+  without overwrite, cleanup, setup/task start or inferred export permission. Input
+  storage synchronization is not the retained-setup qualifier or cloud durability.
 - `containers/remote-worker/setup-launch.py` owns the separate worker-only bounded
   handoff: it delegates strict input/root observation to `setup-status`, returns
   existing observations without launch, and passes only an absent intent through a

--- a/docs/remote-overlay-transfer.md
+++ b/docs/remote-overlay-transfer.md
@@ -1,0 +1,90 @@
+# Worker overlay receipt
+
+The worker's `horizon-repository` helper accepts one explicitly supplied canonical
+overlay bundle into an existing private bundle store. This is a transfer primitive,
+not permission to capture/export local files, transfer Git objects, start repository
+setup/tasks, select a provider or mark a workspace ready. Existing commands remain
+compatible; nothing invokes these commands automatically.
+
+## Receive
+
+```sh
+horizon-repository receive-overlay < framed-request.bin
+```
+
+Stdin contains exactly these ordered parts:
+
+1. A four-byte unsigned little-endian JSON-header length, from 1 through 32,768.
+2. Exactly that many UTF-8 JSON bytes with the fields below.
+3. Exactly `encoded_bytes` bytes in the existing version-1 overlay bundle codec.
+4. EOF, with no trailing bytes.
+
+| Header field | Contract |
+| --- | --- |
+| `version` | Integer `1`. |
+| `bundle_store` | Explicit existing absolute non-root directory; at most 4,096 UTF-8 path bytes, no parent traversal or NUL. |
+| `bundle_manifest` | Expected canonical metadata SHA-256, 64 hexadecimal characters, normalized to lowercase. |
+| `encoded_bytes` | Positive integer, at most `codec::MAX_ENCODED_BUNDLE_BYTES`. |
+
+Unknown/duplicate fields, unsupported versions, oversized framing, truncated or
+trailing input, invalid canonical encoding, bad payload hashes and manifest mismatch
+are rejected before opening storage. The bundle codec retains its 64 MiB per-file,
+128 MiB aggregate payload and separate metadata/entry limits. This does not add a
+second bundle encoding, accept archives, interpret paths as shell arguments or
+copy arbitrary files from the worker filesystem.
+
+The root must satisfy the existing owned `0700`, no-symlink and confined bundle
+store contract. The caller explicitly authorizes this target, keeps its selection
+and ancestry trusted/stable, and owns capacity and retention policy. No directory
+creation, permission repair, alternate target, overwrite or named-data cleanup is
+implicit. A store is selected for bundle receipt, not inferred from a setup claim.
+
+The complete bounded input buffer is dropped before storage re-encodes the verified
+bundle. An identical retry can hold the verified payload and two encoded copies,
+as documented by `RepositoryBundleStore::put`. Framing limits are not a hard RSS or
+wall-clock deadline; missing EOF and blocked storage can still block the caller.
+The authenticated transport/controller must impose its own admission and budgets.
+
+## Observe a lost acknowledgement
+
+```sh
+horizon-repository overlay-status < request.json
+```
+
+This command reads a bounded ordinary JSON object containing only `version`,
+`bundle_store` and `bundle_manifest`, followed by EOF. It opens the nominated store
+and validates the existing digest-named record and all bundle contents without
+publishing, synchronizing, creating or replacing anything. An unavailable/unsafe
+root or invalid existing record is an error, never a `missing` observation.
+
+Both commands return complete JSON plus newline, at most 1 KiB, with `version`,
+`status`, `bundle_manifest` and `reason`. Only acknowledged/observed responses have
+a non-null manifest. Reasons are bounded static diagnostics, not paths or payloads.
+
+| Status | Exit | Meaning |
+| --- | --- | --- |
+| `acknowledged` | 0 | `put` completed its no-replace publication or identical-record verification and file/directory synchronization. |
+| `observed` | 0 | A complete matching record was read and verified; this does not acknowledge a new synchronization. |
+| `missing` | 4 | A valid opened store had no record for the requested digest. |
+| `rejected` | 2 | Request framing or bundle validation failed before storage access. |
+| `error` | 1 | Storage could not be safely opened or existing data could not be observed. |
+| `write_unconfirmed` | 1 | Publication was not acknowledged; a complete existing or newly published record may remain. |
+
+Exit 3 means the response could not be completely written/flushed. It does not
+undo publication or retry any operation. Re-observe the same store/digest after
+lost output. Explicitly resending the same complete verified bundle can recheck and
+resynchronize the existing immutable record; it cannot overwrite a conflicting or
+unsafe node. This storage retry is not permission to replay retained setup/tasks.
+
+## Storage and product limits
+
+This reuses the bundle store's anonymous-file publication and synchronization
+contract. It does **not** add the retained-setup journaled-ext4 qualifier to that
+store or strengthen storage guarantees. Input staging, qualified setup output,
+remote checkpoints, replication and cloud/PC-off acceptance remain separate gates.
+Read-only observation cannot prove a prior failed synchronization succeeded.
+
+No client wiring, source selection/approval UI, Git base closure transport,
+worker-loss recovery, remote backup scheduling, provider lifetime or image release
+is included. All commands preserve the rule that closing a local view never
+implicitly stops/deletes a persistent environment.


### PR DESCRIPTION
## Purpose

Continue #470 with explicit worker-side receipt and read-only observation of a canonical overlay bundle. This does not capture or export local files, transfer Git objects, start setup/tasks, or change provider/UI behavior.

## Behavior

- `receive-overlay` validates bounded strict framing, the complete canonical encoding, and expected digest before storage access.
- Existing private digest-addressed storage publishes without overwriting; identical retries verify the existing record. `overlay-status` never publishes or turns an unavailable root into a missing record.
- Lost output or an unconfirmed write preserves existing data for observation. No implicit root creation, cleanup, replay, Stop or Delete.
- Linux worker primitive only. Input-store synchronization does not add the retained-setup storage qualifier or prove checkpoint/cloud durability. The transport/controller still owns authentication, source approval and resource budgets.

## Evidence

- Exact head: `8230815daadc2013ebd1cfc7318bb116f72cc6e5`. All eight repository validation lanes pass: formatting, maintainability, version sync, complete default/speech tests, and blocking/strict/pedantic lint tiers. All 17 repository-command tests pass.
- Six final-image smoke lanes pass: overlay receipt, independent setup, packaging, materialization/setup, SSH security, and retained host identity. Includes a 65 MiB-plus multi-blob transfer, fresh-process observation, unchanged retry inode/content, conflicting/unsafe records and lost-output recovery; original synthetic inputs remain unchanged.
- Immutable local image: `sha256:ad6308ee8faa2a9f82bae497ccc5cca0744bd9ef204de23eec6c1775e8d403d5`. Packaged helper SHA-256: `8c7ed57c79d3823e853a8b14bcb5996aa1afa1b64e455a38e60c63aae9448367`. Image remains local and unpublished; synthetic smoke is not cloud/PC-off acceptance.

Independent local review completed; its sole documentation correction is included. Scope: five source/test files, 686 changed source/test lines, plus three documentation files. No dependencies, defaults, release or published image changes.
