### PR TITLE
Inspect retained repository packs through pinned worker queries

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -23,7 +23,10 @@ pub mod remote_environment_observation;
 mod remote_hosts;
 pub mod remote_panel_attachment;
 pub mod remote_provider_config;
+pub mod remote_repository_pack;
 pub mod remote_ssh_identity;
+#[cfg(target_os = "linux")]
+mod remote_worker_inspection;
 #[cfg(target_os = "linux")]
 mod remote_worker_ssh;
 pub mod remote_worker_status;

--- a/crates/horizon-core/src/remote_repository_pack.rs
+++ b/crates/horizon-core/src/remote_repository_pack.rs
@@ -1,0 +1,152 @@
+//! Pinned, non-creating inspection of an explicitly nominated retained repository pack.
+
+#[cfg(target_os = "linux")]
+mod protocol;
+
+use crate::{
+    cloud_run::{ArtifactDigest, CloudWorkflowStore, GitCommitSha},
+    remote_worker_status::RemotePanelStatusError,
+    remote_workspace_recovery::RecoveredRemoteWorkspace,
+};
+
+/// Expected existing remote input, not source-export, upload or setup approval.
+#[derive(Clone, Copy)]
+pub struct RemotePackExpectation<'a> {
+    pub path: &'a str,
+    pub base_commit: &'a GitCommitSha,
+    pub sha256: &'a ArtifactDigest,
+    pub encoded_bytes: u64,
+}
+
+/// A point-in-time identity observation, not immutable publication, synchronization
+/// or a ready checkout. Its path and ancestry must remain stable until consumption.
+pub struct RemotePackObservation {
+    path: String,
+    objects_directory: String,
+    base_commit: GitCommitSha,
+    sha256: ArtifactDigest,
+    encoded_bytes: u64,
+    objects: u32,
+}
+
+impl RemotePackObservation {
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+    #[must_use]
+    pub fn objects_directory(&self) -> &str {
+        &self.objects_directory
+    }
+    #[must_use]
+    pub fn base_commit(&self) -> &GitCommitSha {
+        &self.base_commit
+    }
+    #[must_use]
+    pub fn sha256(&self) -> &ArtifactDigest {
+        &self.sha256
+    }
+    #[must_use]
+    pub fn encoded_bytes(&self) -> u64 {
+        self.encoded_bytes
+    }
+    #[must_use]
+    pub fn objects(&self) -> u32 {
+        self.objects
+    }
+}
+
+impl std::fmt::Debug for RemotePackObservation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("RemotePackObservation").finish_non_exhaustive()
+    }
+}
+
+/// Inspect one existing candidate after owned recovery, without uploading, creating,
+/// adopting, repairing, deleting or starting anything. Both complete allocation
+/// snapshots, retained worker/key/host and lifetime are checked before and after I/O.
+/// The exact base must agree with the saved workspace. Caller-owned provider/cost
+/// admission and source/namespace trust remain separate. Run off the render thread.
+/// Local query teardown does not stop the remote worker or its independent tasks.
+/// # Errors
+/// Rejects unsupported platforms, stale ownership, pending management, unavailable
+/// retained identity, invalid expectations, failed/timed-out SSH or invalid output.
+/// Failure is an unknown observation, never absence or a grant to retry setup/upload.
+pub fn inspect_remote_repository_pack(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    expected: RemotePackExpectation<'_>,
+) -> Result<RemotePackObservation, RemotePackInspectionError> {
+    #[cfg(target_os = "linux")]
+    {
+        inspect_with(store, recovered, expected, query)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, recovered, expected);
+        Err(RemotePackInspectionError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_with(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    expected: RemotePackExpectation<'_>,
+    execute: impl FnOnce(
+        &crate::remote_ssh_identity::RemoteSshIdentity,
+        &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+        &[u8],
+    ) -> Result<Vec<u8>, RemotePackInspectionError>,
+) -> Result<RemotePackObservation, RemotePackInspectionError> {
+    use crate::remote_worker_inspection::validate_current;
+    let endpoint = validate_current(store, recovered, None)?;
+    if expected.base_commit != &recovered.allocation().workspace().state().spec.repository.commit {
+        return Err(RemotePackInspectionError::InvalidRequest);
+    }
+    let request = protocol::request(expected)?;
+    let response = execute(recovered.identity(), endpoint, &request)?;
+    let observation = protocol::response(&response, expected)?;
+    validate_current(store, recovered, None)?;
+    Ok(observation)
+}
+
+#[cfg(target_os = "linux")]
+fn query(
+    identity: &crate::remote_ssh_identity::RemoteSshIdentity,
+    endpoint: &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+    input: &[u8],
+) -> Result<Vec<u8>, RemotePackInspectionError> {
+    use crate::remote_worker_ssh::{known_hosts, prepared_pack_status, query};
+    // Verification has two separately bounded native Git phases plus bounded
+    // encoded input hashing; a deadline does not imply the candidate is absent.
+    const DEADLINE: std::time::Duration = std::time::Duration::from_secs(90);
+    let trust = known_hosts(identity, endpoint)?;
+    let command = prepared_pack_status(identity.private_key_path(), trust.path(), endpoint)?;
+    query::run(command, input, DEADLINE, protocol::RESPONSE_LIMIT).map_err(|error| match error {
+        query::Error::ClientUnavailable => RemotePanelStatusError::ClientUnavailable.into(),
+        query::Error::QueryFailed => RemotePackInspectionError::QueryFailed,
+        query::Error::Deadline => RemotePackInspectionError::Deadline,
+        query::Error::OutputLimit => RemotePackInspectionError::InvalidResponse,
+    })
+}
+
+/// Diagnostics never include candidate paths, identities or remote subprocess data.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemotePackInspectionError {
+    #[error(transparent)]
+    Admission(#[from] RemotePanelStatusError),
+    #[error("remote pack expectation is invalid or does not match the owned repository base")]
+    InvalidRequest,
+    #[error("remote pack inspection failed; retain input and do not replay setup or upload")]
+    QueryFailed,
+    #[error("remote pack inspection exceeded its deadline; the candidate state is unknown")]
+    Deadline,
+    #[error("remote pack observation is invalid or exceeds its size limit")]
+    InvalidResponse,
+    #[error("protected remote pack inspection is not yet supported on this platform")]
+    UnsupportedPlatform,
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_repository_pack/protocol.rs
+++ b/crates/horizon-core/src/remote_repository_pack/protocol.rs
@@ -1,0 +1,114 @@
+use super::{RemotePackExpectation, RemotePackInspectionError as Error, RemotePackObservation};
+use crate::{
+    cloud_run::{ArtifactDigest, GitCommitSha},
+    repository_overlay::{
+        checkout::publication::MAX_SIBLING_NAME_BYTES,
+        seed::{MAX_OBJECTS, MAX_PACK_PATH_BYTES, receive::PackReceiveLimits},
+    },
+};
+use serde::{Deserialize, Serialize};
+
+const VERSION: u32 = 1;
+const REQUEST_LIMIT: usize = (6 * MAX_PACK_PATH_BYTES + 4096).next_power_of_two();
+pub(super) const RESPONSE_LIMIT: usize = (2 * 6 * (MAX_PACK_PATH_BYTES + 16) + 4096).next_power_of_two();
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Identity {
+    base_commit: GitCommitSha,
+    sha256: ArtifactDigest,
+    encoded_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct Request<'a> {
+    version: u32,
+    path: &'a str,
+    pack: Identity,
+}
+
+pub(super) fn request(expected: RemotePackExpectation<'_>) -> Result<Vec<u8>, Error> {
+    let path = expected.path;
+    if path.len() > MAX_PACK_PATH_BYTES
+        || !path.starts_with('/')
+        || path.contains('\0')
+        || path[1..]
+            .split('/')
+            .any(|part| part.is_empty() || matches!(part, "." | "..") || part.len() > MAX_SIBLING_NAME_BYTES)
+        || expected.base_commit.as_str().bytes().all(|byte| byte == b'0')
+        || !(32..=PackReceiveLimits::default().encoded_bytes).contains(&expected.encoded_bytes)
+    {
+        return Err(Error::InvalidRequest);
+    }
+    let bytes = serde_json::to_vec(&Request {
+        version: VERSION,
+        path,
+        pack: Identity {
+            base_commit: expected.base_commit.clone(),
+            sha256: expected.sha256.clone(),
+            encoded_bytes: expected.encoded_bytes,
+        },
+    })
+    .map_err(|_| Error::InvalidRequest)?;
+    if bytes.len() > REQUEST_LIMIT {
+        return Err(Error::InvalidRequest);
+    }
+    Ok(bytes)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Observed,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Response {
+    version: u32,
+    status: Status,
+    pack: Pack,
+    retained: (),
+    reason: (),
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Pack {
+    path: String,
+    objects_directory: String,
+    identity: Identity,
+    objects: u32,
+}
+
+pub(super) fn response(bytes: &[u8], expected: RemotePackExpectation<'_>) -> Result<RemotePackObservation, Error> {
+    if bytes.len() > RESPONSE_LIMIT {
+        return Err(Error::InvalidResponse);
+    }
+    let Response {
+        version,
+        status: Status::Observed,
+        pack,
+        retained: (),
+        reason: (),
+    } = serde_json::from_slice(bytes).map_err(|_| Error::InvalidResponse)?;
+    if version != VERSION
+        || pack.path != expected.path
+        || pack.objects_directory != format!("{}/decoded/objects", expected.path)
+        || pack.identity.base_commit != *expected.base_commit
+        || pack.identity.sha256 != *expected.sha256
+        || pack.identity.encoded_bytes != expected.encoded_bytes
+        || pack.objects == 0
+        || u64::from(pack.objects) > MAX_OBJECTS as u64
+    {
+        return Err(Error::InvalidResponse);
+    }
+    Ok(RemotePackObservation {
+        path: pack.path,
+        objects_directory: pack.objects_directory,
+        base_commit: pack.identity.base_commit,
+        sha256: pack.identity.sha256,
+        encoded_bytes: pack.identity.encoded_bytes,
+        objects: pack.objects,
+    })
+}

--- a/crates/horizon-core/src/remote_repository_pack/tests.rs
+++ b/crates/horizon-core/src/remote_repository_pack/tests.rs
@@ -1,0 +1,306 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{CloudProvider, StoredRemoteAllocation, interactive_worker::*},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
+    remote_workspace_recovery::recover_remote_workspace,
+};
+
+#[path = "tests/protocol.rs"]
+mod wire;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+struct Expected {
+    path: String,
+    base: GitCommitSha,
+    digest: ArtifactDigest,
+    bytes: u64,
+}
+
+impl Expected {
+    fn new() -> Self {
+        Self {
+            path: "/retained/private-candidate".into(),
+            base: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+            digest: ArtifactDigest::parse_sha256("a".repeat(64)).expect("digest"),
+            bytes: 64,
+        }
+    }
+
+    fn request(&self) -> RemotePackExpectation<'_> {
+        RemotePackExpectation {
+            path: &self.path,
+            base_commit: &self.base,
+            sha256: &self.digest,
+            encoded_bytes: self.bytes,
+        }
+    }
+
+    fn response(&self) -> serde_json::Value {
+        serde_json::json!({
+            "version": 1, "status": "observed", "retained": null, "reason": null,
+            "pack": {"path": self.path, "objects_directory": format!("{}/decoded/objects", self.path),
+                "identity": {"base_commit": self.base, "sha256": self.digest, "encoded_bytes": self.bytes},
+                "objects": 3}
+        })
+    }
+
+    fn response_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(&self.response()).expect("response")
+    }
+}
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    recovered: RecoveredRemoteWorkspace,
+}
+
+impl Fixture {
+    fn new(lifecycle: Option<InteractiveWorkerLifecycle>) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+        let directory = tempfile::tempdir().expect("fixture");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let identities = RemoteSshIdentityStore::new(&home);
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": {"provider": "local_docker", "profile": "development",
+                    "image": format!("example/worker@sha256:{}", "a".repeat(64)),
+                    "disk_gib": 20, "lifetime": "persistent"},
+                "repository": {"repository": "example/project", "commit": "b".repeat(40)}
+            }
+        }))
+        .expect("state");
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");
+        let identity = identities
+            .prepare_new(runtime.workflow_id, runtime.job_id)
+            .expect("identity");
+        let allocation = store
+            .reserve_remote_worker_request(&allocation, identity.public_key())
+            .expect("request");
+        let request = allocation.worker_request().expect("request");
+        let status = lifecycle.map(|lifecycle| InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: request.target.provider,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: "synthetic-worker".into(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            lifecycle,
+            ssh: Some(InteractiveWorkerSshEndpoint {
+                host: "127.0.0.1".into(),
+                port: 2222,
+                username: "horizon".into(),
+                host_key: identity.public_key().into(),
+            }),
+        });
+        let recovered = recover_remote_workspace(&store, &identities, &Provider(status), OWNER, "workspace")
+            .expect("fixture recovery");
+        Self {
+            _directory: directory,
+            store,
+            recovered,
+        }
+    }
+
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn check(
+        &self,
+        expected: &Expected,
+        execute: impl FnOnce(&[u8]) -> Result<Vec<u8>, RemotePackInspectionError>,
+    ) -> Result<RemotePackObservation, RemotePackInspectionError> {
+        inspect_with(
+            &self.store,
+            &self.recovered,
+            expected.request(),
+            |identity, endpoint, input| {
+                assert_eq!(identity.public_key(), self.recovered.identity().public_key());
+                assert_eq!(
+                    Some(endpoint),
+                    self.recovered.observation().and_then(|status| status.ssh.as_ref())
+                );
+                execute(input)
+            },
+        )
+    }
+
+    fn edit(&self, stop: bool) {
+        let current = self.current();
+        if stop {
+            self.store
+                .record_remote_stop_phase(&current, RemoteRuntimePhase::Stopping { requested_at_millis: 1 })
+                .expect("stop intent");
+        } else {
+            let mut state = current.workspace().state().clone();
+            state.spec.working_directory = "src".into();
+            self.store
+                .replace_remote_workspace(current.workspace(), &state)
+                .expect("new intent");
+        }
+    }
+}
+
+struct Provider(Option<InteractiveWorkerStatus>);
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::LocalDocker
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(self.0.clone())
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(self.0.clone())
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no delete")
+    }
+}
+
+#[test]
+fn zero_panel_workspace_queries_exact_pack_without_mutating_saved_state_or_identity() {
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let expected = Expected::new();
+    let before = fixture.current();
+    assert!(before.workspace().state().spec.panels.is_empty());
+    let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+    let observation = fixture
+        .check(&expected, |input| {
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(input).expect("request"),
+                serde_json::json!({
+                    "version": 1, "path": expected.path,
+                    "pack": {"base_commit": expected.base, "sha256": expected.digest, "encoded_bytes": expected.bytes}
+                })
+            );
+            Ok(expected.response_bytes())
+        })
+        .expect("observation");
+    assert_eq!(observation.path(), expected.path);
+    assert_eq!(
+        observation.objects_directory(),
+        format!("{}/decoded/objects", expected.path)
+    );
+    assert_eq!(observation.base_commit(), &expected.base);
+    assert_eq!(observation.sha256(), &expected.digest);
+    assert_eq!(observation.encoded_bytes(), expected.bytes);
+    assert_eq!(observation.objects(), 3);
+    assert!(!format!("{observation:?}").contains("private-candidate"));
+    assert_eq!(fixture.current(), before);
+    assert_eq!(
+        std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+        key
+    );
+}
+
+#[test]
+fn database_loss_before_or_during_query_rejects_observation_without_recreation() {
+    for during_query in [false, true] {
+        let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let expected = Expected::new();
+        let path = fixture.store.path();
+        let retained = path.with_file_name("retained.sqlite3");
+        let before = std::fs::read(path).expect("saved database");
+        if !during_query {
+            std::fs::rename(path, &retained).expect("retain database before query");
+        }
+        let result = fixture.check(&expected, |_| {
+            assert!(during_query, "storage admission must precede SSH");
+            std::fs::rename(path, &retained).expect("retain database during query");
+            Ok(expected.response_bytes())
+        });
+        assert!(matches!(
+            result,
+            Err(RemotePackInspectionError::Admission(
+                RemotePanelStatusError::StorageUnavailable
+            ))
+        ));
+        assert!(!path.exists(), "query must not recreate the database");
+        assert_eq!(std::fs::read(retained).expect("preserved database"), before);
+    }
+}
+
+#[test]
+fn wrong_base_missing_or_nonready_worker_never_crosses_ssh() {
+    let mut expected = Expected::new();
+    for lifecycle in [None, Some(InteractiveWorkerLifecycle::Stopped)] {
+        let fixture = Fixture::new(lifecycle);
+        assert!(matches!(
+            fixture.check(&expected, |_| panic!("no SSH")),
+            Err(RemotePackInspectionError::Admission(
+                RemotePanelStatusError::WorkerUnavailable
+            ))
+        ));
+    }
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    expected.base = GitCommitSha::parse("c".repeat(40)).expect("other base");
+    assert!(matches!(
+        fixture.check(&expected, |_| panic!("no SSH")),
+        Err(RemotePackInspectionError::InvalidRequest)
+    ));
+}
+
+#[test]
+fn snapshot_or_management_drift_before_and_during_query_rejects_late_results() {
+    let expected = Expected::new();
+    for stop in [false, true] {
+        for during_query in [false, true] {
+            let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+            if !during_query {
+                fixture.edit(stop);
+            }
+            assert!(matches!(
+                fixture.check(&expected, |_| {
+                    assert!(during_query, "stale request must reject before SSH");
+                    fixture.edit(stop);
+                    Ok(expected.response_bytes())
+                }),
+                Err(RemotePackInspectionError::Admission(
+                    RemotePanelStatusError::StateChanged
+                ))
+            ));
+            assert_ne!(fixture.current(), *fixture.recovered.allocation());
+        }
+    }
+}
+
+#[test]
+fn query_failures_preserve_the_candidate_and_do_not_invent_absence_or_replay_authority() {
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let expected = Expected::new();
+    let before = fixture.current();
+    for error in [
+        RemotePackInspectionError::QueryFailed,
+        RemotePackInspectionError::Deadline,
+        RemotePackInspectionError::InvalidResponse,
+    ] {
+        let diagnostic = error.to_string();
+        let result = fixture.check(&expected, |_| Err(error)).expect_err("query failure");
+        assert_eq!(result.to_string(), diagnostic);
+        assert!(!diagnostic.contains("private-candidate"));
+        assert_eq!(fixture.current(), before);
+    }
+}

