### PR TITLE
Prepare bounded exact-base Git packs for remote repository transfer

### DIFF
--- a/crates/horizon-core/src/cloud_run/artifact_digest.rs
+++ b/crates/horizon-core/src/cloud_run/artifact_digest.rs
@@ -5,9 +5,13 @@ impl ArtifactDigest {
     /// Hash already-owned bytes without I/O. This does not authenticate or authorize their source.
     #[must_use]
     pub fn sha256(bytes: &[u8]) -> Self {
+        Self::from_sha256_bytes(Sha256::digest(bytes).into())
+    }
+
+    pub(crate) fn from_sha256_bytes(bytes: [u8; 32]) -> Self {
         const HEX: &[u8; 16] = b"0123456789abcdef";
         let mut encoded = String::with_capacity(64);
-        for byte in Sha256::digest(bytes) {
+        for byte in bytes {
             encoded.push(char::from(HEX[usize::from(byte >> 4)]));
             encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
         }

--- a/crates/horizon-core/src/repository_overlay/seed/export/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/mod.rs
@@ -1,0 +1,173 @@
+//! Explicit local exact-base pack preparation, not remote transfer or publication.
+
+mod output;
+
+use super::{
+    MAX_BYTES, PreparedGitSeed, SeedError, SeedFailure,
+    packed::{PackedSourceLimits, process::Session, view},
+    staging,
+};
+use crate::cloud_run::ArtifactDigest;
+use git2::Oid;
+use std::{
+    fmt,
+    fs::OpenOptions,
+    io::{self, Write},
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+};
+
+/// Native child limits plus a separate packed-output ceiling. The source timeout
+/// bounds the entire pipe operation, excluding blocking storage/spawn/reap calls.
+#[derive(Clone, Copy, Debug)]
+pub struct PackExportLimits {
+    pub source: PackedSourceLimits,
+    pub encoded_bytes: u64,
+}
+
+impl PackExportLimits {
+    pub const DEFAULT_ENCODED_BYTES: u64 = 256 * 1024 * 1024;
+    pub const MAX_ENCODED_BYTES: u64 = MAX_BYTES * 2;
+
+    fn validate(self) -> Result<(), SeedError> {
+        self.source.validate()?;
+        if !(32..=Self::MAX_ENCODED_BYTES).contains(&self.encoded_bytes) {
+            return Err(SeedError::Limit);
+        }
+        Ok(())
+    }
+}
+
+impl Default for PackExportLimits {
+    fn default() -> Self {
+        Self {
+            source: PackedSourceLimits::default(),
+            encoded_bytes: Self::DEFAULT_ENCODED_BYTES,
+        }
+    }
+}
+
+/// Finished trusted-producer output in retained private scratch, not an immutable
+/// store record, synchronized publication or export authorization. Keep the file
+/// and its ancestry stable/exclusive until a later consumer revalidates its digest.
+pub struct PreparedGitPack {
+    path: PathBuf,
+    base_commit: Oid,
+    sha256: ArtifactDigest,
+    encoded_bytes: u64,
+}
+
+impl PreparedGitPack {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn base_commit(&self) -> Oid {
+        self.base_commit
+    }
+
+    #[must_use]
+    pub fn sha256(&self) -> &ArtifactDigest {
+        &self.sha256
+    }
+
+    #[must_use]
+    pub fn encoded_bytes(&self) -> u64 {
+        self.encoded_bytes
+    }
+}
+
+impl fmt::Debug for PreparedGitPack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedGitPack")
+            .field("encoded_bytes", &self.encoded_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Prepare one non-thin standard Git pack from an already verified private seed.
+/// The caller explicitly authorizes its complete base closure, including removed
+/// files and raw commit metadata, and keeps seed/ancestry stable and exclusively
+/// controlled. No original repository configuration, refs, history, hooks, filters
+/// or recursive alternates are inherited. Exact shallow metadata is synthesized.
+/// Requires trusted `/usr/bin/git` and `/usr/bin/prlimit`; run off the UI thread.
+/// No network, provider, setup/task start, source mutation, retry or cleanup occurs.
+/// A failed partial pack remains in the reported scratch directory, unconfirmed.
+/// Success checks framing/size, trusted child success and file flush, not an
+/// independent pack decode or crash durability. The recipient must still validate
+/// the expected closure, shallow boundary and digest before admitting setup.
+/// # Errors
+/// Rejects invalid limits, unsafe/overlapping source and output ancestry, cancellation,
+/// child failure, oversized/truncated output and storage failure, retaining residue.
+pub fn prepare_git_base_pack(
+    parent: &Path,
+    seed: &PreparedGitSeed,
+    limits: PackExportLimits,
+    cancelled: impl Fn() -> bool,
+) -> Result<PreparedGitPack, SeedFailure> {
+    let objects = seed.path().join(".git/objects");
+    let preflight = limits.validate().and_then(|()| {
+        // Reject output inside any seed node, not merely inside its object store.
+        view::validate(seed.path(), parent, &cancelled)?;
+        view::validate(&objects, parent, &cancelled)
+    });
+    preflight.map_err(|reason| SeedFailure { reason, residue: None })?;
+    let metadata = staging::reserve(parent, &cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
+    produce(&metadata, &objects, seed, limits, &cancelled).map_err(|reason| SeedFailure {
+        reason,
+        residue: Some(metadata),
+    })
+}
+
+fn produce(
+    metadata: &Path,
+    objects: &Path,
+    seed: &PreparedGitSeed,
+    limits: PackExportLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<PreparedGitPack, SeedError> {
+    let command = view::command(
+        metadata,
+        objects,
+        limits.source,
+        view::Operation::Pack(seed.base_commit()),
+    )?;
+    let path = metadata.join("base.pack");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|_| SeedError::Storage)?;
+    let mut session = Session::spawn(command, limits.source.object_timeout, Box::new(cancelled))?;
+    session
+        .begin_pack(seed.base_commit())
+        .map_err(|error| source_error(error.kind()))?;
+    let summary = output::copy(
+        &mut |bytes| session.read(bytes),
+        &mut file,
+        limits.encoded_bytes,
+        seed.imported_objects(),
+    )?;
+    session.finish().map_err(|error| source_error(error.kind()))?;
+    file.flush().map_err(|_| SeedError::Storage)?;
+    Ok(PreparedGitPack {
+        path,
+        base_commit: seed.base_commit(),
+        sha256: summary.sha256,
+        encoded_bytes: summary.bytes,
+    })
+}
+
+fn source_error(error: io::ErrorKind) -> SeedError {
+    if error == io::ErrorKind::ConnectionAborted {
+        SeedError::Cancelled
+    } else {
+        SeedError::Source
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/export/output.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/output.rs
@@ -1,0 +1,55 @@
+use super::{ArtifactDigest, SeedError, source_error};
+use sha2::{Digest, Sha256};
+use std::io::{self, Write};
+
+pub(super) struct Summary {
+    pub(super) bytes: u64,
+    pub(super) sha256: ArtifactDigest,
+}
+
+pub(super) fn copy(
+    read: &mut impl FnMut(&mut [u8]) -> io::Result<usize>,
+    output: &mut impl Write,
+    limit: u64,
+    objects: usize,
+) -> Result<Summary, SeedError> {
+    let mut header = [0; 12];
+    let mut position = 0;
+    while position < header.len() {
+        let count = read(&mut header[position..]).map_err(|error| source_error(error.kind()))?;
+        if count == 0 {
+            return Err(SeedError::Object);
+        }
+        position += count;
+    }
+    let count = u32::from_be_bytes(header[8..].try_into().map_err(|_| SeedError::Object)?);
+    if header[..8] != *b"PACK\0\0\0\x02" || count == 0 || u64::from(count) > objects as u64 || limit < 32 {
+        return Err(SeedError::Object);
+    }
+    let mut hash = Sha256::new();
+    hash.update(header);
+    output.write_all(&header).map_err(|_| SeedError::Storage)?;
+    let mut total = header.len() as u64;
+    let mut buffer = [0; 16 * 1024];
+    loop {
+        let length = usize::try_from(limit.saturating_sub(total).saturating_add(1).min(buffer.len() as u64))
+            .map_err(|_| SeedError::Limit)?;
+        let count = read(&mut buffer[..length]).map_err(|error| source_error(error.kind()))?;
+        if count == 0 {
+            break;
+        }
+        total = total
+            .checked_add(count as u64)
+            .filter(|bytes| *bytes <= limit)
+            .ok_or(SeedError::Limit)?;
+        output.write_all(&buffer[..count]).map_err(|_| SeedError::Storage)?;
+        hash.update(&buffer[..count]);
+    }
+    if total < 32 {
+        return Err(SeedError::Object);
+    }
+    Ok(Summary {
+        bytes: total,
+        sha256: ArtifactDigest::from_sha256_bytes(hash.finalize().into()),
+    })
+}

--- a/crates/horizon-core/src/repository_overlay/seed/export/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/tests.rs
@@ -1,0 +1,375 @@
+use super::super::{
+    prepare_git_seed,
+    tests::{Fixture, commit, private_fixture, snapshot},
+};
+use super::*;
+use crate::repository_overlay::{OverlayChange, OverlayContent, bundle::VerifiedOverlayBlob};
+use git2::Repository;
+use std::{
+    cell::Cell,
+    collections::BTreeSet,
+    fs::{self, File},
+    io::{Cursor, Read},
+    os::unix::fs::{MetadataExt, symlink},
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+fn seed(fixture: &Fixture, parent: &Path) -> PreparedGitSeed {
+    let blob = VerifiedOverlayBlob::new(b"staged-only overlay bytes".to_vec()).unwrap();
+    let added = OverlayChange::new(
+        "staged-only".into(),
+        OverlayContent::File {
+            sha256: blob.sha256().clone(),
+            bytes: blob.bytes().len() as u64,
+            executable: false,
+        },
+    )
+    .unwrap();
+    let removed = OverlayChange::new("removed".into(), OverlayContent::Remove).unwrap();
+    let resolved = fixture.resolve(vec![added], vec![removed], vec![blob]);
+    prepare_git_seed(parent, &resolved, &mut fixture.source(), || false).unwrap()
+}
+
+fn unpack(pack: &PreparedGitPack, parent: &Path) -> Repository {
+    let repository = Repository::init(parent).unwrap();
+    fs::write(repository.path().join("shallow"), format!("{}\n", pack.base_commit())).unwrap();
+    let result = Command::new("/usr/bin/git")
+        .arg("--git-dir")
+        .arg(repository.path())
+        .args(["index-pack", "--stdin", "--strict", "--threads=1"])
+        .env_clear()
+        .envs([
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_CONFIG_SYSTEM", "/dev/null"),
+            ("GIT_ALLOW_PROTOCOL", ""),
+            ("LC_ALL", "C"),
+        ])
+        .stdin(Stdio::from(File::open(pack.path()).unwrap()))
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    repository
+}
+
+#[test]
+fn actual_seed_exports_exact_base_not_overlay_history_or_seed_configuration() {
+    let fixture = Fixture::new();
+    let parent = private_fixture();
+    let seed = seed(&fixture, parent.path());
+    let seeded = Repository::open(seed.path()).unwrap();
+    let ancestor = fixture.repository.find_commit(fixture.ancestor).unwrap();
+    for oid in [fixture.ancestor, ancestor.tree_id(), fixture.private_blob] {
+        let database = fixture.repository.odb().unwrap();
+        let raw = database.read(oid).unwrap();
+        assert_eq!(seeded.odb().unwrap().write(raw.kind(), raw.data()).unwrap(), oid);
+    }
+    // The isolated view must ignore even changed private seed metadata.
+    fs::write(seeded.path().join("HEAD"), format!("{}\n", fixture.ancestor)).unwrap();
+    fs::write(seeded.path().join("shallow"), "").unwrap();
+    fs::write(
+        seeded.path().join("config"),
+        "[include]\npath = /not-an-authorized-config\n",
+    )
+    .unwrap();
+    let before = snapshot(seed.path());
+    let original = snapshot(fixture.directory.path());
+    let pack = prepare_git_base_pack(parent.path(), &seed, PackExportLimits::default(), || false).unwrap();
+    assert_eq!(snapshot(seed.path()), before);
+    assert_eq!(snapshot(fixture.directory.path()), original);
+    assert_eq!(pack.base_commit(), fixture.commit);
+    let metadata = fs::metadata(pack.path()).unwrap();
+    assert_eq!(metadata.mode() & 0o7777, 0o600);
+    assert_eq!(metadata.nlink(), 1);
+    let bytes = fs::read(pack.path()).unwrap();
+    assert_eq!(pack.encoded_bytes(), bytes.len() as u64);
+    assert_eq!(pack.sha256(), &ArtifactDigest::sha256(&bytes));
+    let target = private_fixture();
+    let receiver = unpack(&pack, target.path());
+    let base = fixture.repository.find_commit(fixture.commit).unwrap();
+    let expected = BTreeSet::from([fixture.commit, base.tree_id(), fixture.base_blob]);
+    let mut actual = BTreeSet::new();
+    receiver
+        .odb()
+        .unwrap()
+        .foreach(|oid| {
+            actual.insert(*oid);
+            true
+        })
+        .unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(
+        receiver.find_blob(fixture.base_blob).unwrap().content(),
+        b"base\0literal\xff"
+    );
+    let root = receiver.find_tree(base.tree_id()).unwrap();
+    assert!(root.get_name("removed").is_some());
+    assert!(root.get_name("staged-only").is_none());
+    let retained = pack.path().to_path_buf();
+    assert!(!format!("{pack:?}").contains(retained.to_str().unwrap()));
+    drop(pack);
+    assert!(retained.exists());
+}
+
+#[test]
+fn invalid_bounds_cancellation_and_overlapping_or_unsafe_roots_do_not_mutate_seed() {
+    let fixture = Fixture::new();
+    let parent = private_fixture();
+    let seed = seed(&fixture, parent.path());
+    let before = snapshot(parent.path());
+    for encoded_bytes in [0, 31, PackExportLimits::MAX_ENCODED_BYTES + 1] {
+        let limits = PackExportLimits {
+            encoded_bytes,
+            ..PackExportLimits::default()
+        };
+        let failure = prepare_git_base_pack(parent.path(), &seed, limits, || false).unwrap_err();
+        assert_eq!(failure.reason, SeedError::Limit);
+        assert!(failure.residue().is_none());
+    }
+    let failure = prepare_git_base_pack(parent.path(), &seed, PackExportLimits::default(), || true).unwrap_err();
+    assert_eq!(failure.reason, SeedError::Cancelled);
+    assert!(failure.residue().is_none());
+    for overlap in [
+        seed.path().to_path_buf(),
+        seed.path().join(".git"),
+        seed.path().join(".git/objects"),
+    ] {
+        let failure = prepare_git_base_pack(&overlap, &seed, PackExportLimits::default(), || false).unwrap_err();
+        assert_eq!(failure.reason, SeedError::UnsafeParent);
+        assert!(failure.residue().is_none());
+    }
+    assert_eq!(snapshot(parent.path()), before);
+    let alias = parent.path().join("alias");
+    symlink(seed.path(), &alias).unwrap();
+    let failure = prepare_git_base_pack(&alias, &seed, PackExportLimits::default(), || false).unwrap_err();
+    assert_eq!(failure.reason, SeedError::UnsafeParent);
+    assert!(failure.residue().is_none());
+}
+
+#[test]
+fn large_removed_base_blob_streams_through_real_seed_pack_and_strict_receiver() {
+    let mut fixture = Fixture::new();
+    let mut bytes = vec![b'a'; 65 * 1024 * 1024 + 1];
+    *bytes.last_mut().unwrap() = b'z';
+    let object = fixture.repository.blob(&bytes).unwrap();
+    fixture.commit = commit(
+        &fixture.repository,
+        &[
+            ("kept", object, 0o100_644),
+            ("nested/leaf", object, 0o100_644),
+            ("removed", object, 0o100_755),
+        ],
+        &[fixture.commit],
+    );
+    fixture.base_blob = object;
+    let parent = private_fixture();
+    let seed = seed(&fixture, parent.path());
+    let pack = prepare_git_base_pack(parent.path(), &seed, PackExportLimits::default(), || false).unwrap();
+    assert!(pack.encoded_bytes() > 32 * 1024);
+    let target = private_fixture();
+    let receiver = unpack(&pack, target.path());
+    assert_eq!(receiver.find_blob(object).unwrap().content(), bytes);
+    let tree = receiver.find_commit(fixture.commit).unwrap().tree().unwrap();
+    assert_eq!(tree.get_name("removed").unwrap().filemode(), 0o100_755);
+    assert_eq!(tree.get_path(Path::new("nested/leaf")).unwrap().id(), object);
+}
+
+#[test]
+fn initial_commits_and_empty_base_trees_have_complete_shallow_packs() {
+    for empty in [false, true] {
+        let mut fixture = Fixture::new();
+        fixture.commit = if empty {
+            commit(&fixture.repository, &[], &[fixture.commit])
+        } else {
+            fixture.ancestor
+        };
+        let resolved = fixture.resolve(vec![], vec![], vec![]);
+        let parent = private_fixture();
+        let seed = prepare_git_seed(parent.path(), &resolved, &mut fixture.source(), || false).unwrap();
+        let pack = prepare_git_base_pack(parent.path(), &seed, PackExportLimits::default(), || false).unwrap();
+        let target = private_fixture();
+        let receiver = unpack(&pack, target.path());
+        let tree = receiver.find_commit(fixture.commit).unwrap().tree().unwrap();
+        assert_eq!(tree.is_empty(), empty);
+        let mut count = 0;
+        receiver
+            .odb()
+            .unwrap()
+            .foreach(|_| {
+                count += 1;
+                true
+            })
+            .unwrap();
+        assert_eq!(count, if empty { 2 } else { 3 });
+    }
+}
+
+#[test]
+fn pack_command_uses_exact_private_boundary_and_single_resource_limited_process() {
+    let parent = private_fixture();
+    let metadata = staging::reserve(parent.path(), &|| false).unwrap();
+    let source = parent.path().join("not-read-source");
+    let limits = PackedSourceLimits::default();
+    let command = view::command(&metadata, &source, limits, view::Operation::Pack(Oid::ZERO_SHA1)).unwrap();
+    let arguments: Vec<_> = command.get_args().map(|arg| arg.to_str().unwrap()).collect();
+    assert_eq!(command.get_program(), "/usr/bin/prlimit");
+    for option in [
+        "--stdout",
+        "--revs",
+        "--no-reuse-delta",
+        "--no-reuse-object",
+        "--window=0",
+        "--threads=1",
+    ] {
+        assert!(arguments.contains(&option));
+    }
+    for forbidden in ["--all", "--thin", "--include-tag", "cat-file", "--batch-command"] {
+        assert!(!arguments.contains(&forbidden));
+    }
+    assert!(arguments.contains(&format!("--as={0}:{0}", limits.address_space_bytes).as_str()));
+    assert!(arguments.contains(&format!("--cpu={0}:{0}", limits.cpu_seconds).as_str()));
+    assert_eq!(
+        fs::read_to_string(metadata.join("shallow")).unwrap(),
+        format!("{}\n", Oid::ZERO_SHA1)
+    );
+    let environment: std::collections::BTreeMap<_, _> = command.get_envs().collect();
+    for key in ["GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM"] {
+        assert_eq!(
+            environment.get(std::ffi::OsStr::new(key)),
+            Some(&Some(std::ffi::OsStr::new("/dev/null")))
+        );
+    }
+    assert_eq!(
+        environment.get(std::ffi::OsStr::new("GIT_ALLOW_PROTOCOL")),
+        Some(&Some(std::ffi::OsStr::new("")))
+    );
+    assert_eq!(command.get_current_dir(), Some(metadata.as_path()));
+}
+
+#[test]
+fn oversized_pack_retains_unconfirmed_private_artifact_and_source() {
+    let fixture = Fixture::new();
+    let parent = private_fixture();
+    let seed = seed(&fixture, parent.path());
+    let before = snapshot(seed.path());
+    let failure = prepare_git_base_pack(
+        parent.path(),
+        &seed,
+        PackExportLimits {
+            encoded_bytes: 32,
+            ..PackExportLimits::default()
+        },
+        || false,
+    )
+    .unwrap_err();
+    assert_eq!(failure.reason, SeedError::Limit);
+    let residue = failure.residue().unwrap().to_path_buf();
+    assert!(fs::metadata(residue.join("base.pack")).unwrap().len() <= 32);
+    assert!(!format!("{failure:?}").contains(residue.to_str().unwrap()));
+    drop(failure);
+    assert!(residue.exists());
+    assert_eq!(snapshot(seed.path()), before);
+}
+
+fn synthetic_pack(size: usize) -> Vec<u8> {
+    let mut bytes = b"PACK\0\0\0\x02\0\0\0\x01".to_vec();
+    bytes.resize(size, 0);
+    bytes
+}
+
+#[test]
+fn output_bounds_framing_short_writes_and_read_failures_are_explicit() {
+    struct ShortWrites(Vec<u8>);
+    impl Write for ShortWrites {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            let count = bytes.len().min(3);
+            self.0.extend_from_slice(&bytes[..count]);
+            Ok(count)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    for size in [32, 65_537] {
+        let bytes = synthetic_pack(size);
+        let mut input = Cursor::new(&bytes);
+        let mut output = ShortWrites(Vec::new());
+        let result = output::copy(&mut |bytes| input.read(bytes), &mut output, size as u64, 1).unwrap();
+        assert_eq!(output.0, bytes);
+        assert_eq!(result.sha256, ArtifactDigest::sha256(&bytes));
+        assert_eq!(result.bytes, size as u64);
+    }
+    for mut bytes in [vec![], synthetic_pack(11), synthetic_pack(31), synthetic_pack(33)] {
+        let mut input = Cursor::new(&mut bytes);
+        let mut output = Vec::new();
+        assert!(output::copy(&mut |bytes| input.read(bytes), &mut output, 32, 1).is_err());
+        assert!(output.len() <= 32);
+    }
+    for offset in [0, 7, 11] {
+        let mut bytes = synthetic_pack(32);
+        bytes[offset] = 9;
+        let mut input = Cursor::new(bytes);
+        let mut output = Vec::new();
+        assert_eq!(
+            output::copy(&mut |bytes| input.read(bytes), &mut output, 32, 1).err(),
+            Some(SeedError::Object)
+        );
+        assert!(output.is_empty());
+    }
+    let mut input = |_bytes: &mut [u8]| Err(io::Error::from(io::ErrorKind::ConnectionAborted));
+    assert_eq!(
+        output::copy(&mut input, &mut Vec::new(), 32, 1).err(),
+        Some(SeedError::Cancelled)
+    );
+    let mut input = Cursor::new(synthetic_pack(32));
+    assert_eq!(
+        output::copy(
+            &mut |bytes| input.read(bytes),
+            &mut Cursor::new(&mut [0u8; 0][..]),
+            32,
+            1
+        )
+        .err(),
+        Some(SeedError::Storage)
+    );
+}
+
+#[test]
+fn one_shot_session_closes_input_checks_exit_deadline_and_cancellation() {
+    fn peer(script: &str, timeout: Duration) -> Session<'static> {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", script]).env_clear();
+        Session::spawn(command, timeout, Box::new(|| false)).unwrap()
+    }
+    for exit in [0, 7] {
+        let mut session = peer(
+            &format!("read oid; if read extra; then exit 9; fi; printf done; exit {exit}"),
+            Duration::from_secs(2),
+        );
+        session.begin_pack(Oid::ZERO_SHA1).unwrap();
+        let mut bytes = [0; 10];
+        assert_eq!(session.read(&mut bytes).unwrap(), 4);
+        assert_eq!(session.read(&mut bytes).unwrap(), 0);
+        assert_eq!(session.finish().is_ok(), exit == 0);
+    }
+    let mut stalled = peer("read oid; while :; do :; done", Duration::from_millis(50));
+    let stalled_process = PathBuf::from(format!("/proc/{}", stalled.id().unwrap()));
+    stalled.begin_pack(Oid::ZERO_SHA1).unwrap();
+    assert!(stalled.read(&mut [0]).is_err());
+    drop(stalled);
+    assert!(!stalled_process.exists());
+    let cancelled = Cell::new(false);
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", "read oid; while :; do :; done"]).env_clear();
+    let mut session = Session::spawn(command, Duration::from_secs(2), Box::new(|| cancelled.get())).unwrap();
+    let cancelled_process = PathBuf::from(format!("/proc/{}", session.id().unwrap()));
+    session.begin_pack(Oid::ZERO_SHA1).unwrap();
+    cancelled.set(true);
+    assert_eq!(
+        session.read(&mut [0]).unwrap_err().kind(),
+        io::ErrorKind::ConnectionAborted
+    );
+    drop(session);
+    assert!(!cancelled_process.exists());
+}

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -1,6 +1,8 @@
 //! Unpublished exact-base Git material; never a ready checkout or export authority.
 
 #[cfg(target_os = "linux")]
+pub mod export;
+#[cfg(target_os = "linux")]
 mod import;
 #[cfg(target_os = "linux")]
 mod index;

--- a/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/mod.rs
@@ -1,8 +1,8 @@
 //! Bounded raw objects from an explicitly authorized, stable Linux object store.
 
-mod process;
+pub(super) mod process;
 mod protocol;
-mod view;
+pub(super) mod view;
 
 use super::{GitObjectInspector, GitObjectMetadata, GitObjectSource, GitObjectStream, SeedError, SeedFailure, staging};
 use git2::Oid;
@@ -33,7 +33,7 @@ impl Default for PackedSourceLimits {
 }
 
 impl PackedSourceLimits {
-    fn validate(self) -> Result<(), SeedError> {
+    pub(super) fn validate(self) -> Result<(), SeedError> {
         if !(64 * 1024 * 1024..=16 * 1024 * 1024 * 1024).contains(&self.address_space_bytes)
             || !(1..=3600).contains(&self.cpu_seconds)
             || self.object_timeout.is_zero()
@@ -80,7 +80,7 @@ impl<'a> PackedGitObjectSource<'a> {
             .and_then(|()| view::validate(objects, parent, &cancelled));
         preflight.map_err(|reason| SeedFailure { reason, residue: None })?;
         let metadata = staging::reserve(parent, &cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
-        let result = view::command(&metadata, objects, limits)
+        let result = view::command(&metadata, objects, limits, view::Operation::Inspect)
             .and_then(|command| process::Session::spawn(command, limits.object_timeout, Box::new(cancelled)));
         match result {
             Ok(session) => Ok(Self { session, metadata }),

--- a/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
@@ -9,9 +9,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub(super) struct Session<'a> {
+pub(in crate::repository_overlay::seed) struct Session<'a> {
     child: Option<OwnedChild>,
-    input: ChildStdin,
+    input: Option<ChildStdin>,
     output: ChildStdout,
     cancelled: Box<dyn Fn() -> bool + 'a>,
     timeout: Duration,
@@ -19,7 +19,7 @@ pub(super) struct Session<'a> {
 }
 
 impl<'a> Session<'a> {
-    pub(super) fn spawn(
+    pub(in crate::repository_overlay::seed) fn spawn(
         mut command: Command,
         timeout: Duration,
         cancelled: Box<dyn Fn() -> bool + 'a>,
@@ -41,7 +41,7 @@ impl<'a> Session<'a> {
         nonblocking(&output)?;
         Ok(Self {
             child: Some(child),
-            input,
+            input: Some(input),
             output,
             cancelled,
             timeout,
@@ -61,10 +61,13 @@ impl<'a> Session<'a> {
 
     pub(super) fn request(&mut self, command: &str, oid: Oid) -> io::Result<()> {
         let request = format!("{command} {oid}\n");
-        let mut pending = request.as_bytes();
+        self.write_request(request.as_bytes())
+    }
+
+    fn write_request(&mut self, mut pending: &[u8]) -> io::Result<()> {
         while !pending.is_empty() {
             self.check()?;
-            match self.input.write(pending) {
+            match self.input.as_mut().ok_or_else(failed)?.write(pending) {
                 Ok(0) => return Err(failed()),
                 Ok(n) => pending = &pending[n..],
                 Err(e) if retry(&e) => self.pause(),
@@ -72,6 +75,24 @@ impl<'a> Session<'a> {
             }
         }
         Ok(())
+    }
+
+    pub(in crate::repository_overlay::seed) fn begin_pack(&mut self, oid: Oid) -> io::Result<()> {
+        self.deadline = Instant::now() + self.timeout;
+        self.write_request(format!("{oid}\n").as_bytes())?;
+        self.input.take();
+        Ok(())
+    }
+
+    pub(in crate::repository_overlay::seed) fn finish(&mut self) -> io::Result<()> {
+        loop {
+            self.check()?;
+            match self.child.as_mut().ok_or_else(failed)?.0.try_wait()? {
+                Some(status) if status.success() => return Ok(()),
+                Some(_) => return Err(failed()),
+                None => self.pause(),
+            }
+        }
     }
 
     pub(super) fn header(&mut self, oid: Oid) -> io::Result<Header> {
@@ -85,7 +106,7 @@ impl<'a> Session<'a> {
         Err(failed())
     }
 
-    pub(super) fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+    pub(in crate::repository_overlay::seed) fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
         loop {
             self.check()?;
             match self.output.read(buffer) {
@@ -132,7 +153,7 @@ impl<'a> Session<'a> {
     }
 
     #[cfg(test)]
-    pub(super) fn id(&self) -> Option<u32> {
+    pub(in crate::repository_overlay::seed) fn id(&self) -> Option<u32> {
         self.child.as_ref().map(|child| child.0.id())
     }
 }

--- a/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/tests.rs
@@ -206,6 +206,7 @@ fn isolated_command_discards_source_configuration_and_missing_promisors() {
         &staging::reserve(parent.path(), &|| false).unwrap(),
         &objects,
         PackedSourceLimits::default(),
+        view::Operation::Inspect,
     )
     .unwrap();
     let environment: std::collections::BTreeMap<_, _> = command.get_envs().collect();

--- a/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
@@ -1,5 +1,6 @@
 use super::{PackedSourceLimits, SeedError as Error, staging};
 use crate::repository_overlay::reader::SelectedRepositoryReader;
+use git2::Oid;
 use std::{
     fmt::Write as _,
     fs::{self, OpenOptions},
@@ -15,7 +16,11 @@ use std::{
 pub(super) const MAX_NODES: usize = 262_144;
 pub(super) const MAX_PATH_BYTES: usize = 16 * 1024 * 1024;
 
-pub(super) fn validate(objects: &Path, parent: &Path, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+pub(in crate::repository_overlay::seed) fn validate(
+    objects: &Path,
+    parent: &Path,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), Error> {
     staging::check_cancel(cancelled)?;
     if !objects.is_absolute() {
         return Err(Error::UnsafeParent);
@@ -74,7 +79,18 @@ pub(super) fn validate(objects: &Path, parent: &Path, cancelled: &impl Fn() -> b
     Ok(())
 }
 
-pub(super) fn command(path: &Path, objects: &Path, limits: PackedSourceLimits) -> Result<Command, Error> {
+#[derive(Clone, Copy)]
+pub(in crate::repository_overlay::seed) enum Operation {
+    Inspect,
+    Pack(Oid),
+}
+
+pub(in crate::repository_overlay::seed) fn command(
+    path: &Path,
+    objects: &Path,
+    limits: PackedSourceLimits,
+    operation: Operation,
+) -> Result<Command, Error> {
     for directory in ["objects", "objects/info", "objects/pack", "refs"] {
         fs::create_dir(path.join(directory)).map_err(|_| Error::Storage)?;
     }
@@ -125,8 +141,6 @@ pub(super) fn command(path: &Path, objects: &Path, limits: PackedSourceLimits) -
             "core.deltaBaseCacheLimit=16m",
             "-c",
             "core.bigFileThreshold=1m",
-            "cat-file",
-            "--batch-command",
         ])
         .current_dir(path)
         .env_clear()
@@ -140,5 +154,33 @@ pub(super) fn command(path: &Path, objects: &Path, limits: PackedSourceLimits) -
             ("GIT_TERMINAL_PROMPT", "0"),
         ])
         .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", quoted);
+    match operation {
+        Operation::Inspect => {
+            command.args(["cat-file", "--batch-command"]);
+        }
+        Operation::Pack(commit) => {
+            // The exact original commit is a shallow boundary, not rewritten history.
+            OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(path.join("shallow"))
+                .and_then(|mut file| writeln!(file, "{commit}"))
+                .map_err(|_| Error::Storage)?;
+            command.args([
+                "-c",
+                "pack.useSparse=false",
+                "pack-objects",
+                "--stdout",
+                "--revs",
+                "--no-reuse-delta",
+                "--no-reuse-object",
+                "--window=0",
+                "--depth=0",
+                "--threads=1",
+                "--compression=1",
+            ]);
+        }
+    }
     Ok(command)
 }

--- a/crates/horizon-core/src/repository_overlay/seed/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/tests.rs
@@ -17,13 +17,13 @@ use std::{
     os::unix::fs::{PermissionsExt, symlink},
 };
 
-struct Fixture {
-    directory: tempfile::TempDir,
-    repository: Repository,
-    commit: Oid,
-    ancestor: Oid,
-    private_blob: Oid,
-    base_blob: Oid,
+pub(super) struct Fixture {
+    pub(super) directory: tempfile::TempDir,
+    pub(super) repository: Repository,
+    pub(super) commit: Oid,
+    pub(super) ancestor: Oid,
+    pub(super) private_blob: Oid,
+    pub(super) base_blob: Oid,
 }
 
 pub(super) fn private_fixture() -> tempfile::TempDir {
@@ -34,7 +34,7 @@ pub(super) fn private_fixture() -> tempfile::TempDir {
 }
 
 impl Fixture {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         let directory = private_fixture();
         let repository = Repository::init(directory.path()).unwrap();
         let private_blob = repository.blob(b"unrelated older private data").unwrap();
@@ -60,7 +60,7 @@ impl Fixture {
         }
     }
 
-    fn resolve(
+    pub(super) fn resolve(
         &self,
         changes: Vec<OverlayChange>,
         working: Vec<OverlayChange>,
@@ -76,7 +76,7 @@ impl Fixture {
         resolve_namespaces(&self.repository, bundle).unwrap()
     }
 
-    fn source(&self) -> LooseFixtureSource<'_> {
+    pub(super) fn source(&self) -> LooseFixtureSource<'_> {
         LooseFixtureSource {
             database: self.repository.odb().unwrap(),
             calls: BTreeMap::new(),
@@ -85,7 +85,7 @@ impl Fixture {
 }
 
 // Fixture-only adapter: production does not mistake libgit2 loose streaming for packed support.
-struct LooseFixtureSource<'a> {
+pub(super) struct LooseFixtureSource<'a> {
     database: Odb<'a>,
     calls: BTreeMap<Oid, usize>,
 }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -227,6 +227,14 @@ back into large multi-purpose modules.
   inherited. Cancellation/failure or an unfinished stream terminates only its owned
   child; private metadata remains explicit. Stable source/ancestry and exclusive
   scratch ownership are prerequisites, not confinement against concurrent mutation.
+  Linux `seed/export/` prepares one bounded standard non-thin base pack from an
+  existing verified seed. It shares the isolated metadata view and owned native
+  process with packed acquisition, but selects an exact synthesized shallow
+  boundary and closes request input before draining/validating producer completion.
+  Framing, chunked file writes and digesting live in its output leaf. Private
+  success/partial artifacts remain explicit; no network, setup start, immutable
+  publication or durability is inferred. Input/output overlap checks cover the
+  entire seed, not only its object store. See [pack preparation](../remote-repository-pack.md).
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;

--- a/docs/remote-repository-pack.md
+++ b/docs/remote-repository-pack.md
@@ -1,0 +1,83 @@
+# Preparing an exact-base Git pack
+
+The Linux `repository_overlay::seed::export::prepare_git_base_pack` API prepares
+one standard, non-thin Git pack from an existing `PreparedGitSeed`. This is an
+explicit local derived artifact, not a network transfer, worker setup command,
+checkpoint, published store record or new export-approval boundary. No current
+UI or worker command invokes this API automatically.
+
+The caller must authorize the complete base closure, including files removed by
+the overlay and the original raw commit metadata. Existing namespace resolution
+and seed preparation remain required; the exporter does not accept an arbitrary
+original repository path or walk another unchecked source tree.
+
+## Isolation and contents
+
+The exporter reuses the packed source's private metadata view, native child and
+object-store validation. The nominated scratch parent must be private, outside
+the entire seed tree, and exclusively controlled with stable ancestry. Symlinks,
+recursive alternates, unsafe topology and source/scratch overlap are rejected.
+These checks do not defend against concurrent same-user or privileged mutation.
+
+The new view supplies only the exact base object ID and its synthesized shallow
+boundary to trusted `/usr/bin/git`, through `/usr/bin/prlimit`. Original source
+and private seed configuration, HEAD, refs, hooks, filters, replacement objects,
+ambient Git configuration and network transports are not inherited. Parent
+history, unreferenced objects and staged-only overlay blobs are not selected.
+The original commit is preserved, not rewritten to remove its parent metadata.
+
+Packing uses low-cost compression, one thread and no delta search/reuse. This
+trades potentially larger output for simpler resource behavior. It does not use
+thin packs. Standard packs contain their delta dependencies; `--shallow` alone
+is not an exact-one-commit export boundary. See the [Git pack documentation](https://git-scm.com/docs/git-pack-objects).
+
+## Receipt and failure
+
+Successful preparation returns `PreparedGitPack`: the private file path, original
+base commit, encoded byte length and SHA-256 digest. The file is newly created as
+`0600` inside retained `0700` scratch. The exporter checks version-2 framing,
+nonzero bounded object count, minimum length, encoded-byte ceiling, successful
+trusted-producer exit and file flush. Hashing and copying use bounded chunks.
+
+This is **not** an independent pack decode, immutable publication, file/directory
+synchronization or crash-durability acknowledgement. The caller must keep the
+artifact and ancestry stable until a later consumer revalidates its digest.
+That consumer must also validate the expected complete closure and exact shallow
+boundary. Strict Git decoding without that boundary rejects the deliberately
+absent parent history; [Git index-pack](https://git-scm.com/docs/git-index-pack)
+alone does not establish source approval or setup ownership.
+
+Failures before reservation report no residue. Later failures retain the named
+scratch directory and any partial `base.pack` as unconfirmed. No rollback,
+overwrite, automatic retry, cleanup, task start or provider action occurs. Error
+and debug output omit source contents and private paths. Dropping either a
+success receipt or failure keeps the artifact; the exact owned Git child is
+terminated/reaped when necessary, never an existing worker or task.
+
+## Limits
+
+`PackExportLimits` defaults to a 256 MiB encoded-output ceiling and the existing
+native source defaults: 1 GiB child address space, 60 CPU seconds, and a 30-second
+pipe deadline. For export, that deadline covers the complete pack pipe operation,
+not each chunk. Valid seeds may exceed these limits and are rejected, not truncated
+into successful artifacts. The maximum configurable output is derived from the
+existing seed import ceiling; it is not permission to lift source-selection limits.
+
+Blocking filesystem calls, process creation and kill/reap latency are outside the
+pipe deadline. These are not hard application RSS or total wall-clock guarantees.
+Run off the render thread. Caller admission/capacity budgets and later receiver
+decompression limits remain separate; compressed byte limits do not bound decoded
+memory. Revisit compression and concurrency only with representative measurements.
+
+## Validation boundary
+
+Native tests use the real resolver and seed importer, then strict Git receipt.
+They verify exact base contents, removed files, exclusion of parent history and
+staged-only/unrelated objects, ignored seed metadata, unchanged input snapshots,
+private file identity, a 65 MiB-plus raw base blob, bounded output, cancellation,
+write failure and exact owned-child cleanup. Pure tests exercise framing and
+limits; they are not independent cryptographic pack-validation tests.
+
+Worker receipt/publication, pinned transport, source-approval UI, repository setup,
+remote checkpoints and cloud/PC-off acceptance remain separate work. Closing local
+views must never implicitly stop or delete a persistent environment.


### PR DESCRIPTION
## Purpose and behavior

Refs #383 and #470. Prepare one bounded, standard non-thin Git pack from an existing verified private seed, preserving the exact original base commit and complete base tree. This is the local producer for later repository transfer, not the worker receiver or end-to-end workspace feature.

- Reuse the isolated, resource-limited native Git process with an exact synthesized shallow boundary. Exclude parent history, staged-only/unrelated objects, original configuration, hooks, filters, refs and network access.
- Stream into a fresh private artifact with bounded encoded bytes and incremental SHA-256. Check framing and successful trusted-producer completion; retain partial artifacts as unconfirmed on failure.
- Keep source and scratch separate. Do not mutate source data, publish immutable/durable state, approve export, start setup/tasks, retry, clean up or perform provider actions.

Linux only, with trusted Git/prlimit and stable, exclusively owned seed/scratch ancestry. The producer is not an independent pack decoder; the later recipient must validate the digest, exact complete closure and shallow boundary. Native limits can reject otherwise valid large repositories. No UI or worker command invokes this API automatically.

Scope: 10 source/test files, 729 changed lines, plus two focused docs. No new dependencies or configuration changes.

## Validation

Candidate: `f011b36f3985359822c2e2e074c4ebb07e05c212`.

- All eight exact-commit local gates pass: formatting, maintainability, version sync, full workspace default/speech tests, blocking/strict Clippy and the advisory pedantic audit. All three Clippy logs are warning-free.
- Independent local review clear, with committed tree/patch parity verified.
- 29 focused native seed tests pass, including eight exporter tests: real resolver/seed/strict receiver, exact object set, initial and parented/empty bases, nested/repeated blobs, removed executable file, ignored source metadata, 65 MiB-plus raw blob, limits, cancellation, failed output and exact owned-child cleanup.
- Existing conditional casefold fixture was unavailable locally; no native casefold coverage is claimed.
- Six final-image lanes pass: overlay receipt, detached setup, source/layer packaging, repository materialization/status, worker security and retained reconnect identity. They cover lost responses, no replay, a 65 MiB-plus checkout, retained data, unchanged read-only inputs and rejection of the wrong access identity. Only task-owned fixtures and containers were cleaned up.
- Final Linux amd64 image: `sha256:c0ed0a6e67b7c0ef3518657ba96e9b1026a87f46dc995bbe918b868f2803ea83`; image version `smoke-base-pack-20260909`; helper binary SHA-256 `918ba9a92965038a9769430c1fdb8d296406df37f1ced5c7e90a2a5b64e49908`. Packaging verified 357 allowlisted inputs and all 31 final layers.

Local synthetic mechanism proof only, not provider-volume qualification, cloud/PC-off acceptance, image publication or release.
