### PR TITLE
Add retained cloud worker Stop

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -12,6 +12,7 @@ mod create_request;
 mod http;
 mod interactive;
 mod models;
+mod stop;
 #[cfg(test)]
 mod tests;
 
@@ -381,6 +382,7 @@ trait Transport: Send + Sync {
     fn list_by_name(&self, name: &str) -> Result<Vec<ApiPod>, RunPodError>;
     fn create(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError>;
     fn get(&self, pod_id: &str) -> Result<Option<ApiPod>, RunPodError>;
+    fn stop(&self, pod_id: &str) -> Result<(), RunPodError>;
     fn delete(&self, pod_id: &str) -> Result<RunPodCleanup, RunPodError>;
 }
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -394,6 +396,8 @@ struct ApiPod {
     env: BTreeMap<String, String>,
     #[serde(default, deserialize_with = "deserialize_hourly_cost")]
     cost: Option<u64>,
+    #[serde(flatten)]
+    stop: stop::StopMetadata,
 }
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]

--- a/crates/horizon-core/src/cloud_run/runpod/http.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http.rs
@@ -105,6 +105,19 @@ impl Transport for RunPodHttp {
             .then_some(Some(pod))
             .ok_or(RunPodError::ResourceIdentityMismatch)
     }
+    fn stop(&self, pod_id: &str) -> Result<(), RunPodError> {
+        let url = format!("{}/action", Self::pod_url(pod_id)?);
+        let response = self
+            .agent
+            .post(url.as_str())
+            .header("Authorization", &self.authorization)
+            .send_json(serde_json::json!({"action": "stop"}))
+            .map_err(|_| RunPodError::RequestFailed { operation: "pod Stop" })?;
+        let pod: ApiPod = decode_json(response, 200, "pod Stop")?;
+        (pod.id == pod_id)
+            .then_some(())
+            .ok_or(RunPodError::ResourceIdentityMismatch)
+    }
     fn delete(&self, pod_id: &str) -> Result<RunPodCleanup, RunPodError> {
         let url = Self::pod_url(pod_id)?;
         let response = self
@@ -186,4 +199,111 @@ where
         .limit(RESPONSE_LIMIT_BYTES)
         .read_json()
         .map_err(|_| RunPodError::InvalidResponse { operation })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        io::Read as _,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+    use ureq::{
+        Body, SendBody,
+        http::{Request, Response},
+        middleware::MiddlewareNext,
+    };
+
+    #[test]
+    fn stop_http_uses_only_exact_fixed_action_and_bounded_redacted_responses() {
+        for (status, body, expected) in [
+            (200, r#"{"id":"pod_stop"}"#.to_string(), Ok(())),
+            (
+                200,
+                r#"{"id":"foreign"}"#.to_string(),
+                Err(RunPodError::ResourceIdentityMismatch),
+            ),
+            (
+                200,
+                "private-malformed-payload".into(),
+                Err(RunPodError::InvalidResponse { operation: "pod Stop" }),
+            ),
+            (
+                200,
+                format!(r#"{{"id":"pod_stop","padding":"{}"}}"#, "x".repeat(2 * 1024 * 1024)),
+                Err(RunPodError::InvalidResponse { operation: "pod Stop" }),
+            ),
+            (
+                403,
+                "private-forbidden-payload".into(),
+                Err(RunPodError::UnexpectedStatus {
+                    operation: "pod Stop",
+                    status: 403,
+                }),
+            ),
+            (
+                204,
+                String::new(),
+                Err(RunPodError::UnexpectedStatus {
+                    operation: "pod Stop",
+                    status: 204,
+                }),
+            ),
+            (
+                302,
+                "private-redirect-payload".into(),
+                Err(RunPodError::UnexpectedStatus {
+                    operation: "pod Stop",
+                    status: 302,
+                }),
+            ),
+        ] {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let count = Arc::clone(&calls);
+            let agent = ureq::Agent::config_builder()
+                .middleware(move |request: Request<SendBody>, _: MiddlewareNext| {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(request.method(), "POST");
+                    assert_eq!(request.uri(), "https://api.runpod.io/v2/pods/pod_stop/action");
+                    assert_eq!(request.headers()["Authorization"], "Bearer synthetic-credential");
+                    assert_eq!(request.headers()["Content-Type"], "application/json; charset=utf-8");
+                    let mut payload = String::new();
+                    request
+                        .into_body()
+                        .into_reader()
+                        .read_to_string(&mut payload)
+                        .expect("payload");
+                    assert_eq!(
+                        serde_json::from_str::<serde_json::Value>(&payload).expect("request JSON"),
+                        serde_json::json!({"action": "stop"})
+                    );
+                    Ok(Response::builder()
+                        .status(status)
+                        .body(Body::builder().data(body.clone()))
+                        .expect("response"))
+                })
+                .build()
+                .new_agent();
+            let http = RunPodHttp {
+                agent,
+                authorization: "Bearer synthetic-credential".into(),
+            };
+            assert_eq!(http.stop("pod_stop"), expected);
+            for invalid in ["", "../other", "pod_stop/action", "pod_stop?terminate=true"] {
+                assert_eq!(http.stop(invalid), Err(RunPodError::ResourceIdentityMismatch));
+            }
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+            if let Err(error) = expected {
+                assert!(!format!("{error:?} {error}").contains("private-"));
+                assert!(!format!("{error:?} {error}").contains("synthetic-credential"));
+            }
+        }
+        let production = RunPodHttp::new(&RunPodApiKey::new("synthetic-credential").expect("key"));
+        assert!(production.agent.config().https_only());
+        assert_eq!(production.agent.config().max_redirects(), 0);
+        assert_eq!(production.agent.config().timeouts().global, Some(REQUEST_TIMEOUT));
+    }
 }

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -5,6 +5,7 @@ use super::super::{
         InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerSshEndpoint,
         InteractiveWorkerStatus, valid_ssh_coordinates,
     },
+    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
 };
 use super::{
     RunPodCleanup, RunPodClient, RunPodEnsure, RunPodError, RunPodLifecycle, RunPodProfile, RunPodSshEndpoint,
@@ -176,6 +177,15 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
             RunPodCleanup::Deleted => InteractiveWorkerCleanup::Deleted,
             RunPodCleanup::AlreadyAbsent => InteractiveWorkerCleanup::AlreadyAbsent,
         })