--- a/crates/horizon-core/src/remote_repository_pack/tests/protocol.rs
+++ b/crates/horizon-core/src/remote_repository_pack/tests/protocol.rs
@@ -1,0 +1,160 @@
+use super::*;
+use crate::repository_overlay::seed::{MAX_PACK_PATH_BYTES, receive::PackReceiveLimits};
+use serde_json::{Value, json};
+
+fn path_with_bytes(bytes: usize, character: char) -> String {
+    let mut path = String::new();
+    while path.len() < bytes {
+        path.push('/');
+        let count = (bytes - path.len()).min(255);
+        path.extend(std::iter::repeat_n(character, count));
+    }
+    path
+}
+
+#[test]
+fn request_paths_are_normalized_posix_inputs_not_shell_fragments() {
+    let mut expected = Expected::new();
+    for path in [
+        "", "/", "relative", "é", "//a", "/a/", "/a//b", "/a/../b", "/a/./b", "/a\0b",
+    ] {
+        expected.path = path.into();
+        assert_eq!(
+            protocol::request(expected.request()),
+            Err(RemotePackInspectionError::InvalidRequest)
+        );
+    }
+    for path in [
+        format!("/{}", "a".repeat(256)),
+        path_with_bytes(MAX_PACK_PATH_BYTES + 1, 'a'),
+    ] {
+        expected.path = path;
+        assert_eq!(
+            protocol::request(expected.request()),
+            Err(RemotePackInspectionError::InvalidRequest)
+        );
+    }
+    for path in [
+        "/a ;$()\"\\\né".into(),
+        path_with_bytes(MAX_PACK_PATH_BYTES, 'a'),
+        path_with_bytes(MAX_PACK_PATH_BYTES, '\u{1f}'),
+    ] {
+        expected.path = path;
+        let request = protocol::request(expected.request()).expect("bounded literal path");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&request).expect("request")["path"],
+            expected.path
+        );
+        protocol::response(&expected.response_bytes(), expected.request()).expect("escaped bounded response");
+    }
+}
+
+#[test]
+fn request_identity_uses_the_worker_pack_limits() {
+    let mut expected = Expected::new();
+    for bytes in [0, 31, PackReceiveLimits::default().encoded_bytes + 1, u64::MAX] {
+        expected.bytes = bytes;
+        assert_eq!(
+            protocol::request(expected.request()),
+            Err(RemotePackInspectionError::InvalidRequest)
+        );
+    }
+    for bytes in [32, PackReceiveLimits::default().encoded_bytes] {
+        expected.bytes = bytes;
+        protocol::request(expected.request()).expect("supported size");
+    }
+    expected.base = GitCommitSha::parse("0".repeat(40)).expect("zero commit");
+    assert_eq!(
+        protocol::request(expected.request()),
+        Err(RemotePackInspectionError::InvalidRequest)
+    );
+}
+
+fn reject(value: &Value, expected: &Expected) {
+    assert!(matches!(
+        protocol::response(&serde_json::to_vec(value).expect("response"), expected.request()),
+        Err(RemotePackInspectionError::InvalidResponse)
+    ));
+}
+
+#[test]
+fn response_binds_version_status_paths_identity_counts_and_required_null_fields() {
+    let expected = Expected::new();
+    for (pointer, invalid) in [
+        ("/version", json!(2)),
+        ("/version", json!("1")),
+        ("/status", json!("received")),
+        ("/retained", json!("private-path")),
+        ("/reason", json!("failure")),
+        ("/pack/path", json!("/other")),
+        ("/pack/objects_directory", json!("/other/decoded/objects")),
+        (
+            "/pack/objects_directory",
+            json!(format!("{}/decoded/../decoded/objects", expected.path)),
+        ),
+        ("/pack/identity/base_commit", json!("c".repeat(40))),
+        ("/pack/identity/sha256", json!("d".repeat(64))),
+        ("/pack/identity/encoded_bytes", json!(63)),
+        ("/pack/objects", json!(0)),
+        ("/pack/objects", json!(-1)),
+        ("/pack/objects", json!(u64::MAX)),
+    ] {
+        let mut value = expected.response();
+        *value.pointer_mut(pointer).expect("field") = invalid;
+        reject(&value, &expected);
+    }
+    for (pointer, names) in [
+        ("", ["version", "status", "pack", "retained", "reason"].as_slice()),
+        ("/pack", ["path", "objects_directory", "identity", "objects"].as_slice()),
+        ("/pack/identity", ["base_commit", "sha256", "encoded_bytes"].as_slice()),
+    ] {
+        for name in names {
+            let mut value = expected.response();
+            value
+                .pointer_mut(pointer)
+                .expect("object")
+                .as_object_mut()
+                .expect("map")
+                .remove(*name);
+            reject(&value, &expected);
+        }
+        let mut value = expected.response();
+        value
+            .pointer_mut(pointer)
+            .expect("object")
+            .as_object_mut()
+            .expect("map")
+            .insert("unknown".into(), json!(1));
+        reject(&value, &expected);
+    }
+    let mut value = expected.response();
+    value["pack"]["objects"] = json!(crate::repository_overlay::seed::MAX_OBJECTS);
+    protocol::response(&serde_json::to_vec(&value).expect("response"), expected.request()).expect("count ceiling");
+    value["pack"]["objects"] = json!(crate::repository_overlay::seed::MAX_OBJECTS + 1);
+    reject(&value, &expected);
+}
+
+#[test]
+fn duplicate_trailing_malformed_and_oversize_output_is_not_an_observation() {
+    let expected = Expected::new();
+    let valid = String::from_utf8(expected.response_bytes()).expect("json");
+    for output in [
+        "private malformed response".to_string(),
+        format!("{valid} {{}}"),
+        valid.replacen("\"version\":1", "\"version\":1,\"version\":1", 1),
+        valid.replacen("\"objects\":3", "\"objects\":3,\"objects\":3", 1),
+    ] {
+        assert!(matches!(
+            protocol::response(output.as_bytes(), expected.request()),
+            Err(RemotePackInspectionError::InvalidResponse)
+        ));
+    }
+    let mut boundary = expected.response_bytes();
+    boundary.resize(protocol::RESPONSE_LIMIT, b' ');
+    protocol::response(&boundary, expected.request()).expect("exact response limit");
+    boundary.push(b' ');
+    assert!(matches!(
+        protocol::response(&boundary, expected.request()),
+        Err(RemotePackInspectionError::InvalidResponse)
+    ));
+}

