### PR TITLE
Connect explicit setup and retained recovery

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -413,7 +413,7 @@ struct ApiSshEndpoint {
     host: String,
     port: u16,
 }
-fn validate_target(target: &WorkerTarget, profile: &RunPodProfile) -> Result<(), RunPodError> {
+pub(crate) fn validate_target(target: &WorkerTarget, profile: &RunPodProfile) -> Result<(), RunPodError> {
     let safe_text = |value: &str| {
         !value.is_empty() && value.len() <= 191 && value.trim() == value && !value.chars().any(char::is_control)
     };

--- a/crates/horizon-core/src/remote_workspace_setup.rs
+++ b/crates/horizon-core/src/remote_workspace_setup.rs
@@ -1,13 +1,18 @@
 //! Explicit initial setup and interrupted-setup retry, separate from client reconnect.
 //! All operations are synchronous and must run off the render thread.
 
+mod runpod;
+pub use runpod::{
+    RunPodWorkspaceSetupError, recover_runpod_workspace, retry_runpod_workspace_setup, start_task_free_runpod_workspace,
+};
+
 use crate::{
     cloud_run::{
         CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, StoredRemoteWorkspace,
         interactive_worker::InteractiveWorkerProvider,
     },
     remote_ssh_identity::{RemoteSshIdentityError, RemoteSshIdentityStore},
-    remote_workspace_recovery::{RemoteWorkspaceRecoveryError, recover_remote_workspace},
+    remote_workspace_recovery::{RemoteWorkspaceRecoveryError, inspect_remote_allocation},
 };
 
 /// Allocate once for an explicitly requested new worker, then retain its request before ensure.
@@ -125,16 +130,25 @@ fn recover<P: InteractiveWorkerProvider + ?Sized>(
     provider: &P,
     expected: &StoredRemoteAllocation,
 ) -> Result<StoredRemoteAllocation, RemoteWorkspaceSetupError> {
+    validate_allocation(store, expected)?;
+    let recovered = inspect_remote_allocation(identities, provider, expected)?;
+    store
+        .record_remote_worker_recovery(expected, recovered.observation())
+        .map_err(Into::into)
+}
+
+fn validate_allocation(
+    store: &CloudWorkflowStore,
+    expected: &StoredRemoteAllocation,
+) -> Result<(), RemoteWorkspaceSetupError> {
     let workspace = expected.workspace();
-    recover_remote_workspace(
-        store,
-        identities,
-        provider,
-        workspace.session_id(),
-        &workspace.state().spec.workspace_local_id,
-    )
-    .map(|result| result.allocation().clone())
-    .map_err(Into::into)
+    let current = store
+        .load_remote_allocation(workspace.session_id(), &workspace.state().spec.workspace_local_id)?
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    if current != *expected {
+        return Err(RemoteWorkspaceRecoveryError::StateChanged.into());
+    }
+    Ok(())
 }
 
 /// Private identity, provider payloads and storage details never appear in setup diagnostics.

--- a/crates/horizon-core/src/remote_workspace_setup/runpod.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod.rs
@@ -1,0 +1,222 @@
+//! Explicit supplied-profile setup; missing trust never authorizes first-pin bootstrap.
+
+use super::{
+    CloudWorkflowStore, InteractiveWorkerProvider, RemoteSshIdentityError, RemoteSshIdentityStore,
+    RemoteWorkspaceRecoveryError, RemoteWorkspaceSetupError, RemoteWorkspaceStoreError, StoredRemoteAllocation,
+    StoredRemoteWorkspace, prepare_identity, recover, retry_remote_workspace_setup, validate_allocation,
+};
+use crate::cloud_run::{
+    WorkerTarget,
+    runpod::{
+        RunPodApiKey, RunPodClient, RunPodHostTrust, RunPodInteractiveWorkerProvider, RunPodProfile, validate_target,
+    },
+};
+
+/// Allocate one explicitly approved, task-free generation and retain first-pin intent.
+/// The caller selects an approved digest-pinned entrypoint-only image and must permit
+/// no arbitrary setup, task or attachment before the first pin is committed. Intent
+/// is not creation or task authority. Run synchronously off the render thread.
+/// A pre-intent failure preserves an unmarked allocation; retry must refuse it.
+/// No config/credential lookup, implicit cleanup or readiness promotion occurs.
+/// # Errors
+/// Rejects unsupported platforms, invalid supplied profiles, stale selections and
+/// identity/intent/provider failures. Admitted ensure retains its provider cleanup contract.
+pub fn start_task_free_runpod_workspace(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    start_with(
+        store,
+        identities,
+        api_key,
+        profile,
+        expected,
+        retain_until_millis,
+        |trust| provider(store, api_key, profile, trust),
+    )
+}
+
+/// Retry this exact setup using positive initial intent or the complete retained pin.
+/// Never prepares a replacement key or records new intent. Claimed, observed or
+/// expired setup uses non-creating recovery. Success remains Reconciling, not ready.
+/// Supplied profile validation does not detect historical edits under the same name.
+/// Run synchronously off the render thread; the supplied store owns explicit writes.
+/// # Errors
+/// Rejects invalid profiles, missing trust/keys, management intent and snapshot drift.
+pub fn retry_runpod_workspace_setup(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    dispatch(
+        store,
+        identities,
+        api_key,
+        profile,
+        expected,
+        Operation::Retry,
+        |trust| provider(store, api_key, profile, trust),
+    )
+}
+
+/// Inspect/reconcile only, even if the marked setup has never consumed a creation claim.
+/// Trust selection and publication bind the same owned snapshot. Admission is
+/// point-in-time: a later pin/management change can overlap inspection, but its stale
+/// result cannot be committed. No continuous revocation or implicit cleanup is promised.
+/// Run synchronously off the render thread. No credential/config discovery occurs.
+/// # Errors
+/// Rejects invalid profiles, missing trust/keys, management intent and snapshot drift.
+pub fn recover_runpod_workspace(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    dispatch(
+        store,
+        identities,
+        api_key,
+        profile,
+        expected,
+        Operation::Recover,
+        |trust| provider(store, api_key, profile, trust),
+    )
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    Retry,
+    Recover,
+}
+
+enum TrustSelection {
+    Initial(RunPodHostTrust),
+    Retained(RunPodHostTrust),
+}
+
+fn provider(
+    store: &CloudWorkflowStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    trust: TrustSelection,
+) -> RunPodInteractiveWorkerProvider {
+    let (TrustSelection::Initial(trust) | TrustSelection::Retained(trust)) = trust;
+    RunPodInteractiveWorkerProvider::new(RunPodClient::new(api_key, store.clone()), profile.clone(), trust)
+}
+
+fn validate_profile(target: &WorkerTarget, profile: &RunPodProfile) -> Result<(), RunPodWorkspaceSetupError> {
+    if !cfg!(target_os = "linux") {
+        return Err(RemoteSshIdentityError::UnsupportedPlatform.into());
+    }
+    validate_target(target, profile).map_err(|_| RunPodWorkspaceSetupError::InvalidProfile)
+}
+
+fn start_with<P: InteractiveWorkerProvider>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+    factory: impl FnOnce(TrustSelection) -> P,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    validate_profile(&expected.state().spec.target, profile)?;
+    let allocation = store.allocate_remote_runtime(expected, retain_until_millis)?;
+    let allocation = prepare_identity(store, identities, &allocation)?;
+    store.record_remote_first_pin_intent(&allocation)?;
+    dispatch(
+        store,
+        identities,
+        api_key,
+        profile,
+        &allocation,
+        Operation::Retry,
+        factory,
+    )
+}
+
+fn dispatch<P: InteractiveWorkerProvider>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteAllocation,
+    operation: Operation,
+    factory: impl FnOnce(TrustSelection) -> P,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    validate_profile(&expected.workspace().state().spec.target, profile)?;
+    validate_allocation(store, expected)?;
+    let request = expected.recovery_request()?;
+    let runtime = expected
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteWorkspaceRecoveryError::MissingAllocation)?;
+    let trust = if let Some(ssh) = &runtime.ssh {
+        let worker = runtime
+            .worker
+            .as_ref()
+            .ok_or(RemoteWorkspaceRecoveryError::InvalidObservation)?;
+        TrustSelection::Retained(
+            RunPodHostTrust::retained(worker, ssh).map_err(|_| RemoteWorkspaceRecoveryError::InvalidObservation)?,
+        )
+    } else {
+        let initial = store
+            .load_remote_first_pin_request(expected)?
+            .ok_or(RunPodWorkspaceSetupError::FirstPinIntentUnavailable)?;
+        TrustSelection::Initial(
+            RunPodHostTrust::initial_task_free(api_key, &initial)
+                .map_err(|_| RemoteWorkspaceRecoveryError::InvalidObservation)?,
+        )
+    };
+    identities.recover(request.workflow_id, request.job_id, &request.ssh_public_key)?;
+    let provider = factory(trust);
+    match operation {
+        Operation::Retry => retry_remote_workspace_setup(store, identities, &provider, expected),
+        Operation::Recover => recover(store, identities, &provider, expected),
+    }
+    .map_err(Into::into)
+}
+
+/// Diagnostics contain no supplied credentials, profile payloads or private paths.
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum RunPodWorkspaceSetupError {
+    #[error("supplied worker profile does not match the saved target or valid setup requirements")]
+    InvalidProfile,
+    #[error("explicit first-pin setup intent is unavailable; missing trust cannot authorize bootstrap")]
+    FirstPinIntentUnavailable,
+    #[error(transparent)]
+    Setup(#[from] RemoteWorkspaceSetupError),
+}
+
+impl From<RemoteWorkspaceStoreError> for RunPodWorkspaceSetupError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        match error {
+            RemoteWorkspaceStoreError::RuntimeSetupUnavailable => Self::FirstPinIntentUnavailable,
+            _ => Self::Setup(error.into()),
+        }
+    }
+}
+
+impl From<RemoteWorkspaceRecoveryError> for RunPodWorkspaceSetupError {
+    fn from(error: RemoteWorkspaceRecoveryError) -> Self {
+        Self::Setup(error.into())
+    }
+}
+
+impl From<RemoteSshIdentityError> for RunPodWorkspaceSetupError {
+    fn from(error: RemoteSshIdentityError) -> Self {
+        Self::Setup(error.into())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace_setup/runpod/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod/tests.rs
@@ -1,0 +1,355 @@
+use super::*;
+use crate::{HorizonHome, remote_workspace::RemoteWorkspaceState};
+#[cfg(target_os = "linux")]
+use crate::{
+    cloud_run::{ArtifactDigest, CloudProvider, interactive_worker::*},
+    remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteRuntimePhase},
+};
+#[cfg(target_os = "linux")]
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+#[cfg(target_os = "linux")]
+mod admission;
+#[cfg(target_os = "linux")]
+mod lifecycle;
+#[cfg(target_os = "linux")]
+mod races;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    identities: RemoteSshIdentityStore,
+    dormant: StoredRemoteWorkspace,
+    profile: RunPodProfile,
+    key: RunPodApiKey,
+    #[cfg(target_os = "linux")]
+    remote: Arc<Remote>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("private fixture");
+        }
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1, "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": {"provider": "run_pod", "profile": "development", "disk_gib": 20,
+                    "image": format!("example/worker@sha256:{}", "a".repeat(64)), "lifetime": "persistent"},
+                "repository": {"repository": "example/project", "commit": "b".repeat(40)}
+            }
+        }))
+        .expect("workspace");
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("dormant");
+        Self {
+            directory,
+            identities: RemoteSshIdentityStore::new(&home),
+            store,
+            dormant,
+            profile: serde_json::from_value(serde_json::json!({
+                "name": "development", "gpu_type_ids": ["synthetic-gpu"], "gpu_count": 1,
+                "ports": ["22/tcp"], "volume_gib": 0
+            }))
+            .expect("profile"),
+            key: RunPodApiKey::new("synthetic-private-credential").expect("key"),
+            #[cfg(target_os = "linux")]
+            remote: Arc::default(),
+        }
+    }
+
+    fn counts(&self) -> [i64; 4] {
+        rusqlite::Connection::open(self.store.path())
+            .expect("database")
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM cloud_workflows), (SELECT COUNT(*) FROM remote_runtime_allocations),
+             (SELECT COUNT(*) FROM cloud_worker_creation_claims), (SELECT COUNT(*) FROM remote_first_pin_intents)",
+                [],
+                |row| Ok([row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?]),
+            )
+            .expect("counts")
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn public_apis_refuse_unsupported_platform_before_identity_or_provider_work() {
+    let f = Fixture::new();
+    let error = RunPodWorkspaceSetupError::from(RemoteSshIdentityError::UnsupportedPlatform);
+    assert_eq!(
+        start_task_free_runpod_workspace(&f.store, &f.identities, &f.key, &f.profile, &f.dormant, i64::MAX),
+        Err(error)
+    );
+    assert_eq!(f.counts(), [0; 4]);
+    let allocation = f
+        .store
+        .allocate_remote_runtime(&f.dormant, i64::MAX)
+        .expect("fixture allocation");
+    for operation in [retry_runpod_workspace_setup, recover_runpod_workspace] {
+        assert_eq!(
+            operation(&f.store, &f.identities, &f.key, &f.profile, &allocation),
+            Err(RemoteSshIdentityError::UnsupportedPlatform.into())
+        );
+    }
+    assert_eq!(f.counts(), [1, 1, 0, 0]);
+    assert!(!f.directory.path().join("home/remote-ssh-identities").exists());
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, PartialEq)]
+struct Snapshot {
+    allocation: StoredRemoteAllocation,
+    counts: [i64; 4],
+    keys: Vec<(std::ffi::OsString, ArtifactDigest)>,
+}
+
+#[cfg(target_os = "linux")]
+impl Fixture {
+    fn allocation(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn keys(&self) -> Vec<(std::ffi::OsString, ArtifactDigest)> {
+        let path = self.directory.path().join("home/remote-ssh-identities");
+        let mut files = match std::fs::read_dir(path) {
+            Ok(entries) => entries
+                .map(|entry| {
+                    let entry = entry.expect("entry");
+                    let digest = ArtifactDigest::sha256(&std::fs::read(entry.path()).expect("key bytes"));
+                    (entry.file_name(), digest)
+                })
+                .collect::<Vec<_>>(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(error) => panic!("fixture key read failed: {error}"),
+        };
+        files.sort_by(|a, b| a.0.cmp(&b.0));
+        files
+    }
+
+    fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            allocation: self.allocation(),
+            counts: self.counts(),
+            keys: self.keys(),
+        }
+    }
+
+    fn reserve(&self, intent: bool) -> StoredRemoteAllocation {
+        let allocation = self
+            .store
+            .allocate_remote_runtime(&self.dormant, i64::MAX)
+            .expect("allocate");
+        let allocation = prepare_identity(&self.store, &self.identities, &allocation).expect("reserve identity");
+        if intent {
+            self.store.record_remote_first_pin_intent(&allocation).expect("intent");
+        }
+        allocation
+    }
+
+    fn factory(&self, trust: &TrustSelection) -> Provider {
+        let initial = matches!(trust, TrustSelection::Initial(_));
+        self.remote.selections.lock().expect("selections")[usize::from(!initial)] += 1;
+        Provider {
+            store: self.store.clone(),
+            remote: self.remote.clone(),
+        }
+    }
+
+    fn start(&self) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+        self.start_using(i64::MAX, |trust| self.factory(&trust))
+    }
+
+    fn start_using(
+        &self,
+        retention: i64,
+        factory: impl FnOnce(TrustSelection) -> Provider,
+    ) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+        let Self {
+            store,
+            identities,
+            key,
+            profile,
+            dormant,
+            ..
+        } = self;
+        start_with(store, identities, key, profile, dormant, retention, factory)
+    }
+
+    fn run(&self, operation: Operation) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+        self.run_expected(&self.allocation(), operation, |trust| self.factory(&trust))
+    }
+
+    fn run_expected(
+        &self,
+        expected: &StoredRemoteAllocation,
+        operation: Operation,
+        factory: impl FnOnce(TrustSelection) -> Provider,
+    ) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+        let Self {
+            store,
+            identities,
+            key,
+            profile,
+            ..
+        } = self;
+        dispatch(store, identities, key, profile, expected, operation, factory)
+    }
+
+    fn assert_refused(&self, error: &RunPodWorkspaceSetupError) {
+        let diagnostic = format!("{error:?} {error}");
+        for secret in [
+            "synthetic-private-credential",
+            self.directory.path().to_str().expect("fixture path"),
+        ] {
+            assert!(!diagnostic.contains(secret));
+        }
+        let before = self.snapshot();
+        for operation in [Operation::Retry, Operation::Recover] {
+            assert_eq!(&self.run(operation).expect_err("refused"), error);
+        }
+        assert_eq!(self.snapshot(), before);
+        assert_eq!(*self.remote.calls.lock().expect("calls"), [0; 5]);
+        assert_eq!(*self.remote.selections.lock().expect("selections"), [0; 2]);
+    }
+
+    fn claim(&self, allocation: &StoredRemoteAllocation) {
+        let r = allocation.worker_request().expect("request");
+        assert!(
+            self.store
+                .claim_worker_creation(r.workflow_id, r.job_id, &r.target, "synthetic-worker")
+                .expect("claim")
+        );
+    }
+
+    fn status(&self) -> InteractiveWorkerStatus {
+        status(&self.allocation().worker_request().expect("request"), false)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn record_management(store: &CloudWorkflowStore, expected: &StoredRemoteAllocation) {
+    let mut state = expected.workspace().state().clone();
+    let runtime = state.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::Cancelling;
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 1,
+    });
+    store
+        .replace_remote_workspace(expected.workspace(), &state)
+        .expect("management");
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct Remote {
+    calls: Mutex<[usize; 5]>,      // ensure, create, reconcile, inspect, delete
+    selections: Mutex<[usize; 2]>, // initial, retained
+    observation: Mutex<Option<InteractiveWorkerStatus>>,
+    provisioning: AtomicBool,
+    lose_response: AtomicBool,
+    after_read: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+}
+
+#[cfg(target_os = "linux")]
+struct Provider {
+    store: CloudWorkflowStore,
+    remote: Arc<Remote>,
+}
+
+#[cfg(target_os = "linux")]
+fn status(request: &InteractiveWorkerRequest, provisioning: bool) -> InteractiveWorkerStatus {
+    InteractiveWorkerStatus {
+        worker: InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::RunPod,
+                workflow_id: request.workflow_id,
+                job_id: request.job_id,
+                resource_id: "synthetic-worker".into(),
+            },
+            target: request.target.clone(),
+            ssh_public_key: request.ssh_public_key.clone(),
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        },
+        lifecycle: if provisioning {
+            InteractiveWorkerLifecycle::Provisioning
+        } else {
+            InteractiveWorkerLifecycle::Ready
+        },
+        ssh: (!provisioning).then(|| InteractiveWorkerSshEndpoint {
+            host: "127.0.0.1".into(),
+            port: 2222,
+            username: "horizon".into(),
+            host_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcH".into(),
+        }),
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Provider {
+    fn read(&self, index: usize) -> Option<InteractiveWorkerStatus> {
+        self.remote.calls.lock().expect("calls")[index] += 1;
+        let value = self.remote.observation.lock().expect("observation").clone();
+        if let Some(action) = self.remote.after_read.lock().expect("hook").take() {
+            action();
+        }
+        value
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::RunPod
+    }
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        self.remote.calls.lock().expect("calls")[0] += 1;
+        let created = self
+            .store
+            .claim_worker_creation(request.workflow_id, request.job_id, &request.target, "synthetic-worker")
+            .map_err(|_| std::io::Error::other("private-fence-payload"))?;
+        if created {
+            self.remote.calls.lock().expect("calls")[1] += 1;
+            *self.remote.observation.lock().expect("observation") =
+                Some(status(request, self.remote.provisioning.load(Ordering::SeqCst)));
+        }
+        if self.remote.lose_response.swap(false, Ordering::SeqCst) {
+            return Err(std::io::Error::other("private-provider-payload"));
+        }
+        let value = self
+            .remote
+            .observation
+            .lock()
+            .expect("observation")
+            .clone()
+            .ok_or_else(|| std::io::Error::other("unresolved"))?;
+        Ok(if created {
+            InteractiveWorkerEnsure::Created(value)
+        } else {
+            InteractiveWorkerEnsure::Reused(value)
+        })
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(self.read(2))
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(self.read(3))
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.remote.calls.lock().expect("calls")[4] += 1;
+        Err(std::io::Error::other("delete forbidden"))
+    }
+}

