### PR TITLE
feat(repository): expose bounded worker intake commands

### DIFF
--- a/crates/horizon-repository/src/intake.rs
+++ b/crates/horizon-repository/src/intake.rs
@@ -1,0 +1,132 @@
+//! Combined worker-only intake framing; neither parsing nor observation grants setup.
+use horizon_core::repository_overlay::intake::{self, IntakeError, IntakeRequest, IntakeResponse, REQUEST_LIMIT};
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+pub(super) fn run(
+    observe: bool,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    let response = match read_request(observe, input) {
+        Ok(request) if observe => intake::observe(&request, || false),
+        Ok(request) => intake::receive(&request, input, || false),
+        Err(()) => IntakeResponse::failure(IntakeError::Invalid),
+    };
+    super::write_response(
+        &response,
+        response.exit_code(),
+        intake::RESPONSE_LIMIT,
+        output,
+        diagnostics,
+    )
+}
+
+fn read_request(observe: bool, input: &mut impl Read) -> Result<IntakeRequest, ()> {
+    let length = if observe {
+        REQUEST_LIMIT + 1
+    } else {
+        let mut prefix = [0; 4];
+        input.read_exact(&mut prefix).map_err(|_| ())?;
+        let length = usize::try_from(u32::from_le_bytes(prefix)).map_err(|_| ())?;
+        if length == 0 || length > REQUEST_LIMIT {
+            return Err(());
+        }
+        length
+    };
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(length).map_err(|_| ())?;
+    input.take(length as u64).read_to_end(&mut bytes).map_err(|_| ())?;
+    if !observe && bytes.len() != length {
+        return Err(());
+    }
+    IntakeRequest::decode(&bytes).map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn bad_headers_are_bounded_redacted_and_output_loss_is_distinct() {
+        for header in [
+            b"{}".to_vec(),
+            b"private-invalid-input".to_vec(),
+            vec![b' '; REQUEST_LIMIT + 1],
+        ] {
+            for observe in [false, true] {
+                let mut bytes = if observe {
+                    vec![]
+                } else {
+                    u32::try_from(header.len()).unwrap().to_le_bytes().to_vec()
+                };
+                bytes.extend(&header);
+                let mut output = vec![];
+                assert_eq!(
+                    run(observe, &mut bytes.as_slice(), &mut output, &mut io::sink()),
+                    ExitCode::from(2)
+                );
+                let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+                assert!(
+                    response["roots"].is_null() && response["pack"].is_null() && response["intent_sha256"].is_null()
+                );
+                assert!(!String::from_utf8(output).unwrap().contains("private-invalid-input"));
+            }
+        }
+        let mut bytes = (u32::try_from(REQUEST_LIMIT).unwrap() + 1).to_le_bytes().to_vec();
+        bytes.extend(b"unread payload");
+        let mut input = bytes.as_slice();
+        assert!(read_request(false, &mut input).is_err());
+        assert_eq!(input, b"unread payload");
+        assert_eq!(
+            run(
+                true,
+                &mut b"{}".as_slice(),
+                &mut [0; 0].as_mut_slice(),
+                &mut [0; 0].as_mut_slice()
+            ),
+            ExitCode::from(3)
+        );
+    }
+
+    #[test]
+    fn valid_short_reads_stop_at_header_and_status_requires_eof() {
+        struct Short<'a>(&'a [u8]);
+        impl Read for Short<'_> {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                let count = buffer.len().min(1);
+                self.0.read(&mut buffer[..count])
+            }
+        }
+        let header = serde_json::to_vec(&serde_json::json!({
+            "version":1,"workspace_local_id":"fixture-workspace",
+            "workflow_id":"11111111-1111-4111-8111-111111111111",
+            "job_id":"22222222-2222-4222-8222-222222222222",
+            "runtime_generation":1,"worker_resource_id":"fixture-worker",
+            "client_key_sha256":"a".repeat(64),
+            "source":{"repository":"fixture/repository","commit":"a".repeat(40),"branch":null},
+            "pack":{"sha256":"b".repeat(64),"encoded_bytes":32},
+            "overlay":{"sha256":"c".repeat(64),"encoded_bytes":1}
+        }))
+        .unwrap();
+        let mut bytes = u32::try_from(header.len()).unwrap().to_le_bytes().to_vec();
+        bytes.extend(&header);
+        bytes.extend(b"pack-and-overlay");
+        let mut short = Short(&bytes);
+        let received = read_request(false, &mut short).unwrap();
+        assert_eq!(short.0, b"pack-and-overlay");
+        assert_eq!(read_request(true, &mut Short(&header)).unwrap(), received);
+        let mut trailing = header.clone();
+        trailing.extend(b"payload");
+        assert!(read_request(true, &mut Short(&trailing)).is_err());
+        let truncated = &bytes[..4 + header.len() - 1];
+        assert!(read_request(false, &mut Short(truncated)).is_err());
+        for prefix in [&[0, 0, 0, 0][..], &[1, 0, 0][..]] {
+            assert!(read_request(false, &mut Short(prefix)).is_err());
+        }
+    }
+}

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod intake;
 mod pack;
 mod protocol;
 mod receive;
