### PR TITLE
Share bounded worker query transport

### DIFF
--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -1,5 +1,6 @@
 //! Crate-private pinned SSH command construction, not remote attachment authority.
 
+pub(crate) mod query;
 mod trust;
 
 use trust::KnownHosts;

--- a/crates/horizon-core/src/remote_worker_ssh/query.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/query.rs
@@ -1,4 +1,5 @@
-use super::{RemotePanelStatusError as Error, protocol::RESPONSE_LIMIT};
+//! Bounded local query-child I/O, independent of a worker protocol or admission.
+
 use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
 use std::{
     io::{self, Read, Write},
@@ -8,7 +9,24 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub(super) fn run(mut command: Command, input: &[u8], timeout: Duration) -> Result<Vec<u8>, Error> {
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("worker query client is unavailable")]
+    ClientUnavailable,
+    #[error("worker query failed")]
+    QueryFailed,
+    #[error("worker query exceeded its deadline")]
+    Deadline,
+    #[error("worker query output exceeds its size limit")]
+    OutputLimit,
+}
+
+pub(crate) fn run(
+    mut command: Command,
+    input: &[u8],
+    timeout: Duration,
+    response_limit: usize,
+) -> Result<Vec<u8>, Error> {
     let started = Instant::now();
     let child = command
         .stdin(Stdio::piped())
@@ -34,7 +52,7 @@ pub(super) fn run(mut command: Command, input: &[u8], timeout: Duration) -> Resu
             return Err(Error::Deadline);
         }
         write_pending(&mut stdin, &mut pending)?;