--- a/crates/horizon-core/src/remote_workspace_setup/runpod/tests/admission.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod/tests/admission.rs
@@ -1,0 +1,132 @@
+use super::*;
+
+#[test]
+fn every_public_entry_rejects_invalid_profiles_before_key_or_provider_work() {
+    for case in 0..4 {
+        let mut f = Fixture::new();
+        match case {
+            0 => f.profile.name = "private-profile-sentinel".into(),
+            1 => f.profile.gpu_count = 0,
+            2 => f.profile.ports.clear(),
+            _ => f.profile.gpu_type_ids.clear(),
+        }
+        let error = start_task_free_runpod_workspace(&f.store, &f.identities, &f.key, &f.profile, &f.dormant, i64::MAX)
+            .expect_err("invalid profile");
+        assert_eq!(error, RunPodWorkspaceSetupError::InvalidProfile);
+        assert!(!format!("{error:?} {error}").contains("private-profile-sentinel"));
+        assert_eq!(f.counts(), [0; 4]);
+        assert!(f.keys().is_empty());
+        let saved = f.reserve(true);
+        let before = f.snapshot();
+        for operation in [retry_runpod_workspace_setup, recover_runpod_workspace] {
+            assert_eq!(
+                operation(&f.store, &f.identities, &f.key, &f.profile, &saved),
+                Err(RunPodWorkspaceSetupError::InvalidProfile)
+            );
+        }
+        assert_eq!(f.snapshot(), before);
+    }
+}
+
+#[test]
+fn invalid_target_stale_selection_and_bad_retention_do_not_allocate_or_prepare() {
+    for case in 0..3 {
+        let mut f = Fixture::new();
+        if case < 2 {
+            let mut state = f.dormant.state().clone();
+            match case {
+                0 => state.spec.target.provider = CloudProvider::LocalDocker,
+                _ => state.spec.working_directory = "changed".into(),
+            }
+            let changed = f
+                .store
+                .replace_remote_workspace(&f.dormant, &state)
+                .expect("fixture edit");
+            if case == 0 {
+                f.dormant = changed;
+            }
+        }
+        let retained = if case == 2 { 0 } else { i64::MAX };
+        assert!(f.start_using(retained, |_| panic!("no factory")).is_err());
+        assert_eq!(f.counts(), [0; 4]);
+        assert!(f.keys().is_empty());
+    }
+    let f = Fixture::new();
+    let mut state = f.dormant.state().clone();
+    state.spec.target.image = "example/worker:mutable".into();
+    assert!(f.store.replace_remote_workspace(&f.dormant, &state).is_err());
+    assert_eq!(
+        validate_profile(&state.spec.target, &f.profile),
+        Err(RunPodWorkspaceSetupError::InvalidProfile)
+    );
+    assert_eq!(f.counts(), [0; 4]);
+    assert!(f.keys().is_empty());
+}
+
+#[test]
+fn pre_intent_interruptions_never_mint_authority_on_retry_or_recovery() {
+    for stage in 0..3 {
+        let f = Fixture::new();
+        if stage == 0 {
+            f.store
+                .allocate_remote_runtime(&f.dormant, i64::MAX)
+                .expect("allocation only");
+        } else {
+            let reserved = f.reserve(false);
+            if stage == 2 {
+                let status = status(&reserved.worker_request().expect("request"), true);
+                f.store
+                    .record_remote_worker_recovery(&reserved, Some(&status))
+                    .expect("legacy worker without pin");
+            }
+        }
+        f.assert_refused(&if stage == 0 {
+            RemoteWorkspaceRecoveryError::MissingRequest.into()
+        } else {
+            RunPodWorkspaceSetupError::FirstPinIntentUnavailable
+        });
+    }
+}
+
+#[test]
+fn missing_and_mismatched_private_keys_are_not_replaced() {
+    for missing in [false, true] {
+        let f = Fixture::new();
+        let saved = f.reserve(true);
+        let request = saved.worker_request().expect("request");
+        let identity = f
+            .identities
+            .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+            .expect("identity");
+        if missing {
+            std::fs::remove_file(identity.private_key_path()).expect("remove fixture key");
+        } else {
+            let other = f
+                .identities
+                .prepare_new(
+                    crate::cloud_run::CloudWorkflowId::new(),
+                    crate::cloud_run::CloudJobId::new(),
+                )
+                .expect("other fixture key");
+            std::fs::copy(other.private_key_path(), identity.private_key_path()).expect("substitute fixture bytes");
+        }
+        f.assert_refused(&if missing {
+            RemoteSshIdentityError::Missing.into()
+        } else {
+            RemoteSshIdentityError::Mismatch.into()
+        });
+    }
+}
+
+#[test]
+fn management_and_foreign_allocations_refuse_before_the_factory() {
+    let f = Fixture::new();
+    let saved = f.reserve(true);
+    let foreign = Fixture::new().reserve(true);
+    assert!(
+        f.run_expected(&foreign, Operation::Recover, |_| panic!("foreign dispatch"))
+            .is_err()
+    );
+    record_management(&f.store, &saved);
+    f.assert_refused(&RemoteWorkspaceRecoveryError::ManagementPending.into());
+}

