### PR TITLE
refactor(remote): share bounded query streaming

### DIFF
--- a/crates/horizon-core/src/remote_worker_ssh/query.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/query.rs
@@ -4,7 +4,7 @@ use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
 use std::{
     io::{self, Read, Write},
     os::fd::AsFd,
-    process::{Child, ChildStdin, Command, Stdio},
+    process::{Child, ChildStdin, Command, ExitStatus, Stdio},
     thread,
     time::{Duration, Instant},
 };
@@ -22,66 +22,32 @@ pub(crate) enum Error {
 }
 
 pub(crate) fn run(
-    mut command: Command,
-    input: &[u8],
+    command: Command,
+    mut input: &[u8],
     timeout: Duration,
     response_limit: usize,
 ) -> Result<Vec<u8>, Error> {
-    let started = Instant::now();
-    let child = command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
-                Error::ClientUnavailable
-            } else {
-                Error::QueryFailed
-            }
-        })?;
-    let mut child = OwnedChild(child);
-    let mut stdin = Some(child.0.stdin.take().ok_or(Error::QueryFailed)?);
-    let mut stdout = child.0.stdout.take().ok_or(Error::QueryFailed)?;
-    nonblocking(stdin.as_ref().ok_or(Error::QueryFailed)?)?;
-    nonblocking(&stdout)?;
-    let mut pending = input;
-    let mut output = Vec::new();
-    loop {
-        if started.elapsed() >= timeout {
-            return Err(Error::Deadline);
-        }
-        write_pending(&mut stdin, &mut pending)?;
-        let finished = read_available(&mut stdout, &mut output, response_limit)?;
-        if let Some(status) = child.0.try_wait().map_err(|_| Error::QueryFailed)? {
-            if !status.success() || !pending.is_empty() {
-                return Err(Error::QueryFailed);
-            }
-            if finished {
-                return Ok(output);
-            }
-        }
-        thread::sleep(Duration::from_millis(10).min(timeout.saturating_sub(started.elapsed())));
+    let expected = input.len() as u64;
+    let result = exchange(command, &mut input, timeout, response_limit, || false, Some(expected))?;
+    known_response(result, expected)
+}
+
+fn known_response(result: Exchange, expected: u64) -> Result<Vec<u8>, Error> {
+    check_known(result.status, result.input.written(), expected)?;
+    Ok(result.output)
+}
+
+fn check_known(status: ExitStatus, written: u64, expected: u64) -> Result<(), Error> {
+    if status.success() && written == expected {
+        Ok(())
+    } else {
+        Err(Error::QueryFailed)
     }
 }
 
 fn nonblocking(fd: &impl AsFd) -> Result<(), Error> {
     let flags = fcntl_getfl(fd).map_err(|_| Error::QueryFailed)?;
     fcntl_setfl(fd, flags | OFlags::NONBLOCK).map_err(|_| Error::QueryFailed)
-}
-
-fn write_pending(stdin: &mut Option<ChildStdin>, pending: &mut &[u8]) -> Result<(), Error> {
-    if let Some(stream) = stdin {
-        match stream.write(pending) {
-            Ok(count) => *pending = &pending[count..],
-            Err(error) if matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) => {}
-            Err(_) => return Err(Error::QueryFailed),
-        }
-        if pending.is_empty() {
-            stdin.take();
-        }
-    }
-    Ok(())
 }
 
 fn read_available(stream: &mut impl Read, output: &mut Vec<u8>, limit: usize) -> Result<bool, Error> {
@@ -99,7 +65,180 @@ fn read_available(stream: &mut impl Read, output: &mut Vec<u8>, limit: usize) ->
     }
 }
 
