### PR TITLE
feat(remote): bind tasks to approved repository setup

### DIFF
--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -48,7 +48,9 @@ def execute_request(service, stream):
         raise SessionError("structured session request is invalid")
     if request.get("operation") == "status" and set(request) == common:
         return service.status(request["runtime"], request["panel"])
-    if request.get("operation") not in ("start", "verify") or set(request) != common | {"directory", "argv"}:
+    prepared = request.get("operation") == "start-prepared"
+    expected = common | {"directory", "argv"} | ({"repository"} if prepared else set())
+    if request.get("operation") not in ("start", "verify", "start-prepared") or set(request) != expected:
         raise SessionError("unsupported structured session request")
     if (
         not isinstance(request["directory"], str)
@@ -56,8 +58,33 @@ def execute_request(service, stream):
         or not all(isinstance(argument, str) for argument in request["argv"])
     ):
         raise SessionError("structured task intent is invalid")
+    if prepared:
+        return service.start_prepared(request["runtime"], request["panel"], request["directory"],
+                                      request["argv"], request["repository"])
     operation = service.verify if request["operation"] == "verify" else service.start
     return operation(request["runtime"], request["panel"], request["directory"], request["argv"])
+
+
+def repository_selection(operation, selection):
+    """Only the fixed trusted core helper canonicalizes and inspects this selection."""
+    if operation not in ("setup-binding", "setup-checkout"):
+        raise SessionError("unsupported repository inspection")
+    encoded = json.dumps(selection, ensure_ascii=False).encode()
+    if len(encoded) > 34 * 1024:
+        raise SessionError("prepared repository selection exceeds its limit")
+    result = subprocess.run(["/usr/local/bin/horizon-repository", operation], input=encoded,
+                            capture_output=True, timeout=120, check=False, close_fds=True,
+                            cwd="/", env={"PATH": "/usr/bin:/bin", "LC_ALL": "C"})
+    if result.returncode or result.stderr or len(result.stdout) > 16 * 1024 or not result.stdout.endswith(b"\n"):
+        raise SessionError("prepared repository inspection did not complete")
+    value = json.loads(result.stdout, object_pairs_hook=unique_fields)
+    if (not isinstance(value, dict) or set(value) != {"version", "binding_sha256", "runtime", "root", "reason"}
+            or type(value["version"]) is not int or value["version"] != 1 or value["reason"] is not None
+            or not isinstance(value["runtime"], str) or not isinstance(value["binding_sha256"], str)
+            or not re.fullmatch(r"[0-9a-f]{64}", value["binding_sha256"])
+            or operation == "setup-binding" and value["root"] is not None):
+        raise SessionError("prepared repository inspection is invalid")
+    return value
 
 
 def private_directory(path):
@@ -143,16 +170,20 @@ class PanelSessions:
             raw = stream.read(4097)
         if len(raw) > 4096:
             raise SessionError("session marker exceeds its limit")
-        marker = json.loads(raw)
+        marker = json.loads(raw, object_pairs_hook=unique_fields)
         expected = {"version", "runtime", "panel", "nonce", "intent"}
+        if isinstance(marker, dict) and marker.get("version") == 2:
+            expected.add("repository")
         if (
             not isinstance(marker, dict) or set(marker) != expected
-            or type(marker["version"]) is not int or marker["version"] != 1
+            or type(marker["version"]) is not int or marker["version"] not in (1, 2)
             or marker["runtime"] != runtime or marker["panel"] != panel
             or not isinstance(marker["nonce"], str)
             or not re.fullmatch(r"[0-9a-f]{32}", marker["nonce"])
             or not isinstance(marker["intent"], str)
             or not re.fullmatch(r"[0-9a-f]{64}", marker["intent"])
+            or marker["version"] == 2 and (not isinstance(marker["repository"], str)
+                                            or not re.fullmatch(r"[0-9a-f]{64}", marker["repository"]))
         ):
             raise SessionError("session marker identity is invalid")
         return marker
@@ -206,8 +237,54 @@ class PanelSessions:
         return working_directory, intent
 
     def start(self, runtime, panel, directory, arguments):
-        _, name = self.identities(runtime, panel)
+        self.identities(runtime, panel)
         working_directory, intent = self.launch_intent(directory, arguments)
+        return self._start_at(runtime, panel, working_directory, arguments, intent)
+
+    def start_prepared(self, runtime, panel, directory, arguments, selection):
+        self.identities(runtime, panel)
+        intent = self.intent_digest(directory, arguments)
+        binding = repository_selection("setup-binding", selection)
+        if binding["runtime"] != runtime:
+            raise SessionError("prepared repository runtime does not match the task")
+        try:
+            marker = self.read_marker(runtime, panel)
+        except FileNotFoundError:
+            marker = None
+        if marker is not None:
+            self.match_intent(marker, intent, binding["binding_sha256"])
+            return self.status(runtime, panel)
+        inspected = repository_selection("setup-checkout", selection)
+        root = inspected["root"]
+        if (inspected["runtime"] != runtime or inspected["binding_sha256"] != binding["binding_sha256"]
+                or not isinstance(root, dict) or set(root) != {"path", "device", "inode"}
+                or not isinstance(root["path"], str) or not Path(root["path"]).is_absolute()
+                or any(type(root[key]) is not int or root[key] < 0 for key in ("device", "inode"))):
+            raise SessionError("prepared repository root is invalid")
+        repository = Path(root["path"])
+        descriptor = os.open(repository, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        try:
+            held = os.fstat(descriptor)
+            if (held.st_uid != os.geteuid() or stat.S_IMODE(held.st_mode) != 0o700 or held.st_nlink == 0
+                    or (held.st_dev, held.st_ino) != (root["device"], root["inode"])):
+                raise SessionError("prepared repository root changed")
+            working_directory = (repository / directory).resolve(strict=True)
+            if not working_directory.is_dir() or not working_directory.is_relative_to(repository):
+                raise SessionError("task directory must remain inside the repository")
+            named = repository.lstat()
+            if (named.st_dev, named.st_ino) != (held.st_dev, held.st_ino):
+                raise SessionError("prepared repository root changed")
+            return self._start_at(runtime, panel, working_directory, arguments, intent, binding["binding_sha256"])
+        finally:
+            os.close(descriptor)
+
+    @staticmethod
+    def match_intent(marker, intent, repository):
+        if marker["intent"] != intent or marker.get("repository") != repository:
+            raise SessionError("panel launch intent differs from its retained task")
+
+    def _start_at(self, runtime, panel, working_directory, arguments, intent, repository=None):
+        _, name = self.identities(runtime, panel)
         try:
             marker = self.read_marker(runtime, panel)
         except FileNotFoundError:
@@ -215,7 +292,10 @@ class PanelSessions:
         if marker is None:
             if self.tmux(runtime, "has-session", "-t", f"={name}", check=False).returncode == 0:
                 raise SessionError("an unowned session already uses this panel identity")
-            marker = {"version": 1, "runtime": runtime, "panel": panel, "nonce": uuid.uuid4().hex, "intent": intent}
+            marker = {"version": 2 if repository else 1, "runtime": runtime, "panel": panel,
+                      "nonce": uuid.uuid4().hex, "intent": intent}
+            if repository is not None:
+                marker["repository"] = repository
             if self.publish_marker(runtime, panel, marker):
                 private_directory(self.sockets)
                 # The wrapper plus program always supplies multiple arguments to tmux,
@@ -226,8 +306,7 @@ class PanelSessions:
                 )
             else:
                 marker = self.read_marker(runtime, panel)