--- a/crates/horizon-core/src/remote_workspace_setup/runpod/tests/lifecycle.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod/tests/lifecycle.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+#[test]
+fn new_start_records_identity_and_intent_before_factory_then_retains_complete_trust() {
+    let f = Fixture::new();
+    let saved = f
+        .start_using(i64::MAX, |trust| {
+            assert!(matches!(&trust, TrustSelection::Initial(_)));
+            let allocation = f.allocation();
+            let request = allocation.worker_request().expect("reserved request");
+            f.identities
+                .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+                .expect("durable key");
+            assert_eq!(
+                f.store.load_remote_first_pin_request(&allocation).expect("intent"),
+                Some(request)
+            );
+            assert_eq!(f.counts(), [1, 1, 0, 1]);
+            f.factory(&trust)
+        })
+        .expect("start");
+    assert_eq!(f.counts(), [1, 1, 1, 0]);
+    assert_eq!(
+        saved.workspace().state().runtime.as_ref().expect("runtime").phase,
+        RemoteRuntimePhase::Reconciling
+    );
+    assert!(saved.workspace().state().spec.panels.is_empty());
+    let before = f.snapshot();
+    for operation in [Operation::Retry, Operation::Recover] {
+        assert_eq!(f.run(operation).expect("retained"), saved);
+    }
+    assert_eq!(f.snapshot(), before);
+    assert_eq!(*f.remote.selections.lock().expect("selections"), [1, 2]);
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [1, 1, 0, 2, 0]);
+}
+
+#[test]
+fn provisioning_and_lost_response_recover_after_controller_restart_without_ensure() {
+    for lost in [false, true] {
+        let f = Fixture::new();
+        f.remote.provisioning.store(!lost, Ordering::SeqCst);
+        f.remote.lose_response.store(lost, Ordering::SeqCst);
+        let first = f.start();
+        if lost {
+            let error = first.expect_err("lost response");
+            assert_eq!(error, RemoteWorkspaceSetupError::ProviderUnavailable.into());
+            assert!(!format!("{error:?} {error}").contains("private-provider-payload"));
+        } else {
+            first.expect("provisioning");
+        }
+        let before = f.snapshot();
+        assert_eq!(before.counts, [1, 1, 1, 1]);
+        *f.remote.observation.lock().expect("observation") = Some(f.status());
+        let reopened = CloudWorkflowStore::open_path(f.store.path()).expect("new controller store");
+        let saved = dispatch(
+            &reopened,
+            &f.identities,
+            &f.key,
+            &f.profile,
+            &before.allocation,
+            Operation::Retry,
+            |trust| f.factory(&trust),
+        )
+        .expect("recover initial trust");
+        assert_eq!(
+            saved.worker_request().expect("request"),
+            before.allocation.worker_request().expect("old request")
+        );
+        assert_eq!(saved.workflow(), before.allocation.workflow());
+        assert_eq!(f.keys(), before.keys);
+        assert_eq!(f.counts(), [1, 1, 1, 0]);
+        assert_eq!(
+            *f.remote.calls.lock().expect("calls"),
+            if lost { [1, 1, 1, 0, 0] } else { [1, 1, 0, 1, 0] }
+        );
+        f.run(Operation::Recover).expect("retained trust");
+        assert_eq!(*f.remote.selections.lock().expect("selections"), [2, 1]);
+    }
+}
+
+#[test]
+fn recovery_and_consumed_claim_absence_never_reopen_creation() {
+    for claimed in [false, true] {
+        let f = Fixture::new();
+        let saved = f.reserve(true);
+        if claimed {
+            f.claim(&saved);
+        }
+        let keys = f.keys();
+        f.run(if claimed { Operation::Retry } else { Operation::Recover })
+            .expect("absence");
+        f.run(Operation::Retry).expect("repeated absence");
+        assert_eq!(f.counts(), [1, 1, i64::from(claimed), 1]);
+        assert_eq!(f.keys(), keys);
+        assert_eq!(*f.remote.calls.lock().expect("calls"), [0, 0, 2, 0, 0]);
+    }
+}
+
+#[test]
+fn expired_setup_recovers_persistent_worker_but_expired_ready_lease_is_rejected() {
+    let f = Fixture::new();
+    f.reserve(true);
+    let mut workflow = f.allocation().workflow().workflow().clone();
+    workflow.created_at_millis = 1000;
+    workflow.updated_at_millis = 1000;
+    workflow.retain_until_millis = 2000;
+    rusqlite::Connection::open(f.store.path()).expect("database").execute(
+        "UPDATE cloud_workflows SET created_at_millis=1000,updated_at_millis=1000,retain_until_millis=2000,snapshot=?1 WHERE workflow_id=?2",
+        rusqlite::params![serde_json::to_vec(&workflow).expect("snapshot"), workflow.id.to_string()],
+    ).expect("expire fixture");
+    *f.remote.observation.lock().expect("observation") = Some(f.status());
+    f.run(Operation::Retry).expect("persistent recovery");
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [0, 0, 1, 0, 0]);
+
+    let mut f = Fixture::new();
+    let mut state = f.dormant.state().clone();
+    state.spec.target.lifetime = crate::cloud_run::WorkerLifetime::TimeLimited { seconds: 600 };
+    f.dormant = f
+        .store
+        .replace_remote_workspace(&f.dormant, &state)
+        .expect("timed fixture");
+    f.reserve(true);
+    let mut observed = f.status();
+    observed.worker.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+        terminate_after: "2000-01-01T00:00:00Z".into(),
+    });
+    *f.remote.observation.lock().expect("observation") = Some(observed);
+    let before = f.snapshot();
+    assert_eq!(
+        f.run(Operation::Recover),
+        Err(RemoteWorkspaceRecoveryError::InvalidObservation.into())
+    );
+    assert_eq!(f.snapshot(), before);
+}

