### PR TITLE
Compare retained repository recovery snapshots

### DIFF
--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -9,6 +9,7 @@ pub mod materialize;
 pub mod namespace;
 mod paths;
 pub mod reader;
+pub mod recovery;
 pub mod retained_setup;
 pub mod seed;
 #[cfg(target_os = "linux")]

--- a/crates/horizon-core/src/repository_overlay/recovery/compare.rs
+++ b/crates/horizon-core/src/repository_overlay/recovery/compare.rs
@@ -1,0 +1,191 @@
+use super::{
+    ChangeRelation, ComparisonSide, EntryChange, LayerComparison, PathComparison, RecoveryComparison,
+    RecoveryComparisonError as Error, StructuralConflict, check_cancel, identity::Identities,
+};
+use crate::repository_overlay::{
+    MAX_CHANGES, MAX_METADATA_BYTES,
+    bundle::RepositoryOverlayBundle,
+    namespace::{RepositoryNamespace, ResolvedRepositoryOverlay},
+};
+use std::{collections::BTreeSet, ops::Bound};
+
+pub(super) fn run<'a>(
+    local: &'a ResolvedRepositoryOverlay,
+    remote: &'a ResolvedRepositoryOverlay,
+    cancelled: &impl Fn() -> bool,
+) -> Result<RecoveryComparison<'a>, Error> {
+    check_cancel(cancelled)?;
+    if local.bundle().plan().source() != remote.bundle().plan().source() {
+        return Err(Error::SourceMismatch);
+    }
+    if local.base_commit() != remote.base_commit()
+        || local.base_tree() != remote.base_tree()
+        || local.base().entries().len() != remote.base().entries().len()
+    {
+        return Err(Error::BaseMismatch);
+    }
+    for (a, b) in local.base().entries().zip(remote.base().entries()) {
+        check_cancel(cancelled)?;
+        if a != b {
+            return Err(Error::BaseMismatch);
+        }
+    }
+    let mut identities = Identities::new(cancelled);
+    let index = layer(
+        Side {
+            before: local.base(),
+            after: local.index(),
+            bundle: local.bundle(),
+        },
+        Side {
+            before: remote.base(),
+            after: remote.index(),
+            bundle: remote.bundle(),
+        },
+        local.base(),
+        &mut identities,
+        cancelled,
+    )?;
+    let working_tree = layer(
+        Side {
+            before: local.index(),
+            after: local.working_tree(),
+            bundle: local.bundle(),
+        },
+        Side {
+            before: remote.index(),
+            after: remote.working_tree(),
+            bundle: remote.bundle(),
+        },
+        local.base(),
+        &mut identities,
+        cancelled,
+    )?;
+    check_cancel(cancelled)?;
+    Ok(RecoveryComparison {
+        local,
+        remote,
+        index,
+        working_tree,
+    })
+}
+
+#[derive(Clone, Copy)]
+struct Side<'a> {
+    before: &'a RepositoryNamespace,
+    after: &'a RepositoryNamespace,
+    bundle: &'a RepositoryOverlayBundle,
+}
+
+fn layer<'a>(
+    local: Side<'a>,
+    remote: Side<'a>,
+    base: &'a RepositoryNamespace,
+    identities: &mut Identities<'a, '_, impl Fn() -> bool>,
+    cancelled: &impl Fn() -> bool,
+) -> Result<LayerComparison<'a>, Error> {
+    let mut paths = BTreeSet::new();
+    let mut bytes = 0usize;
+    for namespace in [local.before, local.after, remote.before, remote.after] {
+        for (path, _) in namespace.entries() {
+            check_cancel(cancelled)?;
+            if paths.insert(path) {
+                bytes = bytes
+                    .checked_add(path.len())
+                    .filter(|n| *n <= 4 * MAX_METADATA_BYTES)
+                    .ok_or(Error::Limit)?;
+                if paths.len() > 4 * MAX_CHANGES {
+                    return Err(Error::Limit);
+                }
+            }
+        }
+    }
+    let mut result = LayerComparison::default();
+    let mut local_leaves = BTreeSet::new();
+    let mut remote_leaves = BTreeSet::new();
+    for path in paths {
+        check_cancel(cancelled)?;
+        let a = EntryChange {
+            before: local.before.entry(path),
+            after: local.after.entry(path),
+        };
+        let b = EntryChange {
+            before: remote.before.entry(path),
+            after: remote.after.entry(path),
+        };
+        let same_base = identities.equal(a.before, local.bundle, b.before, remote.bundle)?;
+        let ac = !identities.equal(a.before, local.bundle, a.after, local.bundle)?;
+        let bc = !identities.equal(b.before, remote.bundle, b.after, remote.bundle)?;
+        let relation = if same_base {
+            match (ac, bc) {
+                (false, false) => None,
+                (true, false) => Some(ChangeRelation::LocalOnly),
+                (false, true) => Some(ChangeRelation::RemoteOnly),
+                (true, true) => Some(if identities.equal(a.after, local.bundle, b.after, remote.bundle)? {
+                    ChangeRelation::SameChange
+                } else {
+                    ChangeRelation::Divergent
+                }),
+            }
+        } else {
+            Some(ChangeRelation::DifferentIndexBases)
+        };
+        if let Some(relation) = relation {
+            result.paths.push(PathComparison {
+                path,
+                relation,
+                local: a,
+                remote: b,
+            });
+        }
+        if a.after.is_some() && !identities.equal(a.after, local.bundle, base.entry(path), local.bundle)? {
+            local_leaves.insert(path);
+        }
+        if b.after.is_some() && !identities.equal(b.after, remote.bundle, base.entry(path), local.bundle)? {
+            remote_leaves.insert(path);
+        }
+    }
+    conflicts(
+        &local_leaves,
+        &remote_leaves,
+        ComparisonSide::Local,
+        &mut result,
+        cancelled,
+    )?;
+    conflicts(
+        &remote_leaves,
+        &local_leaves,
+        ComparisonSide::Remote,
+        &mut result,
+        cancelled,
+    )?;
+    Ok(result)
+}
+
+fn conflicts<'a>(
+    ancestors: &BTreeSet<&'a str>,
+    descendants: &BTreeSet<&'a str>,
+    side: ComparisonSide,
+    result: &mut LayerComparison<'a>,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), Error> {
+    for ancestor in ancestors {
+        check_cancel(cancelled)?;
+        let prefix = format!("{ancestor}/");
+        for descendant in descendants.range::<str, _>((Bound::Included(prefix.as_str()), Bound::Unbounded)) {
+            check_cancel(cancelled)?;
+            if !descendant.starts_with(&prefix) {
+                break;
+            }
+            if result.structural_conflicts.len() == 2 * MAX_CHANGES {
+                return Err(Error::Limit);
+            }
+            result.structural_conflicts.push(StructuralConflict {
+                ancestor,
+                descendant,
+                ancestor_side: side,
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/recovery/identity.rs
+++ b/crates/horizon-core/src/repository_overlay/recovery/identity.rs
@@ -1,0 +1,83 @@
+use super::{RecoveryComparisonError as Error, check_cancel};
+use crate::repository_overlay::{
+    bundle::{MAX_BUNDLE_BYTES, RepositoryOverlayBundle},
+    namespace::{NamespaceEntry, NamespaceFile},
+};
+use git2::{ObjectType, Oid};
+use std::collections::BTreeMap;
+
+pub(super) struct Identities<'a, 'c, C> {
+    objects: BTreeMap<&'a str, Oid>,
+    bytes: usize,
+    cancelled: &'c C,
+    #[cfg(test)]
+    pub hashes: usize,
+}
+
+impl<'a, 'c, C: Fn() -> bool> Identities<'a, 'c, C> {
+    pub fn new(cancelled: &'c C) -> Self {
+        Self {
+            objects: BTreeMap::new(),
+            bytes: 0,
+            cancelled,
+            #[cfg(test)]
+            hashes: 0,
+        }
+    }
+
+    pub fn equal(
+        &mut self,
+        left: Option<&'a NamespaceEntry>,
+        left_bundle: &'a RepositoryOverlayBundle,
+        right: Option<&'a NamespaceEntry>,
+        right_bundle: &'a RepositoryOverlayBundle,
+    ) -> Result<bool, Error> {
+        match (left, right) {
+            (None, None) => Ok(true),
+            (Some(NamespaceEntry::Symlink { target: a }), Some(NamespaceEntry::Symlink { target: b })) => Ok(a == b),
+            (
+                Some(NamespaceEntry::File {
+                    source: a,
+                    executable: am,
+                }),
+                Some(NamespaceEntry::File {
+                    source: b,
+                    executable: bm,
+                }),
+            ) if am == bm && a.bytes() == b.bytes() => match (a, b) {
+                (NamespaceFile::Base { object: a, .. }, NamespaceFile::Base { object: b, .. }) => Ok(a == b),
+                (NamespaceFile::Overlay { sha256: a, .. }, NamespaceFile::Overlay { sha256: b, .. }) => Ok(a == b),
+                _ => Ok(self.object(a, left_bundle)? == self.object(b, right_bundle)?),
+            },
+            _ => Ok(false),
+        }
+    }
+
+    fn object(&mut self, file: &'a NamespaceFile, bundle: &'a RepositoryOverlayBundle) -> Result<Oid, Error> {
+        let (sha256, bytes) = match file {
+            NamespaceFile::Base { object, .. } => return Ok(*object),
+            NamespaceFile::Overlay { sha256, bytes } => (sha256, bytes),
+        };
+        if let Some(object) = self.objects.get(sha256.as_str()) {
+            return Ok(*object);
+        }
+        let payload = bundle
+            .blob(sha256)
+            .filter(|payload| payload.len() as u64 == *bytes)
+            .ok_or(Error::Object)?;
+        self.bytes = self
+            .bytes
+            .checked_add(payload.len())
+            .filter(|n| *n <= 2 * MAX_BUNDLE_BYTES)
+            .ok_or(Error::Limit)?;
+        check_cancel(self.cancelled)?;
+        let object = Oid::hash_object(ObjectType::Blob, payload).map_err(|_| Error::Object)?;
+        #[cfg(test)]
+        {
+            self.hashes += 1;
+        }
+        check_cancel(self.cancelled)?;
+        self.objects.insert(sha256.as_str(), object);
+        Ok(object)
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/recovery/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/recovery/mod.rs
@@ -1,0 +1,174 @@
+//! Inert comparison preserving both snapshots, not a merge or recovery authorization.
+
+mod compare;
+mod identity;
+
+use super::namespace::{NamespaceEntry, ResolvedRepositoryOverlay};
+use std::fmt;
+
+/// A relationship within one layer, not permission to choose or overwrite either side.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChangeRelation {
+    LocalOnly,
+    RemoteOnly,
+    SameChange,
+    Divergent,
+    /// Working-tree baselines differ because the two index entries differ.
+    /// This remains explicit even if the final working entries are equal.
+    DifferentIndexBases,
+}
+
+/// Borrowed literal states; absence means no leaf, never recursive directory deletion.
+#[derive(Clone, Copy, Debug)]
+pub struct EntryChange<'a> {
+    pub before: Option<&'a NamespaceEntry>,
+    pub after: Option<&'a NamespaceEntry>,
+}
+
+/// One changed or baseline-incompatible path, with both sides retained for inspection.
+pub struct PathComparison<'a> {
+    pub path: &'a str,
+    pub relation: ChangeRelation,
+    pub local: EntryChange<'a>,
+    pub remote: EntryChange<'a>,
+}
+
+impl fmt::Debug for PathComparison<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PathComparison")
+            .field("relation", &self.relation)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ComparisonSide {
+    Local,
+    Remote,
+}
+
+/// A leaf conflicts with the other side's descendant; both differ from the common Git base.
+/// This includes inherited index changes when examining the working-tree namespace.
+pub struct StructuralConflict<'a> {
+    pub ancestor: &'a str,
+    pub descendant: &'a str,
+    pub ancestor_side: ComparisonSide,
+}
+
+impl fmt::Debug for StructuralConflict<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StructuralConflict")
+            .field("ancestor_side", &self.ancestor_side)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Default)]
+pub struct LayerComparison<'a> {
+    paths: Vec<PathComparison<'a>>,
+    structural_conflicts: Vec<StructuralConflict<'a>>,
+}
+
+impl<'a> LayerComparison<'a> {
+    /// Byte-ordered paths. Paths unchanged on both sides with equal baselines are omitted.
+    #[must_use]
+    pub fn paths(&self) -> &[PathComparison<'a>] {
+        &self.paths
+    }
+
+    /// Local ancestors first, then remote ancestors; each group is byte-ordered.
+    #[must_use]
+    pub fn structural_conflicts(&self) -> &[StructuralConflict<'a>] {
+        &self.structural_conflicts
+    }
+}
+
+/// Borrows both complete original bundles and namespaces without cloning payloads.
+/// No conflict-free result promises safe composition: combining independent links,
+/// for example, still requires complete topology validation by a separately authorized writer.
+pub struct RecoveryComparison<'a> {
+    local: &'a ResolvedRepositoryOverlay,
+    remote: &'a ResolvedRepositoryOverlay,
+    index: LayerComparison<'a>,
+    working_tree: LayerComparison<'a>,
+}
+
+impl<'a> RecoveryComparison<'a> {
+    #[must_use]
+    pub fn local(&self) -> &'a ResolvedRepositoryOverlay {
+        self.local
+    }
+
+    #[must_use]
+    pub fn remote(&self) -> &'a ResolvedRepositoryOverlay {
+        self.remote
+    }
+
+    #[must_use]
+    pub fn index(&self) -> &LayerComparison<'a> {
+        &self.index
+    }
+
+    #[must_use]
+    pub fn working_tree(&self) -> &LayerComparison<'a> {
+        &self.working_tree
+    }
+}
+
+impl fmt::Debug for RecoveryComparison<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RecoveryComparison")
+            .field("index_paths", &self.index.paths.len())
+            .field("working_paths", &self.working_tree.paths.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Compare an exact common source/base without filesystem, process or transport I/O.
+/// Index baselines are the common Git tree; working baselines are each side's index.
+/// Git identity comparisons do not newly read or verify regular base blob payloads.
+/// No source ownership, capture coherence, secrecy, merge, recovery or durability is proved.
+/// Both inputs remain caller-owned on success, failure and cancellation. Run off the UI
+/// thread: at most 256 MiB of distinct verified overlay bytes are hashed, once per digest.
+/// Cancellation is checked between traversal steps and before/after hashing; a single
+/// bounded native blob hash (at most 64 MiB) is not interruptible or wall-time limited.
+/// Per layer, paths/metadata are bounded by four existing namespace budgets and structural
+/// conflicts by twice the namespace entry bound. Report paths and payloads are borrowed.
+/// # Errors
+/// Rejects source/base mismatch, inconsistent payload identity, bounded-resource excess
+/// and cancellation. Diagnostics redact repository, path, content and digest values.
+pub fn compare_recovery<'a>(
+    local: &'a ResolvedRepositoryOverlay,
+    remote: &'a ResolvedRepositoryOverlay,
+    cancelled: impl Fn() -> bool,
+) -> Result<RecoveryComparison<'a>, RecoveryComparisonError> {
+    compare::run(local, remote, &cancelled)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RecoveryComparisonError {
+    #[error("repository comparison requires the exact same source identity")]
+    SourceMismatch,
+    #[error("repository comparison requires consistent common base identities")]
+    BaseMismatch,
+    #[error("repository comparison encountered inconsistent content identity")]
+    Object,
+    #[error("repository comparison exceeds a supported bound")]
+    Limit,
+    #[error("repository comparison was cancelled")]
+    Cancelled,
+}
+
+fn check_cancel(cancelled: &impl Fn() -> bool) -> Result<(), RecoveryComparisonError> {
+    if cancelled() {
+        Err(RecoveryComparisonError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/recovery/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/recovery/tests.rs
@@ -1,0 +1,175 @@
+use super::{ChangeRelation, ComparisonSide, RecoveryComparisonError as Error, compare_recovery, identity::Identities};
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{
+        OverlayChange, OverlayContent, RepositoryOverlayPlan,
+        bundle::{RepositoryOverlayBundle, VerifiedOverlayBlob, codec},
+        namespace::{NamespaceEntry, ResolvedRepositoryOverlay, resolve_namespaces},
+    },
+};
+use git2::{Index, IndexEntry, IndexTime, Oid, Repository, RepositoryInitOptions, Signature, Time};
+
+mod bounds;
+mod layers;
+
+struct Fixture {
+    repository: Repository,
+    directory: tempfile::TempDir,
+    commit: Oid,
+}
+
+impl Fixture {
+    fn new(files: &[(&str, &[u8], u32)]) -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let mut options = RepositoryInitOptions::new();
+        options.no_reinit(true).external_template(false).initial_head("fixture");
+        let repository = Repository::init_opts(directory.path(), &options).unwrap();
+        let mut index = Index::new().unwrap();
+        for (path, bytes, mode) in files {
+            index
+                .add(&IndexEntry {
+                    ctime: IndexTime::new(0, 0),
+                    mtime: IndexTime::new(0, 0),
+                    dev: 0,
+                    ino: 0,
+                    mode: *mode,
+                    uid: 0,
+                    gid: 0,
+                    file_size: u32::try_from(bytes.len()).unwrap(),
+                    id: repository.blob(bytes).unwrap(),
+                    flags: 0,
+                    flags_extended: 0,
+                    path: path.as_bytes().to_vec(),
+                })
+                .unwrap();
+        }
+        let tree = index.write_tree_to(&repository).unwrap();
+        let signature = Signature::new("Fixture", "fixture@example.invalid", &Time::new(1, 0)).unwrap();
+        let commit = repository
+            .commit(
+                None,
+                &signature,
+                &signature,
+                "Synthetic",
+                &repository.find_tree(tree).unwrap(),
+                &[],
+            )
+            .unwrap();
+        Self {
+            repository,
+            directory,
+            commit,
+        }
+    }
+
+    fn source(&self) -> GitSource {
+        GitSource {
+            repository: "synthetic/project".into(),
+            commit: GitCommitSha::parse(self.commit.to_string()).unwrap(),
+            branch: None,
+        }
+    }
+
+    fn bundle(
+        &self,
+        index: Vec<OverlayChange>,
+        working: Vec<OverlayChange>,
+        blobs: Vec<VerifiedOverlayBlob>,
+    ) -> RepositoryOverlayBundle {
+        RepositoryOverlayBundle::new(
+            RepositoryOverlayPlan::new(self.source(), index, working).unwrap(),
+            blobs,
+        )
+        .unwrap()
+    }
+
+    fn resolve(
+        &self,
+        index: Vec<OverlayChange>,
+        working: Vec<OverlayChange>,
+        blobs: Vec<VerifiedOverlayBlob>,
+    ) -> ResolvedRepositoryOverlay {
+        resolve_namespaces(&self.repository, self.bundle(index, working, blobs)).unwrap()
+    }
+}
+
+fn file(path: &str, bytes: &[u8], executable: bool) -> (OverlayChange, VerifiedOverlayBlob) {
+    let blob = VerifiedOverlayBlob::new(bytes.to_vec()).unwrap();
+    let change = OverlayChange::new(
+        path.into(),
+        OverlayContent::File {
+            sha256: blob.sha256().clone(),
+            bytes: bytes.len() as u64,
+            executable,
+        },
+    )
+    .unwrap();
+    (change, blob)
+}
+
+fn remove(path: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Remove).unwrap()
+}
+fn link(path: &str, target: &str) -> OverlayChange {
+    OverlayChange::new(path.into(), OverlayContent::Symlink { target: target.into() }).unwrap()
+}
+
+#[test]
+fn comparison_borrows_originals_and_works_after_source_removal() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    let (change, blob) = file("item", b"local", false);
+    let local = fixture.resolve(vec![change], vec![], vec![blob]);
+    let remote = fixture.resolve(vec![], vec![], vec![]);
+    let original = [
+        codec::encode(local.bundle()).unwrap(),
+        codec::encode(remote.bundle()).unwrap(),
+    ];
+    let path = fixture.directory.path().to_owned();
+    drop(fixture);
+    assert!(!path.exists());
+    let comparison = compare_recovery(&local, &remote, || false).unwrap();
+    assert!(std::ptr::eq(comparison.local(), &raw const local));
+    assert!(std::ptr::eq(comparison.remote(), &raw const remote));
+    assert_eq!(comparison.index().paths()[0].relation, ChangeRelation::LocalOnly);
+    assert_eq!(
+        original,
+        [
+            codec::encode(local.bundle()).unwrap(),
+            codec::encode(remote.bundle()).unwrap()
+        ]
+    );
+    let debug = format!("{comparison:?} {:?}", comparison.index().paths()[0]);
+    for private in ["item", "synthetic/project", "local", "base"] {
+        assert!(!debug.contains(private));
+    }
+}
+
+#[test]
+fn exact_source_and_commit_mismatch_leave_bundles_available() {
+    let fixture = Fixture::new(&[]);
+    let local = fixture.resolve(vec![], vec![], vec![]);
+    for variant in 0..3 {
+        let other = Fixture::new(&[("item", b"different", 0o100_644)]);
+        let mut source = fixture.source();
+        match variant {
+            0 => source.repository = "Synthetic/project".into(),
+            1 => source.branch = Some("other-branch".into()),
+            _ => source = other.source(),
+        }
+        let bundle =
+            RepositoryOverlayBundle::new(RepositoryOverlayPlan::new(source, vec![], vec![]).unwrap(), vec![]).unwrap();
+        let repository = if variant == 2 {
+            &other.repository
+        } else {
+            &fixture.repository
+        };
+        let remote = resolve_namespaces(repository, bundle).unwrap();
+        let original = codec::encode(remote.bundle()).unwrap();
+        assert_eq!(
+            compare_recovery(&local, &remote, || false).unwrap_err(),
+            Error::SourceMismatch
+        );
+        assert_eq!(codec::encode(remote.bundle()).unwrap(), original);
+        assert!(local.index().entries().next().is_none());
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/recovery/tests/bounds.rs
+++ b/crates/horizon-core/src/repository_overlay/recovery/tests/bounds.rs
@@ -1,0 +1,162 @@
+use super::*;
+use crate::repository_overlay::{
+    namespace::resolve_namespaces_from_source,
+    seed::{GitObjectInspector, GitObjectMetadata, GitObjectSource, GitObjectStream, SeedError},
+};
+use std::{cell::Cell, io::Cursor};
+
+#[test]
+fn canonical_base_overlay_identity_is_cached_and_checks_mode() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    let (change, blob) = file("item", b"base", false);
+    let local = fixture.resolve(vec![change], vec![], vec![blob]);
+    let remote = fixture.resolve(vec![], vec![], vec![]);
+    let mut identities = Identities::new(&|| false);
+    for _ in 0..1_000 {
+        assert!(
+            identities
+                .equal(
+                    local.index().entry("item"),
+                    local.bundle(),
+                    remote.index().entry("item"),
+                    remote.bundle()
+                )
+                .unwrap()
+        );
+    }
+    assert_eq!(identities.hashes, 1);
+    let report = compare_recovery(&local, &remote, || false).unwrap();
+    assert!(report.index().paths().is_empty());
+    assert!(report.working_tree().paths().is_empty());
+}
+
+#[test]
+fn cancellation_before_after_hash_and_during_traversal_preserves_both_inputs() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    let (change, blob) = file("item", b"base", false);
+    let local = fixture.resolve(vec![change], vec![], vec![blob]);
+    let remote = fixture.resolve(vec![], vec![], vec![]);
+    let original = codec::encode(local.bundle()).unwrap();
+    for threshold in [0, 2, 10] {
+        let calls = Cell::new(0);
+        assert_eq!(
+            compare_recovery(&local, &remote, || {
+                let count = calls.replace(calls.get() + 1);
+                count >= threshold
+            })
+            .unwrap_err(),
+            Error::Cancelled
+        );
+        assert_eq!(codec::encode(local.bundle()).unwrap(), original);
+    }
+    let calls = Cell::new(0);
+    let cancelled = || calls.replace(calls.get() + 1) > 0;
+    let mut identities = Identities::new(&cancelled);
+    assert_eq!(
+        identities.equal(
+            local.index().entry("item"),
+            local.bundle(),
+            remote.index().entry("item"),
+            remote.bundle()
+        ),
+        Err(Error::Cancelled)
+    );
+    assert_eq!(identities.hashes, 1);
+    assert!(remote.bundle().blobs().next().is_none());
+}
+
+#[test]
+fn shared_deep_prefixes_use_bounded_scans_not_all_prefixes_or_pairs() {
+    let fixture = Fixture::new(&[]);
+    let prefix = "d/".repeat(1_000);
+    let make = |start| {
+        let blob = VerifiedOverlayBlob::new(b"same".to_vec()).unwrap();
+        let changes = (start..start + 1_000)
+            .map(|n| {
+                OverlayChange::new(
+                    format!("{prefix}{n:04}"),
+                    OverlayContent::File {
+                        sha256: blob.sha256().clone(),
+                        bytes: 4,
+                        executable: false,
+                    },
+                )
+                .unwrap()
+            })
+            .collect();
+        fixture.resolve(changes, vec![], vec![blob])
+    };
+    let local = make(0);
+    let remote = make(1_000);
+    let calls = Cell::new(0);
+    let report = compare_recovery(&local, &remote, || {
+        calls.set(calls.get() + 1);
+        false
+    })
+    .unwrap();
+    assert_eq!(report.index().paths().len(), 2_000);
+    assert!(report.working_tree().structural_conflicts().is_empty());
+    assert!(calls.get() < 20_000, "{} traversal checks", calls.get());
+}
+
+struct HeaderSource<'a> {
+    repository: &'a Repository,
+    length: u64,
+    opened: usize,
+}
+
+impl GitObjectSource for HeaderSource<'_> {
+    fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        self.opened += 1;
+        let database = self.repository.odb().map_err(|_| SeedError::Source)?;
+        let object = database.read(object).map_err(|_| SeedError::Source)?;
+        Ok(GitObjectStream {
+            kind: object.kind(),
+            bytes: object.len() as u64,
+            reader: Box::new(Cursor::new(object.data().to_vec())),
+        })
+    }
+}
+
+impl GitObjectInspector for HeaderSource<'_> {
+    fn inspect(&mut self, object: Oid) -> Result<GitObjectMetadata, SeedError> {
+        let (_, kind) = self
+            .repository
+            .odb()
+            .and_then(|database| database.read_header(object))
+            .map_err(|_| SeedError::Source)?;
+        Ok(GitObjectMetadata {
+            kind,
+            bytes: self.length,
+        })
+    }
+}
+
+#[test]
+fn large_base_references_are_not_read_and_inconsistent_base_headers_reject() {
+    // Synthetic header claims only; this does not verify a large blob's payload.
+    let fixture = Fixture::new(&[("large", b"unread", 0o100_644)]);
+    let mut source = HeaderSource {
+        repository: &fixture.repository,
+        length: 65 * 1024 * 1024 + 1,
+        opened: 0,
+    };
+    let local = resolve_namespaces_from_source(&mut source, fixture.bundle(vec![], vec![], vec![]), || false).unwrap();
+    let remote = resolve_namespaces_from_source(&mut source, fixture.bundle(vec![], vec![], vec![]), || false).unwrap();
+    assert_eq!(source.opened, 4, "only commit and tree payloads per resolver");
+    assert!(
+        compare_recovery(&local, &remote, || false)
+            .unwrap()
+            .index()
+            .paths()
+            .is_empty()
+    );
+    assert_eq!(source.opened, 4);
+    source.length += 1;
+    let inconsistent =
+        resolve_namespaces_from_source(&mut source, fixture.bundle(vec![], vec![], vec![]), || false).unwrap();
+    assert_eq!(
+        compare_recovery(&local, &inconsistent, || false).unwrap_err(),
+        Error::BaseMismatch
+    );
+}