-        if marker["intent"] != intent:
-            raise SessionError("panel launch intent differs from its retained task")
+        self.match_intent(marker, intent, repository)
         return self.status(runtime, panel)
 
     def verify(self, runtime, panel, directory, arguments):

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -32,7 +32,7 @@ class PanelSessionTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory(prefix="hps-", dir="/tmp")
         self.root = Path(self.temporary.name)
         self.repository = self.root / "repo"
-        self.repository.mkdir()
+        self.repository.mkdir(mode=0o700)
         (self.repository / "nested space").mkdir()
         self.runtimes = [str(uuid.uuid4()), str(uuid.uuid4())]
         self.service = MODULE.PanelSessions(self.repository, self.root / "state", self.root / "sockets",
@@ -494,7 +494,7 @@ class PanelSessionTests(unittest.TestCase):
         self.service.start(runtime, "owned", ".", self.tick_command())
         path = self.service.marker_path(runtime, "owned")
         original = path.read_text()
-        for version in (2, True):
+        for version in (2, 3, True):
             marker = json.loads(original)
             marker["version"] = version
             path.write_text(json.dumps(marker))
@@ -504,6 +504,174 @@ class PanelSessionTests(unittest.TestCase):
         path.chmod(0o644)
         with self.assertRaises(MODULE.SessionError):
             self.service.status(runtime, "owned")
+
+    def prepared_request(self, panel="prepared", directory=".", argv=None):
+        selection = {"version": 1, "destination": "published", "intake": {
+            "version": 1, "workspace_local_id": "fixture-workspace", "workflow_id": self.runtimes[1],
+            "job_id": self.runtimes[0], "runtime_generation": 1, "worker_resource_id": "fixture-worker",
+            "client_key_sha256": "a" * 64,
+            "source": {"repository": "fixture/repository", "commit": "a" * 40, "branch": None},
+            "pack": {"sha256": "b" * 64, "encoded_bytes": 32},
+            "overlay": {"sha256": "c" * 64, "encoded_bytes": 1}}}
+        return self.request("start-prepared", panel, directory=directory, argv=argv or self.tick_command(), repository=selection)
+
+    def prepared_helper(self, operation, selection):
+        # This seam tests panel admission, not Rust canonicalization or full setup.
+        same = selection == self.prepared_request()["repository"]
+        root = None
+        if operation == "setup-checkout":
+            info = self.repository.stat()
+            root = {"path": str(self.repository), "device": info.st_dev, "inode": info.st_ino}
+        self.assertIn(operation, ("setup-binding", "setup-checkout"))
+        return {"version": 1, "binding_sha256": ("a" if same else "b") * 64,
+                "runtime": selection["intake"]["job_id"], "root": root, "reason": None}
+
+    def test_prepared_panels_share_evolving_commits_index_and_working_tree(self):
+        environment = {"PATH": "/usr/bin:/bin", "LC_ALL": "C", "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": "/dev/null"}
+        def git(*arguments):
+            return MODULE.subprocess.run(["git", "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", *arguments],
+                cwd=self.repository, env=environment, capture_output=True, timeout=5, check=True).stdout
+        git("init", "--template=", "-q")
+        content = self.repository / "tracked"
+        content.write_text("base")
+        git("add", "tracked")
+        git("commit", "-qm", "fixture")
+        old_head = git("rev-parse", "HEAD")
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.prepared_helper):
+            first = self.execute(self.prepared_request("first"))
+            self.wait_for(lambda: (self.repository / "ticks").exists())
+            content.write_text("new commit")
+            git("commit", "-qam", "development")
+            self.assertNotEqual(git("rev-parse", "HEAD"), old_head)
+            content.write_text("staged")
+            git("add", "tracked")
+            content.write_text("working")
+            second = self.execute(self.prepared_request("second", argv=self.command(
+                "from pathlib import Path; import time; Path('seen').write_text(Path('tracked').read_text()); time.sleep(30)")))
+            self.wait_for(lambda: (self.repository / "seen").exists())
+            self.assertEqual((self.repository / "seen").read_text(), "working")
+            self.assertEqual(git("show", ":tracked"), b"staged")
+            self.assertNotEqual(first["pid"], second["pid"])
+            self.assertEqual(self.service.status(self.runtimes[0], "first")["pid"], first["pid"])
+            markers = [self.service.read_marker(self.runtimes[0], panel) for panel in ("first", "second")]
+            self.assertEqual([marker["repository"] for marker in markers], ["a" * 64] * 2)
+
+    def test_prepared_retained_task_survives_repository_removal_without_inspection(self):
+        request = self.prepared_request(directory="nested space", argv=self.command("raise SystemExit(42)"))
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.prepared_helper) as helper:
+            first = self.execute(request)
+            self.wait_for(lambda: self.service.status(self.runtimes[0], "prepared")["state"] == "exited")
+            marker = self.service.marker_path(self.runtimes[0], "prepared")
+            before = marker.read_bytes(), marker.stat().st_mtime_ns
+            (self.repository / "nested space").rmdir()
+            self.repository.rmdir()
+            helper.reset_mock()
+            self.assertEqual(self.execute(request)["pid"], first["pid"])
+            self.assertEqual(self.service.verify(self.runtimes[0], "prepared", "nested space", request["argv"])["exit_status"], 42)
+            self.attach_and_disconnect(self.runtimes[0], "prepared")
+            self.assertEqual([call.args[0] for call in helper.call_args_list], ["setup-binding"])
+            self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), before)
+
+    def test_prepared_binding_and_legacy_marker_mismatches_never_launch(self):
+        request = self.prepared_request()
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.prepared_helper) as helper:
+            self.execute(request)
+            request["repository"]["destination"] = "different"
+            with self.assertRaises(MODULE.SessionError):
+                self.execute(request)
+            with self.assertRaises(MODULE.SessionError):
+                self.service.start(self.runtimes[0], "prepared", ".", request["argv"])
+            self.service.start(self.runtimes[0], "legacy", ".", request["argv"])
+            helper.reset_mock()
+            with self.assertRaises(MODULE.SessionError):
+                self.execute(self.prepared_request("legacy"))
+            self.assertEqual([call.args[0] for call in helper.call_args_list], ["setup-binding"])
+            self.assertEqual(len(self.service.tmux(self.runtimes[0], "list-sessions").stdout.splitlines()), 2)
+
+    def test_prepared_uncertain_claim_and_server_loss_never_replay(self):
+        request = self.prepared_request()
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.prepared_helper) as helper:
+            # Simulate interruption after the same irreversible marker publication.
+            intent = self.service.intent_digest(".", request["argv"])
+            self.service.publish_marker(self.runtimes[0], "prepared", {"version": 2, "runtime": self.runtimes[0],
+                "panel": "prepared", "nonce": uuid.uuid4().hex, "intent": intent, "repository": "a" * 64})
+            self.assertEqual(self.execute(request)["state"], "unavailable")
+            self.assertFalse((self.repository / "ticks").exists())
+            running = self.prepared_request("running")
+            self.execute(running)
+            self.wait_for(lambda: (self.repository / "ticks").exists())
+            self.service.tmux(self.runtimes[0], "kill-server")
+            helper.reset_mock()
+            before = (self.repository / "ticks").read_bytes()
+            self.assertEqual(self.execute(running)["state"], "unavailable")
+            self.assertEqual((self.repository / "ticks").read_bytes(), before)
+            self.assertEqual([call.args[0] for call in helper.call_args_list], ["setup-binding"])
+
+    def test_prepared_lost_start_response_retains_the_one_actual_task(self):
+        request = self.prepared_request()
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.prepared_helper) as helper:
+            with mock.patch.object(self.service, "status", side_effect=MODULE.SessionError("lost response")), self.assertRaises(MODULE.SessionError):
+                self.execute(request)
+            self.wait_for(lambda: (self.repository / "ticks").exists())
+            first = self.service.status(self.runtimes[0], "prepared")
+            helper.reset_mock()
+            self.assertEqual(self.execute(request)["pid"], first["pid"])
+            self.assertEqual([call.args[0] for call in helper.call_args_list], ["setup-binding"])
+
+    def test_prepared_concurrent_starts_claim_once(self):
+        command = self.command("from pathlib import Path; import time; Path('runs').open('a').write('once\\n'); time.sleep(30)")
+        request = self.prepared_request(argv=command)
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.prepared_helper):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(lambda _: self.execute(request), range(2)))
+        self.wait_for(lambda: (self.repository / "runs").exists() and (self.repository / "runs").read_text() == "once\n")
+        self.assertTrue(all(result["state"] in ("running", "unavailable") for result in results))
+        self.assertEqual(len(self.service.tmux(self.runtimes[0], "list-sessions").stdout.splitlines()), 1)
+
+    def test_prepared_failure_identity_drift_and_escape_have_no_marker(self):
+        outside = self.root / "outside"
+        outside.mkdir()
+        (self.repository / "escape").symlink_to(outside)
+        for fault in ("failure", "runtime", "binding", "inode", "mode", "escape"):
+            request = self.prepared_request(directory="escape" if fault == "escape" else ".")
+            def helper(operation, selection):
+                response = self.prepared_helper(operation, selection)
+                if operation == "setup-checkout":
+                    if fault == "failure":
+                        raise MODULE.SessionError("unconfirmed setup")
+                    if fault in ("runtime", "binding"):
+                        response["runtime" if fault == "runtime" else "binding_sha256"] = "different"
+                    if fault == "inode":
+                        response["root"]["inode"] += 1
+                    if fault == "mode":
+                        self.repository.chmod(0o755)
+                return response
+            try:
+                with mock.patch.object(MODULE, "repository_selection", side_effect=helper), self.assertRaises(MODULE.SessionError):
+                    self.execute(request)
+                self.assertFalse(self.service.state.exists())
+                self.assertFalse(self.service.sockets.exists())
+            finally:
+                self.repository.chmod(0o700)
+
+    def test_fixed_repository_helper_uses_literal_bounded_commands_and_rejects_bad_responses(self):
+        selected = self.prepared_request()["repository"]
+        reply = self.prepared_helper("setup-binding", selected)
+        completed = MODULE.subprocess.CompletedProcess([], 0, json.dumps(reply).encode() + b"\n", b"")
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(MODULE.repository_selection("setup-binding", selected), reply)
+            self.assertEqual(run.call_args.args[0], ["/usr/local/bin/horizon-repository", "setup-binding"])
+            self.assertEqual(run.call_args.kwargs["env"], {"PATH": "/usr/bin:/bin", "LC_ALL": "C"})
+            self.assertEqual(json.loads(run.call_args.kwargs["input"]), selected)
+            for status, stdout, stderr in [(1, completed.stdout, b""), (0, completed.stdout, b"error"),
+                    (0, b"x" * (16 * 1024 + 1), b""), (0, b"{}\n", b"")]:
+                run.return_value = MODULE.subprocess.CompletedProcess([], status, stdout, stderr)
+                with self.assertRaises(MODULE.SessionError):
+                    MODULE.repository_selection("setup-binding", selected)
+            run.reset_mock()
+            with self.assertRaises(MODULE.SessionError):
+                MODULE.repository_selection("setup", selected)
+            run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/crates/horizon-core/src/repository_overlay/intake/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/mod.rs
@@ -1,6 +1,8 @@
 //! Retained repository intake with a Linux export-approval controller.
 //! Neither worker intake nor controller handoff grants setup or task authority.
 