--- a/crates/horizon-core/src/remote_workspace_setup/runpod/tests/races.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod/tests/races.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+#[test]
+fn competing_first_pin_after_trust_selection_fails_before_recovery_dispatch() {
+    let f = Fixture::new();
+    let expected = f.reserve(true);
+    f.claim(&expected);
+    let observed = f.status();
+    *f.remote.observation.lock().expect("observation") = Some(observed.clone());
+    let mut winner = None;
+    let result = f.run_expected(&expected, Operation::Recover, |trust| {
+        assert!(matches!(&trust, TrustSelection::Initial(_)));
+        let provider = f.factory(&trust);
+        winner = Some(
+            f.store
+                .record_remote_worker_recovery(&expected, Some(&observed))
+                .expect("competing first pin"),
+        );
+        provider
+    });
+    assert_eq!(result, Err(RemoteWorkspaceRecoveryError::StateChanged.into()));
+    assert_eq!(f.allocation(), winner.expect("winner"));
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [0; 5]);
+    assert_eq!(f.counts(), [1, 1, 1, 0]);
+}
+
+#[test]
+fn updates_after_inspection_starts_cannot_be_overwritten_or_trigger_cleanup() {
+    for kind in 0..3 {
+        let f = Fixture::new();
+        let expected = f.reserve(true);
+        f.claim(&expected);
+        *f.remote.observation.lock().expect("observation") = Some(f.status());
+        let store = f.store.clone();
+        let winner = Arc::new(Mutex::new(None));
+        let recorded = winner.clone();
+        let mut status = f.status();
+        *f.remote.after_read.lock().expect("hook") = Some(Box::new(move || {
+            match kind {
+                0 => {
+                    status.ssh.as_mut().expect("ssh").host = "127.0.0.2".into();
+                    store
+                        .record_remote_worker_recovery(&expected, Some(&status))
+                        .expect("winning pin");
+                }
+                1 => {
+                    let mut workflow = expected.workflow().workflow().clone();
+                    workflow.title = "winning edit".into();
+                    workflow.updated_at_millis += 1;
+                    store.replace(expected.workflow(), &workflow).expect("winning workflow");
+                }
+                _ => record_management(&store, &expected),
+            }
+            *recorded.lock().expect("recorded") = store.load_remote_allocation(OWNER, "workspace").expect("winner");
+        }));
+        let keys = f.keys();
+        assert_eq!(
+            f.run(Operation::Recover),
+            Err(RemoteWorkspaceRecoveryError::StateChanged.into())
+        );
+        assert_eq!(f.allocation(), winner.lock().expect("winner").clone().expect("stored"));
+        assert_eq!(f.keys(), keys);
+        assert_eq!(*f.remote.calls.lock().expect("calls"), [0, 0, 1, 0, 0]);
+    }
+}
+
+#[test]
+fn concurrent_explicit_starts_and_retries_never_allocate_or_create_twice() {
+    use std::sync::Barrier;
+    for retry in [false, true] {
+        let f = Fixture::new();
+        if retry {
+            f.reserve(true);
+        }
+        let barrier = Barrier::new(2);
+        std::thread::scope(|scope| {
+            let tasks = (0..2)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        if retry { f.run(Operation::Retry) } else { f.start() }
+                    })
+                })
+                .collect::<Vec<_>>();
+            let results = tasks
+                .into_iter()
+                .map(|task| task.join().expect("thread"))
+                .collect::<Vec<_>>();
+            assert!(results.iter().any(Result::is_ok));
+        });
+        assert_eq!(f.counts()[..3], [1, 1, 1]);
+        let keys = f.keys();
+        assert_eq!(keys.len(), 1);
+        let calls = *f.remote.calls.lock().expect("calls");
+        assert_eq!(calls[1], 1);
+        f.run(Operation::Recover).expect("noncreating convergence");
+        assert_eq!(f.counts(), [1, 1, 1, 0]);
+        assert_eq!(f.remote.calls.lock().expect("calls")[..2], calls[..2]);
+        assert_eq!(f.remote.calls.lock().expect("calls")[4], 0);
+        assert_eq!(f.keys(), keys);
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -124,6 +124,10 @@ back into large multi-purpose modules.
   admission leaf checks exact snapshots without granting creation authority;
   claimed, observed or expired retries use non-creating recovery. Setup remains
   separate from attachment, task readiness and explicit remote management.