@@ -24,12 +25,14 @@ fn main() -> ExitCode {
                     | "overlay-status"
                     | "receive-pack"
                     | "pack-status"
+                    | "intake"
+                    | "intake-status"
             )
         )
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|receive-overlay|overlay-status|receive-pack|pack-status < request"
+            "Usage: horizon-repository materialize|setup|setup-status|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status < request"
         );
         return ExitCode::from(2);
     }
@@ -43,6 +46,8 @@ fn main() -> ExitCode {
         Some("overlay-status") => receive::run(receive::Command::Observe, &mut input, &mut output, &mut diagnostics),
         Some("receive-pack") => pack::run(pack::Command::Receive, &mut input, &mut output, &mut diagnostics),
         Some("pack-status") => pack::run(pack::Command::Observe, &mut input, &mut output, &mut diagnostics),
+        Some("intake") => intake::run(false, &mut input, &mut output, &mut diagnostics),
+        Some("intake-status") => intake::run(true, &mut input, &mut output, &mut diagnostics),
         _ => run(&mut input, &mut output, &mut diagnostics),
     }
 }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -285,8 +285,11 @@ back into large multi-purpose modules.
   noncreating observation. Its pure request/response shell keeps strict identities;
   the Linux leaf owns the create-new claim, held directory bindings and component
   orchestration. Existing claims never consume payload or grant another receiver.
-  See [combined core intake](../remote-repository-intake.md); CLI/controller and
-  setup/task authority remain separate.
+  See [combined core intake](../remote-repository-intake.md); controller and
+  setup/task authority remain separate. The worker CLI's `intake` leaf bounds a
+  little-endian request-length prefix, then delegates payload consumption to that
+  API. `intake-status` accepts only a bounded request and EOF; neither command
+  starts setup or tasks.
   `checkout/` prepares the seed and raw working namespace together, using exclusive
   descriptor-relative writes, incremental loose decoding and pinned-file verification.
   Literal links are created last. This private logical checkout retains failures;

--- a/docs/remote-repository-intake.md
+++ b/docs/remote-repository-intake.md
@@ -1,8 +1,9 @@
 # Combined retained repository intake
 
-`repository_overlay::intake::{receive, observe}` is a worker core API. It does not
-add a shipped CLI, SSH controller, provider operation, setup execution or task.
-Those adapters must separately enforce explicit export approval and full retained
+`repository_overlay::intake::{receive, observe}` is a worker core API, exposed by
+the worker-only `horizon-repository intake` and `intake-status` commands. Neither
+adds an SSH controller, provider operation, setup execution or task. A transport
+caller must separately enforce explicit export approval and full retained
 worker/client ownership. Constructing a request, capturing an overlay, computing a
 digest or successfully recovering a provider allocation is not export approval.
 
