### PR TITLE
Keep remote workspace observation noncreating

### DIFF
--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -57,6 +57,7 @@ impl StoredWorkflow {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CloudWorkflowStore {
     path: PathBuf,
+    read_only: bool,
 }
 
 impl CloudWorkflowStore {
@@ -77,10 +78,35 @@ impl CloudWorkflowStore {
         let path = path.into();
         let store = Self {
             path: prepare_private_store(&path)?,
+            read_only: false,
         };
         let mut connection = store.connection()?;
         initialize_schema(&mut connection)?;
         Ok(store)
+    }
+
+    /// Open the existing default store without creating, migrating, or repairing it.
+    /// All connections on this handle are read-only, including on clones.
+    /// SQLite may maintain WAL bookkeeping files; committed live updates remain visible.
+    ///
+    /// # Errors
+    /// Fails when the database is missing, unreadable, or has an incompatible schema.
+    pub fn open_read_only(home: &HorizonHome) -> Result<Self, CloudStoreError> {
+        Self::open_read_only_path(home.cloud_workflow_store_path())
+    }
+
+    /// Open an explicit existing path with the same read-only guarantees.
+    ///
+    /// # Errors
+    /// Fails when the database is missing, unreadable, or has an incompatible schema.
+    pub fn open_read_only_path(path: impl Into<PathBuf>) -> Result<Self, CloudStoreError> {
+        let path = std::path::absolute(path.into())?;
+        #[cfg(unix)]
+        let path = database::canonical_store_path(&path)?;
+        let mut connection = database::open_read_connection(&path)?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        Ok(Self { path, read_only: true })
     }
 
     #[must_use]
@@ -290,7 +316,11 @@ impl CloudWorkflowStore {
     }
 
     fn connection(&self) -> Result<Connection, CloudStoreError> {
-        database::open_connection(&self.path)
+        if self.read_only {
+            database::open_read_connection(&self.path)
+        } else {
+            database::open_connection(&self.path)
+        }
     }
 }
 
@@ -515,6 +545,8 @@ pub enum CloudStoreError {
     Io(#[from] std::io::Error),
     #[error("cloud workflow store directory must not be accessible by group or other users")]
     InsecureStoreDirectory,
+    #[error("cloud workflow store database must not be accessible by group or other users")]
+    InsecureStoreFile,
     #[error("cloud workflow store path must not be a symbolic link")]
     SymlinkStorePath,
     #[error("cloud workflow store database failed: {0}")]

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -73,6 +73,35 @@ pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError
     Ok(connection)
 }
 
+pub(super) fn open_read_connection(path: &Path) -> Result<Connection, CloudStoreError> {
+    validate_read_path(path)?;
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+    let connection = Connection::open_with_flags(path, flags)?;
+    connection.busy_timeout(BUSY_TIMEOUT)?;
+    Ok(connection)
+}
+
+fn validate_read_path(path: &Path) -> Result<(), CloudStoreError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(CloudStoreError::SymlinkStorePath);
+    }
+    #[cfg(unix)]
+    {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        if parent.metadata()?.permissions().mode() & 0o077 != 0 {
+            return Err(CloudStoreError::InsecureStoreDirectory);
+        }
+        if metadata.permissions().mode() & 0o077 != 0 {
+            return Err(CloudStoreError::InsecureStoreFile);
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), CloudStoreError> {
     connection.pragma_update(None, "journal_mode", "WAL")?;
     let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -127,6 +156,17 @@ fn validate_allocation_schema(connection: &Connection) -> Result<(), CloudStoreE
     Ok(())
 }
 
+#[cfg(unix)]
+pub(super) fn canonical_store_path(path: &Path) -> Result<PathBuf, CloudStoreError> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    Ok(parent
+        .canonicalize()?
+        .join(path.file_name().unwrap_or(path.as_os_str())))
+}
+
 pub(super) fn prepare_private_store(path: &Path) -> Result<PathBuf, CloudStoreError> {
     let parent = path
         .parent()
@@ -143,9 +183,7 @@ pub(super) fn prepare_private_store(path: &Path) -> Result<PathBuf, CloudStoreEr
         }
     }
     #[cfg(unix)]