+    }
+}
+
+impl InteractiveWorkerStopProvider for RunPodInteractiveWorkerProvider {
+    fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error> {
+        let retained = runpod_worker(worker)?;
+        super::validate_target(&worker.target, &self.profile)?;
+        self.client
+            .stop_interactive_worker(&retained, &worker.ssh_public_key, &self.profile)
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/runpod/models.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/models.rs
@@ -200,6 +200,16 @@ pub enum RunPodError {
     PersistentCreationReconciliationRequired { name: String, pod_id: String },
     #[error("RunPod pod {pod_id} deletion could not be verified")]
     DeletionVerificationFailed { pod_id: String },
+    #[error("data-retaining RunPod Stop requires a persistent worker")]
+    StopUnsupportedLifetime,
+    #[error("RunPod Stop requires a verified retained /workspace volume")]
+    StopRetentionUnverified,
+    #[error("RunPod lifecycle or Stop capability could not be verified")]
+    StopStateUnverified,
+    #[error("RunPod resource disappeared during Stop; retained data cannot be certified")]
+    StopResourceLost,
+    #[error("RunPod Stop was not verified; retain identity and explicitly reconcile before retrying")]
+    StopVerificationFailed,
     #[error("RunPod recovered worker lease was outside the requested bound and was deleted")]
     LeaseDeadlineRejected { worker: Box<RunPodWorker> },
     #[error("RunPod recovered worker lease was outside the requested bound but cleanup failed")]

--- a/crates/horizon-core/src/cloud_run/runpod/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/stop.rs
@@ -1,0 +1,120 @@
+//! Exact-Pod Stop with ordinary volume retention, separate from termination.
+//! Provider metadata proves only point-in-time retained/inactive state, not a backup,
+//! successful task exit, preserved process memory, or qualified filesystem durability.
+
+use super::{
+    ApiPod, InteractiveWorkerLifetime, RunPodClient, RunPodError, RunPodLifecycle, RunPodProfile, RunPodWorker,
+    status_from_resource, valid_ssh_public_key,
+};
+use crate::cloud_run::interactive_worker_stop::InteractiveWorkerStop;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Optional metadata is ignored by existing lifecycle reads; Stop requires positive proof.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct StopMetadata {
+    mounts: Value,
+    actions: Value,
+    locked: Value,
+    cloud: Value,
+    cluster: Value,
+    runtime: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Mounts {
+    persistent: PersistentMount,
+}
+
+#[derive(Debug, Eq, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistentMount {
+    size: u32,
+    path: String,
+}
+
+struct RetainedState {
+    mount: PersistentMount,
+    stopped: bool,
+}
+
+impl RunPodClient {
+    /// One exact mutation, then a fresh observation even if its response was lost.
+    /// No implicit polling/retry, host-key access, restart or compensating deletion.
+    pub(super) fn stop_interactive_worker(
+        &self,
+        worker: &RunPodWorker,
+        ssh_public_key: &str,
+        profile: &RunPodProfile,
+    ) -> Result<InteractiveWorkerStop, RunPodError> {
+        worker.validate()?;
+        if worker.lifetime != InteractiveWorkerLifetime::Persistent {
+            return Err(RunPodError::StopUnsupportedLifetime);
+        }
+        if !valid_ssh_public_key(ssh_public_key) {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        if profile.volume_gib == 0 {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
+        let Some(before) = self.transport.get(&worker.pod_id)? else {
+            return Ok(InteractiveWorkerStop::AlreadyAbsent);
+        };
+        let before = retained_state(&before, worker, ssh_public_key, profile)?;
+        if before.stopped {
+            return Ok(InteractiveWorkerStop::Stopped);
+        }
+        let stopping = self.transport.stop(&worker.pod_id);
+        let after = self
+            .transport
+            .get(&worker.pod_id)?
+            .ok_or(RunPodError::StopResourceLost)?;
+        let after = retained_state(&after, worker, ssh_public_key, profile)?;
+        if before.mount != after.mount {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
+        if after.stopped {
+            return Ok(InteractiveWorkerStop::Stopped);
+        }
+        stopping?;
+        Err(RunPodError::StopVerificationFailed)
+    }
+}
+
+fn retained_state(
+    pod: &ApiPod,
+    worker: &RunPodWorker,
+    ssh_public_key: &str,
+    profile: &RunPodProfile,
+) -> Result<RetainedState, RunPodError> {
+    let status = status_from_resource(pod, worker, Some(ssh_public_key))?;
+    let metadata = &pod.stop;
+    let mounts: Mounts =
+        serde_json::from_value(metadata.mounts.clone()).map_err(|_| RunPodError::StopRetentionUnverified)?;
+    if metadata.cloud != "SECURE"
+        || !metadata.cluster.is_null()
+        || mounts.persistent.path != "/workspace"
+        || mounts.persistent.size < profile.volume_gib
+    {
+        return Err(RunPodError::StopRetentionUnverified);
+    }
+    let stopped = match status.lifecycle {
+        RunPodLifecycle::Exited if metadata.runtime.is_null() => true,
+        RunPodLifecycle::Provisioning | RunPodLifecycle::Running
+            if metadata.locked == false
+                && metadata
+                    .actions
+                    .as_array()
+                    .is_some_and(|actions| actions.iter().any(|value| value == "stop")) =>
+        {
+            false
+        }
+        _ => return Err(RunPodError::StopStateUnverified),
+    };
+    Ok(RetainedState {
+        mount: mounts.persistent,
+        stopped,
+    })
+}

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -4,6 +4,7 @@ use super::super::interactive_worker::{
     InteractiveWorkerLease, InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
     InteractiveWorkerRequest,
 };
+use super::stop::StopMetadata;
 use super::*;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use std::sync::{Arc, Mutex};
@@ -12,6 +13,7 @@ mod noncreating;
 mod persistence;
 mod reconciliation;
 mod snapshots;
+mod stop;
 
 const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
 
@@ -25,6 +27,9 @@ struct FakeState {
     create_rejection: Option<RunPodError>,
     create_requests: Vec<CreatePodRequest>,
     deleted: Vec<String>,
+    stopped: Vec<String>,
+    stop_error: Option<RunPodError>,
+    on_stop: Option<Box<dyn Fn() + Send + Sync>>,
     inspected: Vec<String>,
     scripted_lists: Vec<Vec<ApiPod>>,
     scripted_gets: Vec<Result<Option<ApiPod>, RunPodError>>,
@@ -90,6 +95,17 @@ impl Transport for FakeTransport {
         state.pods.retain(|pod| pod.id != pod_id);
         Ok(RunPodCleanup::Deleted)
     }
+    fn stop(&self, pod_id: &str) -> Result<(), RunPodError> {
+        let mut state = self.0.lock().expect("state");
+        if let Some(hook) = &state.on_stop {
+            hook();
+        }
+        state.stopped.push(pod_id.to_string());
+        for pod in state.pods.iter_mut().filter(|pod| pod.id == pod_id) {
+            pod.status = Some("EXITED".into());
+        }
+        state.stop_error.take().map_or(Ok(()), Err)
+    }
 }
 fn target() -> WorkerTarget {
     WorkerTarget {
@@ -149,6 +165,7 @@ fn api_pod(
             (TERMINATE_ENV.to_string(), terminate_after),
         ]),
         cost: hourly_cost_micros,
+        stop: StopMetadata::default(),
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/runpod/tests/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/stop.rs
@@ -1,0 +1,439 @@
+use super::{persistence::persistent_pod, persistence::persistent_request, *};
+use crate::{
+    cloud_run::{
+        CloudWorkflowStore, StoredRemoteAllocation,
+        interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+    },
+    remote_workspace::stop::{RemoteWorkspaceStopError, stop_remote_workspace},
+    remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
+};
+use serde_json::{Value, json};
+
+struct Fixture {
+    worker: InteractiveWorker,
+    transport: FakeTransport,
+    keys: FakeHostKeySource,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::from_request(persistent_request())
+    }
+
+    fn from_request(request: InteractiveWorkerRequest) -> Self {
+        let mut pod = persistent_pod(&request);
+        pod.stop = serde_json::from_value(metadata()).expect("retention metadata");
+        Self {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::RunPod,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: pod.id.clone(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            transport: FakeTransport::with_pods(vec![pod]),
+            keys: FakeHostKeySource::new(None),
+        }
+    }
+
+    fn provider(&self) -> RunPodInteractiveWorkerProvider {
+        RunPodInteractiveWorkerProvider::new(
+            RunPodClient::with_transport(self.transport.clone()),
+            profile(),
+            self.keys.clone(),
+        )
+    }
+
+    fn pod(&self) -> ApiPod {
+        self.transport.0.lock().expect("state").pods[0].clone()
+    }
+
+    fn assert_calls(&self, reads: usize, stops: usize) {
+        let state = self.transport.0.lock().expect("state");
+        assert_eq!(state.inspected, vec![self.worker.identity.resource_id.clone(); reads]);
+        assert_eq!(state.stopped, vec![self.worker.identity.resource_id.clone(); stops]);
+        assert_eq!(state.list_calls, 0);
+        assert!(state.create_requests.is_empty());
+        assert!(state.deleted.is_empty());
+        assert!(self.keys.calls.lock().expect("keys").is_empty());
+    }
+}
+
+fn metadata() -> Value {
+    json!({"mounts":{"persistent":{"size":20,"path":"/workspace"}},
+        "cloud":"SECURE", "cluster":null, "locked":false,
+        "actions":["stop","restart","terminate"], "runtime":null})
+}
+
+fn stopping_failure() -> RunPodError {
+    RunPodError::RequestFailed { operation: "pod Stop" }
+}
+
+#[test]
+fn explicit_stop_and_fresh_retry_retain_worker_without_keys_or_other_provider_operations() {
+    let fixture = Fixture::new();
+    let before = fixture.pod();
+    assert_eq!(
+        fixture.provider().stop_worker(&fixture.worker),
+        Ok(InteractiveWorkerStop::Stopped)
+    );
+    fixture.assert_calls(2, 1);
+    let retained = fixture.pod();
+    assert_eq!(retained.id, before.id);
+    assert_eq!(retained.env, before.env);
+    assert_eq!(retained.status.as_deref(), Some("EXITED"));
+    assert_eq!(
+        fixture.provider().stop_worker(&fixture.worker),
+        Ok(InteractiveWorkerStop::Stopped)
+    );
+    fixture.assert_calls(3, 1);
+}
+
+#[test]
+fn stop_validates_worker_lifetime_and_profile_before_io() {
+    for changed in 0..6 {
+        let fixture = Fixture::new();
+        let mut worker = fixture.worker.clone();
+        let expected = match changed {
+            0 => {
+                worker.identity.resource_id = "../foreign".into();
+                RunPodError::InvalidPersistedWorker
+            }
+            1 => {
+                worker.identity.provider = CloudProvider::LocalDocker;
+                RunPodError::InvalidPersistedWorker
+            }
+            2 => {
+                worker.ssh_public_key.clear();
+                RunPodError::InvalidPersistedWorker
+            }
+            3 => {
+                worker.target.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
+                worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                    terminate_after: termination_deadline(900).expect("deadline"),
+                });
+                RunPodError::StopUnsupportedLifetime
+            }
+            4 => {
+                worker.target.profile = "other-profile".into();
+                RunPodError::InvalidTarget
+            }
+            _ => {
+                worker.target.image = "example/worker:latest".into();
+                RunPodError::InvalidPersistedWorker
+            }
+        };
+        assert_eq!(fixture.provider().stop_worker(&worker), Err(expected));
+        fixture.assert_calls(0, 0);
+    }
+    let fixture = Fixture::new();
+    let mut configuration = profile();
+    configuration.volume_gib = 0;
+    let provider = RunPodInteractiveWorkerProvider::new(
+        RunPodClient::with_transport(fixture.transport.clone()),
+        configuration,
+        fixture.keys.clone(),
+    );
+    assert_eq!(
+        provider.stop_worker(&fixture.worker),
+        Err(RunPodError::StopRetentionUnverified)
+    );
+    fixture.assert_calls(0, 0);
+}
+
+#[test]
+fn stop_rejects_missing_ambiguous_or_unowned_retention_before_mutation() {
+    for changed in 0..12 {
+        let fixture = Fixture::new();
+        let mut data = metadata();
+        match changed {
+            0 => {
+                data.as_object_mut().expect("metadata").remove("mounts");
+            }
+            1 => data["mounts"] = json!({}),
+            2 => data["mounts"]["persistent"]["size"] = json!(0),
+            3 => data["mounts"]["persistent"]["size"] = json!(19),
+            4 => data["mounts"]["persistent"]["path"] = json!("/workspace/../private"),
+            5 => data["mounts"] = json!({"network":[{"volumeId":"volume","path":"/workspace"}]}),
+            6 => data["mounts"]["network"] = json!([]),
+            7 => data["mounts"]["other"] = json!({"path":"/workspace"}),
+            8 => data["mounts"]["persistent"]["size"] = json!(20.5),
+            9 => data["cloud"] = json!("COMMUNITY"),
+            10 => {
+                data.as_object_mut().expect("metadata").remove("cloud");
+            }
+            _ => data["cluster"] = json!({"id":"foreign-cluster"}),
+        }
+        fixture.transport.0.lock().expect("state").pods[0].stop = serde_json::from_value(data).expect("raw metadata");
+        assert_eq!(
+            fixture.provider().stop_worker(&fixture.worker),
+            Err(RunPodError::StopRetentionUnverified)
+        );
+        fixture.assert_calls(1, 0);
+    }
+}
+
+#[test]
+fn provisioning_stop_requires_unlocked_capability_and_retained_volume() {
+    for status in ["PROVISIONING", "STARTING"] {
+        for rejected in 0..4 {
+            let fixture = Fixture::new();
+            let mut pod = fixture.pod();
+            pod.status = Some(status.into());
+            let mut data = metadata();
+            match rejected {
+                1 => data["locked"] = json!(true),
+                2 => data["actions"] = json!(["terminate"]),
+                3 => data["mounts"]["persistent"]["size"] = json!(0),
+                _ => {}
+            }
+            pod.stop = serde_json::from_value(data).expect("raw metadata");
+            fixture.transport.0.lock().expect("state").pods = vec![pod];
+            let expected = match rejected {
+                0 => Ok(InteractiveWorkerStop::Stopped),
+                3 => Err(RunPodError::StopRetentionUnverified),
+                _ => Err(RunPodError::StopStateUnverified),
+            };
+            assert_eq!(fixture.provider().stop_worker(&fixture.worker), expected);
+            if rejected == 0 {
+                fixture.assert_calls(2, 1);
+            } else {
+                fixture.assert_calls(1, 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn stop_rejects_unknown_states_capabilities_and_conflicting_live_state() {
+    for changed in 0..8 {
+        let fixture = Fixture::new();
+        let mut pod = fixture.pod();
+        let mut data = metadata();
+        match changed {
+            0 => pod.status = None,
+            1 => pod.status = Some("TERMINATED".into()),
+            2 => pod.status = Some("ERROR".into()),
+            3 => pod.status = Some("UNRECOGNIZED".into()),
+            4 => data["locked"] = json!(true),
+            5 => data["actions"] = json!(["terminate"]),
+            6 => {
+                data.as_object_mut().expect("metadata").remove("locked");
+            }
+            _ => {
+                pod.status = Some("EXITED".into());
+                data["runtime"] = json!({"uptime":1});
+            }
+        }
+        pod.stop = serde_json::from_value(data).expect("raw metadata");
+        fixture.transport.0.lock().expect("state").pods = vec![pod];
+        assert_eq!(
+            fixture.provider().stop_worker(&fixture.worker),
+            Err(RunPodError::StopStateUnverified)
+        );
+        fixture.assert_calls(1, 0);
+    }
+}
+
+#[test]
+fn exact_ownership_is_checked_on_both_sides_of_stop() {
+    for after_stop in [false, true] {
+        for changed in 0..7 {
+            let fixture = Fixture::new();
+            let before = fixture.pod();
+            let mut invalid = before.clone();
+            match changed {
+                0 => invalid.id = "another-pod".into(),
+                1 => invalid.name = "foreign-name".into(),
+                2 => invalid.image = format!("example/foreign@sha256:{}", "e".repeat(64)),
+                3 => {
+                    invalid
+                        .env
+                        .insert(WORKFLOW_ENV.into(), CloudWorkflowId::new().to_string());
+                }
+                4 => {
+                    invalid.env.insert(JOB_ENV.into(), CloudJobId::new().to_string());
+                }
+                5 => {
+                    invalid.env.insert(SSH_PUBLIC_KEY_ENV.into(), ed25519_key(9));
+                }
+                _ => {
+                    invalid
+                        .env
+                        .insert(TERMINATE_ENV.into(), termination_deadline(900).expect("deadline"));
+                }
+            }
+            fixture.transport.0.lock().expect("state").scripted_gets = if after_stop {
+                vec![Ok(Some(before)), Ok(Some(invalid))]
+            } else {
+                vec![Ok(Some(invalid))]
+            };
+            assert_eq!(
+                fixture.provider().stop_worker(&fixture.worker),
+                Err(RunPodError::ResourceIdentityMismatch)
+            );
+            fixture.assert_calls(usize::from(after_stop) + 1, usize::from(after_stop));
+        }
+    }
+}
+
+#[test]
+fn lost_stop_response_is_accepted_only_after_verified_retained_exit() {
+    let fixture = Fixture::new();
+    fixture.transport.0.lock().expect("state").stop_error = Some(stopping_failure());
+    assert_eq!(
+        fixture.provider().stop_worker(&fixture.worker),
+        Ok(InteractiveWorkerStop::Stopped)
+    );
+    fixture.assert_calls(2, 1);
+    for failed_command in [false, true] {
+        let fixture = Fixture::new();
+        let before = fixture.pod();
+        {
+            let mut state = fixture.transport.0.lock().expect("state");
+            state.scripted_gets = vec![Ok(Some(before.clone())), Ok(Some(before))];
+            state.stop_error = failed_command.then(stopping_failure);
+        }
+        let expected = if failed_command {
+            stopping_failure()
+        } else {
+            RunPodError::StopVerificationFailed
+        };
+        assert_eq!(fixture.provider().stop_worker(&fixture.worker), Err(expected));
+        fixture.assert_calls(2, 1);
+    }
+}
+
+#[test]
+fn absence_and_post_stop_retention_changes_are_never_stopped_acknowledgements() {
+    let absent = Fixture::new();
+    absent.transport.0.lock().expect("state").pods.clear();
+    assert_eq!(
+        absent.provider().stop_worker(&absent.worker),
+        Ok(InteractiveWorkerStop::AlreadyAbsent)
+    );
+    absent.assert_calls(1, 0);
+    for changed in 0..5 {
+        let fixture = Fixture::new();
+        let before = fixture.pod();
+        let mut after = before.clone();
+        after.status = Some("EXITED".into());
+        let (observation, expected) = match changed {
+            0 => (Ok(None), RunPodError::StopResourceLost),
+            1 => {
+                after.status = Some("TERMINATED".into());
+                (Ok(Some(after)), RunPodError::StopStateUnverified)
+            }
+            2 => {
+                let mut data = metadata();
+                data["mounts"]["persistent"]["size"] = json!(21);
+                after.stop = serde_json::from_value(data).expect("changed mount");
+                (Ok(Some(after)), RunPodError::StopRetentionUnverified)
+            }
+            3 => {
+                after.stop = StopMetadata::default();
+                (Ok(Some(after)), RunPodError::StopRetentionUnverified)
+            }
+            _ => (Err(stopping_failure()), stopping_failure()),
+        };
+        fixture.transport.0.lock().expect("state").scripted_gets = vec![Ok(Some(before)), observation];
+        assert_eq!(fixture.provider().stop_worker(&fixture.worker), Err(expected));
+        fixture.assert_calls(2, 1);
+    }
+}
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+fn stored_fixture(store: &CloudWorkflowStore) -> (StoredRemoteAllocation, Fixture) {
+    let state: RemoteWorkspaceState = serde_json::from_value(json!({
+        "version":1, "spec":{"workspace_local_id":"workspace", "working_directory":".", "generation":0,
+            "target":persistent_request().target,
+            "repository":{"repository":"example/project", "commit":"b".repeat(40)}, "panels":[]}
+    }))
+    .expect("state");
+    let dormant = store.create_remote_workspace(OWNER, &state).expect("dormant");
+    let allocated = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocate");
+    let reserved = store
+        .reserve_remote_worker_request(&allocated, &ed25519_key(41))
+        .expect("reserve");
+    let fixture = Fixture::from_request(reserved.worker_request().expect("request"));
+    let mut saved = reserved.workspace().state().clone();
+    let runtime = saved.runtime.as_mut().expect("runtime");
+    runtime.worker = Some(fixture.worker.clone());
+    runtime.phase = RemoteRuntimePhase::Reconciling;
+    store
+        .replace_remote_workspace(reserved.workspace(), &saved)
+        .expect("saved worker");
+    (
+        store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("read")
+            .expect("allocation"),
+        fixture,
+    )
+}
+
+#[test]
+fn real_store_intent_precedes_stop_and_uncertain_result_survives_controller_reopen() {
+    let directory = tempfile::tempdir().expect("private fixture");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let (before, fixture) = stored_fixture(&store);
+    let hook_store = store.clone();
+    let expected_worker = fixture.worker.clone();
+    let mut before_pod = fixture.pod();
+    before_pod.status = Some("STARTING".into());
+    {
+        let mut state = fixture.transport.0.lock().expect("state");
+        state.scripted_gets = vec![Ok(Some(before_pod.clone())), Ok(Some(before_pod))];
+        state.on_stop = Some(Box::new(move || {
+            let saved = hook_store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("read")
+                .expect("allocation");
+            let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+            assert!(matches!(runtime.phase, RemoteRuntimePhase::Stopping { .. }));
+            assert_eq!(runtime.worker.as_ref(), Some(&expected_worker));
+        }));
+    }
+    assert_eq!(
+        stop_remote_workspace(&store, &fixture.provider(), before.workspace()),
+        Err(RemoteWorkspaceStopError::ProviderUnavailable)
+    );
+    let pending = store
+        .load_remote_allocation(OWNER, "workspace")
+        .expect("read")
+        .expect("pending");
+    let requested = pending
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .expect("runtime")
+        .phase
+        .stop_requested_at_millis()
+        .expect("intent");
+    let mut expected = before.workspace().state().clone();
+    expected.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Stopping {
+        requested_at_millis: requested,
+    };
+    assert_eq!(pending.workspace().state(), &expected);
+    assert_eq!(pending.workflow(), before.workflow());
+    assert_eq!(pending.workspace().revision(), before.workspace().revision() + 1);
+    let path = store.path().to_path_buf();
+    fixture.transport.0.lock().expect("state").on_stop = None;
+    drop(store);
+    let reopened = CloudWorkflowStore::open_path(path).expect("reopened control store");
+    let stopped = stop_remote_workspace(&reopened, &fixture.provider(), pending.workspace()).expect("verified retry");
+    let phase = stopped.workspace().state().runtime.as_ref().expect("runtime").phase;
+    assert!(
+        matches!(phase, RemoteRuntimePhase::Stopped { requested_at_millis, .. } if requested_at_millis == requested)
+    );
+    expected.runtime.as_mut().expect("runtime").phase = phase;
+    assert_eq!(stopped.workspace().state(), &expected);
+    assert_eq!(stopped.workflow(), before.workflow());
+    fixture.assert_calls(3, 1);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -389,6 +389,11 @@ back into large multi-purpose modules.
   creation-request construction. Public type re-exports remain stable. HTTP
   transport and common interactive-worker adaptation stay in their existing
   `http.rs` and `interactive.rs` leaves.
+- `cloud_run/runpod/stop.rs` adds only explicit, exact-Pod Stop for persistent
+  workers with a verified ordinary `/workspace` volume. It verifies retained
+  inactive state after a single Stop action, including a lost response, without
+  deletion, restart, SSH, or UI admission. This is not a backup or filesystem
+  durability claim; the existing durable Stop coordinator owns saved intent.
 - `cloud_run/store.rs` owns workflow snapshots and creation-claim transactions.
   Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
   schema initialization, and compatibility checks. Keep database opening separate


### PR DESCRIPTION
## Purpose

Add the existing GPU Pod adapter to the durable, explicit Stop coordinator for
persistent workers. This is one part of #473, not completion of the first-cloud
workflow.

Candidate: `c61401bad3a3c3ea628968322381ecdc145c6d79`, based on
`975eb64104891051defd651705a61524388ea3a6`. Scope: seven source/test files,
720 added lines, plus five architecture lines.

## Behavior

- Validate the saved worker, configured profile, exact ownership and ordinary
  persistent `/workspace` mount before sending a Stop action.
- Permit known provisioning/starting and running states only when unlocked and
  the provider explicitly advertises Stop; readiness is not a prerequisite to
  requesting Stop. Unknown states still fail closed.
- Send at most one fixed Stop action, then inspect the exact Pod again even if
  the action response was lost. Only matching, retained `EXITED` state
  acknowledges Stop. Already-exited retries perform no action.
- Reject timed workers, network/cluster or ambiguous mounts, conflicting
  lifecycle metadata, changed identities and disappearance. Uncertain results
  preserve the durable pending intent and worker identity for explicit recovery.
- No creation, termination, deletion, restart, host-key access, automatic retry,
  task launch, UI/configuration change or new dependency.

## Validation

- 41 focused adapter tests and 18 Stop coordinator tests pass. The added
  provisioning/starting regression first reproduced the previous refusal, then
  passed for stoppable workers while still refusing locked, unsupported-action
  and unverified-volume cases before mutation.
- Production HTTP-client tests use a non-forwarding mock and verify the exact
  authenticated action, request bounds, malformed responses and redacted errors.
- A real synthetic SQLite regression proves that `Stopping` is persisted before
  the provider mutation, an uncertain response retains the complete allocation,
  and a fresh controller/provider can finish without another Stop action.
- Full corrected exact-commit validation passes: formatting, maintainability,
  version synchronization, default and speech workspace tests with warnings
  denied, blocking Clippy, strict Clippy and advisory pedantic Clippy. Resolution
  was locked; source and lockfile remained unchanged. Independent correction
  review is clear.

## Boundaries

This verifies provider metadata and local protocol/store behavior, not actual
cloud data retention, a backup, filesystem durability, preserved process memory
or successful task completion. No live cloud resource or credential was used.
Retained storage billing and capacity on a later start remain separate concerns.
The public Stop API is available; cloud UI admission and trusted SSH bootstrap
remain separate work.
