### PR TITLE
Reopen received Git packs without mutation

### DIFF
--- a/crates/horizon-core/src/repository_overlay/reader/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/reader/linux.rs
@@ -94,7 +94,7 @@ struct PinnedNode {
 
 impl PinnedNode {
     fn verify(&self, current: &Metadata) -> Result<(), Error> {
-        if fingerprint(&self.metadata) == fingerprint(current) {
+        if same_metadata(&self.metadata, current) {
             Ok(())
         } else {
             Err(Error::Changed)
@@ -166,6 +166,10 @@ struct Fingerprint {
     links: u64,
     modified: (i64, i64),
     changed: (i64, i64),
+}
+
+pub(in crate::repository_overlay) fn same_metadata(left: &Metadata, right: &Metadata) -> bool {
+    fingerprint(left) == fingerprint(right)
 }
 
 fn fingerprint(metadata: &Metadata) -> Fingerprint {

--- a/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/packed/view.rs
@@ -15,6 +15,12 @@ use std::{
 
 pub(super) const MAX_NODES: usize = 262_144;
 pub(super) const MAX_PATH_BYTES: usize = 16 * 1024 * 1024;
+pub(in crate::repository_overlay::seed) const INITIAL_HEAD: &str = "ref: refs/heads/isolated\n";
+pub(in crate::repository_overlay::seed) const INITIAL_CONFIG: &str =
+    "[core]\nrepositoryformatversion = 0\nbare = true\n";
+pub(in crate::repository_overlay::seed) const INITIAL_DIRECTORIES: [&str; 4] =
+    ["objects", "objects/info", "objects/pack", "refs"];
+const CLOSURE_ARGUMENTS: [&str; 4] = ["rev-list", "--objects", "--no-object-names", "--stdin"];
 
 pub(in crate::repository_overlay::seed) fn validate(
     objects: &Path,
@@ -87,13 +93,10 @@ pub(in crate::repository_overlay::seed) enum Operation {
 }
 
 fn initialize(path: &Path) -> Result<(), Error> {
-    for directory in ["objects", "objects/info", "objects/pack", "refs"] {
+    for directory in INITIAL_DIRECTORIES {
         fs::create_dir(path.join(directory)).map_err(|_| Error::Storage)?;
     }
-    for (name, contents) in [
-        ("HEAD", "ref: refs/heads/isolated\n"),
-        ("config", "[core]\nrepositoryformatversion = 0\nbare = true\n"),
-    ] {
+    for (name, contents) in [("HEAD", INITIAL_HEAD), ("config", INITIAL_CONFIG)] {
         OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -159,7 +162,7 @@ pub(in crate::repository_overlay::seed) fn command(
         }
         Operation::Closure(commit) => {
             shallow(path, commit)?;
-            command.args(["rev-list", "--objects", "--no-object-names", "--stdin"]);
+            command.args(CLOSURE_ARGUMENTS);
         }
     }
     Ok(command)
@@ -173,6 +176,33 @@ pub(in crate::repository_overlay::seed) fn index_command(
 ) -> Result<Command, Error> {
     initialize(path)?;
     shallow(path, commit)?;
+    let mut command = index_process(path, limits, encoded_bytes);
+    command
+        .arg("-o")
+        .arg(path.join("objects/pack/received.idx"))
+        .arg(path.join("objects/pack/received.pack"));
+    Ok(command)
+}
+
+pub(in crate::repository_overlay::seed) fn verify_command(
+    path: &Path,
+    pack: &Path,
+    index: &Path,
+    limits: PackedSourceLimits,
+    encoded_bytes: u64,
+) -> Command {
+    let mut command = index_process(path, limits, encoded_bytes);
+    command.args(["--verify", "-o"]).arg(index).arg(pack);
+    command
+}
+
+pub(in crate::repository_overlay::seed) fn stored_closure_command(path: &Path, limits: PackedSourceLimits) -> Command {
+    let mut command = git_process(path, limits);
+    command.args(CLOSURE_ARGUMENTS);
+    command
+}
+
+fn index_process(path: &Path, limits: PackedSourceLimits, encoded_bytes: u64) -> Command {
     let mut command = git_process(path, limits);
     command
         .args([
@@ -182,11 +212,8 @@ pub(in crate::repository_overlay::seed) fn index_command(
             "--no-rev-index",
             "--object-format=sha1",
         ])
-        .arg(format!("--max-input-size={encoded_bytes}"))
-        .arg("-o")
-        .arg(path.join("objects/pack/received.idx"))
-        .arg(path.join("objects/pack/received.pack"));
-    Ok(command)
+        .arg(format!("--max-input-size={encoded_bytes}"));
+    command
 }
 
 fn git_process(path: &Path, limits: PackedSourceLimits) -> Command {

--- a/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
@@ -1,6 +1,9 @@
 //! Bounded private pack receipt, independent of source approval and setup admission.
 
 mod native;
+mod observe;
+
+pub use observe::observe_git_base_pack;
 
 use super::{
     MAX_OBJECTS, SeedError, SeedFailure,

--- a/crates/horizon-core/src/repository_overlay/seed/receive/native.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/native.rs
@@ -56,6 +56,16 @@ pub(super) fn closure(
     cancelled: &impl Fn() -> bool,
 ) -> Result<(), SeedError> {
     let command = view::command(metadata, objects_directory, limits, view::Operation::Closure(commit))?;
+    enumerate(command, commit, objects, limits, cancelled)
+}
+
+pub(super) fn enumerate(
+    command: Command,
+    commit: Oid,
+    objects: u32,
+    limits: PackedSourceLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), SeedError> {
     let mut session = Session::spawn(command, limits.object_timeout, Box::new(cancelled))?;
     session
         .begin_commit(commit)
@@ -78,6 +88,19 @@ pub(super) fn closure(
         return Err(SeedError::Object);
     }
     Ok(())
+}
+
+pub(super) fn verify(
+    command: Command,
+    limits: PackedSourceLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), SeedError> {
+    let mut session = Session::spawn(command, limits.object_timeout, Box::new(cancelled))?;
+    session.begin_without_input();
+    if session.read(&mut [0]).map_err(|error| source_error(error.kind()))? != 0 {
+        return Err(SeedError::Object);
+    }
+    session.finish().map_err(|error| source_error(error.kind()))
 }
 
 fn line(session: &mut Session<'_>) -> Result<Option<[u8; 40]>, SeedError> {

--- a/crates/horizon-core/src/repository_overlay/seed/receive/observe/layout.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/observe/layout.rs
@@ -1,0 +1,232 @@
+use super::{ExpectedGitPack, MAX_OBJECTS, SeedError as Error, staging, view};
+use crate::repository_overlay::reader::{SelectedRepositoryReader, linux::same_metadata};
+use git2::Oid;
+use rustix::fs::{Dir, Mode, OFlags, ResolveFlags, openat2};
+use std::{
+    fs::{File, Metadata, OpenOptions},
+    io::{Read, Seek, SeekFrom},
+    os::{
+        fd::AsRawFd,
+        unix::fs::{MetadataExt, OpenOptionsExt},
+    },
+    path::{Path, PathBuf},
+};
+
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+struct Node {
+    name: String,
+    handle: File,
+    metadata: Metadata,
+}
+
+pub(super) struct Layout {
+    path: PathBuf,
+    reader: SelectedRepositoryReader,
+    nodes: Vec<Node>,
+    pack_hash: Oid,
+    index_bytes: u64,
+    pub(super) pack_path: PathBuf,
+    pub(super) index_path: PathBuf,
+    pub(super) pack: File,
+}
+
+impl Layout {
+    pub(super) fn open(
+        path: &Path,
+        expected: ExpectedGitPack<'_>,
+        cancelled: &impl Fn() -> bool,
+    ) -> Result<Self, Error> {
+        let reader = SelectedRepositoryReader::open(path).map_err(|_| Error::UnsafeParent)?;
+        let mut nodes = vec![bind(&reader, "", true)?];
+        for prefix in ["decoded", "selection"] {
+            staging::check_cancel(cancelled)?;
+            nodes.push(bind(&reader, prefix, true)?);
+            for directory in view::INITIAL_DIRECTORIES {
+                nodes.push(bind(&reader, &format!("{prefix}/{directory}"), true)?);
+            }
+            for (name, contents) in [
+                ("HEAD", view::INITIAL_HEAD.to_owned()),
+                ("config", view::INITIAL_CONFIG.to_owned()),
+                ("shallow", format!("{}\n", expected.base_commit)),
+            ] {
+                let name = format!("{prefix}/{name}");
+                nodes.push(bind(&reader, &name, false)?);
+                let record = reader.root.read_private_file(&name, 128).map_err(|_| Error::Object)?;
+                if record.bytes != contents.as_bytes() {
+                    return Err(Error::Object);
+                }
+            }
+        }
+        let pack_directory = nodes
+            .iter()
+            .find(|node| node.name == "decoded/objects/pack")
+            .ok_or(Error::Object)?;
+        let names = children(pack_directory, 2)?;
+        let (pack_name, hash) = names
+            .iter()
+            .find_map(|name| {
+                name.strip_prefix("pack-")
+                    .and_then(|tail| tail.strip_suffix(".pack"))
+                    .map(|hash| (name, hash))
+            })
+            .ok_or(Error::Object)?;
+        if hash.len() != 40
+            || !hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(Error::Object);
+        }
+        let index_name = format!("pack-{hash}.idx");
+        let pack_hash = Oid::from_str(hash).map_err(|_| Error::Object)?;
+        if names.len() != 2 || !names.contains(&index_name) {
+            return Err(Error::Object);
+        }
+        let pack_name = format!("decoded/objects/pack/{pack_name}");
+        let index_name = format!("decoded/objects/pack/{index_name}");
+        let pack_node = bind(&reader, &pack_name, false)?;
+        let index_node = bind(&reader, &index_name, false)?;
+        if pack_node.metadata.len() != expected.encoded_bytes
+            || index_node.metadata.len() > MAX_OBJECTS as u64 * 40 + 2048
+        {
+            return Err(Error::Limit);
+        }
+        let pack = reopen(&pack_node.handle)?;
+        let index_bytes = index_node.metadata.len();
+        let result = Self {
+            path: path.to_path_buf(),
+            reader,
+            pack_hash,
+            index_bytes,
+            nodes: {
+                nodes.extend([pack_node, index_node]);
+                nodes
+            },
+            pack_path: path.join(pack_name),
+            index_path: path.join(index_name),
+            pack,
+        };
+        result.recheck(cancelled)?;
+        Ok(result)
+    }
+
+    pub(super) fn recheck(&self, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+        let current = SelectedRepositoryReader::open(&self.path).map_err(|_| Error::UnsafeParent)?;
+        let first = self.nodes.first().ok_or(Error::Object)?;
+        if !same_metadata(
+            &first.metadata,
+            &current.root.handle().metadata().map_err(|_| Error::Storage)?,
+        ) {
+            return Err(Error::UnsafeParent);
+        }
+        for node in &self.nodes {
+            staging::check_cancel(cancelled)?;
+            let named = bind(&self.reader, &node.name, node.metadata.is_dir())?;
+            if !same_metadata(&node.metadata, &named.metadata)
+                || !same_metadata(&node.metadata, &node.handle.metadata().map_err(|_| Error::Storage)?)
+            {
+                return Err(Error::Object);
+            }
+            if node.metadata.is_dir() {
+                let prefix = if node.name.is_empty() {
+                    String::new()
+                } else {
+                    format!("{}/", node.name)
+                };
+                let expected = self
+                    .nodes
+                    .iter()
+                    .filter_map(|child| {
+                        child
+                            .name
+                            .strip_prefix(&prefix)
+                            .filter(|name| !name.is_empty() && !name.contains('/'))
+                    })
+                    .collect::<Vec<_>>();
+                let actual = children(node, expected.len())?;
+                if actual.len() != expected.len() || actual.iter().any(|name| !expected.contains(&name.as_str())) {
+                    return Err(Error::Object);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn check_pack_identity(&mut self, objects: u32) -> Result<(), Error> {
+        if self.index_bytes > u64::from(objects) * 40 + 2048 {
+            Err(Error::Limit)
+        } else {
+            let mut trailer = [0; 20];
+            self.pack.seek(SeekFrom::End(-20)).map_err(|_| Error::Source)?;
+            self.pack.read_exact(&mut trailer).map_err(|_| Error::Source)?;
+            if trailer == self.pack_hash.as_bytes() {
+                Ok(())
+            } else {
+                Err(Error::Object)
+            }
+        }
+    }
+}
+
+fn bind(reader: &SelectedRepositoryReader, name: &str, directory: bool) -> Result<Node, Error> {
+    let handle = File::from(
+        openat2(
+            reader.root.handle(),
+            if name.is_empty() { "." } else { name },
+            OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        )
+        .map_err(|_| Error::UnsafeParent)?,
+    );
+    let metadata = handle.metadata().map_err(|_| Error::Storage)?;
+    let root = reader.root.handle().metadata().map_err(|_| Error::Storage)?;
+    if metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.dev() != root.dev()
+        || metadata.nlink() == 0
+        || metadata.mode() & 0o7000 != 0
+    {
+        return Err(Error::UnsafeParent);
+    }
+    // Inner modes inherit umask; the verified 0700 root and views provide privacy.
+    if directory {
+        if !metadata.is_dir() || (matches!(name, "" | "decoded" | "selection") && metadata.mode() & 0o7777 != 0o700) {
+            return Err(Error::UnsafeParent);
+        }
+    } else if !metadata.is_file() || metadata.nlink() != 1 || metadata.mode() & 0o7777 != 0o600 {
+        return Err(Error::UnsafeParent);
+    }
+    Ok(Node {
+        name: name.to_owned(),
+        handle,
+        metadata,
+    })
+}
+
+fn reopen(handle: &File) -> Result<File, Error> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(format!("/proc/self/fd/{}", handle.as_raw_fd()))
+        .map_err(|_| Error::Storage)
+}
+
+fn children(node: &Node, limit: usize) -> Result<Vec<String>, Error> {
+    let mut names = Vec::new();
+    for entry in Dir::read_from(&reopen(&node.handle)?).map_err(|_| Error::Storage)? {
+        let entry = entry.map_err(|_| Error::Storage)?;
+        let name = entry.file_name().to_str().map_err(|_| Error::Object)?;
+        if matches!(name, "." | "..") {
+            continue;
+        }
+        if names.len() >= limit {
+            return Err(Error::Object);
+        }
+        names.push(name.to_owned());
+    }
+    Ok(names)
+}

--- a/crates/horizon-core/src/repository_overlay/seed/receive/observe/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/observe/mod.rs
@@ -1,0 +1,80 @@
+mod layout;
+
+use super::{
+    ExpectedGitPack, MAX_OBJECTS, PackReceiveLimits, ReceivedGitPack, SeedError, native, output, staging, view,
+};
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+/// Reopen one explicit existing received pack without creating, repairing, writing,
+/// renaming or removing named state. Revalidate the fixed private layout, encoded
+/// identity, existing native index and exact shallow commit closure. Missing or
+/// unverified input never authorizes another receive, setup or task execution.
+/// This is not source-export approval, immutable publication, synchronization or
+/// a ready checkout. Existing namespace/seed/setup verification remains required.
+/// Requires trusted Git/prlimit and stable exclusive ancestry, mounts and input
+/// throughout verification and consumption. Run off the UI thread; filesystem and
+/// blocking reads are outside native pipe deadlines. Drop retains all data.
+/// # Errors
+/// Invalid expectations/limits, missing, unsafe, changed, corrupt or incomplete
+/// input, cancellation and native failures return redacted errors without repair.
+pub fn observe_git_base_pack(
+    path: &Path,
+    expected: ExpectedGitPack<'_>,
+    limits: PackReceiveLimits,
+    cancelled: impl Fn() -> bool,
+) -> Result<ReceivedGitPack, SeedError> {
+    limits.validate(expected)?;
+    staging::check_cancel(&cancelled)?;
+    let mut layout = layout::Layout::open(path, expected, &cancelled)?;
+    let summary = output::copy(
+        &mut |bytes| {
+            if cancelled() {
+                return Err(io::ErrorKind::ConnectionAborted.into());
+            }
+            layout.pack.read(bytes)
+        },
+        &mut io::sink(),
+        expected.encoded_bytes,
+        MAX_OBJECTS,
+    )?;
+    if summary.bytes != expected.encoded_bytes || &summary.sha256 != expected.sha256 {
+        return Err(SeedError::Object);
+    }
+    layout.check_pack_identity(summary.objects)?;
+    layout.recheck(&cancelled)?;
+    let decoded = path.join("decoded");
+    native::verify(
+        view::verify_command(
+            &decoded,
+            &layout.pack_path,
+            &layout.index_path,
+            limits.source,
+            expected.encoded_bytes,
+        ),
+        limits.source,
+        &cancelled,
+    )?;
+    layout.recheck(&cancelled)?;
+    native::enumerate(
+        view::stored_closure_command(&decoded, limits.source),
+        expected.base_commit,
+        summary.objects,
+        limits.source,
+        &cancelled,
+    )?;
+    layout.recheck(&cancelled)?;
+    Ok(ReceivedGitPack {
+        path: path.to_path_buf(),
+        objects_directory: decoded.join("objects"),
+        base_commit: expected.base_commit,
+        sha256: summary.sha256,
+        encoded_bytes: summary.bytes,
+        objects: summary.objects,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/observe/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/observe/tests.rs
@@ -1,0 +1,416 @@
+use super::*;
+use crate::repository_overlay::seed::{
+    export::{PackExportLimits, PreparedGitPack, prepare_git_base_pack},
+    prepare_git_seed,
+    receive::receive_git_base_pack,
+    tests::{Fixture, commit, private_fixture},
+};
+use crate::repository_overlay::{
+    bundle::codec,
+    checkout::prepare_private_checkout,
+    namespace::resolve_namespaces_from_source,
+    seed::packed::{PackedGitObjectSource, PackedSourceLimits},
+};
+use std::{
+    cell::Cell,
+    collections::BTreeMap,
+    fs::{self, File},
+    io::{Seek, SeekFrom},
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{MetadataExt, PermissionsExt, symlink},
+        net::UnixListener,
+    },
+    path::PathBuf,
+    process::Command,
+    time::Duration,
+};
+
+struct Prepared {
+    fixture: Fixture,
+    _source: tempfile::TempDir,
+    destination: tempfile::TempDir,
+    pack: PreparedGitPack,
+    path: PathBuf,
+}
+
+impl Prepared {
+    fn new() -> Self {
+        Self::from_fixture(Fixture::new())
+    }
+
+    fn from_fixture(fixture: Fixture) -> Self {
+        let source = private_fixture();
+        let resolved = fixture.resolve(vec![], vec![], vec![]);
+        let seed = prepare_git_seed(source.path(), &resolved, &mut fixture.source(), || false).unwrap();
+        let pack = prepare_git_base_pack(source.path(), &seed, PackExportLimits::default(), || false).unwrap();
+        let destination = private_fixture();
+        let received = receive_git_base_pack(
+            destination.path(),
+            (&pack).into(),
+            &mut File::open(pack.path()).unwrap(),
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap();
+        let path = received.path().to_path_buf();
+        drop(received);
+        Self {
+            fixture,
+            _source: source,
+            destination,
+            pack,
+            path,
+        }
+    }
+
+    fn observe(&self) -> Result<ReceivedGitPack, SeedError> {
+        observe_git_base_pack(&self.path, (&self.pack).into(), PackReceiveLimits::default(), || false)
+    }
+
+    fn packed(&self) -> PathBuf {
+        fs::read_dir(self.path.join("decoded/objects/pack"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| path.extension().unwrap() == "pack")
+            .unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct SnapshotNode {
+    device: u64,
+    inode: u64,
+    mode: u32,
+    links: u64,
+    bytes: u64,
+    modified: (i64, i64),
+    changed: (i64, i64),
+    contents: Vec<u8>,
+}
+
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, SnapshotNode> {
+    let mut result = BTreeMap::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let metadata = fs::symlink_metadata(&path).unwrap();
+        if metadata.is_dir() {
+            pending.extend(fs::read_dir(&path).unwrap().map(|entry| entry.unwrap().path()));
+        }
+        let contents = if metadata.is_file() {
+            fs::read(&path).unwrap()
+        } else if metadata.is_symlink() {
+            fs::read_link(&path).unwrap().as_os_str().as_bytes().to_vec()
+        } else {
+            vec![]
+        };
+        result.insert(
+            path,
+            SnapshotNode {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+                mode: metadata.mode(),
+                links: metadata.nlink(),
+                bytes: metadata.len(),
+                modified: (metadata.mtime(), metadata.mtime_nsec()),
+                changed: (metadata.ctime(), metadata.ctime_nsec()),
+                contents,
+            },
+        );
+    }
+    result
+}
+
+#[test]
+fn dropped_receipt_reopens_without_changing_existing_input() {
+    let prepared = Prepared::new();
+    let before = snapshot(prepared.destination.path());
+    let observed = prepared.observe().unwrap();
+    assert_eq!(observed.base_commit(), prepared.fixture.commit);
+    assert_eq!(observed.sha256(), prepared.pack.sha256());
+    assert_eq!(observed.encoded_bytes(), prepared.pack.encoded_bytes());
+    assert_eq!(observed.objects(), 3);
+    let scratch = private_fixture();
+    let mut reader = PackedGitObjectSource::new(
+        scratch.path(),
+        observed.objects_directory(),
+        PackedSourceLimits::default(),
+        || false,
+    )
+    .unwrap();
+    let encoded = codec::encode(prepared.fixture.resolve(vec![], vec![], vec![]).bundle()).unwrap();
+    let bundle = codec::decode(&encoded).unwrap();
+    let resolved = resolve_namespaces_from_source(&mut reader, bundle, || false).unwrap();
+    let checkout = prepare_private_checkout(scratch.path(), &resolved, &mut reader, || false).unwrap();
+    assert_eq!(fs::read(checkout.path().join("kept")).unwrap(), b"base\0literal\xff");
+    let repository = git2::Repository::open(checkout.path()).unwrap();
+    assert_eq!(repository.head().unwrap().target(), Some(prepared.fixture.commit));
+    assert!(repository.find_commit(prepared.fixture.ancestor).is_err());
+    assert_eq!(snapshot(prepared.destination.path()), before);
+    drop(observed);
+    assert_eq!(snapshot(prepared.destination.path()), before);
+}
+
+#[test]
+fn corrupt_missing_extra_and_unsafe_nodes_are_not_repaired_or_removed() {
+    for case in [
+        "pack",
+        "index",
+        "missing-index",
+        "head",
+        "config",
+        "shallow",
+        "selection",
+        "alternates",
+        "extra",
+        "reference",
+        "root-mode",
+        "view-mode",
+        "file-mode",
+        "hardlink",
+        "symlink",
+        "socket",
+    ] {
+        let prepared = Prepared::new();
+        let pack = prepared.packed();
+        let index = pack.with_extension("idx");
+        let _listener = if case == "socket" {
+            Some(UnixListener::bind(prepared.path.join("socket")).unwrap())
+        } else {
+            None
+        };
+        match case {
+            "pack" | "index" => {
+                let path = if case == "pack" { &pack } else { &index };
+                let mut bytes = fs::read(path).unwrap();
+                let last = bytes.len() - 1;
+                bytes[last] ^= 1;
+                fs::write(path, bytes).unwrap();
+            }
+            "missing-index" => fs::remove_file(index).unwrap(),
+            "head" => fs::write(prepared.path.join("decoded/HEAD"), "ref: refs/heads/private-marker\n").unwrap(),
+            "config" => fs::write(prepared.path.join("decoded/config"), "[include]\npath=private-marker\n").unwrap(),
+            "shallow" => fs::write(
+                prepared.path.join("decoded/shallow"),
+                format!("{}\n", prepared.fixture.ancestor),
+            )
+            .unwrap(),
+            "selection" => fs::write(prepared.path.join("selection/config"), "private-marker").unwrap(),
+            "alternates" => fs::write(prepared.path.join("decoded/objects/info/alternates"), "private-marker").unwrap(),
+            "extra" => fs::write(prepared.path.join("private-marker"), "unchanged").unwrap(),
+            "reference" => fs::write(prepared.path.join("decoded/refs/unexpected"), "private-marker").unwrap(),
+            "root-mode" => fs::set_permissions(&prepared.path, fs::Permissions::from_mode(0o755)).unwrap(),
+            "view-mode" => {
+                fs::set_permissions(prepared.path.join("decoded"), fs::Permissions::from_mode(0o755)).unwrap();
+            }
+            "file-mode" => fs::set_permissions(&pack, fs::Permissions::from_mode(0o640)).unwrap(),
+            "hardlink" => fs::hard_link(&pack, prepared.destination.path().join("extra-link")).unwrap(),
+            "symlink" => {
+                let retained = prepared.destination.path().join("retained-pack");
+                fs::rename(&pack, &retained).unwrap();
+                symlink(retained, &pack).unwrap();
+            }
+            "socket" => {}
+            _ => unreachable!(),
+        }
+        let before = snapshot(prepared.destination.path());
+        let error = prepared.observe().unwrap_err();
+        assert!(!format!("{error:?} {error}").contains("private-marker"));
+        assert!(!format!("{error:?} {error}").contains(prepared.path.to_str().unwrap()));
+        assert_eq!(snapshot(prepared.destination.path()), before, "{case}");
+    }
+}
+
+#[test]
+fn expectation_errors_missing_roots_and_cancellation_are_read_only() {
+    let prepared = Prepared::new();
+    let before = snapshot(prepared.destination.path());
+    let wrong_digest = crate::cloud_run::ArtifactDigest::sha256(b"unrelated");
+    for case in [
+        "digest",
+        "base",
+        "zero-base",
+        "short",
+        "long",
+        "missing",
+        "relative",
+        "limit",
+    ] {
+        let mut expected = ExpectedGitPack::from(&prepared.pack);
+        let mut limits = PackReceiveLimits::default();
+        let mut path = prepared.path.clone();
+        match case {
+            "digest" => expected.sha256 = &wrong_digest,
+            "base" => expected.base_commit = prepared.fixture.ancestor,
+            "zero-base" => expected.base_commit = git2::Oid::ZERO_SHA1,
+            "short" => expected.encoded_bytes -= 1,
+            "long" => expected.encoded_bytes += 1,
+            "missing" => path = prepared.destination.path().join("absent"),
+            "relative" => path = PathBuf::from("relative"),
+            "limit" => limits.encoded_bytes = expected.encoded_bytes - 1,
+            _ => unreachable!(),
+        }
+        assert!(
+            observe_git_base_pack(&path, expected, limits, || false).is_err(),
+            "{case}"
+        );
+        assert_eq!(snapshot(prepared.destination.path()), before, "{case}");
+    }
+    for threshold in [0, 1, 3, 15, 25, 45, 70] {
+        let calls = Cell::new(0);
+        let error = observe_git_base_pack(
+            &prepared.path,
+            (&prepared.pack).into(),
+            PackReceiveLimits::default(),
+            || {
+                let call = calls.get();
+                calls.set(call + 1);
+                call >= threshold
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error, SeedError::Cancelled, "{threshold}");
+        assert_eq!(snapshot(prepared.destination.path()), before);
+    }
+}
+
+#[test]
+fn pack_name_identity_cannot_be_substituted() {
+    let prepared = Prepared::new();
+    let pack = prepared.packed();
+    let renamed = pack.with_file_name(format!("pack-{}.pack", "0".repeat(40)));
+    fs::rename(pack.with_extension("idx"), renamed.with_extension("idx")).unwrap();
+    fs::rename(pack, renamed).unwrap();
+    let before = snapshot(prepared.destination.path());
+    assert!(prepared.observe().is_err());
+    assert_eq!(snapshot(prepared.destination.path()), before);
+}
+
+#[test]
+fn held_root_and_file_bindings_reject_replacement_without_mutation() {
+    for replace_root in [false, true] {
+        let prepared = Prepared::new();
+        let layout = layout::Layout::open(&prepared.path, (&prepared.pack).into(), &|| false).unwrap();
+        if replace_root {
+            fs::rename(&prepared.path, prepared.destination.path().join("retained-original")).unwrap();
+            fs::create_dir(&prepared.path).unwrap();
+            fs::set_permissions(&prepared.path, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::write(prepared.path.join("sentinel"), "unchanged").unwrap();
+        } else {
+            fs::write(prepared.path.join("decoded/config"), "changed").unwrap();
+        }
+        let before = snapshot(prepared.destination.path());
+        assert!(layout.recheck(&|| false).is_err());
+        assert_eq!(snapshot(prepared.destination.path()), before);
+    }
+}
+
+#[test]
+fn observation_commands_are_read_only_and_native_output_exit_and_deadline_are_checked() {
+    let prepared = Prepared::new();
+    let pack = prepared.packed();
+    let limits = PackedSourceLimits::default();
+    let before = snapshot(prepared.destination.path());
+    let command = view::verify_command(
+        &prepared.path.join("decoded"),
+        &pack,
+        &pack.with_extension("idx"),
+        limits,
+        prepared.pack.encoded_bytes(),
+    );
+    let args: Vec<_> = command.get_args().map(|arg| arg.to_str().unwrap()).collect();
+    assert_eq!(command.get_program(), "/usr/bin/prlimit");
+    for required in [
+        "index-pack",
+        "--verify",
+        "--strict",
+        "--no-rev-index",
+        "--threads=1",
+        "--object-format=sha1",
+    ] {
+        assert!(args.contains(&required));
+    }
+    assert!(!args.contains(&"--stdin") && !args.contains(&"--fix-thin"));
+    assert!(
+        !command
+            .get_envs()
+            .any(|(key, _)| key == "GIT_ALTERNATE_OBJECT_DIRECTORIES")
+    );
+    assert_eq!(snapshot(prepared.destination.path()), before);
+    for (script, expected) in [
+        ("exit 0", None),
+        ("printf unexpected", Some(SeedError::Object)),
+        ("exit 1", Some(SeedError::Source)),
+        ("exec sleep 30", Some(SeedError::Source)),
+    ] {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", script]);
+        let limits = PackedSourceLimits {
+            object_timeout: Duration::from_millis(100),
+            ..limits
+        };
+        assert_eq!(native::verify(command, limits, &|| false).err(), expected);
+        assert_eq!(snapshot(prepared.destination.path()), before);
+    }
+}
+
+#[test]
+fn initial_and_empty_parented_bases_reopen() {
+    for empty in [false, true] {
+        let mut fixture = Fixture::new();
+        fixture.commit = if empty {
+            commit(&fixture.repository, &[], &[fixture.commit])
+        } else {
+            fixture.ancestor
+        };
+        let prepared = Prepared::from_fixture(fixture);
+        let before = snapshot(prepared.destination.path());
+        let observed = prepared.observe().unwrap();
+        assert_eq!(observed.base_commit(), prepared.fixture.commit);
+        assert_eq!(observed.objects(), if empty { 2 } else { 3 });
+        assert_eq!(snapshot(prepared.destination.path()), before);
+    }
+}
+
+#[test]
+fn large_nested_repeated_objects_reopen_and_materialize_without_input_changes() {
+    const BYTES: usize = 65 * 1024 * 1024 + 1;
+    let mut fixture = Fixture::new();
+    let mut bytes = vec![b'z'; BYTES];
+    bytes[BYTES - 1] = 0xfd;
+    let blob = fixture.repository.blob(&bytes).unwrap();
+    drop(bytes);
+    fixture.commit = commit(
+        &fixture.repository,
+        &[
+            ("nested/executable", blob, 0o100_755),
+            ("nested/repeated", blob, 0o100_644),
+        ],
+        &[fixture.commit],
+    );
+    let prepared = Prepared::from_fixture(fixture);
+    let before = snapshot(prepared.destination.path());
+    let observed = prepared.observe().unwrap();
+    assert_eq!(observed.objects(), 4);
+    let scratch = private_fixture();
+    let mut reader = PackedGitObjectSource::new(
+        scratch.path(),
+        observed.objects_directory(),
+        PackedSourceLimits::default(),
+        || false,
+    )
+    .unwrap();
+    let encoded = codec::encode(prepared.fixture.resolve(vec![], vec![], vec![]).bundle()).unwrap();
+    let resolved = resolve_namespaces_from_source(&mut reader, codec::decode(&encoded).unwrap(), || false).unwrap();
+    let checkout = prepare_private_checkout(scratch.path(), &resolved, &mut reader, || false).unwrap();
+    for (name, executable) in [("executable", true), ("repeated", false)] {
+        let mut file = File::open(checkout.path().join("nested").join(name)).unwrap();
+        assert_eq!(file.metadata().unwrap().len(), BYTES as u64);
+        assert_eq!(file.metadata().unwrap().mode() & 0o100 != 0, executable);
+        file.seek(SeekFrom::End(-1)).unwrap();
+        let mut tail = [0];
+        file.read_exact(&mut tail).unwrap();
+        assert_eq!(tail, [0xfd]);
+    }
+    assert_eq!(snapshot(prepared.destination.path()), before);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -241,6 +241,10 @@ back into large multi-purpose modules.
   command isolation and framed chunk-copy/digest work remain shared with existing
   packed acquisition/export helpers. A received object directory still requires
   namespace/seed/setup policy checks; no publication or task admission is inferred.
+  Its `observe/` subtree reopens only the fixed generated layout without mutation:
+  a layout leaf pins/checks known nodes and pack identities; orchestration streams
+  encoded verification before shared read-only native index/closure checks. The
+  reader's existing metadata fingerprint is reused for held/named comparisons.
   See [private pack receipt](../remote-repository-pack-receipt.md).
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.

--- a/docs/remote-repository-pack-receipt.md
+++ b/docs/remote-repository-pack-receipt.md
@@ -45,6 +45,32 @@ approval, repository URL ownership or task admission. Existing namespace policy,
 link handling, seed identity and checkout verification remain required. Do not
 treat a received pack as a ready repository or as authority to retry setup.
 
+## Read-only reopening
+
+Use `observe_git_base_pack(existing_root, expected, limits, cancelled)` to verify
+an existing received pack after the original in-memory receipt has been dropped.
+It returns a new `ReceivedGitPack` only after checking the current bytes and layout;
+it does not rely on a cached receipt. Missing or invalid input returns an error,
+never a request to create, repair, receive again or rerun setup.
+
+Observation accepts only the receiver's fixed generated layout. It verifies exact
+HEAD/config/shallow metadata, the pack/index pair and its filename/trailer identity,
+encoded length/EOF/SHA-256, bounded native `index-pack --verify --strict`, and the
+original commit's complete shallow closure. Unknown entries, unsafe links and
+changed bindings are rejected. Held node identities and metadata are checked again
+around native operations. There is no index repair or filesystem synchronization.
+
+The root and both generated views must remain owned `0700` directories; these
+private boundaries protect inner directories whose modes inherit the creation
+umask. Files must remain owned `0600` regular single-link inodes. Stable exclusive
+ancestry and input remain caller preconditions: repeated checks do not create a
+snapshot or confinement against hostile same-user mutation. Ordinary reads may
+update filesystem access times; observation issues no data/permission writes.
+
+The same native/encoded limits and off-UI-thread requirements below apply. A
+successful observation verifies private input, not source approval, immutable
+publication, storage durability, remote task liveness or setup replay authority.
+
 ## Ownership, limits and failure
 
 The caller controls stable, exclusive scratch ancestry and supplies trusted
@@ -75,6 +101,12 @@ truncation/trailing input, checksum corruption, wrong base, extra objects/histor
 unsafe parents, cancellation, short reads and redacted reader errors. Existing
 shared-process/copy tests cover resource limits, stalled children and failed writes.
 
-Worker immutable input publication/observation, pinned transport, source-approval
+Observation tests compare contents, names, permissions and inode/time metadata
+before and after successful reopening, checkout consumption and rejected input.
+They cover corruption, missing/extra entries, unsafe links/modes, identity
+substitution, root rebinding, cancellation and native output/exit/deadline failures,
+including initial/empty bases and large repeated nested objects.
+
+Worker immutable input publication and protocol/status integration, pinned transport, source-approval
 UI and full cloud/PC-off acceptance remain separate. Closing local views must never
 implicitly stop or delete a persistent environment.


### PR DESCRIPTION
## Purpose

Add read-only reopening of an explicitly identified received Git pack after the original in-memory receipt is lost or dropped. Refs #383 and #470; this does not close either issue.

## Behavior

- Verify the fixed private layout and exact HEAD/config/shallow bytes, pack/index filename and trailer identity, encoded length/EOF/SHA-256, existing native index, and original commit's complete shallow object closure.
- Reject missing, corrupt, extra, unsafe or changed input without creation, repair, writes, rename, synchronization or removal. Recheck held and named node fingerprints around bounded native operations.
- Return verified private input for the existing namespace/checkout path. Missing/error results never authorize receive or setup replay. Dropping a receipt retains data.
- Linux library API only. Requires trusted Git/prlimit and stable exclusive ancestry, mounts and input through consumption. Private roots/views remain 0700 and files 0600; inner directories inherit umask. Ordinary reads may update access times. This is not hostile same-user race confinement.

No protocol, transport, source-approval UI, worker publication, durability acknowledgement, task start, cloud-provider action or release is added. Existing close/detach behavior remains unchanged.

## Validation

Candidate: `7f2194a9a1b7cc5746dbe68e000a519e3cb902e8`.

- Independent local review clear; seven source/test files, 809 changed lines, plus two documentation files.
- All eight required lanes passed on the source snapshot and again on the exact commit: formatting, maintainability, version sync, default/speech workspace tests, blocking/strict/pedantic Clippy.
- Native seed/pack family: 45 passed. Includes receive/drop/reopen/checkout, unchanged-input snapshots, 16 unsafe/corrupt cases, expectation failures, cancellation, pack-name substitution, root rebinding, native output/exit/deadline errors, initial/empty bases and 65 MiB-plus nested repeated objects. The existing casefold-only fixture explicitly skipped because this filesystem lacks that capability; no casefold execution proof is claimed.
- All six source-image lanes passed and passed again on the exact candidate images: overlay receipt/output loss, independent setup, build-context/final-layer packaging, repository materialization, runtime isolation and retained host identity. Packaging verified 363 allowlisted inputs and all 31 final layers. These are local synthetic regression checks, not cloud/PC-off acceptance.

Runtime image: `sha256:ca0605facdc769e47baede037ecbcdd536900c3670abe3b0ac44de323bb33380`.
Builder image: `sha256:bb3021c9f7796088932728e58db941160da31f963a8b1fb4df9af36773a22965`.
Repository helper SHA-256: `5a0d1aa2e53fe828fbac883142a7eb3047891ab5badee7c68c1a898b61bfe856`.
