### PR TITLE
Receive bounded exact-base Git packs into private storage

### DIFF
--- a/crates/horizon-core/src/repository_overlay/seed/export/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/mod.rs
@@ -1,6 +1,6 @@
 //! Explicit local exact-base pack preparation, not remote transfer or publication.
 
-mod output;
+pub(super) mod output;
 
 use super::{
     MAX_BYTES, PreparedGitSeed, SeedError, SeedFailure,
@@ -143,7 +143,7 @@ fn produce(
         .map_err(|_| SeedError::Storage)?;
     let mut session = Session::spawn(command, limits.source.object_timeout, Box::new(cancelled))?;
     session
-        .begin_pack(seed.base_commit())
+        .begin_commit(seed.base_commit())
         .map_err(|error| source_error(error.kind()))?;
     let summary = output::copy(
         &mut |bytes| session.read(bytes),
@@ -161,7 +161,7 @@ fn produce(
     })
 }
 
-fn source_error(error: io::ErrorKind) -> SeedError {
+pub(super) fn source_error(error: io::ErrorKind) -> SeedError {
     if error == io::ErrorKind::ConnectionAborted {
         SeedError::Cancelled
     } else {

--- a/crates/horizon-core/src/repository_overlay/seed/export/output.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/output.rs
@@ -2,12 +2,13 @@ use super::{ArtifactDigest, SeedError, source_error};
 use sha2::{Digest, Sha256};
 use std::io::{self, Write};
 
-pub(super) struct Summary {
-    pub(super) bytes: u64,
-    pub(super) sha256: ArtifactDigest,
+pub(in crate::repository_overlay::seed) struct Summary {
+    pub(in crate::repository_overlay::seed) bytes: u64,
+    pub(in crate::repository_overlay::seed) sha256: ArtifactDigest,
+    pub(in crate::repository_overlay::seed) objects: u32,
 }
 
-pub(super) fn copy(
+pub(in crate::repository_overlay::seed) fn copy(
     read: &mut impl FnMut(&mut [u8]) -> io::Result<usize>,
     output: &mut impl Write,
     limit: u64,
@@ -51,5 +52,6 @@ pub(super) fn copy(
     Ok(Summary {
         bytes: total,
         sha256: ArtifactDigest::from_sha256_bytes(hash.finalize().into()),
+        objects: count,
     })
 }

--- a/crates/horizon-core/src/repository_overlay/seed/export/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/tests.rs
@@ -347,7 +347,7 @@ fn one_shot_session_closes_input_checks_exit_deadline_and_cancellation() {
             &format!("read oid; if read extra; then exit 9; fi; printf done; exit {exit}"),
             Duration::from_secs(2),
         );
-        session.begin_pack(Oid::ZERO_SHA1).unwrap();
+        session.begin_commit(Oid::ZERO_SHA1).unwrap();
         let mut bytes = [0; 10];
         assert_eq!(session.read(&mut bytes).unwrap(), 4);
         assert_eq!(session.read(&mut bytes).unwrap(), 0);
@@ -355,7 +355,7 @@ fn one_shot_session_closes_input_checks_exit_deadline_and_cancellation() {
     }
     let mut stalled = peer("read oid; while :; do :; done", Duration::from_millis(50));
     let stalled_process = PathBuf::from(format!("/proc/{}", stalled.id().unwrap()));
-    stalled.begin_pack(Oid::ZERO_SHA1).unwrap();
+    stalled.begin_commit(Oid::ZERO_SHA1).unwrap();
     assert!(stalled.read(&mut [0]).is_err());
     drop(stalled);
     assert!(!stalled_process.exists());
@@ -364,7 +364,7 @@ fn one_shot_session_closes_input_checks_exit_deadline_and_cancellation() {
     command.args(["-c", "read oid; while :; do :; done"]).env_clear();
     let mut session = Session::spawn(command, Duration::from_secs(2), Box::new(|| cancelled.get())).unwrap();
     let cancelled_process = PathBuf::from(format!("/proc/{}", session.id().unwrap()));
-    session.begin_pack(Oid::ZERO_SHA1).unwrap();
+    session.begin_commit(Oid::ZERO_SHA1).unwrap();
     cancelled.set(true);
     assert_eq!(
         session.read(&mut [0]).unwrap_err().kind(),

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -9,6 +9,8 @@ mod index;
 #[cfg(target_os = "linux")]
 pub mod packed;
 #[cfg(target_os = "linux")]
+pub mod receive;
+#[cfg(target_os = "linux")]
 mod staging;
 
 use super::namespace::ResolvedRepositoryOverlay;

--- a/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/process.rs
@@ -77,11 +77,16 @@ impl<'a> Session<'a> {
         Ok(())
     }
 
-    pub(in crate::repository_overlay::seed) fn begin_pack(&mut self, oid: Oid) -> io::Result<()> {
+    pub(in crate::repository_overlay::seed) fn begin_commit(&mut self, oid: Oid) -> io::Result<()> {
         self.deadline = Instant::now() + self.timeout;
-        self.write_request(format!("{oid}\n").as_bytes())?;
+        self.write_request(format!("{oid}^{{commit}}\n").as_bytes())?;
         self.input.take();
         Ok(())
+    }
+
+    pub(in crate::repository_overlay::seed) fn begin_without_input(&mut self) {
+        self.deadline = Instant::now() + self.timeout;
+        self.input.take();
     }
 
     pub(in crate::repository_overlay::seed) fn finish(&mut self) -> io::Result<()> {

--- a/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
@@ -83,14 +83,10 @@ pub(in crate::repository_overlay::seed) fn validate(
 pub(in crate::repository_overlay::seed) enum Operation {
     Inspect,
     Pack(Oid),
+    Closure(Oid),
 }
 
-pub(in crate::repository_overlay::seed) fn command(
-    path: &Path,
-    objects: &Path,
-    limits: PackedSourceLimits,
-    operation: Operation,
-) -> Result<Command, Error> {
+fn initialize(path: &Path) -> Result<(), Error> {
     for directory in ["objects", "objects/info", "objects/pack", "refs"] {
         fs::create_dir(path.join(directory)).map_err(|_| Error::Storage)?;
     }
@@ -106,6 +102,26 @@ pub(in crate::repository_overlay::seed) fn command(
             .and_then(|mut file| file.write_all(contents.as_bytes()))
             .map_err(|_| Error::Storage)?;
     }
+    Ok(())
+}
+
+fn shallow(path: &Path, commit: Oid) -> Result<(), Error> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path.join("shallow"))
+        .and_then(|mut file| writeln!(file, "{commit}"))
+        .map_err(|_| Error::Storage)
+}
+
+pub(in crate::repository_overlay::seed) fn command(
+    path: &Path,
+    objects: &Path,
+    limits: PackedSourceLimits,
+    operation: Operation,
+) -> Result<Command, Error> {
+    initialize(path)?;
     let mut quoted = String::from("\"");
     for &byte in objects.as_os_str().as_bytes() {
         match byte {
@@ -118,6 +134,62 @@ pub(in crate::repository_overlay::seed) fn command(
         }
     }
     quoted.push('"');
+    let mut command = git_process(path, limits);
+    command.env("GIT_ALTERNATE_OBJECT_DIRECTORIES", quoted);
+    match operation {
+        Operation::Inspect => {
+            command.args(["cat-file", "--batch-command"]);
+        }
+        Operation::Pack(commit) => {
+            // The exact original commit is a shallow boundary, not rewritten history.
+            shallow(path, commit)?;
+            command.args([
+                "-c",
+                "pack.useSparse=false",
+                "pack-objects",
+                "--stdout",
+                "--revs",
+                "--no-reuse-delta",
+                "--no-reuse-object",
+                "--window=0",
+                "--depth=0",
+                "--threads=1",
+                "--compression=1",
+            ]);
+        }
+        Operation::Closure(commit) => {
+            shallow(path, commit)?;
+            command.args(["rev-list", "--objects", "--no-object-names", "--stdin"]);
+        }
+    }
+    Ok(command)
+}
+
+pub(in crate::repository_overlay::seed) fn index_command(
+    path: &Path,
+    commit: Oid,
+    limits: PackedSourceLimits,
+    encoded_bytes: u64,
+) -> Result<Command, Error> {
+    initialize(path)?;
+    shallow(path, commit)?;
+    let mut command = git_process(path, limits);
+    command
+        .args([
+            "index-pack",
+            "--strict",
+            "--threads=1",
+            "--no-rev-index",
+            "--object-format=sha1",
+        ])
+        .arg(format!("--max-input-size={encoded_bytes}"))
+        .arg("-o")
+        .arg(path.join("objects/pack/received.idx"))
+        .arg(path.join("objects/pack/received.pack"));
+    Ok(command)
+}
+
+fn git_process(path: &Path, limits: PackedSourceLimits) -> Command {
     let mut command = Command::new("/usr/bin/prlimit");
     command
         .args([
@@ -152,35 +224,6 @@ pub(in crate::repository_overlay::seed) fn command(
             ("GIT_ALLOW_PROTOCOL", ""),
             ("GIT_OPTIONAL_LOCKS", "0"),
             ("GIT_TERMINAL_PROMPT", "0"),
-        ])
-        .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", quoted);
-    match operation {
-        Operation::Inspect => {
-            command.args(["cat-file", "--batch-command"]);
-        }
-        Operation::Pack(commit) => {
-            // The exact original commit is a shallow boundary, not rewritten history.
-            OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(path.join("shallow"))
-                .and_then(|mut file| writeln!(file, "{commit}"))
-                .map_err(|_| Error::Storage)?;
-            command.args([
-                "-c",
-                "pack.useSparse=false",
-                "pack-objects",
-                "--stdout",
-                "--revs",
-                "--no-reuse-delta",
-                "--no-reuse-object",
-                "--window=0",
-                "--depth=0",
-                "--threads=1",
-                "--compression=1",
-            ]);
-        }
-    }
-    Ok(command)
+        ]);
+    command
 }

--- a/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
@@ -1,0 +1,209 @@
+//! Bounded private pack receipt, independent of source approval and setup admission.
+
+mod native;
+
+use super::{
+    MAX_OBJECTS, SeedError, SeedFailure,
+    export::{PackExportLimits, PreparedGitPack, output, source_error},
+    packed::{PackedSourceLimits, view},
+    staging,
+};
+use crate::cloud_run::ArtifactDigest;
+use git2::Oid;
+use std::{
+    fmt,
+    fs::{self, OpenOptions},
+    io::{self, Read, Write},
+    os::unix::fs::{DirBuilderExt, OpenOptionsExt},
+    path::{Path, PathBuf},
+};
+
+/// Expected identity, not source-export approval or a trust assertion about input bytes.
+#[derive(Clone, Copy)]
+pub struct ExpectedGitPack<'a> {
+    pub base_commit: Oid,
+    pub sha256: &'a ArtifactDigest,
+    pub encoded_bytes: u64,
+}
+
+impl<'a> From<&'a PreparedGitPack> for ExpectedGitPack<'a> {
+    fn from(pack: &'a PreparedGitPack) -> Self {
+        Self {
+            base_commit: pack.base_commit(),
+            sha256: pack.sha256(),
+            encoded_bytes: pack.encoded_bytes(),
+        }
+    }
+}
+
+/// Encoded input ceiling and per-child decoding/enumeration limits. Blocking reader
+/// and filesystem calls remain the caller's latency responsibility.
+#[derive(Clone, Copy, Debug)]
+pub struct PackReceiveLimits {
+    pub source: PackedSourceLimits,
+    pub encoded_bytes: u64,
+}
+
+impl Default for PackReceiveLimits {
+    fn default() -> Self {
+        Self {
+            source: PackedSourceLimits::default(),
+            encoded_bytes: PackExportLimits::DEFAULT_ENCODED_BYTES,
+        }
+    }
+}
+
+impl PackReceiveLimits {
+    fn validate(self, expected: ExpectedGitPack<'_>) -> Result<(), SeedError> {
+        self.source.validate()?;
+        if !(32..=PackExportLimits::MAX_ENCODED_BYTES).contains(&self.encoded_bytes)
+            || !(32..=self.encoded_bytes).contains(&expected.encoded_bytes)
+        {
+            return Err(SeedError::Limit);
+        }
+        if expected.base_commit.as_bytes().len() != 20 || expected.base_commit.is_zero() {
+            return Err(SeedError::Object);
+        }
+        Ok(())
+    }
+}
+
+/// Strictly decoded private exact-base pack, not a policy-verified namespace, durable
+/// publication or ready checkout. Keep its path and ancestry stable/exclusive until
+/// existing namespace/seed/setup verification consumes it. Drop never removes data.
+pub struct ReceivedGitPack {
+    path: PathBuf,
+    objects_directory: PathBuf,
+    base_commit: Oid,
+    sha256: ArtifactDigest,
+    encoded_bytes: u64,
+    objects: u32,
+}
+
+impl ReceivedGitPack {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+    #[must_use]
+    pub fn objects_directory(&self) -> &Path {
+        &self.objects_directory
+    }
+    #[must_use]
+    pub fn base_commit(&self) -> Oid {
+        self.base_commit
+    }
+    #[must_use]
+    pub fn sha256(&self) -> &ArtifactDigest {
+        &self.sha256
+    }
+    #[must_use]
+    pub fn encoded_bytes(&self) -> u64 {
+        self.encoded_bytes
+    }
+    #[must_use]
+    pub fn objects(&self) -> u32 {
+        self.objects
+    }
+}
+
+impl fmt::Debug for ReceivedGitPack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceivedGitPack")
+            .field("encoded_bytes", &self.encoded_bytes)
+            .field("objects", &self.objects)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Receive one explicit standard SHA-1 pack in fresh private scratch. Verify exact
+/// length/EOF/SHA-256 before trusted resource-limited Git decodes it. An isolated
+/// shallow traversal must account for every packed object from the expected base;
+/// extra history/unreachable objects and incomplete/thin packs are rejected.
+/// Source selection, namespace policy, seed preparation and setup admission remain
+/// separate. No network/configuration inheritance, publication, sync acknowledgement,
+/// task start, retry or cleanup occurs. Requires stable exclusive scratch ancestry
+/// and trusted `/usr/bin/git` and `/usr/bin/prlimit`; run off the UI thread.
+/// Cancellation is checked between reader chunks and native operations. Blocking
+/// reader/storage calls, spawn and kill/reap are outside native pipe deadlines.
+/// # Errors
+/// Invalid metadata/limits and unsafe parents fail before reservation. All later
+/// failures retain the whole private reservation, including partial files, as
+/// unconfirmed. No failure or lost receipt authorizes replay or deletion.
+pub fn receive_git_base_pack(
+    parent: &Path,
+    expected: ExpectedGitPack<'_>,
+    input: &mut impl Read,
+    limits: PackReceiveLimits,
+    cancelled: impl Fn() -> bool,
+) -> Result<ReceivedGitPack, SeedFailure> {
+    limits
+        .validate(expected)
+        .and_then(|()| staging::check_cancel(&cancelled))
+        .map_err(|reason| SeedFailure { reason, residue: None })?;
+    let path = staging::reserve(parent, &cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
+    receive(&path, expected, input, limits, &cancelled).map_err(|reason| SeedFailure {
+        reason,
+        residue: Some(path),
+    })
+}
+
+fn receive(
+    path: &Path,
+    expected: ExpectedGitPack<'_>,
+    input: &mut impl Read,
+    limits: PackReceiveLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<ReceivedGitPack, SeedError> {
+    let decoded = path.join("decoded");
+    let selection = path.join("selection");
+    for directory in [&decoded, &selection] {
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(directory)
+            .map_err(|_| SeedError::Storage)?;
+    }
+    let command = view::index_command(&decoded, expected.base_commit, limits.source, expected.encoded_bytes)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(decoded.join("objects/pack/received.pack"))
+        .map_err(|_| SeedError::Storage)?;
+    let summary = output::copy(
+        &mut |bytes| {
+            if cancelled() {
+                return Err(io::Error::from(io::ErrorKind::ConnectionAborted));
+            }
+            input.read(bytes)
+        },
+        &mut file,
+        expected.encoded_bytes,
+        MAX_OBJECTS,
+    )?;
+    if summary.bytes != expected.encoded_bytes || &summary.sha256 != expected.sha256 {
+        return Err(SeedError::Object);
+    }
+    file.flush().map_err(|_| SeedError::Storage)?;
+    native::index(command, &decoded, summary.objects, limits.source, cancelled)?;
+    let objects_directory = decoded.join("objects");
+    native::closure(
+        &selection,
+        &objects_directory,
+        expected.base_commit,
+        summary.objects,
+        limits.source,
+        cancelled,
+    )?;
+    Ok(ReceivedGitPack {
+        path: path.to_path_buf(),
+        objects_directory,
+        base_commit: expected.base_commit,
+        sha256: summary.sha256,
+        encoded_bytes: summary.bytes,
+        objects: summary.objects,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/native.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/native.rs
@@ -1,0 +1,107 @@
+use super::{PackedSourceLimits, SeedError, source_error, view};
+use crate::repository_overlay::seed::packed::process::Session;
+use git2::Oid;
+use rustix::fs::{CWD, RenameFlags, renameat_with};
+use std::{
+    fs,
+    os::unix::fs::{MetadataExt, PermissionsExt},
+    path::Path,
+    process::Command,
+};
+
+pub(super) fn index(
+    command: Command,
+    path: &Path,
+    objects: u32,
+    limits: PackedSourceLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), SeedError> {
+    let mut session = Session::spawn(command, limits.object_timeout, Box::new(cancelled))?;
+    session.begin_without_input();
+    let hash = line(&mut session)?.ok_or(SeedError::Object)?;
+    if line(&mut session)?.is_some() {
+        return Err(SeedError::Object);
+    }
+    session.finish().map_err(|error| source_error(error.kind()))?;
+    let hash = std::str::from_utf8(&hash).map_err(|_| SeedError::Object)?;
+    let index = path.join("objects/pack/received.idx");
+    let metadata = fs::symlink_metadata(&index).map_err(|_| SeedError::Storage)?;
+    if !metadata.is_file()
+        || metadata.nlink() != 1
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.len() > u64::from(objects) * 40 + 2048
+    {
+        return Err(SeedError::Object);
+    }
+    fs::set_permissions(&index, fs::Permissions::from_mode(0o600)).map_err(|_| SeedError::Storage)?;
+    for extension in ["pack", "idx"] {
+        renameat_with(
+            CWD,
+            path.join(format!("objects/pack/received.{extension}")),
+            CWD,
+            path.join(format!("objects/pack/pack-{hash}.{extension}")),
+            RenameFlags::NOREPLACE,
+        )
+        .map_err(|_| SeedError::Storage)?;
+    }
+    Ok(())
+}
+
+pub(super) fn closure(
+    metadata: &Path,
+    objects_directory: &Path,
+    commit: Oid,
+    objects: u32,
+    limits: PackedSourceLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), SeedError> {
+    let command = view::command(metadata, objects_directory, limits, view::Operation::Closure(commit))?;
+    let mut session = Session::spawn(command, limits.object_timeout, Box::new(cancelled))?;
+    session
+        .begin_commit(commit)
+        .map_err(|error| source_error(error.kind()))?;
+    let first = line(&mut session)?.ok_or(SeedError::Object)?;
+    if first != commit.to_string().as_bytes() {
+        return Err(SeedError::Object);
+    }
+    // The isolated strict pack is the only object source. Native traversal deduplicates
+    // its complete shallow closure, so equality excludes all unselected packed objects.
+    let mut count = 1;
+    while line(&mut session)?.is_some() {
+        count += 1;
+        if count > objects {
+            return Err(SeedError::Object);
+        }
+    }
+    session.finish().map_err(|error| source_error(error.kind()))?;
+    if count != objects {
+        return Err(SeedError::Object);
+    }
+    Ok(())
+}
+
+fn line(session: &mut Session<'_>) -> Result<Option<[u8; 40]>, SeedError> {
+    let mut bytes = [0; 41];
+    let mut position = 0;
+    while position < bytes.len() {
+        let count = session
+            .read(&mut bytes[position..])
+            .map_err(|error| source_error(error.kind()))?;
+        if count == 0 {
+            return if position == 0 {
+                Ok(None)
+            } else {
+                Err(SeedError::Object)
+            };
+        }
+        position += count;
+    }
+    if bytes[40] != b'\n'
+        || !bytes[..40]
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(SeedError::Object);
+    }
+    Ok(Some(bytes[..40].try_into().map_err(|_| SeedError::Object)?))
+}

--- a/crates/horizon-core/src/repository_overlay/seed/receive/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/tests.rs
@@ -1,0 +1,523 @@
+use super::*;
+use crate::repository_overlay::{
+    OverlayChange, OverlayContent,
+    bundle::{VerifiedOverlayBlob, codec},
+    checkout::prepare_private_checkout,
+    namespace::resolve_namespaces_from_source,
+    seed::{
+        export::prepare_git_base_pack,
+        packed::PackedGitObjectSource,
+        prepare_git_seed,
+        tests::{Fixture, commit, private_fixture, snapshot},
+    },
+};
+use git2::Repository;
+use std::{
+    cell::Cell,
+    fs::File,
+    io::Cursor,
+    os::unix::fs::{MetadataExt, PermissionsExt, symlink},
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+fn prepared(fixture: &Fixture, parent: &Path, overlay: bool) -> (PreparedGitPack, Box<[u8]>) {
+    let resolved = if overlay {
+        let blob = VerifiedOverlayBlob::new(b"staged-only bytes".to_vec()).unwrap();
+        let added = OverlayChange::new(
+            "staged-only".into(),
+            OverlayContent::File {
+                sha256: blob.sha256().clone(),
+                bytes: blob.bytes().len() as u64,
+                executable: false,
+            },
+        )
+        .unwrap();
+        let removed = OverlayChange::new("removed".into(), OverlayContent::Remove).unwrap();
+        fixture.resolve(vec![added], vec![removed], vec![blob])
+    } else {
+        fixture.resolve(vec![], vec![], vec![])
+    };
+    let bundle = codec::encode(resolved.bundle()).unwrap();
+    let seed = prepare_git_seed(parent, &resolved, &mut fixture.source(), || false).unwrap();
+    (
+        prepare_git_base_pack(parent, &seed, PackExportLimits::default(), || false).unwrap(),
+        bundle,
+    )
+}
+
+fn receive_pack(parent: &Path, pack: &PreparedGitPack) -> ReceivedGitPack {
+    receive_git_base_pack(
+        parent,
+        pack.into(),
+        &mut File::open(pack.path()).unwrap(),
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap()
+}
+
+#[test]
+fn actual_export_receipt_and_existing_checkout_preserve_base_and_overlay_semantics() {
+    let fixture = Fixture::new();
+    let source = private_fixture();
+    let (pack, bundle) = prepared(&fixture, source.path(), true);
+    let before = snapshot(source.path());
+    let original = snapshot(fixture.directory.path());
+    let destination = private_fixture();
+    let received = receive_pack(destination.path(), &pack);
+    assert_eq!(received.base_commit(), fixture.commit);
+    assert_eq!(received.sha256(), pack.sha256());
+    assert_eq!(received.encoded_bytes(), pack.encoded_bytes());
+    assert_eq!(received.objects(), 3);
+    let mut reader = PackedGitObjectSource::new(
+        destination.path(),
+        received.objects_directory(),
+        PackedSourceLimits::default(),
+        || false,
+    )
+    .unwrap();
+    let resolved = resolve_namespaces_from_source(&mut reader, codec::decode(&bundle).unwrap(), || false).unwrap();
+    let checkout = prepare_private_checkout(destination.path(), &resolved, &mut reader, || false).unwrap();
+    assert_eq!(fs::read(checkout.path().join("kept")).unwrap(), b"base\0literal\xff");
+    assert_eq!(
+        fs::read(checkout.path().join("staged-only")).unwrap(),
+        b"staged-only bytes"
+    );
+    assert!(!checkout.path().join("removed").exists());
+    let repository = Repository::open(checkout.path()).unwrap();
+    assert_eq!(repository.head().unwrap().target(), Some(fixture.commit));
+    assert!(repository.head_detached().unwrap() && repository.is_shallow());
+    assert!(repository.find_blob(fixture.private_blob).is_err());
+    assert_eq!(snapshot(source.path()), before);
+    assert_eq!(snapshot(fixture.directory.path()), original);
+    for entry in fs::read_dir(received.objects_directory().join("pack")).unwrap() {
+        let metadata = entry.unwrap().metadata().unwrap();
+        assert!(metadata.is_file());
+        assert_eq!((metadata.mode() & 0o7777, metadata.nlink()), (0o600, 1));
+    }
+    let retained = received.path().to_path_buf();
+    assert!(!format!("{received:?}").contains(retained.to_str().unwrap()));
+    drop(received);
+    assert!(retained.exists());
+}
+
+#[test]
+fn initial_empty_and_large_nested_repeated_base_objects_round_trip() {
+    for shape in ["initial", "empty", "large"] {
+        let mut fixture = Fixture::new();
+        let mut bytes = vec![];
+        fixture.commit = match shape {
+            "initial" => fixture.ancestor,
+            "empty" => commit(&fixture.repository, &[], &[fixture.commit]),
+            _ => {
+                bytes = vec![b'a'; 65 * 1024 * 1024 + 1];
+                *bytes.last_mut().unwrap() = b'z';
+                let blob = fixture.repository.blob(&bytes).unwrap();
+                commit(
+                    &fixture.repository,
+                    &[("kept", blob, 0o100_644), ("nested/leaf", blob, 0o100_755)],
+                    &[fixture.commit],
+                )
+            }
+        };
+        let source = private_fixture();
+        let (pack, bundle) = prepared(&fixture, source.path(), false);
+        let destination = private_fixture();
+        let received = receive_pack(destination.path(), &pack);
+        assert_eq!(
+            received.objects(),
+            if shape == "empty" {
+                2
+            } else if shape == "large" {
+                4
+            } else {
+                3
+            }
+        );
+        let mut reader = PackedGitObjectSource::new(
+            destination.path(),
+            received.objects_directory(),
+            PackedSourceLimits::default(),
+            || false,
+        )
+        .unwrap();
+        let resolved = resolve_namespaces_from_source(&mut reader, codec::decode(&bundle).unwrap(), || false).unwrap();
+        let checkout = prepare_private_checkout(destination.path(), &resolved, &mut reader, || false).unwrap();
+        if shape == "large" {
+            assert_eq!(fs::read(checkout.path().join("nested/leaf")).unwrap(), bytes);
+            assert_eq!(
+                fs::metadata(checkout.path().join("nested/leaf")).unwrap().mode() & 0o111,
+                0o111
+            );
+        }
+    }
+}
+
+#[test]
+fn invalid_metadata_limits_and_unsafe_parent_fail_without_read_or_residue() {
+    struct Unread;
+    impl Read for Unread {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            panic!("invalid preflight read input")
+        }
+    }
+    let fixture = Fixture::new();
+    let parent = private_fixture();
+    let digest = ArtifactDigest::sha256(b"unread");
+    let valid = ExpectedGitPack {
+        base_commit: fixture.commit,
+        sha256: &digest,
+        encoded_bytes: 32,
+    };
+    let before = snapshot(parent.path());
+    for expected in [
+        ExpectedGitPack {
+            base_commit: Oid::ZERO_SHA1,
+            ..valid
+        },
+        ExpectedGitPack {
+            encoded_bytes: 31,
+            ..valid
+        },
+        ExpectedGitPack {
+            encoded_bytes: PackExportLimits::MAX_ENCODED_BYTES + 1,
+            ..valid
+        },
+    ] {
+        let failure = receive_git_base_pack(
+            parent.path(),
+            expected,
+            &mut Unread,
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap_err();
+        assert!(failure.residue().is_none());
+    }
+    for encoded_bytes in [0, 31, PackExportLimits::MAX_ENCODED_BYTES + 1] {
+        let limits = PackReceiveLimits {
+            encoded_bytes,
+            ..PackReceiveLimits::default()
+        };
+        assert!(
+            receive_git_base_pack(parent.path(), valid, &mut Unread, limits, || false)
+                .unwrap_err()
+                .residue()
+                .is_none()
+        );
+    }
+    let limits = PackReceiveLimits {
+        source: PackedSourceLimits {
+            object_timeout: Duration::ZERO,
+            ..PackedSourceLimits::default()
+        },
+        ..PackReceiveLimits::default()
+    };
+    assert!(
+        receive_git_base_pack(parent.path(), valid, &mut Unread, limits, || false)
+            .unwrap_err()
+            .residue()
+            .is_none()
+    );
+    assert!(
+        receive_git_base_pack(parent.path(), valid, &mut Unread, PackReceiveLimits::default(), || true)
+            .unwrap_err()
+            .residue()
+            .is_none()
+    );
+    assert_eq!(snapshot(parent.path()), before);
+    let alias = parent.path().join("alias");
+    symlink(parent.path(), &alias).unwrap();
+    for unsafe_parent in [
+        alias.as_path(),
+        Path::new("relative"),
+        Path::new("/not-a-receiver-directory"),
+    ] {
+        let failure = receive_git_base_pack(unsafe_parent, valid, &mut Unread, PackReceiveLimits::default(), || {
+            false
+        })
+        .unwrap_err();
+        assert_eq!(failure.reason, SeedError::UnsafeParent);
+        assert!(failure.residue().is_none());
+    }
+}
+
+#[test]
+fn non_private_parent_fails_before_reading() {
+    let fixture = Fixture::new();
+    let parent = private_fixture();
+    fs::set_permissions(parent.path(), fs::Permissions::from_mode(0o755)).unwrap();
+    let digest = ArtifactDigest::sha256(b"unread");
+    let expected = ExpectedGitPack {
+        base_commit: fixture.commit,
+        sha256: &digest,
+        encoded_bytes: 32,
+    };
+    let failure = receive_git_base_pack(
+        parent.path(),
+        expected,
+        &mut io::empty(),
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap_err();
+    assert_eq!(failure.reason, SeedError::UnsafeParent);
+    assert!(failure.residue().is_none());
+}
+
+#[test]
+fn mismatched_truncated_trailing_and_corrupt_input_remains_unconfirmed() {
+    let fixture = Fixture::new();
+    let source = private_fixture();
+    let (pack, _) = prepared(&fixture, source.path(), false);
+    let original = fs::read(pack.path()).unwrap();
+    for kind in ["digest", "short", "extra", "checksum", "wrong-base"] {
+        let mut bytes = original.clone();
+        if kind == "short" {
+            bytes.pop();
+        }
+        if kind == "extra" {
+            bytes.push(0);
+        }
+        if kind == "checksum" {
+            *bytes.last_mut().unwrap() ^= 1;
+        }
+        let digest = if kind == "digest" {
+            ArtifactDigest::sha256(b"different")
+        } else {
+            ArtifactDigest::sha256(&bytes)
+        };
+        let expected = ExpectedGitPack {
+            base_commit: if kind == "wrong-base" {
+                fixture.ancestor
+            } else {
+                fixture.commit
+            },
+            sha256: &digest,
+            encoded_bytes: pack.encoded_bytes(),
+        };
+        let destination = private_fixture();
+        let failure = receive_git_base_pack(
+            destination.path(),
+            expected,
+            &mut Cursor::new(bytes),
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap_err();
+        let retained = failure.residue().unwrap().to_path_buf();
+        assert!(!format!("{failure:?} {failure}").contains(retained.to_str().unwrap()));
+        assert!(
+            fs::metadata(retained.join("decoded/objects/pack/received.pack"))
+                .unwrap()
+                .len()
+                <= pack.encoded_bytes()
+        );
+        if matches!(kind, "digest" | "short" | "extra") {
+            assert!(!retained.join("decoded/objects/pack/received.idx").exists());
+        }
+        drop(failure);
+        assert!(retained.exists());
+    }
+    assert_eq!(fs::read(pack.path()).unwrap(), original);
+}
+
+#[test]
+fn otherwise_valid_packs_with_extras_or_non_commit_roots_are_rejected() {
+    let fixture = Fixture::new();
+    let root = fixture.repository.find_commit(fixture.commit).unwrap().tree_id();
+    let old_root = fixture.repository.find_commit(fixture.ancestor).unwrap().tree_id();
+    let tag = fixture
+        .repository
+        .odb()
+        .unwrap()
+        .write(
+            git2::ObjectType::Tag,
+            format!(
+                "object {}\ntype commit\ntag receipt\ntagger Fixture <fixture@example.invalid> 1 +0000\n\nreceipt\n",
+                fixture.ancestor
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    for (base_commit, ids) in [
+        (
+            fixture.commit,
+            vec![fixture.commit, root, fixture.base_blob, fixture.private_blob],
+        ),
+        (
+            fixture.commit,
+            vec![
+                fixture.commit,
+                root,
+                fixture.base_blob,
+                fixture.ancestor,
+                old_root,
+                fixture.private_blob,
+            ],
+        ),
+        (fixture.base_blob, vec![fixture.base_blob]),
+        (root, vec![root, fixture.base_blob]),
+        (tag, vec![tag, fixture.ancestor, old_root, fixture.private_blob]),
+    ] {
+        let temporary = private_fixture();
+        let request = temporary.path().join("objects");
+        let mut input = File::create(&request).unwrap();
+        for id in ids {
+            writeln!(input, "{id}").unwrap();
+        }
+        drop(input);
+        let result = Command::new("/usr/bin/git")
+            .args(["--no-replace-objects", "--git-dir"])
+            .arg(fixture.repository.path())
+            .args(["pack-objects", "--stdout", "--window=0", "--depth=0", "--threads=1"])
+            .env_clear()
+            .envs([
+                ("GIT_CONFIG_NOSYSTEM", "1"),
+                ("GIT_CONFIG_GLOBAL", "/dev/null"),
+                ("GIT_ALLOW_PROTOCOL", ""),
+            ])
+            .stdin(Stdio::from(File::open(request).unwrap()))
+            .output()
+            .unwrap();
+        assert!(result.status.success());
+        let digest = ArtifactDigest::sha256(&result.stdout);
+        let expected = ExpectedGitPack {
+            base_commit,
+            sha256: &digest,
+            encoded_bytes: result.stdout.len() as u64,
+        };
+        let failure = receive_git_base_pack(
+            temporary.path(),
+            expected,
+            &mut result.stdout.as_slice(),
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap_err();
+        assert_eq!(failure.reason, SeedError::Object);
+        let files: Vec<_> = fs::read_dir(failure.residue().unwrap().join("decoded/objects/pack"))
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        if base_commit == tag {
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0], "received.pack");
+            continue;
+        }
+        assert_eq!(
+            files.len(),
+            2,
+            "strict decoding succeeded but exact commit closure must reject this pack"
+        );
+        assert!(files.iter().all(|name| name.to_str().unwrap().starts_with("pack-")));
+    }
+}
+
+#[test]
+fn short_reads_cancellation_and_private_reader_errors_preserve_unconfirmed_data() {
+    struct Chunks<'a> {
+        input: Cursor<&'a [u8]>,
+        cancel: &'a Cell<bool>,
+        fail: bool,
+        stop: bool,
+    }
+    impl Read for Chunks<'_> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            if self.fail {
+                return Err(io::Error::other("private-reader-marker"));
+            }
+            let count = bytes.len().min(3);
+            let read = self.input.read(&mut bytes[..count]);
+            self.cancel.set(self.stop);
+            read
+        }
+    }
+    let fixture = Fixture::new();
+    let source = private_fixture();
+    let (pack, _) = prepared(&fixture, source.path(), false);
+    let bytes = fs::read(pack.path()).unwrap();
+    for (fail, stop) in [(false, false), (true, false), (false, true)] {
+        let destination = private_fixture();
+        let cancelled = Cell::new(false);
+        let mut input = Chunks {
+            input: Cursor::new(&bytes),
+            cancel: &cancelled,
+            fail,
+            stop,
+        };
+        let result = receive_git_base_pack(
+            destination.path(),
+            (&pack).into(),
+            &mut input,
+            PackReceiveLimits::default(),
+            || cancelled.get(),
+        );
+        if fail || stop {
+            let failure = result.unwrap_err();
+            assert_eq!(
+                failure.reason,
+                if stop { SeedError::Cancelled } else { SeedError::Source }
+            );
+            assert!(!format!("{failure:?} {failure}").contains("private-reader-marker"));
+            assert!(failure.residue().unwrap().exists());
+            assert!(
+                !failure
+                    .residue()
+                    .unwrap()
+                    .join("decoded/objects/pack/received.idx")
+                    .exists()
+            );
+        } else {
+            assert_eq!(result.unwrap().objects(), 3);
+        }
+    }
+}
+
+#[test]
+fn receipt_commands_use_only_the_isolated_pack_and_bounded_exact_traversal() {
+    let parent = private_fixture();
+    let metadata = staging::reserve(parent.path(), &|| false).unwrap();
+    let limits = PackedSourceLimits::default();
+    let command = view::index_command(&metadata, Oid::ZERO_SHA1, limits, 4096).unwrap();
+    let args: Vec<_> = command.get_args().map(|arg| arg.to_str().unwrap()).collect();
+    assert_eq!(command.get_program(), "/usr/bin/prlimit");
+    for required in [
+        "index-pack",
+        "--strict",
+        "--threads=1",
+        "--no-rev-index",
+        "--object-format=sha1",
+        "--max-input-size=4096",
+    ] {
+        assert!(args.contains(&required));
+    }
+    for forbidden in ["--stdin", "--fix-thin", "--promisor", "--fsck-objects"] {
+        assert!(!args.contains(&forbidden));
+    }
+    assert!(
+        command
+            .get_envs()
+            .all(|(key, _)| key != "GIT_ALTERNATE_OBJECT_DIRECTORIES")
+    );
+    assert_eq!(
+        fs::read_to_string(metadata.join("shallow")).unwrap(),
+        format!("{}\n", Oid::ZERO_SHA1)
+    );
+    let selection = staging::reserve(parent.path(), &|| false).unwrap();
+    let command = view::command(
+        &selection,
+        &metadata.join("objects"),
+        limits,
+        view::Operation::Closure(Oid::ZERO_SHA1),
+    )
+    .unwrap();
+    let args: Vec<_> = command.get_args().map(|arg| arg.to_str().unwrap()).collect();
+    assert_eq!(
+        &args[args.len() - 4..],
+        ["rev-list", "--objects", "--no-object-names", "--stdin"]
+    );
+    assert!(args.contains(&format!("--as={0}:{0}", limits.address_space_bytes).as_str()));
+    assert!(args.contains(&format!("--cpu={0}:{0}", limits.cpu_seconds).as_str()));
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -235,6 +235,13 @@ back into large multi-purpose modules.
   success/partial artifacts remain explicit; no network, setup start, immutable
   publication or durability is inferred. Input/output overlap checks cover the
   entire seed, not only its object store. See [pack preparation](../remote-repository-pack.md).
+  `seed/receive/` verifies expected encoded pack identity before isolated strict
+  indexing and bounded exact-base closure enumeration. Its native leaf handles
+  bounded hash-line responses, private index validation and no-replace relocation;
+  command isolation and framed chunk-copy/digest work remain shared with existing
+  packed acquisition/export helpers. A received object directory still requires
+  namespace/seed/setup policy checks; no publication or task admission is inferred.
+  See [private pack receipt](../remote-repository-pack-receipt.md).
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;

--- a/docs/remote-repository-pack-receipt.md
+++ b/docs/remote-repository-pack-receipt.md
@@ -1,0 +1,80 @@
+# Receiving a private exact-base pack
+
+The Linux `repository_overlay::seed::receive::receive_git_base_pack` API receives
+one explicitly identified pack into fresh private scratch. It returns an object
+directory for the existing namespace, seed and checkout verification APIs. It does
+not publish a worker input record, approve source export, create a ready checkout,
+start a task or perform network/provider operations. No current command/UI invokes
+it automatically. The matching producer is documented in [pack preparation](remote-repository-pack.md).
+
+## Input and verification
+
+Supply `ExpectedGitPack` (exact SHA-1 base commit, SHA-256 and encoded byte length),
+an existing private scratch parent, a caller-owned reader, `PackReceiveLimits`, and
+a cancellation callback. A prepared producer receipt converts to the expected
+identity directly; identity is not an authorization decision.
+
+```text
+expected identity + bounded reader
+  -> fresh private pack + exact length/EOF/SHA-256
+  -> isolated strict Git indexing + exact shallow boundary
+  -> bounded exact-base closure enumeration
+  -> private object directory -> existing namespace/seed/checkout checks
+```
+
+Invalid metadata/limits and unsafe parents are rejected before reservation.
+Framing, object count, length and SHA-256 are checked before native decoding. The
+shared pack-copy leaf streams bounded chunks rather than buffering the whole pack.
+
+Trusted resource-limited Git indexes the file with strict integrity checks and a
+synthesized shallow boundary for the original base commit. The command does not
+repair thin packs or use promisors. Indexing reads no original repository metadata,
+ambient configuration or external object stores. The generated index is private,
+and pack/index relocation refuses replacement of any existing destination.
+
+A second isolated native process enumerates the expected shallow closure without
+object names. Its generated revision request requires a commit object, and the
+output must begin with the original requested ID and account for every packed
+object; a blob, tree or peeled tag cannot stand in for the commit. Strict decoding
+plus this bounded count rejects missing closure, unreachable objects and extra
+parent history; strict indexing alone does not prove that selection. The raw
+original commit is preserved, not rewritten.
+
+This verifies Git pack/closure integrity, not namespace safety, source-export
+approval, repository URL ownership or task admission. Existing namespace policy,
+link handling, seed identity and checkout verification remain required. Do not
+treat a received pack as a ready repository or as authority to retry setup.
+
+## Ownership, limits and failure
+
+The caller controls stable, exclusive scratch ancestry and supplies trusted
+`/usr/bin/git` and `/usr/bin/prlimit`. No-follow parent checks are not confinement
+against concurrent same-user or privileged mutation. Keep received files and their
+ancestry stable until the existing verification pipeline consumes them.
+
+Defaults are the producer's 256 MiB encoded ceiling and the native source defaults:
+1 GiB address space, 60 CPU seconds and a 30-second pipe deadline **per child**.
+Indexing and closure enumeration are separate children; these are not whole-call
+CPU/wall-time or application RSS guarantees. Valid repositories may exceed limits.
+Blocking reader/filesystem calls, process creation and kill/reap are outside the
+pipe deadline. The reader owns transport latency and cancellation; run off the UI
+thread. Cancellation is checked between chunks and native operations.
+
+After reservation, any failure retains the entire named private root, including
+partial pack/index/metadata, as unconfirmed. Success retains it too. Display/Debug
+omit contents and private paths. Only owned native children are terminated/reaped
+when necessary; existing workers and tasks are untouched. There is no automatic
+retry, cleanup, file/directory synchronization or crash-durability acknowledgement.
+
+## Evidence and remaining integration
+
+Native tests exercise the real exporter, receiver and existing raw checkout path,
+including staged overlay/deletion semantics, initial/empty/parented bases, repeated
+nested objects and a 65 MiB-plus raw blob. Failure tests cover digest mismatch,
+truncation/trailing input, checksum corruption, wrong base, extra objects/history,
+unsafe parents, cancellation, short reads and redacted reader errors. Existing
+shared-process/copy tests cover resource limits, stalled children and failed writes.
+
+Worker immutable input publication/observation, pinned transport, source-approval
+UI and full cloud/PC-off acceptance remain separate. Closing local views must never
+implicitly stop or delete a persistent environment.

--- a/docs/remote-repository-pack.md
+++ b/docs/remote-repository-pack.md
@@ -78,6 +78,8 @@ private file identity, a 65 MiB-plus raw base blob, bounded output, cancellation
 write failure and exact owned-child cleanup. Pure tests exercise framing and
 limits; they are not independent cryptographic pack-validation tests.
 
+The separate [private pack receiver](remote-repository-pack-receipt.md) performs
+strict decoding and exact-base closure checks before existing setup verification.
 Worker receipt/publication, pinned transport, source-approval UI, repository setup,
 remote checkpoints and cloud/PC-off acceptance remain separate work. Closing local
 views must never implicitly stop or delete a persistent environment.


### PR DESCRIPTION
## Purpose and behavior

Refs #383 and #470. Add the Linux private receiver for the exact-base packs produced by #483: explicit expected commit, SHA-256 and encoded length plus a caller-owned reader become a retained private object store for the existing namespace/seed/checkout verification path.

- Reuse bounded streaming framing/hash checks and owned resource-limited native Git. Verify exact length, EOF and digest before strict indexing; reject incomplete/corrupt packs without thin repair, ambient configuration or network.
- Enumerate the exact shallow commit closure in an isolated second process. Require the original commit identity and every packed object, rejecting blob/tree/tag substitutions, unrelated objects and parent history.
- Keep private pack/index files and the entire reservation on success or failure. No automatic cleanup, overwrite, retry, setup or task start.

This is private input preparation, not immutable publication, crash-durability acknowledgement, source-export approval or a ready checkout. Trusted Git/prlimit and stable exclusive scratch ancestry remain preconditions; caller-owned blocking reads/storage are outside native pipe deadlines. No client/UI/provider integration or cloud/PC-off acceptance is claimed. Worker publication and pinned transport remain follow-up work.

## Validation

Candidate: `de8c838530269eb87be5dae0db09c990b139fb9d`.

- All 37 native seed/export/receipt tests pass. Real exporter-to-receiver-to-checkout coverage preserves the raw base, staged overlay and working deletion, detached shallow identity, initial/empty/parented commits, executable mode and a 65 MiB-plus nested/repeated blob. Invalid metadata, private-root violations, digest/framing corruption, short/trailing input, wrong object type, wrong base, extra objects/history, short reads and cancellation are rejected while retaining unconfirmed data. The conditional casefold fixture is unavailable; no casefold proof is claimed.
- Independent local review and committed parity are clear. Full source and exact-commit eight-lane Horizon validation pass: formatting, maintainability, version sync, default and speech workspace tests, blocking Clippy, strict unwrap/expect Clippy and the advisory pedantic audit.
- All six exact-image regression lanes pass: overlay receipt, detached setup, packaging, repository helper behavior, worker security and retained host identity. Packaging verified 360 allowlisted inputs and 31 final layers. Local disconnected-task progress and reconnect passed; these regressions do not substitute for the new API's native tests or cloud acceptance.
- Runtime image: `sha256:6ce455986922e6f9ac70658119941f25b12e724526fd76c9bbf86abb7f9fcfb6`; helper binary SHA-256: `b540a0bc8f14b0d0ed879f2af89de8d280e1f0165152989e8d74621988660d04`. Local Linux amd64 image version: `smoke-pack-receive-20260909`.

Scope: nine source/test files, 989 changed source/test lines, plus three documentation files. No new dependencies or configuration changes.