-        let finished = read_available(&mut stdout, &mut output)?;
+        let finished = read_available(&mut stdout, &mut output, response_limit)?;
         if let Some(status) = child.0.try_wait().map_err(|_| Error::QueryFailed)? {
             if !status.success() || !pending.is_empty() {
                 return Err(Error::QueryFailed);
@@ -66,16 +84,16 @@ fn write_pending(stdin: &mut Option<ChildStdin>, pending: &mut &[u8]) -> Result<
     Ok(())
 }
 
-fn read_available(stream: &mut impl Read, output: &mut Vec<u8>) -> Result<bool, Error> {
+fn read_available(stream: &mut impl Read, output: &mut Vec<u8>, limit: usize) -> Result<bool, Error> {
     let mut buffer = [0; 1024];
     // One read per pass keeps even a peer's endless output inside the elapsed-time budget.
     match stream.read(&mut buffer) {
         Ok(0) => Ok(true),
-        Ok(count) if output.len() + count <= RESPONSE_LIMIT => {
+        Ok(count) if count <= limit.saturating_sub(output.len()) => {
             output.extend_from_slice(&buffer[..count]);
             Ok(false)
         }
-        Ok(_) => Err(Error::InvalidResponse),
+        Ok(_) => Err(Error::OutputLimit),
         Err(error) if matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) => Ok(false),
         Err(_) => Err(Error::QueryFailed),
     }
@@ -91,3 +109,6 @@ impl Drop for OwnedChild {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_worker_ssh/query/tests.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/query/tests.rs
@@ -4,6 +4,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+const INPUT: &[u8] = b"synthetic query";
+const TEST_LIMIT: usize = 4096;
+
 fn shell(script: &str) -> Command {
     let mut command = Command::new("/bin/sh");
     command.args(["-c", script]);
@@ -13,28 +16,30 @@ fn shell(script: &str) -> Command {
 #[test]
 fn bounded_command_closes_stdin_and_never_exposes_subprocess_errors() {
     assert_eq!(
-        command::run(shell("exec cat"), RUNNING, Duration::from_secs(2)),
-        Ok(RUNNING.to_vec())
+        run(shell("exec cat"), INPUT, Duration::from_secs(2), TEST_LIMIT),
+        Ok(INPUT.to_vec())
     );
-    let error = command::run(
+    let error = run(
         shell("printf synthetic-private-response >&2; exit 7"),
         b"",
         Duration::from_secs(2),
+        TEST_LIMIT,
     )
     .expect_err("failure");
-    assert_eq!(error, RemotePanelStatusError::QueryFailed);
+    assert_eq!(error, Error::QueryFailed);
     assert!(!format!("{error:?} {error}").contains("synthetic-private-response"));
     assert_eq!(
-        command::run(
+        run(
             Command::new("/nonexistent-horizon-status-client"),
             b"",
-            Duration::from_secs(2)
+            Duration::from_secs(2),
+            TEST_LIMIT
         ),
-        Err(RemotePanelStatusError::ClientUnavailable)
+        Err(Error::ClientUnavailable)
     );
     assert_eq!(
-        command::run(shell("printf '%06000d' 0"), b"", Duration::from_secs(2)),
-        Err(RemotePanelStatusError::InvalidResponse)
+        run(shell("printf '%06000d' 0"), b"", Duration::from_secs(2), TEST_LIMIT),
+        Err(Error::OutputLimit)
     );
 }
 
@@ -43,8 +48,8 @@ fn stdin_backpressure_and_inherited_output_cannot_extend_the_deadline() {
     for (script, input) in [("exec sleep 5", vec![b'x'; 1024 * 1024]), ("sleep 1 & exit 0", vec![])] {
         let started = Instant::now();
         assert_eq!(
-            command::run(shell(script), &input, Duration::from_millis(40)),
-            Err(RemotePanelStatusError::Deadline)
+            run(shell(script), &input, Duration::from_millis(40), TEST_LIMIT),
+            Err(Error::Deadline)
         );
         assert!(started.elapsed() < Duration::from_millis(800));
     }
@@ -57,12 +62,24 @@ fn timed_out_client_is_reaped_without_signalling_any_other_process() {
     let mut child = shell("printf '%s' \"$$\" > \"$1\"; exec sleep 5");
     child.arg("fixture").arg(&pid_file);
     assert_eq!(
-        command::run(child, b"", Duration::from_millis(100)),
-        Err(RemotePanelStatusError::Deadline)
+        run(child, b"", Duration::from_millis(100), TEST_LIMIT),
+        Err(Error::Deadline)
     );
     let pid: u32 = std::fs::read_to_string(pid_file)
         .expect("owned PID")
         .parse()
         .expect("PID");
     assert!(!std::path::Path::new("/proc").join(pid.to_string()).exists());
+}
+
+#[test]
+fn each_caller_selects_its_exact_output_ceiling() {
+    for size in [0, 1, 4096, 8192] {
+        let input = vec![b'x'; size];
+        assert_eq!(run(shell("exec cat"), &input, Duration::from_secs(2), size), Ok(input));
+        assert_eq!(
+            run(shell("exec cat"), &vec![b'x'; size + 1], Duration::from_secs(2), size),
+            Err(Error::OutputLimit)
+        );
+    }
 }

--- a/crates/horizon-core/src/remote_worker_status.rs
+++ b/crates/horizon-core/src/remote_worker_status.rs
@@ -2,8 +2,6 @@
 //! Calls are synchronous and must run off the render thread.
 
 #[cfg(target_os = "linux")]
-mod command;
-#[cfg(target_os = "linux")]
 mod protocol;
 #[cfg(target_os = "linux")]
 mod ssh;

--- a/crates/horizon-core/src/remote_worker_status/ssh.rs
+++ b/crates/horizon-core/src/remote_worker_status/ssh.rs
@@ -1,8 +1,8 @@
-use super::{RemotePanelStatusError as Error, command};
+use super::{RemotePanelStatusError as Error, protocol::RESPONSE_LIMIT};
 use crate::{
     cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
     remote_ssh_identity::RemoteSshIdentity,
-    remote_worker_ssh::{known_hosts, prepared_command},
+    remote_worker_ssh::{known_hosts, prepared_command, query},
 };
 use std::time::Duration;
 
@@ -15,5 +15,33 @@ pub(super) fn request(
 ) -> Result<Vec<u8>, Error> {
     let known_hosts = known_hosts(identity, endpoint)?;
     let command = prepared_command(identity.private_key_path(), known_hosts.path(), endpoint)?;
-    command::run(command, input, DEADLINE)
+    query::run(command, input, DEADLINE, RESPONSE_LIMIT).map_err(Error::from)
+}
+
+impl From<query::Error> for Error {
+    fn from(error: query::Error) -> Self {
+        match error {
+            query::Error::ClientUnavailable => Self::ClientUnavailable,
+            query::Error::QueryFailed => Self::QueryFailed,
+            query::Error::Deadline => Self::Deadline,
+            query::Error::OutputLimit => Self::InvalidResponse,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_failures_preserve_the_public_panel_error_contract() {
+        for (transport, expected) in [
+            (query::Error::ClientUnavailable, Error::ClientUnavailable),
+            (query::Error::QueryFailed, Error::QueryFailed),
+            (query::Error::Deadline, Error::Deadline),
+            (query::Error::OutputLimit, Error::InvalidResponse),
+        ] {
+            assert_eq!(Error::from(transport), expected);
+        }
+    }
 }

--- a/crates/horizon-core/src/remote_worker_status/tests.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests.rs
@@ -7,8 +7,6 @@ use crate::{
     remote_workspace_recovery::recover_remote_workspace,
 };
 
-#[path = "tests/command.rs"]
-mod command_tests;
 #[path = "tests/intent.rs"]
 mod intent_tests;
 #[path = "tests/ssh.rs"]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -132,9 +132,10 @@ back into large multi-purpose modules.
   stale overview summaries before passing the owned snapshot to the observation gate.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
-  wire types; `ssh.rs` owns the query's private host-pin lifetime; `command.rs` owns
-  bounded nonblocking local-child I/O. It neither grants attachment/task startup
-  nor changes the general user-configured SSH API or remote execution lifetime.
+  wire types; `ssh.rs` owns the query's private host-pin lifetime and retains the
+  panel deadline, response ceiling and public error projection. It neither grants
+  attachment/task startup nor changes the general user-configured SSH API or remote
+  execution lifetime.
   Explicit saved shell/command verification reuses those gates and compares
   literal argv plus the effective directory with the worker's retained intent;
   unresolved agent launch/handoff/resume semantics stay fail-closed.
@@ -147,6 +148,9 @@ back into large multi-purpose modules.
   descriptor path for both modes, with no named-file fallback. Holding the exact
   descriptor preserves each pin through local teardown; process exit cannot leave
   a named trust file, even when normal shutdown bypasses Rust destructors.
+  Its shared `query.rs` leaf owns bounded nonblocking local-child I/O, explicit
+  caller response ceilings and typed transport failures without owning protocol
+  parsing, admission, remote tasks or provider lifetime. Query tests are colocated.
 - `remote_panel_attachment.rs` consumes explicit exact-allocation admission, fresh
   read-only identity/worker inspection and saved-intent verification before a pinned
   local PTY. Only explicit recovery commits observations; attachment preserves saved phases.


### PR DESCRIPTION
## Purpose

Share the existing bounded local SSH-query executor as a focused prerequisite for
owned repository pack inspection in #470 and #383.

## Behavior

- Move query I/O and its process tests under the private worker SSH module.
- Give callers an explicit response ceiling and protocol-independent typed errors.
- Preserve panel inspection's 10-second deadline, 4,096-byte ceiling, public errors,
  pinned host-key lifetime, nonblocking I/O and owned-child cleanup.
- Keep protocol parsing, ownership/admission and remote task/provider lifetime
  outside the executor. No new SSH commands, retries, uploads, task starts or UI.

The implementation remains Linux-gated; unsupported-platform behavior is unchanged.
There are eight source/test paths and 399 changed lines when both sides of moves
are counted. Maintainability documentation tracks the new module boundary.

## Validation

Candidate: `2a07a80b2dbe1aae7eecafb4fa00dffe2e34507d`.

All eight source and exact-commit validation lanes passed. The actual local SSH/API
smoke also passed independently on the source tree and final commit.

Validation passed formatting, maintainability, version sync, the complete
default and speech test suites, blocking and strict Clippy, and advisory pedantic
Clippy. Process tests cover EOF, failure redaction, missing clients, exact/oversized
output, blocked stdin, inherited output, deadlines and owned-child reaping. An
explicit regression preserves all four public panel-error conversions. All 21
worker query, SSH and panel-status regressions pass in the full suite.

The disposable local SSH smoke uses the retained immutable worker image from #487
and a public API client built from this candidate. It verifies repeated running
and exited status/intent queries, wrong-host-key and mismatched-intent rejection,
missing/unknown panels, unchanged worker/task identities, continuing task progress,
unchanged saved snapshots/client key and no named trust residue. Only verified
task-owned fixtures are removed after each pass.

Independent local review and committed-source parity verification are complete.
This is transport parity evidence, not cloud/PC-off acceptance or transfer authority.
No release or image publication is included.
