### PR TITLE
Add worker pack receive and status commands

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -80,7 +80,11 @@ The same helper can explicitly receive a canonical overlay bundle into an existi
 private bundle store and inspect a lost acknowledgement without writing. See
 [worker overlay receipt](../../docs/remote-overlay-transfer.md) for the framed
 input and storage limits. No local files are captured/exported automatically.
-This packaging does not add Git-object transport, client setup, worker-loss recovery,
+Explicit `receive-pack` and `pack-status` commands stream/publish a supplied exact-base
+pack and reopen a nominated candidate. See [worker pack receipt](../../docs/remote-pack-transfer.md)
+for framing, retained failure states and lost-response rules, plus the dedicated
+`test_pack_receive_image.py` smoke. They do not connect the client transport.
+This packaging does not add authenticated Git-object transport, client setup, worker-loss recovery,
 checkpointing or task admission. Existing workers are not
 upgraded by rebuilding an image. Neither the helper nor a locally retained volume
 proves cloud durability or PC-off operation.

--- a/containers/remote-worker/test_pack_receive_image.py
+++ b/containers/remote-worker/test_pack_receive_image.py
@@ -33,10 +33,50 @@ def state(root):
                             for path in [root, *root.rglob('*')]}
 
 
+def pathname_boundaries(smoke, payload, pack):
+    program = '''
+import json,os,shutil,struct,subprocess,sys
+wire=sys.stdin.buffer.read(); size=struct.unpack('<I',wire[:4])[0]
+request=json.loads(wire[4:4+size]); payload=wire[4+size:]
+for length in (3840,3839,3584,3583):
+    root='/retained/path-'+str(length); parent=root; os.mkdir(root,0o700)
+    try:
+        while len(parent)+202<length:
+            parent+='/'+'x'*200; os.mkdir(parent,0o700)
+        parent+='/'+'z'*(length-len(parent)-1); os.mkdir(parent,0o700)
+        request.update(parent=parent,destination='d'*255)
+        header=json.dumps(request).encode()
+        result=subprocess.run(['/usr/local/bin/horizon-repository','receive-pack'],
+            input=struct.pack('<I',len(header))+header+payload,capture_output=True,timeout=30)
+        received=json.loads(result.stdout)
+        assert not result.stderr
+        if length>3583:
+            assert result.returncode==2 and received['status']=='rejected', (length,received['status'])
+            assert not os.listdir(parent)
+        else:
+            assert result.returncode==0 and received['status']=='acknowledged', received
+            observation=dict(version=1,path=received['pack']['path'],pack=request['pack'])
+            result=subprocess.run(['/usr/local/bin/horizon-repository','pack-status'],
+                input=json.dumps(observation).encode(),capture_output=True,timeout=30)
+            observed=json.loads(result.stdout)
+            assert result.returncode==0 and not result.stderr and observed['status']=='observed', observed
+            assert observed['pack']==received['pack'] and os.listdir(parent)==['d'*255]
+    finally:
+        shutil.rmtree(root)
+print('PASS actual filesystem pathname bounds, maximum publication and native recovery')
+'''
+    result = smoke.command('/usr/bin/python3', ['-c', program],
+                           frame({'version': 1, 'pack': pack}, payload), mount_inputs=False)
+    assert result.returncode == 0 and not result.stderr, (result.stdout, result.stderr)
+    print(result.stdout.decode().strip(), flush=True)
+    smoke.retire_completed()
+
+
 def test(smoke):
     smoke.fixture()
     before = snapshot(smoke.root / 'source'), snapshot(smoke.root / 'bundles')
     payload, pack = prepare(smoke, smoke.ancestor, 'small-view')
+    pathname_boundaries(smoke, payload, pack)
 
     def private(name, expected=pack):
         root = smoke.root / 'retained' / name

--- a/containers/remote-worker/test_pack_receive_image.py
+++ b/containers/remote-worker/test_pack_receive_image.py
@@ -70,6 +70,7 @@ def test(smoke):
     original = state(root)
     invoke('pack-status', encoded(observation(request)), 'error', 1)
     for invalid in (b'private-input-marker', frame(dict(request, version=2), payload),
+                    frame(dict(request, parent='/' + 'x'*3840), payload),
                     frame(dict(request, destination='../escape'), payload),
                     frame(dict(request, pack=dict(pack, sha256='private-input-marker')), payload)):
         invoke('receive-pack', invalid, 'rejected', 2)