--- a/crates/horizon-core/src/remote_worker_inspection.rs
+++ b/crates/horizon-core/src/remote_worker_inspection.rs
@@ -1,0 +1,43 @@
+//! Shared current-owned-worker fence for read-only queries, never execution authority.
+
+use crate::{
+    cloud_run::{CloudWorkflowStore, interactive_worker::InteractiveWorkerSshEndpoint},
+    remote_worker_status::RemotePanelStatusError as Error,
+    remote_workspace_recovery::RecoveredRemoteWorkspace,
+};
+
+/// A workspace query has no panel scope; a panel query additionally checks its
+/// genuine saved identity. Preserve the admission order for existing panel calls.
+pub(crate) fn validate_current<'a>(
+    store: &CloudWorkflowStore,
+    recovered: &'a RecoveredRemoteWorkspace,
+    panel_id: Option<&str>,
+) -> Result<&'a InteractiveWorkerSshEndpoint, Error> {
+    let allocation = recovered.allocation();
+    let workspace = allocation.workspace();
+    let current = store.load_remote_allocation(workspace.session_id(), &workspace.state().spec.workspace_local_id)?;
+    if current.as_ref() != Some(allocation) {
+        return Err(Error::StateChanged);
+    }
+    let request = allocation.recovery_request()?;
+    if panel_id.is_some_and(|id| {
+        !workspace
+            .state()
+            .spec
+            .panels
+            .iter()
+            .any(|panel| panel.panel_local_id == id)
+    }) {
+        return Err(Error::UnknownPanel);
+    }
+    let runtime = workspace.state().runtime.as_ref().ok_or(Error::WorkerUnavailable)?;
+    let observation = recovered.observation().ok_or(Error::WorkerUnavailable)?;
+    if !observation.is_ready_for(&request, time::OffsetDateTime::now_utc())
+        || recovered.identity().public_key() != request.ssh_public_key
+        || runtime.worker.as_ref() != Some(&observation.worker)
+        || runtime.ssh != observation.ssh
+    {
+        return Err(Error::WorkerUnavailable);
+    }
+    observation.ssh.as_ref().ok_or(Error::WorkerUnavailable)
+}

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -23,9 +23,18 @@ pub(crate) fn prepared_command(
     command_for(identity, known_hosts, endpoint, Operation::Request)
 }
 
