### PR TITLE
feat(remote): send approved repository intake over pinned SSH

### DIFF
--- a/crates/horizon-core/src/remote_repository_pack.rs
+++ b/crates/horizon-core/src/remote_repository_pack.rs
@@ -149,4 +149,4 @@ pub enum RemotePackInspectionError {
 }
 
 #[cfg(all(test, target_os = "linux"))]
-mod tests;
+pub(crate) mod tests;

--- a/crates/horizon-core/src/remote_repository_pack/tests.rs
+++ b/crates/horizon-core/src/remote_repository_pack/tests.rs
@@ -52,14 +52,14 @@ impl Expected {
     }
 }
 
-struct Fixture {
-    _directory: tempfile::TempDir,
-    store: CloudWorkflowStore,
-    recovered: RecoveredRemoteWorkspace,
+pub(crate) struct Fixture {
+    pub(crate) directory: tempfile::TempDir,
+    pub(crate) store: CloudWorkflowStore,
+    pub(crate) recovered: RecoveredRemoteWorkspace,
 }
 
 impl Fixture {
-    fn new(lifecycle: Option<InteractiveWorkerLifecycle>) -> Self {
+    pub(crate) fn new(lifecycle: Option<InteractiveWorkerLifecycle>) -> Self {
         use std::os::unix::fs::PermissionsExt;
         let directory = tempfile::tempdir().expect("fixture");
         std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
@@ -110,13 +110,13 @@ impl Fixture {
         let recovered = recover_remote_workspace(&store, &identities, &Provider(status), OWNER, "workspace")
             .expect("fixture recovery");
         Self {
-            _directory: directory,
+            directory,
             store,
             recovered,
         }
     }
 
-    fn current(&self) -> StoredRemoteAllocation {
+    pub(crate) fn current(&self) -> StoredRemoteAllocation {
         self.store
             .load_remote_allocation(OWNER, "workspace")
             .expect("load")
@@ -143,7 +143,7 @@ impl Fixture {
         )
     }
 
-    fn edit(&self, stop: bool) {
+    pub(crate) fn edit(&self, stop: bool) {
         let current = self.current();
         if stop {
             self.store

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -31,10 +31,30 @@ pub(crate) fn prepared_pack_status(
     command_for(identity, known_hosts, endpoint, Operation::PackStatus)
 }
 
+pub(crate) fn prepared_intake(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+    observe: bool,
+) -> Result<Command, Error> {
+    command_for(
+        identity,
+        known_hosts,
+        endpoint,
+        if observe {
+            Operation::IntakeStatus
+        } else {
+            Operation::Intake
+        },
+    )
+}
+
 #[derive(Clone, Copy)]
 enum Operation<'a> {
     Request,
     PackStatus,
+    Intake,
+    IntakeStatus,
     Attach { runtime: CloudJobId, panel: &'a str },
 }
 
@@ -49,7 +69,7 @@ fn command_for(
     }
     let mut command = Command::new("ssh");
     let terminal_mode = match operation {
-        Operation::Request | Operation::PackStatus => "-T",
+        Operation::Request | Operation::PackStatus | Operation::Intake | Operation::IntakeStatus => "-T",
         Operation::Attach { panel, .. } if valid_local_id(panel) => "-tt",
         Operation::Attach { .. } => return Err(Error::UnknownPanel),
     };
@@ -99,6 +119,8 @@ fn command_for(
     command.arg(match operation {
         Operation::Request => "/usr/local/bin/horizon-panel-session request".into(),
         Operation::PackStatus => "/usr/local/bin/horizon-repository pack-status".into(),
+        Operation::Intake => "/usr/local/bin/horizon-repository intake".into(),
+        Operation::IntakeStatus => "/usr/local/bin/horizon-repository intake-status".into(),
         Operation::Attach { runtime, panel } => {
             format!("/usr/local/bin/horizon-panel-session attach -- {runtime} {panel}")
         }
@@ -207,6 +229,16 @@ mod tests {
             pack.get_envs().collect::<Vec<_>>(),
             query.get_envs().collect::<Vec<_>>()
         );
+        for (observe, operation) in [(false, "intake"), (true, "intake-status")] {
+            let intake = prepared_intake(identity.private_key_path(), &first_path, &endpoint, observe).expect("intake");
+            *pack_args.last_mut().expect("fixed intake") =
+                format!("/usr/local/bin/horizon-repository {operation}").into();
+            assert_eq!(intake.get_args().collect::<Vec<_>>(), pack_args);
+            assert_eq!(
+                intake.get_envs().collect::<Vec<_>>(),
+                query.get_envs().collect::<Vec<_>>()
+            );
+        }
         let mut expected: Vec<_> = query.get_args().map(std::ffi::OsStr::to_os_string).collect();
         expected[4] = "-tt".into();
         *expected.last_mut().expect("helper") =

--- a/crates/horizon-core/src/repository_overlay/intake/controller.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/controller.rs
@@ -1,0 +1,382 @@
+//! Explicit export approval and pinned one-shot handoff; never setup/task authority.
+mod input;
+
+use super::{
+    ArtifactDigest, BundleState, EncodedIdentity, IntakeError, IntakeRequest, IntakeResponse, IntakeState, PackState,
+    RESPONSE_LIMIT, codec,
+};
+use crate::{
+    cloud_run::{CloudWorkflowStore, StoredRemoteAllocation},
+    remote_worker_inspection::validate_current,
+    remote_worker_ssh::{known_hosts, prepared_intake, query},
+    remote_worker_status::RemotePanelStatusError,
+    remote_workspace_recovery::RecoveredRemoteWorkspace,
+    repository_overlay::{
+        bundle::RepositoryOverlayBundle,
+        seed::{MAX_OBJECTS, export::PreparedGitPack},
+    },
+};
+use std::{cell::Cell, io::Read, path::Path, time::Duration};
+
+/// Inert proposal borrowing caller-owned inputs. Retain `request` before approval.
+/// The caller must keep pack bytes and ancestry stable/exclusive through handoff.
+pub struct RepositoryIntakeProposal<'a> {
+    allocation: &'a StoredRemoteAllocation,
+    path: &'a Path,
+    request: IntakeRequest,
+    overlay: Vec<u8>,
+}
+
+/// Consumed caller assertion, neither cloneable nor deserializable. Hashes, capture,
+/// recovery and persistence cannot supply the caller's positive export decision.
+pub struct ApprovedRepositoryIntake<'a>(RepositoryIntakeProposal<'a>);
+
+impl<'a> RepositoryIntakeProposal<'a> {
+    #[must_use]
+    pub fn request(&self) -> &IntakeRequest {
+        &self.request
+    }
+
+    /// Prepare exact metadata, without filesystem/provider/SSH access or approval.
+    /// # Errors
+    /// Rejects mismatched full source/base, unavailable identity or invalid limits.
+    pub fn new(
+        allocation: &'a StoredRemoteAllocation,
+        pack: &'a PreparedGitPack,
+        bundle: &RepositoryOverlayBundle,
+    ) -> Result<Self, ControllerError> {
+        if bundle.plan().source() != &allocation.workspace().state().spec.repository
+            || pack.base_commit().to_string() != bundle.plan().source().commit.as_str()
+        {
+            return Err(ControllerError::Request);
+        }
+        let overlay = codec::encode(bundle).map_err(|_| ControllerError::Request)?.into_vec();
+        let request = bound_request(
+            allocation,
+            EncodedIdentity {
+                sha256: pack.sha256().clone(),
+                encoded_bytes: pack.encoded_bytes(),
+            },
+            EncodedIdentity {
+                sha256: bundle.manifest_sha256().clone(),
+                encoded_bytes: overlay.len() as u64,
+            },
+        )?;
+        Ok(Self {
+            allocation,
+            path: pack.path(),
+            request,
+            overlay,
+        })
+    }
+
+    /// Assert explicit approval for the ENTIRE base closure, including removed files
+    /// and commit metadata, and both layers of this one bundle. Not a human signature.
+    #[must_use]
+    pub fn approve_export(self) -> ApprovedRepositoryIntake<'a> {
+        ApprovedRepositoryIntake(self)
+    }
+}
+
+fn bound_request(
+    allocation: &StoredRemoteAllocation,
+    pack: EncodedIdentity,
+    overlay: EncodedIdentity,
+) -> Result<IntakeRequest, ControllerError> {
+    let state = allocation.workspace().state();
+    let runtime = state.runtime.as_ref().ok_or(ControllerError::Request)?;
+    let worker = runtime.worker.as_ref().ok_or(ControllerError::Request)?;
+    let key = allocation
+        .recovery_request()
+        .map_err(|_| ControllerError::Request)?
+        .ssh_public_key;
+    let endpoint = runtime.ssh.as_ref().ok_or(ControllerError::Request)?;
+    if !endpoint.is_complete() {
+        return Err(ControllerError::Request);
+    }
+    let request = IntakeRequest {
+        version: 1,
+        workspace_local_id: state.spec.workspace_local_id.clone(),
+        workflow_id: runtime.workflow_id,
+        job_id: runtime.job_id,
+        runtime_generation: runtime.generation,
+        worker_resource_id: worker.identity.resource_id.clone(),
+        client_key_sha256: ArtifactDigest::sha256(key.as_bytes()),
+        source: state.spec.repository.clone(),
+        pack,
+        overlay,
+    };
+    request.encode().map_err(|_| ControllerError::Request)?;
+    Ok(request)
+}
+
+/// Consume one approval; failure retains the request and any verified remote response.
+/// Run off the UI thread. Blocking reads/spawn/reap are outside the ten-minute pipe
+/// deadline. Source mutation may already have disclosed bytes; exclusive ownership
+/// is required. No original repository files, automatic retry or cleanup are used.
+/// # Errors
+/// Any local/remote uncertainty requires observation of this SAME request, not resend.
+pub fn send_approved_repository_intake(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    approved: ApprovedRepositoryIntake<'_>,
+    cancelled: impl Fn() -> bool,
+) -> Result<IntakeResponse, Box<ControllerFailure>> {
+    let ApprovedRepositoryIntake(proposal) = approved;
+    perform(
+        store,
+        recovered,
+        proposal.request.clone(),
+        Some(&proposal),
+        &cancelled,
+        exchange,
+    )
+}
+
+/// Observe a retained request without approval, local source reads, initialization or replay.
+/// # Errors
+/// Missing/invalid response or stale ownership is unknown, never absence.
+pub fn observe_repository_intake(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    request: &IntakeRequest,
+    cancelled: impl Fn() -> bool,
+) -> Result<IntakeResponse, Box<ControllerFailure>> {
+    perform(store, recovered, request.clone(), None, &cancelled, exchange)
+}
+
+fn perform(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    request: IntakeRequest,
+    proposal: Option<&RepositoryIntakeProposal<'_>>,
+    cancelled: &dyn Fn() -> bool,
+    execute: impl FnOnce(
+        &RecoveredRemoteWorkspace,
+        bool,
+        &mut dyn Read,
+        &dyn Fn() -> bool,
+    ) -> Result<query::Exchange, ControllerError>,
+) -> Result<IntakeResponse, Box<ControllerFailure>> {
+    let observed_cancellation = Cell::new(false);
+    let track_cancellation = || {
+        let current = cancelled();
+        observed_cancellation.set(observed_cancellation.get() || current);
+        current
+    };
+    let cancelled: &dyn Fn() -> bool = &track_cancellation;
+    let mut response = None;
+    let result = (|| {
+        validate_current(store, recovered, None)?;
+        if proposal.is_some_and(|proposal| proposal.allocation != recovered.allocation())
+            || bound_request(recovered.allocation(), request.pack.clone(), request.overlay.clone())? != request
+        {
+            return Err(ControllerError::Request);
+        }
+        let encoded = request.encode().map_err(|_| ControllerError::Request)?;
+        check_cancel(cancelled)?;
+        let mut held = proposal
+            .map(|proposal| input::Input::open(proposal.path, &request.pack, cancelled))
+            .transpose()?;
+        validate_current(store, recovered, None)?;
+        let exchange = if let (Some(proposal), Some(held)) = (proposal, &mut held) {
+            let prefix = u32::try_from(encoded.len())
+                .map_err(|_| ControllerError::Request)?
+                .to_le_bytes();
+            let mut stream = prefix
+                .as_slice()
+                .chain(encoded.as_slice())
+                .chain((&mut held.file).take(request.pack.encoded_bytes))
+                .chain(proposal.overlay.as_slice());
+            execute(recovered, false, &mut stream, cancelled)?
+        } else {
+            execute(recovered, true, &mut encoded.as_slice(), cancelled)?
+        };
+        response = Some(decode(&exchange, &request, proposal.is_none())?);
+        if let Some(held) = held {
+            held.verify()?;
+        }
+        validate_current(store, recovered, None)?;
+        check_cancel(cancelled)
+    })();
+    match (result, response) {
+        (Ok(()), Some(response)) if !observed_cancellation.get() => Ok(response),
+        (result, response) => Err(Box::new(ControllerFailure {
+            request,
+            response,
+            reason: if observed_cancellation.get() {
+                ControllerError::Cancelled
+            } else {
+                result.err().unwrap_or(ControllerError::Response)
+            },
+        })),
+    }
+}
+
+fn exchange(
+    recovered: &RecoveredRemoteWorkspace,
+    observe: bool,
+    input: &mut dyn Read,
+    cancelled: &dyn Fn() -> bool,
+) -> Result<query::Exchange, ControllerError> {
+    let endpoint = recovered
+        .observation()
+        .and_then(|status| status.ssh.as_ref())
+        .ok_or(ControllerError::Request)?;
+    let identity = recovered.identity();
+    let trust = known_hosts(identity, endpoint)?;
+    let command = prepared_intake(identity.private_key_path(), trust.path(), endpoint, observe)?;
+    query::exchange(
+        command,
+        input,
+        Duration::from_secs(600),
+        RESPONSE_LIMIT,
+        cancelled,
+        None,
+    )
+    .map_err(|error| query_error(&error))
+}
+
+fn query_error(error: &query::Error) -> ControllerError {
+    match error {
+        query::Error::ClientUnavailable => RemotePanelStatusError::ClientUnavailable.into(),
+        query::Error::OutputLimit => ControllerError::Response,
+        query::Error::Deadline | query::Error::QueryFailed => ControllerError::Transport,
+    }
+}
+
+fn decode(
+    exchange: &query::Exchange,
+    request: &IntakeRequest,
+    observe: bool,
+) -> Result<IntakeResponse, ControllerError> {
+    let invalid = ControllerError::Response;
+    if exchange.output.len() > RESPONSE_LIMIT {
+        return Err(invalid);
+    }
+    let response: IntakeResponse = serde_json::from_slice(&exchange.output).map_err(|_| ControllerError::Response)?;
+    if response.version != 1
+        || exchange.status.code() != Some(i32::from(response.exit_code()))
+        || (observe && matches!(response.state, IntakeState::Acknowledged | IntakeState::Unconfirmed))
+        || (response.state == IntakeState::Acknowledged && !matches!(exchange.input, query::InputProgress::Complete(_)))
+    {
+        return Err(invalid);
+    }
+    let complete = matches!(response.state, IntakeState::Acknowledged | IntakeState::Observed);
+    if complete != response.reason.is_none()
+        || (response.reason == Some(IntakeError::Invalid)) != (response.state == IntakeState::Rejected)
+    {
+        return Err(invalid);
+    }
+    let bound = response.intent_sha256.as_ref()
+        == Some(&ArtifactDigest::sha256(
+            &request.encode().map_err(|_| ControllerError::Request)?,
+        ));
+    let roots = response.roots.as_ref();
+    let root = Path::new("/workspace/.horizon-worker");
+    if bound != roots.is_some()
+        || (response.intent_sha256.is_some() && !bound)
+        || roots.is_some_and(|roots| {
+            roots.packs.as_os_str() != root.join("repository-inputs/packs").as_os_str()
+                || roots.bundles.as_os_str() != root.join("repository-inputs/bundles").as_os_str()
+                || roots.setup.as_os_str() != root.join("repository-setup").as_os_str()
+        })
+    {
+        return Err(invalid);
+    }
+    let pack_state = response.pack.as_ref().map(|pack| pack.state);
+    if let Some(pack) = &response.pack {
+        let roots = roots.ok_or(ControllerError::Response)?;
+        let source = pack.source.as_ref().is_some_and(|path| {
+            path.file_name().and_then(|name| name.to_str()).is_some_and(|name| {
+                path.as_os_str() == roots.packs.join(name).as_os_str()
+                    && name.len() <= crate::repository_overlay::checkout::publication::MAX_SIBLING_NAME_BYTES
+                    && name.strip_prefix("repository-seed-").is_some_and(|suffix| {
+                        !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
+                    })
+            })
+        });
+        let destination = pack
+            .destination
+            .as_ref()
+            .is_some_and(|path| path.as_os_str() == roots.packs.join("base").as_os_str());
+        let objects = pack
+            .objects
+            .is_some_and(|count| count > 0 && u64::from(count) <= MAX_OBJECTS as u64);
+        let valid = match pack.state {
+            PackState::ReceiveUnconfirmed => {
+                (source || pack.source.is_none()) && pack.destination.is_none() && pack.objects.is_none()
+            }
+            PackState::Unpublished => source && pack.destination.is_none() && objects,
+            PackState::RenameUnconfirmed => source && destination && objects,
+            _ => pack.source.is_none() && destination && objects,
+        };
+        if !valid {
+            return Err(invalid);
+        }
+    }
+    let observed_progress = pack_state.is_none_or(|state| state == PackState::Observed)
+        && response.bundle.is_none_or(|state| state == BundleState::Observed)
+        && (response.bundle.is_none() || pack_state.is_some());
+    let valid = match response.state {
+        IntakeState::Acknowledged => {
+            bound && pack_state == Some(PackState::Acknowledged) && response.bundle == Some(BundleState::Acknowledged)
+        }
+        IntakeState::Observed => {
+            bound && pack_state == Some(PackState::Observed) && response.bundle == Some(BundleState::Observed)
+        }
+        IntakeState::ClaimedUnknown => bound && observed_progress,
+        IntakeState::Unconfirmed => {
+            bound
+                && pack_state != Some(PackState::Observed)
+                && response.bundle != Some(BundleState::Observed)
+                && (response.bundle.is_none() || pack_state == Some(PackState::Acknowledged))
+        }
+        IntakeState::Rejected => {
+            !bound && response.reason == Some(IntakeError::Invalid) && pack_state.is_none() && response.bundle.is_none()
+        }
+        IntakeState::Error => {
+            bound
+                && pack_state.is_none()
+                && response.bundle.is_none()
+                && response.reason != Some(IntakeError::Unsupported)
+        }
+        IntakeState::Unsupported => response.reason == Some(IntakeError::Unsupported) && observed_progress,
+    };
+    valid.then_some(response).ok_or(invalid)
+}
+
+fn check_cancel(cancelled: &dyn Fn() -> bool) -> Result<(), ControllerError> {
+    if cancelled() {
+        Err(ControllerError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{reason}")]
+pub struct ControllerFailure {
+    pub request: IntakeRequest,
+    pub response: Option<IntakeResponse>,
+    pub reason: ControllerError,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ControllerError {
+    #[error(transparent)]
+    Admission(#[from] RemotePanelStatusError),
+    #[error("repository export proposal does not match retained ownership")]
+    Request,
+    #[error("prepared repository input is unsafe, unavailable or changed")]
+    Input,
+    #[error("repository intake was cancelled; retain request and do not resend")]
+    Cancelled,
+    #[error("repository intake transport is uncertain; observe without resending")]
+    Transport,
+    #[error("repository intake response is invalid or inconsistent")]
+    Response,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/intake/controller/input.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/controller/input.rs
@@ -1,0 +1,120 @@
+//! Held-file verification, not immutable storage or hostile-writer confinement.
+use super::{ControllerError as Error, EncodedIdentity};
+use crate::repository_overlay::reader::{
+    SelectedRepositoryReader,
+    linux::{Root, same_metadata},
+};
+use rustix::fs::{Mode, OFlags, ResolveFlags, openat2};
+use sha2::{Digest, Sha256};
+use std::{
+    fs::{File, Metadata, OpenOptions},
+    io::{Read, Seek},
+    os::{
+        fd::AsRawFd,
+        unix::fs::{MetadataExt, OpenOptionsExt},
+    },
+    path::Path,
+};
+
+pub(super) struct Input<'a> {
+    pub file: File,
+    path: &'a Path,
+    parent: Root,
+    metadata: Metadata,
+}
+
+impl<'a> Input<'a> {
+    pub fn open(path: &'a Path, expected: &EncodedIdentity, cancelled: &dyn Fn() -> bool) -> Result<Self, Error> {
+        let parent = SelectedRepositoryReader::open(path.parent().ok_or(Error::Input)?)
+            .map_err(|_| Error::Input)?
+            .root;
+        private_parent(parent.handle())?;
+        let pinned = pin(&parent, path)?;
+        let metadata = pinned.metadata().map_err(|_| Error::Input)?;
+        if !metadata.is_file()
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o600
+            || metadata.nlink() != 1
+            || metadata.len() != expected.encoded_bytes
+        {
+            return Err(Error::Input);
+        }
+        // Reopen the already pinned regular inode, never a replacement device/FIFO.
+        let file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(format!("/proc/self/fd/{}", pinned.as_raw_fd()))
+            .map_err(|_| Error::Input)?;
+        let mut input = Self {
+            file,
+            path,
+            parent,
+            metadata,
+        };
+        input.verify()?;
+        let mut hash = Sha256::new();
+        let mut buffer = [0; 16 * 1024];
+        let mut total = 0;
+        loop {
+            super::check_cancel(cancelled)?;
+            let count = input.file.read(&mut buffer).map_err(|_| Error::Input)?;
+            total += count as u64;
+            if total > expected.encoded_bytes {
+                return Err(Error::Input);
+            }
+            if count == 0 {
+                break;
+            }
+            hash.update(&buffer[..count]);
+        }
+        if total != expected.encoded_bytes
+            || crate::cloud_run::ArtifactDigest::from_sha256_bytes(hash.finalize().into()) != expected.sha256
+        {
+            return Err(Error::Input);
+        }
+        input.verify()?;
+        input.file.rewind().map_err(|_| Error::Input)?;
+        super::check_cancel(cancelled)?;
+        Ok(input)
+    }
+
+    pub fn verify(&self) -> Result<(), Error> {
+        let named =
+            SelectedRepositoryReader::open(self.path.parent().ok_or(Error::Input)?).map_err(|_| Error::Input)?;
+        private_parent(named.root.handle())?;
+        let parent = self.parent.handle().metadata().map_err(|_| Error::Input)?;
+        let current = named.root.handle().metadata().map_err(|_| Error::Input)?;
+        let named_file = pin(&named.root, self.path)?.metadata().map_err(|_| Error::Input)?;
+        if (parent.dev(), parent.ino()) != (current.dev(), current.ino())
+            || !same_metadata(&self.metadata, &self.file.metadata().map_err(|_| Error::Input)?)
+            || !same_metadata(&self.metadata, &named_file)
+        {
+            return Err(Error::Input);
+        }
+        Ok(())
+    }
+}
+
+fn pin(parent: &Root, path: &Path) -> Result<File, Error> {
+    openat2(
+        parent.handle(),
+        path.file_name().ok_or(Error::Input)?,
+        OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+        ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS | ResolveFlags::NO_XDEV,
+    )
+    .map(File::from)
+    .map_err(|_| Error::Input)
+}
+
+fn private_parent(file: &File) -> Result<(), Error> {
+    let metadata = file.metadata().map_err(|_| Error::Input)?;
+    if !metadata.is_dir()
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.mode() & 0o7777 != 0o700
+        || metadata.nlink() == 0
+    {
+        return Err(Error::Input);
+    }
+    Ok(())
+}

--- a/crates/horizon-core/src/repository_overlay/intake/controller/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/controller/tests.rs
@@ -1,0 +1,386 @@
+//! Synthetic exchange/pack bytes isolate controller fences, not native Git decoding
+//! or the public `PreparedGitPack` constructor; the pinned smoke must exercise those.
+use super::*;
+use crate::{
+    cloud_run::interactive_worker::InteractiveWorkerLifecycle, remote_repository_pack::tests::Fixture,
+    repository_overlay::RepositoryOverlayPlan,
+};
+use ControllerError as Error;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    os::unix::{
+        fs::{PermissionsExt, symlink},
+        process::ExitStatusExt,
+    },
+    path::PathBuf,
+    process::ExitStatus,
+};
+
+const PACKS: &str = "/workspace/.horizon-worker/repository-inputs/packs";
+const PACK: [u8; 64] = [b'x'; 64];
+
+struct InputFixture {
+    control: Fixture,
+    path: PathBuf,
+    overlay: Vec<u8>,
+    request: IntakeRequest,
+}
+
+impl InputFixture {
+    fn new() -> Self {
+        let control = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let allocation = control.recovered.allocation();
+        let path = control.directory.path().join("synthetic.pack");
+        fs::write(&path, PACK).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let source = allocation.workspace().state().spec.repository.clone();
+        let plan = RepositoryOverlayPlan::new(source, [], []).unwrap();
+        let bundle = RepositoryOverlayBundle::new(plan, []).unwrap();
+        let overlay = codec::encode(&bundle).unwrap().into_vec();
+        let request = bound_request(
+            allocation,
+            EncodedIdentity {
+                sha256: ArtifactDigest::sha256(&PACK),
+                encoded_bytes: PACK.len() as u64,
+            },
+            EncodedIdentity {
+                sha256: bundle.manifest_sha256().clone(),
+                encoded_bytes: overlay.len() as u64,
+            },
+        )
+        .unwrap();
+        Self {
+            control,
+            path,
+            overlay,
+            request,
+        }
+    }
+
+    fn check(
+        &self,
+        send: bool,
+        cancelled: &dyn Fn() -> bool,
+        execute: impl FnOnce(&mut dyn Read, &dyn Fn() -> bool) -> Result<query::Exchange, Error>,
+    ) -> Result<IntakeResponse, Box<ControllerFailure>> {
+        let proposal = RepositoryIntakeProposal {
+            allocation: self.control.recovered.allocation(),
+            path: &self.path,
+            request: self.request.clone(),
+            overlay: self.overlay.clone(),
+        };
+        perform(
+            &self.control.store,
+            &self.control.recovered,
+            self.request.clone(),
+            send.then(|| proposal.approve_export().0).as_ref(),
+            cancelled,
+            |_, observe, input, cancelled| {
+                assert_eq!(observe, !send);
+                execute(input, cancelled)
+            },
+        )
+    }
+
+    fn response(&self, state: &str) -> Value {
+        json!({"version":1,"state":state,"intent_sha256":ArtifactDigest::sha256(&self.request.encode().unwrap()),
+            "roots":{"packs":"/workspace/.horizon-worker/repository-inputs/packs","bundles":"/workspace/.horizon-worker/repository-inputs/bundles","setup":"/workspace/.horizon-worker/repository-setup"},
+            "pack":{"state":state,"source":null,"destination":"/workspace/.horizon-worker/repository-inputs/packs/base","objects":2},
+            "bundle":state,"reason":null})
+    }
+}
+
+fn wire(value: &Value, complete: bool) -> query::Exchange {
+    let code = match value["state"].as_str().unwrap() {
+        "acknowledged" | "observed" => 0,
+        "rejected" => 2,
+        "claimed_unknown" => 4,
+        _ => 1,
+    };
+    query::Exchange {
+        status: ExitStatus::from_raw(code << 8),
+        output: serde_json::to_vec(value).unwrap(),
+        input: if complete {
+            query::InputProgress::Complete(0)
+        } else {
+            query::InputProgress::Incomplete(0)
+        },
+    }
+}
+
+#[test]
+fn synthetic_approval_preserves_exact_frames_ownership_and_early_replies() {
+    let fixture = InputFixture::new();
+    let allocation = fixture.control.current();
+    assert!(allocation.workspace().state().spec.panels.is_empty());
+    let key_path = fixture.control.recovered.identity().private_key_path();
+    let key = ArtifactDigest::sha256(&fs::read(key_path).unwrap());
+    let response = fixture.response("acknowledged");
+    let result = fixture
+        .check(true, &|| false, |input, _| {
+            let mut actual = Vec::new();
+            input.read_to_end(&mut actual).unwrap();
+            let header = fixture.request.encode().unwrap();
+            let mut expected = u32::try_from(header.len()).unwrap().to_le_bytes().to_vec();
+            expected.extend(header);
+            expected.extend(PACK);
+            expected.extend(&fixture.overlay);
+            assert_eq!(actual, expected);
+            Ok(wire(&response, true))
+        })
+        .unwrap();
+    assert_eq!(result.state, IntakeState::Acknowledged);
+    assert_eq!(fixture.control.current(), allocation);
+    assert_eq!(ArtifactDigest::sha256(&fs::read(key_path).unwrap()), key);
+    assert_eq!(fs::read(&fixture.path).unwrap(), PACK);
+    let observed = fixture.response("observed");
+    let response = fixture
+        .check(true, &|| false, |_, _| Ok(wire(&observed, false)))
+        .unwrap();
+    assert_eq!(response.state, IntakeState::Observed);
+    let ack = fixture.response("acknowledged");
+    let failure = fixture
+        .check(true, &|| false, |_, _| Ok(wire(&ack, false)))
+        .unwrap_err();
+    assert!(matches!(failure.reason, Error::Response) && failure.response.is_none());
+    fs::remove_file(&fixture.path).unwrap();
+    let response = fixture
+        .check(false, &|| false, |input, _| {
+            let mut bytes = Vec::new();
+            input.read_to_end(&mut bytes).unwrap();
+            assert_eq!(IntakeRequest::decode(&bytes).unwrap(), fixture.request);
+            Ok(wire(&observed, false))
+        })
+        .unwrap();
+    assert_eq!(response.state, IntakeState::Observed);
+    let failure = fixture
+        .check(false, &|| false, |_, _| Err(Error::Transport))
+        .unwrap_err();
+    assert_eq!(failure.request, fixture.request);
+    assert!(matches!(failure.reason, Error::Transport) && failure.response.is_none());
+    assert!(!format!("{failure:?}").contains("synthetic-worker"));
+}
+
+#[test]
+fn stale_ownership_missing_database_and_unsafe_inputs_never_exchange() {
+    for case in 0..9 {
+        let mut fixture = InputFixture::new();
+        let parent = fixture.control.store.path().parent().unwrap().to_path_buf();
+        match case {
+            0 | 1 => fixture.control.edit(case == 1),
+            2 => fixture.request.worker_resource_id.push_str("-changed"),
+            3 => fixture.request.source.repository.push_str("-changed"),
+            4 => fs::rename(&parent, parent.with_extension("retained")).unwrap(),
+            5 => fs::write(&fixture.path, vec![b'z'; PACK.len()]).unwrap(),
+            6 => fs::set_permissions(&fixture.path, fs::Permissions::from_mode(0o644)).unwrap(),
+            7 => {
+                fs::rename(&fixture.path, fixture.path.with_extension("held")).unwrap();
+                symlink(fixture.path.with_extension("held"), &fixture.path).unwrap();
+            }
+            _ => fs::hard_link(&fixture.path, fixture.path.with_extension("linked")).unwrap(),
+        }
+        let failure = fixture
+            .check(true, &|| false, |_, _| panic!("no exchange"))
+            .unwrap_err();
+        assert!(matches!(
+            (case, failure.reason),
+            (0 | 1 | 4, Error::Admission(_)) | (2 | 3, Error::Request) | (5..=8, Error::Input)
+        ));
+        assert!(failure.response.is_none());
+        assert_eq!(failure.request, fixture.request);
+        assert!(fixture.path.exists());
+        if case == 4 {
+            assert!(!parent.exists());
+        }
+    }
+}
+
+#[test]
+fn late_ownership_input_or_cancellation_changes_preserve_receipts() {
+    for case in 0..3 {
+        let fixture = InputFixture::new();
+        let cancelled = std::cell::Cell::new(false);
+        let value = fixture.response("observed");
+        let failure = fixture
+            .check(true, &|| cancelled.get(), |_, _| {
+                match case {
+                    0 => fixture.control.edit(false),
+                    1 => fs::write(&fixture.path, b"changed").unwrap(),
+                    _ => cancelled.set(true),
+                }
+                Ok(wire(&value, false))
+            })
+            .unwrap_err();
+        assert!(matches!(
+            (case, failure.reason),
+            (0, Error::Admission(_)) | (1, Error::Input) | (2, Error::Cancelled)
+        ));
+        assert_eq!(serde_json::to_value(failure.response.unwrap()).unwrap(), value);
+        assert_eq!(failure.request, fixture.request);
+        assert!(fixture.path.exists());
+    }
+}
+
+#[test]
+fn one_shot_exchange_cancellation_preserves_receipts_and_transport_failures() {
+    for send in [false, true] {
+        for (cancel, reply) in [(false, false), (true, false), (true, true)] {
+            let fixture = InputFixture::new();
+            let cancel_next = Cell::new(false);
+            let value = fixture.response("observed");
+            let failure = fixture
+                .check(send, &|| cancel_next.replace(false), |_, cancelled| {
+                    cancel_next.set(cancel);
+                    assert_eq!(cancelled(), cancel);
+                    assert!(!cancelled());
+                    if reply {
+                        Ok(wire(&value, false))
+                    } else {
+                        Err(Error::Transport)
+                    }
+                })
+                .unwrap_err();
+            assert!(matches!(
+                (cancel, failure.reason),
+                (true, Error::Cancelled) | (false, Error::Transport)
+            ));
+            assert_eq!(failure.request, fixture.request);
+            assert_eq!(
+                failure.response.map(|response| serde_json::to_value(response).unwrap()),
+                reply.then_some(value)
+            );
+        }
+    }
+}
+
+#[test]
+fn query_failures_preserve_protocol_and_admission_categories() {
+    for send in [false, true] {
+        for cancel in [false, true] {
+            for (error, expected) in [
+                (query::Error::ClientUnavailable, "client-unavailable"),
+                (query::Error::OutputLimit, "response"),
+                (query::Error::Deadline, "transport"),
+                (query::Error::QueryFailed, "transport"),
+            ] {
+                let fixture = InputFixture::new();
+                let cancel_next = Cell::new(false);
+                let failure = fixture
+                    .check(send, &|| cancel_next.replace(false), |_, cancelled| {
+                        cancel_next.set(cancel);
+                        assert_eq!(cancelled(), cancel);
+                        assert!(!cancelled());
+                        Err(query_error(&error))
+                    })
+                    .unwrap_err();
+                assert_eq!(failure.request, fixture.request);
+                assert!(failure.response.is_none());
+                let actual = match failure.reason {
+                    Error::Admission(RemotePanelStatusError::ClientUnavailable) => "client-unavailable",
+                    Error::Response => "response",
+                    Error::Transport => "transport",
+                    Error::Cancelled => "cancelled",
+                    other => panic!("unexpected query failure: {other}"),
+                };
+                assert_eq!(actual, if cancel { "cancelled" } else { expected });
+            }
+        }
+    }
+}
+
+#[test]
+fn every_retained_publication_projection_and_unknown_progress_roundtrips() {
+    let fixture = InputFixture::new();
+    for (state, pack, bundle) in [
+        ("error", None, None),
+        ("unconfirmed", Some("receive_unconfirmed"), None),
+        ("unconfirmed", Some("unpublished"), None),
+        ("unconfirmed", Some("published_unsynchronized"), None),
+        ("unconfirmed", Some("rename_unconfirmed"), None),
+        ("unconfirmed", Some("acknowledged"), None),
+        ("unconfirmed", Some("acknowledged"), Some("write_unconfirmed")),
+        ("unconfirmed", Some("acknowledged"), Some("acknowledged")),
+        ("claimed_unknown", None, None),
+        ("claimed_unknown", Some("observed"), None),
+        ("claimed_unknown", Some("observed"), Some("observed")),
+        ("unsupported", None, None),
+        ("unsupported", Some("observed"), None),
+        ("unsupported", Some("observed"), Some("observed")),
+    ] {
+        let mut value = fixture.response(state);
+        value["reason"] = json!(match state {
+            "unsupported" => "unsupported",
+            "claimed_unknown" => "input",
+            _ => "storage",
+        });
+        value["bundle"] = json!(bundle);
+        value["pack"] = pack.map_or(Value::Null, |pack| {
+            json!({
+                "state": pack,
+                "source": matches!(pack, "receive_unconfirmed" | "unpublished" | "rename_unconfirmed")
+                    .then(|| format!("{PACKS}/repository-seed-abc123")),
+                "destination": (!matches!(pack, "receive_unconfirmed" | "unpublished"))
+                    .then(|| format!("{PACKS}/base")),
+                "objects": (pack != "receive_unconfirmed").then_some(2)
+            })
+        });
+        let response = decode(&wire(&value, false), &fixture.request, state != "unconfirmed").unwrap();
+        assert_eq!(serde_json::to_value(response).unwrap(), value);
+    }
+    let portable = serde_json::to_value(IntakeResponse::failure(IntakeError::Unsupported)).unwrap();
+    assert!(decode(&wire(&portable, false), &fixture.request, true).is_ok());
+}
+
+#[test]
+fn malformed_or_inconsistent_replies_are_not_validated_by_a_false_green_control() {
+    let fixture = InputFixture::new();
+    let valid = fixture.response("acknowledged");
+    assert!(decode(&wire(&valid, true), &fixture.request, false).is_ok());
+    for (path, value) in [
+        ("/version", json!(2)),
+        ("/intent_sha256", json!("a".repeat(64))),
+        ("/roots", Value::Null),
+        ("/roots/packs", json!(format!("{PACKS}//"))),
+        ("/pack/destination", json!(format!("{PACKS}/base/."))),
+        ("/pack/objects", json!(0)),
+        ("/pack/source", json!("/outside")),
+        ("/pack", Value::Null),
+        ("/bundle", Value::Null),
+        ("/reason", json!("storage")),
+    ] {
+        let mut altered = valid.clone();
+        *altered.pointer_mut(path).unwrap() = value;
+        assert!(
+            decode(&wire(&altered, true), &fixture.request, false).is_err(),
+            "{path}"
+        );
+    }
+    for field in ["intent_sha256", "roots", "pack", "bundle", "reason"] {
+        let mut altered = valid.clone();
+        altered.as_object_mut().unwrap().remove(field);
+        assert!(decode(&wire(&altered, true), &fixture.request, false).is_err());
+    }
+    let mut extra = valid.clone();
+    extra["unknown"] = json!(1);
+    let mut duplicate = wire(&valid, true);
+    duplicate.output.splice(1..1, b"\"version\":1,".iter().copied());
+    let mut trailing = wire(&valid, true);
+    trailing.output.push(b'x');
+    let mut oversized = wire(&valid, true);
+    oversized.output = vec![b' '; RESPONSE_LIMIT + 1];
+    let mut exit = wire(&valid, true);
+    exit.status = ExitStatus::from_raw(1 << 8);
+    let unbound = serde_json::to_value(IntakeResponse::failure(IntakeError::Storage)).unwrap();
+    for invalid in [
+        wire(&extra, true),
+        wire(&unbound, true),
+        duplicate,
+        trailing,
+        oversized,
+        exit,
+    ] {
+        assert!(decode(&invalid, &fixture.request, false).is_err());
+    }
+    assert!(decode(&wire(&valid, true), &fixture.request, true).is_err());
+}

--- a/crates/horizon-core/src/repository_overlay/intake/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/mod.rs
@@ -1,5 +1,8 @@
-//! Explicit retained repository intake, never export approval, setup or task authority.
+//! Retained repository intake with a Linux export-approval controller.
+//! Neither worker intake nor controller handoff grants setup or task authority.
 
+#[cfg(target_os = "linux")]
+pub mod controller;
 #[cfg(target_os = "linux")]
 mod linux;
 
@@ -83,7 +86,7 @@ impl fmt::Debug for IntakeRequest {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IntakeState {
     Acknowledged,
@@ -95,7 +98,7 @@ pub enum IntakeState {
     Unsupported,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PackState {
     Acknowledged,
@@ -106,7 +109,7 @@ pub enum PackState {
     RenameUnconfirmed,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BundleState {
     Acknowledged,
@@ -114,30 +117,41 @@ pub enum BundleState {
     WriteUnconfirmed,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct IntakeRoots {
     pub packs: PathBuf,
     pub bundles: PathBuf,
     pub setup: PathBuf,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PackProgress {
     pub state: PackState,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub source: Option<PathBuf>,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub destination: Option<PathBuf>,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub objects: Option<u32>,
 }
 
 /// Known progress survives failure. These paths are historical candidates, not cleanup grants.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct IntakeResponse {
     pub version: u8,
     pub state: IntakeState,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub intent_sha256: Option<ArtifactDigest>,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub roots: Option<IntakeRoots>,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub pack: Option<PackProgress>,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub bundle: Option<BundleState>,
+    #[serde(deserialize_with = "Option::deserialize")]
     pub reason: Option<IntakeError>,
 }
 
@@ -179,7 +193,7 @@ impl fmt::Debug for IntakeResponse {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, thiserror::Error)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, thiserror::Error)]
 #[serde(rename_all = "snake_case")]
 pub enum IntakeError {
     #[error("invalid repository intake identity or framing")]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -285,11 +285,11 @@ back into large multi-purpose modules.
   noncreating observation. Its pure request/response shell keeps strict identities;
   the Linux leaf owns the create-new claim, held directory bindings and component
   orchestration. Existing claims never consume payload or grant another receiver.
-  See [combined core intake](../remote-repository-intake.md); controller and
-  setup/task authority remain separate. The worker CLI's `intake` leaf bounds a
-  little-endian request-length prefix, then delegates payload consumption to that
-  API. `intake-status` accepts only a bounded request and EOF; neither command
-  starts setup or tasks.
+  Its Linux `controller` owns explicit approval and retained-owner/pin validation;
+  `controller/input` owns held local pack verification. The repository binary's
+  `intake` leaf handles bounded command framing, not export approval or task setup.
+  See [combined intake](../remote-repository-intake.md); setup/task authority remains
+  separate from both worker receipt and controller handoff.
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;

--- a/docs/remote-repository-intake.md
+++ b/docs/remote-repository-intake.md
@@ -1,11 +1,10 @@
 # Combined retained repository intake
 
-`repository_overlay::intake::{receive, observe}` is a worker core API, exposed by
-the worker-only `horizon-repository intake` and `intake-status` commands. Neither
-adds an SSH controller, provider operation, setup execution or task. A transport
-caller must separately enforce explicit export approval and full retained
-worker/client ownership. Constructing a request, capturing an overlay, computing a
-digest or successfully recovering a provider allocation is not export approval.
+`repository_overlay::intake::{receive, observe}` is the worker core API. The
+repository binary supplies its framing commands, and the Linux `intake::controller`
+module supplies explicit export approval and pinned handoff. These do not create a
+provider allocation, execute setup or start a task. Constructing a request, capturing
+an overlay, computing a digest or recovering an allocation is not export approval.
 
 The caller approves the **complete** exact base closure, including raw commit
 metadata and files that overlays will delete, and both index/worktree layers of
@@ -21,7 +20,7 @@ is the existing complete bundle manifest, not a second encoding or wire digest.
 Canonical request JSON is capped at 32 KiB and its SHA-256 identifies the claim.
 Unknown/duplicate fields, malformed IDs, zero generation/commit and excessive
 lengths are rejected before storage access. Worker-supplied labels do not themselves
-authenticate provider ownership; a future pinned controller must establish that.
+authenticate provider ownership; the pinned controller checks the retained allocation.
 
 The core receiver consumes exactly the declared pack bytes, then exactly the declared
 canonical overlay bytes, then EOF. Its bounded pack reader exposes local EOF without
@@ -91,3 +90,31 @@ partial/conflicting claims, concurrent claim writers, existing-child refusal,
 directory replacement, cancellation, exact payload framing and qualified observation.
 The qualified positive unit test reports an explicit skip when capability is absent;
 delivery additionally requires a real qualified positive smoke of this exact API.
+
+## Pinned controller
+
+`RepositoryIntakeProposal::new` binds a prepared pack and existing bundle to the
+complete retained allocation and source without filesystem, provider or SSH access.
+Retain its canonical `request()` before calling `approve_export` after a positive
+caller export decision. Approval covers the entire base closure and both overlay
+layers; the consumed approval type is not a human signature or persisted permission.
+
+`send_approved_repository_intake` validates current ownership before and after
+handoff, including workspaces with no attached panels. It hashes and rewinds one
+held no-follow regular pack file, checks its private parent/file identity, and streams
+from that same handle. The caller must keep its bytes and ancestry exclusively
+stable: post-transfer detection cannot retract bytes already disclosed. Run this
+off the UI thread. The ten-minute pipe budget does not bound blocking local reads,
+process spawning or reaping.
+
+The controller invokes the fixed [worker commands](#worker-command-framing) using
+the retained SSH identity and pin, never an interactive trust prompt. The selected
+worker binary must contain these commands; an older local runtime image alone is
+not evidence that they are deployed.
+
+`observe_repository_intake` uses the saved request without approval, local source
+or pack reads, initialization, automatic resend or cleanup. Decode checks response
+identity, fixed paths, state/progress combinations and process status. A validated
+response can still describe uncertainty rather than acknowledgement. Failures keep
+the request and any already-validated response for observation; neither cancellation
+nor lost acknowledgement grants another upload, setup or task.


### PR DESCRIPTION
## Purpose

Complete the approved repository handoff from a retained allocation through pinned SSH to worker intake commands. This focused step in #470 / #383 builds on merged CLI prerequisite #503; it does not complete the cloud workflow.

## Behavior

- An inert proposal binds the exact prepared base pack and both overlay layers to the retained allocation. Sending consumes explicit caller export approval for the entire base closure, including removed files and commit metadata.
- The controller checks current ownership before and after handoff, streams from the same verified private pack handle, and validates bounded response identity, paths, progress and exit status.
- Fresh observation calls the fixed `intake-status` command using only the retained request and pinned identity. It does not reopen source inputs, initialize storage, resend, run setup or start tasks.
- Late ownership, input or cancellation failures preserve the request and any already-validated response. A lost acknowledgement never authorizes replay or cleanup.
- Any observed cancellation remains cancellation even if the callback subsequently returns false. Without cancellation, a missing SSH client is an admission failure, oversized output is an invalid response, and query/deadline failures remain uncertain transport outcomes.
- Worker Error responses require the matching retained request digest and fixed roots. Intentionally unbound portable Unsupported responses remain accepted.

The controller is Linux-only. Call it off the UI thread. The caller must keep pack bytes and ancestry exclusively stable; post-transfer checks cannot retract disclosed bytes. The pipe budget does not bound blocking local reads, spawn or reap. The selected worker binary must actually contain the prerequisite commands before production use.

## Validation

Candidate `c23645fabce41f36c8d0b446a19a8ddff55c8965`, parent `0984f137`:

- The cancellation, unbound Error and query-error-classification regressions each failed at their intended assertions on the unfixed behavior. The classification test covers send/observe, all four query errors, and cancellation precedence.
- Seven controller, eleven SSH-query and two CLI framing tests passed. Independent review of the final source and documentation completed.
- All eight exact-commit gates passed: formatting, maintainability, version sync, default tests, speech tests, blocking Clippy, strict Clippy and advisory pedantic Clippy.
- All six fresh public-controller/shipped-CLI native lanes passed: inert proposal and private-input refusals; approved large-pack/two-layer intake and content verification; fresh-client observation and early retained reply; lost SSH output without resend; partial CLI frame with unknown-state observation and no replay; tmpfs, missing-control-database and saved-pin refusals.
- The native run used a newly built candidate core/API driver on the host and a newly built CLI mounted read-only into the existing immutable local runtime. CLI SHA-256 `4e142e5991f88ace76e927468f103a3573c7a078fb9ceb9932866b124bea9f7b`; public API driver SHA-256 `c6520ea0a9ae4ac860f8bb18a35f7cce98e7e9b9b5c9e73ba5571daf93c3c615`. Locked dependency identities matched. All exact task-owned test resources and the generated fixture were removed after success; evidence was retained.
- This is local integration proof, not a newly packaged worker image or cloud/PC-off acceptance.

## Scope

Seven source/test files, 970 changed lines; two focused documentation updates. The CLI implementation is already delivered by #503 and is not duplicated here. No UI, provider lifecycle, configuration, dependency, image publication, setup/task execution or PC-off acceptance changes.