+  Its `runpod` leaf accepts an explicit supplied profile/key and selects trust from
+  positive first-pin intent or a complete retained pin. Selection and non-creating
+  recovery bind the same owned snapshot; an unmarked interrupted start is refused,
+  never inferred as first-bootstrap authority or automatically cleaned up.
 - `remote_environment_observation.rs` produces overview-safe, point-in-time
   provider observations with exact snapshot checks but no private-key access or
   saved-state writes. It shares allocation observation validation with recovery;


### PR DESCRIPTION
## Purpose

Connect explicit task-free setup and non-creating recovery to the existing worker adapter and durable allocation store. Part of #473 and #383.

## Behavior

- Accept an explicitly supplied profile and API key; validate the saved target before allocation, private-key access or provider work.
- For an explicit new start, reserve one allocation and client identity, retain positive first-pin intent, then construct the provider using that trust and the same durable creation fence.
- Retry/recover only with positive initial intent or a complete saved pin and matching retained private key. Never infer bootstrap permission from missing trust or replace lost keys.
- Bind trust selection, recovery inspection and result publication to the same owned snapshot. Reject intervening changes; later concurrent updates cannot be overwritten by a stale result.
- Keep claimed, observed and expired setup recovery non-creating. Explicit recovery never creates, including when no creation claim exists. Successful observation remains reconciling, not task-ready.