+pub mod setup;
+
 #[cfg(target_os = "linux")]
 pub mod controller;
 #[cfg(target_os = "linux")]

--- a/crates/horizon-core/src/repository_overlay/intake/setup.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/setup.rs
@@ -1,0 +1,258 @@
+//! Explicit task selection and point-in-time checkout inspection; never setup or start.
+
+use super::IntakeRequest;
+use crate::{
+    cloud_run::{ArtifactDigest, CloudJobId},
+    repository_overlay::checkout::publication::validate_sibling_name,
+};
+use serde::{Deserialize, Serialize};
+use std::{fmt, path::PathBuf};
+
+pub const SETUP_SELECTION_LIMIT: usize = super::REQUEST_LIMIT + 2048;
+
+/// Immutable repository identity, not current working-tree contents or task authority.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetupCheckoutSelection {
+    version: u8,
+    intake: IntakeRequest,
+    destination: String,
+}
+
+impl SetupCheckoutSelection {
+    /// Validate a selection without inspecting storage or granting execution.
+    /// # Errors
+    /// Rejects invalid intake identities and destination components.
+    pub fn new(intake: IntakeRequest, destination: String) -> Result<Self, SetupCheckoutError> {
+        let selection = Self {
+            version: 1,
+            intake,
+            destination,
+        };
+        selection.binding()?;
+        Ok(selection)
+    }
+
+    /// Decode bounded strict input. Equivalent JSON field order has one binding.
+    /// # Errors
+    /// Rejects malformed, duplicate, unknown, oversized or invalid fields.
+    pub fn decode(bytes: &[u8]) -> Result<Self, SetupCheckoutError> {
+        if bytes.len() > SETUP_SELECTION_LIMIT {
+            return Err(SetupCheckoutError::Invalid);
+        }
+        let selection: Self = serde_json::from_slice(bytes).map_err(|_| SetupCheckoutError::Invalid)?;
+        selection.binding()?;
+        Ok(selection)
+    }
+
+    /// Inert canonical identity; no checkout, key, provider or retained-file access.
+    /// # Errors
+    /// Rejects invalid or unsupported selection metadata.
+    pub fn binding(&self) -> Result<ArtifactDigest, SetupCheckoutError> {
+        if self.version != 1 || self.intake.encode().is_err() || validate_sibling_name(&self.destination).is_err() {
+            return Err(SetupCheckoutError::Invalid);
+        }
+        let bytes = serde_json::to_vec(&("horizon-prepared-task-v1", self)).map_err(|_| SetupCheckoutError::Invalid)?;
+        Ok(ArtifactDigest::sha256(&bytes))
+    }
+
+    #[must_use]
+    pub fn runtime(&self) -> CloudJobId {
+        self.intake.job_id
+    }
+
+    /// Inspect the matching intake/setup and current private checkout root without writes.
+    /// HEAD, index and working files may evolve; their original contents are not rehashed.
+    /// Requires stable exclusively controlled ancestry/root and the existing storage/tool
+    /// premises through consumption. This is not historical inode proof or continuous
+    /// revocation. Run off the UI thread; blocking storage has no hard deadline.
+    /// # Errors
+    /// Unknown setup, conflicting identities, unsafe/missing roots and cancellation refuse
+    /// new task admission. Nothing is created, repaired, synchronized, started or removed.
+    pub fn inspect(&self, cancelled: impl Fn() -> bool) -> Result<SetupCheckoutLocation, SetupCheckoutError> {
+        self.binding()?;
+        if cancelled() {
+            return Err(SetupCheckoutError::Cancelled);
+        }
+        #[cfg(target_os = "linux")]
+        return inspect(self, &cancelled);
+        #[cfg(not(target_os = "linux"))]
+        Err(SetupCheckoutError::Unsupported)
+    }
+}
+
+impl fmt::Debug for SetupCheckoutSelection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetupCheckoutSelection").finish_non_exhaustive()
+    }
+}
+
+/// Current root identity for an immediate same-selection recheck, not an execution grant.
+#[derive(Serialize)]
+pub struct SetupCheckoutLocation {
+    pub path: PathBuf,
+    pub device: u64,
+    pub inode: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupCheckoutError {
+    #[error("invalid prepared task repository selection")]
+    Invalid,
+    #[error("prepared task repository is not confirmed published")]
+    Unconfirmed,
+    #[error("prepared task repository storage is unavailable or changed")]
+    Storage,
+    #[error("prepared task repository inspection is unsupported")]
+    Unsupported,
+    #[error("prepared task repository inspection was cancelled")]
+    Cancelled,
+}
+
+#[cfg(target_os = "linux")]
+fn inspect(
+    selection: &SetupCheckoutSelection,
+    cancelled: &impl Fn() -> bool,
+) -> Result<SetupCheckoutLocation, SetupCheckoutError> {
+    inspect_observed(selection, super::observe(&selection.intake, cancelled), cancelled)
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_observed(
+    selection: &SetupCheckoutSelection,
+    observed: super::IntakeResponse,
+    cancelled: &impl Fn() -> bool,
+) -> Result<SetupCheckoutLocation, SetupCheckoutError> {
+    use super::IntakeError;
+    use crate::repository_overlay::retained_setup::{RetainedSetup, SetupIntent};
+    if observed.state != super::IntakeState::Observed
+        || observed.reason.is_some()
+        || observed.bundle != Some(super::BundleState::Observed)
+        || !observed
+            .pack
+            .as_ref()
+            .is_some_and(|pack| pack.state == super::PackState::Observed)
+    {
+        return Err(match observed.reason {
+            Some(IntakeError::Cancelled) => SetupCheckoutError::Cancelled,
+            Some(IntakeError::Unsupported) => SetupCheckoutError::Unsupported,
+            Some(IntakeError::Storage) => SetupCheckoutError::Storage,
+            _ => SetupCheckoutError::Unconfirmed,
+        });
+    }
+    let roots = observed.roots.ok_or(SetupCheckoutError::Unconfirmed)?;
+    let intent = SetupIntent::new(
+        selection.intake.workspace_local_id.clone(),
+        roots.packs.join("base/decoded/objects"),
+        roots.bundles,
+        selection.intake.overlay.sha256.clone(),
+        selection.destination.clone(),
+    )
+    .map_err(|_| SetupCheckoutError::Invalid)?;
+    let store = RetainedSetup::open(&roots.setup).map_err(|error| record_error(error.into()))?;
+    let completion = store
+        .completion(&intent)
+        .map_err(record_error)?
+        .ok_or(SetupCheckoutError::Unconfirmed)?;
+    let path = roots.setup.join("setup-data").join(&selection.destination);
+    if !published(
+        selection,
+        completion.state(),
+        completion.base_commit(),
+        completion.bundle_manifest(),
+    ) || completion.checkout() != Some(path.as_path())
+    {
+        return Err(SetupCheckoutError::Unconfirmed);
+    }
+    let pinned = pin_location(&roots.setup, &path)?;
+    if cancelled() {
+        return Err(SetupCheckoutError::Cancelled);
+    }
+    if store.completion(&intent).map_err(record_error)?.as_ref() != Some(&completion) {
+        return Err(SetupCheckoutError::Storage);
+    }
+    let current = pin_location(&roots.setup, &path)?;
+    if (pinned.0.device, pinned.0.inode) != (current.0.device, current.0.inode) {
+        return Err(SetupCheckoutError::Storage);
+    }
+    if cancelled() {
+        return Err(SetupCheckoutError::Cancelled);
+    }
+    Ok(pinned.0)
+}
+
+#[cfg(target_os = "linux")]
+fn record_error(error: crate::repository_overlay::retained_setup::SetupRecordError) -> SetupCheckoutError {
+    use crate::repository_overlay::retained_setup::{SetupBoundaryError as Boundary, SetupRecordError as Record};
+    match error {
+        Record::Boundary(Boundary::Unsupported) => SetupCheckoutError::Unsupported,
+        Record::Boundary(Boundary::Cancelled) => SetupCheckoutError::Cancelled,
+        Record::Boundary(Boundary::InvalidClaim) | Record::InvalidRecord => SetupCheckoutError::Unconfirmed,
+        _ => SetupCheckoutError::Storage,
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn published(
+    selection: &SetupCheckoutSelection,
+    state: crate::repository_overlay::retained_setup::SetupCompletionState,
+    base: Option<&str>,
+    manifest: Option<&ArtifactDigest>,
+) -> bool {
+    state == crate::repository_overlay::retained_setup::SetupCompletionState::Published
+        && base == Some(selection.intake.source.commit.as_str())
+        && manifest == Some(&selection.intake.overlay.sha256)
+}
+
+#[cfg(target_os = "linux")]
+fn pin_location(
+    parent: &std::path::Path,
+    path: &std::path::Path,
+) -> Result<(SetupCheckoutLocation, std::fs::File), SetupCheckoutError> {
+    use crate::repository_overlay::reader::{RepositoryReadError, SelectedRepositoryReader};
+    use rustix::fs::{Mode, OFlags, ResolveFlags, openat2};
+    use std::{fs::File, os::unix::fs::MetadataExt};
+    let root = SelectedRepositoryReader::open(parent).map_err(|error| match error {
+        RepositoryReadError::Unsupported => SetupCheckoutError::Unsupported,
+        _ => SetupCheckoutError::Storage,
+    })?;
+    let relative = path.strip_prefix(parent).map_err(|_| SetupCheckoutError::Storage)?;
+    let file = File::from(
+        openat2(
+            root.root.handle(),
+            relative,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS | ResolveFlags::NO_XDEV,
+        )
+        .map_err(|error| match error {
+            rustix::io::Errno::NOSYS | rustix::io::Errno::INVAL | rustix::io::Errno::OPNOTSUPP => {
+                SetupCheckoutError::Unsupported
+            }
+            _ => SetupCheckoutError::Storage,
+        })?,
+    );
+    let metadata = file.metadata().map_err(|_| SetupCheckoutError::Storage)?;
+    let parent_metadata = root.root.handle().metadata().map_err(|_| SetupCheckoutError::Storage)?;
+    if [&metadata, &parent_metadata].iter().any(|node| {
+        !node.is_dir()
+            || node.nlink() == 0
+            || node.uid() != rustix::process::geteuid().as_raw()
+            || node.mode() & 0o7777 != 0o700
+    }) || metadata.dev() != parent_metadata.dev()
+    {
+        return Err(SetupCheckoutError::Storage);
+    }
+    Ok((
+        SetupCheckoutLocation {
+            path: path.to_owned(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        },
+        file,
+    ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/intake/setup/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/setup/tests.rs
@@ -1,0 +1,246 @@
+use super::super::tests::request;
+use super::*;
+use crate::repository_overlay::retained_setup::SetupCompletionState as State;
+
+fn selection() -> SetupCheckoutSelection {
+    SetupCheckoutSelection::new(request(), "published".into()).unwrap()
+}
+
+#[test]
+fn canonical_binding_is_inert_strict_and_covers_runtime_and_destination() {
+    let selected = selection();
+    let bytes = serde_json::to_vec(&selected).unwrap();
+    assert_eq!(SetupCheckoutSelection::decode(&bytes).unwrap(), selected);
+    let value = serde_json::to_value(&selected).unwrap();
+    assert_eq!(
+        SetupCheckoutSelection::decode(&serde_json::to_vec(&value).unwrap())
+            .unwrap()
+            .binding(),
+        selected.binding()
+    );
+    for bytes in [
+        vec![b' '; SETUP_SELECTION_LIMIT + 1],
+        b"{}".to_vec(),
+        [b"{\"version\":1,".as_slice(), &bytes[1..]].concat(),
+    ] {
+        assert_eq!(
+            SetupCheckoutSelection::decode(&bytes).err(),
+            Some(SetupCheckoutError::Invalid)
+        );
+    }
+    for (field, value) in [
+        ("version", serde_json::json!(2)),
+        ("extra", serde_json::json!(true)),
+        ("destination", serde_json::json!("../escape")),
+    ] {
+        let mut changed = serde_json::to_value(&selected).unwrap();
+        changed[field] = value;
+        assert!(SetupCheckoutSelection::decode(&serde_json::to_vec(&changed).unwrap()).is_err());
+    }
+    let mut changed = selected.clone();
+    changed.intake.runtime_generation += 1;
+    assert_ne!(changed.binding(), selected.binding());
+    changed = selected.clone();
+    changed.destination.push('2');
+    assert_ne!(changed.binding(), selected.binding());
+    assert_eq!(selected.runtime(), selected.intake.job_id);
+    assert_eq!(selected.inspect(|| true).err(), Some(SetupCheckoutError::Cancelled));
+    assert!(!format!("{selected:?}").contains("fixture"));
+}
+
+#[test]
+fn only_exact_published_completion_matches_original_repository_identity() {
+    let selected = selection();
+    for state in [
+        State::Rejected,
+        State::Unpublished,
+        State::RenameUnconfirmed,
+        State::PublishedUnsynchronized,
+        State::Published,
+    ] {
+        assert_eq!(
+            published(
+                &selected,
+                state,
+                Some(selected.intake.source.commit.as_str()),
+                Some(&selected.intake.overlay.sha256)
+            ),
+            state == State::Published
+        );
+    }
+    for (base, manifest) in [
+        (None, Some(&selected.intake.overlay.sha256)),
+        (
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            Some(&selected.intake.overlay.sha256),
+        ),
+        (Some(selected.intake.source.commit.as_str()), None),
+    ] {
+        assert!(!published(&selected, State::Published, base, manifest));
+    }
+    assert!(!published(
+        &selected,
+        State::Published,
+        Some(selected.intake.source.commit.as_str()),
+        Some(&ArtifactDigest::sha256(b"wrong"))
+    ));
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn inspection_refuses_unsupported_platform_without_losing_binding() {
+    let selected = selection();
+    assert_eq!(selected.inspect(|| false).err(), Some(SetupCheckoutError::Unsupported));
+    assert!(selected.binding().is_ok());
+}
+
+#[cfg(target_os = "linux")]
+mod supported {
+    use super::*;
+    use crate::repository_overlay::{
+        intake::{BundleState, IntakeError, IntakeResponse, IntakeRoots, IntakeState, PackProgress, PackState},
+        retained_setup::{RetainedSetup, SetupClaimError, SetupIntent, completion_fixture},
+    };
+    use std::{
+        fs,
+        os::unix::fs::{DirBuilderExt, PermissionsExt, symlink},
+    };
+
+    #[test]
+    fn retained_record_reasons_preserve_unsupported_cancellation_and_uncertainty() {
+        use crate::repository_overlay::retained_setup::{SetupBoundaryError as Boundary, SetupRecordError as Record};
+        for (error, expected) in [
+            (Record::Boundary(Boundary::Unsupported), SetupCheckoutError::Unsupported),
+            (Record::Boundary(Boundary::Cancelled), SetupCheckoutError::Cancelled),
+            (
+                Record::Boundary(Boundary::InvalidClaim),
+                SetupCheckoutError::Unconfirmed,
+            ),
+            (Record::InvalidRecord, SetupCheckoutError::Unconfirmed),
+            (Record::Boundary(Boundary::UnsafeRoot), SetupCheckoutError::Storage),
+            (Record::Read, SetupCheckoutError::Storage),
+            (Record::Storage, SetupCheckoutError::Storage),
+        ] {
+            assert_eq!(record_error(error), expected);
+        }
+    }
+
+    #[test]
+    fn checkout_pin_does_not_freeze_development_files_and_rejects_unsafe_roots() {
+        let directory = tempfile::Builder::new()
+            .permissions(fs::Permissions::from_mode(0o700))
+            .tempdir()
+            .unwrap();
+        let root = directory.path().join("published");
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let held = pin_location(directory.path(), &root).unwrap();
+        for name in ["HEAD", "index", "working"] {
+            fs::write(root.join(name), b"evolving development bytes").unwrap();
+        }
+        let current = pin_location(directory.path(), &root).unwrap();
+        assert_eq!((held.0.device, held.0.inode), (current.0.device, current.0.inode));
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(pin_location(directory.path(), &root).is_err());
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let moved = directory.path().join("retained");
+        fs::rename(&root, &moved).unwrap();
+        assert!(pin_location(directory.path(), &root).is_err());
+        symlink(&moved, &root).unwrap();
+        assert!(pin_location(directory.path(), &root).is_err());
+        assert!(pin_location(&root, &moved).is_err());
+        assert_eq!(fs::read(moved.join("working")).unwrap(), b"evolving development bytes");
+    }
+
+    #[test]
+    fn existing_setup_records_are_read_only_and_unknown_or_conflicting_results_refuse() {
+        let directory = tempfile::Builder::new()
+            .permissions(fs::Permissions::from_mode(0o700))
+            .tempdir()
+            .unwrap();
+        let parent = directory.path();
+        if matches!(RetainedSetup::open(parent), Err(SetupClaimError::Unsupported)) {
+            eprintln!("SKIP setup checkout record fixture: qualified ext4 unavailable");
+            return;
+        }
+        let selected = selection();
+        let roots = IntakeRoots {
+            packs: parent.join("packs"),
+            bundles: parent.join("bundles"),
+            setup: parent.to_owned(),
+        };
+        let observed = || {
+            let mut response = IntakeResponse::failure(IntakeError::Input);
+            response.state = IntakeState::Observed;
+            response.reason = None;
+            response.roots = Some(roots.clone());
+            response.bundle = Some(BundleState::Observed);
+            response.pack = Some(PackProgress {
+                state: PackState::Observed,
+                source: None,
+                destination: None,
+                objects: None,
+            });
+            response
+        };
+        let intent = SetupIntent::new(
+            selected.intake.workspace_local_id.clone(),
+            roots.packs.join("base/decoded/objects"),
+            roots.bundles.clone(),
+            selected.intake.overlay.sha256.clone(),
+            selected.destination.clone(),
+        )
+        .unwrap();
+        let (claim, result) = completion_fixture(parent, &intent, State::Published);
+        assert!(inspect_observed(&selected, observed(), &|| false).is_err());
+        let claim_path = parent.join("setup-claim.json");
+        fs::write(&claim_path, &claim).unwrap();
+        fs::set_permissions(&claim_path, fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(
+            inspect_observed(&selected, observed(), &|| false).err(),
+            Some(SetupCheckoutError::Unconfirmed)
+        );
+        let checkout = parent.join("setup-data/published");
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&checkout)
+            .unwrap();
+        let result_path = parent.join("setup-result.json");
+        for state in [
+            State::Rejected,
+            State::Unpublished,
+            State::RenameUnconfirmed,
+            State::PublishedUnsynchronized,
+            State::Published,
+        ] {
+            fs::write(&result_path, completion_fixture(parent, &intent, state).1).unwrap();
+            fs::set_permissions(&result_path, fs::Permissions::from_mode(0o600)).unwrap();
+            let before = fs::read(&result_path).unwrap();
+            assert_eq!(
+                inspect_observed(&selected, observed(), &|| false).is_ok(),
+                state == State::Published
+            );
+            assert_eq!(fs::read(&result_path).unwrap(), before);
+        }
+        assert_eq!(fs::read(&result_path).unwrap(), result);
+        let mut changed = selected.clone();
+        changed.destination.push('2');
+        assert!(inspect_observed(&changed, observed(), &|| false).is_err());
+        let swapped = std::cell::Cell::new(false);
+        let retained = parent.join("retained-checkout");
+        let outcome = inspect_observed(&selected, observed(), &|| {
+            if !swapped.replace(true) {
+                fs::rename(&checkout, &retained).unwrap();
+                fs::DirBuilder::new().mode(0o700).create(&checkout).unwrap();
+            }
+            false
+        });
+        assert_eq!(outcome.err(), Some(SetupCheckoutError::Storage));
+        fs::remove_dir(&checkout).unwrap();
+        fs::rename(&retained, &checkout).unwrap();
+        fs::rename(&checkout, parent.join("retained-checkout")).unwrap();
+        assert!(inspect_observed(&selected, observed(), &|| false).is_err());
+        assert_eq!(fs::read(&claim_path).unwrap(), claim);
+        assert_eq!(fs::read(&result_path).unwrap(), result);
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/retained_setup/mod.rs
@@ -157,5 +157,17 @@ pub enum SetupClaimError {
     Storage,
 }
 
+#[cfg(all(test, target_os = "linux"))]
+pub(in crate::repository_overlay) fn completion_fixture(
+    root: &Path,
+    intent: &SetupIntent,
+    state: SetupCompletionState,
+) -> (Vec<u8>, Vec<u8>) {
+    (
+        codec::encode(intent).unwrap(),
+        outcome::codec::encode(root, intent, &outcome::tests::snapshot(root, intent, state)).unwrap(),
+    )
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -5,6 +5,7 @@ mod pack;
 mod protocol;
 mod receive;
 mod setup;
+mod setup_checkout;
 
 use std::{
     io::{self, Read, Write},
@@ -20,6 +21,8 @@ fn main() -> ExitCode {
             Some(
                 "materialize"
                     | "setup"
+                    | "setup-binding"
+                    | "setup-checkout"
                     | "setup-status"
                     | "receive-overlay"
                     | "overlay-status"
@@ -32,7 +35,7 @@ fn main() -> ExitCode {
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status < request"
+            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status < request"
         );
         return ExitCode::from(2);
     }
@@ -42,6 +45,18 @@ fn main() -> ExitCode {
     match command {
         Some("setup") => setup::run(setup::Command::Execute, &mut input, &mut output, &mut diagnostics),
         Some("setup-status") => setup::run(setup::Command::Observe, &mut input, &mut output, &mut diagnostics),
+        Some("setup-binding") => setup_checkout::run(
+            setup_checkout::Command::Binding,
+            &mut input,
+            &mut output,
+            &mut diagnostics,
+        ),
+        Some("setup-checkout") => setup_checkout::run(
+            setup_checkout::Command::Inspect,
+            &mut input,
+            &mut output,
+            &mut diagnostics,
+        ),
         Some("receive-overlay") => receive::run(receive::Command::Receive, &mut input, &mut output, &mut diagnostics),
         Some("overlay-status") => receive::run(receive::Command::Observe, &mut input, &mut output, &mut diagnostics),
         Some("receive-pack") => pack::run(pack::Command::Receive, &mut input, &mut output, &mut diagnostics),

--- a/crates/horizon-repository/src/setup_checkout.rs
+++ b/crates/horizon-repository/src/setup_checkout.rs
@@ -1,0 +1,65 @@
+use horizon_core::{
+    cloud_run::{ArtifactDigest, CloudJobId},
+    repository_overlay::intake::setup::{
+        SETUP_SELECTION_LIMIT, SetupCheckoutError, SetupCheckoutLocation, SetupCheckoutSelection,
+    },
+};
+use serde::Serialize;
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+#[derive(Clone, Copy)]
+pub(super) enum Command {
+    Binding,
+    Inspect,
+}
+
+#[derive(Serialize)]
+struct Response {
+    version: u8,
+    binding_sha256: Option<ArtifactDigest>,
+    runtime: Option<CloudJobId>,
+    root: Option<SetupCheckoutLocation>,
+    reason: Option<SetupCheckoutError>,
+}
+
+pub(super) fn run(
+    command: Command,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    let mut response = Response {
+        version: 1,
+        binding_sha256: None,
+        runtime: None,
+        root: None,
+        reason: None,
+    };
+    let result = (|| {
+        let mut bytes = Vec::new();
+        input
+            .take(SETUP_SELECTION_LIMIT as u64 + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| SetupCheckoutError::Invalid)?;
+        let selection = SetupCheckoutSelection::decode(&bytes)?;
+        response.binding_sha256 = Some(selection.binding()?);
+        response.runtime = Some(selection.runtime());
+        if matches!(command, Command::Inspect) {
+            response.root = Some(selection.inspect(|| false)?);
+        }
+        Ok(())
+    })();
+    response.reason = result.err();
+    let code = match response.reason {
+        None => 0,
+        Some(SetupCheckoutError::Invalid) => 2,
+        Some(_) => 1,
+    };
+    super::write_response(&response, code, 16 * 1024, output, diagnostics)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/setup_checkout/tests.rs
+++ b/crates/horizon-repository/src/setup_checkout/tests.rs
@@ -1,0 +1,83 @@
+use super::*;
+use std::io;
+
+fn selection() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "version": 1, "destination": "published", "intake": {
+            "version": 1, "workspace_local_id": "fixture-workspace",
+            "workflow_id": "11111111-1111-4111-8111-111111111111",
+            "job_id": "22222222-2222-4222-8222-222222222222", "runtime_generation": 1,
+            "worker_resource_id": "fixture-worker", "client_key_sha256": "a".repeat(64),
+            "source": {"repository": "fixture/repository", "commit": "a".repeat(40), "branch": null},
+            "pack": {"sha256": "b".repeat(64), "encoded_bytes": 32},
+            "overlay": {"sha256": "c".repeat(64), "encoded_bytes": 1}
+        }
+    }))
+    .unwrap()
+}
+
+#[test]
+fn binding_is_inert_and_output_failure_is_distinct() {
+    let mut bytes = Vec::new();
+    assert_eq!(
+        run(
+            Command::Binding,
+            &mut selection().as_slice(),
+            &mut bytes,
+            &mut io::sink()
+        ),
+        ExitCode::SUCCESS
+    );
+    let response: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(response["runtime"], "22222222-2222-4222-8222-222222222222");
+    assert_eq!(response["binding_sha256"].as_str().unwrap().len(), 64);
+    assert!(response["root"].is_null() && response["reason"].is_null());
+    assert_eq!(
+        run(
+            Command::Binding,
+            &mut selection().as_slice(),
+            &mut [].as_mut_slice(),
+            &mut io::sink()
+        ),
+        ExitCode::from(3)
+    );
+}
+
+#[test]
+fn malformed_duplicate_and_oversized_inputs_have_no_identity() {
+    let valid = selection();
+    for bytes in [
+        b"private-invalid".to_vec(),
+        b"{}".to_vec(),
+        vec![b' '; SETUP_SELECTION_LIMIT + 1],
+        [b"{\"version\":1,".as_slice(), &valid[1..]].concat(),
+    ] {
+        let mut output = Vec::new();
+        assert_eq!(
+            run(Command::Binding, &mut bytes.as_slice(), &mut output, &mut io::sink()),
+            ExitCode::from(2)
+        );
+        let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(response["reason"], "invalid");
+        assert!(response["root"].is_null() && response["binding_sha256"].is_null() && response["runtime"].is_null());
+        assert!(!String::from_utf8(output).unwrap().contains("private-invalid"));
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_inspection_preserves_inert_identity() {
+    let mut output = Vec::new();
+    assert_eq!(
+        run(
+            Command::Inspect,
+            &mut selection().as_slice(),
+            &mut output,
+            &mut io::sink()
+        ),
+        ExitCode::from(1)
+    );
+    let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(response["reason"], "unsupported");
+    assert!(response["root"].is_null() && response["binding_sha256"].is_string());
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -7,6 +7,11 @@ back into large multi-purpose modules.
 
 ### Remote worker image
 
+- Prepared task admission keeps immutable intake/setup selection and read-only
+  checkout inspection in `repository_overlay::intake::setup`. The fixed
+  `setup-binding` and `setup-checkout` helpers never materialize or start tasks.
+  The panel helper reuses its single claim/nonce path, binds prepared markers to
+  that selection, and observes matching retained tasks without checkout reads.
 - `containers/remote-worker/panel-session.py` owns the worker-side one-shot task
   marker and verified tmux status/attachment contract. Its dedicated `tmux.conf`
   retains sessions independently of clients. Provider lifecycle, repository


### PR DESCRIPTION
## Purpose

Advance #470 and #383 with explicit task admission into the matching published repository setup. Reuse the retained intake, setup launcher and panel-session claim mechanisms; no automatic setup or task execution is added.

## Behavior

- Add a strict canonical repository selection binding the complete intake identity, runtime and setup destination.
- Expose inert `setup-binding` and read-only `setup-checkout` commands. Fresh task admission requires matching published setup plus a current private checkout-root identity check.
- Add structured `start-prepared` using the existing one-shot marker/nonce/tmux path. Version-2 markers retain repository identity separately from literal command intent; legacy and prepared starts cannot adopt each other's tasks.
- Independent panels share the evolving checkout, including new commits, staged changes and working files. Matching retained starts/status/verification do not require the original intake files or checkout to remain present.
- Lost output, an uncertain marker, or a missing tmux server never permits a replacement task. Closing a client remains a disconnect.

## Boundaries

Runtime checkout inspection is Linux-only. The selection/binding protocol is portable and unsupported inspection refuses explicitly. These are worker-side operations, not configured UI/provider admission or cloud/PC-off acceptance.

Fresh inspection requires the existing trusted-tools/storage and stable, exclusively controlled root/ancestry premises through use. It provides a current root check, not historical inode proof, protection against a hostile same-user writer, or continuous revocation. The original repository selection is immutable; the development checkout is intentionally mutable.

No configuration defaults, dependencies, provider lifecycle, image publication or release behavior changes.

## Validation

Candidate: `4d3219adc0e8398de590a65976c54899991e8a8a`, based on controller squash `497e8890`.

- Precommit: 54 focused Rust tests, formatting, blocking and strict Clippy passed.
- Full final validation: formatting, maintainability, version sync, default and speech-enabled workspace tests, blocking/strict/advisory Clippy all passed.
- Final-source panel tests: all 41 passed with pinned tmux 3.7c in an isolated runtime; exact test container removed.
- Five native setup/task lanes with the candidate repository CLI and panel helper passed, with independent evidence review and owned-resource cleanup.

The native tests covered approved real pack/two-layer intake, detached explicit setup after output loss, independent tasks sharing new commits, actual pinned SSH attach/input/detach, v1/v2 conflicts, observation with inputs hidden, original exit status and server-loss refusal without replay. The runtime image was reused with read-only candidate helper binds; this is not newly packaged-image or cloud proof.

Scope: 9 source/test files, 948 changed lines, plus 5 architecture-documentation lines.
