### PR TITLE
Publish verified Git packs on qualified storage

### DIFF
--- a/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
@@ -2,6 +2,7 @@
 
 mod native;
 mod observe;
+pub mod publication;
 
 pub use observe::observe_git_base_pack;
 
@@ -116,6 +117,16 @@ impl fmt::Debug for ReceivedGitPack {
             .field("encoded_bytes", &self.encoded_bytes)
             .field("objects", &self.objects)
             .finish_non_exhaustive()
+    }
+}
+
+impl<'a> From<&'a ReceivedGitPack> for ExpectedGitPack<'a> {
+    fn from(pack: &'a ReceivedGitPack) -> Self {
+        Self {
+            base_commit: pack.base_commit(),
+            sha256: pack.sha256(),
+            encoded_bytes: pack.encoded_bytes(),
+        }
     }
 }
 

--- a/crates/horizon-core/src/repository_overlay/seed/receive/observe/layout.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/observe/layout.rs
@@ -23,7 +23,7 @@ struct Node {
     metadata: Metadata,
 }
 
-pub(super) struct Layout {
+pub(in super::super) struct Layout {
     path: PathBuf,
     reader: SelectedRepositoryReader,
     nodes: Vec<Node>,
@@ -35,7 +35,7 @@ pub(super) struct Layout {
 }
 
 impl Layout {
-    pub(super) fn open(
+    pub(in super::super) fn open(
         path: &Path,
         expected: ExpectedGitPack<'_>,
         cancelled: &impl Fn() -> bool,
@@ -114,7 +114,7 @@ impl Layout {
         Ok(result)
     }
 
-    pub(super) fn recheck(&self, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+    pub(in super::super) fn recheck(&self, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
         let current = SelectedRepositoryReader::open(&self.path).map_err(|_| Error::UnsafeParent)?;
         let first = self.nodes.first().ok_or(Error::Object)?;
         if !same_metadata(
@@ -151,6 +151,42 @@ impl Layout {
                 if actual.len() != expected.len() || actual.iter().any(|name| !expected.contains(&name.as_str())) {
                     return Err(Error::Object);
                 }
+            }
+        }
+        Ok(())
+    }
+
+    pub(in super::super) fn root(&self) -> &File {
+        self.reader.root.handle()
+    }
+
+    pub(in super::super) fn files(&self) -> impl Iterator<Item = &File> {
+        self.nodes
+            .iter()
+            .filter(|node| node.metadata.is_file())
+            .map(|node| &node.handle)
+    }
+
+    pub(in super::super) fn directories(&self) -> impl DoubleEndedIterator<Item = &File> {
+        self.nodes
+            .iter()
+            .filter(|node| node.metadata.is_dir())
+            .map(|node| &node.handle)
+    }
+
+    pub(in super::super) fn matches_relocated(&self, original: &Self) -> Result<(), Error> {
+        if self.nodes.len() != original.nodes.len() {
+            return Err(Error::Object);
+        }
+        for (current, previous) in self.nodes.iter().zip(&original.nodes) {
+            // Rename changes the root's ctime, not its held identity or child inodes.
+            let expected = if current.name.is_empty() {
+                previous.handle.metadata().map_err(|_| Error::Storage)?
+            } else {
+                previous.metadata.clone()
+            };
+            if current.name != previous.name || !same_metadata(&current.metadata, &expected) {
+                return Err(Error::Object);
             }
         }
         Ok(())
@@ -207,7 +243,7 @@ fn bind(reader: &SelectedRepositoryReader, name: &str, directory: bool) -> Resul
     })
 }
 
-fn reopen(handle: &File) -> Result<File, Error> {
+pub(in super::super) fn reopen(handle: &File) -> Result<File, Error> {
     OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)

--- a/crates/horizon-core/src/repository_overlay/seed/receive/observe/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/observe/mod.rs
@@ -1,4 +1,4 @@
-mod layout;
+pub(super) mod layout;
 
 use super::{
     ExpectedGitPack, MAX_OBJECTS, PackReceiveLimits, ReceivedGitPack, SeedError, native, output, staging, view,
@@ -77,4 +77,4 @@ pub fn observe_git_base_pack(
 }
 
 #[cfg(test)]
-mod tests;
+pub(super) mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/observe/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/observe/tests.rs
@@ -78,7 +78,7 @@ impl Prepared {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-struct SnapshotNode {
+pub(in super::super) struct SnapshotNode {
     device: u64,
     inode: u64,
     mode: u32,
@@ -89,7 +89,7 @@ struct SnapshotNode {
     contents: Vec<u8>,
 }
 
-fn snapshot(root: &Path) -> BTreeMap<PathBuf, SnapshotNode> {
+pub(in super::super) fn snapshot(root: &Path) -> BTreeMap<PathBuf, SnapshotNode> {
     let mut result = BTreeMap::new();
     let mut pending = vec![root.to_path_buf()];
     while let Some(path) = pending.pop() {

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/linux.rs
@@ -1,0 +1,177 @@
+use super::super::{
+    observe::layout::{Layout, reopen},
+    observe_git_base_pack, staging,
+};
+use super::{
+    PackPublicationError as Error, PackPublicationFailure as Failure, PackReceiveLimits, PublishedGitPack,
+    ReceivedGitPack,
+};
+use crate::repository_overlay::{
+    checkout::publication::validate_sibling_name, reader::SelectedRepositoryReader, storage,
+};
+use rustix::fs::{RenameFlags, renameat_with};
+use std::{
+    ffi::OsString,
+    fs::File,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SyncPoint {
+    File,
+    Directory,
+    PublishedRoot,
+    Parent,
+}
+
+pub(super) struct Binding {
+    parent: File,
+    parent_path: PathBuf,
+    source: OsString,
+    layout: Layout,
+}
+
+pub(super) fn publish(
+    mut pack: ReceivedGitPack,
+    sibling: &str,
+    limits: PackReceiveLimits,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+    rename: &mut impl FnMut(&Binding, &str) -> rustix::io::Result<()>,
+    storage: &impl Fn(&File) -> Result<(), Error>,
+) -> Result<PublishedGitPack, Failure> {
+    let binding = match before(&pack, sibling, limits, cancelled, sync, storage) {
+        Ok(binding) => binding,
+        Err(reason) => return Err(Failure::Unpublished { reason, pack }),
+    };
+    if let Err(error) = rename(&binding, sibling) {
+        let reason = match error {
+            rustix::io::Errno::EXIST | rustix::io::Errno::NOTEMPTY => Error::DestinationExists,
+            rustix::io::Errno::NOSYS => Error::Unsupported,
+            _ => {
+                return Err(Failure::RenameUnconfirmed {
+                    destination: pack.path.with_file_name(sibling),
+                    pack: Box::new(pack),
+                });
+            }
+        };
+        return Err(Failure::Unpublished { reason, pack });
+    }
+    // No later failure may describe a successful rename as an unpublished source.
+    pack.path.set_file_name(sibling);
+    pack.objects_directory = pack.path.join("decoded/objects");
+    let pack = PublishedGitPack(pack);
+    if let Err(reason) = after(pack.pack(), &binding, cancelled, sync) {
+        return Err(Failure::PublishedUnsynchronized { reason, pack });
+    }
+    Ok(pack)
+}
+
+fn before(
+    pack: &ReceivedGitPack,
+    sibling: &str,
+    limits: PackReceiveLimits,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+    storage: &impl Fn(&File) -> Result<(), Error>,
+) -> Result<Binding, Error> {
+    staging::check_cancel(cancelled)?;
+    limits.validate(pack.into())?;
+    validate_sibling_name(sibling).map_err(|_| Error::InvalidName)?;
+    if pack.path.file_name() == Some(std::ffi::OsStr::new(sibling)) {
+        return Err(Error::InvalidName);
+    }
+    let parent_path = pack.path.parent().ok_or(Error::Storage)?.to_path_buf();
+    let parent = directory(&parent_path)?;
+    let binding = Binding {
+        parent,
+        parent_path,
+        source: pack.path.file_name().ok_or(Error::Storage)?.to_os_string(),
+        layout: Layout::open(&pack.path, pack.into(), cancelled)?,
+    };
+    binding.verify_parent()?;
+    storage(&binding.parent)?;
+    observe_git_base_pack(&pack.path, pack.into(), limits, cancelled)?;
+    binding.layout.recheck(cancelled)?;
+    for (point, files) in [
+        (SyncPoint::File, binding.layout.files().collect::<Vec<_>>()),
+        (SyncPoint::Directory, binding.layout.directories().rev().collect()),
+    ] {
+        for file in files {
+            staging::check_cancel(cancelled)?;
+            sync(point, &reopen(file)?)?;
+            binding.layout.recheck(cancelled)?;
+        }
+    }
+    binding.verify_parent()?;
+    Ok(binding)
+}
+
+fn after(
+    pack: &ReceivedGitPack,
+    binding: &Binding,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
+    staging::check_cancel(cancelled)?;
+    binding.verify_parent()?;
+    let layout = Layout::open(&pack.path, pack.into(), cancelled)?;
+    layout.matches_relocated(&binding.layout)?;
+    for (point, file) in [
+        (SyncPoint::PublishedRoot, layout.root()),
+        (SyncPoint::Parent, &binding.parent),
+    ] {
+        staging::check_cancel(cancelled)?;
+        sync(point, &reopen(file)?)?;
+        layout.recheck(cancelled)?;
+        layout.matches_relocated(&binding.layout)?;
+        binding.verify_parent()?;
+    }
+    Ok(())
+}
+
+impl Binding {
+    fn verify_parent(&self) -> Result<(), Error> {
+        let named = directory(&self.parent_path)?.metadata().map_err(|_| Error::Storage)?;
+        let held = self.parent.metadata().map_err(|_| Error::Storage)?;
+        let root = self.layout.root().metadata().map_err(|_| Error::Storage)?;
+        if (named.dev(), named.ino()) != (held.dev(), held.ino()) || root.dev() != held.dev() {
+            Err(Error::Storage)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn directory(path: &Path) -> Result<File, Error> {
+    let reader = SelectedRepositoryReader::open(path).map_err(|_| Error::Storage)?;
+    let file = reader.root.handle().try_clone().map_err(|_| Error::Storage)?;
+    let metadata = file.metadata().map_err(|_| Error::Storage)?;
+    if !metadata.is_dir()
+        || metadata.mode() & 0o7777 != 0o700
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.nlink() == 0
+    {
+        Err(Error::Storage)
+    } else {
+        Ok(file)
+    }
+}
+
+pub(super) fn rename(binding: &Binding, sibling: &str) -> rustix::io::Result<()> {
+    renameat_with(
+        &binding.parent,
+        &binding.source,
+        &binding.parent,
+        sibling,
+        RenameFlags::NOREPLACE,
+    )
+}
+
+pub(super) fn supported_storage(parent: &File) -> Result<(), Error> {
+    storage::qualify(parent).map_err(|error| match error {
+        storage::StorageQualificationError::Unsupported => Error::Unsupported,
+        storage::StorageQualificationError::Storage => Error::Storage,
+    })
+}

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/linux.rs
@@ -45,6 +45,12 @@ pub(super) fn publish(
         Ok(binding) => binding,
         Err(reason) => return Err(Failure::Unpublished { reason, pack }),
     };
+    if let Err(reason) = staging::check_cancel(cancelled) {
+        return Err(Failure::Unpublished {
+            reason: reason.into(),
+            pack,
+        });
+    }
     if let Err(error) = rename(&binding, sibling) {
         let reason = match error {
             rustix::io::Errno::EXIST | rustix::io::Errno::NOTEMPTY => Error::DestinationExists,

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/mod.rs
@@ -1,0 +1,100 @@
+//! Explicit qualified no-replace pack publication, not setup or source approval.
+
+mod linux;
+
+use super::{PackReceiveLimits, ReceivedGitPack, SeedError};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+/// Rename succeeded; the containing result states whether synchronization and
+/// final verification were acknowledged. Drop always retains the named data.
+#[derive(Debug)]
+pub struct PublishedGitPack(ReceivedGitPack);
+
+impl PublishedGitPack {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        self.0.path()
+    }
+
+    #[must_use]
+    pub fn pack(&self) -> &ReceivedGitPack {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PackPublicationError {
+    #[error("pack publication requires a fresh single-component sibling name")]
+    InvalidName,
+    #[error("pack publication destination already exists")]
+    DestinationExists,
+    #[error("pack publication storage is unsupported")]
+    Unsupported,
+    #[error("pack publication synchronization or binding verification failed")]
+    Storage,
+    #[error(transparent)]
+    Verification(#[from] SeedError),
+}
+
+/// Pre-rename failure, acknowledged rename and uncertain rename are distinct.
+/// No error, dropped receipt or lost response authorizes cleanup or replay.
+#[derive(thiserror::Error)]
+pub enum PackPublicationFailure {
+    #[error("pack remains unpublished: {reason}")]
+    Unpublished {
+        reason: PackPublicationError,
+        pack: ReceivedGitPack,
+    },
+    #[error("pack was renamed but final confirmation is incomplete: {reason}")]
+    PublishedUnsynchronized {
+        reason: PackPublicationError,
+        pack: PublishedGitPack,
+    },
+    #[error("pack rename outcome is uncertain; retain and inspect both names")]
+    RenameUnconfirmed {
+        pack: Box<ReceivedGitPack>,
+        destination: PathBuf,
+    },
+}
+
+impl fmt::Debug for PackPublicationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+/// Reverify a received pack, synchronize its fixed private tree and publish to one
+/// fresh sibling using no-replace rename. Requires stable exclusive ownership of
+/// input/ancestry, unchanged mounts and trusted kernel metadata/Git/prlimit. Linux
+/// journaled ext4 with barriers is required; no copy or filesystem fallback occurs.
+/// Acknowledgement means bounded file/directory synchronization and binding checks
+/// succeeded on healthy storage, not proof of power-loss survival or cloud durability.
+/// The input is immutable by protocol, not protected against hostile same-user writes.
+/// Run off the UI thread: cancellation cannot interrupt filesystem/native blocking
+/// calls. Source approval, namespace/setup checks and task admission remain separate.
+/// # Errors
+/// Failures preserve the source, destination or both names according to the returned
+/// variant. After successful rename, all errors retain the destination receipt; no
+/// retry, repair, overwrite, rollback, deletion or task start occurs, including Drop.
+pub fn publish_sibling_git_pack(
+    pack: ReceivedGitPack,
+    sibling: &str,
+    limits: PackReceiveLimits,
+    cancelled: impl Fn() -> bool,
+) -> Result<PublishedGitPack, PackPublicationFailure> {
+    linux::publish(
+        pack,
+        sibling,
+        limits,
+        &cancelled,
+        &mut |_, file| file.sync_all().map_err(|_| PackPublicationError::Storage),
+        &mut linux::rename,
+        &linux::supported_storage,
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/tests.rs
@@ -217,6 +217,51 @@ fn cancellation_before_and_after_rename_never_rolls_back_or_replays() {
     }
 }
 
+#[test]
+fn cancellation_after_final_layout_check_prevents_rename() {
+    let parent = private_fixture();
+    let pack = received(parent.path());
+    let before = snapshot(parent.path());
+    let nodes = snapshot(pack.path()).len();
+    let root = fs::metadata(pack.path()).unwrap().ino();
+    let checks_left = Cell::new(None);
+    let renamed = Cell::new(false);
+    let result = linux::publish(
+        pack,
+        "ready",
+        PackReceiveLimits::default(),
+        &|| match checks_left.get() {
+            Some(0) => true,
+            Some(left) => {
+                checks_left.set(Some(left - 1));
+                false
+            }
+            None => false,
+        },
+        &mut |point, file| {
+            sync(point, file)?;
+            if point == SyncPoint::Directory && file.metadata().unwrap().ino() == root {
+                // Finish the last layout check, then cancel before parent verification
+                // returns. There must be a fresh cancellation check before rename.
+                checks_left.set(Some(nodes));
+            }
+            Ok(())
+        },
+        &mut |binding, sibling| {
+            renamed.set(true);
+            linux::rename(binding, sibling)
+        },
+        &|_| Ok(()),
+    );
+    drop(unpublished(
+        result.unwrap_err(),
+        Error::Verification(SeedError::Cancelled),
+    ));
+    assert!(!renamed.get());
+    assert_eq!(checks_left.get(), Some(0));
+    assert_eq!(snapshot(parent.path()), before);
+}
+
 fn unpublished(failure: Failure, expected: Error) -> ReceivedGitPack {
     assert!(!format!("{failure:?} {failure}").contains("/tmp/"));
     let Failure::Unpublished { reason, pack } = failure else {

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/tests.rs
@@ -1,0 +1,527 @@
+use super::super::observe::tests::{SnapshotNode, snapshot};
+use super::*;
+use crate::repository_overlay::seed::{
+    export::{PackExportLimits, prepare_git_base_pack},
+    prepare_git_seed,
+    receive::{observe_git_base_pack, receive_git_base_pack},
+    tests::{Fixture, private_fixture},
+};
+use crate::repository_overlay::{
+    bundle::codec,
+    checkout::prepare_private_checkout,
+    namespace::resolve_namespaces_from_source,
+    seed::packed::{PackedGitObjectSource, PackedSourceLimits},
+};
+use PackPublicationError as Error;
+use PackPublicationFailure as Failure;
+use linux::SyncPoint;
+use std::{
+    cell::Cell,
+    collections::BTreeMap,
+    fs::{self, File},
+    os::unix::{
+        fs::{MetadataExt, PermissionsExt, symlink},
+        net::UnixListener,
+    },
+};
+
+fn received(parent: &Path) -> ReceivedGitPack {
+    let fixture = Fixture::new();
+    received_fixture(parent, &fixture)
+}
+
+fn received_fixture(parent: &Path, fixture: &Fixture) -> ReceivedGitPack {
+    let source = private_fixture();
+    let resolved = fixture.resolve(vec![], vec![], vec![]);
+    let seed = prepare_git_seed(source.path(), &resolved, &mut fixture.source(), || false).unwrap();
+    let pack = prepare_git_base_pack(source.path(), &seed, PackExportLimits::default(), || false).unwrap();
+    receive_git_base_pack(
+        parent,
+        (&pack).into(),
+        &mut File::open(pack.path()).unwrap(),
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap()
+}
+
+fn tree(root: &Path) -> BTreeMap<PathBuf, SnapshotNode> {
+    snapshot(root)
+        .into_iter()
+        .filter_map(|(path, node)| {
+            let relative = path.strip_prefix(root).unwrap();
+            (!relative.as_os_str().is_empty()).then(|| (relative.to_path_buf(), node))
+        })
+        .collect()
+}
+
+fn sync(_: SyncPoint, file: &File) -> Result<(), Error> {
+    file.sync_all().map_err(|_| Error::Storage)
+}
+
+#[test]
+fn qualified_pack_publication_reopens_without_recreation() {
+    let parent = private_fixture();
+    if linux::supported_storage(&File::open(parent.path()).unwrap()) == Err(Error::Unsupported) {
+        eprintln!("SKIP qualified pack publication: journaled ext4 capability unavailable");
+        return;
+    }
+    let fixture = Fixture::new();
+    let pack = received_fixture(parent.path(), &fixture);
+    let old = pack.path().to_path_buf();
+    let before = tree(&old);
+    let inode = fs::metadata(&old).unwrap().ino();
+    let published = publish_sibling_git_pack(pack, "ready", PackReceiveLimits::default(), || false).unwrap();
+    assert_eq!(published.path(), parent.path().join("ready"));
+    assert!(!old.exists());
+    assert_eq!(fs::metadata(published.path()).unwrap().ino(), inode);
+    assert_eq!(tree(published.path()), before);
+    let observed = observe_git_base_pack(
+        published.path(),
+        published.pack().into(),
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap();
+    assert_eq!(observed.sha256(), published.pack().sha256());
+    let scratch = private_fixture();
+    let mut source = PackedGitObjectSource::new(
+        scratch.path(),
+        observed.objects_directory(),
+        PackedSourceLimits::default(),
+        || false,
+    )
+    .unwrap();
+    let encoded = codec::encode(fixture.resolve(vec![], vec![], vec![]).bundle()).unwrap();
+    let resolved = resolve_namespaces_from_source(&mut source, codec::decode(&encoded).unwrap(), || false).unwrap();
+    let checkout = prepare_private_checkout(scratch.path(), &resolved, &mut source, || false).unwrap();
+    assert_eq!(fs::read(checkout.path().join("kept")).unwrap(), b"base\0literal\xff");
+    assert_eq!(
+        git2::Repository::open(checkout.path())
+            .unwrap()
+            .head()
+            .unwrap()
+            .target(),
+        Some(fixture.commit)
+    );
+    assert_eq!(tree(published.path()), before);
+    drop(observed);
+    drop(published);
+    assert!(fs::metadata(parent.path().join("ready")).unwrap().is_dir());
+}
+
+#[test]
+fn every_sync_failure_retains_the_correct_name_and_unmodified_data() {
+    let expected = [
+        vec![SyncPoint::File; 8],
+        vec![SyncPoint::Directory; 11],
+        vec![SyncPoint::PublishedRoot, SyncPoint::Parent],
+    ]
+    .concat();
+    for failure_at in 0..=expected.len() {
+        let parent = private_fixture();
+        let pack = received(parent.path());
+        let old = pack.path().to_path_buf();
+        let target = parent.path().join("ready");
+        let before = snapshot(parent.path());
+        let contents = tree(&old);
+        let mut points = Vec::new();
+        let result = linux::publish(
+            pack,
+            "ready",
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut |point, file| {
+                assert_eq!(
+                    target.exists(),
+                    matches!(point, SyncPoint::PublishedRoot | SyncPoint::Parent)
+                );
+                let index = points.len();
+                points.push(point);
+                if index == failure_at {
+                    Err(Error::Storage)
+                } else {
+                    sync(point, file)
+                }
+            },
+            &mut linux::rename,
+            &|_| Ok(()),
+        );
+        assert_eq!(points, expected[..(failure_at + 1).min(expected.len())]);
+        if failure_at == expected.len() {
+            drop(result.unwrap());
+        } else {
+            let failure = result.unwrap_err();
+            assert!(!format!("{failure:?} {failure}").contains(parent.path().to_str().unwrap()));
+            match failure {
+                Failure::Unpublished { reason, pack } if failure_at < 19 => {
+                    assert_eq!(reason, Error::Storage);
+                    assert_eq!(pack.path(), old);
+                    drop(pack);
+                    assert_eq!(snapshot(parent.path()), before);
+                }
+                Failure::PublishedUnsynchronized { reason, pack } if failure_at >= 19 => {
+                    assert_eq!(reason, Error::Storage);
+                    assert_eq!(pack.path(), target);
+                    drop(pack);
+                }
+                _ => panic!("incorrect publication state"),
+            }
+        }
+        assert_eq!(old.exists(), failure_at < 19);
+        assert_eq!(target.exists(), failure_at >= 19);
+        assert_eq!(tree(if failure_at < 19 { &old } else { &target }), contents);
+    }
+}
+
+#[test]
+fn cancellation_before_and_after_rename_never_rolls_back_or_replays() {
+    for after in [false, true] {
+        let parent = private_fixture();
+        let pack = received(parent.path());
+        let old = pack.path().to_path_buf();
+        let target = parent.path().join("ready");
+        let root = fs::metadata(&old).unwrap().ino();
+        let stop = Cell::new(false);
+        let result = linux::publish(
+            pack,
+            "ready",
+            PackReceiveLimits::default(),
+            &|| {
+                if after { target.exists() } else { stop.get() }
+            },
+            &mut |point, file| {
+                sync(point, file)?;
+                if point == SyncPoint::Directory && file.metadata().unwrap().ino() == root {
+                    stop.set(true);
+                }
+                Ok(())
+            },
+            &mut linux::rename,
+            &|_| Ok(()),
+        );
+        let reason = match result.unwrap_err() {
+            Failure::Unpublished { reason, pack } if !after => {
+                assert_eq!(pack.path(), old);
+                reason
+            }
+            Failure::PublishedUnsynchronized { reason, pack } if after => {
+                assert_eq!(pack.path(), target);
+                reason
+            }
+            _ => panic!("incorrect cancellation state"),
+        };
+        assert_eq!(reason, Error::Verification(SeedError::Cancelled));
+        assert_eq!(old.exists(), !after);
+        assert_eq!(target.exists(), after);
+    }
+}
+
+fn unpublished(failure: Failure, expected: Error) -> ReceivedGitPack {
+    assert!(!format!("{failure:?} {failure}").contains("/tmp/"));
+    let Failure::Unpublished { reason, pack } = failure else {
+        panic!("incorrect unpublished state")
+    };
+    assert_eq!(reason, expected);
+    pack
+}
+
+#[test]
+fn invalid_and_existing_siblings_never_replace_or_change_data() {
+    let parent = private_fixture();
+    let mut pack = received(parent.path());
+    let own_name = pack.path().file_name().unwrap().to_str().unwrap().to_owned();
+    fs::write(parent.path().join("file"), b"private-marker").unwrap();
+    fs::create_dir(parent.path().join("directory")).unwrap();
+    fs::create_dir(parent.path().join("nonempty")).unwrap();
+    fs::write(parent.path().join("nonempty/sentinel"), b"retained").unwrap();
+    symlink("missing", parent.path().join("symlink")).unwrap();
+    let _socket = UnixListener::bind(parent.path().join("socket")).unwrap();
+    let before = snapshot(parent.path());
+    for name in [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "a/b",
+        "a\\b",
+        ".git",
+        "nul\0private-marker",
+        "line\n",
+        "bad.",
+        &own_name,
+    ] {
+        pack = unpublished(
+            linux::publish(
+                pack,
+                name,
+                PackReceiveLimits::default(),
+                &|| false,
+                &mut |_, _| panic!("invalid name reached synchronization"),
+                &mut linux::rename,
+                &|_| Ok(()),
+            )
+            .unwrap_err(),
+            Error::InvalidName,
+        );
+        assert_eq!(snapshot(parent.path()), before);
+    }
+    for name in ["file", "directory", "nonempty", "symlink", "socket"] {
+        pack = unpublished(
+            linux::publish(
+                pack,
+                name,
+                PackReceiveLimits::default(),
+                &|| false,
+                &mut sync,
+                &mut linux::rename,
+                &|_| Ok(()),
+            )
+            .unwrap_err(),
+            Error::DestinationExists,
+        );
+        assert_eq!(snapshot(parent.path()), before);
+    }
+    drop(pack);
+    assert_eq!(snapshot(parent.path()), before);
+}
+
+#[test]
+fn qualification_limits_and_unsafe_inputs_fail_before_synchronization() {
+    for case in [
+        "unsupported",
+        "qualification-error",
+        "limit",
+        "cancel",
+        "corrupt",
+        "parent-mode",
+        "root-mode",
+    ] {
+        let parent = private_fixture();
+        let pack = received(parent.path());
+        match case {
+            "corrupt" => fs::write(pack.path().join("decoded/config"), b"private-marker").unwrap(),
+            "parent-mode" => fs::set_permissions(parent.path(), fs::Permissions::from_mode(0o755)).unwrap(),
+            "root-mode" => fs::set_permissions(pack.path(), fs::Permissions::from_mode(0o755)).unwrap(),
+            _ => {}
+        }
+        let before = snapshot(parent.path());
+        let limits = if case == "limit" {
+            PackReceiveLimits {
+                encoded_bytes: 0,
+                ..PackReceiveLimits::default()
+            }
+        } else {
+            PackReceiveLimits::default()
+        };
+        let failure = linux::publish(
+            pack,
+            "ready",
+            limits,
+            &|| case == "cancel",
+            &mut |_, _| panic!("invalid input reached synchronization"),
+            &mut linux::rename,
+            &|_| match case {
+                "unsupported" => Err(Error::Unsupported),
+                "qualification-error" => Err(Error::Storage),
+                _ => Ok(()),
+            },
+        )
+        .unwrap_err();
+        assert!(!format!("{failure:?} {failure}").contains("private-marker"));
+        assert!(matches!(failure, Failure::Unpublished { .. }));
+        drop(failure);
+        assert_eq!(snapshot(parent.path()), before);
+    }
+}
+
+#[test]
+fn uncertain_rename_retains_both_candidate_names_without_post_sync_or_replay() {
+    for moved in [false, true] {
+        let parent = private_fixture();
+        let pack = received(parent.path());
+        let old = pack.path().to_path_buf();
+        let target = parent.path().join("ready");
+        let before = tree(&old);
+        let failure = linux::publish(
+            pack,
+            "ready",
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut |point, file| {
+                assert!(matches!(point, SyncPoint::File | SyncPoint::Directory));
+                sync(point, file)
+            },
+            &mut |binding, sibling| {
+                if moved {
+                    linux::rename(binding, sibling)?;
+                }
+                Err(rustix::io::Errno::IO)
+            },
+            &|_| Ok(()),
+        )
+        .unwrap_err();
+        assert!(!format!("{failure:?} {failure}").contains(parent.path().to_str().unwrap()));
+        let Failure::RenameUnconfirmed { pack, destination } = failure else {
+            panic!("incorrect uncertain state")
+        };
+        assert_eq!(pack.path(), old);
+        assert_eq!(destination, target);
+        assert_eq!(old.exists(), !moved);
+        assert_eq!(target.exists(), moved);
+        let retained = if moved { &target } else { &old };
+        let observed =
+            observe_git_base_pack(retained, pack.as_ref().into(), PackReceiveLimits::default(), || false).unwrap();
+        drop(observed);
+        drop(pack);
+        assert_eq!(tree(retained), before);
+    }
+}
+
+#[test]
+fn same_content_inode_substitution_cannot_receive_a_sync_acknowledgement() {
+    for when in [SyncPoint::Directory, SyncPoint::PublishedRoot, SyncPoint::Parent] {
+        let parent = private_fixture();
+        let pack = received(parent.path());
+        let old = pack.path().to_path_buf();
+        let target = parent.path().join("ready");
+        let mut changed = None;
+        let failure = linux::publish(
+            pack,
+            "ready",
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut |point, file| {
+                sync(point, file)?;
+                if point == when && changed.is_none() {
+                    let root = if target.exists() { &target } else { &old };
+                    let configuration = root.join("decoded/config");
+                    let bytes = fs::read(&configuration).unwrap();
+                    let replacement = parent.path().join("replacement");
+                    fs::write(&replacement, &bytes).unwrap();
+                    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+                    fs::rename(replacement, &configuration).unwrap();
+                    assert_eq!(fs::read(configuration).unwrap(), bytes);
+                    changed = Some(snapshot(parent.path()));
+                }
+                Ok(())
+            },
+            &mut linux::rename,
+            &|_| Ok(()),
+        )
+        .unwrap_err();
+        let receipt = match failure {
+            Failure::Unpublished { reason, pack } if when == SyncPoint::Directory => {
+                assert_eq!(reason, Error::Verification(SeedError::Object));
+                assert_eq!(pack.path(), old);
+                pack
+            }
+            Failure::PublishedUnsynchronized { reason, pack } if when != SyncPoint::Directory => {
+                assert_eq!(reason, Error::Verification(SeedError::Object));
+                assert_eq!(pack.path(), target);
+                pack.0
+            }
+            _ => panic!("incorrect changed-input state"),
+        };
+        assert_eq!(snapshot(parent.path()), changed.unwrap());
+        // Current content can still verify; that is not a past synchronization receipt.
+        let observed = observe_git_base_pack(receipt.path(), (&receipt).into(), PackReceiveLimits::default(), || {
+            false
+        })
+        .unwrap();
+        drop(observed);
+        drop(receipt);
+    }
+}
+
+#[test]
+fn replaced_source_and_parent_bindings_fail_without_cleanup() {
+    for (replace_parent, after) in [(false, false), (true, false), (false, true), (true, true)] {
+        let outer = private_fixture();
+        let parent = outer.path().join("parent");
+        fs::create_dir(&parent).unwrap();
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o700)).unwrap();
+        let pack = received(&parent);
+        let old = pack.path().to_path_buf();
+        let active = if after { parent.join("ready") } else { old.clone() };
+        let change_at = if after { SyncPoint::Parent } else { SyncPoint::Directory };
+        let moved = outer.path().join("retained-original");
+        let mut changed = None;
+        let failure = linux::publish(
+            pack,
+            "ready",
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut |point, file| {
+                sync(point, file)?;
+                if point == change_at && changed.is_none() {
+                    let replaced = if replace_parent { &parent } else { &active };
+                    fs::rename(replaced, &moved).unwrap();
+                    fs::create_dir(replaced).unwrap();
+                    fs::set_permissions(replaced, fs::Permissions::from_mode(0o700)).unwrap();
+                    fs::write(replaced.join("sentinel"), b"unchanged").unwrap();
+                    changed = Some(snapshot(outer.path()));
+                }
+                Ok(())
+            },
+            &mut linux::rename,
+            &|_| Ok(()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            (&failure, after),
+            (Failure::Unpublished { .. }, false) | (Failure::PublishedUnsynchronized { .. }, true)
+        ));
+        drop(failure);
+        assert_eq!(snapshot(outer.path()), changed.unwrap());
+        let retained = if replace_parent {
+            moved.join(active.file_name().unwrap())
+        } else {
+            moved
+        };
+        assert!(retained.join("decoded/config").is_file());
+        if !after {
+            assert!(!parent.join("ready").exists());
+        }
+    }
+}
+
+#[test]
+fn concurrent_same_destination_publishers_have_one_winner_and_retain_the_loser() {
+    for _ in 0..4 {
+        let parent = private_fixture();
+        let first = received(parent.path());
+        let second = received(parent.path());
+        let old = [first.path().to_path_buf(), second.path().to_path_buf()];
+        let barrier = std::sync::Barrier::new(2);
+        let results = std::thread::scope(|scope| {
+            let publish = |pack| {
+                barrier.wait();
+                linux::publish(
+                    pack,
+                    "ready",
+                    PackReceiveLimits::default(),
+                    &|| false,
+                    &mut sync,
+                    &mut linux::rename,
+                    &|_| Ok(()),
+                )
+            };
+            let left = scope.spawn(move || publish(first));
+            let right = scope.spawn(move || publish(second));
+            [left.join().unwrap(), right.join().unwrap()]
+        });
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        for result in results {
+            match result {
+                Ok(pack) => assert_eq!(pack.path(), parent.path().join("ready")),
+                Err(failure) => {
+                    drop(unpublished(failure, Error::DestinationExists));
+                }
+            }
+        }
+        assert_eq!(old.iter().filter(|path| path.exists()).count(), 1);
+        assert!(parent.path().join("ready/decoded/config").is_file());
+        assert_eq!(fs::read_dir(parent.path()).unwrap().count(), 2);
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -246,6 +246,12 @@ back into large multi-purpose modules.
   encoded verification before shared read-only native index/closure checks. The
   reader's existing metadata fingerprint is reused for held/named comparisons.
   See [private pack receipt](../remote-repository-pack-receipt.md).
+  Its peer `publication/` subtree owns explicit qualified no-replace publication
+  and distinct pre/post/uncertain rename receipts. It reuses the read-only fixed
+  layout's bound handles and fingerprints for synchronization instead of adding
+  another repository walker. Storage qualification and sibling-name policy remain
+  shared; non-root fingerprints survive relocation unchanged. See
+  [pack publication](../remote-repository-pack-publication.md).
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;

--- a/docs/remote-repository-pack-publication.md
+++ b/docs/remote-repository-pack-publication.md
@@ -1,0 +1,76 @@
+# Qualified private pack publication
+
+`receive::publication::publish_sibling_git_pack` explicitly publishes one already
+received exact-base pack to a fresh sibling. It reuses
+[pack receipt and read-only observation](remote-repository-pack-receipt.md);
+neither receipt nor observation implicitly publishes input or starts setup.
+
+## Contract
+
+The caller supplies a `ReceivedGitPack`, one fresh single-component sibling name,
+`PackReceiveLimits` and cancellation. The existing private parent and received
+tree must remain exclusively controlled and unchanged through verification,
+publication and later consumption. Parent/root identities, ownership, modes and
+same-device placement are checked; symlink ancestry and unsafe nodes fail closed.
+
+Linux journaled ext4 with barriers is required, using the existing storage
+qualifier and trusted kernel metadata. Unsupported or unreadable qualification
+fails without synchronization or rename. There is no copy, alternate-filesystem,
+global-sync or remote-storage fallback. Mount configuration must remain unchanged.
+
+The operation pins the fixed received layout before rechecking encoded identity,
+native index and complete shallow commit closure. It synchronizes eight files,
+then eleven directories in reverse parent order. Bindings are rechecked during
+synchronization. A descriptor-relative `RENAME_NOREPLACE` transfers the directory
+to the explicit sibling; an existing file, directory or link is never replaced.
+
+After rename, the published root and parent are synchronized and checked again.
+The root keeps its inode; its rename-induced change time is permitted. Every
+non-root node must retain its previously verified metadata fingerprint. Even a
+same-content inode replacement after file synchronization prevents acknowledgement.
+No new named metadata, data writes or permission changes are introduced.
+
+## Result and failure ownership
+
+`PublishedGitPack::pack()` exposes the underlying verified input for existing
+namespace and checkout consumers. A successful result acknowledges the completed
+file/directory synchronization and binding checks on healthy qualified storage.
+
+| Result | Retained identity | Meaning |
+| --- | --- | --- |
+| Success | Destination | Rename and final synchronization/verification acknowledged |
+| `Unpublished` | Source receipt | This publication did not confirm a rename |
+| `PublishedUnsynchronized` | Destination receipt | Rename succeeded; later synchronization, verification or cancellation prevented final confirmation |
+| `RenameUnconfirmed` | Source receipt and destination candidate | The rename result is uncertain; inspect both names |
+
+The destination receipt is updated immediately after a successful rename, before
+any later fallible operation. Unknown rename results do not assume the source
+still has its original name. No variant authorizes rollback, repair, retry,
+overwrite, cleanup or task execution. Dropping any receipt retains data. Private
+paths and contents are excluded from error formatting.
+
+Use `observe_git_base_pack` with an explicit candidate path and expected identity
+to inspect current data after a lost result. Successful observation proves current
+private input, not that a previous synchronization was acknowledged. It does not
+reissue a publication acknowledgement, source approval or setup grant.
+
+## Limits and evidence
+
+The same encoded/native limits as receipt apply. Run off the UI thread:
+cancellation is checked between operations and cannot interrupt blocking storage
+calls. Publication is immutable by protocol, not protected against hostile
+same-user or privileged mutation. This is not a snapshot, proof of power-loss
+survival, proof against earlier writeback errors, provider durability or PC-off
+acceptance. Source approval, namespace policy and setup admission remain separate.
+
+Native tests cover real qualified publication, reopening and checkout consumption;
+all 21 synchronization boundaries; pre/post-rename cancellation and binding changes;
+same-content inode substitution; existing/invalid names; unsafe input and failed
+qualification; both uncertain-rename outcomes; and competing same-name publishers.
+Snapshots assert retained names, bytes and inode metadata. The real qualification
+test explicitly reports unavailable filesystem capability rather than substituting
+a different filesystem or claiming durability from an injected qualifier.
+
+Worker receive/status commands, pinned transport, client/UI integration and cloud
+acceptance remain separate. Closing local views never implicitly stops or deletes
+a persistent environment.

--- a/docs/remote-repository-pack-receipt.md
+++ b/docs/remote-repository-pack-receipt.md
@@ -107,6 +107,8 @@ They cover corruption, missing/extra entries, unsafe links/modes, identity
 substitution, root rebinding, cancellation and native output/exit/deadline failures,
 including initial/empty bases and large repeated nested objects.
 
-Worker immutable input publication and protocol/status integration, pinned transport, source-approval
-UI and full cloud/PC-off acceptance remain separate. Closing local views must never
+An explicit [qualified sibling publication API](remote-repository-pack-publication.md)
+can synchronize and publish verified input separately; receipt/observation never
+invoke it implicitly. Worker publication/status protocol integration, pinned transport,
+source-approval UI and full cloud/PC-off acceptance remain separate. Closing local views must never
 implicitly stop or delete a persistent environment.


### PR DESCRIPTION
## Purpose

Explicitly publish one verified received Git pack to a fresh sibling on qualified storage, preserving data and ownership through every failure boundary. Refs #383 and #470; this does not close either issue.

## Behavior

- Pin and revalidate the existing fixed received layout; reuse encoded/native/index/shallow-closure verification and the shared journaled-ext4-with-barriers qualifier.
- Synchronize eight files and eleven directories child-before-parent, perform a descriptor-relative no-replace rename, then synchronize and recheck the published root and parent.
- Preserve the original verified child fingerprints through rename. A same-content inode replacement cannot inherit an earlier synchronization acknowledgement.
- Return distinct retained source, renamed destination or uncertain source/destination candidates on failure. Update the receipt immediately after a successful rename. Drop, cancellation and error never remove data or authorize replay.
- Linux library API only, requiring trusted kernel/Git/prlimit, stable mounts and exclusively controlled ancestry/input through consumption. Blocking storage operations remain the caller's latency responsibility. No alternate-filesystem or global-sync fallback.

Success acknowledges these checks and synchronization on healthy qualified storage; it is not power-loss survival, provider durability, source approval, namespace validation, setup admission or task execution. No wire command, transport, UI, cloud action or release is added. Closing views still only detaches from persistent environments.

## Validation

The hosted review's cancellation finding is fixed by checking cancellation immediately before rename. A deterministic regression failed on the original code and now verifies an unpublished receipt, no rename attempt and an unchanged filesystem snapshot.

Candidate: `4e85adc46a1d4025721b1dbe49584ad02d6f9a88`.

- Independent local review clear; seven source/test files, 918 changed lines, plus three documentation files.
- All eight validation lanes passed on the revised source snapshot and again on the exact commit: formatting, maintainability, version sync, default/speech workspace tests, blocking/strict/pedantic Clippy.
- Native seed/pack family: 55 passed, including ten publication tests. Actual qualified publication/reopening/checkout ran locally. Coverage includes all 21 synchronization failure boundaries, cancellation, invalid/existing targets, unsafe input and failed qualification, unchanged snapshots, source/parent rebinding, same-content inode substitutions, both uncertain-rename outcomes and competing publishers. The existing casefold-only fixture explicitly skipped because this filesystem lacks that capability; no casefold execution proof is claimed.
- All six revised-source image lanes passed and passed again on the exact candidate images: overlay receipt/output loss, independent setup, build-context/final-layer packaging, repository materialization, runtime isolation and retained host identity. Packaging verified 366 allowlisted inputs and all 31 final layers. These exercise existing worker behavior and shared helpers; the new publication API's execution evidence is native testing, not a new worker command or cloud/PC-off acceptance.

Runtime image: `sha256:696c4850373e0449cb6c89fb879533aa60902812b07003cada97720f7aab1dba`.
Builder image: `sha256:6509fa1e467fea66b83443fd5b7221debfd3d73ea2b014618953823a491a3b2f`.
Repository helper SHA-256: `dedab361cfb0dbd193554d85f0fbd195f6e1f20e4c5549d7f8430a689498d4c8`.