--- a/containers/remote-worker/test_pack_receive_image.py
+++ b/containers/remote-worker/test_pack_receive_image.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Exercise explicit pack commands on disposable synthetic retained storage."""
+
+import argparse
+import json
+from pathlib import Path
+import struct
+
+from test_overlay_receive_image import identity
+from test_repository_image import ImageSmoke, digest, encoded, snapshot
+
+
+def frame(request, payload):
+    header = encoded(request)
+    return struct.pack('<I', len(header)) + header + payload
+
+
+def prepare(smoke, base, name):
+    view = smoke.root / name
+    view.mkdir(mode=0o700)
+    smoke.git(view, 'init', '--bare', '--template=', '--object-format=sha1')
+    (view / 'objects/info/alternates').write_text(str(smoke.root / 'source/objects') + '\n')
+    (view / 'HEAD').write_text(base + '\n')
+    (view / 'shallow').write_text(base + '\n')
+    payload = smoke.git(view, 'pack-objects', '--stdout', '--revs', '--shallow',
+                        '--no-reuse-delta', '--no-reuse-object', '--window=0', '--threads=1',
+                        data=(base + '\n').encode()).stdout
+    return payload, {'base_commit': base, 'sha256': digest(payload), 'encoded_bytes': len(payload)}
+
+
+def state(root):
+    return snapshot(root), {str(path.relative_to(root)): identity(path)
+                            for path in [root, *root.rglob('*')]}
+
+
+def test(smoke):
+    smoke.fixture()
+    before = snapshot(smoke.root / 'source'), snapshot(smoke.root / 'bundles')
+    payload, pack = prepare(smoke, smoke.ancestor, 'small-view')
+
+    def private(name, expected=pack):
+        root = smoke.root / 'retained' / name
+        root.mkdir(mode=0o700)
+        return root, {'version': 1, 'parent': '/retained/' + name, 'destination': 'ready', 'pack': expected}
+
+    def observation(request, path=None):
+        return {'version': 1, 'path': path or request['parent'] + '/' + request['destination'],
+                'pack': request['pack']}
+
+    def response(output, status, code):
+        assert output.returncode == code and not output.stderr, (output.returncode, output.stdout, output.stderr)
+        assert output.stdout.endswith(b'\n') and len(output.stdout) <= 128 * 1024
+        value = json.loads(output.stdout)
+        assert set(value) == {'version', 'status', 'pack', 'retained', 'reason'}
+        assert value['version'] == 1 and value['status'] == status, value
+        assert 'private-input-marker' not in str(value)
+        if status in ('acknowledged', 'observed'):
+            assert value['retained'] is None and value['reason'] is None
+        else:
+            assert value['pack'] is None and value['reason']
+        return value
+
+    def invoke(command, data, status, code):
+        result = response(smoke.command('/usr/local/bin/horizon-repository', [command], data,
+                                        mount_inputs=False), status, code)
+        smoke.retire_completed()
+        return result
+
+    root, request = private('receiver')
+    original = state(root)
+    invoke('pack-status', encoded(observation(request)), 'error', 1)
+    for invalid in (b'private-input-marker', frame(dict(request, version=2), payload),
+                    frame(dict(request, destination='../escape'), payload),
+                    frame(dict(request, pack=dict(pack, sha256='private-input-marker')), payload)):
+        invoke('receive-pack', invalid, 'rejected', 2)
+    invoke('receive-pack', frame(dict(request, pack=dict(pack, encoded_bytes=2**64-1)), payload), 'error', 1)
+    assert state(root) == original
+    receipt = invoke('receive-pack', frame(request, payload), 'acknowledged', 0)
+    assert receipt['pack']['identity'] == pack and receipt['pack']['objects'] == 3
+    assert receipt['pack']['path'] == '/retained/receiver/ready'
+    assert receipt['pack']['objects_directory'] == '/retained/receiver/ready/decoded/objects'
+    ready = root / 'ready'
+    assert (ready / 'decoded/objects/pack' / ('pack-' + payload[-20:].hex() + '.pack')).read_bytes() == payload
+    saved = state(ready)
+    observed = invoke('pack-status', encoded(observation(request)), 'observed', 0)
+    assert observed['pack'] == receipt['pack'] and state(ready) == saved
+    wrong = dict(observation(request), pack=dict(pack, sha256='0'*64))
+    invoke('pack-status', encoded(wrong), 'error', 1)
+    assert state(ready) == saved
+
+    collision = invoke('receive-pack', frame(request, payload), 'unpublished', 1)
+    assert collision['retained']['destination'] is None
+    retained_path = Path(collision['retained']['source'])
+    assert retained_path.parent == Path(request['parent']) and retained_path.name != 'ready'
+    retained = root / retained_path.name
+    retained_state = state(retained)
+    invoke('pack-status', encoded(observation(request, str(retained_path))), 'observed', 0)
+    assert state(retained) == retained_state and state(ready) == saved and len(list(root.iterdir())) == 2
+
+    for name, contents, expected in (
+        ('truncated', payload[:-1], pack), ('trailing', payload+b'extra', pack),
+        ('mismatch', payload, dict(pack, sha256='0'*64)),
+    ):
+        failed, request = private(name, expected)
+        outcome = invoke('receive-pack', frame(request, contents), 'receive_unconfirmed', 1)
+        assert outcome['retained']['destination'] is None
+        source = Path(outcome['retained']['source'])
+        assert source.parent == Path(request['parent']) and source.name != 'ready'
+        assert (failed / source.name).is_dir() and not (failed / 'ready').exists()
+        saved_failure = state(failed)
+        invoke('pack-status', encoded(observation(request)), 'error', 1)
+        assert state(failed) == saved_failure
+
+    sentinel, request = private('sentinel')
+    (sentinel / 'ready').write_bytes(b'private-input-marker')
+    saved_sentinel = identity(sentinel / 'ready')
+    invoke('receive-pack', frame(request, payload), 'unpublished', 1)
+    assert (sentinel / 'ready').read_bytes() == b'private-input-marker'
+    assert identity(sentinel / 'ready') == saved_sentinel
+    missing = dict(request, parent='/retained/missing')
+    invoke('receive-pack', frame(missing, payload), 'error', 1)
+    invoke('pack-status', encoded(observation(missing)), 'error', 1)
+    assert not (smoke.root / 'retained/missing').exists()
+    unsafe, request = private('unsafe')
+    unsafe.chmod(0o755)
+    saved_unsafe = state(unsafe)
+    invoke('receive-pack', frame(request, payload), 'error', 1)
+    assert state(unsafe) == saved_unsafe
+
+    lost, request = private('lost-output')
+    output = smoke.command('/bin/sh', ['-c', 'exec /usr/local/bin/horizon-repository receive-pack > /dev/full'],
+                           frame(request, payload), mount_inputs=False)
+    assert output.returncode == 3 and not output.stdout
+    assert output.stderr == b'Could not write a complete response; retain data and inspect before any retry.\n'
+    saved_lost = state(lost)
+    smoke.retire_completed()
+    invoke('pack-status', encoded(observation(request)), 'observed', 0)
+    assert state(lost) == saved_lost and len(list(lost.iterdir())) == 1
+
+    output = smoke.command('/usr/bin/python3', ['-c',
+        "import json,os,subprocess,sys; os.mkdir('/tmp/private-smoke',0o700); "
+        "r=subprocess.run(['/usr/local/bin/horizon-repository','receive-pack'],stdin=sys.stdin.buffer,capture_output=True); "
+        "v=json.loads(r.stdout); assert v['status']=='unpublished'; "
+        "assert os.path.isdir(v['retained']['source']); assert not os.path.exists('/tmp/private-smoke/ready'); "
+        "sys.stdout.buffer.write(r.stdout); sys.stderr.buffer.write(r.stderr); sys.exit(r.returncode)"],
+        frame(dict(request, parent='/tmp/private-smoke'), payload), overlay=True, mount_inputs=False)
+    response(output, 'unpublished', 1)
+    smoke.retire_completed()
+
+    large_payload, large_pack = prepare(smoke, smoke.base, 'large-view')
+    assert len(large_payload) > 65*1024*1024
+    large, request = private('large', large_pack)
+    receipt = invoke('receive-pack', frame(request, large_payload), 'acknowledged', 0)
+    assert receipt['pack']['identity'] == large_pack and receipt['pack']['objects'] == 7
+    saved_large = state(large)
+    observed = invoke('pack-status', encoded(observation(request)), 'observed', 0)
+    assert receipt['pack'] == observed['pack'] and state(large) == saved_large
+    checkout, _ = private('checkout')
+    materialize = dict(smoke.request, scratch_parent='/retained/checkout',
+                       objects_directory=receipt['pack']['objects_directory'])
+    smoke.materialize(encoded(materialize), 'published', 0)
+    smoke.verify_checkout(checkout / 'published')
+    assert state(large) == saved_large
+    assert before == (snapshot(smoke.root / 'source'), snapshot(smoke.root / 'bundles'))
+    assert not list((smoke.root / 'retained').rglob('setup-claim.json'))
+    print('PASS pack commands: small and 65 MiB-plus exact-base pack receipt/publication, fresh-container '
+          'non-mutating observation, retained failed transfers/collisions, no root creation, unsafe and '
+          'unqualified storage rejection, output-loss recovery, and large shallow raw checkout with '
+          'overlay/index/LFS/link/mode semantics; source inputs unchanged and no setup started. '
+          'Synthetic local proof, not client transport or cloud/PC-off durability.', flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--image', required=True)
+    parser.add_argument('--docker-host', required=True)
+    parser.add_argument('--fixture-parent', default='/tmp')
+    smoke = ImageSmoke(parser.parse_args())
+    print(f'Task-owned pack fixture: {smoke.root}; label: {smoke.label}; image: {smoke.image}', flush=True)
+    try:
+        test(smoke)
+    finally:
+        smoke.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
@@ -81,7 +81,11 @@ pub enum PublicationError {
     Cancelled,
 }
 
-pub(crate) fn validate_sibling_name(sibling: &str) -> Result<(), PublicationError> {
+/// Validate one bounded portable destination component without accessing storage.
+/// # Errors
+/// Rejects unsafe or unsupported names. Success does not prove a fresh destination,
+/// ownership, storage qualification or permission to publish.
+pub fn validate_sibling_name(sibling: &str) -> Result<(), PublicationError> {
     if sibling.len() > 255 || sibling.contains('/') || paths::validate(sibling).is_err() {
         Err(PublicationError::InvalidName)
     } else {

--- a/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkout/publication/mod.rs
@@ -81,12 +81,15 @@ pub enum PublicationError {
     Cancelled,
 }
 
+/// Maximum UTF-8 bytes in one portable publication destination component.
+pub const MAX_SIBLING_NAME_BYTES: usize = 255;
+
 /// Validate one bounded portable destination component without accessing storage.
 /// # Errors
 /// Rejects unsafe or unsupported names. Success does not prove a fresh destination,
 /// ownership, storage qualification or permission to publish.
 pub fn validate_sibling_name(sibling: &str) -> Result<(), PublicationError> {
-    if sibling.len() > 255 || sibling.contains('/') || paths::validate(sibling).is_err() {
+    if sibling.len() > MAX_SIBLING_NAME_BYTES || sibling.contains('/') || paths::validate(sibling).is_err() {
         Err(PublicationError::InvalidName)
     } else {
         Ok(())

--- a/crates/horizon-core/src/repository_overlay/materialize/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/materialize/mod.rs
@@ -133,7 +133,11 @@ pub fn materialize_repository(
     }
 }
 
-pub(super) fn valid_path(path: &Path) -> bool {
+/// Check the bounded absolute UTF-8 request-path syntax without accessing storage.
+/// This grants no ownership or filesystem-safety guarantee; consumers must verify
+/// their existing ancestry, identity and private-storage contracts separately.
+#[must_use]
+pub fn valid_path(path: &Path) -> bool {
     path.is_absolute()
         && path
             .to_str()

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod pack;
 mod protocol;
 mod receive;
 mod setup;
@@ -15,12 +16,20 @@ fn main() -> ExitCode {
     if arguments.len() != 1
         || !matches!(
             command,
-            Some("materialize" | "setup" | "setup-status" | "receive-overlay" | "overlay-status")
+            Some(
+                "materialize"
+                    | "setup"
+                    | "setup-status"
+                    | "receive-overlay"
+                    | "overlay-status"
+                    | "receive-pack"
+                    | "pack-status"
+            )
         )
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|receive-overlay|overlay-status < request"
+            "Usage: horizon-repository materialize|setup|setup-status|receive-overlay|overlay-status|receive-pack|pack-status < request"
         );
         return ExitCode::from(2);
     }
@@ -32,6 +41,8 @@ fn main() -> ExitCode {
         Some("setup-status") => setup::run(setup::Command::Observe, &mut input, &mut output, &mut diagnostics),
         Some("receive-overlay") => receive::run(receive::Command::Receive, &mut input, &mut output, &mut diagnostics),
         Some("overlay-status") => receive::run(receive::Command::Observe, &mut input, &mut output, &mut diagnostics),
+        Some("receive-pack") => pack::run(pack::Command::Receive, &mut input, &mut output, &mut diagnostics),
+        Some("pack-status") => pack::run(pack::Command::Observe, &mut input, &mut output, &mut diagnostics),
         _ => run(&mut input, &mut output, &mut diagnostics),
     }
 }

--- a/crates/horizon-repository/src/pack/linux.rs
+++ b/crates/horizon-repository/src/pack/linux.rs
@@ -1,0 +1,72 @@
+use super::{
+    request::Request,
+    response::{Response, Status},
+};
+use horizon_core::repository_overlay::seed::receive::{
+    ExpectedGitPack, PackReceiveLimits, observe_git_base_pack,
+    publication::{PackPublicationFailure, publish_sibling_git_pack},
+    receive_git_base_pack,
+};
+use std::io::Read;
+
+pub(super) fn execute(request: &Request, mut input: &mut dyn Read) -> Response {
+    let Ok(base_commit) = request.pack.base_commit.as_str().parse() else {
+        return Response::new(Status::Rejected, "invalid pack identity");
+    };
+    let expected = ExpectedGitPack {
+        base_commit,
+        sha256: &request.pack.sha256,
+        encoded_bytes: request.pack.encoded_bytes,
+    };
+    let limits = PackReceiveLimits::default();
+    let Some(destination) = &request.destination else {
+        return match observe_git_base_pack(&request.path, expected, limits, || false) {
+            Ok(pack) => Response::verified(Status::Observed, &pack, &request.pack),
+            Err(_) => Response::new(
+                Status::Error,
+                "pack could not be safely observed; retain data and do not replay",
+            ),
+        };
+    };
+    let pack = match receive_git_base_pack(&request.path, expected, &mut input, limits, || false) {
+        Ok(pack) => pack,
+        Err(failure) => {
+            return match failure.residue() {
+                Some(path) => Response::retained(
+                    Status::ReceiveUnconfirmed,
+                    Some(path.to_owned()),
+                    None,
+                    "pack receipt failed; retain unconfirmed input and do not replay",
+                ),
+                None => Response::new(Status::Error, "pack receipt failed before a reservation was returned"),
+            };
+        }
+    };
+    match publish_sibling_git_pack(pack, destination, limits, || false) {
+        Ok(pack) => Response::verified(Status::Acknowledged, pack.pack(), &request.pack),
+        Err(failure) => publication_failure(failure),
+    }
+}
+
+fn publication_failure(failure: PackPublicationFailure) -> Response {
+    match failure {
+        PackPublicationFailure::Unpublished { pack, .. } => Response::retained(
+            Status::Unpublished,
+            Some(pack.path().to_owned()),
+            None,
+            "pack was not published; retain input and do not replay",
+        ),
+        PackPublicationFailure::PublishedUnsynchronized { pack, .. } => Response::retained(
+            Status::PublishedUnsynchronized,
+            None,
+            Some(pack.path().to_owned()),
+            "pack was renamed without final confirmation; retain destination and observe",
+        ),
+        PackPublicationFailure::RenameUnconfirmed { pack, destination } => Response::retained(
+            Status::RenameUnconfirmed,
+            Some(pack.path().to_owned()),
+            Some(destination),
+            "pack rename is unconfirmed; retain and inspect both candidate names",
+        ),
+    }
+}

--- a/crates/horizon-repository/src/pack/mod.rs
+++ b/crates/horizon-repository/src/pack/mod.rs
@@ -1,0 +1,65 @@
+//! Explicit streaming pack receipt and current observation, never setup authority.
+
+#[cfg(target_os = "linux")]
+mod linux;
+mod request;
+mod response;
+
+use request::Request;
+use response::{Response, Status};
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+const VERSION: u32 = 1;
+
+#[derive(Clone, Copy)]
+pub(super) enum Command {
+    Receive,
+    Observe,
+}
+
+pub(super) fn run(
+    command: Command,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    run_with(command, input, output, diagnostics, execute)
+}
+
+fn run_with(
+    command: Command,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+    execute: impl FnOnce(&Request, &mut dyn Read) -> Response,
+) -> ExitCode {
+    let response = match request::read(command, input) {
+        Ok(request) => execute(&request, input),
+        Err(()) => Response::new(Status::Rejected, "invalid or unsupported pack request"),
+    };
+    super::write_response(
+        &response,
+        response.exit_code(),
+        super::protocol::RESPONSE_LIMIT,
+        output,
+        diagnostics,
+    )
+}
+
+fn execute(request: &Request, input: &mut dyn Read) -> Response {
+    #[cfg(target_os = "linux")]
+    {
+        linux::execute(request, input)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (request, input);
+        Response::new(Status::Unsupported, "pack commands require Linux")
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/pack/request.rs
+++ b/crates/horizon-repository/src/pack/request.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 use std::{io::Read, path::PathBuf};
 
 pub(super) const HEADER_LIMIT: usize = (6 * MAX_REQUEST_PATH_BYTES + 4096).next_power_of_two();
-pub(super) const MAX_RECEIVE_PARENT_BYTES: usize = MAX_REQUEST_PATH_BYTES - 1 - MAX_SIBLING_NAME_BYTES;
+// Reserve the Linux terminating NUL and a component-sized budget for fixed inner
+// pack paths: native verification reopens those paths, not only the candidate root.
+pub(super) const MAX_PACK_PATH_BYTES: usize = MAX_REQUEST_PATH_BYTES - 2 - MAX_SIBLING_NAME_BYTES;
+pub(super) const MAX_RECEIVE_PARENT_BYTES: usize = MAX_PACK_PATH_BYTES - 1 - MAX_SIBLING_NAME_BYTES;
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -53,11 +56,14 @@ impl Request {
         if version != VERSION
             || !valid_path(&request.path)
             || request.path.parent().is_none()
-            || (request.destination.is_some()
-                && request
-                    .path
-                    .to_str()
-                    .is_none_or(|path| path.len() > MAX_RECEIVE_PARENT_BYTES))
+            || request.path.to_str().is_none_or(|path| {
+                path.len()
+                    > if request.destination.is_some() {
+                        MAX_RECEIVE_PARENT_BYTES
+                    } else {
+                        MAX_PACK_PATH_BYTES
+                    }
+            })
             || request
                 .destination
                 .as_deref()

--- a/crates/horizon-repository/src/pack/request.rs
+++ b/crates/horizon-repository/src/pack/request.rs
@@ -2,7 +2,7 @@ use super::{Command, VERSION};
 use horizon_core::{
     cloud_run::{ArtifactDigest, GitCommitSha},
     repository_overlay::{
-        checkout::publication::validate_sibling_name,
+        checkout::publication::{MAX_SIBLING_NAME_BYTES, validate_sibling_name},
         materialize::{MAX_REQUEST_PATH_BYTES, valid_path},
     },
 };
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::{io::Read, path::PathBuf};
 
 pub(super) const HEADER_LIMIT: usize = (6 * MAX_REQUEST_PATH_BYTES + 4096).next_power_of_two();
+pub(super) const MAX_RECEIVE_PARENT_BYTES: usize = MAX_REQUEST_PATH_BYTES - 1 - MAX_SIBLING_NAME_BYTES;
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -52,6 +53,11 @@ impl Request {
         if version != VERSION
             || !valid_path(&request.path)
             || request.path.parent().is_none()
+            || (request.destination.is_some()
+                && request
+                    .path
+                    .to_str()
+                    .is_none_or(|path| path.len() > MAX_RECEIVE_PARENT_BYTES))
             || request
                 .destination
                 .as_deref()

--- a/crates/horizon-repository/src/pack/request.rs
+++ b/crates/horizon-repository/src/pack/request.rs
@@ -1,0 +1,99 @@
+use super::{Command, VERSION};
+use horizon_core::{
+    cloud_run::{ArtifactDigest, GitCommitSha},
+    repository_overlay::{
+        checkout::publication::validate_sibling_name,
+        materialize::{MAX_REQUEST_PATH_BYTES, valid_path},
+    },
+};
+use serde::{Deserialize, Serialize};
+use std::{io::Read, path::PathBuf};
+
+pub(super) const HEADER_LIMIT: usize = (6 * MAX_REQUEST_PATH_BYTES + 4096).next_power_of_two();
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Identity {
+    pub(super) base_commit: GitCommitSha,
+    pub(super) sha256: ArtifactDigest,
+    pub(super) encoded_bytes: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReceiveHeader {
+    version: u32,
+    parent: PathBuf,
+    destination: String,
+    pack: Identity,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ObservationRequest {
+    version: u32,
+    path: PathBuf,
+    pack: Identity,
+}
+
+pub(super) struct Request {
+    pub(super) path: PathBuf,
+    pub(super) destination: Option<String>,
+    pub(super) pack: Identity,
+}
+
+impl Request {
+    fn new(version: u32, path: PathBuf, destination: Option<String>, pack: Identity) -> Result<Self, ()> {
+        let request = Self {
+            path,
+            destination,
+            pack,
+        };
+        if version != VERSION
+            || !valid_path(&request.path)
+            || request.path.parent().is_none()
+            || request
+                .destination
+                .as_deref()
+                .is_some_and(|name| validate_sibling_name(name).is_err())
+            || request.pack.base_commit.as_str().bytes().all(|byte| byte == b'0')
+            || request.pack.encoded_bytes == 0
+        {
+            return Err(());
+        }
+        Ok(request)
+    }
+}
+
+pub(super) fn read(command: Command, input: &mut impl Read) -> Result<Request, ()> {
+    match command {
+        Command::Receive => {
+            let mut prefix = [0; 4];
+            input.read_exact(&mut prefix).map_err(|_| ())?;
+            let length = usize::try_from(u32::from_le_bytes(prefix)).map_err(|_| ())?;
+            if length == 0 || length > HEADER_LIMIT {
+                return Err(());
+            }
+            let mut bytes = Vec::new();
+            bytes.try_reserve_exact(length).map_err(|_| ())?;
+            input.take(length as u64).read_to_end(&mut bytes).map_err(|_| ())?;
+            if bytes.len() != length {
+                return Err(());
+            }
+            let wire: ReceiveHeader = serde_json::from_slice(&bytes).map_err(|_| ())?;
+            Request::new(wire.version, wire.parent, Some(wire.destination), wire.pack)
+        }
+        Command::Observe => {
+            let mut bytes = Vec::new();
+            input
+                .take(HEADER_LIMIT as u64 + 1)
+                .read_to_end(&mut bytes)
+                .map_err(|_| ())?;
+            if bytes.len() > HEADER_LIMIT {
+                return Err(());
+            }
+            let wire: ObservationRequest = serde_json::from_slice(&bytes).map_err(|_| ())?;
+            Request::new(wire.version, wire.path, None, wire.pack)
+        }
+    }
+}

--- a/crates/horizon-repository/src/pack/response.rs
+++ b/crates/horizon-repository/src/pack/response.rs
@@ -1,0 +1,93 @@
+use super::{VERSION, request::Identity};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum Status {
+    Acknowledged,
+    Observed,
+    Rejected,
+    Error,
+    Unsupported,
+    ReceiveUnconfirmed,
+    Unpublished,
+    PublishedUnsynchronized,
+    RenameUnconfirmed,
+}
+
+#[derive(Serialize)]
+struct VerifiedPack {
+    path: PathBuf,
+    objects_directory: PathBuf,
+    identity: Identity,
+    objects: u32,
+}
+
+#[derive(Serialize)]
+struct Retained {
+    source: Option<PathBuf>,
+    destination: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+pub(super) struct Response {
+    version: u32,
+    status: Status,
+    pack: Option<VerifiedPack>,
+    retained: Option<Retained>,
+    reason: Option<&'static str>,
+}
+
+impl Response {
+    pub(super) fn new(status: Status, reason: &'static str) -> Self {
+        Self {
+            version: VERSION,
+            status,
+            pack: None,
+            retained: None,
+            reason: Some(reason),
+        }
+    }
+
+    pub(super) fn exit_code(&self) -> u8 {
+        match self.status {
+            Status::Acknowledged | Status::Observed => 0,
+            Status::Rejected => 2,
+            _ => 1,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(super) fn retained(
+        status: Status,
+        source: Option<PathBuf>,
+        destination: Option<PathBuf>,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            retained: Some(Retained { source, destination }),
+            ..Self::new(status, reason)
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(super) fn verified(
+        status: Status,
+        pack: &horizon_core::repository_overlay::seed::receive::ReceivedGitPack,
+        identity: &Identity,
+    ) -> Self {
+        Self {
+            version: VERSION,
+            status,
+            pack: Some(VerifiedPack {
+                path: pack.path().to_owned(),
+                objects_directory: pack.objects_directory().to_owned(),
+                identity: identity.clone(),
+                objects: pack.objects(),
+            }),
+            retained: None,
+            reason: None,
+        }
+    }
+}

--- a/crates/horizon-repository/src/pack/tests.rs
+++ b/crates/horizon-repository/src/pack/tests.rs
@@ -305,12 +305,44 @@ fn non_linux_execution_is_explicitly_unsupported_without_reading_the_pack() {
     }
 }
 
+#[test]
+fn receive_parents_reserve_space_for_observable_child_candidates() {
+    use horizon_core::repository_overlay::{
+        checkout::publication::MAX_SIBLING_NAME_BYTES, materialize::MAX_REQUEST_PATH_BYTES,
+    };
+    let destination = "x".repeat(MAX_SIBLING_NAME_BYTES);
+    let maximum_parent = MAX_REQUEST_PATH_BYTES - 1 - destination.len();
+    for fill in ["x", "\u{1}"] {
+        for length in [maximum_parent, maximum_parent + 1, MAX_REQUEST_PATH_BYTES] {
+            let parent = format!("{}{}", fixture_path(), fill.repeat(length - fixture_path().len()));
+            let mut value = wire(Command::Receive);
+            value["parent"] = json!(parent);
+            value["destination"] = json!(destination);
+            let bytes = encode(Command::Receive, &value);
+            if length > maximum_parent {
+                rejected(Command::Receive, &bytes);
+                continue;
+            }
+            let received = request::read(Command::Receive, &mut bytes.as_slice()).unwrap();
+            for child in [destination.as_str(), "repository-seed-abcdef"] {
+                let candidate = received.path.join(child);
+                assert!(candidate.to_str().unwrap().len() <= MAX_REQUEST_PATH_BYTES);
+                let mut observation = wire(Command::Observe);
+                observation["path"] = json!(candidate);
+                let bytes = encode(Command::Observe, &observation);
+                let reopened = request::read(Command::Observe, &mut bytes.as_slice()).unwrap();
+                assert_eq!(reopened.path, candidate);
+            }
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn maximum_escaped_retained_paths_fit_without_claiming_verified_data() {
-    use horizon_core::repository_overlay::materialize::MAX_REQUEST_PATH_BYTES;
-    let path =
-        std::path::PathBuf::from(format!("/{}", "\u{1}".repeat(MAX_REQUEST_PATH_BYTES - 1))).join("x".repeat(255));
+    use horizon_core::repository_overlay::checkout::publication::MAX_SIBLING_NAME_BYTES;
+    let path = std::path::PathBuf::from(format!("/{}", "\u{1}".repeat(request::MAX_RECEIVE_PARENT_BYTES - 1)))
+        .join("x".repeat(MAX_SIBLING_NAME_BYTES));
     for (name, source, destination) in [
         ("receive_unconfirmed", true, false),
         ("unpublished", true, false),

--- a/crates/horizon-repository/src/pack/tests.rs
+++ b/crates/horizon-repository/src/pack/tests.rs
@@ -311,7 +311,7 @@ fn receive_parents_reserve_space_for_observable_child_candidates() {
         checkout::publication::MAX_SIBLING_NAME_BYTES, materialize::MAX_REQUEST_PATH_BYTES,
     };
     let destination = "x".repeat(MAX_SIBLING_NAME_BYTES);
-    let maximum_parent = MAX_REQUEST_PATH_BYTES - 1 - destination.len();
+    let maximum_parent = request::MAX_RECEIVE_PARENT_BYTES;
     for fill in ["x", "\u{1}"] {
         for length in [maximum_parent, maximum_parent + 1, MAX_REQUEST_PATH_BYTES] {
             let parent = format!("{}{}", fixture_path(), fill.repeat(length - fixture_path().len()));
@@ -326,7 +326,7 @@ fn receive_parents_reserve_space_for_observable_child_candidates() {
             let received = request::read(Command::Receive, &mut bytes.as_slice()).unwrap();
             for child in [destination.as_str(), "repository-seed-abcdef"] {
                 let candidate = received.path.join(child);
-                assert!(candidate.to_str().unwrap().len() <= MAX_REQUEST_PATH_BYTES);
+                assert!(candidate.to_str().unwrap().len() <= request::MAX_PACK_PATH_BYTES);
                 let mut observation = wire(Command::Observe);
                 observation["path"] = json!(candidate);
                 let bytes = encode(Command::Observe, &observation);
@@ -335,6 +335,13 @@ fn receive_parents_reserve_space_for_observable_child_candidates() {
             }
         }
     }
+    let mut observation = wire(Command::Observe);
+    observation["path"] = json!(format!(
+        "{}{}",
+        fixture_path(),
+        "x".repeat(request::MAX_PACK_PATH_BYTES + 1 - fixture_path().len())
+    ));
+    rejected(Command::Observe, &encode(Command::Observe, &observation));
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/horizon-repository/src/pack/tests.rs
+++ b/crates/horizon-repository/src/pack/tests.rs
@@ -1,0 +1,345 @@
+use super::*;
+use serde_json::json;
+use std::io;
+
+fn fixture_path() -> &'static str {
+    if cfg!(windows) {
+        "C:/private/input"
+    } else {
+        "/private/input"
+    }
+}
+
+fn wire(command: Command) -> serde_json::Value {
+    let mut value = json!({"version":1,
+        "pack":{"base_commit":"1".repeat(40),"sha256":"a".repeat(64),"encoded_bytes":32}});
+    match command {
+        Command::Receive => {
+            value["parent"] = json!(fixture_path());
+            value["destination"] = json!("ready");
+        }
+        Command::Observe => value["path"] = json!(fixture_path()),
+    }
+    value
+}
+
+fn encode(command: Command, value: &serde_json::Value) -> Vec<u8> {
+    let bytes = serde_json::to_vec(value).unwrap();
+    match command {
+        Command::Receive => [u32::try_from(bytes.len()).unwrap().to_le_bytes().as_slice(), &bytes].concat(),
+        Command::Observe => bytes,
+    }
+}
+
+fn rejected(command: Command, mut bytes: &[u8]) {
+    let mut output = Vec::new();
+    assert_eq!(
+        run_with(command, &mut bytes, &mut output, &mut io::sink(), |_, _| panic!(
+            "invalid request executed"
+        )),
+        ExitCode::from(2)
+    );
+    assert!(output.ends_with(b"\n"));
+    let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(response["status"], "rejected");
+    assert!(response["pack"].is_null() && response["retained"].is_null());
+    assert!(!String::from_utf8(output).unwrap().contains("private-marker"));
+}
+
+#[test]
+fn observation_request_parses_without_executing_a_receive() {
+    let body = encode(Command::Observe, &wire(Command::Observe));
+    let mut output = Vec::new();
+    let code = run_with(
+        Command::Observe,
+        &mut body.as_slice(),
+        &mut output,
+        &mut io::sink(),
+        |request, input| {
+            assert!(request.destination.is_none());
+            assert_eq!(request.path.to_str(), Some(fixture_path()));
+            assert_eq!(input.read(&mut [0]).unwrap(), 0);
+            Response::new(Status::Error, "synthetic observation")
+        },
+    );
+    assert_eq!(code, ExitCode::from(1));
+    let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(response["status"], "error");
+    assert!(response["pack"].is_null() && response["retained"].is_null());
+}
+
+#[test]
+fn receive_parser_consumes_only_the_exact_header_and_leaves_streaming_payload() {
+    let header = encode(Command::Receive, &wire(Command::Receive));
+    let payload = b"private-marker-payload";
+    let mut input = io::Cursor::new([header.as_slice(), payload].concat());
+    let request = request::read(Command::Receive, &mut input).unwrap();
+    assert_eq!(input.position(), header.len() as u64);
+    assert_eq!(request.destination.as_deref(), Some("ready"));
+    assert_eq!(request.pack.encoded_bytes, 32);
+    let mut retained = Vec::new();
+    input.read_to_end(&mut retained).unwrap();
+    assert_eq!(retained, payload);
+}
+
+#[test]
+fn framing_bounds_and_truncation_fail_before_execution() {
+    let header = encode(Command::Receive, &wire(Command::Receive));
+    for length in [0, 1, 3, 4, header.len() - 1] {
+        rejected(Command::Receive, &header[..length]);
+    }
+    for length in [0_u32, u32::try_from(request::HEADER_LIMIT + 1).unwrap(), u32::MAX] {
+        let mut input = io::Cursor::new([length.to_le_bytes().as_slice(), b"private-marker"].concat());
+        assert!(request::read(Command::Receive, &mut input).is_err());
+        assert_eq!(input.position(), 4);
+    }
+    rejected(Command::Observe, &vec![b' '; request::HEADER_LIMIT + 1]);
+    rejected(
+        Command::Observe,
+        &[encode(Command::Observe, &wire(Command::Observe)), b"{}".to_vec()].concat(),
+    );
+    let mut maximum = encode(Command::Observe, &wire(Command::Observe));
+    maximum.resize(request::HEADER_LIMIT, b' ');
+    assert!(request::read(Command::Observe, &mut maximum.as_slice()).is_ok());
+    maximum.push(b' ');
+    rejected(Command::Observe, &maximum);
+}
+
+#[test]
+fn schemas_identities_and_paths_are_strict_before_execution() {
+    for command in [Command::Receive, Command::Observe] {
+        let original = wire(command);
+        for (field, value) in [
+            ("version", json!(0)),
+            ("version", json!(2)),
+            ("version", json!(1.5)),
+            ("unknown", json!(true)),
+        ] {
+            let mut invalid = original.clone();
+            invalid[field] = value;
+            rejected(command, &encode(command, &invalid));
+        }
+        for (field, value) in [
+            ("base_commit", json!("0".repeat(40))),
+            ("base_commit", json!("g".repeat(40))),
+            ("base_commit", json!("1".repeat(39))),
+            ("base_commit", json!("private-marker")),
+            ("sha256", json!("g".repeat(64))),
+            ("sha256", json!("a".repeat(63))),
+            ("encoded_bytes", json!(0)),
+            ("encoded_bytes", json!(-1)),
+            ("unknown", json!(true)),
+        ] {
+            let mut invalid = original.clone();
+            invalid["pack"][field] = value;
+            rejected(command, &encode(command, &invalid));
+        }
+        let path_field = match command {
+            Command::Receive => "parent",
+            Command::Observe => "path",
+        };
+        for path in [
+            "relative".into(),
+            "/".into(),
+            "/private/../escape".into(),
+            "/private/nul\0private-marker".into(),
+            format!(
+                "/{}",
+                "x".repeat(horizon_core::repository_overlay::materialize::MAX_REQUEST_PATH_BYTES)
+            ),
+        ] {
+            let mut invalid = original.clone();
+            invalid[path_field] = json!(path);
+            rejected(command, &encode(command, &invalid));
+        }
+        let text = serde_json::to_string(&original)
+            .unwrap()
+            .replacen('{', "{\"version\":1,", 1);
+        let duplicate = match command {
+            Command::Receive => [
+                u32::try_from(text.len()).unwrap().to_le_bytes().as_slice(),
+                text.as_bytes(),
+            ]
+            .concat(),
+            Command::Observe => text.into_bytes(),
+        };
+        rejected(command, &duplicate);
+    }
+    for name in [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "a/b",
+        "a\\b",
+        ".git",
+        "nul\0private-marker",
+        "bad.",
+    ] {
+        let mut invalid = wire(Command::Receive);
+        invalid["destination"] = json!(name);
+        rejected(Command::Receive, &encode(Command::Receive, &invalid));
+    }
+}
+
+#[test]
+fn short_reads_and_interrupted_prefix_reads_preserve_framing() {
+    struct Failed;
+    impl Read for Failed {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("private-marker"))
+        }
+    }
+    struct Chunks {
+        bytes: io::Cursor<Vec<u8>>,
+        interrupt: bool,
+    }
+    impl Read for Chunks {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            if self.interrupt {
+                self.interrupt = false;
+                return Err(io::ErrorKind::Interrupted.into());
+            }
+            let length = bytes.len().min(1);
+            self.bytes.read(&mut bytes[..length])
+        }
+    }
+    let mut input = Chunks {
+        bytes: io::Cursor::new(encode(Command::Receive, &wire(Command::Receive))),
+        interrupt: true,
+    };
+    assert!(request::read(Command::Receive, &mut input).is_ok());
+    for command in [Command::Receive, Command::Observe] {
+        assert!(request::read(command, &mut Failed).is_err());
+    }
+}
+
+#[test]
+fn shared_identity_types_normalize_hexadecimal_case() {
+    for command in [Command::Receive, Command::Observe] {
+        let mut value = wire(command);
+        value["pack"]["base_commit"] = json!("AB".repeat(20));
+        value["pack"]["sha256"] = json!("CD".repeat(32));
+        let request = request::read(command, &mut encode(command, &value).as_slice()).unwrap();
+        assert_eq!(request.pack.base_commit.as_str(), "ab".repeat(20));
+        assert_eq!(request.pack.sha256.as_str(), "cd".repeat(32));
+    }
+}
+
+#[test]
+fn output_loss_never_reexecutes_the_operation() {
+    struct Lost(usize);
+    impl Write for Lost {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.0 == 0 {
+                return Err(io::ErrorKind::BrokenPipe.into());
+            }
+            let count = bytes.len().min(self.0);
+            self.0 -= count;
+            Ok(count)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::ErrorKind::BrokenPipe.into())
+        }
+    }
+    for remaining in [0, 1, usize::MAX] {
+        let calls = std::cell::Cell::new(0);
+        let mut diagnostics = Vec::new();
+        let result = run_with(
+            Command::Observe,
+            &mut encode(Command::Observe, &wire(Command::Observe)).as_slice(),
+            &mut Lost(remaining),
+            &mut diagnostics,
+            |_, _| {
+                calls.set(calls.get() + 1);
+                Response::new(Status::Error, "synthetic outcome")
+            },
+        );
+        assert_eq!(result, ExitCode::from(3));
+        assert_eq!(calls.get(), 1);
+        assert_eq!(
+            diagnostics,
+            b"Could not write a complete response; retain data and inspect before any retry.\n"
+        );
+    }
+}
+
+#[test]
+fn status_wire_values_round_trip_without_aliases() {
+    for name in [
+        "acknowledged",
+        "observed",
+        "rejected",
+        "error",
+        "unsupported",
+        "receive_unconfirmed",
+        "unpublished",
+        "published_unsynchronized",
+        "rename_unconfirmed",
+    ] {
+        let status: Status = serde_json::from_value(json!(name)).unwrap();
+        assert_eq!(serde_json::to_value(status).unwrap(), json!(name));
+    }
+    assert!(serde_json::from_value::<Status>(json!("running")).is_err());
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn non_linux_execution_is_explicitly_unsupported_without_reading_the_pack() {
+    for command in [Command::Receive, Command::Observe] {
+        let header = encode(command, &wire(command));
+        let mut bytes = header.clone();
+        if matches!(command, Command::Receive) {
+            bytes.extend_from_slice(b"unread-pack");
+        }
+        let mut input = io::Cursor::new(bytes);
+        let mut output = Vec::new();
+        assert_eq!(
+            run(command, &mut input, &mut output, &mut io::sink()),
+            ExitCode::from(1)
+        );
+        assert_eq!(input.position(), header.len() as u64);
+        let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(response["status"], "unsupported");
+        assert!(response["pack"].is_null() && response["retained"].is_null());
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn maximum_escaped_retained_paths_fit_without_claiming_verified_data() {
+    use horizon_core::repository_overlay::materialize::MAX_REQUEST_PATH_BYTES;
+    let path =
+        std::path::PathBuf::from(format!("/{}", "\u{1}".repeat(MAX_REQUEST_PATH_BYTES - 1))).join("x".repeat(255));
+    for (name, source, destination) in [
+        ("receive_unconfirmed", true, false),
+        ("unpublished", true, false),
+        ("published_unsynchronized", false, true),
+        ("rename_unconfirmed", true, true),
+    ] {
+        let status = serde_json::from_value(json!(name)).unwrap();
+        let response = Response::retained(
+            status,
+            source.then(|| path.clone()),
+            destination.then(|| path.clone()),
+            "retained",
+        );
+        let mut output = Vec::new();
+        assert_eq!(
+            super::super::write_response(
+                &response,
+                response.exit_code(),
+                super::super::protocol::RESPONSE_LIMIT,
+                &mut output,
+                &mut io::sink()
+            ),
+            ExitCode::from(1)
+        );
+        assert!(output.len() < super::super::protocol::RESPONSE_LIMIT && output.ends_with(b"\n"));
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(value["status"], name);
+        assert!(value["pack"].is_null());
+        assert_eq!(value["retained"]["source"], json!(source.then_some(&path)));
+        assert_eq!(value["retained"]["destination"], json!(destination.then_some(&path)));
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -315,6 +315,12 @@ back into large multi-purpose modules.
   synchronization. Lost output/write acknowledgement retains possible publication
   without overwrite, cleanup, setup/task start or inferred export permission. Input
   storage synchronization is not the retained-setup qualifier or cloud durability.
+  Its separate `pack/` tree owns bounded framed request validation, typed response
+  projection and Linux routing to existing pack receipt/publication/observation.
+  Shared core path/name validators expose lexical checks only, not storage authority.
+  Pack payloads stream to core; uncertain receipt, pre/post-rename and unknown-rename
+  failures retain distinct candidates. Status never writes or fabricates missing,
+  readiness or synchronization acknowledgement. See [pack commands](../remote-pack-transfer.md).
 - `containers/remote-worker/setup-launch.py` owns the separate worker-only bounded
   handoff: it delegates strict input/root observation to `setup-status`, returns
   existing observations without launch, and passes only an absent intent through a

--- a/docs/remote-pack-transfer.md
+++ b/docs/remote-pack-transfer.md
@@ -1,0 +1,119 @@
+# Worker pack receipt and observation
+
+`horizon-repository receive-pack` streams one explicitly supplied exact-base Git
+pack into private staging, then performs qualified no-overwrite publication.
+`pack-status` inspects one explicit candidate without writing. These Linux commands
+reuse the [receiver](remote-repository-pack-receipt.md),
+[observer](remote-repository-pack-receipt.md#read-only-reopening) and
+[publisher](remote-repository-pack-publication.md). They are not source-export
+approval, authenticated transport, setup/task admission or workspace readiness.
+Nothing invokes them automatically; existing commands remain compatible.
+
+## Requests
+
+For `receive-pack`, stdin is a four-byte unsigned little-endian header length
+(1–32,768), exactly that many UTF-8 JSON bytes, exactly `pack.encoded_bytes` pack
+bytes, then EOF. The header has only these fields:
+
+```json
+{
+  "version": 1,
+  "parent": "/retained/explicit-private-parent",
+  "destination": "base-pack",
+  "pack": {
+    "base_commit": "1111111111111111111111111111111111111111",
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "encoded_bytes": 123
+  }
+}
+```
+
+The identifiers above are illustrative, not a usable fixture. `base_commit` is
+an exact nonzero 40-character SHA-1 commit identity; `sha256` is the expected
+64-character encoded-pack SHA-256. Shared core types normalize either hex case to
+lowercase. The core default encoded limit is 256 MiB, with a minimum of 32 bytes.
+Existing native decoding, object-count and per-process resource limits also apply.
+The binary does not buffer the complete pack or accept archives/thin packs.
+
+`parent` must be an explicit existing absolute non-root path, at most 4,096 UTF-8
+bytes, without NUL or parent traversal. `destination` uses the shared portable
+single-component naming policy, at most 255 bytes. Unknown/duplicate fields,
+unsupported versions, malformed identities, paths and headers fail before storage
+access. Core length limits fail before reservation. Payload truncation, trailing
+bytes, digest mismatch or decoding failure can leave unconfirmed private staging.
+
+For `pack-status`, stdin is ordinary JSON, at most 32,768 bytes plus EOF:
+
+```json
+{
+  "version": 1,
+  "path": "/retained/explicit-private-parent/base-pack",
+  "pack": {
+    "base_commit": "1111111111111111111111111111111111111111",
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "encoded_bytes": 123
+  }
+}
+```
+
+Only those fields are accepted. `path` follows the same lexical path rules. Status
+revalidates the existing fixed layout, pack bytes and exact-base object closure.
+It does not create, synchronize, repair or distinguish missing from unsafe,
+unreadable or invalid data. Observation is not a new publication acknowledgement.
+
+## Responses and retained data
+
+Both commands return bounded JSON plus newline, at most 128 KiB:
+`version`, `status`, `pack`, `retained` and `reason`. Only success/observation has
+non-null `pack`, containing `path`, `objects_directory`, the verified request
+`identity` and decoded `objects` count. That object directory still needs existing
+namespace/seed/setup verification before use. Success has null `retained`/`reason`.
+Failure has null `pack` and a static redacted reason; candidate paths appear only
+in typed `retained.source` and `retained.destination` fields.
+
+| Status | Exit | Meaning / retained candidate |
+| --- | --- | --- |
+| `acknowledged` | 0 | This invocation completed qualified publication and final confirmation. |
+| `observed` | 0 | Existing matching data was read and verified, with no write. |
+| `rejected` | 2 | Invalid request; execution did not begin. |
+| `unsupported` | 1 | Non-Linux platform; no storage operation. |
+| `error` | 1 | Receipt failed without a returned reservation, or observation failed. No path receipt is available; this is not cleanup/replay authority. |
+| `receive_unconfirmed` | 1 | Partial or unverified data may remain at `source`. |
+| `unpublished` | 1 | Publication did not rename the verified input; retain `source`. |
+| `published_unsynchronized` | 1 | Rename succeeded, final confirmation failed; retain `destination`. |
+| `rename_unconfirmed` | 1 | Rename outcome is uncertain; retain and inspect both candidates. |
+
+An existing destination never bypasses payload validation or fabricates success.
+A repeated receive can leave another unpublished private source; it is not an
+idempotent status request. No failure triggers retransmission, cleanup or setup.
+
+Exit 3 means a response could not be fully written/flushed, including after a
+successful publication. Persist the intended destination and expected identity
+**before** sending input. After output loss, use status on that same destination.
+Error/missing output never authorizes another receive or deletion. If failure
+occurred before publication, random private staging may remain under the nominated
+parent without a received path; explicit inventory/cleanup is separate work. A
+later successful observation does not prove a prior failed synchronization succeeded.
+
+## Preconditions and proof boundary
+
+The caller authorizes the nominated paths and keeps their private ownership,
+contents, ancestry and mounts stable/exclusive. Publication requires qualified
+journaled ext4 with barriers and trusted readable proc/sysfs metadata; container
+overlay storage fails closed. No fallback, ownership repair or permission change
+is attempted. Acknowledgement is not proof of power-loss survival/cloud durability.
+
+These commands are synchronous. Blocking stdin/EOF and filesystem calls are the
+caller's latency responsibility; native child bounds are not an end-to-end deadline.
+The future authenticated controller must impose admission, transport and capacity
+budgets without treating disconnect as cancellation or replay permission.
+No keys, credentials, provider resources, client transport, task supervision,
+checkpoints or image release are added. Closing local views still only detaches.
+
+Run actual command proof against a locally built image and trusted ext4 fixture
+parent with `python3 -B containers/remote-worker/test_pack_receive_image.py
+--docker-host unix:///path/to/docker.sock --image <immutable-image-id>`. The harness
+uses only synthetic data and no network, checks small/65 MiB-plus receipt and
+fresh-container observation, failure retention, output loss and materialization,
+then removes only its owned fixtures/containers. Images remain. This is local
+mechanism proof, not authenticated transfer or cloud/PC-off acceptance.

--- a/docs/remote-pack-transfer.md
+++ b/docs/remote-pack-transfer.md
@@ -35,9 +35,11 @@ lowercase. The core default encoded limit is 256 MiB, with a minimum of 32 bytes
 Existing native decoding, object-count and per-process resource limits also apply.
 The binary does not buffer the complete pack or accept archives/thin packs.
 
-`parent` must be an explicit existing absolute non-root path, at most 4,096 UTF-8
+`parent` must be an explicit existing absolute non-root path, at most 3,840 UTF-8
 bytes, without NUL or parent traversal. `destination` uses the shared portable
-single-component naming policy, at most 255 bytes. Unknown/duplicate fields,
+single-component naming policy, at most 255 bytes. The parent bound reserves a
+separator and full child component so both generated staging and final candidate
+paths fit the 4,096-byte observation bound. Unknown/duplicate fields,
 unsupported versions, malformed identities, paths and headers fail before storage
 access. Core length limits fail before reservation. Payload truncation, trailing
 bytes, digest mismatch or decoding failure can leave unconfirmed private staging.
@@ -56,7 +58,8 @@ For `pack-status`, stdin is ordinary JSON, at most 32,768 bytes plus EOF:
 }
 ```
 
-Only those fields are accepted. `path` follows the same lexical path rules. Status
+Only those fields are accepted. `path` follows the same lexical path rules with
+a 4,096-byte limit on the complete candidate. Status
 revalidates the existing fixed layout, pack bytes and exact-base object closure.
 It does not create, synchronize, repair or distinguish missing from unsafe,
 unreadable or invalid data. Observation is not a new publication acknowledgement.

--- a/docs/remote-pack-transfer.md
+++ b/docs/remote-pack-transfer.md
@@ -35,11 +35,13 @@ lowercase. The core default encoded limit is 256 MiB, with a minimum of 32 bytes
 Existing native decoding, object-count and per-process resource limits also apply.
 The binary does not buffer the complete pack or accept archives/thin packs.
 
-`parent` must be an explicit existing absolute non-root path, at most 3,840 UTF-8
+`parent` must be an explicit existing absolute non-root path, at most 3,583 UTF-8
 bytes, without NUL or parent traversal. `destination` uses the shared portable
 single-component naming policy, at most 255 bytes. The parent bound reserves a
 separator and full child component so both generated staging and final candidate
-paths fit the 4,096-byte observation bound. Unknown/duplicate fields,
+paths fit the 3,839-byte observation bound. Both commands also reserve the Linux
+terminating NUL and 256 bytes for the fixed inner pack paths used by native
+verification; a reopenable root alone is insufficient. Unknown/duplicate fields,
 unsupported versions, malformed identities, paths and headers fail before storage
 access. Core length limits fail before reservation. Payload truncation, trailing
 bytes, digest mismatch or decoding failure can leave unconfirmed private staging.
@@ -59,7 +61,7 @@ For `pack-status`, stdin is ordinary JSON, at most 32,768 bytes plus EOF:
 ```
 
 Only those fields are accepted. `path` follows the same lexical path rules with
-a 4,096-byte limit on the complete candidate. Status
+a 3,839-byte limit on the complete candidate. Status
 revalidates the existing fixed layout, pack bytes and exact-base object closure.
 It does not create, synchronize, repair or distinguish missing from unsafe,
 unreadable or invalid data. Observation is not a new publication acknowledgement.


### PR DESCRIPTION
## Purpose

Expose explicit worker commands for streaming receipt/publication and read-only observation of one exact-base Git pack. Refs #383 and #470; neither issue closes here.

## Behavior

- `receive-pack` validates a bounded versioned JSON header, streams the remaining pack through existing core identity/length/closure checks, then uses qualified no-overwrite publication.
- `pack-status` revalidates one explicit candidate without creating, repairing or synchronizing it. Observation is not a publication acknowledgement or proof that an earlier synchronization succeeded.
- Preserve distinct unconfirmed receipt, unpublished source, renamed destination and uncertain-rename candidates. Existing targets do not bypass verification; lost output never retries, deletes data or starts setup.
- Receive parents reserve space for the shared maximum child name. Both commands also reserve the Linux terminator and 256 bytes for fixed internal pack paths used by native verification. Parent paths are bounded to 3,583 bytes and observation candidates to 3,839 bytes. This fixes both the parser round-trip issue and the actual renamed-but-unreopenable filesystem case.
- Reuse shared typed identifiers and lexical path/name validation. The command shell, parser, response projection and Linux execution stay separate; non-Linux execution is explicitly unsupported.

Requires explicitly authorized private stable paths, trusted native tools/kernel metadata and qualified journaled ext4 for publication. Blocking stdin/filesystem calls remain the caller's latency responsibility; encoded and native-process limits are not an end-to-end deadline or aggregate decoded-data budget. No authenticated client transport, source approval, provider/UI action, task admission, image publication or release is added. Closing views still only detaches.

## Validation

Candidate: `87978b71a7d9ebcb24f45ab5ada2094356150e50`.

- Independent local review clear; nine source/test files, 985 changed lines, plus three documentation files.
- All eight source and exact-commit validation lanes pass: formatting, maintainability, version sync, default/speech workspace tests and blocking/strict/pedantic Clippy.
- Ten Linux protocol tests cover strict framing/schema/path/identity bounds, short/interrupted reads, payload position, response limits and output loss without re-execution. Platform-correct fixtures and a real non-Linux unsupported dispatch regression are included.
- All seven source and exact-commit image lanes pass. The new real-filesystem regression reproduced the original renamed-but-unreopenable result, then passes with the correction: valid-sized components, rejection before mutation above the bound, and actual publication followed by native recovery at the maximum supported path.
- Actual command smoke also covers small and 65 MiB-plus packs, fresh-container non-mutating observation, retained transfer failures/collisions, missing/unsafe/unqualified storage, lost stdout and the existing shallow materializer with overlay/index/LFS/link/mode semantics. Existing overlay, independent setup, packaging/provenance, repository, runtime isolation and retained-host-key lanes pass. Packaging verifies 371 allowlisted inputs, all 31 final layers and the independently built executable hash.

All image fixtures are synthetic; no cloud services or real credentials are used. Only their owned containers and fixtures are cleaned. Images remain local. This is worker mechanism proof, not authenticated transfer or cloud/PC-off acceptance.

Runtime image: `sha256:23b3b27dc8a6f3bf28b9a233390c8ef905b1080e38c3113919d7eafc5cf51a92`.
Builder image: `sha256:0a9e8cadca5f825a34c5ecfa5dc56d933c87261639ef04bc041457cb41e552e2`.
Repository helper SHA-256: `5addedeb80df70cbdc8cf7efbc6def62cc0fef9eacca04fd0a4514d3563357b2`.