+pub(crate) fn prepared_pack_status(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<Command, Error> {
+    command_for(identity, known_hosts, endpoint, Operation::PackStatus)
+}
+
 #[derive(Clone, Copy)]
 enum Operation<'a> {
     Request,
+    PackStatus,
     Attach { runtime: CloudJobId, panel: &'a str },
 }
 
@@ -40,7 +49,7 @@ fn command_for(
     }
     let mut command = Command::new("ssh");
     let terminal_mode = match operation {
-        Operation::Request => "-T",
+        Operation::Request | Operation::PackStatus => "-T",
         Operation::Attach { panel, .. } if valid_local_id(panel) => "-tt",
         Operation::Attach { .. } => return Err(Error::UnknownPanel),
     };
@@ -89,6 +98,7 @@ fn command_for(
     ]);
     command.arg(match operation {
         Operation::Request => "/usr/local/bin/horizon-panel-session request".into(),
+        Operation::PackStatus => "/usr/local/bin/horizon-repository pack-status".into(),
         Operation::Attach { runtime, panel } => {
             format!("/usr/local/bin/horizon-panel-session attach -- {runtime} {panel}")
         }
@@ -189,6 +199,14 @@ mod tests {
             format!("{HOST_ALIAS} {}\n", endpoint.host_key)
         );
         let query = prepared_command(identity.private_key_path(), &first_path, &endpoint).expect("query");
+        let pack = prepared_pack_status(identity.private_key_path(), &first_path, &endpoint).expect("pack query");
+        let mut pack_args: Vec<_> = query.get_args().map(std::ffi::OsStr::to_os_string).collect();
+        *pack_args.last_mut().expect("fixed helper") = "/usr/local/bin/horizon-repository pack-status".into();
+        assert_eq!(pack.get_args().collect::<Vec<_>>(), pack_args);
+        assert_eq!(
+            pack.get_envs().collect::<Vec<_>>(),
+            query.get_envs().collect::<Vec<_>>()
+        );
         let mut expected: Vec<_> = query.get_args().map(std::ffi::OsStr::to_os_string).collect();
         expected[4] = "-tt".into();
         *expected.last_mut().expect("helper") =

--- a/crates/horizon-core/src/remote_worker_status.rs
+++ b/crates/horizon-core/src/remote_worker_status.rs
@@ -101,33 +101,7 @@ fn validate_current<'a>(
     recovered: &'a RecoveredRemoteWorkspace,
     panel_id: &str,
 ) -> Result<&'a crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, RemotePanelStatusError> {
-    use RemotePanelStatusError as Error;
-    let allocation = recovered.allocation();
-    let workspace = allocation.workspace();
-    let current = store.load_remote_allocation(workspace.session_id(), &workspace.state().spec.workspace_local_id)?;
-    if current.as_ref() != Some(allocation) {
-        return Err(Error::StateChanged);
-    }
-    let request = allocation.recovery_request()?;
-    if !workspace
-        .state()
-        .spec
-        .panels
-        .iter()
-        .any(|panel| panel.panel_local_id == panel_id)
-    {
-        return Err(Error::UnknownPanel);
-    }
-    let runtime = workspace.state().runtime.as_ref().ok_or(Error::WorkerUnavailable)?;
-    let observation = recovered.observation().ok_or(Error::WorkerUnavailable)?;
-    if !observation.is_ready_for(&request, time::OffsetDateTime::now_utc())
-        || recovered.identity().public_key() != request.ssh_public_key
-        || runtime.worker.as_ref() != Some(&observation.worker)
-        || runtime.ssh != observation.ssh
-    {
-        return Err(Error::WorkerUnavailable);
-    }
-    observation.ssh.as_ref().ok_or(Error::WorkerUnavailable)
+    crate::remote_worker_inspection::validate_current(store, recovered, Some(panel_id))
 }
 
 /// No error includes private paths, task data, provider payloads or subprocess output.

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -14,8 +14,14 @@ pub mod receive;
 mod staging;
 
 use super::namespace::ResolvedRepositoryOverlay;