## Validation

Commit `4e924f151127d7e8d88249007a3f4cfe23098d3e` passed all eight exact-head local gates: formatting, maintainability, version synchronization, default and speech workspace tests, and blocking, strict and advisory pedantic Clippy. The worktree and dependency lock remained unchanged after every gate. An additional focused pass covered 27 setup, 12 recovery and 39 allocation tests.

The stale-selection regression first reproduced with the old helper: a competing controller committed the first pin after trust selection, and recovery adopted its newer allocation instead of refusing the stale snapshot. The corrected test passes. Coverage also exercises invalid profile/target/retention, pre-intent interruption, lost responses, reopened controllers, missing/mismatched private keys, management races, timed expiry and concurrent starts/retries. Key snapshots use digests, not private-key bytes.

Independent local review is complete. Seven source/test files, 981 changed source/test lines, plus four architecture-note lines.

## Runtime assumptions and limits

Synchronous core APIs must run off the render thread. Private identity setup currently supports Linux; other platforms refuse before provider/key work. The caller must nominate an approved digest-pinned entrypoint-only image and permit no arbitrary setup/task before pin persistence. Supplied profile validation does not detect historical changes under the same profile name.

No UI/config integration, credential discovery, repository transfer, task attachment, automatic cleanup, provider allocation, image publication or cloud/PC-off acceptance is included. Persistent workers remain independent of client closure. Requested hosted review and CI are separate gates before merge.