--- a/crates/horizon-core/src/repository_overlay/recovery/tests/layers.rs
+++ b/crates/horizon-core/src/repository_overlay/recovery/tests/layers.rs
@@ -1,0 +1,162 @@
+use super::*;
+
+#[test]
+fn index_relationships_use_semantic_content_modes_and_exact_paths() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    for (left, right, expected) in [
+        (b"base".as_slice(), b"base".as_slice(), None),
+        (b"local", b"base", Some(ChangeRelation::LocalOnly)),
+        (b"base", b"remote", Some(ChangeRelation::RemoteOnly)),
+        (b"same", b"same", Some(ChangeRelation::SameChange)),
+        (b"local", b"remote", Some(ChangeRelation::Divergent)),
+    ] {
+        let (a, ab) = file("item", left, false);
+        let (b, bb) = file("item", right, false);
+        let local = fixture.resolve(vec![a], vec![], vec![ab]);
+        let remote = fixture.resolve(vec![b], vec![], vec![bb]);
+        let comparison = compare_recovery(&local, &remote, || false).unwrap();
+        assert_eq!(comparison.index().paths().first().map(|path| path.relation), expected);
+    }
+    let (mode, blob) = file("item", b"base", true);
+    let local = fixture.resolve(vec![mode], vec![], vec![blob]);
+    let remote = fixture.resolve(vec![remove("item")], vec![], vec![]);
+    assert_eq!(
+        compare_recovery(&local, &remote, || false).unwrap().index().paths()[0].relation,
+        ChangeRelation::Divergent
+    );
+    let (a, ab) = file("Case", b"A", false);
+    let (b, bb) = file("case", b"B", false);
+    let local = fixture.resolve(vec![a], vec![], vec![ab]);
+    let remote = fixture.resolve(vec![b], vec![], vec![bb]);
+    let report = compare_recovery(&local, &remote, || false).unwrap();
+    assert_eq!(
+        report
+            .index()
+            .paths()
+            .iter()
+            .map(|p| (p.path, p.relation))
+            .collect::<Vec<_>>(),
+        [
+            ("Case", ChangeRelation::LocalOnly),
+            ("case", ChangeRelation::RemoteOnly)
+        ]
+    );
+}
+
+#[test]
+fn unstaged_revert_is_relative_to_shared_index_not_git_base() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    let (a, ab) = file("item", b"staged", false);
+    let (b, bb) = file("item", b"staged", false);
+    let (revert, rb) = file("item", b"base", false);
+    let local = fixture.resolve(vec![a], vec![revert], vec![ab, rb]);
+    let remote = fixture.resolve(vec![b], vec![], vec![bb]);
+    let report = compare_recovery(&local, &remote, || false).unwrap();
+    assert_eq!(report.index().paths()[0].relation, ChangeRelation::SameChange);
+    assert_eq!(report.working_tree().paths()[0].relation, ChangeRelation::LocalOnly);
+    assert!(report.working_tree().paths()[0].local.before.is_some());
+    assert!(report.working_tree().paths()[0].local.after.is_some());
+}
+
+#[test]
+fn working_layer_distinguishes_unilateral_equal_and_divergent_edits() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    for (left, right, expected) in [
+        (Some(b"edit".as_slice()), None, ChangeRelation::LocalOnly),
+        (None, Some(b"edit".as_slice()), ChangeRelation::RemoteOnly),
+        (
+            Some(b"edit".as_slice()),
+            Some(b"edit".as_slice()),
+            ChangeRelation::SameChange,
+        ),
+        (
+            Some(b"left".as_slice()),
+            Some(b"right".as_slice()),
+            ChangeRelation::Divergent,
+        ),
+    ] {
+        let make = |value: Option<&[u8]>| match value {
+            Some(bytes) => {
+                let (c, b) = file("item", bytes, false);
+                fixture.resolve(vec![], vec![c], vec![b])
+            }
+            None => fixture.resolve(vec![], vec![], vec![]),
+        };
+        let local = make(left);
+        let remote = make(right);
+        let report = compare_recovery(&local, &remote, || false).unwrap();
+        assert!(report.index().paths().is_empty());
+        assert_eq!(report.working_tree().paths()[0].relation, expected);
+    }
+}
+
+#[test]
+fn different_index_baselines_remain_explicit_even_when_working_bytes_agree() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    let (index, ib) = file("item", b"staged", false);
+    let (working, wb) = file("item", b"base", false);
+    let local = fixture.resolve(vec![index], vec![working], vec![ib, wb]);
+    let remote = fixture.resolve(vec![], vec![], vec![]);
+    let report = compare_recovery(&local, &remote, || false).unwrap();
+    assert_eq!(report.index().paths()[0].relation, ChangeRelation::LocalOnly);
+    assert_eq!(
+        report.working_tree().paths()[0].relation,
+        ChangeRelation::DifferentIndexBases
+    );
+}
+
+#[test]
+fn literal_link_divergence_and_two_sided_deletion_are_preserved() {
+    let fixture = Fixture::new(&[("item", b"base", 0o100_644)]);
+    let local = fixture.resolve(vec![link("item", "left")], vec![], vec![]);
+    let remote = fixture.resolve(vec![link("item", "right")], vec![], vec![]);
+    let report = compare_recovery(&local, &remote, || false).unwrap();
+    assert_eq!(report.index().paths()[0].relation, ChangeRelation::Divergent);
+    assert_eq!(
+        report.index().paths()[0].local.after,
+        Some(&NamespaceEntry::Symlink { target: "left".into() })
+    );
+    let local = fixture.resolve(vec![remove("item")], vec![], vec![]);
+    let remote = fixture.resolve(vec![remove("item")], vec![], vec![]);
+    assert_eq!(
+        compare_recovery(&local, &remote, || false).unwrap().index().paths()[0].relation,
+        ChangeRelation::SameChange
+    );
+}
+
+#[test]
+fn structural_conflicts_include_inherited_index_changes_but_not_unilateral_transitions() {
+    let fixture = Fixture::new(&[("node/old", b"base", 0o100_644)]);
+    let (leaf, lb) = file("node", b"leaf", false);
+    let local = fixture.resolve(vec![remove("node/old"), leaf], vec![], vec![lb]);
+    let remote = fixture.resolve(vec![], vec![], vec![]);
+    let unilateral = compare_recovery(&local, &remote, || false).unwrap();
+    assert!(unilateral.index().structural_conflicts().is_empty());
+    assert!(unilateral.working_tree().structural_conflicts().is_empty());
+    for staged in [false, true] {
+        let (child, cb) = file("node/new", b"new", false);
+        let changes = vec![child, file("node-other", b"new", false).0];
+        let remote = if staged {
+            fixture.resolve(changes, vec![], vec![cb])
+        } else {
+            fixture.resolve(vec![], changes, vec![cb])
+        };
+        for (a, b, side) in [
+            (&local, &remote, ComparisonSide::Local),
+            (&remote, &local, ComparisonSide::Remote),
+        ] {
+            let report = compare_recovery(a, b, || false).unwrap();
+            assert_eq!(report.index().structural_conflicts().len(), usize::from(staged));
+            let conflicts = report.working_tree().structural_conflicts();
+            assert_eq!(conflicts.len(), 1);
+            assert_eq!(
+                (
+                    conflicts[0].ancestor,
+                    conflicts[0].descendant,
+                    conflicts[0].ancestor_side
+                ),
+                ("node", "node/new", side)
+            );
+        }
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -219,6 +219,11 @@ back into large multi-purpose modules.
   resolver remains available and shares the whole-layer composition path. Header-only
   inspection is additive to `seed/` object streaming, without abandoning lazy payloads;
   the packed adapter shares one strict failure/poison path for both operations.
+  `recovery/` compares two borrowed exact-source/base snapshots without I/O or a
+  merged result. Index and unstaged changes retain their separate baselines; differing
+  indexes and cross-side leaf/directory conflicts remain explicit. Cached Git blob
+  identities normalize verified overlay bytes without reading base payloads. Both
+  inputs survive errors/cancellation; comparison grants no recovery or durability.
   `seed/` streams verified exact-base objects into an internally fresh private Git
   repository and constructs its detached HEAD, shallow boundary and independent
   staged index. Source adapters own their I/O behavior; private Git pathname writes


### PR DESCRIPTION
## Purpose

Part of #471 and parent #383. Add read-only comparison of two already-resolved repository snapshots before any separately authorized recovery choice. This does not close either issue.

## Behavior

- Require the exact same source, base commit/tree and consistent base namespace.
- Compare index changes against the common Git base; compare unstaged changes against each side's own index. Different index baselines remain explicit even when final working bytes agree.
- Preserve both original bundles and literal paths, modes, symlinks, deletions and divergent changes. Report cross-side file/directory conflicts without treating a valid unilateral transition as a conflict.
- Normalize base-object versus verified overlay identity with cached canonical Git blob hashes. Borrow paths and payloads, bound traversal/output, and check cancellation between steps and around hashing.

This performs no filesystem, process, provider or transport I/O. It does not merge, overwrite, acknowledge checkpoints, grant recovery authority or prove durability. Regular base payloads are not newly read or verified. A single bounded native hash is not interruptible; callers must stay off the render thread.

## Validation

Candidate: `998ab6f86473c0803706c9b3fd582d2061664bda`.

- All eight required local source and exact-commit lanes: formatting, maintainability, version sync, default/speech workspace tests and blocking/strict/pedantic Clippy.
- Twelve focused tests cover semantic identity, separate index/unstaged baselines, literal links, modes, case, deletion, structural conflicts and cancellation.
- Synthetic native Git fixtures prove comparison still works after the source directory is removed and both original bundles remain byte-identical and caller-owned.
- A canonical overlay hash is reused across 1,000 comparisons. Two sets of 1,000 leaves under a 1,000-deep prefix stay below 20,000 counted traversal checks.
- The large-base header fixture tests lazy identity handling only, not payload verification or cloud storage.
- Independent local review completed. No UI behavior changed; no cloud resources or releases involved.

Scope: seven source/test files, 948 changed source/test lines, plus five architecture-note lines. Existing setup, transfer, lifecycle and management behavior is unchanged.
