### PR TITLE
Inspect selected retained tasks explicitly

### DIFF
--- a/crates/horizon-core/src/remote_worker_status.rs
+++ b/crates/horizon-core/src/remote_worker_status.rs
@@ -1,6 +1,13 @@
 //! Bounded, non-creating panel inspection through the retained worker's pinned SSH identity.
 //! Calls are synchronous and must run off the render thread.
 
+mod configured;
+
+pub use configured::{
+    ConfiguredRemotePanelStatusError, ConfiguredRemotePanelStatusRequest, RemotePanelObservation,
+    inspect_configured_remote_panel,
+};
+
 #[cfg(target_os = "linux")]
 mod protocol;
 #[cfg(target_os = "linux")]

--- a/crates/horizon-core/src/remote_worker_status/configured.rs
+++ b/crates/horizon-core/src/remote_worker_status/configured.rs
@@ -1,0 +1,152 @@
+//! Explicit selected-panel observation without recovery persistence or attachment.
+
+use super::{RemotePanelStatus, RemotePanelStatusError};
+use crate::{
+    cloud_run::CloudWorkflowStore,
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace::RemoteEnvironmentSummary,
+    remote_workspace_recovery::RemoteWorkspaceRecoveryError,
+};
+
+#[derive(Clone, Copy)]
+pub struct ConfiguredRemotePanelStatusRequest<'a> {
+    pub expected: &'a RemoteEnvironmentSummary,
+    /// Actual resolved persistent client session, never copied from an inventory claim.
+    pub client_session_id: &'a str,
+    pub panel_id: &'a str,
+}
+
+/// Overview-safe point-in-time status, not task intent, repository or connection readiness.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemotePanelObservation {
+    pub panel_id: String,
+    pub status: RemotePanelStatus,
+    pub observed_at_millis: i64,
+}
+
+impl RemotePanelObservation {
+    /// Absolute UTC label; no ticking clock or continued freshness is implied.
+    #[must_use]
+    pub fn observed_at_rfc3339(&self) -> Option<String> {
+        time::OffsetDateTime::from_unix_timestamp_nanos(i128::from(self.observed_at_millis) * 1_000_000)
+            .ok()?
+            .format(&time::format_description::well_known::Rfc3339)
+            .ok()
+    }
+}
+
+/// Check one owned saved task through its explicit local provider and retained SSH pin.
+/// All storage, retained-key, provider and SSH work must run off the render thread.
+/// Requires an already recorded worker and host pin; never repairs missing identity.
+/// No key creation, recovery persistence, task startup, local view, attachment,
+/// allocation, Stop, Delete or provider fallback occurs. The caller must discard
+/// results after client/session, selection or configuration changes. Observations
+/// are not continuous monitoring or authority for subsequent lifecycle actions.
+/// # Errors
+/// Rejects unsupported providers/platforms, foreign or stale selections, unknown
+/// panels, pending management, missing retained identity and failed bounded queries.
+pub fn inspect_configured_remote_panel(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    config: &RemoteProviderConfig,
+    request: ConfiguredRemotePanelStatusRequest<'_>,
+) -> Result<RemotePanelObservation, ConfiguredRemotePanelStatusError> {
+    #[cfg(target_os = "linux")]
+    {
+        inspect_with(
+            store,
+            identities,
+            config,
+            request,
+            |profile| {
+                crate::cloud_run::local_docker::LocalDockerInteractiveWorkerProvider::new(
+                    profile.clone(),
+                    store.clone(),
+                )
+                .map_err(|_| RemoteWorkspaceRecoveryError::ProviderUnavailable.into())
+            },
+            super::inspect_remote_panel,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, identities, config, request);
+        Err(RemotePanelStatusError::UnsupportedPlatform.into())
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn inspect_with<P: crate::cloud_run::interactive_worker::InteractiveWorkerProvider>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    config: &RemoteProviderConfig,
+    request: ConfiguredRemotePanelStatusRequest<'_>,
+    provider: impl FnOnce(
+        &crate::cloud_run::local_docker::LocalDockerProfile,
+    ) -> Result<P, ConfiguredRemotePanelStatusError>,
+    inspect: impl FnOnce(
+        &CloudWorkflowStore,
+        &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+        &str,
+    ) -> Result<RemotePanelStatus, RemotePanelStatusError>,
+) -> Result<RemotePanelObservation, ConfiguredRemotePanelStatusError> {
+    if request.client_session_id != request.expected.owning_session_id {
+        return Err(ConfiguredRemotePanelStatusError::ClientSessionMismatch);
+    }
+    if request.expected.provider != crate::cloud_run::CloudProvider::LocalDocker {
+        return Err(ConfiguredRemotePanelStatusError::UnsupportedProvider);
+    }
+    let profile = config.local_docker_profile(&request.expected.profile)?;
+    let allocation = store
+        .load_remote_allocation(request.client_session_id, &request.expected.workspace_local_id)
+        .map_err(RemoteWorkspaceRecoveryError::from)?
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    if allocation.workspace().environment_summary() != *request.expected {
+        return Err(RemoteWorkspaceRecoveryError::StateChanged.into());
+    }
+    allocation
+        .recovery_request()
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    let state = allocation.workspace().state();
+    if !state
+        .spec
+        .panels
+        .iter()
+        .any(|panel| panel.panel_local_id == request.panel_id)
+    {
+        return Err(RemotePanelStatusError::UnknownPanel.into());
+    }
+    if !state
+        .runtime
+        .as_ref()
+        .is_some_and(|runtime| runtime.worker.is_some() && runtime.ssh.is_some())
+    {
+        return Err(RemotePanelStatusError::WorkerUnavailable.into());
+    }
+    let provider = provider(profile)?;
+    let recovered = crate::remote_workspace_recovery::inspect_remote_allocation(identities, &provider, &allocation)?;
+    let status = inspect(store, &recovered, request.panel_id)?;
+    let observed_at_millis = i64::try_from(time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000)
+        .map_err(|_| RemotePanelStatusError::InvalidResponse)?;
+    Ok(RemotePanelObservation {
+        panel_id: request.panel_id.into(),
+        status,
+        observed_at_millis,
+    })
+}
+
+/// Diagnostics contain no provider output, task payload, SSH coordinates or private paths.
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum ConfiguredRemotePanelStatusError {
+    #[error("task checks are not yet supported for this environment's provider")]
+    UnsupportedProvider,
+    #[error("the active client session does not own the selected environment")]
+    ClientSessionMismatch,
+    #[error(transparent)]
+    Configuration(#[from] RemoteProviderConfigError),
+    #[error(transparent)]
+    Recovery(#[from] RemoteWorkspaceRecoveryError),
+    #[error(transparent)]
+    Inspection(#[from] RemotePanelStatusError),
+}

--- a/crates/horizon-core/src/remote_worker_status/tests.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests.rs
@@ -7,6 +7,8 @@ use crate::{
     remote_workspace_recovery::recover_remote_workspace,
 };
 
+mod configured;
+
 #[path = "tests/intent.rs"]
 mod intent_tests;
 #[path = "tests/ssh.rs"]

--- a/crates/horizon-core/src/remote_worker_status/tests/configured.rs
+++ b/crates/horizon-core/src/remote_worker_status/tests/configured.rs
@@ -1,0 +1,275 @@
+use super::super::configured::inspect_with as configured_with;
+use super::*;
+use crate::remote_workspace_recovery::RemoteWorkspaceRecoveryError;
+use crate::{cloud_run::local_docker::LocalDockerProfile, remote_provider_config::RemoteProviderConfig};
+
+fn config() -> RemoteProviderConfig {
+    RemoteProviderConfig {
+        local_docker: vec![LocalDockerProfile {
+            name: "development".into(),
+            docker_host: "unix:///unused-task-check/socket".into(),
+        }],
+    }
+}
+
+fn identities(fixture: &Fixture) -> RemoteSshIdentityStore {
+    RemoteSshIdentityStore::new(&HorizonHome::from_root(fixture.directory.path().join("home")))
+}
+
+fn request(expected: &crate::remote_workspace::RemoteEnvironmentSummary) -> ConfiguredRemotePanelStatusRequest<'_> {
+    ConfiguredRemotePanelStatusRequest {
+        expected,
+        client_session_id: OWNER,
+        panel_id: "terminal",
+    }
+}
+
+fn check(
+    fixture: &Fixture,
+    query: impl FnOnce() -> Result<Vec<u8>, RemotePanelStatusError>,
+) -> Result<RemotePanelObservation, ConfiguredRemotePanelStatusError> {
+    configured_with(
+        &fixture.store,
+        &identities(fixture),
+        &config(),
+        request(&fixture.current().workspace().environment_summary()),
+        |profile| {
+            assert_eq!(profile, &config().local_docker[0]);
+            Ok(Provider(fixture.recovered.observation().expect("observation").clone()))
+        },
+        |store, recovered, panel| {
+            super::super::inspect_with(store, recovered, panel, Inspection::Status, |_, _, _| query())
+        },
+    )
+}
+
+#[test]
+fn selected_admission_rejects_before_provider_or_ssh_access() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    for fault in 0..8 {
+        let mut expected = before.workspace().environment_summary();
+        let mut config = config();
+        let mut owner = OWNER;
+        let mut panel = "terminal";
+        let error = match fault {
+            0 => {
+                owner = "copied-owner";
+                ConfiguredRemotePanelStatusError::ClientSessionMismatch
+            }
+            1 => {
+                expected.provider = CloudProvider::Azure;
+                ConfiguredRemotePanelStatusError::UnsupportedProvider
+            }
+            2 => {
+                config.local_docker.clear();
+                crate::remote_provider_config::RemoteProviderConfigError::UnconfiguredLocalProfile.into()
+            }
+            3 => {
+                config.local_docker[0].name = "Development".into();
+                crate::remote_provider_config::RemoteProviderConfigError::UnconfiguredLocalProfile.into()
+            }
+            4 => {
+                expected.revision += 1;
+                RemoteWorkspaceRecoveryError::StateChanged.into()
+            }
+            5 => {
+                expected.panel_count += 1;
+                RemoteWorkspaceRecoveryError::StateChanged.into()
+            }
+            6 => {
+                expected.generation += 1;
+                RemoteWorkspaceRecoveryError::StateChanged.into()
+            }
+            _ => {
+                panel = "unknown;start";
+                RemotePanelStatusError::UnknownPanel.into()
+            }
+        };
+        assert_eq!(
+            configured_with::<Provider>(
+                &fixture.store,
+                &identities(&fixture),
+                &config,
+                ConfiguredRemotePanelStatusRequest {
+                    expected: &expected,
+                    client_session_id: owner,
+                    panel_id: panel
+                },
+                |_| panic!("must not construct provider"),
+                |_, _, _| panic!("must not query"),
+            ),
+            Err(error)
+        );
+    }
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn exact_selected_status_preserves_snapshots_keys_and_unknown_exit_semantics() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+    for (response, status) in [
+        (RUNNING, RemotePanelStatus::Running { pid: 123 }),
+        (
+            br#"{"state":"exited","panel":"terminal","pid":123,"exit_status":42}"#.as_slice(),
+            RemotePanelStatus::Exited {
+                pid: 123,
+                exit_status: Some(42),
+            },
+        ),
+        (
+            br#"{"state":"exited","panel":"terminal","pid":123,"exit_status":null}"#.as_slice(),
+            RemotePanelStatus::Exited {
+                pid: 123,
+                exit_status: None,
+            },
+        ),
+        (
+            br#"{"state":"unavailable","panel":"terminal"}"#.as_slice(),
+            RemotePanelStatus::Unavailable,
+        ),
+    ] {
+        let observation = check(&fixture, || Ok(response.to_vec())).expect("task check");
+        assert_eq!(observation.panel_id, "terminal");
+        assert_eq!(observation.status, status);
+        assert!(observation.observed_at_millis > 0);
+        assert_eq!(fixture.current(), before);
+    }
+    assert_eq!(
+        std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+        key
+    );
+    let path = fixture.recovered.identity().private_key_path();
+    let retained = path.with_extension("retained-fixture");
+    std::fs::rename(path, &retained).expect("hide exact fixture key");
+    assert!(matches!(
+        check(&fixture, || panic!("no SSH without key")),
+        Err(ConfiguredRemotePanelStatusError::Recovery(
+            RemoteWorkspaceRecoveryError::Identity(_)
+        ))
+    ));
+    assert!(!path.exists(), "no replacement identity");
+    assert_eq!(std::fs::read(retained).expect("retained key"), key);
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn changes_during_provider_or_query_io_reject_the_observation() {
+    for during_query in [false, true] {
+        let fixture = Fixture::new();
+        let expected = fixture.current().workspace().environment_summary();
+        assert_eq!(
+            configured_with(
+                &fixture.store,
+                &identities(&fixture),
+                &config(),
+                request(&expected),
+                |_| {
+                    if !during_query {
+                        fixture.edit_intent();
+                    }
+                    Ok(Provider(fixture.recovered.observation().expect("observation").clone()))
+                },
+                |store, recovered, panel| super::super::inspect_with(
+                    store,
+                    recovered,
+                    panel,
+                    Inspection::Status,
+                    |_, _, _| {
+                        assert!(during_query, "provider drift must reject before SSH");
+                        fixture.edit_intent();
+                        Ok(RUNNING.to_vec())
+                    }
+                ),
+            ),
+            Err(RemotePanelStatusError::StateChanged.into())
+        );
+        assert_eq!(fixture.current().workspace().state().spec.working_directory, "src");
+    }
+}
+
+#[test]
+fn pending_management_and_unrecorded_pins_are_not_recovered_or_repaired() {
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let mut state = before.workspace().state().clone();
+    state.spec.workspace_local_id = "unobserved".into();
+    state.spec.generation = 0;
+    state.runtime = None;
+    let dormant = fixture.store.create_remote_workspace(OWNER, &state).expect("dormant");
+    let allocation = fixture
+        .store
+        .allocate_remote_runtime(&dormant, i64::MAX)
+        .expect("allocation");
+    let allocation = fixture
+        .store
+        .reserve_remote_worker_request(&allocation, fixture.recovered.identity().public_key())
+        .expect("request");
+    let stopped = fixture
+        .store
+        .record_remote_stop_phase(
+            &before,
+            crate::remote_workspace::RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+        )
+        .expect("stop intent");
+    for (allocation, expected_error) in [
+        (allocation, RemotePanelStatusError::WorkerUnavailable.into()),
+        (stopped, RemoteWorkspaceRecoveryError::ManagementPending.into()),
+    ] {
+        assert_eq!(
+            configured_with::<Provider>(
+                &fixture.store,
+                &identities(&fixture),
+                &config(),
+                request(&allocation.workspace().environment_summary()),
+                |_| panic!("no provider"),
+                |_, _, _| panic!("no SSH")
+            ),
+            Err(expected_error)
+        );
+        assert_eq!(
+            fixture
+                .store
+                .load_remote_allocation(OWNER, &allocation.workspace().state().spec.workspace_local_id)
+                .expect("load"),
+            Some(allocation)
+        );
+    }
+}
+
+#[test]
+fn nonready_or_wrong_pinned_worker_and_query_failures_do_not_become_task_results() {
+    let fixture = Fixture::with_lifecycle(InteractiveWorkerLifecycle::Stopped);
+    assert_eq!(
+        check(&fixture, || panic!("no stopped-worker SSH")),
+        Err(RemotePanelStatusError::WorkerUnavailable.into())
+    );
+    let fixture = Fixture::new();
+    let before = fixture.current();
+    let mut wrong = fixture.recovered.observation().expect("observation").clone();
+    wrong.ssh.as_mut().expect("pin").port += 1;
+    assert_eq!(
+        configured_with(
+            &fixture.store,
+            &identities(&fixture),
+            &config(),
+            request(&before.workspace().environment_summary()),
+            |_| Ok(Provider(wrong)),
+            |_, _, _| panic!("no mismatched-pin SSH")
+        ),
+        Err(RemoteWorkspaceRecoveryError::InvalidObservation.into())
+    );
+    for (error, expected) in [
+        (RemotePanelStatusError::QueryFailed, RemotePanelStatusError::QueryFailed),
+        (RemotePanelStatusError::Deadline, RemotePanelStatusError::Deadline),
+        (
+            RemotePanelStatusError::InvalidResponse,
+            RemotePanelStatusError::InvalidResponse,
+        ),
+    ] {
+        assert_eq!(check(&fixture, || Err(error)), Err(expected.into()));
+    }
+    assert_eq!(fixture.current(), before);
+}

--- a/crates/horizon-ui/src/app/remote_environments.rs
+++ b/crates/horizon-ui/src/app/remote_environments.rs
@@ -70,6 +70,7 @@ enum InventoryAction {
     Reconnect(horizon_core::PanelId),
     ListReopenPanels,
     ReopenView(usize),
+    InspectTask(usize),
 }
 
 struct WakeOnDrop(Context);
@@ -212,7 +213,9 @@ impl RemoteEnvironments {
             | InventoryAction::RequestStop
             | InventoryAction::ConfirmStop => {}
             InventoryAction::ListReconnectViews | InventoryAction::Reconnect(_) => self.reopen.invalidate(),
-            InventoryAction::ListReopenPanels | InventoryAction::ReopenView(_) => self.reconnect.invalidate(),
+            InventoryAction::ListReopenPanels | InventoryAction::ReopenView(_) | InventoryAction::InspectTask(_) => {
+                self.reconnect.invalidate();
+            }
             InventoryAction::CancelStop => self.stop.cancel_confirmation(),
             InventoryAction::Close => self.close(),
             InventoryAction::Select(index) => {
@@ -306,7 +309,7 @@ impl RemoteEnvironments {
 }
 
 fn load_page(home: &HorizonHome, cursor: Option<&str>) -> Result<InventoryPage, LoadError> {
-    let store = CloudWorkflowStore::open(home).map_err(|_| LoadError::OpenStore)?;
+    let store = CloudWorkflowStore::open_read_only(home).map_err(|_| LoadError::OpenStore)?;
     let page = store
         .list_remote_environment_page(cursor)
         .map_err(|_| LoadError::ReadPage)?;

--- a/crates/horizon-ui/src/app/remote_environments/reopen.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen.rs
@@ -1,5 +1,6 @@
-//! Explicit saved-view loading and inert reopening, never remote task startup.
+//! Explicit saved-panel loading, inert reopening and read-only task checks.
 
+mod inspection;
 mod paint;
 
 use super::{Context, HorizonHome, InventoryAction, RemoteEnvironmentSummary, WakeOnDrop};
@@ -26,17 +27,20 @@ struct CachedCatalog {
 struct SavedView {
     id: String,
     present: bool,
+    inspection: inspection::TaskObservation,
 }
 
 struct PendingReopen {
     rx: Receiver<Result<Completion, String>>,
     scope: RequestScope,
     discard: bool,
+    inspection: Option<String>,
 }
 
 enum Completion {
     Catalog(Box<RemoteViewCatalog>),
     View(Box<PreparedRemoteViewReopen>),
+    Inspection(horizon_core::remote_worker_status::RemotePanelObservation),
 }
 
 #[derive(Clone)]
@@ -168,7 +172,7 @@ impl ReopenState {
             .name("remote-view-reopening".into())
             .spawn(move || {
                 let _wake = wake;
-                let result = CloudWorkflowStore::open(&home)
+                let result = CloudWorkflowStore::open_read_only(&home)
                     .map_err(|_| "The saved environment could not be safely read. Refresh and retry.".to_string())
                     .and_then(|store| work(&store));
                 let _ = tx.send(result);
@@ -181,6 +185,7 @@ impl ReopenState {
                     rx,
                     scope,
                     discard: false,
+                    inspection: None,
                 });
             }
             Err(_) => self.notice = Some(worker_failure().into()),
@@ -203,8 +208,13 @@ impl ReopenState {
             tracing::debug!(
                 prepared = matches!(&result, Ok(Completion::View(_))),
                 catalog_loaded = matches!(&result, Ok(Completion::Catalog(_))),
+                task_checked = matches!(&result, Ok(Completion::Inspection(_))),
                 "Discarding a stale remote view reopening result"
             );
+            return None;
+        }
+        if let Some(panel) = pending.inspection {
+            self.accept_inspection(&panel, result);
             return None;
         }
         match result {
@@ -217,6 +227,7 @@ impl ReopenState {
                         .map(|id| SavedView {
                             id: id.clone(),
                             present: catalog.view_is_present(board, id),
+                            inspection: inspection::TaskObservation::default(),
                         })
                         .collect(),
                     catalog,
@@ -238,13 +249,16 @@ impl ReopenState {
                 Err(error) => self.notice = Some(error.to_string()),
             },
             Err(message) => self.notice = Some(message),
+            Ok(Completion::Inspection(_)) => {
+                self.notice = Some("The task result did not match its request. Check the task again.".into());
+            }
         }
         None
     }
 }
 
 fn worker_failure() -> &'static str {
-    "The saved-view worker could not start or finish. Show saved panels to retry."
+    "The saved-panel worker could not start or finish. You can retry now."
 }
 
 pub(super) fn show(ui: &mut egui::Ui, state: &ReopenState, enabled: bool, action: &mut InventoryAction) {
@@ -284,6 +298,10 @@ impl super::HorizonApp {
                 InventoryAction::ReopenView(index) => {
                     state.stop.cancel_confirmation();
                     state.reopen.reopen(&client, &self.board, index, ctx);
+                }
+                InventoryAction::InspectTask(index) => {
+                    state.stop.cancel_confirmation();
+                    state.reopen.inspect_task(&client, index, ctx);
                 }
                 _ => {}
             }

--- a/crates/horizon-ui/src/app/remote_environments/reopen/inspection.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/inspection.rs
@@ -1,0 +1,123 @@
+//! Cached selected-task presentation; reuse the saved-panel worker and invalidation scope.
+
+use super::{ClientContext, Completion, Context, ReopenState};
+use horizon_core::{
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_worker_status::{
+        ConfiguredRemotePanelStatusRequest, RemotePanelObservation, RemotePanelStatus, inspect_configured_remote_panel,
+    },
+};
+
+#[derive(Default)]
+pub(super) struct TaskObservation {
+    last_success: Option<CachedTask>,
+    failure: Option<String>,
+}
+
+struct CachedTask {
+    status: String,
+    checked_at: String,
+}
+
+impl TaskObservation {
+    fn accept(&mut self, result: Result<RemotePanelObservation, String>) {
+        match result {
+            Ok(observation) => {
+                let status = match observation.status {
+                    RemotePanelStatus::Running { pid } => format!("Running at check (PID {pid})"),
+                    RemotePanelStatus::Exited {
+                        pid,
+                        exit_status: Some(code),
+                    } => {
+                        format!("Exited at check (PID {pid}, exit status {code})")
+                    }
+                    RemotePanelStatus::Exited { pid, exit_status: None } => {
+                        format!("Exited at check (PID {pid}, exit status unknown)")
+                    }
+                    RemotePanelStatus::Unavailable => "Retained task unavailable at check. Nothing was created.".into(),
+                };
+                let checked_at = observation
+                    .observed_at_rfc3339()
+                    .unwrap_or_else(|| format!("{} Unix ms", observation.observed_at_millis));
+                self.last_success = Some(CachedTask { status, checked_at });
+                self.failure = None;
+            }
+            Err(message) => self.failure = Some(message),
+        }
+    }
+
+    pub(super) fn show(&self, ui: &mut egui::Ui) {
+        if let Some(previous) = &self.last_success {
+            ui.label(&previous.status);
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Last successful task check (UTC):");
+                ui.monospace(&previous.checked_at);
+            });
+        }
+        if let Some(message) = &self.failure {
+            ui.colored_label(crate::theme::PALETTE_YELLOW(), message);
+            if self.last_success.is_some() {
+                ui.colored_label(
+                    crate::theme::PALETTE_YELLOW(),
+                    "Latest task check failed; the previous observation may be stale.",
+                );
+            }
+        } else if self.last_success.is_none() {
+            ui.label("Retained task has not been checked.");
+        }
+    }
+}
+
+impl ReopenState {
+    pub(super) fn inspect_task(&mut self, client: &ClientContext<'_>, index: usize, ctx: &Context) {
+        if self.is_pending() {
+            return;
+        }
+        let Some(cached) = &mut self.catalog else { return };
+        if !cached.scope.matches(client) {
+            self.invalidate();
+            self.set_notice("The session or saved selection changed. Show saved panels again.", ctx);
+            return;
+        }
+        let Some(row) = cached.rows.get_mut(index) else { return };
+        row.inspection.failure = None;
+        let panel = row.id.clone();
+        let requested_panel = panel.clone();
+        let scope = cached.scope.clone();
+        let requested_scope = scope.clone();
+        let identities = RemoteSshIdentityStore::new(client.home);
+        self.spawn(client.home, scope, ctx, move |store| {
+            inspect_configured_remote_panel(
+                store,
+                &identities,
+                &requested_scope.config,
+                ConfiguredRemotePanelStatusRequest {
+                    expected: &requested_scope.expected,
+                    client_session_id: &requested_scope.owner,
+                    panel_id: &requested_panel,
+                },
+            )
+            .map(Completion::Inspection)
+            .map_err(|error| error.to_string())
+        });
+        if let Some(pending) = &mut self.pending {
+            pending.inspection = Some(panel);
+        } else {
+            let error = self.notice.take().unwrap_or_else(|| super::worker_failure().into());
+            self.accept_inspection(&panel, Err(error));
+        }
+    }
+
+    pub(super) fn accept_inspection(&mut self, panel: &str, result: Result<Completion, String>) {
+        if let Some(row) = self
+            .catalog
+            .as_mut()
+            .and_then(|cached| cached.rows.iter_mut().find(|row| row.id == panel))
+        {
+            row.inspection.accept(result.and_then(|completion| match completion {
+                Completion::Inspection(observation) if observation.panel_id == panel => Ok(observation),
+                _ => Err("The task result did not match its request. Check the task again.".into()),
+            }));
+        }
+    }
+}

--- a/crates/horizon-ui/src/app/remote_environments/reopen/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/paint.rs
@@ -2,8 +2,8 @@ use super::{InventoryAction, ReopenState};
 
 pub(super) fn show(ui: &mut egui::Ui, state: &ReopenState, enabled: bool, action: &mut InventoryAction) {
     ui.separator();
-    ui.strong("Reopen closed views");
-    ui.label("Restore local views in their owning session. They stay disconnected; remote tasks are unchanged.");
+    ui.strong("Saved panels");
+    ui.label("Check a retained task or reopen its local view. Reopened views stay disconnected.");
     if ui
         .add_enabled(enabled && !state.is_pending(), egui::Button::new("Show saved panels"))
         .clicked()
@@ -11,8 +11,12 @@ pub(super) fn show(ui: &mut egui::Ui, state: &ReopenState, enabled: bool, action
         *action = InventoryAction::ListReopenPanels;
     }
     if let Some(pending) = &state.pending {
-        ui.label(if pending.discard {
+        ui.label(if pending.discard && pending.inspection.is_some() {
+            "Waiting for the discarded task check to finish…"
+        } else if pending.discard {
             "Waiting for the discarded saved-view request to finish…"
+        } else if pending.inspection.is_some() {
+            "Checking the selected retained task…"
         } else {
             "Preparing saved local views…"
         });
@@ -33,9 +37,21 @@ pub(super) fn show(ui: &mut egui::Ui, state: &ReopenState, enabled: bool, action
                     {
                         *action = InventoryAction::ReopenView(index);
                     }
+                    let check =
+                        ui.add_enabled(enabled && !state.is_pending(), egui::Button::new("Check retained task"));
+                    #[cfg(test)]
+                    ui.ctx().data_mut(|data| {
+                        data.insert_temp(egui::Id::new(("inspect-task-test", index)), check.rect);
+                    });
+                    if check.clicked() {
+                        *action = InventoryAction::InspectTask(index);
+                    }
                 });
+                row.inspection.show(ui);
             });
         }
+        ui.label("Task checks are point-in-time, not monitoring or proof of repository or attachment readiness.");
+        ui.label("Checking does not start, reconnect, stop or delete remote work.");
     }
     if let Some(notice) = &state.notice {
         ui.label(notice);

--- a/crates/horizon-ui/src/app/remote_environments/reopen/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/tests.rs
@@ -5,6 +5,8 @@ use crate::test_egui::DiscardTextures;
 use horizon_core::{CanvasViewState, PanelKind, PanelOptions, RuntimeState, WindowConfig};
 use std::time::{Duration, Instant};
 
+mod inspection;
+
 const OWNER: &str = "00000000-0000-4000-8000-000000000001";
 const FOREIGN: &str = "00000000-0000-4000-8000-000000000002";
 
@@ -56,6 +58,7 @@ fn pending(
         rx,
         scope: scope.clone(),
         discard: false,
+        inspection: None,
     });
     state.repaint_context = Some(ctx.clone());
     tx

--- a/crates/horizon-ui/src/app/remote_environments/reopen/tests/inspection.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/tests/inspection.rs
@@ -300,7 +300,12 @@ fn rendered_check_uses_only_selected_panel_and_completed_or_pending_display_does
         &mut app.board,
         &ctx,
     );
-    assert!(text(&app.remote_environments.reopen, &ctx).contains("no local provider profile exactly matches"));
+    let expected = if cfg!(target_os = "linux") {
+        "no local provider profile exactly matches"
+    } else {
+        "protected remote panel inspection is not yet supported on this platform"
+    };
+    assert!(text(&app.remote_environments.reopen, &ctx).contains(expected));
     let tx = queue(&mut app.remote_environments.reopen, &scope, &ctx);
     for _ in 0..30 {
         let _ = text(&app.remote_environments.reopen, &ctx);

--- a/crates/horizon-ui/src/app/remote_environments/reopen/tests/inspection.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/tests/inspection.rs
@@ -1,0 +1,319 @@
+use super::*;
+use horizon_core::remote_worker_status::{RemotePanelObservation, RemotePanelStatus};
+
+fn loaded(store: &CloudWorkflowStore, scope: &RequestScope, ctx: &Context) -> ReopenState {
+    let mut state = ReopenState::default();
+    let catalog = RemoteViewCatalog::load(store, &scope.owner, &scope.expected).expect("catalog");
+    let tx = pending(&mut state, scope, ctx);
+    assert!(
+        tx.send(Ok(Completion::Catalog(Box::new(catalog)))).is_ok(),
+        "catalog result"
+    );
+    let home = HorizonHome::from_root("/unused-test-home".into());
+    state.drain(&client(&home, scope), &mut Board::new(), ctx);
+    state
+}
+
+fn observation(status: RemotePanelStatus) -> Completion {
+    Completion::Inspection(RemotePanelObservation {
+        panel_id: "task-0".into(),
+        status,
+        observed_at_millis: 1_700_000_000_000,
+    })
+}
+
+fn text(state: &ReopenState, ctx: &Context) -> String {
+    let output = ctx
+        .run_ui(raw_input([1000.0, 900.0], None), |ui| {
+            super::super::paint::show(ui, state, true, &mut InventoryAction::None);
+        })
+        .discard_textures();
+    output
+        .shapes
+        .iter()
+        .filter_map(|shape| match &shape.shape {
+            egui::Shape::Text(text) => Some(text.galley.job.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn queue(state: &mut ReopenState, scope: &RequestScope, ctx: &Context) -> mpsc::SyncSender<Result<Completion, String>> {
+    let tx = pending(state, scope, ctx);
+    state.pending.as_mut().expect("pending").inspection = Some("task-0".into());
+    tx
+}
+
+#[test]
+fn zero_view_results_preserve_board_runtime_and_show_unknown_completion_honestly() {
+    let (_temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    let before = store
+        .load_remote_workspace(&scope.owner, "environment")
+        .expect("record");
+    let saved = app
+        .session_store
+        .resume_session(&scope.owner)
+        .expect("session")
+        .runtime_state
+        .to_yaml()
+        .expect("yaml");
+    app.runtime_dirty_since = None;
+    app.remote_environments.reopen = loaded(&store, &scope, &ctx);
+    for (status, expected) in [
+        (RemotePanelStatus::Running { pid: 42 }, "Running at check (PID 42)"),
+        (
+            RemotePanelStatus::Exited {
+                pid: 42,
+                exit_status: None,
+            },
+            "exit status unknown",
+        ),
+        (
+            RemotePanelStatus::Exited {
+                pid: 42,
+                exit_status: Some(7),
+            },
+            "exit status 7",
+        ),
+        (RemotePanelStatus::Unavailable, "Retained task unavailable at check"),
+    ] {
+        assert!(
+            queue(&mut app.remote_environments.reopen, &scope, &ctx)
+                .send(Ok(observation(status)))
+                .is_ok(),
+            "result"
+        );
+        app.remote_reopen_action(InventoryAction::None, &ctx);
+        let text = text(&app.remote_environments.reopen, &ctx);
+        assert!(text.contains(expected) && text.contains("2023-11-14") && text.contains("not monitoring"));
+        assert!(!text.contains("private-") && app.board.panels.is_empty() && app.board.workspaces.is_empty());
+        assert!(app.runtime_dirty_since.is_none());
+    }
+    assert_eq!(
+        store
+            .load_remote_workspace(&scope.owner, "environment")
+            .expect("record"),
+        before
+    );
+    assert_eq!(
+        app.session_store
+            .resume_session(&scope.owner)
+            .expect("session")
+            .runtime_state
+            .to_yaml()
+            .expect("yaml"),
+        saved
+    );
+}
+
+#[test]
+fn failed_or_wrong_panel_results_keep_prior_observation_explicitly_stale_and_retryable() {
+    let (_temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    app.remote_environments.reopen = loaded(&store, &scope, &ctx);
+    app.remote_environments
+        .reopen
+        .accept_inspection("task-0", Ok(observation(RemotePanelStatus::Running { pid: 42 })));
+    let mut wrong = RemotePanelObservation {
+        panel_id: "wrong".into(),
+        status: RemotePanelStatus::Unavailable,
+        observed_at_millis: 2,
+    };
+    for result in [
+        Err("Task check failed; retry now.".into()),
+        Ok(Completion::Inspection(wrong.clone())),
+    ] {
+        assert!(
+            queue(&mut app.remote_environments.reopen, &scope, &ctx)
+                .send(result)
+                .is_ok(),
+            "failure"
+        );
+        app.remote_reopen_action(InventoryAction::None, &ctx);
+        let text = text(&app.remote_environments.reopen, &ctx);
+        assert!(text.contains("Running at check") && text.contains("previous observation may be stale"));
+        assert!(!app.remote_environments.reopen.is_pending());
+    }
+    wrong.panel_id = "task-0".into();
+    assert!(
+        queue(&mut app.remote_environments.reopen, &scope, &ctx)
+            .send(Ok(Completion::Inspection(wrong)))
+            .is_ok(),
+        "retry"
+    );
+    app.remote_reopen_action(InventoryAction::None, &ctx);
+    assert!(!text(&app.remote_environments.reopen, &ctx).contains("may be stale"));
+}
+
+#[test]
+fn disappeared_database_is_not_recreated_by_task_catalog_or_inventory_reads() {
+    let (temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    let home = app.session_store.home().clone();
+    app.remote_environments.reopen = loaded(&store, &scope, &ctx);
+    app.remote_environments
+        .reopen
+        .accept_inspection("task-0", Ok(observation(RemotePanelStatus::Running { pid: 42 })));
+    let saved = app
+        .session_store
+        .resume_session(&scope.owner)
+        .expect("session")
+        .runtime_state
+        .to_yaml()
+        .expect("runtime YAML");
+    app.runtime_dirty_since = None;
+    let directory = store.path().parent().expect("database directory");
+    let retained = temp.path().join("retained-cloud-store");
+    let database = std::fs::read(store.path()).expect("database bytes");
+    std::fs::rename(directory, &retained).expect("retain database and any WAL sidecars");
+
+    app.remote_reopen_action(InventoryAction::InspectTask(0), &ctx);
+    assert!(app.remote_environments.reopen.is_pending());
+    settle(
+        &mut app.remote_environments.reopen,
+        &client(&home, &scope),
+        &mut app.board,
+        &ctx,
+    );
+    let rendered = text(&app.remote_environments.reopen, &ctx);
+    assert!(rendered.contains("The saved environment could not be safely read. Refresh and retry."));
+    assert!(rendered.contains("Running at check (PID 42)") && rendered.contains("previous observation may be stale"));
+    assert!(!app.remote_environments.reopen.is_pending() && !directory.exists());
+
+    app.remote_reopen_action(InventoryAction::ListReopenPanels, &ctx);
+    settle(
+        &mut app.remote_environments.reopen,
+        &client(&home, &scope),
+        &mut app.board,
+        &ctx,
+    );
+    assert!(app.remote_environments.reopen.catalog.is_none());
+    assert_eq!(
+        app.remote_environments.reopen.notice.as_deref(),
+        Some("The saved environment could not be safely read. Refresh and retry.")
+    );
+    assert!(matches!(
+        super::super::super::load_page(&home, None),
+        Err(super::super::super::LoadError::OpenStore)
+    ));
+    assert!(
+        !directory.exists(),
+        "no replacement directory, database or WAL sidecars"
+    );
+    assert_eq!(
+        std::fs::read(retained.join(store.path().file_name().expect("database name"))).expect("retained database"),
+        database
+    );
+    assert!(app.board.panels.is_empty() && app.board.workspaces.is_empty() && app.runtime_dirty_since.is_none());
+    assert_eq!(
+        app.session_store
+            .resume_session(&scope.owner)
+            .expect("session")
+            .runtime_state
+            .to_yaml()
+            .expect("runtime YAML"),
+        saved
+    );
+}
+
+#[test]
+fn queued_checks_are_discarded_for_session_selection_config_close_and_stop_without_freeing_slot_early() {
+    for fault in 0..5 {
+        let (_temp, mut app, store, scope) = app_fixture();
+        let ctx = Context::default();
+        app.remote_environments.reopen = loaded(&store, &scope, &ctx);
+        let tx = queue(&mut app.remote_environments.reopen, &scope, &ctx);
+        match fault {
+            0 => app.remote_environments.invalidate_session_views(),
+            1 => app
+                .remote_environments
+                .apply(InventoryAction::Refresh, app.session_store.home(), &ctx),
+            2 => app.remote_environments.invalidate_provider_state(),
+            3 => app
+                .remote_environments
+                .apply(InventoryAction::Close, app.session_store.home(), &ctx),
+            _ => app.remote_environments.stop_action(
+                InventoryAction::RequestStop,
+                app.session_store.home(),
+                &scope.config,
+                &ctx,
+            ),
+        }
+        let home = app.session_store.home().clone();
+        app.remote_environments
+            .reopen
+            .inspect_task(&client(&home, &scope), 0, &ctx);
+        assert!(
+            app.remote_environments
+                .reopen
+                .pending
+                .as_ref()
+                .expect("retained slot")
+                .discard
+        );
+        assert!(
+            tx.send(Ok(observation(RemotePanelStatus::Running { pid: 42 }))).is_ok(),
+            "late result"
+        );
+        app.remote_reopen_action(InventoryAction::None, &ctx);
+        assert!(!app.remote_environments.reopen.is_pending() && app.remote_environments.reopen.catalog.is_none());
+        assert!(app.board.panels.is_empty());
+    }
+}
+
+#[test]
+fn rendered_check_uses_only_selected_panel_and_completed_or_pending_display_does_not_poll() {
+    let (_temp, mut app, store, scope) = app_fixture();
+    let ctx = Context::default();
+    app.remote_environments.reopen = loaded(&store, &scope, &ctx);
+    let _ = text(&app.remote_environments.reopen, &ctx);
+    let position = ctx
+        .data(|data| data.get_temp::<egui::Rect>(egui::Id::new(("inspect-task-test", 0_usize))))
+        .expect("check button")
+        .center();
+    let mut action = InventoryAction::None;
+    for pressed in [true, false] {
+        let mut input = raw_input([1000.0, 900.0], None);
+        input.events.extend([
+            egui::Event::PointerMoved(position),
+            egui::Event::PointerButton {
+                pos: position,
+                button: egui::PointerButton::Primary,
+                pressed,
+                modifiers: egui::Modifiers::NONE,
+            },
+        ]);
+        let _ = ctx
+            .run_ui(input, |ui| {
+                super::super::paint::show(ui, &app.remote_environments.reopen, true, &mut action);
+            })
+            .discard_textures();
+    }
+    assert!(matches!(action, InventoryAction::InspectTask(0)));
+    app.remote_reopen_action(action, &ctx);
+    let home = app.session_store.home().clone();
+    settle(
+        &mut app.remote_environments.reopen,
+        &client(&home, &scope),
+        &mut app.board,
+        &ctx,
+    );
+    assert!(text(&app.remote_environments.reopen, &ctx).contains("no local provider profile exactly matches"));
+    let tx = queue(&mut app.remote_environments.reopen, &scope, &ctx);
+    for _ in 0..30 {
+        let _ = text(&app.remote_environments.reopen, &ctx);
+    }
+    assert!(
+        !ctx.has_requested_repaint(),
+        "pending task check must not animate or poll"
+    );
+    drop(tx);
+    app.remote_reopen_action(InventoryAction::None, &ctx);
+    for _ in 0..30 {
+        let _ = text(&app.remote_environments.reopen, &ctx);
+    }
+    assert!(!ctx.has_requested_repaint(), "completed task check must not poll");
+    assert!(app.board.panels.is_empty());
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -139,6 +139,9 @@ back into large multi-purpose modules.
   Explicit saved shell/command verification reuses those gates and compares
   literal argv plus the effective directory with the worker's retained intent;
   unresolved agent launch/handoff/resume semantics stay fail-closed.
+  Its `configured` leaf admits one actual owner's saved panel and exact local
+  profile, reuses non-writing recovery and returns timestamped status only.
+  Missing worker pins are not repaired, and observations never persist recovery.
 - `remote_worker_ssh.rs` centralizes crate-private pinned client options and SSH
   path quoting without granting attachment authority. Typed query/attach modes
   share isolation options; each owns private trust material. Status queries retain
@@ -183,6 +186,9 @@ back into large multi-purpose modules.
   prepares inert missing views off-thread. It shares lifecycle invalidation with
   reconnect; competing actions discard queued results before either handoff drains.
   Adoption marks reference-only runtime state dirty without starting remote tasks.
+  Its `inspection` leaf caches explicit retained-task observations in the same
+  bounded worker slot, including with no local views. Labels are point-in-time;
+  session, selection, config and Stop invalidation also discard late task results.
 - `repository_overlay/` owns bounded exact-base metadata for separate index and
   working-tree changes. Its `paths.rs` applies the lexical transfer exclusion policy.
   Planning performs no filesystem, Git, provider or transfer I/O; actual capture/apply


### PR DESCRIPTION
## Purpose and behavior

Advances #472 with an explicit check of one selected retained task in Remote
Environments, including environments with no local views. Results show observed
running/exited status and an absolute UTC observation time, not continuous
freshness or readiness. Failed retries retain the previous observation with an
explicit stale warning; late results are discarded after selection, session,
configuration or modal changes.

The configured bridge validates exact ownership, saved summary and revision,
retained identity and the existing bounded SSH inspection contract. Inventory,
catalog and inspection use the non-creating read-only store handle: a missing
database fails visibly without creating a replacement. No polling, recovery
persistence, task startup, attachment or worker lifecycle action is added.

## Validation

Exact commit: `a9e8624fc76a48d825049978576c0f42294f348e`.
Scope: ten source/test files, 939 changed lines, plus six architecture lines.

- All eight local gates passed in the final commit's checkout: formatting,
  maintainability, version sync, default and speech workspace tests, blocking,
  strict and advisory pedantic Clippy. Core: 1,116 tests in each tier; UI: 593
  default and 638 speech. The actual async missing-database regression passed
  for inspection, catalog and inventory in both tiers.
- The initial macOS CI run exposed a Linux-only expected error in one new test.
  The corrected assertion selects the existing platform-specific message without
  skipping the rendered-action or no-polling checks. The full local matrix was
  rerun on the corrected commit; hosted macOS verification remains required.
- Native smoke used a copied debug/trace binary from the earlier `541fa4b0`
  source tree on an isolated Linux display and an exclusively owned local worker.
  All production files remain byte-identical after the test-only correction.
  Verified zero-view checks; missing-database failure without replacement and
  restoration/retry; successful stale-result dismissal; separate inert reopening
  and explicit reconnect/input isolation; pending normal close and saved-session
  relaunch; full/narrow screenshots, Fit and sampled resize geometry.
- Fresh preservation checks covered original task identities, progress, retained
  exit state, saved snapshots, keys and exact attachment/input counts. All
  disposable resources were removed after ownership and preservation checks.

## Runtime and evidence boundaries

This slice supports the existing explicitly configured Linux local provider and
requires a recorded worker, retained private identity and matching SSH host pin.
Other providers/platforms fail explicitly. Observations do not authorize later
actions. A never-started task is a failed query, not fabricated absence.

The native fixture validates the matching retained-task helper, not the latest
complete worker image or repository transport. This is not paid-cloud acceptance,
cross-platform native proof or a fresh performance comparison. No screenshots
containing private fixture identifiers or credentials are attached.