+pub(crate) struct Exchange {
+    pub status: ExitStatus,
+    pub output: Vec<u8>,
+    pub input: InputProgress,
+}
+
+/// Actual successful pipe writes; EOF is separate from a caller's known length.
+pub(crate) enum InputProgress {
+    Incomplete(u64),
+    Complete(u64),
+}
+
+impl InputProgress {
+    fn written(&self) -> u64 {
+        match self {
+            Self::Incomplete(written) | Self::Complete(written) => *written,
+        }
+    }
+}
+
+/// Stream bounded chunks and retain early/nonzero responses even when stdin closes.
+/// Cancellation tears down only the owned local child; remote completion is unknown.
+/// Blocking source reads, spawn and reap are outside the best-effort pipe deadline.
+/// A known length retains legacy success-only early-exit/error precedence. Streaming
+/// callers omit it so early/nonzero responses are drained even with incomplete input.
+pub(crate) fn exchange(
+    mut command: Command,
+    input: &mut dyn Read,
+    timeout: Duration,
+    response_limit: usize,
+    cancelled: impl Fn() -> bool,
+    known_input: Option<u64>,
+) -> Result<Exchange, Error> {
+    if cancelled() {
+        return Err(Error::QueryFailed);
+    }
+    let started = Instant::now();
+    let admit = || {
+        if cancelled() {
+            Err(Error::QueryFailed)
+        } else if started.elapsed() >= timeout {
+            Err(Error::Deadline)
+        } else {
+            Ok(())
+        }
+    };
+    let mut child = spawn(&mut command)?;
+    let mut stdin = Some(child.0.stdin.take().ok_or(Error::QueryFailed)?);
+    let mut stdout = child.0.stdout.take().ok_or(Error::QueryFailed)?;
+    nonblocking(stdin.as_ref().ok_or(Error::QueryFailed)?)?;
+    nonblocking(&stdout)?;
+    let mut buffer = [0; 16 * 1024];
+    let mut pending = 0..0;
+    let mut input_complete = false;
+    let mut written = 0;
+    let mut output = Vec::new();
+    loop {
+        admit()?;
+        let previous = (written, output.len());
+        if let Some(expected) = known_input {
+            if written != expected {
+                stream_input(
+                    &mut stdin,
+                    input,
+                    &mut buffer,
+                    &mut pending,
+                    &mut input_complete,
+                    &mut written,
+                    &admit,
+                )?;
+            }
+            if written == expected {
+                stdin.take();
+            } else if stdin.is_none() {
+                return Err(Error::QueryFailed);
+            }
+        }
+        let finished = read_available(&mut stdout, &mut output, response_limit)?;
+        if let Some(status) = child.0.try_wait().map_err(|_| Error::QueryFailed)? {
+            if let Some(expected) = known_input {
+                check_known(status, written, expected)?;
+            }
+            stdin.take();
+            if finished {
+                return Ok(Exchange {
+                    status,
+                    output,
+                    input: if input_complete {
+                        InputProgress::Complete(written)
+                    } else {
+                        InputProgress::Incomplete(written)
+                    },
+                });
+            }
+        }
+        if known_input.is_none() {
+            stream_input(
+                &mut stdin,
+                input,
+                &mut buffer,
+                &mut pending,
+                &mut input_complete,
+                &mut written,
+                &admit,
+            )?;
+        }
+        if previous == (written, output.len()) {
+            thread::sleep(Duration::from_millis(10).min(timeout.saturating_sub(started.elapsed())));
+        }
+    }
+}
+
+fn stream_input(
+    stdin: &mut Option<ChildStdin>,
+    input: &mut dyn Read,
+    buffer: &mut [u8],
+    pending: &mut std::ops::Range<usize>,
+    complete: &mut bool,
+    written: &mut u64,
+    admit: &impl Fn() -> Result<(), Error>,
+) -> Result<(), Error> {
+    let Some(stream) = stdin.as_mut() else {
+        return Ok(());
+    };
+    if pending.start == pending.end {
+        let read = input.read(buffer);
+        // A source read may block past the previous point-in-time admission.
+        admit()?;
+        match read {
+            Ok(0) => {
+                *complete = true;
+                stdin.take();
+                return Ok(());
+            }
+            Ok(count) => *pending = 0..count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => return Ok(()),
+            Err(_) => return Err(Error::QueryFailed),
+        }
+    }
+    admit()?;
+    match stream.write(&buffer[pending.clone()]) {
+        Ok(0) => {
+            stdin.take();
+        }
+        Ok(count) => {
+            pending.start += count;
+            *written = written.checked_add(count as u64).ok_or(Error::QueryFailed)?;
+        }
+        Err(error) if matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) => {}
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
+            stdin.take();
+        }
+        Err(_) => return Err(Error::QueryFailed),
+    }
+    Ok(())
+}
+
 struct OwnedChild(Child);
