### PR TITLE
Retain explicit first-pin setup intent

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -11,7 +11,7 @@ use rusqlite::{Connection, OpenFlags, TransactionBehavior};
 
 use super::{CloudStoreError, remote_workspaces::creation_fences};
 
-const STORE_SCHEMA_VERSION: i64 = 4;
+const STORE_SCHEMA_VERSION: i64 = 5;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS cloud_workflows (
@@ -60,6 +60,16 @@ const REMOTE_ALLOCATION_SCHEMA: [&str; 3] = [
     "CREATE UNIQUE INDEX remote_runtime_allocations_workflow ON remote_runtime_allocations(workflow_id)",
     "CREATE UNIQUE INDEX remote_runtime_allocations_job ON remote_runtime_allocations(job_id)",
 ];
+
+const FIRST_PIN_SCHEMA: &str = r"CREATE TABLE remote_first_pin_intents (
+    workspace_local_id TEXT PRIMARY KEY NOT NULL REFERENCES remote_runtime_allocations(workspace_local_id),
+    session_id TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    workflow_id TEXT NOT NULL UNIQUE,
+    job_id TEXT NOT NULL UNIQUE,
+    version INTEGER NOT NULL CHECK (version = 1),
+    request_digest TEXT NOT NULL CHECK (length(request_digest) = 64)
+) STRICT, WITHOUT ROWID";
 
 pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
     let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
@@ -127,6 +137,11 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
         creation_fences::migrate(&transaction)?;
     }
     creation_fences::validate_schema(&transaction)?;
+    if version < 5 {
+        // Existing allocations never acquire first-use provenance through migration.
+        transaction.execute_batch(FIRST_PIN_SCHEMA)?;
+    }
+    validate_first_pin_schema(&transaction)?;
     transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
     transaction.commit()?;
     Ok(())
@@ -138,7 +153,21 @@ pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), Cloud
         return Err(CloudStoreError::UnsupportedSchema(version));
     }
     validate_allocation_schema(connection)?;
-    creation_fences::validate_schema(connection)
+    creation_fences::validate_schema(connection)?;
+    validate_first_pin_schema(connection)
+}
+
+fn validate_first_pin_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    let matches: bool = connection.query_row(
+        "SELECT COUNT(*) = 1 AND COUNT(CASE WHEN sql = ?1 THEN 1 END) = 1
+         FROM main.sqlite_schema WHERE tbl_name = 'remote_first_pin_intents' AND sql IS NOT NULL",
+        [FIRST_PIN_SCHEMA],
+        |row| row.get(0),
+    )?;
+    if !matches {
+        return Err(CloudStoreError::InvalidAllocationSchema);
+    }
+    Ok(())
 }
 
 fn validate_allocation_schema(connection: &Connection) -> Result<(), CloudStoreError> {

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -149,11 +149,28 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
 
 pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), CloudStoreError> {
     let version = connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
-    if version != STORE_SCHEMA_VERSION {
+    let legacy_read = version == 4 && connection.is_readonly(rusqlite::MAIN_DB)?;
+    if version != STORE_SCHEMA_VERSION && !legacy_read {
         return Err(CloudStoreError::UnsupportedSchema(version));
     }
     validate_allocation_schema(connection)?;
     creation_fences::validate_schema(connection)?;
+    if legacy_read {
+        // Existing inventory must remain readable without migration. Partial
+        // first-pin metadata is never treated as compatible legacy storage.
+        let partial: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema
+             WHERE tbl_name = 'remote_first_pin_intents' COLLATE NOCASE
+                OR name = 'remote_first_pin_intents' COLLATE NOCASE)",
+            [],
+            |row| row.get(0),
+        )?;
+        return if partial {
+            Err(CloudStoreError::InvalidAllocationSchema)
+        } else {
+            Ok(())
+        };
+    }
     validate_first_pin_schema(connection)
 }
 

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -110,7 +110,8 @@ fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations
     let connection = open_connection(fixture.store.path()).expect("raw store");
     connection
         .execute_batch(
-            "DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; PRAGMA user_version=2;",
+            "DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences;
+             DROP TABLE remote_runtime_allocations; PRAGMA user_version=2;",
         )
         .expect("schema two fixture");
     let before = saved_bytes(&connection);
@@ -120,7 +121,7 @@ fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations
         connection
             .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
             .expect("version"),
-        4
+        5
     );
     assert_eq!(allocation_count(&connection), 0);
     let workflow = fixture.workflow.workflow();
@@ -187,6 +188,24 @@ fn schema_three_definitions_match_the_frozen_storage_format() {
         "CREATE UNIQUE INDEX remote_runtime_allocations_job ON remote_runtime_allocations(job_id)",
     );
     assert_eq!(REMOTE_ALLOCATION_SCHEMA.join(";\n"), frozen);