+/// Worker pack candidates reserve the native terminator and fixed inner-path headroom.
+pub const MAX_PACK_PATH_BYTES: usize =
+    super::materialize::MAX_REQUEST_PATH_BYTES - 2 - super::checkout::publication::MAX_SIBLING_NAME_BYTES;
+/// Receive parents additionally reserve a separator and a full destination component.
+pub const MAX_PACK_RECEIVE_PARENT_BYTES: usize =
+    MAX_PACK_PATH_BYTES - 1 - super::checkout::publication::MAX_SIBLING_NAME_BYTES;
 #[cfg(target_os = "linux")]
-pub(super) const MAX_OBJECTS: usize = super::MAX_CHANGES * 2 + 2;
+pub(crate) const MAX_OBJECTS: usize = super::MAX_CHANGES * 2 + 2;
 #[cfg(target_os = "linux")]
 pub(super) const MAX_BYTES: u64 =
     super::MAX_CONTENT_BYTES + super::bundle::MAX_BUNDLE_BYTES as u64 + 3 * super::MAX_METADATA_BYTES as u64;

--- a/crates/horizon-repository/src/pack/request.rs
+++ b/crates/horizon-repository/src/pack/request.rs
@@ -2,7 +2,7 @@ use super::{Command, VERSION};
 use horizon_core::{
     cloud_run::{ArtifactDigest, GitCommitSha},
     repository_overlay::{
-        checkout::publication::{MAX_SIBLING_NAME_BYTES, validate_sibling_name},
+        checkout::publication::validate_sibling_name,
         materialize::{MAX_REQUEST_PATH_BYTES, valid_path},
     },
 };
