### PR TITLE
Scope CI dependency installation sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
-      - run: sudo apt-get update && sudo apt-get install -y bison libevent-dev libncurses-dev pkg-config
+      - run: bash scripts/install-ci-ubuntu-dependencies.sh bison libevent-dev libncurses-dev pkg-config
       - name: Build the pinned worker multiplexer
         run: bash containers/remote-worker/build-tmux.sh "$RUNNER_TEMP/horizon-panel-tmux"
       - name: Verify retained task sessions
@@ -73,6 +73,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           lfs: true
+      - name: Verify Ubuntu dependency installer
+        run: python3 -B scripts/test_install_ci_ubuntu_dependencies.py -v
       - run: ./scripts/check-maintainability.sh
 
   clippy:
@@ -89,7 +91,7 @@ jobs:
       # speech-cuda needs nvcc and speech-vulkan the Vulkan SDK, and their
       # Rust surface is identical to `speech` (they only toggle native
       # backends). cpal needs the ALSA headers on Linux.
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+      - run: bash scripts/install-ci-ubuntu-dependencies.sh libasound2-dev pkg-config
       - run: cargo clippy --locked --all-targets --features speech,trace-profiling -- -D warnings
 
   clippy-strict:
@@ -104,7 +106,7 @@ jobs:
       - run: rustup component add clippy
       # `--features speech` so the unwrap/expect ban also covers the speech
       # runtime code (needs the ALSA headers to build cpal on Linux).
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+      - run: bash scripts/install-ci-ubuntu-dependencies.sh libasound2-dev pkg-config
       - run: cargo clippy --locked --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
 
   clippy-pedantic:
@@ -117,7 +119,7 @@ jobs:
           lfs: true
       - uses: Swatinem/rust-cache@v2
       - run: rustup component add clippy
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+      - run: bash scripts/install-ci-ubuntu-dependencies.sh libasound2-dev pkg-config
       - name: Run pedantic audit (non-blocking)
         run: |
           cargo clippy --locked --workspace --all-targets --features speech -- -D warnings -W clippy::pedantic || {
@@ -157,7 +159,7 @@ jobs:
       # linkage (ALSA / CoreAudio) is exercised on each supported target;
       # the no-mic and real-model paths stay env-gated off.
       - if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+        run: bash scripts/install-ci-ubuntu-dependencies.sh libasound2-dev pkg-config
       - run: cargo test --locked --workspace --features speech
 
   windows-smoke:

--- a/scripts/install-ci-ubuntu-dependencies.sh
+++ b/scripts/install-ci-ubuntu-dependencies.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_ubuntu_ci_sources() {
+  if [[ ! -f "$1" || ! -r "$1" || ! -s "$1" ]]; then
+    printf 'Required Ubuntu runner source file is unavailable: %s\n' "$1" >&2
+    return 1
+  fi
+}
+
+install_ci_ubuntu_dependencies() {
+  if [[ "${GITHUB_ACTIONS:-}" != true || "${RUNNER_OS:-}" != Linux ]]; then
+    printf 'This installer is only for Linux GitHub Actions runners.\n' >&2
+    return 2
+  fi
+  if (( $# == 0 )); then
+    printf 'Provide at least one Ubuntu package name.\n' >&2
+    return 2
+  fi
+  local package
+  for package in "$@"; do
+    if [[ ! "$package" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+      printf 'Only plain Ubuntu package names are accepted.\n' >&2
+      return 2
+    fi
+  done
+
+  local sources=/etc/apt/sources.list.d/ubuntu.sources
+  require_ubuntu_ci_sources "$sources" || return "$?"
+  # Scope both commands without changing runner repositories or pruning their cached lists.
+  local -a apt_options=(
+    -o "Dir::Etc::sourcelist=$sources"
+    -o Dir::Etc::sourceparts=/dev/null
+    -o APT::Get::List-Cleanup=0
+  )
+  sudo -n apt-get "${apt_options[@]}" -o APT::Update::Error-Mode=any update || return "$?"
+  sudo -n apt-get "${apt_options[@]}" install -y -- "$@"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  install_ci_ubuntu_dependencies "$@"
+fi

--- a/scripts/test_install_ci_ubuntu_dependencies.py
+++ b/scripts/test_install_ci_ubuntu_dependencies.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Exercise the runner-only installer without sudo, APT, network, or system writes."""
+
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALLER = ROOT / "scripts/install-ci-ubuntu-dependencies.sh"
+SOURCES = "/etc/apt/sources.list.d/ubuntu.sources"
+OPTIONS = [
+    "-o", f"Dir::Etc::sourcelist={SOURCES}",
+    "-o", "Dir::Etc::sourceparts=/dev/null",
+    "-o", "APT::Get::List-Cleanup=0",
+]
+FAKE_SUDO = r'''#!/bin/bash
+printf '%s\0' "$@" >> "$CI_TEST_COMMAND_LOG"
+printf '\0' >> "$CI_TEST_COMMAND_LOG"
+[[ "$1" == -n && "$2" == apt-get ]] || exit 97
+for argument in "$@"; do
+  case "$argument" in
+    update) exit "$CI_TEST_UPDATE_STATUS" ;;
+    install) exit "$CI_TEST_INSTALL_STATUS" ;;
+  esac
+done
+exit 98
+'''
+SOURCED_RUN = r'''
+source "$1"
+shift
+require_ubuntu_ci_sources() {
+  [[ "$#" == 1 && "$1" == /etc/apt/sources.list.d/ubuntu.sources ]] || return 99
+  return "$CI_TEST_SOURCE_STATUS"
+}
+'''
+
+
+class InstallerTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory(prefix="horizon-ci-apt-test-")
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.commands = self.root / "commands"
+        fake_sudo = self.root / "sudo"
+        fake_sudo.write_text(FAKE_SUDO)
+        fake_sudo.chmod(0o700)
+        # No host command can be found through PATH, including sudo or apt-get.
+        self.env = {
+            "PATH": str(self.root),
+            "GITHUB_ACTIONS": "true",
+            "RUNNER_OS": "Linux",
+            "CI_TEST_COMMAND_LOG": str(self.commands),
+            "CI_TEST_SOURCE_STATUS": "0",
+            "CI_TEST_UPDATE_STATUS": "0",
+            "CI_TEST_INSTALL_STATUS": "0",
+        }
+
+    def run_installer(self, *packages, cli=False, conditional=False):
+        invocation = 'install_ci_ubuntu_dependencies "$@"'
+        if conditional:
+            invocation = 'if install_ci_ubuntu_dependencies "$@"; then exit 0; else exit "$?"; fi'
+        command = ["/bin/bash", str(INSTALLER)] if cli else [
+            "/bin/bash", "-c", SOURCED_RUN + invocation, "fixture", str(INSTALLER)
+        ]
+        return subprocess.run(command + list(packages), env=self.env, capture_output=True, timeout=5)
+
+    def calls(self):
+        if not self.commands.exists():
+            return []
+        return [
+            record.decode().split("\0")
+            for record in self.commands.read_bytes().split(b"\0\0") if record
+        ]
+
+    def test_update_and_install_share_exact_source_options_and_literal_packages(self):
+        packages = ["libasound2-dev", "pkg-config"]
+        result = self.run_installer(*packages)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls(), [
+            ["-n", "apt-get", *OPTIONS, "-o", "APT::Update::Error-Mode=any", "update"],
+            ["-n", "apt-get", *OPTIONS, "install", "-y", "--", *packages],
+        ])
+
+    def test_update_failure_preserves_exit_status_and_never_installs(self):
+        self.env["CI_TEST_UPDATE_STATUS"] = "100"
+        result = self.run_installer("pkg-config")
+        self.assertEqual(result.returncode, 100)
+        self.assertEqual(self.calls(), [
+            ["-n", "apt-get", *OPTIONS, "-o", "APT::Update::Error-Mode=any", "update"]
+        ])
+
+    def test_install_failure_is_not_hidden_or_retried(self):
+        self.env["CI_TEST_INSTALL_STATUS"] = "42"
+        result = self.run_installer("pkg-config")
+        self.assertEqual(result.returncode, 42)
+        self.assertEqual(len(self.calls()), 2)
+
+    def test_conditional_function_context_preserves_failures_without_errexit(self):
+        for update, install, expected, count in [(100, 0, 100, 1), (0, 42, 42, 2)]:
+            with self.subTest(update=update, install=install):
+                self.commands.unlink(missing_ok=True)
+                self.env.update(CI_TEST_UPDATE_STATUS=str(update), CI_TEST_INSTALL_STATUS=str(install))
+                result = self.run_installer("pkg-config", conditional=True)
+                self.assertEqual(result.returncode, expected)
+                self.assertEqual(len(self.calls()), count)
+
+    def test_normal_cli_propagates_failures_when_the_runner_source_is_available(self):
+        source = Path(SOURCES)
+        if not source.is_file() or not os.access(source, os.R_OK) or source.stat().st_size == 0:
+            self.skipTest("normal CLI requires the supported Ubuntu runner source layout")
+        for update, install, expected, count in [(100, 0, 100, 1), (0, 42, 42, 2)]:
+            with self.subTest(update=update, install=install):
+                self.commands.unlink(missing_ok=True)
+                self.env.update(CI_TEST_UPDATE_STATUS=str(update), CI_TEST_INSTALL_STATUS=str(install))
+                result = self.run_installer("pkg-config", cli=True)
+                self.assertEqual(result.returncode, expected)
+                self.assertEqual(len(self.calls()), count)
+
+    def test_missing_source_refuses_before_sudo(self):
+        self.env["CI_TEST_SOURCE_STATUS"] = "1"
+        result = self.run_installer("pkg-config")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(self.calls(), [])
+
+    def test_real_source_check_requires_a_nonempty_readable_regular_file(self):
+        empty = self.root / "empty.sources"
+        empty.touch()
+        source = self.root / "ubuntu.sources"
+        content = "Types: deb\nURIs: https://example.invalid/ubuntu\n"
+        source.write_text(content)
+        for path, expected in [(self.root / "missing", 1), (self.root, 1), (empty, 1), (source, 0)]:
+            with self.subTest(path=path.name):
+                result = subprocess.run([
+                    "/bin/bash", "-c", 'source "$1"; require_ubuntu_ci_sources "$2"',
+                    "fixture", str(INSTALLER), str(path),
+                ], env=self.env, capture_output=True, timeout=5)
+                self.assertEqual(result.returncode, expected, result.stderr)
+        source.chmod(0o000)
+        expected = 0 if os.access(source, os.R_OK) else 1
+        result = subprocess.run([
+            "/bin/bash", "-c", 'source "$1"; require_ubuntu_ci_sources "$2"',
+            "fixture", str(INSTALLER), str(source),
+        ], env=self.env, capture_output=True, timeout=5)
+        self.assertEqual(result.returncode, expected, result.stderr)
+        source.chmod(0o600)
+        self.assertEqual(source.read_text(), content)
+        self.assertEqual(self.calls(), [])
+
+    def test_normal_cli_rejects_nonrunner_and_nonlinux_contexts(self):
+        for actions, operating_system in [("", "Linux"), ("false", "Linux"), ("true", "macOS")]:
+            with self.subTest(actions=actions, operating_system=operating_system):
+                self.env.update(GITHUB_ACTIONS=actions, RUNNER_OS=operating_system)
+                result = self.run_installer("pkg-config", cli=True)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(b"only for Linux GitHub Actions runners", result.stderr)
+                self.assertEqual(self.calls(), [])
+
+    def test_normal_cli_rejects_options_paths_and_shell_text_before_sudo(self):
+        for packages in [(), ("--allow-unauthenticated",), ("-o", "Dir::Etc::sourceparts=/tmp"),
+                         ("./local.deb",), ("liba;echo bad",), ("liba\nlibb",), ("liba libb",),
+                         ("bash-",), ("bash+",), ("lib.a",), ("lib.*",), (".",), ("g++",)]:
+            with self.subTest(packages=packages):
+                result = self.run_installer(*packages, cli=True)
+                self.assertEqual(result.returncode, 2)
+                self.assertEqual(self.calls(), [])
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_only_the_five_ubuntu_dependency_sites_use_the_helper_with_unchanged_packages(self):
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        jobs = dict(re.findall(r"^  ([\w-]+):\n(.*?)(?=^  [\w-]+:|\Z)", workflow, re.M | re.S))
+        prefix = "bash scripts/install-ci-ubuntu-dependencies.sh "
+        expected = {
+            "remote-panel-sessions": ["bison", "libevent-dev", "libncurses-dev", "pkg-config"],
+            "clippy": ["libasound2-dev", "pkg-config"],
+            "clippy-strict": ["libasound2-dev", "pkg-config"],
+            "clippy-pedantic": ["libasound2-dev", "pkg-config"],
+            "rust-test": ["libasound2-dev", "pkg-config"],
+        }
+        self.assertEqual(workflow.count(prefix), len(expected))
+        self.assertNotIn("apt-get", workflow)
+        for name, packages in expected.items():
+            with self.subTest(job=name):
+                commands = re.findall(r"run: " + re.escape(prefix) + r"([^\n]+)", jobs[name])
+                self.assertEqual([shlex.split(command) for command in commands], [packages])
+                if name == "rust-test":
+                    self.assertIn("- if: matrix.os == 'ubuntu-latest'\n        run: " + prefix, jobs[name])
+                else:
+                    self.assertIn("runs-on: ubuntu-latest", jobs[name])
+        self.assertIn(
+            "python3 -B scripts/test_install_ci_ubuntu_dependencies.py -v", jobs["maintainability"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Unrelated third-party APT index hash mismatches repeatedly prevented the Ubuntu checks for #495 from reaching tests or lint. Scope the five existing dependency-installation steps to the runner's Ubuntu sources without changing global repository configuration or relaxing signature/hash verification.

## Behavior

- Reuse one runner-only helper at the five existing CI sites, preserving every package list and the Linux-only matrix condition.
- Select `/etc/apt/sources.list.d/ubuntu.sources` for both update and install, disable other source parts and list cleanup for those commands, and fail on any update error. Missing or unreadable source files fail closed.
- Require a Linux GitHub Actions context, noninteractive `sudo -n`, and plain package names. Preserve command failures, including when the sourced function runs in a conditional context.
- Run the deterministic helper/workflow tests in the existing maintainability job. No product source, dependencies, or other workflows change.

## Validation

Exact commit `6f6f4e4cf09a5305505b31c6145a72c521508835` passed all eight local gates: formatting, maintainability, version synchronization, default and speech workspace tests, and blocking, strict and pedantic Clippy. The final worktree is clean.

All 10 installer/workflow regressions and Bash syntax checks passed on that commit. The tests use fake commands and synthetic files; no local package installation, privileged package operation or network update was performed. Separate selector validation used real APT in print-only mode, not installation mode.

The helper requires the current hosted Ubuntu runner source layout; it has no fallback for unsupported layouts and does not ignore failures from the selected sources. Successful hosted Ubuntu dependency jobs remain the decisive end-to-end installation proof. Native UI, cloud and performance testing are not applicable to this CI-only change.

Related: #383, #495.