+}
+
+#[test]
+fn first_pin_schema_five_definition_matches_the_frozen_storage_format() {
+    assert_eq!(
+        FIRST_PIN_SCHEMA,
+        concat!(
+            "CREATE TABLE remote_first_pin_intents (\n",
+            "    workspace_local_id TEXT PRIMARY KEY NOT NULL REFERENCES remote_runtime_allocations(workspace_local_id),\n",
+            "    session_id TEXT NOT NULL,\n",
+            "    generation INTEGER NOT NULL CHECK (generation > 0),\n",
+            "    workflow_id TEXT NOT NULL UNIQUE,\n",
+            "    job_id TEXT NOT NULL UNIQUE,\n",
+            "    version INTEGER NOT NULL CHECK (version = 1),\n",
+            "    request_digest TEXT NOT NULL CHECK (length(request_digest) = 64)\n",
+            ") STRICT, WITHOUT ROWID",
+        )
+    );
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
@@ -72,7 +72,11 @@ impl CloudWorkflowStore {
         }
         // Absence never clears saved identity, panel intent, checkpoints, or permits replacement.
         runtime.phase = RemoteRuntimePhase::Reconciling;
+        if runtime.ssh.is_some() {
+            super::setup::consume_first_pin_intent(&transaction, &current)?;
+        }
         if next == *current.workspace.state() {
+            transaction.commit()?;
             return Ok(current);
         }
         let workspace = WorkspaceReplacement::new(&current.workspace, &next)?.persist(&transaction)?;

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
@@ -64,7 +64,8 @@ impl CloudWorkflowStore {
     /// authority. Claimed/provisioning attempts remain inspectable after restart or
     /// setup expiry; the provider and pin CAS still enforce ownership and lifetime.
     /// `None` requires retained trust or refusal, never a missing-pin bootstrap fallback.
-    /// A saved full pin always returns `None`. No database creation/migration or writes.
+    /// A saved full pin or validated schema-four store returns `None`.
+    /// No database creation/migration or writes.
     /// # Errors
     /// Rejects snapshot drift, management intent, missing requests and corrupt storage.
     pub fn load_remote_first_pin_request(
@@ -76,6 +77,9 @@ impl CloudWorkflowStore {
         ensure_current_schema(&transaction)?;
         let current = exact_allocation(&transaction, expected)?;
         let request = current.recovery_request()?;
+        if transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))? == 4 {
+            return Ok(None);
+        }
         let runtime = current
             .workspace
             .state()

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
@@ -1,32 +1,177 @@
 //! Setup admission is a point-in-time check, never a provider creation grant.
 
-use super::super::{current_unix_millis, database::ensure_current_schema, validate_claim_target};
+use super::super::{
+    CloudStoreError, current_unix_millis,
+    database::{ensure_current_schema, open_read_connection},
+    validate_claim_target,
+};
 use super::{CloudWorkflowStore, Error, RemoteRuntimePhase, StoredRemoteAllocation, binding, request::CLAIM_LOOKUP};
+use crate::cloud_run::{ArtifactDigest, CloudProvider, interactive_worker::InteractiveWorkerRequest};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 impl CloudWorkflowStore {
     pub(crate) fn validate_unclaimed_remote_setup(&self, expected: &StoredRemoteAllocation) -> Result<(), Error> {
         let mut connection = self.connection()?;
         let transaction = connection.transaction()?;
         ensure_current_schema(&transaction)?;
-        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)?
-            .ok_or(Error::UnboundRuntime)?;
-        let current = binding::recover(&transaction, &row)?;
-        if current != *expected {
-            return Err(Error::SnapshotConflict);
+        let current = exact_allocation(&transaction, expected)?;
+        validate_unclaimed(&transaction, &current)
+    }
+
+    /// Explicitly retain first-pin intent for this unclaimed, task-free `RunPod` setup.
+    /// The caller selects an approved entrypoint-only image and must not run setup or
+    /// tasks before the first pin is committed. The private client key must already be
+    /// durable and its public request reserved. No provider or credential I/O occurs.
+    /// This neither consumes a creation grant nor authorizes tasks or attachment.
+    /// Run synchronously off the render thread; repeated pre-claim calls are idempotent.
+    /// # Errors
+    /// Rejects stale/foreign allocations, unsupported targets, missing requests, late
+    /// intent, expired setup and malformed storage without changing existing snapshots.
+    pub fn record_remote_first_pin_intent(&self, expected: &StoredRemoteAllocation) -> Result<(), Error> {
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        ensure_current_schema(&transaction)?;
+        let current = exact_allocation(&transaction, expected)?;
+        validate_unclaimed(&transaction, &current)?;
+        let request = current.worker_request()?;
+        if request.target.provider != CloudProvider::RunPod {
+            return Err(Error::RuntimeSetupUnavailable);
+        }
+        if has_first_pin_intent(&transaction, &current, &request)? {
+            return Ok(());
         }
         let state = current.workspace.state();
         let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
-        if runtime.phase != RemoteRuntimePhase::Provisioning
-            || runtime.worker.is_some()
-            || runtime.cleanup.is_some()
-            || current.workflow.workflow().retain_until_millis < current_unix_millis()?
-            || validate_claim_target(current.workflow.workflow(), runtime.job_id, &state.spec.target).is_err()
-            || transaction.query_row(CLAIM_LOOKUP, [runtime.workflow_id.to_string()], |row| {
-                row.get::<_, bool>(0)
-            })?
-        {
-            return Err(Error::RuntimeSetupUnavailable);
-        }
+        transaction.execute(
+            "INSERT INTO remote_first_pin_intents
+             (workspace_local_id, session_id, generation, workflow_id, job_id, version, request_digest)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6)",
+            params![
+                state.spec.workspace_local_id,
+                current.workspace.session_id(),
+                i64::try_from(runtime.generation).map_err(|_| Error::GenerationExhausted)?,
+                request.workflow_id.to_string(),
+                request.job_id.to_string(),
+                request_digest(&request)?.as_str(),
+            ],
+        )?;
+        transaction.commit()?;
         Ok(())
     }
+
+    /// Read positive first-pin intent for this exact owned allocation and request.
+    /// `Some` identifies an explicitly task-free initial setup, never creation or task
+    /// authority. Claimed/provisioning attempts remain inspectable after restart or
+    /// setup expiry; the provider and pin CAS still enforce ownership and lifetime.
+    /// `None` requires retained trust or refusal, never a missing-pin bootstrap fallback.
+    /// A saved full pin always returns `None`. No database creation/migration or writes.
+    /// # Errors
+    /// Rejects snapshot drift, management intent, missing requests and corrupt storage.
+    pub fn load_remote_first_pin_request(
+        &self,
+        expected: &StoredRemoteAllocation,
+    ) -> Result<Option<InteractiveWorkerRequest>, Error> {
+        let mut connection = open_read_connection(self.path())?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        let current = exact_allocation(&transaction, expected)?;
+        let request = current.recovery_request()?;
+        let runtime = current
+            .workspace
+            .state()
+            .runtime
+            .as_ref()
+            .ok_or(Error::UnboundRuntime)?;
+        if runtime.ssh.is_some()
+            || !matches!(
+                runtime.phase,
+                RemoteRuntimePhase::Provisioning | RemoteRuntimePhase::Reconciling
+            )
+        {
+            return Ok(None);
+        }
+        Ok(has_first_pin_intent(&transaction, &current, &request)?.then_some(request))
+    }
+}
+
+fn exact_allocation(
+    connection: &Connection,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, Error> {
+    let row = binding::load_workspace(connection, &expected.workspace.state().spec.workspace_local_id)?
+        .ok_or(Error::UnboundRuntime)?;
+    let current = binding::recover(connection, &row)?;
+    if current != *expected {
+        return Err(Error::SnapshotConflict);
+    }
+    Ok(current)
+}
+
+fn validate_unclaimed(connection: &Connection, current: &StoredRemoteAllocation) -> Result<(), Error> {
+    let state = current.workspace.state();
+    let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+    if runtime.phase != RemoteRuntimePhase::Provisioning
+        || runtime.worker.is_some()
+        || runtime.ssh.is_some()
+        || runtime.cleanup.is_some()
+        || current.workflow.workflow().retain_until_millis < current_unix_millis()?
+        || validate_claim_target(current.workflow.workflow(), runtime.job_id, &state.spec.target).is_err()
+        || connection.query_row(CLAIM_LOOKUP, [runtime.workflow_id.to_string()], |row| {
+            row.get::<_, bool>(0)
+        })?
+    {
+        return Err(Error::RuntimeSetupUnavailable);
+    }
+    Ok(())
+}
+
+fn request_digest(request: &InteractiveWorkerRequest) -> Result<ArtifactDigest, Error> {
+    // Version-one binding: request IDs are separate columns; hash the exact target
+    // and canonical reserved client key with a fixed JSON tuple representation.
+    let bytes = serde_json::to_vec(&(1_u32, &request.target, &request.ssh_public_key))
+        .map_err(|_| Error::InvalidStoredSnapshot)?;
+    Ok(ArtifactDigest::sha256(&bytes))
+}
+
+fn has_first_pin_intent(
+    connection: &Connection,
+    allocation: &StoredRemoteAllocation,
+    request: &InteractiveWorkerRequest,
+) -> Result<bool, Error> {
+    let state = allocation.workspace.state();
+    let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+    let matches: Option<bool> = connection
+        .query_row(
+            "SELECT session_id = ?2 AND generation = ?3 AND workflow_id = ?4 AND job_id = ?5
+             AND version = 1 AND request_digest = ?6
+         FROM remote_first_pin_intents WHERE workspace_local_id = ?1",
+            params![
+                state.spec.workspace_local_id,
+                allocation.workspace.session_id(),
+                i64::try_from(runtime.generation).map_err(|_| Error::GenerationExhausted)?,
+                request.workflow_id.to_string(),
+                request.job_id.to_string(),
+                request_digest(request)?.as_str()
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    match matches {
+        Some(true) if request.target.provider == CloudProvider::RunPod => Ok(true),
+        Some(_) => Err(CloudStoreError::InvalidRemoteAllocation.into()),
+        None => Ok(false),
+    }
+}
+
+pub(super) fn consume_first_pin_intent(
+    transaction: &Transaction<'_>,
+    allocation: &StoredRemoteAllocation,
+) -> Result<(), Error> {
+    if has_first_pin_intent(transaction, allocation, &allocation.worker_request()?)? {
+        transaction.execute(
+            "DELETE FROM remote_first_pin_intents WHERE workspace_local_id = ?1",
+            [&allocation.workspace.state().spec.workspace_local_id],
+        )?;
+    }
+    Ok(())
 }

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
@@ -903,14 +903,14 @@ mod first_pin {
             .expect("fixture connection")
             .execute_batch("DROP TABLE remote_first_pin_intents; PRAGMA user_version=4")
             .expect("schema-four fixture");
-        assert!(matches!(
-            CloudWorkflowStore::open_read_only_path(fixture.store.path()),
-            Err(CloudStoreError::UnsupportedSchema(4))
-        ));
-        assert!(matches!(
-            fixture.store.load_remote_first_pin_request(&saved),
-            Err(Error::Storage(CloudStoreError::UnsupportedSchema(4)))
-        ));
+        CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("compatible read-only open");
+        assert_eq!(
+            fixture
+                .store
+                .load_remote_first_pin_request(&saved)
+                .expect("no legacy intent"),
+            None
+        );
         let connection = Connection::open(fixture.store.path()).expect("fixture connection");
         assert_eq!(
             connection

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
@@ -126,7 +126,9 @@ fn allocation_reopens_one_exact_identity_without_consuming_creation_or_reallocat
     assert_eq!(workflow.nodes[0].source.as_ref(), Some(&state.spec.repository));
     Connection::open(store.path())
         .expect("schema-three allocation fixture")
-        .execute_batch("DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3")
+        .execute_batch(
+            "DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
+        )
         .expect("downgrade fixture before recovery");
     let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
     assert_eq!(
@@ -508,4 +510,465 @@ fn a_setup_deadline_that_expires_waiting_for_the_write_lock_never_allocates() {
             .expect("unchanged"),
         Some(fixture.original)
     );
+}
+
+mod first_pin {
+    use super::*;
+    use crate::cloud_run::interactive_worker::{InteractiveWorkerLifecycle, InteractiveWorkerStatus};
+
+    fn pending() -> (Fixture, StoredRemoteAllocation) {
+        let mut fixture = fixture();
+        let mut state = fixture.original.state().clone();
+        state.spec.target.provider = CloudProvider::RunPod;
+        fixture.original = fixture
+            .store
+            .replace_remote_workspace(&fixture.original, &state)
+            .expect("target");
+        let allocation = fixture.allocate();
+        (fixture, allocation)
+    }
+
+    pub(super) fn reserved() -> (Fixture, StoredRemoteAllocation) {
+        let (fixture, allocation) = pending();
+        let key = observed_worker(allocation.workspace().state()).ssh_public_key;
+        let saved = fixture
+            .store
+            .reserve_remote_worker_request(&allocation, &key)
+            .expect("request");
+        (fixture, saved)
+    }
+
+    pub(super) fn intent_count(store: &CloudWorkflowStore) -> i64 {
+        Connection::open(store.path())
+            .expect("fixture connection")
+            .query_row("SELECT COUNT(*) FROM remote_first_pin_intents", [], |row| row.get(0))
+            .expect("intent count")
+    }
+
+    pub(super) fn status(saved: &StoredRemoteAllocation, ready: bool) -> InteractiveWorkerStatus {
+        let worker = observed_worker(saved.workspace().state());
+        let ssh = ready.then(|| InteractiveWorkerSshEndpoint {
+            host: "127.0.0.1".into(),
+            port: 22,
+            username: "root".into(),
+            host_key: worker.ssh_public_key.clone(),
+        });
+        InteractiveWorkerStatus {
+            worker,
+            ssh,
+            lifecycle: if ready {
+                InteractiveWorkerLifecycle::Ready
+            } else {
+                InteractiveWorkerLifecycle::Provisioning
+            },
+        }
+    }
+
+    fn expire(fixture: &Fixture) -> StoredRemoteAllocation {
+        let mut workflow = fixture.recover().workflow().workflow().clone();
+        workflow.created_at_millis = 1000;
+        workflow.updated_at_millis = 1000;
+        workflow.retain_until_millis = 2000;
+        Connection::open(fixture.store.path())
+            .expect("fixture connection")
+            .execute(
+                "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000,
+             retain_until_millis=2000, snapshot=?1 WHERE workflow_id=?2",
+                params![encode_workflow(&workflow).expect("snapshot"), workflow.id.to_string()],
+            )
+            .expect("expired fixture");
+        fixture.recover()
+    }
+
+    #[test]
+    fn first_pin_intent_requires_reserved_identity_and_never_consumes_or_renews_creation() {
+        let (fixture, allocation) = pending();
+        let store = &fixture.store;
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&allocation),
+            Err(Error::RuntimeRequestRequired)
+        ));
+        assert_eq!(intent_count(store), 0);
+        let saved = store
+            .reserve_remote_worker_request(
+                &allocation,
+                &observed_worker(allocation.workspace().state()).ssh_public_key,
+            )
+            .expect("reserve");
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&allocation),
+            Err(Error::SnapshotConflict)
+        ));
+        assert_eq!(store.load_remote_first_pin_request(&saved).expect("unmarked"), None);
+        store.record_remote_first_pin_intent(&saved).expect("explicit intent");
+        store
+            .record_remote_first_pin_intent(&saved)
+            .expect("idempotent pre-claim intent");
+        assert_eq!(
+            store.load_remote_first_pin_request(&saved).expect("positive"),
+            Some(saved.worker_request().expect("request"))
+        );
+        assert_eq!(fixture.recover(), saved);
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+        assert_eq!(intent_count(store), 1);
+        assert!(claim(store, &saved).expect("first claim"));
+        assert!(!claim(store, &saved).expect("one shot"));
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&saved),
+            Err(Error::RuntimeSetupUnavailable)
+        ));
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+        assert_eq!(intent_count(store), 1);
+    }
+
+    #[test]
+    fn first_pin_intent_survives_lost_response_provisioning_and_restart_then_is_consumed() {
+        let (fixture, saved) = reserved();
+        fixture.store.record_remote_first_pin_intent(&saved).expect("intent");
+        assert!(claim(&fixture.store, &saved).expect("claim"));
+        let lost = fixture
+            .store
+            .record_remote_worker_recovery(&saved, None)
+            .expect("lost response");
+        assert!(
+            lost.workspace()
+                .state()
+                .runtime
+                .as_ref()
+                .expect("runtime")
+                .worker
+                .is_none()
+        );
+        let store = CloudWorkflowStore::open_path(fixture.store.path()).expect("restart");
+        assert_eq!(
+            store.load_remote_first_pin_request(&lost).expect("restart intent"),
+            Some(saved.worker_request().expect("request"))
+        );
+        let provisioned = store
+            .record_remote_worker_recovery(&lost, Some(&status(&lost, false)))
+            .expect("provisioning");
+        assert_eq!(intent_count(&store), 1);
+        assert!(
+            store
+                .load_remote_first_pin_request(&provisioned)
+                .expect("pending pin")
+                .is_some()
+        );
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&provisioned),
+            Err(Error::RuntimeSetupUnavailable)
+        ));
+        let pinned = store
+            .record_remote_worker_recovery(&provisioned, Some(&status(&provisioned, true)))
+            .expect("first pin");
+        let runtime = pinned.workspace().state().runtime.as_ref().expect("runtime");
+        assert!(runtime.ssh.is_some());
+        assert_eq!(runtime.phase, RemoteRuntimePhase::Reconciling);
+        assert_eq!(intent_count(&store), 0);
+        assert_eq!(
+            store.load_remote_first_pin_request(&pinned).expect("retained trust"),
+            None
+        );
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&pinned),
+            Err(Error::RuntimeSetupUnavailable)
+        ));
+        assert_eq!(
+            store
+                .record_remote_worker_recovery(&pinned, None)
+                .expect("later absence"),
+            pinned
+        );
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+        assert_eq!(intent_count(&store), 0);
+    }
+
+    #[test]
+    fn first_pin_snapshot_and_intent_roll_back_together_after_real_write_failure() {
+        let (fixture, saved) = reserved();
+        let store = &fixture.store;
+        store.record_remote_first_pin_intent(&saved).expect("intent");
+        let connection = Connection::open(store.path()).expect("fixture connection");
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_first_pin BEFORE UPDATE ON remote_workspaces
+            BEGIN SELECT RAISE(ABORT, 'synthetic snapshot failure'); END",
+            )
+            .expect("failure injection");
+        let ready = status(&saved, true);
+        assert!(matches!(
+            store.record_remote_worker_recovery(&saved, Some(&ready)),
+            Err(Error::Database(_))
+        ));
+        assert_eq!(fixture.recover(), saved);
+        assert_eq!(intent_count(store), 1);
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+        connection
+            .execute_batch("DROP TRIGGER fail_first_pin")
+            .expect("remove injection");
+        let pinned = store
+            .record_remote_worker_recovery(&saved, Some(&ready))
+            .expect("retry pin");
+        assert_eq!(intent_count(store), 0);
+        assert!(matches!(
+            store.record_remote_worker_recovery(&saved, Some(&ready)),
+            Err(Error::SnapshotConflict)
+        ));
+        let mut changed_pin = ready;
+        changed_pin.ssh.as_mut().expect("ssh").host = "127.0.0.2".into();
+        assert!(matches!(
+            store.record_remote_worker_recovery(&pinned, Some(&changed_pin)),
+            Err(Error::InvalidWorkerObservation)
+        ));
+        assert_eq!(fixture.recover(), pinned);
+        assert_eq!(intent_count(store), 0);
+    }
+
+    #[test]
+    fn first_pin_intent_refuses_late_setup_but_survives_its_original_setup_deadline() {
+        for retain_intent in [false, true] {
+            let (fixture, saved) = reserved();
+            if retain_intent {
+                fixture
+                    .store
+                    .record_remote_first_pin_intent(&saved)
+                    .expect("initial intent");
+            }
+            let expired = expire(&fixture);
+            assert!(matches!(
+                fixture.store.record_remote_first_pin_intent(&expired),
+                Err(Error::RuntimeSetupUnavailable)
+            ));
+            assert_eq!(
+                fixture
+                    .store
+                    .load_remote_first_pin_request(&expired)
+                    .expect("read-only expiry"),
+                retain_intent.then(|| saved.worker_request().expect("request"))
+            );
+            assert_eq!(fixture.recover(), expired);
+            assert_eq!(intent_count(&fixture.store), i64::from(retain_intent));
+            assert!(matches!(
+                claim(&fixture.store, &expired),
+                Err(CloudStoreError::WorkflowExpired(_))
+            ));
+        }
+        for observed in [false, true] {
+            let (fixture, saved) = reserved();
+            let current = if observed {
+                fixture
+                    .store
+                    .record_remote_worker_recovery(&saved, Some(&status(&saved, false)))
+                    .expect("legacy observation")
+            } else {
+                assert!(claim(&fixture.store, &saved).expect("legacy claim"));
+                saved
+            };
+            assert!(matches!(
+                fixture.store.record_remote_first_pin_intent(&current),
+                Err(Error::RuntimeSetupUnavailable)
+            ));
+            assert_eq!(
+                fixture
+                    .store
+                    .load_remote_first_pin_request(&current)
+                    .expect("no inferred authority"),
+                None
+            );
+            assert_eq!(intent_count(&fixture.store), 0);
+        }
+    }
+
+    #[test]
+    fn first_pin_lookup_matches_both_snapshots_and_does_not_authorize_generic_replacement() {
+        let (fixture, saved) = reserved();
+        let store = &fixture.store;
+        store.record_remote_first_pin_intent(&saved).expect("intent");
+        let mut next = saved.workflow().workflow().clone();
+        next.title = "Updated display title".into();
+        next.updated_at_millis += 1;
+        store.replace(saved.workflow(), &next).expect("workflow-only revision");
+        assert!(matches!(
+            store.load_remote_first_pin_request(&saved),
+            Err(Error::SnapshotConflict)
+        ));
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&saved),
+            Err(Error::SnapshotConflict)
+        ));
+        let current = fixture.recover();
+        assert!(
+            store
+                .load_remote_first_pin_request(&current)
+                .expect("fresh snapshots")
+                .is_some()
+        );
+        for retire in [false, true] {
+            let mut state = current.workspace().state().clone();
+            if retire {
+                state.runtime = None;
+            } else {
+                state.spec.generation += 1;
+                state.runtime.as_mut().expect("runtime").generation += 1;
+            }
+            assert!(store.replace_remote_workspace(current.workspace(), &state).is_err());
+        }
+        assert!(matches!(
+            store.allocate_remote_runtime(current.workspace(), i64::MAX),
+            Err(Error::RuntimeAlreadyActive)
+        ));
+        let (_, foreign) = reserved();
+        assert!(matches!(
+            store.load_remote_first_pin_request(&foreign),
+            Err(Error::SnapshotConflict)
+        ));
+        assert!(matches!(
+            store.record_remote_first_pin_intent(&foreign),
+            Err(Error::SnapshotConflict)
+        ));
+        assert_eq!(fixture.recover(), current);
+        assert_eq!(intent_count(store), 1);
+        assert_eq!(fixture.counts(), [1, 1, 0]);
+    }
+
+    #[test]
+    fn first_pin_lookup_rejects_malformed_matching_rows_and_never_adopts_orphans() {
+        for alteration in [
+            "session_id='22222222-2222-4222-8222-222222222222'",
+            "generation=2",
+            "workflow_id='33333333-3333-4333-8333-333333333333'",
+            "job_id='44444444-4444-4444-8444-444444444444'",
+            "version=2",
+            "request_digest=printf('%064d', 0)",
+            "session_id=printf('%4096s', 'x')",
+        ] {
+            let (fixture, saved) = reserved();
+            fixture.store.record_remote_first_pin_intent(&saved).expect("intent");
+            let connection = Connection::open(fixture.store.path()).expect("fixture connection");
+            connection
+                .execute_batch(&format!(
+                    "PRAGMA ignore_check_constraints=ON; UPDATE remote_first_pin_intents SET {alteration}"
+                ))
+                .expect("corrupt intent");
+            assert!(
+                matches!(
+                    fixture.store.load_remote_first_pin_request(&saved),
+                    Err(Error::Storage(CloudStoreError::InvalidRemoteAllocation))
+                ),
+                "{alteration}"
+            );
+            assert!(
+                matches!(
+                    fixture.store.record_remote_first_pin_intent(&saved),
+                    Err(Error::Storage(CloudStoreError::InvalidRemoteAllocation))
+                ),
+                "{alteration}"
+            );
+            assert_eq!(fixture.recover(), saved);
+            assert_eq!(fixture.counts(), [1, 1, 0]);
+        }
+        let (fixture, saved) = reserved();
+        fixture.store.record_remote_first_pin_intent(&saved).expect("intent");
+        Connection::open(fixture.store.path())
+            .expect("fixture connection")
+            .execute_batch("PRAGMA foreign_keys=OFF; UPDATE remote_first_pin_intents SET workspace_local_id='orphan'")
+            .expect("orphan");
+        assert_eq!(
+            fixture
+                .store
+                .load_remote_first_pin_request(&saved)
+                .expect("orphan ignored"),
+            None
+        );
+        assert!(fixture.store.record_remote_first_pin_intent(&saved).is_err());
+        assert_eq!(intent_count(&fixture.store), 1);
+    }
+
+    #[test]
+    fn first_pin_migration_never_backfills_legacy_allocations_or_changes_snapshots_and_claims() {
+        let (fixture, saved) = reserved();
+        assert!(claim(&fixture.store, &saved).expect("legacy claim"));
+        let snapshots = || {
+            Connection::open(fixture.store.path())
+                .expect("fixture connection")
+                .query_row(
+                    "SELECT (SELECT snapshot FROM remote_workspaces), (SELECT snapshot FROM cloud_workflows)",
+                    [],
+                    |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?)),
+                )
+                .expect("raw snapshots")
+        };
+        let before = snapshots();
+        Connection::open(fixture.store.path())
+            .expect("fixture connection")
+            .execute_batch("DROP TABLE remote_first_pin_intents; PRAGMA user_version=4")
+            .expect("schema-four fixture");
+        assert!(matches!(
+            CloudWorkflowStore::open_read_only_path(fixture.store.path()),
+            Err(CloudStoreError::UnsupportedSchema(4))
+        ));
+        assert!(matches!(
+            fixture.store.load_remote_first_pin_request(&saved),
+            Err(Error::Storage(CloudStoreError::UnsupportedSchema(4)))
+        ));
+        let connection = Connection::open(fixture.store.path()).expect("fixture connection");
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("unchanged version"),
+            4
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_schema WHERE name='remote_first_pin_intents'",
+                    [],
+                    |row| row.get::<_, i64>(0)
+                )
+                .expect("no read repair"),
+            0
+        );
+        let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("explicit migration");
+        assert_eq!(snapshots(), before);
+        assert_eq!(fixture.recover(), saved);
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+        assert_eq!(intent_count(&reopened), 0);
+        assert_eq!(
+            reopened
+                .load_remote_first_pin_request(&saved)
+                .expect("no legacy bootstrap"),
+            None
+        );
+        assert!(!claim(&reopened, &saved).expect("claim preserved"));
+    }
+
+    #[test]
+    fn first_pin_and_creation_race_cannot_publish_a_late_intent() {
+        let (fixture, saved) = reserved();
+        let barrier = Arc::new(Barrier::new(2));
+        let claimant = {
+            let barrier = Arc::clone(&barrier);
+            let store = fixture.store.clone();
+            let saved = saved.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                claim(&store, &saved).expect("claim")
+            })
+        };
+        barrier.wait();
+        let result = fixture.store.record_remote_first_pin_intent(&saved);
+        assert!(claimant.join().expect("claimant"));
+        match result {
+            Ok(()) => assert_eq!(intent_count(&fixture.store), 1),
+            Err(Error::RuntimeSetupUnavailable) => assert_eq!(intent_count(&fixture.store), 0),
+            Err(error) => panic!("unexpected intent result: {error}"),
+        }
+        assert!(matches!(
+            fixture.store.record_remote_first_pin_intent(&saved),
+            Err(Error::RuntimeSetupUnavailable)
+        ));
+        assert!(!claim(&fixture.store, &saved).expect("no repeated grant"));
+        assert_eq!(fixture.recover(), saved);
+        assert_eq!(fixture.counts(), [1, 1, 1]);
+    }
 }

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests/hardening.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests/hardening.rs
@@ -1,7 +1,101 @@
 use super::super::super::{MAX_RECOVERED_SNAPSHOT_BYTES, MAX_SNAPSHOT_BYTES};
