### PR TITLE
feat(repository): retain one-shot worker intake

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -368,7 +368,7 @@ fn valid_immutable_image(value: &str) -> bool {
             .is_some_and(|(_, digest)| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
-fn valid_single_token(value: &str, maximum_length: usize) -> bool {
+pub(crate) fn valid_single_token(value: &str, maximum_length: usize) -> bool {
     !value.is_empty()
         && value.len() <= maximum_length
         && !value.starts_with('-')

--- a/crates/horizon-core/src/repository_overlay/intake/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/linux.rs
@@ -1,0 +1,432 @@
+use super::{
+    ArtifactDigest, BundleState, IntakeError, IntakeRequest, IntakeResponse, IntakeRoots, IntakeState, PackProgress,
+    PackState, REQUEST_LIMIT, codec,
+};
+use crate::repository_overlay::{
+    bundle::store::{BundleStoreError, RepositoryBundleStore},
+    reader::{RepositoryReadError, SelectedRepositoryReader, linux::Root},
+    seed::{
+        SeedError,
+        receive::{
+            ExpectedGitPack, PackReceiveLimits, ReceivedGitPack, observe_git_base_pack,
+            publication::{PackPublicationError, PackPublicationFailure, publish_sibling_git_pack},
+            receive_git_base_pack,
+        },
+    },
+    storage,
+};
+use rustix::fs::{AtFlags, Mode, OFlags, ResolveFlags, mkdirat, openat2, statat};
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const INPUTS: &str = "repository-inputs";
+const SETUP: &str = "repository-setup";
+const CLAIM: &str = "repository-intake.claim";
+const DIRECTORIES: [&str; 4] = [INPUTS, "repository-inputs/packs", "repository-inputs/bundles", SETUP];
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+pub(super) fn execute(
+    parent: &Path,
+    request: &IntakeRequest,
+    input: Option<&mut dyn Read>,
+    cancelled: &dyn Fn() -> bool,
+) -> IntakeResponse {
+    execute_with(parent, request, input, cancelled, &mut File::sync_all, &qualify)
+}
+
+pub(super) fn execute_with(
+    parent: &Path,
+    request: &IntakeRequest,
+    input: Option<&mut dyn Read>,
+    cancelled: &dyn Fn() -> bool,
+    sync: &mut impl FnMut(&File) -> io::Result<()>,
+    storage: &impl Fn(&File) -> Result<(), IntakeError>,
+) -> IntakeResponse {
+    let Ok(encoded) = request.encode() else {
+        return IntakeResponse::failure(IntakeError::Invalid);
+    };
+    let roots = IntakeRoots {
+        packs: parent.join(INPUTS).join("packs"),
+        bundles: parent.join(INPUTS).join("bundles"),
+        setup: parent.join(SETUP),
+    };
+    let mut response = IntakeResponse::failure(IntakeError::Storage);
+    response.intent_sha256 = Some(ArtifactDigest::sha256(&encoded));
+    response.roots = Some(roots.clone());
+    let mut attempted = false;
+    let result = (|| {
+        check(cancelled)?;
+        let mut boundary = Boundary::open(parent, storage)?;
+        let fresh = boundary.admit(&encoded, input.is_some(), &mut attempted, sync, cancelled)?;
+        response.state = if fresh {
+            IntakeState::Unconfirmed
+        } else {
+            IntakeState::ClaimedUnknown
+        };
+        boundary.children(&encoded, fresh, sync, cancelled)?;
+        let expected = ExpectedGitPack {
+            base_commit: request
+                .source
+                .commit
+                .as_str()
+                .parse()
+                .map_err(|_| IntakeError::Invalid)?,
+            sha256: &request.pack.sha256,
+            encoded_bytes: request.pack.encoded_bytes,
+        };
+        if fresh {
+            receive_inputs(
+                request,
+                expected,
+                &roots,
+                input.ok_or(IntakeError::Storage)?,
+                &mut response,
+                cancelled,
+            )?;
+        } else {
+            let pack = observe_git_base_pack(
+                &roots.packs.join("base"),
+                expected,
+                PackReceiveLimits::default(),
+                cancelled,
+            )
+            .map_err(seed_error)?;
+            response.pack = Some(progress(PackState::Observed, &pack, false));
+            let bundle = RepositoryBundleStore::open(&roots.bundles)
+                .and_then(|store| store.get(&request.overlay.sha256))
+                .map_err(bundle_error)?;
+            if bundle.plan().source() != &request.source {
+                return Err(IntakeError::Input);
+            }
+            response.bundle = Some(BundleState::Observed);
+        }
+        boundary.verify(&encoded)?;
+        check(cancelled)?;
+        response.state = if fresh {
+            IntakeState::Acknowledged
+        } else {
+            IntakeState::Observed
+        };
+        Ok(())
+    })();
+    if let Err(reason) = result {
+        if attempted && response.state == IntakeState::Error {
+            response.state = IntakeState::Unconfirmed;
+        }
+        if !attempted && reason == IntakeError::Unsupported {
+            response.state = IntakeState::Unsupported;
+        }
+    }
+    response.reason = result.err();
+    response
+}
+
+fn receive_inputs(
+    request: &IntakeRequest,
+    expected: ExpectedGitPack<'_>,
+    roots: &IntakeRoots,
+    mut input: &mut dyn Read,
+    response: &mut IntakeResponse,
+    cancelled: &dyn Fn() -> bool,
+) -> Result<(), IntakeError> {
+    let pack = match receive_git_base_pack(
+        &roots.packs,
+        expected,
+        &mut (&mut input).take(expected.encoded_bytes),
+        PackReceiveLimits::default(),
+        cancelled,
+    ) {
+        Ok(pack) => pack,
+        Err(failure) => {
+            response.pack = Some(PackProgress {
+                state: PackState::ReceiveUnconfirmed,
+                source: failure.residue().map(Path::to_path_buf),
+                destination: None,
+                objects: None,
+            });
+            return Err(seed_error(failure.reason));
+        }
+    };
+    response.pack = Some(progress(PackState::Unpublished, &pack, true));
+    let length = usize::try_from(request.overlay.encoded_bytes).map_err(|_| IntakeError::Invalid)?;
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(length).map_err(|_| IntakeError::Input)?;
+    let mut buffer = [0_u8; 16 * 1024];
+    while bytes.len() < length {
+        check(cancelled)?;
+        let remaining = (length - bytes.len()).min(buffer.len());
+        let count = input.read(&mut buffer[..remaining]).map_err(|_| IntakeError::Input)?;
+        if count == 0 {
+            return Err(IntakeError::Input);
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+    }
+    check(cancelled)?;
+    if input.read(&mut buffer[..1]).map_err(|_| IntakeError::Input)? != 0 {
+        return Err(IntakeError::Input);
+    }
+    let bundle = codec::decode(&bytes).map_err(|_| IntakeError::Input)?;
+    drop(bytes);
+    if bundle.plan().source() != &request.source || bundle.manifest_sha256() != &request.overlay.sha256 {
+        return Err(IntakeError::Input);
+    }
+    check(cancelled)?;
+    match publish_sibling_git_pack(pack, "base", PackReceiveLimits::default(), cancelled) {
+        Ok(published) => response.pack = Some(progress(PackState::Acknowledged, published.pack(), false)),
+        Err(failure) => {
+            let reason = match &failure {
+                PackPublicationFailure::Unpublished { reason, .. }
+                | PackPublicationFailure::PublishedUnsynchronized { reason, .. } => publication_error(*reason),
+                PackPublicationFailure::RenameUnconfirmed { .. } => IntakeError::Storage,
+            };
+            response.pack = Some(match failure {
+                PackPublicationFailure::Unpublished { pack, .. } => progress(PackState::Unpublished, &pack, true),
+                PackPublicationFailure::PublishedUnsynchronized { pack, .. } => {
+                    progress(PackState::PublishedUnsynchronized, pack.pack(), false)
+                }
+                PackPublicationFailure::RenameUnconfirmed { pack, destination } => PackProgress {
+                    destination: Some(destination),
+                    ..progress(PackState::RenameUnconfirmed, &pack, true)
+                },
+            });
+            return Err(reason);
+        }
+    }
+    check(cancelled)?;
+    response.bundle = Some(BundleState::WriteUnconfirmed);
+    RepositoryBundleStore::open(&roots.bundles)
+        .and_then(|store| store.put(&bundle))
+        .map_err(bundle_error)?;
+    response.bundle = Some(BundleState::Acknowledged);
+    Ok(())
+}
+
+fn progress(state: PackState, pack: &ReceivedGitPack, source: bool) -> PackProgress {
+    PackProgress {
+        state,
+        source: source.then(|| pack.path().to_owned()),
+        destination: (!source).then(|| pack.path().to_owned()),
+        objects: Some(pack.objects()),
+    }
+}
+
+struct Boundary {
+    reader: Root,
+    handle: File,
+    path: PathBuf,
+    claim: Option<File>,
+    children: Vec<File>,
+}
+
+impl Boundary {
+    fn open(path: &Path, storage: &impl Fn(&File) -> Result<(), IntakeError>) -> Result<Self, IntakeError> {
+        let reader = SelectedRepositoryReader::open(path).map_err(read_error)?.root;
+        let handle = open(reader.handle(), ".", OFlags::RDONLY | OFlags::DIRECTORY)?;
+        private(&handle)?;
+        storage(&handle)?;
+        Ok(Self {
+            reader,
+            handle,
+            path: path.to_owned(),
+            claim: None,
+            children: Vec::new(),
+        })
+    }
+
+    fn read_claim(&self, encoded: &[u8]) -> Result<Option<File>, IntakeError> {
+        match self.reader.read_private_file(CLAIM, REQUEST_LIMIT) {
+            Ok(record) => {
+                let decoded = IntakeRequest::decode(&record.bytes).map_err(|_| IntakeError::Storage)?;
+                if decoded.encode()? != record.bytes {
+                    return Err(IntakeError::Storage);
+                }
+                if record.bytes != encoded {
+                    return Err(IntakeError::Conflict);
+                }
+                Ok(Some(record.file))
+            }
+            Err(RepositoryReadError::Missing) => Ok(None),
+            Err(error) => Err(read_error(error)),
+        }
+    }
+
+    fn verify(&self, encoded: &[u8]) -> Result<(), IntakeError> {
+        private(&self.handle)?;
+        let named = SelectedRepositoryReader::open(&self.path).map_err(read_error)?;
+        same(&self.handle, named.root.handle())?;
+        if let Some(claim) = &self.claim {
+            same(claim, &self.read_claim(encoded)?.ok_or(IntakeError::Storage)?)?;
+        }
+        for (name, held) in DIRECTORIES.iter().zip(&self.children) {
+            let named = open(&self.handle, name, OFlags::RDONLY | OFlags::DIRECTORY)?;
+            private(&named)?;
+            same(held, &named)?;
+        }
+        Ok(())
+    }
+
+    fn admit(
+        &mut self,
+        encoded: &[u8],
+        write: bool,
+        attempted: &mut bool,
+        sync: &mut impl FnMut(&File) -> io::Result<()>,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<bool, IntakeError> {
+        self.verify(encoded)?;
+        self.claim = self.read_claim(encoded)?;
+        if self.claim.is_some() {
+            return Ok(false);
+        }
+        if !write {
+            return Err(IntakeError::Storage);
+        }
+        for name in [INPUTS, SETUP] {
+            if !matches!(
+                statat(&self.handle, name, AtFlags::SYMLINK_NOFOLLOW),
+                Err(rustix::io::Errno::NOENT)
+            ) {
+                return Err(IntakeError::Storage);
+            }
+        }
+        check(cancelled)?;
+        *attempted = true;
+        let mut claim = match openat2(
+            &self.handle,
+            CLAIM,
+            OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC,
+            Mode::RUSR | Mode::WUSR,
+            CONFINED,
+        ) {
+            Ok(file) => File::from(file),
+            Err(rustix::io::Errno::EXIST) => {
+                self.claim = self.read_claim(encoded)?;
+                return self.claim.as_ref().map(|_| false).ok_or(IntakeError::Storage);
+            }
+            Err(error) => return Err(storage_error(error)),
+        };
+        claim.write_all(encoded).map_err(|_| IntakeError::Storage)?;
+        self.claim = Some(claim);
+        sync(self.claim.as_ref().ok_or(IntakeError::Storage)?)
+            .and_then(|()| sync(&self.handle))
+            .map_err(|_| IntakeError::Storage)?;
+        self.verify(encoded)?;
+        Ok(true)
+    }
+
+    fn children(
+        &mut self,
+        encoded: &[u8],
+        create: bool,
+        sync: &mut impl FnMut(&File) -> io::Result<()>,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<(), IntakeError> {
+        for (index, name) in DIRECTORIES.iter().enumerate() {
+            check(cancelled)?;
+            self.verify(encoded)?;
+            let (parent, leaf) = match index {
+                1 => (&self.children[0], "packs"),
+                2 => (&self.children[0], "bundles"),
+                _ => (&self.handle, *name),
+            };
+            if create {
+                mkdirat(parent, leaf, Mode::RUSR | Mode::WUSR | Mode::XUSR).map_err(storage_error)?;
+            }
+            let child = open(parent, leaf, OFlags::RDONLY | OFlags::DIRECTORY)?;
+            private(&child)?;
+            self.children.push(child);
+        }
+        if create {
+            for file in self.children.iter().rev().chain(std::iter::once(&self.handle)) {
+                check(cancelled)?;
+                sync(file).map_err(|_| IntakeError::Storage)?;
+            }
+        }
+        self.verify(encoded)
+    }
+}
+
+fn open(parent: &File, name: &str, flags: OFlags) -> Result<File, IntakeError> {
+    openat2(parent, name, flags | OFlags::CLOEXEC, Mode::empty(), CONFINED)
+        .map(File::from)
+        .map_err(storage_error)
+}
+fn private(file: &File) -> Result<(), IntakeError> {
+    let metadata = file.metadata().map_err(|_| IntakeError::Storage)?;
+    (metadata.is_dir()
+        && metadata.uid() == rustix::process::geteuid().as_raw()
+        && metadata.mode() & 0o7777 == 0o700
+        && metadata.nlink() != 0)
+        .then_some(())
+        .ok_or(IntakeError::Storage)
+}
+fn same(left: &File, right: &File) -> Result<(), IntakeError> {
+    let left = left.metadata().map_err(|_| IntakeError::Storage)?;
+    let right = right.metadata().map_err(|_| IntakeError::Storage)?;
+    ((left.dev(), left.ino()) == (right.dev(), right.ino()))
+        .then_some(())
+        .ok_or(IntakeError::Storage)
+}
+fn qualify(file: &File) -> Result<(), IntakeError> {
+    storage::qualify(file).map_err(|error| match error {
+        storage::StorageQualificationError::Unsupported => IntakeError::Unsupported,
+        storage::StorageQualificationError::Storage => IntakeError::Storage,
+    })
+}
+fn storage_error(error: rustix::io::Errno) -> IntakeError {
+    match error {
+        rustix::io::Errno::NOSYS | rustix::io::Errno::OPNOTSUPP | rustix::io::Errno::INVAL => IntakeError::Unsupported,
+        _ => IntakeError::Storage,
+    }
+}
+fn read_error(error: RepositoryReadError) -> IntakeError {
+    match error {
+        RepositoryReadError::Unsupported => IntakeError::Unsupported,
+        _ => IntakeError::Storage,
+    }
+}
+fn bundle_error(error: BundleStoreError) -> IntakeError {
+    match error {
+        BundleStoreError::Unsupported | BundleStoreError::Read(RepositoryReadError::Unsupported) => {
+            IntakeError::Unsupported
+        }
+        BundleStoreError::Read(RepositoryReadError::Missing | RepositoryReadError::TooLarge)
+        | BundleStoreError::Missing
+        | BundleStoreError::Conflict
+        | BundleStoreError::DigestMismatch
+        | BundleStoreError::Codec(_) => IntakeError::Input,
+        BundleStoreError::UnsafeDirectory | BundleStoreError::WriteFailed | BundleStoreError::Read(_) => {
+            IntakeError::Storage
+        }
+    }
+}
+fn publication_error(error: PackPublicationError) -> IntakeError {
+    match error {
+        PackPublicationError::Unsupported => IntakeError::Unsupported,
+        PackPublicationError::Verification(error) => seed_error(error),
+        PackPublicationError::InvalidName | PackPublicationError::DestinationExists | PackPublicationError::Storage => {
+            IntakeError::Storage
+        }
+    }
+}
+fn seed_error(error: SeedError) -> IntakeError {
+    match error {
+        SeedError::Cancelled => IntakeError::Cancelled,
+        SeedError::Unsupported => IntakeError::Unsupported,
+        SeedError::Storage | SeedError::UnsafeParent => IntakeError::Storage,
+        _ => IntakeError::Input,
+    }
+}
+fn check(cancelled: &dyn Fn() -> bool) -> Result<(), IntakeError> {
+    (!cancelled()).then_some(()).ok_or(IntakeError::Cancelled)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/intake/linux/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/linux/tests.rs
@@ -1,0 +1,340 @@
+use super::super::{
+    EncodedIdentity,
+    tests::{Unread, request},
+};
+use super::*;
+use crate::repository_overlay::{RepositoryOverlayPlan, bundle::RepositoryOverlayBundle, storage};
+use IntakeError as Error;
+use IntakeState as State;
+use std::{
+    cell::Cell,
+    fs::{self, File},
+    os::unix::fs::{PermissionsExt, symlink},
+    path::Path,
+};
+
+fn private() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir()
+        .unwrap()
+}
+fn call(parent: &Path, request: &IntakeRequest, input: Option<&mut dyn Read>) -> IntakeResponse {
+    execute_with(parent, request, input, &|| false, &mut File::sync_all, &|_| Ok(()))
+}
+fn data() -> (IntakeRequest, Vec<u8>) {
+    let directory = private();
+    let repo = git2::Repository::init_bare(directory.path()).unwrap();
+    let tree = repo
+        .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
+        .unwrap();
+    let signature = git2::Signature::now("Fixture", "fixture@example.invalid").unwrap();
+    let commit = repo
+        .commit(None, &signature, &signature, "fixture", &tree, &[])
+        .unwrap();
+    let mut builder = repo.packbuilder().unwrap();
+    builder.insert_commit(commit).unwrap();
+    let mut pack = git2::Buf::new();
+    builder.write_buf(&mut pack).unwrap();
+    let mut request = request();
+    request.source.commit = crate::cloud_run::GitCommitSha::parse(commit.to_string()).unwrap();
+    let bundle = RepositoryOverlayBundle::new(
+        RepositoryOverlayPlan::new(request.source.clone(), vec![], vec![]).unwrap(),
+        [],
+    )
+    .unwrap();
+    let overlay = codec::encode(&bundle).unwrap();
+    request.pack = EncodedIdentity {
+        sha256: ArtifactDigest::sha256(&pack),
+        encoded_bytes: pack.len() as u64,
+    };
+    request.overlay = EncodedIdentity {
+        sha256: bundle.manifest_sha256().clone(),
+        encoded_bytes: overlay.len() as u64,
+    };
+    (request, [pack.as_ref(), &overlay].concat())
+}
+
+#[test]
+fn missing_unsafe_and_unsupported_parents_do_not_create_or_read() {
+    let directory = private();
+    let parent = directory.path();
+    let request = request();
+    assert_eq!(
+        call(&parent.join("missing"), &request, Some(&mut Unread)).reason,
+        Some(Error::Storage)
+    );
+    assert_eq!(call(parent, &request, None).state, State::Error);
+    let response = execute_with(
+        parent,
+        &request,
+        Some(&mut Unread),
+        &|| false,
+        &mut File::sync_all,
+        &|_| Err(Error::Unsupported),
+    );
+    assert_eq!(response.state, State::Unsupported);
+    fs::set_permissions(parent, fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(call(parent, &request, Some(&mut Unread)).reason, Some(Error::Storage));
+    assert_eq!(fs::read_dir(parent).unwrap().count(), 0);
+}
+
+#[test]
+fn every_root_sync_failure_retains_claim_and_existing_calls_never_replay() {
+    for fault in 0..7 {
+        let directory = private();
+        let parent = directory.path();
+        let request = request();
+        let mut calls = 0;
+        let response = execute_with(
+            parent,
+            &request,
+            Some(&mut Unread),
+            &|| false,
+            &mut |_| {
+                calls += 1;
+                if calls == fault + 1 {
+                    Err(io::Error::other("injected"))
+                } else {
+                    Ok(())
+                }
+            },
+            &|_| Ok(()),
+        );
+        assert_eq!(
+            (response.state, response.reason),
+            (State::Unconfirmed, Some(Error::Storage))
+        );
+        assert_eq!(calls, fault + 1);
+        let claim = parent.join("repository-intake.claim");
+        let before = fs::read(&claim).unwrap();
+        assert_eq!(before, request.encode().unwrap());
+        assert_eq!(call(parent, &request, Some(&mut Unread)).state, State::ClaimedUnknown);
+        assert_eq!(fs::read(&claim).unwrap(), before);
+        let mut conflict = request.clone();
+        conflict.runtime_generation += 1;
+        assert_eq!(call(parent, &conflict, Some(&mut Unread)).reason, Some(Error::Conflict));
+        fs::write(&claim, b"{").unwrap();
+        assert_eq!(call(parent, &request, Some(&mut Unread)).reason, Some(Error::Storage));
+        assert_eq!(fs::read(&claim).unwrap(), b"{");
+    }
+}
+
+#[test]
+fn cancellation_and_replaced_input_parent_stop_before_child_writes() {
+    for replace in [false, true] {
+        let directory = private();
+        let parent = directory.path();
+        let outside = private();
+        let changed = Cell::new(false);
+        let cancelled = || {
+            let inputs = parent.join("repository-inputs");
+            if replace && inputs.exists() && !changed.replace(true) {
+                fs::rename(&inputs, parent.join("held-inputs")).unwrap();
+                symlink(outside.path(), inputs).unwrap();
+            }
+            !replace && parent.join("repository-intake.claim").exists()
+        };
+        let response = execute_with(
+            parent,
+            &request(),
+            Some(&mut Unread),
+            &cancelled,
+            &mut File::sync_all,
+            &|_| Ok(()),
+        );
+        assert_eq!(response.state, State::Unconfirmed);
+        assert_eq!(
+            response.reason,
+            Some(if replace { Error::Storage } else { Error::Cancelled })
+        );
+        assert_eq!(fs::read_dir(outside.path()).unwrap().count(), 0);
+        if replace {
+            assert!(changed.get());
+            assert_eq!(fs::read_dir(parent.join("held-inputs")).unwrap().count(), 0);
+        }
+    }
+}
+
+#[test]
+fn exact_frames_retain_unpublished_pack_until_all_overlay_bytes_verify() {
+    let (request, bytes) = data();
+    for case in 0..4 {
+        let directory = private();
+        let parent = directory.path();
+        let mut bytes = bytes.clone();
+        let mut request = request.clone();
+        match case {
+            0 => {
+                bytes.pop();
+            }
+            1 => bytes.push(0),
+            2 => bytes[usize::try_from(request.pack.encoded_bytes).unwrap()] ^= 1,
+            _ => request.overlay.sha256 = ArtifactDigest::sha256(b"wrong"),
+        }
+        let response = call(parent, &request, Some(&mut bytes.as_slice()));
+        assert_eq!(
+            (response.state, response.reason),
+            (State::Unconfirmed, Some(Error::Input))
+        );
+        let pack = response.pack.unwrap();
+        assert_eq!(pack.state, PackState::Unpublished);
+        assert!(pack.source.unwrap().exists());
+        assert!(response.bundle.is_none());
+        assert!(!parent.join("repository-inputs/packs/base").exists());
+    }
+}
+
+#[test]
+fn qualified_combined_intake_observes_without_sync_replay_or_setup() {
+    let directory = private();
+    let parent = directory.path();
+    let (request, bytes) = data();
+    if storage::qualify(&File::open(parent).unwrap()) == Err(storage::StorageQualificationError::Unsupported) {
+        eprintln!("SKIP combined intake acknowledgement: qualified ext4 unavailable");
+        return;
+    }
+    let response = execute(parent, &request, Some(&mut bytes.as_slice()), &|| false);
+    assert_eq!(response.state, State::Acknowledged, "{response:?}");
+    let observed = execute_with(
+        parent,
+        &request,
+        Some(&mut Unread),
+        &|| false,
+        &mut |_| panic!("observation synchronized"),
+        &|_| Ok(()),
+    );
+    assert_eq!(observed.state, State::Observed);
+    assert_eq!(observed.bundle, Some(BundleState::Observed));
+    assert_eq!(observed.pack.unwrap().state, PackState::Observed);
+    assert_eq!(fs::read_dir(parent.join("repository-setup")).unwrap().count(), 0);
+    let bundle = parent
+        .join("repository-inputs/bundles")
+        .join(format!("{}.hzov", request.overlay.sha256.as_str()));
+    fs::set_permissions(&bundle, fs::Permissions::from_mode(0o644)).unwrap();
+    let failed = call(parent, &request, Some(&mut Unread));
+    assert_eq!(
+        (failed.state, failed.reason),
+        (State::ClaimedUnknown, Some(Error::Storage))
+    );
+    assert_eq!(failed.pack.unwrap().state, PackState::Observed);
+    assert_eq!(fs::metadata(bundle).unwrap().mode() & 0o7777, 0o644);
+}
+
+#[test]
+fn existing_children_without_a_claim_are_never_adopted() {
+    for name in [INPUTS, SETUP] {
+        let directory = private();
+        let parent = directory.path();
+        fs::create_dir(parent.join(name)).unwrap();
+        let sentinel = parent.join(name).join("retained");
+        fs::write(&sentinel, b"unchanged").unwrap();
+        assert_eq!(call(parent, &request(), Some(&mut Unread)).reason, Some(Error::Storage));
+        assert!(!parent.join(CLAIM).exists());
+        assert_eq!(fs::read(sentinel).unwrap(), b"unchanged");
+    }
+}
+
+#[test]
+fn competing_creators_have_one_claim_writer_and_no_retry_after_partial_confirmation() {
+    use std::sync::{
+        Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    let directory = private();
+    let parent = directory.path();
+    let request = request();
+    let barrier = Barrier::new(2);
+    let writers = AtomicUsize::new(0);
+    std::thread::scope(|scope| {
+        let contenders: Vec<_> = (0..2)
+            .map(|_| {
+                scope.spawn(|| {
+                    let checks = Cell::new(0);
+                    execute_with(
+                        parent,
+                        &request,
+                        Some(&mut Unread),
+                        &|| {
+                            checks.set(checks.get() + 1);
+                            if checks.get() == 2 {
+                                barrier.wait();
+                            }
+                            false
+                        },
+                        &mut |_| {
+                            writers.fetch_add(1, Ordering::SeqCst);
+                            Err(io::Error::other("unconfirmed claim sync"))
+                        },
+                        &|_| Ok(()),
+                    )
+                })
+            })
+            .collect();
+        for contender in contenders {
+            let response = contender.join().unwrap();
+            assert!(matches!(response.state, State::Unconfirmed | State::ClaimedUnknown));
+            assert_eq!(response.reason, Some(Error::Storage));
+        }
+    });
+    assert_eq!(writers.load(Ordering::SeqCst), 1);
+    assert_eq!(fs::read(parent.join(CLAIM)).unwrap(), request.encode().unwrap());
+    assert_eq!(call(parent, &request, Some(&mut Unread)).state, State::ClaimedUnknown);
+    assert_eq!(fs::read_dir(parent).unwrap().count(), 1);
+}
+
+#[test]
+fn seed_failure_reasons_preserve_storage_and_input_distinction() {
+    for (source, expected) in [
+        (SeedError::Storage, IntakeError::Storage),
+        (SeedError::UnsafeParent, IntakeError::Storage),
+        (SeedError::Source, IntakeError::Input),
+        (SeedError::Object, IntakeError::Input),
+        (SeedError::Limit, IntakeError::Input),
+        (SeedError::Unsupported, IntakeError::Unsupported),
+        (SeedError::Cancelled, IntakeError::Cancelled),
+    ] {
+        assert_eq!(seed_error(source), expected);
+        assert_eq!(publication_error(PackPublicationError::Verification(source)), expected);
+    }
+    for (source, expected) in [
+        (PackPublicationError::InvalidName, Error::Storage),
+        (PackPublicationError::DestinationExists, Error::Storage),
+        (PackPublicationError::Unsupported, Error::Unsupported),
+        (PackPublicationError::Storage, Error::Storage),
+    ] {
+        assert_eq!(publication_error(source), expected);
+    }
+}
+
+#[test]
+fn bundle_failure_reasons_distinguish_input_storage_and_capability() {
+    use crate::repository_overlay::OverlayPlanError;
+    use BundleStoreError as Bundle;
+    use RepositoryReadError as ReadError;
+    for (source, expected) in [
+        (Bundle::Unsupported, Error::Unsupported),
+        (Bundle::UnsafeDirectory, Error::Storage),
+        (Bundle::Missing, Error::Input),
+        (Bundle::Conflict, Error::Input),
+        (Bundle::DigestMismatch, Error::Input),
+        (Bundle::WriteFailed, Error::Storage),
+        (Bundle::Read(ReadError::Unsupported), Error::Unsupported),
+        (Bundle::Read(ReadError::InvalidRoot), Error::Storage),
+        (Bundle::Read(ReadError::InvalidLimit), Error::Storage),
+        (
+            Bundle::Read(ReadError::Policy(OverlayPlanError::InvalidPath)),
+            Error::Storage,
+        ),
+        (Bundle::Read(ReadError::Missing), Error::Input),
+        (Bundle::Read(ReadError::UnsafePath), Error::Storage),
+        (Bundle::Read(ReadError::UnsupportedNode), Error::Storage),
+        (Bundle::Read(ReadError::Changed), Error::Storage),
+        (Bundle::Read(ReadError::TooLarge), Error::Input),
+        (Bundle::Read(ReadError::ReadFailed), Error::Storage),
+        (Bundle::Codec(codec::OverlayCodecError::Unsupported), Error::Input),
+        (Bundle::Codec(codec::OverlayCodecError::Malformed), Error::Input),
+    ] {
+        assert_eq!(bundle_error(source), expected);
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/intake/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/mod.rs
@@ -1,0 +1,235 @@
+//! Explicit retained repository intake, never export approval, setup or task authority.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+use super::bundle::codec;
+use crate::cloud_run::interactive_worker::valid_single_token;
+use crate::{
+    cloud_run::{ArtifactDigest, CloudJobId, CloudWorkflowId, GitSource},
+    remote_workspace::valid_local_id,
+};
+use serde::{Deserialize, Serialize};
+use std::{fmt, io::Read, path::PathBuf};
+
+pub const REQUEST_LIMIT: usize = 32 * 1024;
+pub const RESPONSE_LIMIT: usize = 128 * 1024;
+pub const PACK_LIMIT: u64 = super::seed::DEFAULT_ENCODED_PACK_BYTES;
+
+/// Bounded immutable recovery identity. Constructing/deserializing it grants no writes.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IntakeRequest {
+    pub version: u8,
+    pub workspace_local_id: String,
+    pub workflow_id: CloudWorkflowId,
+    pub job_id: CloudJobId,
+    pub runtime_generation: u64,
+    pub worker_resource_id: String,
+    pub client_key_sha256: ArtifactDigest,
+    pub source: GitSource,
+    pub pack: EncodedIdentity,
+    pub overlay: EncodedIdentity,
+}
+
+/// Pack digest or the existing complete two-layer bundle manifest, with wire length.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EncodedIdentity {
+    pub sha256: ArtifactDigest,
+    pub encoded_bytes: u64,
+}
+
+impl IntakeRequest {
+    /// Canonical bounded bytes suitable for retaining BEFORE an explicitly approved send.
+    /// # Errors
+    /// Rejects malformed identities, source or limits without filesystem access.
+    pub fn encode(&self) -> Result<Vec<u8>, IntakeError> {
+        let valid = self.version == 1
+            && valid_local_id(&self.workspace_local_id)
+            && self.workflow_id.to_string() != uuid::Uuid::nil().to_string()
+            && self.job_id.to_string() != uuid::Uuid::nil().to_string()
+            && self.runtime_generation > 0
+            && valid_single_token(&self.worker_resource_id, 512)
+            && self.source.validate().is_ok()
+            && self.source.commit.as_str().bytes().any(|byte| byte != b'0')
+            && (32..=PACK_LIMIT).contains(&self.pack.encoded_bytes)
+            && (1..=codec::MAX_ENCODED_BUNDLE_BYTES as u64).contains(&self.overlay.encoded_bytes);
+        if !valid {
+            return Err(IntakeError::Invalid);
+        }
+        serde_json::to_vec(self)
+            .ok()
+            .filter(|bytes| bytes.len() <= REQUEST_LIMIT)
+            .ok_or(IntakeError::Invalid)
+    }
+
+    /// Decode a strict request, not an approval or permission to recreate missing state.
+    /// # Errors
+    /// Rejects invalid JSON/identities, duplicate/unknown fields and excessive length.
+    pub fn decode(bytes: &[u8]) -> Result<Self, IntakeError> {
+        if bytes.len() > REQUEST_LIMIT {
+            return Err(IntakeError::Invalid);
+        }
+        let request: Self = serde_json::from_slice(bytes).map_err(|_| IntakeError::Invalid)?;
+        request.encode()?;
+        Ok(request)
+    }
+}
+
+impl fmt::Debug for IntakeRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntakeRequest").finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IntakeState {
+    Acknowledged,
+    Observed,
+    ClaimedUnknown,
+    Rejected,
+    Unconfirmed,
+    Error,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PackState {
+    Acknowledged,
+    Observed,
+    ReceiveUnconfirmed,
+    Unpublished,
+    PublishedUnsynchronized,
+    RenameUnconfirmed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BundleState {
+    Acknowledged,
+    Observed,
+    WriteUnconfirmed,
+}
+
+#[derive(Clone, Serialize)]
+pub struct IntakeRoots {
+    pub packs: PathBuf,
+    pub bundles: PathBuf,
+    pub setup: PathBuf,
+}
+
+#[derive(Serialize)]
+pub struct PackProgress {
+    pub state: PackState,
+    pub source: Option<PathBuf>,
+    pub destination: Option<PathBuf>,
+    pub objects: Option<u32>,
+}
+
+/// Known progress survives failure. These paths are historical candidates, not cleanup grants.
+#[derive(Serialize)]
+pub struct IntakeResponse {
+    pub version: u8,
+    pub state: IntakeState,
+    pub intent_sha256: Option<ArtifactDigest>,
+    pub roots: Option<IntakeRoots>,
+    pub pack: Option<PackProgress>,
+    pub bundle: Option<BundleState>,
+    pub reason: Option<IntakeError>,
+}
+
+impl IntakeResponse {
+    #[must_use]
+    pub const fn failure(reason: IntakeError) -> Self {
+        Self {
+            version: 1,
+            state: match reason {
+                IntakeError::Invalid => IntakeState::Rejected,
+                IntakeError::Unsupported => IntakeState::Unsupported,
+                _ => IntakeState::Error,
+            },
+            intent_sha256: None,
+            roots: None,
+            pack: None,
+            bundle: None,
+            reason: Some(reason),
+        }
+    }
+
+    #[must_use]
+    pub const fn exit_code(&self) -> u8 {
+        match self.state {
+            IntakeState::Acknowledged | IntakeState::Observed => 0,
+            IntakeState::Rejected => 2,
+            IntakeState::ClaimedUnknown => 4,
+            _ => 1,
+        }
+    }
+}
+
+impl fmt::Debug for IntakeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntakeResponse")
+            .field("state", &self.state)
+            .field("reason", &self.reason)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+pub enum IntakeError {
+    #[error("invalid repository intake identity or framing")]
+    Invalid,
+    #[error("repository intake requires supported qualified storage")]
+    Unsupported,
+    #[error("repository intake storage is unsafe, changed or unavailable")]
+    Storage,
+    #[error("repository intake claim conflicts with this request")]
+    Conflict,
+    #[error("repository intake was cancelled; retain state and do not replay")]
+    Cancelled,
+    #[error("repository intake input could not be verified")]
+    Input,
+}
+
+/// Explicit worker mutation at its fixed existing retained parent. The caller separately
+/// owns export, storage/capacity and pinned transport authority. No setup/task is started.
+/// Existing claims only observe, without reading payload or repairing missing children.
+/// Cancellation/Drop never removes state; blocking input/storage has no hard deadline.
+#[must_use]
+pub fn receive(request: &IntakeRequest, input: &mut impl Read, cancelled: impl Fn() -> bool) -> IntakeResponse {
+    execute(request, Some(input), &cancelled)
+}
+
+/// Read-only observation of the same claim and inputs. Never synchronizes or repairs.
+#[must_use]
+pub fn observe(request: &IntakeRequest, cancelled: impl Fn() -> bool) -> IntakeResponse {
+    execute(request, None, &cancelled)
+}
+
+fn execute(request: &IntakeRequest, input: Option<&mut dyn Read>, cancelled: &dyn Fn() -> bool) -> IntakeResponse {
+    if request.encode().is_err() {
+        return IntakeResponse::failure(IntakeError::Invalid);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::execute(
+            std::path::Path::new("/workspace/.horizon-worker"),
+            request,
+            input,
+            cancelled,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (input, cancelled);
+        IntakeResponse::failure(IntakeError::Unsupported)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/intake/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+#[cfg(not(target_os = "linux"))]
+use IntakeState as State;
+use std::io;
+
+pub(super) fn request() -> IntakeRequest {
+    serde_json::from_value(serde_json::json!({
+        "version":1,"workspace_local_id":"fixture-workspace",
+        "workflow_id":"11111111-1111-4111-8111-111111111111",
+        "job_id":"22222222-2222-4222-8222-222222222222",
+        "runtime_generation":1,"worker_resource_id":"fixture-worker",
+        "client_key_sha256":"a".repeat(64),
+        "source":{"repository":"fixture/repository","commit":"a".repeat(40),"branch":null},
+        "pack":{"sha256":"b".repeat(64),"encoded_bytes":32},
+        "overlay":{"sha256":"c".repeat(64),"encoded_bytes":1}
+    }))
+    .unwrap()
+}
+
+pub(super) struct Unread;
+impl Read for Unread {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        panic!("unexpected payload read")
+    }
+}
+
+#[test]
+fn strict_bounded_identity_preserves_canonical_fields_and_redacts_debug() {
+    let mut request = request();
+    let bytes = request.encode().unwrap();
+    assert_eq!(IntakeRequest::decode(&bytes).unwrap(), request);
+    for (field, replacement) in [
+        ("version", serde_json::json!(2)),
+        ("runtime_generation", serde_json::json!(0)),
+        ("workspace_local_id", serde_json::json!("../outside")),
+        ("worker_resource_id", serde_json::json!("bad\nvalue")),
+        ("worker_resource_id", serde_json::json!("")),
+        ("worker_resource_id", serde_json::json!("bad value")),
+        ("worker_resource_id", serde_json::json!(" worker")),
+        ("worker_resource_id", serde_json::json!("worker ")),
+        ("worker_resource_id", serde_json::json!("bad\u{a0}value")),
+        ("worker_resource_id", serde_json::json!("-worker")),
+        ("worker_resource_id", serde_json::json!("x".repeat(513))),
+        ("job_id", serde_json::json!(uuid::Uuid::nil())),
+        ("extra", serde_json::json!(true)),
+        (
+            "pack",
+            serde_json::json!({"sha256":"b".repeat(64),"encoded_bytes":PACK_LIMIT+1}),
+        ),
+    ] {
+        let mut value = serde_json::to_value(&request).unwrap();
+        value[field] = replacement;
+        assert!(IntakeRequest::decode(&serde_json::to_vec(&value).unwrap()).is_err());
+        if let Ok(invalid) = serde_json::from_value::<IntakeRequest>(value) {
+            let received = receive(&invalid, &mut Unread, || false);
+            for response in [received, observe(&invalid, || false)] {
+                assert_eq!(response.state, IntakeState::Rejected);
+                assert_eq!(response.reason, Some(IntakeError::Invalid));
+                assert!(response.roots.is_none() && response.pack.is_none() && response.bundle.is_none());
+            }
+        }
+    }
+    for bytes in [
+        vec![b' '; REQUEST_LIMIT + 1],
+        [bytes.clone(), b" {}".to_vec()].concat(),
+        [b"{\"version\":1,".as_slice(), &bytes[1..]].concat(),
+    ] {
+        assert!(IntakeRequest::decode(&bytes).is_err());
+    }
+    assert!(!format!("{request:?}").contains("fixture"));
+    request.worker_resource_id = "x".repeat(512);
+    assert_eq!(IntakeRequest::decode(&request.encode().unwrap()).unwrap(), request);
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_never_reads_payload() {
+    for response in [
+        receive(&request(), &mut Unread, || false),
+        observe(&request(), || false),
+    ] {
+        assert_eq!(response.state, State::Unsupported);
+        assert!(response.roots.is_none() && response.pack.is_none());
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -5,6 +5,7 @@
 pub mod bundle;
 pub mod capture;
 pub mod checkout;
+pub mod intake;
 pub mod materialize;
 pub mod namespace;
 mod paths;

--- a/crates/horizon-core/src/repository_overlay/seed/export/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/export/mod.rs
@@ -26,7 +26,7 @@ pub struct PackExportLimits {
 }
 
 impl PackExportLimits {
-    pub const DEFAULT_ENCODED_BYTES: u64 = 256 * 1024 * 1024;
+    pub const DEFAULT_ENCODED_BYTES: u64 = super::DEFAULT_ENCODED_PACK_BYTES;
     pub const MAX_ENCODED_BYTES: u64 = MAX_BYTES * 2;
 
     fn validate(self) -> Result<(), SeedError> {

--- a/crates/horizon-core/src/repository_overlay/seed/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/mod.rs
@@ -14,6 +14,7 @@ pub mod receive;
 mod staging;
 
 use super::namespace::ResolvedRepositoryOverlay;
+pub(crate) const DEFAULT_ENCODED_PACK_BYTES: u64 = 256 * 1024 * 1024;
 /// Worker pack candidates reserve the native terminator and fixed inner-path headroom.
 pub const MAX_PACK_PATH_BYTES: usize =
     super::materialize::MAX_REQUEST_PATH_BYTES - 2 - super::checkout::publication::MAX_SIBLING_NAME_BYTES;

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -281,6 +281,12 @@ back into large multi-purpose modules.
   another repository walker. Storage qualification and sibling-name policy remain
   shared; non-root fingerprints survive relocation unchanged. See
   [pack publication](../remote-repository-pack-publication.md).
+  `intake/` combines fixed retained-root initialization with pack/bundle receipt and
+  noncreating observation. Its pure request/response shell keeps strict identities;
+  the Linux leaf owns the create-new claim, held directory bindings and component
+  orchestration. Existing claims never consume payload or grant another receiver.
+  See [combined core intake](../remote-repository-intake.md); CLI/controller and
+  setup/task authority remain separate.
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;

--- a/docs/remote-repository-intake.md
+++ b/docs/remote-repository-intake.md
@@ -1,0 +1,78 @@
+# Combined retained repository intake
+
+`repository_overlay::intake::{receive, observe}` is a worker core API. It does not
+add a shipped CLI, SSH controller, provider operation, setup execution or task.
+Those adapters must separately enforce explicit export approval and full retained
+worker/client ownership. Constructing a request, capturing an overlay, computing a
+digest or successfully recovering a provider allocation is not export approval.
+
+The caller approves the **complete** exact base closure, including raw commit
+metadata and files that overlays will delete, and both index/worktree layers of
+one existing `RepositoryOverlayBundle`. It keeps source bytes stable and exclusively
+controlled during any later transfer; an open file handle alone is not immutable.
+
+## Request and input
+
+Version 1 binds workspace local ID, workflow/job IDs, runtime generation, worker
+resource ID, client-key SHA-256, complete `GitSource`, pack SHA-256/encoded length,
+and overlay manifest/encoded length. Pack base is `source.commit`. Overlay identity
+is the existing complete bundle manifest, not a second encoding or wire digest.
+Canonical request JSON is capped at 32 KiB and its SHA-256 identifies the claim.
+Unknown/duplicate fields, malformed IDs, zero generation/commit and excessive
+lengths are rejected before storage access. Worker-supplied labels do not themselves
+authenticate provider ownership; a future pinned controller must establish that.
+
+The core receiver consumes exactly the declared pack bytes, then exactly the declared
+canonical overlay bytes, then EOF. Its bounded pack reader exposes local EOF without
+consuming the overlay. The existing native receiver independently verifies the pack,
+index and exact shallow commit closure. The overlay codec verifies all payload hashes,
+manifest and source before either input is published. The pack ceiling is the shared
+256 MiB default; existing bundle inner/encoded limits and native process ceilings apply.
+Pack copying is chunked. Overlay decoding retains bounded complete-buffer copies,
+not constant total memory. No original source repository is read on the worker.
+
+## Fixed roots and replay barrier
+
+Production uses only the existing `/workspace/.horizon-worker` parent. It must be
+owned by the executing UID, mode 0700, with stable private ancestry/mounts and
+healthy journaled ext4 storage accepted by the existing storage qualifier. Git,
+prlimit and kernel metadata must be trusted. There is no path override, chmod,
+repair, filesystem fallback, or claim of hostile same-user race confinement.
+
+The fixed `repository-intake.claim` stores the complete canonical request. Only a
+fresh create-new winner that writes and synchronizes both claim and parent may
+initialize `repository-inputs/{packs,bundles}` and `repository-setup`. These roots
+are mode 0700, created by single-component writes under held parent descriptors,
+synchronized child-before-parent, and checked against their live names. An existing
+child without a claim is refused; existing, partial or conflicting claims cannot
+grant another receiver or replace data. The setup root remains empty and confers
+no permission to start setup or a task.
+
+A matching existing receive request performs observation **without reading its
+payload**, synchronizing, repairing or recreating roots. `observe` never creates a
+claim or infers an absent/replayable operation from missing data. It rechecks the
+published `packs/base` and stored bundle through the existing read-only validators.
+Successful observation is current logical verification, not a new durability proof.
+
+## Retained results and interruption
+
+Responses distinguish acknowledged, observed, claimed-unknown, unconfirmed,
+rejected, error and unsupported outcomes. Known pack progress preserves unpublished,
+published-unsynchronized and rename-unconfirmed states, including both candidate
+names for an uncertain rename. Bundle writes have an explicit unconfirmed state.
+Roots and progress are historical candidates, not assertions that all names exist
+or authority to clean them up. Absent optional fields serialize as explicit null.
+
+Cancellation is checked before admission, directory operations, bounded input reads
+and final acknowledgement, and delegated to native pack operations. Blocking reader,
+storage, spawn and reap calls are not covered by a hard operation deadline. Failure,
+drop or a lost outer response never deletes state or authorizes a resend. A later
+caller can inspect the same intent, but cannot manufacture a fresh claim after loss.
+Synchronization acknowledgement is conditional on the documented storage premises;
+it is not power-loss testing, cloud retention proof, backup or repository readiness.
+
+Unit tests cover strict metadata, unsafe/missing roots, every root-sync failure,
+partial/conflicting claims, concurrent claim writers, existing-child refusal,
+directory replacement, cancellation, exact payload framing and qualified observation.
+The qualified positive unit test reports an explicit skip when capability is absent;
+delivery additionally requires a real qualified positive smoke of this exact API.


### PR DESCRIPTION
## Purpose

Deliver the worker-core half of approved repository intake for #470 and #383: one exact-base pack and one existing two-layer overlay bundle, retained independently of the client.

## Behavior

- Add fixed-root `receive` and read-only `observe` APIs. Require an existing private, qualified retained parent before writing anything.
- Reuse canonical worker-ID validation with the existing 512-byte intake limit; malformed IDs are rejected before reading payloads or accessing storage.
- Persist a create-new immutable claim before creating input/setup roots. Existing, partial, conflicting or uncertain claims never authorize another receiver, root repair or payload replay.
- Verify exact pack framing, bundle identity/source and outer EOF before publication. Preserve known unpublished, unsynchronized and uncertain pack/bundle outcomes without rollback or deletion.
- Preserve typed pack, bundle and publication failure reasons: distinguish unsafe/storage failures from input validation, cancellation and unsupported capabilities without changing progress receipts.
- Keep setup/task execution separate. The reserved setup root remains empty; no provider, panel, UI, configuration or dependency changes are included.

## Validation

- Ten focused intake tests passed, including actual qualified-storage success, concurrent/no-adoption fences, exhaustive error classifications and a real unsafe-bundle observation regression. That regression failed with the old input classification and passed with storage classification, retaining the observed pack and refusing input replay.
- Ten existing interactive-worker contract tests also passed. Request regressions cover empty, ASCII/Unicode whitespace, leading-dash and oversized worker IDs, direct receive/observe refusal without payload reads or storage paths, and the valid 512-byte boundary.
- All eight gates passed on `aaa2524387fa4933347fcfd4ed8622d3c5887544`: formatting, maintainability, version sync, default and speech workspace tests, blocking, strict and advisory pedantic Clippy.
- A private driver linked to that exact public core API was built offline in the retained Linux runtime; all 163 Linux-active registry dependencies matched the candidate lockfile. No shipped-image or CLI claim.
- All six pinned local SSH smoke lanes passed on actual storage: qualified ext4 and non-writing missing-claim observation; a 68,178,739-byte pack plus a 738-byte two-layer bundle acknowledged once; a new container observing the same volume; actual local stdout loss followed by fresh observation without resend; a 1MiB partial upload retained with read-only observation and explicit empty-input replay refusal; and actual tmpfs refusal before claim creation.
- Independent native Git inspection verified the seven-object shallow closure, excluded ancestor and large-blob hash. Retained bundle bytes matched both source layers; setup/task state remained absent. The successful campaign's six containers, three volumes and generated fixture/key files were removed after exact-identity checks; its separate build container was also removed.
- Smoke completion receipt SHA256: `5eab9bc6ada486f84ec25b468ee8052e82b4d17f86916318cf7b1dddb5d9b022`; linked lane receipt: `63e08f225bec5cf9d4992e355ef718a1f3ef54090b255c52d6eb3b3c7d7fac28`.

## Boundaries

This PR exposes the public core API, not the command-line/header adapter or pinned approved-export controller; those form the immediate follow-on. It does not demonstrate a configured cloud workflow, PC-off durability or a completed checkout. Successful observation is logical verification, not a new synchronization claim. Healthy qualified storage and stable trusted ancestry remain explicit premises.

The user approved this unchanged intake outcome up to 1,100 changed source/test lines; the final diff is 1,098 lines across eight source/test files. The additional shared-helper edit only exposes the unchanged canonical token validator within the crate.