+
+fn spawn(command: &mut Command) -> Result<OwnedChild, Error> {
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(OwnedChild)
+        .map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                Error::ClientUnavailable
+            } else {
+                Error::QueryFailed
+            }
+        })
+}
 
 impl Drop for OwnedChild {
     fn drop(&mut self) {

--- a/crates/horizon-core/src/remote_worker_ssh/query/tests.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/query/tests.rs
@@ -1,3 +1,5 @@
+mod streaming;
+
 use super::*;
 use std::{
     process::Command,

--- a/crates/horizon-core/src/remote_worker_ssh/query/tests/streaming.rs
+++ b/crates/horizon-core/src/remote_worker_ssh/query/tests/streaming.rs
@@ -1,0 +1,206 @@
+use super::*;
+
+#[test]
+fn known_input_accepts_exact_written_bytes_without_reading_source_eof() {
+    struct NoEof<'a>(&'a [u8]);
+    impl Read for NoEof<'_> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            assert!(!self.0.is_empty(), "the known-length query must not probe source EOF");
+            self.0.read(bytes)
+        }
+    }
+    for input in [b"".as_slice(), b"known exact input".as_slice()] {
+        let command = || {
+            let mut command = Command::new("/usr/bin/head");
+            command.args(["-c", &input.len().to_string()]);
+            command
+        };
+        let result = exchange(
+            command(),
+            &mut NoEof(input),
+            Duration::from_secs(2),
+            input.len(),
+            || false,
+            Some(input.len() as u64),
+        )
+        .expect("known handoff");
+        assert!(matches!(result.input, InputProgress::Incomplete(written) if written == input.len() as u64));
+        assert_eq!(known_response(result, input.len() as u64), Ok(input.to_vec()));
+        assert_eq!(
+            run(command(), input, Duration::from_secs(2), input.len()),
+            Ok(input.to_vec())
+        );
+    }
+}
+
+#[test]
+fn known_failures_do_not_wait_for_inherited_stdout_but_streaming_does() {
+    for (script, input) in [
+        ("sleep 0.4 & exit 7", vec![]),
+        ("sleep 0.4 & exit 0", vec![b'x'; 1024 * 1024]),
+    ] {
+        let timeout = Duration::from_millis(100);
+        assert_eq!(run(shell(script), &input, timeout, 32), Err(Error::QueryFailed));
+        let result = exchange(shell(script), &mut input.as_slice(), timeout, 32, || false, None);
+        assert!(matches!(result, Err(Error::Deadline)));
+    }
+}
+
+#[test]
+fn continuous_output_still_observes_cancellation_and_deadline() {
+    let checks = std::cell::Cell::new(0);
+    let result = exchange(
+        shell("exec yes"),
+        &mut io::empty(),
+        Duration::from_secs(2),
+        1024 * 1024,
+        || {
+            checks.set(checks.get() + 1);
+            checks.get() > 100
+        },
+        None,
+    );
+    assert!(matches!(result, Err(Error::QueryFailed)));
+    assert!(checks.get() > 100);
+    let result = exchange(
+        shell("exec yes"),
+        &mut io::empty(),
+        Duration::from_millis(50),
+        64 * 1024 * 1024,
+        || false,
+        None,
+    );
+    assert!(matches!(result, Err(Error::Deadline)));
+}
+
+#[test]
+fn source_read_cannot_deliver_bytes_or_eof_after_admission_expires() {
+    struct ChangedDuringRead<'a>(&'a std::cell::Cell<bool>, bool);
+    impl Read for ChangedDuringRead<'_> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            self.0.set(true);
+            bytes[0] = b'x';
+            Ok(usize::from(!self.1))
+        }
+    }
+    for eof in [false, true] {
+        for deadline in [false, true] {
+            let changed = std::cell::Cell::new(false);
+            let mut input = ChangedDuringRead(&changed, eof);
+            let mut child = OwnedChild(
+                Command::new("/bin/cat")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::null())
+                    .spawn()
+                    .expect("child"),
+            );
+            let mut stdin = child.0.stdin.take();
+            let mut complete = false;
+            let mut written = 0;
+            let result = stream_input(
+                &mut stdin,
+                &mut input,
+                &mut [0; 16],
+                &mut (0..0),
+                &mut complete,
+                &mut written,
+                &|| {
+                    if changed.get() {
+                        Err(if deadline { Error::Deadline } else { Error::QueryFailed })
+                    } else {
+                        Ok(())
+                    }
+                },
+            );
+            assert_eq!(result, Err(if deadline { Error::Deadline } else { Error::QueryFailed }));
+            assert!(stdin.is_some() && !complete);
+            assert_eq!(written, 0);
+        }
+    }
+}
+
+#[test]
+fn early_nonzero_response_survives_incomplete_input() {
+    let mut input = io::repeat(b'x').take(8 * 1024 * 1024);
+    let result = exchange(
+        shell("exec 0<&-; printf observed; exit 4"),
+        &mut input,
+        Duration::from_secs(2),
+        32,
+        || false,
+        None,
+    )
+    .expect("retained response");
+    assert_eq!(result.status.code(), Some(4));
+    assert_eq!(result.output, b"observed");
+    assert!(matches!(result.input, InputProgress::Incomplete(_)));
+    assert!(input.limit() > 0);
+}
+
+#[test]
+fn broken_pipe_preserves_output_for_draining() {
+    let mut child = OwnedChild(
+        shell("printf observed; exit 4")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("child"),
+    );
+    let mut stdin = child.0.stdin.take();
+    let mut stdout = child.0.stdout.take().expect("stdout");
+    assert_eq!(child.0.wait().expect("closed reader").code(), Some(4));
+    let mut complete = false;
+    let mut written = 0;
+    assert_eq!(
+        stream_input(
+            &mut stdin,
+            &mut io::repeat(b'x'),
+            &mut [0; 16],
+            &mut (0..0),
+            &mut complete,
+            &mut written,
+            &|| Ok(())
+        ),
+        Ok(())
+    );
+    assert!(stdin.is_none() && !complete);
+    assert_eq!(written, 0);
+    let mut output = Vec::new();
+    assert_eq!(read_available(&mut stdout, &mut output, 32), Ok(false));
+    assert_eq!(read_available(&mut stdout, &mut output, 32), Ok(true));
+    assert_eq!(output, b"observed");
+}
+
+#[test]
+fn complete_stream_and_bounded_failures_preserve_query_contract() {
+    let input = vec![b'x'; 8 * 1024 * 1024];
+    let started = Instant::now();
+    let result = exchange(
+        shell("exec cat"),
+        &mut input.as_slice(),
+        Duration::from_secs(20),
+        input.len(),
+        || false,
+        None,
+    )
+    .expect("stream");
+    eprintln!("bounded local stream: {} bytes in {:?}", input.len(), started.elapsed());
+    assert!(result.status.success() && matches!(result.input, InputProgress::Complete(_)));
+    assert_eq!(result.input.written(), input.len() as u64);
+    assert_eq!(result.output, input);
+    for (script, limit, deadline, cancel, expected) in [
+        ("printf oversized", 2, 2000, false, Error::OutputLimit),
+        ("exec sleep 5", 32, 40, false, Error::Deadline),
+        ("exit 0", 32, 2000, true, Error::QueryFailed),
+    ] {
+        let result = exchange(
+            shell(script),
+            &mut io::empty(),
+            Duration::from_millis(deadline),
+            limit,
+            || cancel,
+            None,
+        );
+        assert!(matches!(result, Err(error) if error == expected));
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -164,6 +164,10 @@ back into large multi-purpose modules.
   Its shared `query.rs` leaf owns bounded nonblocking local-child I/O, explicit
   caller response ceilings and typed transport failures without owning protocol
   parsing, admission, remote tasks or provider lifetime. Query tests are colocated.
+  The existing success-only query adapter now uses the same streaming engine:
+  known-input queries check actual written bytes, while streaming exchanges retain
+  early/nonzero replies and distinguish source EOF. One bounded read/write per
+  iteration preserves cancellation/deadline checks; only no-progress passes sleep.
 - `remote_panel_attachment.rs` consumes explicit exact-allocation admission, fresh
   read-only identity/worker inspection and saved-intent verification before a pinned
   local PTY. Only explicit recovery commits observations; attachment preserves saved phases.


### PR DESCRIPTION
## Purpose

Share bounded streaming I/O for remote worker queries, preparing the approved repository handoff in #470 and #383 without adding intake commands or a controller.

## Behavior

- The existing success-only query adapter uses the shared engine and still requires successful child exit plus every known input byte written. It closes complete known input without an extra EOF read, including zero-length input.
- Streaming callers can retain early and nonzero replies after stdin closes. Actual written bytes and source EOF remain separate; neither is remote acknowledgement by itself.
- Each pass performs bounded I/O and checks cancellation/deadline admission; only passes without progress sleep. Output limits remain enforced under continuous output.
- Cancellation/error cleanup affects only the owned local query child. No remote task, provider lifetime, retry, UI, configuration or dependency changes.

## Validation

- All eight local gates passed on `7952c79894557a794ccb566680c32ab204ce8cd6`: formatting, maintainability, version sync, default/speech workspace tests, blocking/strict/advisory pedantic Clippy.
- All 16 focused SSH/query tests passed. The seven new streaming tests now live in the existing colocated test tree; their behavior and production code are unchanged by this extraction.
- Cases cover empty/nonempty known writes without an EOF probe, inherited stdout after early failure, continuous-output cancellation/deadlines, expired admission during source reads, early nonzero replies, broken pipes, full streaming and bounded failures.
- A synthetic local child echoed 8 MiB with exact byte equality. This is a correctness sample, not SSH/cloud throughput evidence.
- Independent local review of both corrections completed. Three source/test files change by 447 lines; the architecture note adds four lines.
- The previous hosted head failed a browser CLI report-error assertion in unchanged code. Both current local workspace test tiers pass; fresh current-head hosted checks remain required.

## Limits

The pipe-loop deadline is best effort: blocking source reads, process spawn and reap are outside its hard bound. This PR is independently testable and does not depend on the pending worker-intake PR. It does not demonstrate a configured workflow, cloud durability, shipped intake CLI or repository approval flow.