+use super::first_pin::{intent_count, reserved, status};
 use super::*;
 use crate::PanelKind;
 use crate::remote_workspace::RemotePanelBinding;
+
+#[test]
+fn first_pin_intent_rejects_other_providers_management_and_saved_ssh_without_worker() {
+    let fixture = fixture();
+    let allocation = fixture.allocate();
+    let saved = fixture
+        .store
+        .reserve_remote_worker_request(
+            &allocation,
+            &observed_worker(allocation.workspace().state()).ssh_public_key,
+        )
+        .expect("local request");
+    assert!(matches!(
+        fixture.store.record_remote_first_pin_intent(&saved),
+        Err(Error::RuntimeSetupUnavailable)
+    ));
+    assert_eq!(intent_count(&fixture.store), 0);
+    let (fixture, saved) = reserved();
+    fixture.store.record_remote_first_pin_intent(&saved).expect("intent");
+    let mut state = saved.workspace().state().clone();
+    state.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 1000,
+    });
+    fixture
+        .store
+        .replace_remote_workspace(saved.workspace(), &state)
+        .expect("cleanup");
+    let current = fixture.recover();
+    assert!(matches!(
+        fixture.store.record_remote_first_pin_intent(&current),
+        Err(Error::RuntimeSetupUnavailable)
+    ));
+    assert!(matches!(
+        fixture.store.load_remote_first_pin_request(&current),
+        Err(Error::RuntimeRecoveryUnavailable)
+    ));
+    assert_eq!(intent_count(&fixture.store), 1);
+    let (fixture, saved) = reserved();
+    let connection = Connection::open(fixture.store.path()).expect("fixture connection");
+    let bytes: Vec<u8> = connection
+        .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
+        .expect("snapshot");
+    let mut snapshot: serde_json::Value = serde_json::from_slice(&bytes).expect("fixture JSON");
+    snapshot["state"]["runtime"]["ssh"] = serde_json::to_value(status(&saved, true).ssh).expect("endpoint");
+    connection
+        .execute(
+            "UPDATE remote_workspaces SET snapshot=?1",
+            [serde_json::to_vec(&snapshot).expect("corrupt JSON")],
+        )
+        .expect("corrupt fixture");
+    assert!(matches!(
+        fixture.store.record_remote_first_pin_intent(&saved),
+        Err(Error::Storage(CloudStoreError::InvalidRemoteAllocation))
+    ));
+    assert_eq!(intent_count(&fixture.store), 0);
+}
+
+#[test]
+fn first_pin_lookup_refuses_schema_drift_and_missing_storage_without_repair() {
+    for corruption in [
+        "DROP TABLE remote_first_pin_intents",
+        "CREATE INDEX unexpected_first_pin_index ON remote_first_pin_intents(generation)",
+        "ALTER TABLE remote_first_pin_intents ADD COLUMN unexpected INTEGER",
+        "CREATE TRIGGER unexpected_first_pin_trigger AFTER DELETE ON remote_first_pin_intents BEGIN SELECT 1; END",
+    ] {
+        let (fixture, saved) = reserved();
+        fixture.store.record_remote_first_pin_intent(&saved).expect("intent");
+        Connection::open(fixture.store.path())
+            .expect("fixture connection")
+            .execute_batch(corruption)
+            .expect("schema drift");
+        assert!(matches!(
+            fixture.store.load_remote_first_pin_request(&saved),
+            Err(Error::Storage(CloudStoreError::InvalidAllocationSchema))
+        ));
+        assert!(matches!(
+            CloudWorkflowStore::open_path(fixture.store.path()),
+            Err(CloudStoreError::InvalidAllocationSchema)
+        ));
+    }
+    let (fixture, saved) = reserved();
+    fixture.store.record_remote_first_pin_intent(&saved).expect("intent");
+    let parent = fixture.store.path().parent().expect("private parent");
+    let retained = parent.with_file_name("retained-control");
+    std::fs::rename(parent, &retained).expect("retain disappeared fixture database");
+    assert!(fixture.store.load_remote_first_pin_request(&saved).is_err());
+    assert!(!parent.exists());
+    assert!(!fixture.store.path().exists());
+    std::fs::rename(retained, parent).expect("restore fixture");
+    assert_eq!(fixture.recover(), saved);
+    assert_eq!(intent_count(&fixture.store), 1);
+}
 
 #[test]
 fn invalid_setup_retention_and_exhausted_generation_never_allocate() {
@@ -147,7 +241,9 @@ fn active_legacy_unbound_records_stay_recoverable_without_allocation() {
         serde_json::to_vec(&serde_json::json!({"session_id": OWNER, "state": state})).expect("legacy snapshot");
     let connection = Connection::open(store.path()).expect("raw legacy fixture");
     connection
-        .execute_batch("DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3")
+        .execute_batch(
+            "DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
+        )
         .expect("schema-three fixture before migration");
     connection
         .execute(
@@ -201,7 +297,9 @@ fn migrated_bound_allocations_still_require_their_positive_binding() {
         let saved = fixture.allocate();
         let connection = Connection::open(fixture.store.path()).expect("raw migration fixture");
         connection
-            .execute_batch("DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3")
+            .execute_batch(
+                "DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
+            )
             .expect("schema-three bound allocation");
         let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("migrate bound allocation");
         assert_eq!(creation_denial_count(&connection), 1);

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests/hardening.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests/hardening.rs
@@ -5,6 +5,126 @@ use crate::PanelKind;
 use crate::remote_workspace::RemotePanelBinding;
 
 #[test]
+fn first_pin_schema_four_inventory_and_clones_remain_noncreating() {
+    let (fixture, saved) = reserved();
+    assert!(claim(&fixture.store, &saved).expect("legacy claim"));
+    let connection = Connection::open(fixture.store.path()).expect("fixture connection");
+    connection
+        .execute_batch("DROP TABLE remote_first_pin_intents; PRAGMA user_version=4")
+        .expect("legacy schema");
+    let before: (Vec<u8>, Vec<u8>, i64) = connection
+        .query_row(
+            "SELECT (SELECT snapshot FROM remote_workspaces), (SELECT snapshot FROM cloud_workflows),
+         (SELECT claimed_at_millis FROM cloud_worker_creation_claims)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("legacy records");
+    let read_only = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("legacy inventory opener");
+    for reader in [read_only.clone(), read_only] {
+        let page = reader.list_remote_environment_page(None).expect("zero-view inventory");
+        assert_eq!(page.records, vec![saved.workspace().clone()]);
+        assert_eq!(page.next_cursor, None);
+        assert_eq!(
+            reader.load_remote_workspace(OWNER, "workspace").expect("workspace"),
+            Some(saved.workspace().clone())
+        );
+        assert_eq!(
+            reader.load_remote_allocation(OWNER, "workspace").expect("allocation"),
+            Some(saved.clone())
+        );
+        assert_eq!(
+            reader.load(saved.workflow().workflow().id).expect("workflow"),
+            Some(saved.workflow().clone())
+        );
+        assert_eq!(
+            reader
+                .load_remote_first_pin_request(&saved)
+                .expect("legacy is not intent"),
+            None
+        );
+        assert!(matches!(
+            reader.create(&retained_workflow(CloudProvider::LocalDocker, 1000)),
+            Err(CloudStoreError::Database(_))
+        ));
+    }
+    assert!(matches!(
+        fixture.store.record_remote_first_pin_intent(&saved),
+        Err(Error::Storage(CloudStoreError::UnsupportedSchema(4)))
+    ));
+    let after = connection
+        .query_row(
+            "SELECT (SELECT snapshot FROM remote_workspaces), (SELECT snapshot FROM cloud_workflows),
+         (SELECT claimed_at_millis FROM cloud_worker_creation_claims)",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .expect("unchanged records");
+    assert_eq!(after, before);
+    assert_eq!(fixture.counts(), [1, 1, 1]);
+    assert_eq!(
+        connection
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .expect("not migrated"),
+        4
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_schema WHERE name='remote_first_pin_intents'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .expect("no backfill"),
+        0
+    );
+}
+
+#[test]
+fn first_pin_schema_four_refuses_partial_objects_and_query_only_writers() {
+    for corruption in [
+        "",
+        "DROP TABLE remote_first_pin_intents; DROP INDEX remote_runtime_allocations_workflow",
+        "DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences",
+    ] {
+        let (fixture, saved) = reserved();
+        let connection = Connection::open(fixture.store.path()).expect("fixture connection");
+        connection.execute_batch(corruption).expect("partial fixture");
+        connection
+            .pragma_update(None, "user_version", 4)
+            .expect("legacy version");
+        assert!(CloudWorkflowStore::open_read_only_path(fixture.store.path()).is_err());
+        assert!(fixture.store.load_remote_first_pin_request(&saved).is_err());
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("unchanged version"),
+            4
+        );
+    }
+    let (fixture, _) = reserved();
+    let connection = Connection::open(fixture.store.path()).expect("fixture connection");
+    connection
+        .execute_batch("DROP TABLE remote_first_pin_intents; PRAGMA user_version=4; PRAGMA query_only=ON")
+        .expect("query-only writer");
+    assert!(
+        !connection
+            .is_readonly(rusqlite::MAIN_DB)
+            .expect("actual connection mode")
+    );
+    assert!(matches!(
+        ensure_current_schema(&connection),
+        Err(CloudStoreError::UnsupportedSchema(4))
+    ));
+}
+
+#[test]
 fn first_pin_intent_rejects_other_providers_management_and_saved_ssh_without_worker() {
     let fixture = fixture();
     let allocation = fixture.allocate();

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
@@ -54,7 +54,7 @@ fn fixture(version: i64) -> Fixture {
         )
         .expect("legacy record");
     connection
-        .execute_batch("DROP TABLE remote_runtime_creation_fences;")
+        .execute_batch("DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences;")
         .expect("legacy fence schema");
     if version == 2 {
         connection

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
@@ -11,7 +11,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
         .expect("legacy creation fence");
     let connection = Connection::open(store.path()).expect("raw store");
     connection
-        .execute_batch("DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
+        .execute_batch("DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
         .expect("restore schema-one fixture");
     let workflow_bytes: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
@@ -42,7 +42,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .expect("schema version");
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
     let after: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
         .expect("unchanged legacy bytes");
@@ -103,6 +103,6 @@ fn current_schema_with_missing_remote_table_or_index_fails_at_open() {
         let version: i64 = connection
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .expect("schema unchanged");
-        assert_eq!(version, 4);
+        assert_eq!(version, 5);
     }
 }

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
@@ -125,7 +125,7 @@ fn invalid_keys_snapshots_and_future_schema_never_replace_saved_records() {
         .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
         .expect("before");
     connection
-        .pragma_update(None, "user_version", 5)
+        .pragma_update(None, "user_version", 6)
         .expect("future schema");
     assert!(
         store

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -59,7 +59,7 @@ fn worker_target(workflow: &CloudWorkflow) -> &WorkerTarget {
 }
 
 fn assert_unsupported_schema<T>(result: &Result<T, CloudStoreError>) {
-    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(5))));
+    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(6))));
 }
 
 fn store(temp: &TempDir) -> CloudWorkflowStore {
@@ -532,7 +532,7 @@ fn runpod_fence_uses_the_durable_workflow_claim() {
     );
     let connection = Connection::open(store.path()).expect("open raw store");
     connection
-        .pragma_update(None, "user_version", 5)
+        .pragma_update(None, "user_version", 6)
         .expect("set unsupported schema");
     drop(connection);
     let failed_claim = super::super::runpod::RunPodCreationFence::claim_once(
@@ -570,7 +570,7 @@ fn invalid_snapshots_and_future_schema_fail_closed() {
     replacement.updated_at_millis += 1;
     let connection = Connection::open(&future_path).expect("future store");
     connection
-        .pragma_update(None, "user_version", 5)
+        .pragma_update(None, "user_version", 6)
         .expect("future version");
     drop(connection);
     assert_unsupported_schema(&stale_store.load(workflow.id));

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -282,7 +282,11 @@ attachment or lifetime authority. The first complete saved pin consumes the row
 in the same snapshot CAS transaction; failure rolls both changes back. Saved pins
 always select retained trust, never a fresh bootstrap. Missing/malformed intent
 fails closed, and read-only lookup cannot create or migrate storage. Existing
-forbidden generation retirement/rebinding remains unchanged; future explicit
+schema-4 stores remain readable only through actual read-only connections with
+validated allocation/fence metadata and no partial first-pin objects; first-pin
+lookup returns no intent. Explicit mutable open upgrades them without backfill.
+Write connections still require schema 5. Existing restrictions on generation
+retirement/rebinding remain unchanged; future explicit
 retirement must account for any pending row, never reuse it for a new generation.
 
 ## Options considered

--- a/docs/architecture/remote-workspace-storage.md
+++ b/docs/architecture/remote-workspace-storage.md
@@ -268,6 +268,23 @@ triggers protect the append-only rows, and exact versioned table/index/trigger
 validation runs on open and every operation. Missing or altered metadata is
 rejected, not repaired or adopted.
 
+### Explicit first-pin intent
+
+Schema 5 adds private `remote_first_pin_intents` without migrating legacy records
+into positive bootstrap intent. Explicit task-free setup records only a RunPod
+generation with a reserved public request, both exact owned snapshots, no claim,
+worker, saved pin or cleanup, and an unexpired setup deadline. The immediate
+transaction binds owner, generation, workflow/job and a versioned target/key
+digest. Repeated pre-claim calls are idempotent; no snapshot or claim is changed.
+Noncreating exact-allocation lookup keeps this evidence through claimed creation,
+provisioning, restart and setup expiry. It grants no provider creation, task,
+attachment or lifetime authority. The first complete saved pin consumes the row
+in the same snapshot CAS transaction; failure rolls both changes back. Saved pins
+always select retained trust, never a fresh bootstrap. Missing/malformed intent
+fails closed, and read-only lookup cannot create or migrate storage. Existing
+forbidden generation retirement/rebinding remains unchanged; future explicit
+retirement must account for any pending row, never reuse it for a new generation.
+
 ## Options considered
 
 ### Embed the whole aggregate in runtime YAML


### PR DESCRIPTION
## Purpose

Part of #473 and #383: retain positive first-pin intent for an explicitly approved, task-free setup generation. Missing SSH trust alone must never authorize bootstrap.

## Behavior

- Add a store-private schema-5 intent bound to the exact owner, generation, workflow/job, reserved client request and current allocation snapshots. Recording is explicit and only permitted before creation claim, worker observation, saved pin or management intent.
- Preserve that evidence across asynchronous provisioning, restart and consumed creation claims. Commit the first complete pin and intent consumption in the same transaction; failed snapshot writes roll both back.
- Migrate without backfilling legacy intents. Existing schema-4 inventory remains readable through genuinely read-only connections, without migration or database creation; intent lookup returns none. Explicit mutable open still upgrades to schema 5.

## Refresh and validation

Replayed only the two reviewed feature commits onto actual #496 squash `ec3f11e05e01a17de62a09675849f17810e2386e`. Both range-diff entries are unchanged, and the complete feature patch still has SHA256 `7a4f21f3bbc211fcc96fa1a148c82ff104bf7425bfb04b1176453697e5b9985a`.

Refreshed commit `8d7fd8c809e06dd6a1c1d92174053f0dd11820e2` passed all eight exact-head gates: formatting, maintainability, version synchronization, default and speech workspace tests, and blocking, strict and advisory pedantic Clippy. Its inherited 10 installer regressions and Bash syntax check also passed without any real package installation. The final worktree is clean; earlier validation artifacts remain preserved separately.

Regression coverage includes exact-owner/snapshot refusal, claim races, malformed/orphan intent rejection, restart and setup expiry, pin-write rollback, missing-database noncreation, and schema-4 read-only preservation. The schema-4 regression first reproduced `UnsupportedSchema(4)` before the compatibility correction. Independent local source/parity review is complete; current-head hosted review and CI remain separate gates.

## Scope and assumptions

Ten source/test files, 963 changed source/test lines, plus an architecture note. This is a store prerequisite, not a configured provider or UI feature. The caller must explicitly select an approved digest-pinned entrypoint-only image and permit no arbitrary setup/task before pin persistence. Intent grants no creation, task, attachment or lifetime authority and does not repair lost legacy trust.

No credentials, provider operations, cloud allocation, native UI changes, repository transfer or client-off durability proof are included.