@@ -30,6 +31,20 @@ manifest and source before either input is published. The pack ceiling is the sh
 256 MiB default; existing bundle inner/encoded limits and native process ceilings apply.
 Pack copying is chunked. Overlay decoding retains bounded complete-buffer copies,
 not constant total memory. No original source repository is read on the worker.
+
+## Worker command framing
+
+`intake` reads a four-byte little-endian request length in the range 1–32 KiB,
+then that exact JSON header, and delegates the remaining pack/overlay stream to
+the core receiver. A matching existing claim can reply without consuming payload.
+`intake-status` instead accepts only bounded request JSON followed by EOF; it has
+no length prefix or payload. Invalid framing is rejected before storage access.
+
+Both commands emit bounded JSON responses using the shared 128 KiB response limit.
+Exit codes are 0 for acknowledgement/observation, 2 for rejected framing/identity,
+4 for a claimed-unknown result, and 1 for other unsuccessful outcomes. Exit code 3
+means the response could not be written; it does not undo a completed intake.
+Neither command grants export approval or setup/task authority.
 
 ## Fixed roots and replay barrier
 


### PR DESCRIPTION
## Purpose

Expose the existing retained worker intake API through two fixed, bounded commands. This independently testable prerequisite for #502 keeps the controller corrections and regression tests within normal PR limits. Part of #470 / #383; it does not complete the cloud workflow.

## Behavior

- `horizon-repository intake` accepts a four-byte little-endian length, the exact bounded request header, and the existing pack/overlay stream.
- `horizon-repository intake-status` accepts only bounded request JSON and EOF. It does not initialize missing state, consume repository payload, or grant replay.
- Invalid framing is rejected before storage access. Existing one-shot worker claims, response states and exit codes are retained; failure to write a response reports exit 3 without undoing worker state.
- No controller, provider operation, export approval, setup, task execution, dependency, configuration or UI changes.

The receiver's Linux storage qualification and portable Unsupported behavior remain unchanged. Callers must separately enforce export approval and retained worker/client ownership. A missing or lost response never authorizes another intake. Existing images need the new command binary before it can be used remotely.

## Validation

Candidate `5661f971a148be8bb0ce80c3d2b9a3c58522007d`, parent `5b64431f`:

- Focused framing tests, formatting, blocking and strict lint tiers passed in the exact isolated checkout.
- Independent local review of the complete source and documentation diff completed.
- All eight local tiers passed: formatting, maintainability, version sync, default and speech workspace tests, blocking, strict and advisory pedantic lint tiers.
- Fresh native validation used the actual candidate CLI over pinned local SSH on a qualified Linux ext4 volume. All seven groups passed: nonwriting missing-state observation; eight redacted malformed-framing rejections without storage mutation; large pack plus staged/working overlay acknowledgement; new-container same-volume observation without resend; lost local stdout followed by fresh observation; a 1 MiB partial transfer with preserved uncertainty/no replay; and actual tmpfs refusal before claim creation.
- The complete transfer wrote all 68,180,124 frame bytes. Read-only native Git checks proved the selected seven-object closure, absence of the unselected ancestor, and the 68,157,441-byte file hash. The candidate CLI SHA256 was `fa1f9f3fcea591b559ce52ef910b672620d28829c1e61758cb6d320f6ff05af9`.
- The CLI was built locked/offline from this exact workspace; the pinned local runtime was reused without image publication. Exact disposable resources and generated fixtures were removed after successful final state checks.

This establishes local CLI/worker behavior, not controller integration, setup/task execution, cloud storage durability, UI flows or PC-off acceptance.

## Scope

Two source/test files, 139 changed lines; two focused documentation updates. The CLI files are unchanged from the earlier combined candidate; that earlier candidate's smoke evidence is not substituted for this prerequisite's final gates.