@@ -10,10 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::{io::Read, path::PathBuf};
 
 pub(super) const HEADER_LIMIT: usize = (6 * MAX_REQUEST_PATH_BYTES + 4096).next_power_of_two();
-// Reserve the Linux terminating NUL and a component-sized budget for fixed inner
-// pack paths: native verification reopens those paths, not only the candidate root.
-pub(super) const MAX_PACK_PATH_BYTES: usize = MAX_REQUEST_PATH_BYTES - 2 - MAX_SIBLING_NAME_BYTES;
-pub(super) const MAX_RECEIVE_PARENT_BYTES: usize = MAX_PACK_PATH_BYTES - 1 - MAX_SIBLING_NAME_BYTES;
+pub(super) use horizon_core::repository_overlay::seed::{
+    MAX_PACK_PATH_BYTES, MAX_PACK_RECEIVE_PARENT_BYTES as MAX_RECEIVE_PARENT_BYTES,
+};
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -130,6 +130,12 @@ back into large multi-purpose modules.
   neither absence nor observed readiness grants management or attachment authority.
   Its `configured` adapter resolves an explicit named local profile and rejects
   stale overview summaries before passing the owned snapshot to the observation gate.
+- `remote_worker_inspection.rs` shares the current owned-worker fence between
+  workspace and genuine saved-panel queries without granting execution authority.
+  `remote_repository_pack.rs` observes an explicitly nominated existing pack via
+  the fixed pinned worker command; its protocol leaf binds bounded paths and exact
+  identity to the saved repository base. It neither uploads nor grants source,
+  publication, synchronization or checkout-readiness authority.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
   wire types; `ssh.rs` owns the query's private host-pin lifetime and retains the


