### PR TITLE
Bootstrap trusted worker host keys

### DIFF
--- a/containers/remote-worker/host-identity.py
+++ b/containers/remote-worker/host-identity.py
@@ -6,11 +6,13 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
 import tempfile
 import time
+import uuid
 
 LIMIT = 16 * 1024
 KEYGEN_TIMEOUT_SECONDS = 10
@@ -20,6 +22,10 @@ WAIT_SECONDS = 2 * KEYGEN_TIMEOUT_SECONDS + INITIALIZATION_SYNC_GRACE_SECONDS
 KEY_NAME = "ssh_host_ed25519_key"
 STATE_VERSION = 2
 ED25519_PREFIX = b"\x00\x00\x00\x0bssh-ed25519\x00\x00\x00\x20"
+BOOTSTRAP_ENV = "HORIZON_HOST_KEY_BOOTSTRAP_VERSION"
+BOOTSTRAP_VERSION = 1
+BOOTSTRAP_PREFIX = "horizon-worker-host-key "
+BOOTSTRAP_LIMIT = 1024
 
 
 class IdentityError(Exception):
@@ -211,11 +217,44 @@ class HostIdentity:
         synchronize(self.runtime_directory, directory=True)
 
 
+def bootstrap_context(environment):
+    if BOOTSTRAP_ENV not in environment:
+        return None
+    if (environment[BOOTSTRAP_ENV] != str(BOOTSTRAP_VERSION)
+            or environment.get("HORIZON_CLOUD_PROTOCOL_VERSION") != "1"):
+        fail()
+    pod_id = environment.get("RUNPOD_POD_ID", "")
+    if not isinstance(pod_id, str) or re.fullmatch(r"[A-Za-z0-9_-]{1,191}", pod_id) is None:
+        fail()
+    record = {"version": BOOTSTRAP_VERSION, "pod_id": pod_id, "cloud_protocol_version": 1}
+    for field in ("workflow_id", "job_id"):
+        value = environment.get("HORIZON_" + field.upper(), "")
+        if not isinstance(value, str) or len(value) != 36 or str(uuid.UUID(value)) != value:
+            fail()
+        record[field] = value
+    return record
+
+
+def prepare_for_startup(store, environment, output):
+    record = bootstrap_context(environment)
+    host_public_key = store.prepare()
+    if record is not None:
+        digest = hashlib.sha256(public_key(read_file(store.access_key)).encode()).hexdigest()
+        if read_file(store.claim) != digest.encode():
+            fail()
+        record.update(access_digest=digest, host_public_key=host_public_key)
+        line = BOOTSTRAP_PREFIX + json.dumps(record, separators=(",", ":")) + "\n"
+        if len(line.encode()) > BOOTSTRAP_LIMIT or output.write(line) != len(line):
+            fail()
+        output.flush()
+    return host_public_key
+
+
 def main():
     try:
         if len(sys.argv) != 1:
             fail()
-        HostIdentity("/workspace", "/root/.ssh/authorized_keys", "/etc/ssh").prepare()
+        prepare_for_startup(HostIdentity("/workspace", "/root/.ssh/authorized_keys", "/etc/ssh"), os.environ, sys.stdout)
     except (IdentityError, OSError, ValueError, RecursionError, subprocess.SubprocessError):
         print("horizon-worker: retained SSH host identity is unavailable", file=sys.stderr)
         return 64

--- a/containers/remote-worker/test_host_identity.py
+++ b/containers/remote-worker/test_host_identity.py
@@ -48,6 +48,68 @@ class HostIdentityTests(unittest.TestCase):
                 (store or self.store).prepare()
             utility.assert_not_called()
 