-    let path = parent
-        .canonicalize()?
-        .join(path.file_name().unwrap_or(path.as_os_str()));
+    let path = canonical_store_path(path)?;
     #[cfg(not(unix))]
     let path = path.to_path_buf();
     #[cfg(not(unix))]

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -4,6 +4,8 @@ use crate::cloud_run::{CloudProvider, GitCommitSha, GitSource};
 use crate::remote_workspace::{RemoteWorkspaceSpec, RemoteWorkspaceState};
 use rusqlite::params;
 
+mod reads;
+
 const OWNER: &str = "11111111-1111-4111-8111-111111111111";
 
 struct Fixture {

--- a/crates/horizon-core/src/cloud_run/store/database/tests/reads.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests/reads.rs
@@ -1,0 +1,245 @@
+use super::*;
+
+#[test]
+fn single_record_reads_never_recreate_a_missing_database() {
+    for allocation in [false, true] {
+        let fixture = fixture();
+        let path = fixture.store.path();
+        let retained = path.with_file_name("retained.sqlite3");
+        std::fs::rename(path, &retained).expect("retain database");
+        let saved = std::fs::read(&retained).expect("retained bytes");
+        if allocation {
+            assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
+        } else {
+            assert!(fixture.store.load_remote_workspace(OWNER, "workspace").is_err());
+        }
+        assert!(!path.exists(), "a read must not recreate the database");
+        assert_eq!(std::fs::read(retained).expect("preserved database"), saved);
+    }
+}
+
+#[test]
+fn read_only_open_never_creates_database_or_parent_directories() {
+    let directory = tempfile::tempdir().expect("private directory");
+    let parent = directory.path().join("absent");
+    let path = parent.join("workflows.sqlite3");
+    assert!(CloudWorkflowStore::open_read_only_path(&path).is_err());
+    assert!(!parent.exists());
+    std::fs::create_dir(&parent).expect("existing parent");
+    assert!(CloudWorkflowStore::open_read_only_path(&path).is_err());
+    assert_eq!(std::fs::read_dir(parent).expect("unchanged parent").count(), 0);
+}
+
+#[test]
+fn read_only_clones_keep_inventory_noncreating_after_open() {
+    let fixture = fixture();
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("reader");
+    let reader = reader.clone();
+    assert_eq!(
+        reader.list_remote_workspaces(OWNER).expect("inventory"),
+        [fixture.workspace]
+    );
+    let parent = fixture.store.path().parent().expect("control directory");
+    let retained = parent.with_file_name("retained-control");
+    std::fs::rename(parent, &retained).expect("retain whole directory");
+    assert!(reader.list_remote_workspaces(OWNER).is_err());
+    assert!(reader.load_remote_workspace(OWNER, "workspace").is_err());
+    assert!(reader.load_remote_allocation(OWNER, "workspace").is_err());
+    assert!(!parent.exists());
+    assert!(retained.join("workflows.sqlite3").is_file());
+}
+
+#[test]
+fn read_only_handle_rejects_writes_and_preserves_stored_records() {
+    let fixture = fixture();
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("reader");
+    let connection = fixture.store.connection().expect("writer");
+    let before = saved_bytes(&connection);
+    assert!(
+        reader
+            .connection()
+            .expect("read connection")
+            .is_readonly("main")
+            .expect("mode")
+    );
+    assert!(
+        reader
+            .connection()
+            .expect("read connection")
+            .execute("DELETE FROM remote_workspaces", [])
+            .is_err()
+    );
+    assert!(reader.allocate_remote_runtime(&fixture.workspace, i64::MAX).is_err());
+    assert_eq!(saved_bytes(&connection), before);
+    assert_eq!(allocation_count(&connection), 0);
+    assert_eq!(
+        reader.load_remote_workspace(OWNER, "workspace").expect("workspace"),
+        Some(fixture.workspace)
+    );
+}
+
+#[test]
+fn readers_observe_committed_wal_updates_without_mutating_records() {
+    let fixture = fixture();
+    let mut writer = fixture.store.connection().expect("live writer");
+    let allocation = fixture
+        .store
+        .allocate_remote_runtime(&fixture.workspace, i64::MAX)
+        .expect("allocation");
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("reader");
+    let database_before = std::fs::read(fixture.store.path()).expect("database bytes");
+    assert_eq!(
+        reader.load_remote_allocation(OWNER, "workspace").expect("allocation"),
+        Some(allocation.clone())
+    );
+    let transaction = writer.transaction().expect("uncommitted writer");
+    transaction
+        .execute(
+            "UPDATE remote_workspaces SET revision = revision + 1 WHERE workspace_local_id = 'workspace'",
+            [],
+        )
+        .expect("new revision");
+    assert_eq!(
+        reader
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("committed allocation only"),
+        Some(allocation.clone())
+    );
+    transaction.commit().expect("commit update to WAL");
+    let updated = reader
+        .load_remote_allocation(OWNER, "workspace")
+        .expect("fresh allocation")
+        .expect("record");
+    assert_eq!(updated.workspace().revision(), allocation.workspace().revision() + 1);
+    assert_eq!(updated.workspace().state(), allocation.workspace().state());
+    assert_eq!(updated.workflow(), allocation.workflow());
+    assert_eq!(
+        reader
+            .load_remote_workspace(OWNER, "workspace")
+            .expect("fresh workspace"),
+        Some(updated.workspace().clone())
+    );
+    assert_eq!(
+        std::fs::read(fixture.store.path()).expect("database bytes after reads"),
+        database_before
+    );
+}
+
+#[test]
+fn absent_records_are_distinct_from_missing_storage() {
+    let fixture = fixture();
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("reader");
+    assert_eq!(
+        reader.load_remote_workspace(OWNER, "absent").expect("missing record"),
+        None
+    );
+    assert_eq!(
+        reader.load_remote_allocation(OWNER, "absent").expect("missing binding"),
+        None
+    );
+    assert!(
+        reader
+            .load_remote_workspace("22222222-2222-4222-8222-222222222222", "workspace")
+            .is_err()
+    );
+}
+
+#[test]
+fn read_only_open_does_not_migrate_or_repair_storage() {
+    for version in [STORE_SCHEMA_VERSION - 1, STORE_SCHEMA_VERSION + 1] {
+        let fixture = fixture();
+        let connection = fixture.store.connection().expect("writer");
+        connection
+            .pragma_update(None, "user_version", version)
+            .expect("incompatible version");
+        drop(connection);
+        let before = std::fs::read(fixture.store.path()).expect("database");
+        assert!(CloudWorkflowStore::open_read_only_path(fixture.store.path()).is_err());
+        assert!(fixture.store.load_remote_workspace(OWNER, "workspace").is_err());
+        assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
+        assert_eq!(std::fs::read(fixture.store.path()).expect("unchanged database"), before);
+    }
+    let directory = tempfile::tempdir().expect("private directory");
+    let path = directory.path().join("corrupt.sqlite3");
+    let bytes = b"not a database";
+    std::fs::write(&path, bytes).expect("corrupt fixture");
+    assert!(CloudWorkflowStore::open_read_only_path(&path).is_err());
+    assert_eq!(std::fs::read(path).expect("unchanged corruption"), bytes);
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_open_preserves_private_parent_aliases_but_not_database_symlinks() {
+    let fixture = fixture();
+    let directory = tempfile::tempdir().expect("alias directory");
+    let alias = directory.path().join("control");
+    std::os::unix::fs::symlink(fixture.store.path().parent().expect("store parent"), &alias).expect("parent alias");
+    let path = alias.join("workflows.sqlite3");
+    let reader = CloudWorkflowStore::open_read_only_path(&path).expect("private parent alias");
+    assert_eq!(reader.path(), fixture.store.path());
+    assert_eq!(
+        reader.load_remote_workspace(OWNER, "workspace").expect("workspace"),
+        Some(fixture.workspace)
+    );
+    let linked = alias.join("linked.sqlite3");
+    std::os::unix::fs::symlink(&path, &linked).expect("database symlink");
+    assert!(matches!(
+        CloudWorkflowStore::open_read_only_path(linked),
+        Err(CloudStoreError::SymlinkStorePath)
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_open_rejects_exposed_parent_without_changing_permissions() {
+    let fixture = fixture();
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("private reader");
+    let path = fixture.store.path();
+    let parent = path.parent().expect("store parent");
+    let before = std::fs::read(path).expect("database");
+    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755)).expect("exposed parent");
+    assert!(matches!(
+        CloudWorkflowStore::open_read_only_path(path),
+        Err(CloudStoreError::InsecureStoreDirectory)
+    ));
+    assert!(reader.list_remote_environment_page(None).is_err());
+    assert!(fixture.store.load_remote_workspace(OWNER, "workspace").is_err());
+    assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
+    assert_eq!(parent.metadata().expect("parent").permissions().mode() & 0o777, 0o755);
+    assert_eq!(std::fs::read(path).expect("unchanged database"), before);
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_open_rejects_exposed_database_without_repairing_it() {
+    let fixture = fixture();
+    let path = fixture.store.path();
+    let before = std::fs::read(path).expect("database");
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).expect("exposed database");
+    assert!(matches!(
+        CloudWorkflowStore::open_read_only_path(path),
+        Err(CloudStoreError::InsecureStoreFile)
+    ));
+    assert!(fixture.store.load_remote_workspace(OWNER, "workspace").is_err());
+    assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
+    assert_eq!(path.metadata().expect("database").permissions().mode() & 0o777, 0o644);
+    assert_eq!(std::fs::read(path).expect("unchanged database"), before);
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_open_and_single_record_reads_reject_symlink_database() {
+    let fixture = fixture();
+    let path = fixture.store.path();
+    let retained = path.with_file_name("retained.sqlite3");
+    std::fs::rename(path, &retained).expect("retain database");
+    let before = std::fs::read(&retained).expect("retained database");
+    std::os::unix::fs::symlink(&retained, path).expect("symlink fixture");
+    assert!(matches!(
+        CloudWorkflowStore::open_read_only_path(path),
+        Err(CloudStoreError::SymlinkStorePath)
+    ));
+    assert!(fixture.store.load_remote_workspace(OWNER, "workspace").is_err());
+    assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
+    assert_eq!(std::fs::read(retained).expect("preserved database"), before);
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -17,7 +17,7 @@ use super::{
     CloudStoreError, CloudWorkflowStore, MAX_RECOVERED_WORKFLOWS, PreparedWorkflowInsert,
     RemoteWorkspaceStoreError as Error, StoredRemoteWorkspace, StoredWorkflow, check_recovery_budget,
     current_unix_millis,
-    database::ensure_current_schema,
+    database::{ensure_current_schema, open_read_connection},
     remote_workspaces::{WorkspaceReplacement, load_owned, validate_key},
 };
 use crate::cloud_run::{
@@ -98,6 +98,7 @@ impl CloudWorkflowStore {
     /// Unbound active records fail closed and remain available through the record-store API.
     /// Expired setup workflows remain recoverable without granting new creation.
     /// Recovery does not stop/delete workers, clear intent, or change runtime identity.
+    /// Does not create a missing database or repair its schema.
     /// # Errors
     /// Rejects invalid ownership, unbound active snapshots, corrupt relationships, or storage errors.
     pub fn load_remote_allocation(
@@ -106,7 +107,7 @@ impl CloudWorkflowStore {
         workspace_local_id: &str,
     ) -> Result<Option<StoredRemoteAllocation>, Error> {
         validate_key(session_id, workspace_local_id)?;
-        let mut connection = self.connection()?;
+        let mut connection = open_read_connection(self.path())?;
         let transaction = connection.transaction()?;
         ensure_current_schema(&transaction)?;
         let workspace = load_owned(&transaction, session_id, workspace_local_id)?;

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -14,7 +14,8 @@ use thiserror::Error;
 
 use super::{
     CloudStoreError, CloudWorkflowStore, MAX_MATERIALIZED_SNAPSHOT_BYTES, MAX_RECOVERED_SNAPSHOT_BYTES,
-    MAX_SNAPSHOT_BYTES, database::ensure_current_schema,
+    MAX_SNAPSHOT_BYTES,
+    database::{ensure_current_schema, open_read_connection},
 };
 use crate::remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceError, RemoteWorkspaceState};
 pub(super) use validation::validate_key;
@@ -93,6 +94,7 @@ impl CloudWorkflowStore {
     }
 
     /// Load one record only for its owning session, revalidating all stored data.
+    /// Does not create a missing database or repair its schema.
     /// # Errors
     /// Fails closed on ownership mismatch, corruption, incompatible schema, or storage errors.
     pub fn load_remote_workspace(
@@ -101,7 +103,7 @@ impl CloudWorkflowStore {
         workspace_local_id: &str,
     ) -> Result<Option<StoredRemoteWorkspace>, RemoteWorkspaceStoreError> {
         validate_key(session_id, workspace_local_id)?;
-        let mut connection = self.connection()?;
+        let mut connection = open_read_connection(self.path())?;
         let transaction = connection.transaction()?;
         ensure_current_schema(&transaction)?;
         load_owned(&transaction, session_id, workspace_local_id)

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -393,6 +393,9 @@ back into large multi-purpose modules.
   Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
   schema initialization, and compatibility checks. Keep database opening separate
   from domain-specific record operations.
+  Existing-store observers use clone-preserved read-only handles, without private-path
+  creation or migration. Single workspace/allocation getters always use read-only
+  connections; live WAL updates remain visible without granting schema repair.
 - `cloud_run/store/remote_workspaces.rs` owns validated, session-owned remote
   snapshot storage with exact revisions and bounded recovery. Replacement
   invariants live in its `validation.rs` leaf. These records are independent of


### PR DESCRIPTION
## Purpose

Keep remote workspace and allocation observation from recreating a missing control database. Refs #383 and #470; prerequisite for existing repository and task inspection work.

## Behavior

- Single workspace/allocation getters open SQLite read-only and still validate schema, ownership and binding in one transaction.
- New read-only store constructors skip directory/file creation and migrations. Clones preserve read-only connections, including inventory reads after the database disappears.
- Read connections reject insecure Unix parent/database permissions without repairing them. Parent aliases retain the existing canonicalization behavior; database-leaf symlinks are refused.
- Existing writable constructors and lifecycle mutation paths are unchanged. Live committed WAL updates remain visible; SQLite may maintain auxiliary WAL bookkeeping files.
- No UI, provider, worker-image, upload, task-start, release or infrastructure changes.

## Reproduction and evidence

Open a private store, retain its closed database by renaming it, then call a single-record getter. The new regression fails on the base because the read recreates the database; it passes with this fix.

Eleven new regressions cover missing files/parents, cloned inventory handles, rejected writes, live committed versus uncommitted WAL updates, absent records versus storage failures, incompatible/corrupt schemas, Unix permissions and symlink/parent-alias behavior. All 103 store tests pass. Independent local review completed, including the hosted review correction.

Final exact commit: `450329976eb443a5909beeb2624670fb5021bc3d`.
Final full validation passed after the review correction: formatting, maintainability,
version synchronization, workspace default and speech tests, blocking/strict Clippy,
and advisory pedantic Clippy.

Scope: six source/test files, 336 changed lines, plus the architecture note. No graphical behavior changes; native UI/provider acceptance remains with the consuming features. Cross-platform CI checks the final head.