### PR DESCRIPTION
## Purpose

Advance #470 (parent #383) with read-only inspection of an explicitly nominated repository pack on the retained, owned worker. This is a focused transfer/recovery prerequisite, not completion of either milestone.

## Behavior

- Use the existing bounded SSH query transport, retained client identity and pinned worker host key with the fixed `horizon-repository pack-status` command.
- Require the current owned allocation before and after I/O, including management/lifetime fences. Workspace-level inspection supports zero saved panels without inventing a panel identity.
- Bind a strict, bounded success-only response to the expected POSIX path, repository base, pack digest, encoded length, objects directory and object count. Share the unchanged worker pathname limits with the client.
- Preserve the existing saved-panel query behavior and admission order through a shared worker-inspection helper.

Failure or timeout means unknown observation, not absence or permission to replay setup or transfer. This API performs no upload, adoption, task start, database repair or lifecycle action. Observation is not durable publication, synchronization or checkout readiness; caller-owned source, namespace, provider and cost admission remain separate. Run it off the render thread. Local teardown does not stop the worker or its independent tasks.

Protected execution currently supports Linux; other platforms return an explicit unsupported-platform error. There are no new dependencies, config defaults or UI changes.

## Validation

Candidate: `15ddc2cafb5c7f9a06b8e653f736d558eac05a98` on `975eb64104891051defd651705a61524388ea3a6`, including the merged observation-storage prerequisite #491.