+    def bootstrap_environment(self):
+        return {identity.BOOTSTRAP_ENV: "1", "HORIZON_CLOUD_PROTOCOL_VERSION": "1", "RUNPOD_POD_ID": "pod_synthetic",
+                "HORIZON_WORKFLOW_ID": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                "HORIZON_JOB_ID": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"}
+
+    def test_bootstrap_record_is_emitted_only_after_retained_key_materialization(self):
+        output = io.StringIO()
+        observed = []
+
+        def write(line):
+            observed.append((self.store.marker.exists(), (self.runtime / identity.KEY_NAME).exists()))
+            return output.write(line)
+
+        writer = mock.Mock(write=write, flush=output.flush)
+        public = identity.prepare_for_startup(self.store, self.bootstrap_environment(), writer)
+        self.assertEqual([(True, True)], observed)
+        line = output.getvalue()
+        self.assertLessEqual(len(line.encode()), identity.BOOTSTRAP_LIMIT)
+        self.assertTrue(line.startswith(identity.BOOTSTRAP_PREFIX))
+        record = json.loads(line[len(identity.BOOTSTRAP_PREFIX):])
+        self.assertEqual({**identity.bootstrap_context(self.bootstrap_environment()),
+                          "access_digest": self.store.claim.read_text(), "host_public_key": public}, record)
+        self.assertNotIn("PRIVATE KEY", line)
+        self.assertEqual(public, identity.public_key((self.runtime / (identity.KEY_NAME + ".pub")).read_bytes()))
+        before = self.snapshot()
+        reopened = io.StringIO()
+        self.assertEqual(public, identity.prepare_for_startup(self.new_store(), self.bootstrap_environment(), reopened))
+        self.assertEqual(line, reopened.getvalue())
+        self.assertEqual(before, self.snapshot())
+
+    def test_invalid_explicit_bootstrap_context_fails_before_identity_preparation(self):
+        for field in self.bootstrap_environment():
+            for value in (None, "", "invalid/context", "x" * 192):
+                environment = self.bootstrap_environment()
+                if value is None and field != identity.BOOTSTRAP_ENV:
+                    del environment[field]
+                else:
+                    environment[field] = value
+                with self.subTest(field=field, value=value), mock.patch.object(self.store, "prepare") as prepare:
+                    with self.assertRaises((identity.IdentityError, ValueError)):
+                        identity.prepare_for_startup(self.store, environment, io.StringIO())
+                    prepare.assert_not_called()
+        output = io.StringIO()
+        public = identity.prepare_for_startup(self.store, {"RUNPOD_POD_ID": "unrelated"}, output)
+        self.assertEqual("", output.getvalue())
+        self.assertEqual(public, self.store.prepare())
+
+    def test_failed_preparation_or_bootstrap_output_never_replaces_retained_identity(self):
+        environment = self.bootstrap_environment()
+        output = io.StringIO()
+        with mock.patch.object(self.store, "prepare", side_effect=identity.IdentityError):
+            with self.assertRaises(identity.IdentityError):
+                identity.prepare_for_startup(self.store, environment, output)
+        self.assertEqual("", output.getvalue())
+        self.store.prepare()
+        before = self.snapshot()
+        for writer in (mock.Mock(write=mock.Mock(side_effect=BrokenPipeError)), mock.Mock(write=lambda _: 0),
+                       mock.Mock(write=len, flush=mock.Mock(side_effect=OSError))):
+            with self.assertRaises((identity.IdentityError, OSError)):
+                identity.prepare_for_startup(self.new_store(), environment, writer)
+            self.assertEqual(before, self.snapshot())
+
     def test_same_key_after_reopen_and_loss_of_runtime_filesystem(self):
         public = self.store.prepare()
         before = self.snapshot()

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -9,6 +9,7 @@ use super::{
 use serde::{Deserialize, Deserializer, de};
 use std::{collections::BTreeMap, env, fmt};
 mod create_request;
+mod host_key;
 mod http;
 mod interactive;
 mod models;
@@ -17,6 +18,7 @@ mod stop;
 mod tests;
 
 use create_request::CreatePodRequest;
+pub use host_key::RunPodHostTrust;
 pub use interactive::{RunPodHostKeySource, RunPodInteractiveWorkerProvider};
 pub use models::{
     RunPodCleanup, RunPodEnsure, RunPodError, RunPodLifecycle, RunPodProfile, RunPodSshEndpoint, RunPodWorker,
@@ -27,6 +29,7 @@ const WORKFLOW_ENV: &str = "HORIZON_WORKFLOW_ID";
 const JOB_ENV: &str = "HORIZON_JOB_ID";
 const PROTOCOL_ENV: &str = "HORIZON_CLOUD_PROTOCOL_VERSION";
 const SSH_PUBLIC_KEY_ENV: &str = "HORIZON_SSH_PUBLIC_KEY";
+const HOST_KEY_BOOTSTRAP_ENV: &str = "HORIZON_HOST_KEY_BOOTSTRAP_VERSION";
 const TERMINATE_ENV: &str = "HORIZON_TERMINATE_AFTER";
 const LIFETIME_ENV: &str = "HORIZON_WORKER_LIFETIME";
 const PERSISTENT_LIFETIME: &str = "persistent";

--- a/crates/horizon-core/src/cloud_run/runpod/create_request.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/create_request.rs
@@ -1,7 +1,7 @@
 use super::super::CLOUD_RUN_PROTOCOL_VERSION;
 use super::{
-    CloudJobId, CloudWorkflowId, JOB_ENV, LIFETIME_ENV, PERSISTENT_LIFETIME, PROTOCOL_ENV, RunPodError, RunPodProfile,
-    SSH_PUBLIC_KEY_ENV, TERMINATE_ENV, WORKFLOW_ENV, WorkerTarget, termination_deadline,
+    CloudJobId, CloudWorkflowId, HOST_KEY_BOOTSTRAP_ENV, JOB_ENV, LIFETIME_ENV, PERSISTENT_LIFETIME, PROTOCOL_ENV,
+    RunPodError, RunPodProfile, SSH_PUBLIC_KEY_ENV, TERMINATE_ENV, WORKFLOW_ENV, WorkerTarget, termination_deadline,
 };
 use serde::Serialize;
 
@@ -72,6 +72,10 @@ impl CreatePodRequest {
         })
         .collect();
         if let Some(ssh_public_key) = ssh_public_key {
+            env.push(CreatePodEnv {
+                key: HOST_KEY_BOOTSTRAP_ENV.to_string(),
+                value: super::host_key::VERSION.to_string(),
+            });
             env.push(CreatePodEnv {
                 key: SSH_PUBLIC_KEY_ENV.to_string(),
                 value: ssh_public_key.to_string(),

--- a/crates/horizon-core/src/cloud_run/runpod/host_key.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/host_key.rs
@@ -1,0 +1,144 @@
+//! Explicit initial trust and retained-pin paths; neither grants task admission.
+
+use super::{
+    ApiPod, CloudProvider, HOST_KEY_BOOTSTRAP_ENV, InteractiveWorkerRequest, RunPodApiKey, RunPodError,
+    RunPodHostKeySource, RunPodLifecycle, RunPodSshEndpoint, RunPodWorker, Transport, http::RunPodHttp,
+    interactive::runpod_worker, status_from_resource,
+};
+use crate::cloud_run::{
+    ArtifactDigest,
+    interactive_worker::{InteractiveWorker, InteractiveWorkerLifetime, InteractiveWorkerSshEndpoint},
+};
+
+pub(super) mod sample;
+pub(super) const VERSION: u32 = 1;
+#[cfg(test)]
+mod tests;
+
+/// A caller-selected trust mode, never inferred from a missing saved pin.
+/// Provider inspection and this synchronous source must run off the render thread.
+pub struct RunPodHostTrust {
+    expected: InteractiveWorkerRequest,
+    mode: Mode,
+}
+
+enum Mode {
+    InitialTaskFree(RunPodHttp),
+    Retained {
+        pod_id: String,
+        lifetime: InteractiveWorkerLifetime,
+        ssh: InteractiveWorkerSshEndpoint,
+    },
+}
+
+impl RunPodHostTrust {
+    /// Select first-pin bootstrap for this exact expected request.
+    ///
+    /// The caller asserts a controller-created Pod has run only the approved image
+    /// entrypoint, with no arbitrary setup/task before first pin persistence. Do not
+    /// call this constructor to recover lost trust for a previously used worker.
+    /// The returned key must pass the existing owned snapshot/CAS before any task.
+    /// Logs are provider-origin evidence, not boot freshness or complete history.
+    /// # Errors
+    /// Rejects an invalid expected provider/request before any I/O.
+    pub fn initial_task_free(api_key: &RunPodApiKey, expected: &InteractiveWorkerRequest) -> Result<Self, RunPodError> {
+        if !expected.is_valid_for(CloudProvider::RunPod) {
+            return Err(RunPodError::InvalidTarget);
+        }
+        Ok(Self {
+            expected: expected.clone(),
+            mode: Mode::InitialTaskFree(RunPodHttp::new(api_key)),
+        })
+    }
+
+    /// Use an already-retained full SSH pin without any log/HTTP access here.
+    /// The outer provider still freshly inspects ownership; the actual pinned SSH
+    /// handshake proves possession. Endpoint migration and key rotation are refused.
+    /// # Errors
+    /// Rejects incomplete saved identity or trust; absence never selects bootstrap.
+    pub fn retained(worker: &InteractiveWorker, ssh: &InteractiveWorkerSshEndpoint) -> Result<Self, RunPodError> {
+        let retained = runpod_worker(worker)?;
+        if !ssh.is_complete() {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        Ok(Self {
+            expected: InteractiveWorkerRequest {
+                workflow_id: worker.identity.workflow_id,
+                job_id: worker.identity.job_id,
+                target: worker.target.clone(),
+                ssh_public_key: worker.ssh_public_key.clone(),
+            },
+            mode: Mode::Retained {
+                pod_id: retained.pod_id,
+                lifetime: retained.lifetime,
+                ssh: ssh.clone(),
+            },
+        })
+    }
+
+    fn observed(&self, pod: &ApiPod, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> bool {
+        pod.env.get(HOST_KEY_BOOTSTRAP_ENV) == Some(&VERSION.to_string())
+            && status_from_resource(pod, worker, Some(&self.expected.ssh_public_key)).is_ok_and(|status| {
+                status.lifecycle == RunPodLifecycle::Running
+                    && status.ssh_username.as_ref() == Some(&endpoint.username)
+                    && status.ssh_host.as_ref() == Some(&endpoint.host)
+                    && status.ssh_port == Some(endpoint.port)
+            })
+    }
+}
+
+impl RunPodHostKeySource for RunPodHostTrust {
+    fn host_key(
+        &self,
+        worker: &RunPodWorker,
+        endpoint: &RunPodSshEndpoint,
+        expected_client_key: &str,
+    ) -> Option<String> {
+        if worker.validate().is_err()
+            || worker.workflow_id != self.expected.workflow_id
+            || worker.job_id != self.expected.job_id
+            || worker.image != self.expected.target.image
+            || !worker.lifetime.matches_policy(self.expected.target.lifetime)
+            || expected_client_key != self.expected.ssh_public_key
+        {
+            return None;
+        }
+        match &self.mode {
+            Mode::Retained { pod_id, lifetime, ssh } => (worker.pod_id == *pod_id
+                && worker.lifetime == *lifetime
+                && endpoint.host == ssh.host
+                && endpoint.port == ssh.port
+                && endpoint.username == ssh.username)
+                .then(|| ssh.host_key.clone()),
+            Mode::InitialTaskFree(http) => {
+                let before = http.get(&worker.pod_id).ok()??;
+                if !self.observed(&before, worker, endpoint) {
+                    return None;
+                }
+                let bytes = http.host_key_sample(&worker.pod_id).ok()?;
+                let key = sample::parse(&bytes, worker, &client_digest(expected_client_key)).ok()??;
+                let after = http.get(&worker.pod_id).ok()??;
+                (self.observed(&after, worker, endpoint)
+                    && InteractiveWorkerSshEndpoint {
+                        host: endpoint.host.clone(),
+                        port: endpoint.port,
+                        username: endpoint.username.clone(),
+                        host_key: key.clone(),
+                    }
+                    .is_complete())
+                .then_some(key)
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for RunPodHostTrust {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("RunPodHostTrust").finish_non_exhaustive()
+    }
+}
+
+fn client_digest(key: &str) -> String {
+    let normalized = key.split_ascii_whitespace().take(2).collect::<Vec<_>>().join(" ");
+    ArtifactDigest::sha256(normalized.as_bytes()).as_str().to_string()
+}

--- a/crates/horizon-core/src/cloud_run/runpod/host_key/sample.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/host_key/sample.rs
@@ -1,0 +1,125 @@
+//! A bounded sample of complete log events, not an exhaustive history or boot proof.
+
+use super::super::{CloudJobId, CloudWorkflowId, RunPodError, RunPodWorker, http::RESPONSE_LIMIT_BYTES};
+use crate::cloud_run::{CLOUD_RUN_PROTOCOL_VERSION, interactive_worker::valid_ssh_public_key};
+use serde::Deserialize;
+use std::io::{self, Read};
+
+pub(super) const PREFIX: &str = "horizon-worker-host-key ";
+const MAX_LINE_BYTES: usize = 16 * 1024;
+const MAX_LINES: usize = 16_000;
+const MAX_RECORD_BYTES: usize = 1024;
+
+fn invalid() -> RunPodError {
+    RunPodError::InvalidResponse {
+        operation: "host-key bootstrap",
+    }
+}
+
+pub(in super::super) fn read(reader: impl Read) -> Result<Vec<u8>, RunPodError> {
+    let mut bytes = Vec::new();
+    if let Err(error) = reader.take(RESPONSE_LIMIT_BYTES + 1).read_to_end(&mut bytes) {
+        let timeout = error.kind() == io::ErrorKind::TimedOut
+            || matches!(
+                error.get_ref().and_then(|inner| inner.downcast_ref::<ureq::Error>()),
+                Some(ureq::Error::Timeout(_))
+            );
+        if !timeout {
+            return Err(invalid());
+        }
+    }
+    if bytes.len() as u64 > RESPONSE_LIMIT_BYTES {
+        return Err(invalid());
+    }
+    Ok(bytes)
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Event {
+    source: String,
+    line: String,
+    ts: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Record {
+    version: u32,
+    pod_id: String,
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    cloud_protocol_version: u32,
+    access_digest: String,
+    host_public_key: String,
+}
+
+pub(super) fn parse(bytes: &[u8], worker: &RunPodWorker, digest: &str) -> Result<Option<String>, RunPodError> {
+    if bytes.len() as u64 > RESPONSE_LIMIT_BYTES || (!bytes.is_empty() && !bytes.ends_with(b"\n")) {
+        return Err(invalid());
+    }
+    let text = std::str::from_utf8(bytes).map_err(|_| invalid())?;
+    let mut data = None;
+    let mut id = false;
+    let mut selected = None;
+    for (count, raw) in text.split_terminator('\n').enumerate() {
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        if count >= MAX_LINES || line.len() > MAX_LINE_BYTES {
+            return Err(invalid());
+        }
+        if line.is_empty() {
+            if let Some(payload) = data.take() {
+                accept(payload, worker, digest, &mut selected)?;
+            }
+            id = false;
+        } else if let Some(value) = line.strip_prefix("data:") {
+            if data.replace(value.strip_prefix(' ').unwrap_or(value)).is_some() {
+                return Err(invalid());
+            }
+        } else if line.starts_with("id:") && !id {
+            id = true;
+        } else if !line.starts_with(':') {
+            return Err(invalid());
+        }
+    }
+    if data.is_some() || id {
+        return Err(invalid());
+    }
+    Ok(selected)
+}
+
+fn accept(
+    payload: &str,
+    worker: &RunPodWorker,
+    digest: &str,
+    selected: &mut Option<String>,
+) -> Result<(), RunPodError> {
+    let event: Event = serde_json::from_str(payload).map_err(|_| invalid())?;
+    if event.source != "container"
+        || event.ts.len() > 64
+        || time::OffsetDateTime::parse(&event.ts, &time::format_description::well_known::Rfc3339).is_err()
+    {
+        return Err(invalid());
+    }
+    let Some(record) = event.line.strip_prefix(PREFIX) else {
+        return Ok(());
+    };
+    if event.line.len() > MAX_RECORD_BYTES {
+        return Err(invalid());
+    }
+    let record: Record = serde_json::from_str(record).map_err(|_| invalid())?;
+    if record.version != super::VERSION
+        || record.pod_id != worker.pod_id
+        || record.workflow_id != worker.workflow_id
+        || record.job_id != worker.job_id
+        || record.cloud_protocol_version != CLOUD_RUN_PROTOCOL_VERSION
+        || record.access_digest != digest
+        || !valid_ssh_public_key(&record.host_public_key)
+        || record.host_public_key.split_ascii_whitespace().count() != 2
+        || selected.as_ref().is_some_and(|key| *key != record.host_public_key)
+    {
+        return Err(invalid());
+    }
+    *selected = Some(record.host_public_key);
+    Ok(())
+}

--- a/crates/horizon-core/src/cloud_run/runpod/host_key/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/host_key/tests.rs
@@ -1,0 +1,397 @@
+use super::super::{
+    CloudJobId, CloudWorkflowId, HOST_KEY_BOOTSTRAP_ENV, JOB_ENV, LIFETIME_ENV, PERSISTENT_LIFETIME, PROTOCOL_ENV,
+    RunPodApiKey, RunPodClient, RunPodError, RunPodHostKeySource, RunPodInteractiveWorkerProvider, RunPodSshEndpoint,
+    RunPodWorker, SSH_PUBLIC_KEY_ENV, WORKFLOW_ENV,
+    http::RunPodHttp,
+    resource_name,
+    tests::{ed25519_key, interactive_request, profile},
+};
+use super::{Mode, RunPodHostTrust, VERSION, client_digest, sample};
+use crate::cloud_run::{
+    CloudProvider, WorkerLifetime,
+    interactive_worker::{
+        InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLifetime, InteractiveWorkerProvider,
+        InteractiveWorkerRequest, InteractiveWorkerSshEndpoint,
+    },
+};
+use serde_json::{Value, json};
+use std::{
+    collections::VecDeque,
+    io::{self, Cursor, Read},
+    sync::{Arc, Mutex},
+};
+
+struct Fixture {
+    request: InteractiveWorkerRequest,
+    worker: RunPodWorker,
+    endpoint: RunPodSshEndpoint,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let mut request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+        request.target.lifetime = WorkerLifetime::Persistent;
+        let worker = RunPodWorker {
+            workflow_id: request.workflow_id,
+            job_id: request.job_id,
+            pod_id: "pod_synthetic".into(),
+            name: resource_name(request.workflow_id, request.job_id),
+            image: request.target.image.clone(),
+            lifetime: InteractiveWorkerLifetime::Persistent,
+            hourly_cost_micros: None,
+        };
+        Self {
+            request,
+            worker,
+            endpoint: RunPodSshEndpoint {
+                username: "root".into(),
+                host: "worker.example".into(),
+                port: 2200,
+            },
+        }
+    }
+
+    fn record(&self) -> Value {
+        json!({"version": VERSION, "pod_id": self.worker.pod_id, "workflow_id": self.worker.workflow_id,
+            "job_id": self.worker.job_id, "cloud_protocol_version": 1,
+            "access_digest": client_digest(&self.request.ssh_public_key), "host_public_key": ed25519_key(73)})
+    }
+
+    fn pod(&self) -> Value {
+        json!({"id": self.worker.pod_id, "name": self.worker.name, "image": self.worker.image, "status": "RUNNING",
+            "env": {(WORKFLOW_ENV): self.worker.workflow_id, (JOB_ENV): self.worker.job_id,
+                (PROTOCOL_ENV): "1", (SSH_PUBLIC_KEY_ENV): self.request.ssh_public_key,
+                (LIFETIME_ENV): PERSISTENT_LIFETIME, (HOST_KEY_BOOTSTRAP_ENV): VERSION.to_string()},
+            "ssh": {"direct": {"username": self.endpoint.username, "host": self.endpoint.host, "port": self.endpoint.port}}})
+    }
+
+    fn source(&self, responses: Vec<(u16, &'static str, String)>) -> (RunPodHostTrust, Arc<Mutex<Vec<String>>>) {
+        let (http, calls) = mock_http(responses);
+        (
+            RunPodHostTrust {
+                expected: self.request.clone(),
+                mode: Mode::InitialTaskFree(http),
+            },
+            calls,
+        )
+    }
+
+    fn responses(&self, logs: String) -> Vec<(u16, &'static str, String)> {
+        vec![
+            (200, "application/json", self.pod().to_string()),
+            (200, "text/event-stream; charset=utf-8", logs),
+            (200, "application/json", self.pod().to_string()),
+        ]
+    }
+
+    fn key(&self, source: &RunPodHostTrust) -> Option<String> {
+        source.host_key(&self.worker, &self.endpoint, &self.request.ssh_public_key)
+    }
+
+    fn parse(&self, text: &str) -> Result<Option<String>, RunPodError> {
+        sample::parse(
+            text.as_bytes(),
+            &self.worker,
+            &client_digest(&self.request.ssh_public_key),
+        )
+    }
+
+    fn interactive(&self) -> InteractiveWorker {
+        InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::RunPod,
+                workflow_id: self.worker.workflow_id,
+                job_id: self.worker.job_id,
+                resource_id: self.worker.pod_id.clone(),
+            },
+            target: self.request.target.clone(),
+            ssh_public_key: self.request.ssh_public_key.clone(),
+            lifetime: self.worker.lifetime.clone(),
+        }
+    }
+}
+
+fn mock_http(responses: Vec<(u16, &'static str, String)>) -> (RunPodHttp, Arc<Mutex<Vec<String>>>) {
+    let responses = Mutex::new(VecDeque::from(responses));
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let captured = calls.clone();
+    let config = ureq::Agent::config_builder()
+        .middleware(
+            move |request: ureq::http::Request<ureq::SendBody>, _next: ureq::middleware::MiddlewareNext| {
+                assert_eq!(request.method(), "GET");
+                assert_eq!(request.headers()["Authorization"], "Bearer synthetic-credential");
+                captured.lock().expect("calls").push(request.uri().to_string());
+                let (status, content_type, body) = responses
+                    .lock()
+                    .expect("responses")
+                    .pop_front()
+                    .expect("no extra request");
+                Ok(ureq::http::Response::builder()
+                    .status(status)
+                    .header("Content-Type", content_type)
+                    .body(ureq::Body::builder().data(body))
+                    .expect("mock response"))
+            },
+        )
+        .build();
+    (RunPodHttp::mock(ureq::Agent::new_with_config(config)), calls)
+}
+
+fn event(line: &str) -> String {
+    format!(
+        "id: synthetic-cursor\ndata: {}\n\n",
+        json!({"source":"container", "line":line, "ts":"2026-09-09T12:00:00Z"})
+    )
+}
+
+fn record_event(record: &Value) -> String {
+    event(&format!("{}{}", sample::PREFIX, record))
+}
+
+#[test]
+fn initial_sample_binds_expected_identity_between_fresh_reads() {
+    let fixture = Fixture::new();
+    let logs = format!(
+        "{}{}{}",
+        event("ordinary startup"),
+        record_event(&fixture.record()),
+        record_event(&fixture.record())
+    );
+    let (source, calls) = fixture.source(fixture.responses(logs));
+    assert_eq!(fixture.key(&source), Some(ed25519_key(73)));
+    assert_eq!(
+        *calls.lock().expect("calls"),
+        [
+            "https://api.runpod.io/v2/pods/pod_synthetic",
+            "https://api.runpod.io/v2/pods/pod_synthetic/logs?source=container&tail=5000",
+            "https://api.runpod.io/v2/pods/pod_synthetic",
+        ]
+    );
+    assert_eq!(
+        client_digest(&fixture.request.ssh_public_key),
+        client_digest(&format!("{} client comment", fixture.request.ssh_public_key))
+    );
+    assert_eq!(format!("{source:?}"), "RunPodHostTrust { .. }");
+}
+
+#[test]
+fn before_and_after_observations_refuse_identity_or_endpoint_drift() {
+    let fixture = Fixture::new();
+    for pointer in [
+        "/id",
+        "/name",
+        "/image",
+        "/env/HORIZON_WORKFLOW_ID",
+        "/env/HORIZON_JOB_ID",
+        "/env/HORIZON_CLOUD_PROTOCOL_VERSION",
+        "/env/HORIZON_SSH_PUBLIC_KEY",
+        "/env/HORIZON_WORKER_LIFETIME",
+        "/env/HORIZON_HOST_KEY_BOOTSTRAP_VERSION",
+        "/ssh/direct/host",
+        "/ssh/direct/username",
+        "/ssh/direct/port",
+        "/status",
+    ] {
+        for index in [0, 2] {
+            let mut changed = fixture.pod();
+            *changed.pointer_mut(pointer).expect("existing binding") = if pointer.ends_with("/port") {
+                json!(2201)
+            } else {
+                json!("drift")
+            };
+            let mut responses = fixture.responses(record_event(&fixture.record()));
+            responses[index].2 = changed.to_string();
+            let (source, calls) = fixture.source(responses);
+            assert_eq!(fixture.key(&source), None, "{pointer} at read {index}");
+            assert_eq!(calls.lock().expect("calls").len(), index + 1);
+        }
+    }
+    let (source, calls) = fixture.source(Vec::new());
+    assert_eq!(
+        source.host_key(&fixture.worker, &fixture.endpoint, &ed25519_key(99)),
+        None
+    );
+    let mut worker = fixture.worker.clone();
+    worker.pod_id = "bad/../pod".into();
+    assert_eq!(
+        source.host_key(&worker, &fixture.endpoint, &fixture.request.ssh_public_key),
+        None
+    );
+    assert!(calls.lock().expect("calls").is_empty());
+}
+
+#[test]
+fn malformed_mismatched_and_conflicting_records_never_select_a_key() {
+    let fixture = Fixture::new();
+    for (field, value) in [
+        ("version", json!(VERSION + 1)),
+        ("pod_id", json!("other_pod")),
+        ("workflow_id", json!(CloudWorkflowId::new())),
+        ("job_id", json!(CloudJobId::new())),
+        ("cloud_protocol_version", json!(2)),
+        ("access_digest", json!("0".repeat(64))),
+        ("host_public_key", json!(format!("{} comment", ed25519_key(73)))),
+        ("extra", json!("wrong")),
+    ] {
+        let mut record = fixture.record();
+        record[field] = value;
+        assert!(fixture.parse(&record_event(&record)).is_err(), "{field}");
+    }
+    for field in fixture.record().as_object().expect("record").keys() {
+        let mut record = fixture.record();
+        record.as_object_mut().expect("record").remove(field);
+        assert!(fixture.parse(&record_event(&record)).is_err(), "missing {field}");
+    }
+    let mut other = fixture.record();
+    other["host_public_key"] = json!(ed25519_key(74));
+    assert!(
+        fixture
+            .parse(&(record_event(&fixture.record()) + &record_event(&other)))
+            .is_err()
+    );
+    for line in [
+        format!(
+            "{}{{\"version\":1,{}",
+            sample::PREFIX,
+            &fixture.record().to_string()[1..]
+        ),
+        format!("{}not-json", sample::PREFIX),
+        format!("{}{}", sample::PREFIX, "x".repeat(1024)),
+    ] {
+        let error = fixture.parse(&event(&line)).expect_err("invalid bootstrap record");
+        assert_eq!(
+            error,
+            RunPodError::InvalidResponse {
+                operation: "host-key bootstrap"
+            }
+        );
+        assert!(!error.to_string().contains(&line));
+    }
+}
+
+#[test]
+fn sse_framing_is_bounded_complete_and_unambiguous() {
+    let fixture = Fixture::new();
+    let good = record_event(&fixture.record());
+    assert_eq!(fixture.parse(&good.replace('\n', "\r\n")), Ok(Some(ed25519_key(73))));
+    assert_eq!(fixture.parse(&event("no key here")), Ok(None));
+    for invalid in [
+        good.trim_end().to_string(),
+        good.trim_end_matches('\n').to_string() + "\n",
+        good.replace("data:", "data: {}\ndata:"),
+        good.replace("id:", "id: duplicate\nid:"),
+        good.replace("id:", "event:"),
+        good.replace("container", "system"),
+        good.replace("2026-09-09T12:00:00Z", "invalid"),
+        good.replace("data: {", "data: {\"source\":\"container\","),
+        good.replace("data: {", "data: {\"extra\":0,"),
+        format!(":{}\n\n", "x".repeat(16 * 1024)),
+        "\n".repeat(16_001),
+    ] {
+        assert!(fixture.parse(&invalid).is_err());
+    }
+    assert!(sample::parse(&[0xff, b'\n'], &fixture.worker, "digest").is_err());
+}
+
+struct EndingReader {
+    bytes: Cursor<Vec<u8>>,
+    timeout: bool,
+}
+impl Read for EndingReader {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        let count = self.bytes.read(output)?;
+        if count > 0 {
+            return Ok(count);
+        }
+        Err(if self.timeout {
+            io::Error::other(ureq::Error::Timeout(ureq::Timeout::Global))
+        } else {
+            io::Error::other("synthetic private detail")
+        })
+    }
+}
+
+#[test]
+fn deadline_ends_only_a_bounded_sample_and_other_read_failures_reject() {
+    let fixture = Fixture::new();
+    let good = record_event(&fixture.record()).into_bytes();
+    let read = sample::read(EndingReader {
+        bytes: Cursor::new(good.clone()),
+        timeout: true,
+    })
+    .expect("bounded sample");
+    assert_eq!(read, good);
+    assert_eq!(
+        fixture.parse(std::str::from_utf8(&read).expect("UTF-8")),
+        Ok(Some(ed25519_key(73)))
+    );
+    assert!(
+        sample::read(EndingReader {
+            bytes: Cursor::new(good),
+            timeout: false
+        })
+        .is_err()
+    );
+    assert!(sample::read(Cursor::new(vec![b'x'; 2 * 1024 * 1024 + 1])).is_err());
+}
+
+#[test]
+fn unavailable_or_invalid_logs_have_no_retry_or_fallback() {
+    let fixture = Fixture::new();
+    for reply in [
+        (403, "application/json", String::new()),
+        (302, "text/event-stream", String::new()),
+        (200, "application/json", record_event(&fixture.record())),
+        (200, "text/event-stream", event("no key")),
+    ] {
+        let (source, calls) = fixture.source(vec![(200, "application/json", fixture.pod().to_string()), reply]);
+        assert_eq!(fixture.key(&source), None);
+        assert_eq!(calls.lock().expect("calls").len(), 2);
+    }
+}
+
+#[test]
+fn retained_full_pin_needs_only_outer_owned_provider_read_and_no_logs() {
+    let fixture = Fixture::new();
+    let worker = fixture.interactive();
+    let ssh = InteractiveWorkerSshEndpoint {
+        host: fixture.endpoint.host.clone(),
+        port: fixture.endpoint.port,
+        username: fixture.endpoint.username.clone(),
+        host_key: ed25519_key(73),
+    };
+    let source = RunPodHostTrust::retained(&worker, &ssh).expect("retained pin");
+    assert_eq!(fixture.key(&source), Some(ssh.host_key.clone()));
+    assert_eq!(
+        source.host_key(&fixture.worker, &fixture.endpoint, &ed25519_key(99)),
+        None
+    );
+    for field in 0..4 {
+        let mut changed_worker = fixture.worker.clone();
+        let mut endpoint = fixture.endpoint.clone();
+        match field {
+            0 => changed_worker.pod_id = "other_pod".into(),
+            1 => endpoint.host = "other.example".into(),
+            2 => endpoint.port += 1,
+            _ => endpoint.username = "other".into(),
+        }
+        assert_eq!(
+            source.host_key(&changed_worker, &endpoint, &fixture.request.ssh_public_key),
+            None
+        );
+    }
+    let mut missing = ssh.clone();
+    missing.host_key.clear();
+    assert!(RunPodHostTrust::retained(&worker, &missing).is_err());
+    let mut pod = fixture.pod();
+    pod["env"].as_object_mut().expect("env").remove(HOST_KEY_BOOTSTRAP_ENV);
+    let (http, calls) = mock_http(vec![(200, "application/json", pod.to_string())]);
+    let provider = RunPodInteractiveWorkerProvider::new(RunPodClient::with_transport(http), profile(), source);
+    let status = provider.inspect_worker(&worker).expect("inspect").expect("present");
+    assert!(status.is_ready_for(&fixture.request, time::OffsetDateTime::now_utc()));
+    assert_eq!(status.ssh, Some(ssh));
+    assert_eq!(calls.lock().expect("calls").len(), 1);
+    let mut invalid = fixture.request;
+    invalid.ssh_public_key.clear();
+    assert!(RunPodHostTrust::initial_task_free(&RunPodApiKey::new("synthetic-key").expect("key"), &invalid).is_err());
+}

--- a/crates/horizon-core/src/cloud_run/runpod/http.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http.rs
@@ -4,7 +4,7 @@ const PODS_URL: &str = "https://api.runpod.io/v2/pods";
 const GRAPHQL_URL: &str = "https://api.runpod.io/graphql";
 const CREATE_MUTATION: &str =
     "mutation CreatePod($input: PodFindAndDeployOnDemandInput!) { podFindAndDeployOnDemand(input: $input) { id } }";
-const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
+pub(super) const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const PROPAGATION_BACKOFF_MS: [u64; 8] = [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000];
 const CAPACITY_ERROR_MARKERS: [&str; 8] = [
@@ -43,6 +43,48 @@ impl RunPodHttp {
         valid_provider_id(pod_id)
             .then(|| format!("{PODS_URL}/{pod_id}"))
             .ok_or(RunPodError::ResourceIdentityMismatch)
+    }
+
+    pub(super) fn host_key_sample(&self, pod_id: &str) -> Result<Vec<u8>, RunPodError> {
+        let url = format!("{}/logs?source=container&tail=5000", Self::pod_url(pod_id)?);
+        let mut response = self
+            .agent
+            .get(url.as_str())
+            .header("Authorization", &self.authorization)
+            .config()
+            .timeout_global(Some(Duration::from_secs(5)))
+            .build()
+            .call()
+            .map_err(|_| RunPodError::RequestFailed {
+                operation: "host-key bootstrap",
+            })?;
+        if response.status().as_u16() != 200 {
+            return Err(RunPodError::UnexpectedStatus {
+                operation: "host-key bootstrap",
+                status: response.status().as_u16(),
+            });
+        }
+        if response
+            .headers()
+            .get("Content-Type")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.split(';').next())
+            .map(str::trim)
+            != Some("text/event-stream")
+        {
+            return Err(RunPodError::InvalidResponse {
+                operation: "host-key bootstrap",
+            });
+        }
+        super::host_key::sample::read(response.body_mut().as_reader())
+    }
+
+    #[cfg(test)]
+    pub(super) fn mock(agent: ureq::Agent) -> Self {
+        Self {
+            agent,
+            authorization: "Bearer synthetic-credential".into(),
+        }
     }
 }
 impl Transport for RunPodHttp {

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -20,15 +20,25 @@ use super::{
 /// attestation source.
 pub trait RunPodHostKeySource: Send + Sync {
     #[must_use]
-    fn host_key(&self, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> Option<String>;
+    fn host_key(
+        &self,
+        worker: &RunPodWorker,
+        endpoint: &RunPodSshEndpoint,
+        expected_client_key: &str,
+    ) -> Option<String>;
 }
 
 impl<F> RunPodHostKeySource for F
 where
-    F: Fn(&RunPodWorker, &RunPodSshEndpoint) -> Option<String> + Send + Sync,
+    F: Fn(&RunPodWorker, &RunPodSshEndpoint, &str) -> Option<String> + Send + Sync,
 {
-    fn host_key(&self, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> Option<String> {
-        self(worker, endpoint)
+    fn host_key(
+        &self,
+        worker: &RunPodWorker,
+        endpoint: &RunPodSshEndpoint,
+        expected_client_key: &str,
+    ) -> Option<String> {
+        self(worker, endpoint, expected_client_key)
     }
 }
 
@@ -55,7 +65,7 @@ impl RunPodInteractiveWorkerProvider {
         target: &WorkerTarget,
         ssh_public_key: &str,
     ) -> InteractiveWorkerStatus {
-        let (lifecycle, ssh) = self.adapt_connection(&status);
+        let (lifecycle, ssh) = self.adapt_connection(&status, ssh_public_key);
         InteractiveWorkerStatus {
             worker: InteractiveWorker {
                 identity: InteractiveWorkerIdentity {
@@ -76,19 +86,21 @@ impl RunPodInteractiveWorkerProvider {
     fn adapt_connection(
         &self,
         status: &RunPodWorkerStatus,
+        expected_client_key: &str,
     ) -> (InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>) {
         match status.lifecycle {
             RunPodLifecycle::Provisioning => (InteractiveWorkerLifecycle::Provisioning, None),
             RunPodLifecycle::Exited | RunPodLifecycle::Terminated => (InteractiveWorkerLifecycle::Stopped, None),
             RunPodLifecycle::Failed => (InteractiveWorkerLifecycle::Failed, None),
             RunPodLifecycle::Unknown => (InteractiveWorkerLifecycle::Unknown, None),
-            RunPodLifecycle::Running => self.adapt_running_connection(status),
+            RunPodLifecycle::Running => self.adapt_running_connection(status, expected_client_key),
         }
     }
 
     fn adapt_running_connection(
         &self,
         status: &RunPodWorkerStatus,
+        expected_client_key: &str,
     ) -> (InteractiveWorkerLifecycle, Option<InteractiveWorkerSshEndpoint>) {
         let Some((username, host, port)) = status
             .ssh_username
@@ -107,7 +119,7 @@ impl RunPodInteractiveWorkerProvider {
         if !valid_ssh_coordinates(&endpoint.host, endpoint.port, &endpoint.username) {
             return (InteractiveWorkerLifecycle::Failed, None);
         }
-        let Some(host_key) = self.host_keys.host_key(&status.worker, &endpoint) else {
+        let Some(host_key) = self.host_keys.host_key(&status.worker, &endpoint, expected_client_key) else {
             return (InteractiveWorkerLifecycle::Provisioning, None);
         };
         let endpoint = InteractiveWorkerSshEndpoint {
@@ -189,7 +201,7 @@ impl InteractiveWorkerStopProvider for RunPodInteractiveWorkerProvider {
     }
 }
 
-fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError> {
+pub(super) fn runpod_worker(worker: &InteractiveWorker) -> Result<RunPodWorker, RunPodError> {
     if !worker.is_valid_for(CloudProvider::RunPod) {
         return Err(RunPodError::InvalidPersistedWorker);
     }

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -119,7 +119,7 @@ fn target() -> WorkerTarget {
         max_hourly_cost_micros: Some(750_000),
     }
 }
-fn profile() -> RunPodProfile {
+pub(super) fn profile() -> RunPodProfile {
     RunPodProfile {
         name: "nativesdk-gpu".to_string(),
         gpu_type_ids: vec!["NVIDIA RTX A4000".to_string(), "NVIDIA RTX A4500".to_string()],
@@ -135,7 +135,7 @@ fn profile() -> RunPodProfile {
     }
 }
 
-fn ed25519_key(byte: u8) -> String {
+pub(super) fn ed25519_key(byte: u8) -> String {
     let mut blob = ED25519_BLOB_PREFIX.to_vec();
     blob.extend([byte; 32]);
     format!("ssh-ed25519 {}", STANDARD.encode(blob))
@@ -169,7 +169,7 @@ fn api_pod(
     }
 }
 
-fn interactive_request(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> InteractiveWorkerRequest {
+pub(super) fn interactive_request(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> InteractiveWorkerRequest {
     InteractiveWorkerRequest {
         workflow_id,
         job_id,
@@ -207,7 +207,13 @@ impl FakeHostKeySource {
 }
 
 impl RunPodHostKeySource for FakeHostKeySource {
-    fn host_key(&self, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> Option<String> {
+    fn host_key(
+        &self,
+        worker: &RunPodWorker,
+        endpoint: &RunPodSshEndpoint,
+        expected_client_key: &str,
+    ) -> Option<String> {
+        assert_eq!(expected_client_key, ed25519_key(41));
         self.calls
             .lock()
             .expect("host key calls")
@@ -421,6 +427,12 @@ fn interactive_adapter_preserves_identity_and_reaches_attested_ready_state() {
 
     let state = observer.0.lock().expect("state");
     assert_eq!(state.create_requests.len(), 1);
+    assert!(
+        state.create_requests[0]
+            .env
+            .iter()
+            .any(|entry| entry.key == HOST_KEY_BOOTSTRAP_ENV && entry.value == "1")
+    );
     assert!(
         state.create_requests[0]
             .env

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -406,6 +406,11 @@ back into large multi-purpose modules.
   inactive state after a single Stop action, including a lost response, without
   deletion, restart, SSH, or UI admission. This is not a backup or filesystem
   durability claim; the existing durable Stop coordinator owns saved intent.
+- `cloud_run/runpod/host_key.rs` separates explicit task-free first-pin bootstrap
+  from saved-full-pin reconnect. Its `sample.rs` leaf validates bounded authenticated
+  log samples without claiming current-boot freshness or exhaustive history. The
+  worker emits a versioned public binding only after retained identity preparation;
+  the caller must persist the owned pin before admitting setup or tasks.
 - `cloud_run/store.rs` owns workflow snapshots and creation-claim transactions.
   Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
   schema initialization, and compatibility checks. Keep database opening separate


### PR DESCRIPTION
## Purpose

Add explicit first-pin host-key bootstrap and saved-pin reconnect modes for the
existing GPU worker adapter. Part of #473 / #383; this does not complete either issue.

## Behavior and trust boundary

- Initial bootstrap binds a bounded authenticated exact-worker log sample to the
  expected workflow, job, image, lifetime, SSH endpoint, and caller public key,
  with fresh provider observations before and after the sample.
- Initial mode requires an explicitly selected, controller-created, approved-image
  worker that has not admitted arbitrary setup or tasks. Missing saved trust never
  selects initial mode. The caller must persist the owned pin before admission.
- Saved-pin mode needs no log or HTTP access in the trust source and preserves the
  complete saved endpoint/key. Fresh outer provider inspection and pinned SSH are
  still required; endpoint migration and key rotation are not added.
- Opt-in worker startup emits one bounded public binding after retained identity
  validation. Invalid explicit context fails closed; no-opt-in behavior remains
  unchanged. No private host key is exported or obtained through a network scan.

The bounded log sample is not complete-history, current-boot, or hardware
attestation evidence. This change adds no UI/configuration, cloud allocation,
provider credentials, task-admission coordinator, or automatic recovery from lost trust.

## Validation

- Integrated focused tests: 48 provider/bootstrap, 12 recovery, and 18 durable Stop
  tests passed. Blocking and strict lint passed before the integration commit.
- All eight final exact-commit validation lanes passed, including default/speech
  workspace tests and blocking, strict, and pedantic lint. Source and lock were
  checked after every gate.
- Final exact-commit image proof passed opt-in log-derived
  pinned SSH, same-container restart and fresh-container retained-key reuse,
  two pre-identity invalid-context refusals, and existing no-opt-in compatibility.
  All seven new-lane containers and three volumes were verified removed. This is
  local synthetic proof, not authenticated cloud-service or cloud-retention proof.
- Candidate `4f1f7cd57e88c0eee8214a3c231de28a4c9e1825`, base
  `1a518e6443838f55064c624e7a062f089ce8f397`, exact tree
  `4fd68bee5a6155e570005a14b6a9d7d2da88fd89`; ten source/test files,
  872 changed source/test lines, plus five architecture lines. No new dependencies.