All eight final exact-commit lanes passed: format, maintainability, version synchronization, default/speech workspace tests and blocking/strict/pedantic Clippy. Fresh native SSH/API proof also passed all three lanes with the integrated client; its locked core dependency graph matched all 166 normal/build dependency identities. Disposable worker and generated fixture state were removed only after successful ownership, preservation and task-progress checks.

Fresh focused coverage passed nine inspection tests and 12 worker-status regressions; both precommit Clippy tiers passed. The new regression retains the database parent while removing the database before or during the query: admission rejects without SSH, or discards the successful late response, without replacing storage. Independent local source review and amendment/integration review passed. The original nine SSH and ten worker pack-protocol tests remain unchanged.

Native proof uses real local SSH/API clients with zero saved panels: exact existing-pack observation, missing/corrupt/digest-mismatched candidates, wrong host pin, unchanged saved state/keys/pack contents and metadata, and the same independent task continuing after fresh clients exit. The refreshed pass also removes control storage before observation, then restores it and verifies a successful retry. Synthetic input preparation may remain unpublished on local overlay storage; these results do not claim publication, cloud durability or PC-off acceptance.

The immutable worker image is reused: this integration changes client storage handling, not worker/image sources. Its earlier seven image lanes passed pack receipt, overlay receipt, independent setup, build-context/layer packaging, repository helper, worker security/disconnected progress and retained host identity, including all 31 image layers, maximum-path recovery and 65 MiB-plus payloads. These are retained image-specific results, not a claim that the image was rebuilt for this commit. Fresh client evidence is recorded separately above.

Local candidate image: `horizon-470-pinned-pack@sha256:2c8bf36fb5488a0256e05c860d20b9021406a3ca395d4bc731993dd64c4a77b4`.
Repository helper SHA256: `99943190fe51a22aa18d21c1f36c758e5ec37b5aba2ebcd710c9bdaf3114819d`.

Scope: ten source/test files, 843 changed lines; architecture notes additional. No release, image publication, provider registration or paid resource allocation.
