### PR TITLE
feat(remote): expose read-only worker storage status

### DIFF
--- a/crates/horizon-core/src/repository_overlay/intake/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/linux.rs
@@ -32,6 +32,26 @@ const CONFINED: ResolveFlags = ResolveFlags::BENEATH
     .union(ResolveFlags::NO_MAGICLINKS)
     .union(ResolveFlags::NO_XDEV);
 
+pub(super) fn inspect_storage() -> super::storage_status::WorkerStorageStatus {
+    inspect_storage_with(Path::new(super::WORKER_ROOT), &qualify)
+}
+
+fn inspect_storage_with(
+    path: &Path,
+    storage: &impl Fn(&File) -> Result<(), IntakeError>,
+) -> super::storage_status::WorkerStorageStatus {
+    use super::storage_status::WorkerStorageStatus;
+    let result = Boundary::open(path, storage).and_then(|boundary| {
+        // A newly opened boundary holds no claim or children: verify only the root.
+        boundary.verify(&[])
+    });
+    match result {
+        Ok(()) => WorkerStorageStatus::Qualified,
+        Err(IntakeError::Unsupported) => WorkerStorageStatus::Unsupported,
+        Err(_) => WorkerStorageStatus::Unavailable,
+    }
+}
+
 pub(super) fn execute(
     parent: &Path,
     request: &IntakeRequest,
@@ -430,3 +450,6 @@ fn check(cancelled: &dyn Fn() -> bool) -> Result<(), IntakeError> {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod storage_tests;

--- a/crates/horizon-core/src/repository_overlay/intake/linux/storage_tests.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/linux/storage_tests.rs
@@ -1,0 +1,93 @@
+use super::*;
+use crate::repository_overlay::intake::storage_status::WorkerStorageStatus as Status;
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+
+fn private() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir()
+        .unwrap()
+}
+
+#[test]
+fn qualification_is_separate_from_claims_and_preserves_existing_bytes() {
+    let directory = private();
+    let path = directory.path();
+    let before = fs::metadata(path).unwrap();
+    // This injected success covers control flow, not real filesystem qualification.
+    assert_eq!(inspect_storage_with(path, &|_| Ok(())), Status::Qualified);
+    assert_eq!(fs::read_dir(path).unwrap().count(), 0);
+    fs::write(path.join(CLAIM), b"not a valid intake record").unwrap();
+    let record = fs::metadata(path.join(CLAIM)).unwrap();
+    assert_eq!(inspect_storage_with(path, &|_| Ok(())), Status::Qualified);
+    assert_eq!(fs::read(path.join(CLAIM)).unwrap(), b"not a valid intake record");
+    let after = fs::metadata(path.join(CLAIM)).unwrap();
+    assert_eq!(
+        (record.dev(), record.ino(), record.mtime(), record.mtime_nsec()),
+        (after.dev(), after.ino(), after.mtime(), after.mtime_nsec())
+    );
+    assert_eq!(fs::metadata(path).unwrap().ino(), before.ino());
+    assert_eq!(fs::read_dir(path).unwrap().count(), 1);
+}
+
+#[test]
+fn missing_unsafe_and_linked_roots_refuse_before_qualification() {
+    let directory = private();
+    let unexpected = |_: &File| -> Result<(), IntakeError> { panic!("unsafe root reached qualifier") };
+    let missing = directory.path().join("missing");
+    assert_eq!(inspect_storage_with(&missing, &unexpected), Status::Unavailable);
+    assert!(!missing.exists());
+    let link = directory.path().join("link");
+    symlink(directory.path(), &link).unwrap();
+    assert_eq!(inspect_storage_with(&link, &unexpected), Status::Unavailable);
+    let file = directory.path().join("file");
+    fs::write(&file, b"retained").unwrap();
+    assert_eq!(inspect_storage_with(&file, &unexpected), Status::Unavailable);
+    fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(inspect_storage_with(directory.path(), &unexpected), Status::Unavailable);
+    assert_eq!(fs::read(file).unwrap(), b"retained");
+}
+
+#[test]
+fn unsupported_and_unavailable_checks_preserve_an_empty_root() {
+    let directory = private();
+    for (error, expected) in [
+        (IntakeError::Unsupported, Status::Unsupported),
+        (IntakeError::Storage, Status::Unavailable),
+    ] {
+        assert_eq!(inspect_storage_with(directory.path(), &|_| Err(error)), expected);
+        assert_eq!(fs::read_dir(directory.path()).unwrap().count(), 0);
+    }
+}
+
+#[test]
+fn replacement_or_permission_change_during_qualification_cannot_pass() {
+    for replace in [false, true] {
+        let directory = private();
+        let path = directory.path().join("worker");
+        fs::create_dir(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        let original = fs::metadata(&path).unwrap();
+        assert_eq!(
+            inspect_storage_with(&path, &|_| {
+                if replace {
+                    fs::rename(&path, directory.path().join("retained")).unwrap();
+                    fs::create_dir(&path).unwrap();
+                    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+                } else {
+                    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+                }
+                Ok(())
+            }),
+            Status::Unavailable
+        );
+        assert_eq!(fs::read_dir(&path).unwrap().count(), 0);
+        if replace {
+            assert_eq!(
+                fs::metadata(directory.path().join("retained")).unwrap().ino(),
+                original.ino()
+            );
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/intake/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/mod.rs
@@ -2,6 +2,7 @@
 //! Neither worker intake nor controller handoff grants setup or task authority.
 
 pub mod setup;
+pub mod storage_status;
 
 #[cfg(target_os = "linux")]
 pub mod controller;
@@ -20,6 +21,9 @@ use std::{fmt, io::Read, path::PathBuf};
 pub const REQUEST_LIMIT: usize = 32 * 1024;
 pub const RESPONSE_LIMIT: usize = 128 * 1024;
 pub const PACK_LIMIT: u64 = super::seed::DEFAULT_ENCODED_PACK_BYTES;
+
+#[cfg(target_os = "linux")]
+const WORKER_ROOT: &str = "/workspace/.horizon-worker";
 
 /// Bounded immutable recovery identity. Constructing/deserializing it grants no writes.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -233,12 +237,7 @@ fn execute(request: &IntakeRequest, input: Option<&mut dyn Read>, cancelled: &dy
     }
     #[cfg(target_os = "linux")]
     {
-        linux::execute(
-            std::path::Path::new("/workspace/.horizon-worker"),
-            request,
-            input,
-            cancelled,
-        )
+        linux::execute(std::path::Path::new(WORKER_ROOT), request, input, cancelled)
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/crates/horizon-core/src/repository_overlay/intake/storage_status.rs
+++ b/crates/horizon-core/src/repository_overlay/intake/storage_status.rs
@@ -1,0 +1,35 @@
+//! Point-in-time qualification of the fixed worker root, independent of intake claims.
+
+/// A read-only observation, never a retained permission or durability guarantee.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkerStorageStatus {
+    /// The existing private root passed the current confinement and filesystem checks.
+    Qualified,
+    /// The platform, filesystem or required kernel metadata is unsupported.
+    Unsupported,
+    /// The root could not be safely opened or its identity changed during inspection.
+    Unavailable,
+}
+
+/// Inspect only `/workspace/.horizon-worker`; never create, synchronize or repair it.
+/// Requires trusted kernel metadata and stable, exclusively controlled ancestry and
+/// mount configuration. Does not inspect intake/setup records or repository contents.
+/// Qualification grants no writes and proves neither capacity, fsync success, remote
+/// persistence, backup nor retention through provider Stop/Delete. Every later write
+/// must still perform its own admission checks. Run off the UI thread: filesystem
+/// operations have no hard deadline, and the result can become stale immediately.
+#[must_use]
+pub fn inspect_worker_storage() -> WorkerStorageStatus {
+    #[cfg(target_os = "linux")]
+    return super::linux::inspect_storage();
+    #[cfg(not(target_os = "linux"))]
+    WorkerStorageStatus::Unsupported
+}
+
+#[cfg(all(test, not(target_os = "linux")))]
+mod tests {
+    #[test]
+    fn unsupported_platform_never_opens_worker_storage() {
+        assert_eq!(super::inspect_worker_storage(), super::WorkerStorageStatus::Unsupported);
+    }
+}

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -6,6 +6,7 @@ mod protocol;
 mod receive;
 mod setup;
 mod setup_checkout;
+mod storage_status;
 
 use std::{
     io::{self, Read, Write},
@@ -30,12 +31,13 @@ fn main() -> ExitCode {
                     | "pack-status"
                     | "intake"
                     | "intake-status"
+                    | "storage-status"
             )
         )
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status < request"
+            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status < request"
         );
         return ExitCode::from(2);
     }
@@ -63,6 +65,7 @@ fn main() -> ExitCode {
         Some("pack-status") => pack::run(pack::Command::Observe, &mut input, &mut output, &mut diagnostics),
         Some("intake") => intake::run(false, &mut input, &mut output, &mut diagnostics),
         Some("intake-status") => intake::run(true, &mut input, &mut output, &mut diagnostics),
+        Some("storage-status") => storage_status::run(&mut input, &mut output, &mut diagnostics),
         _ => run(&mut input, &mut output, &mut diagnostics),
     }
 }

--- a/crates/horizon-repository/src/storage_status.rs
+++ b/crates/horizon-repository/src/storage_status.rs
@@ -1,0 +1,60 @@
+//! Bounded read-only qualification of the fixed worker root; no caller-selected paths.
+use horizon_core::repository_overlay::intake::storage_status::{WorkerStorageStatus, inspect_worker_storage};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+const REQUEST_LIMIT: usize = 1024;
+const RESPONSE_LIMIT: usize = 1024;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Request {
+    version: u8,
+}
+
+#[derive(Serialize)]
+struct Response {
+    version: u8,
+    status: &'static str,
+}
+
+pub(super) fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Write) -> ExitCode {
+    run_with(input, output, diagnostics, inspect_worker_storage)
+}
+
+fn run_with(
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+    inspect: impl FnOnce() -> WorkerStorageStatus,
+) -> ExitCode {
+    let mut bytes = Vec::new();
+    let request = input
+        .take((REQUEST_LIMIT + 1) as u64)
+        .read_to_end(&mut bytes)
+        .ok()
+        .filter(|_| bytes.len() <= REQUEST_LIMIT)
+        .and_then(|_| serde_json::from_slice::<Request>(&bytes).ok())
+        .filter(|request| request.version == 1);
+    let (status, code) = match request {
+        None => ("rejected", 2),
+        Some(_) => match inspect() {
+            WorkerStorageStatus::Qualified => ("qualified", 0),
+            WorkerStorageStatus::Unsupported => ("unsupported", 1),
+            WorkerStorageStatus::Unavailable => ("unavailable", 1),
+        },
+    };
+    super::write_response(
+        &Response { version: 1, status },
+        code,
+        RESPONSE_LIMIT,
+        output,
+        diagnostics,
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/storage_status/tests.rs
+++ b/crates/horizon-repository/src/storage_status/tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+use std::{cell::Cell, io};
+
+#[test]
+fn exact_status_and_exit_codes_have_no_private_values() {
+    for (status, name, code) in [
+        (WorkerStorageStatus::Qualified, "qualified", 0),
+        (WorkerStorageStatus::Unsupported, "unsupported", 1),
+        (WorkerStorageStatus::Unavailable, "unavailable", 1),
+    ] {
+        let mut output = Vec::new();
+        let mut diagnostics = Vec::new();
+        assert_eq!(
+            run_with(
+                &mut br#"{"version":1}"#.as_slice(),
+                &mut output,
+                &mut diagnostics,
+                || status
+            ),
+            ExitCode::from(code)
+        );
+        assert_eq!(output, format!("{{\"version\":1,\"status\":\"{name}\"}}\n").as_bytes());
+        assert!(diagnostics.is_empty());
+    }
+}
+
+#[test]
+fn malformed_oversized_or_failed_input_never_inspects() {
+    struct Failed;
+    impl Read for Failed {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("private read failure"))
+        }
+    }
+    for bytes in [
+        b"".to_vec(),
+        b"{}".to_vec(),
+        br#"{"version":2}"#.to_vec(),
+        br#"{"version":1,"version":1}"#.to_vec(),
+        br#"{"version":1,"path":"private"}"#.to_vec(),
+        br#"{"version":1}{}"#.to_vec(),
+        br#"{"version":1.0}"#.to_vec(),
+        vec![b' '; REQUEST_LIMIT + 1],
+    ] {
+        let mut output = Vec::new();
+        assert_eq!(
+            run_with(&mut bytes.as_slice(), &mut output, &mut io::sink(), || panic!(
+                "rejected input inspected"
+            )),
+            ExitCode::from(2)
+        );
+        assert_eq!(output, b"{\"version\":1,\"status\":\"rejected\"}\n");
+    }
+    assert_eq!(
+        run_with(&mut Failed, &mut io::sink(), &mut io::sink(), || panic!(
+            "failed input inspected"
+        )),
+        ExitCode::from(2)
+    );
+}
+
+#[test]
+fn output_failure_does_not_repeat_inspection() {
+    let calls = Cell::new(0);
+    let mut diagnostics = Vec::new();
+    assert_eq!(
+        run_with(
+            &mut br#"{"version":1}"#.as_slice(),
+            &mut [].as_mut_slice(),
+            &mut diagnostics,
+            || {
+                calls.set(calls.get() + 1);
+                WorkerStorageStatus::Qualified
+            }
+        ),
+        ExitCode::from(3)
+    );
+    assert_eq!(calls.get(), 1);
+    assert!(!diagnostics.is_empty());
+}
+
+#[test]
+fn short_reads_accept_eof_and_oversized_reads_are_bounded() {
+    struct Short<'a>(&'a [u8]);
+    impl Read for Short<'_> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            let count = bytes.len().min(1);
+            self.0.read(&mut bytes[..count])
+        }
+    }
+    assert_eq!(
+        run_with(
+            &mut Short(b" {\"version\":1} \n"),
+            &mut io::sink(),
+            &mut io::sink(),
+            || WorkerStorageStatus::Qualified
+        ),
+        ExitCode::from(0)
+    );
+    let bytes = vec![b' '; REQUEST_LIMIT + 100];
+    let mut input = bytes.as_slice();
+    assert_eq!(
+        run_with(&mut input, &mut io::sink(), &mut io::sink(), || panic!(
+            "oversized input inspected"
+        )),
+        ExitCode::from(2)
+    );
+    assert_eq!(input.len(), 99);
+}

--- a/crates/horizon-ui/src/app/remote_environments/reopen/tests/inspection.rs
+++ b/crates/horizon-ui/src/app/remote_environments/reopen/tests/inspection.rs
@@ -170,7 +170,7 @@ fn disappeared_database_is_not_recreated_by_task_catalog_or_inventory_reads() {
     std::fs::rename(directory, &retained).expect("retain database and any WAL sidecars");
 
     app.remote_reopen_action(InventoryAction::InspectTask(0), &ctx);
-    assert!(app.remote_environments.reopen.is_pending());
+    // The action may already have drained a fast failure; settle accepts either timing.
     settle(
         &mut app.remote_environments.reopen,
         &client(&home, &scope),

--- a/docs/remote-repository-intake.md
+++ b/docs/remote-repository-intake.md
@@ -45,6 +45,27 @@ Exit codes are 0 for acknowledgement/observation, 2 for rejected framing/identit
 means the response could not be written; it does not undo a completed intake.
 Neither command grants export approval or setup/task authority.
 
+## Read-only worker storage status
+
+`horizon-repository storage-status` accepts only `{"version":1}` followed by EOF,
+with a 1 KiB request limit. It emits `{"version":1,"status":"qualified"}` when
+the existing fixed `/workspace/.horizon-worker` root passes the same private-root,
+confinement and filesystem checks used by intake, including a named-root recheck.
+It neither reads intake/setup records nor creates, repairs or synchronizes files.
+An absent intake claim is irrelevant; an absent or unsafe worker root is not qualified.
+
+Statuses are `qualified` (exit 0), `unsupported` or `unavailable` (exit 1), and
+`rejected` for malformed input (exit 2). A failed response write/flush exits 3.
+Responses are bounded to 1 KiB and contain no paths, kernel details or credentials.
+Unsupported platforms never open storage. The public core entry point is
+`intake::storage_status::inspect_worker_storage`; it has no path override.
+
+Qualification is only a point-in-time observation under the existing trusted-kernel,
+stable-ancestry and mount premises. It grants no operation and proves neither free
+capacity, successful fsync, healthy hardware, remote durability, backup nor provider
+Stop/Delete retention. Later operations still perform their own admission checks.
+Run inspection off the UI thread; filesystem operations have no hard deadline.
+
 ## Fixed roots and replay barrier
 
 Production uses only the existing `/workspace/.horizon-worker` parent. It must be


### PR DESCRIPTION
## Purpose

Advance #473 and #383 with a read-only storage preflight for a fresh worker, independently of repository intake claims. Existing intake observation cannot positively distinguish a fresh unclaimed root from some storage failures.

## Behavior

- Add a fixed-root core inspection and `horizon-repository storage-status` command.
- Reuse the existing confined reader, private-root and filesystem qualification checks, including a final named-root identity check.
- Accept only bounded version-1 JSON with no path override; return qualified, unsupported, unavailable or rejected with documented exit codes.
- Never read intake/setup records, create or synchronize files, repair permissions, upload a repository or start a task. Unsupported platforms refuse without accessing storage.

Qualification is a point-in-time observation under the existing trusted-kernel and stable ancestry/mount assumptions. It is not write approval, free-capacity or fsync proof, a hardware-health guarantee, or evidence of cloud persistence or provider Stop/Delete retention. Later operations retain their own admission checks. Run inspection off the UI thread.

## Validation

Candidate `5d6544e956a14550b8999b27ff32d9833b45513f` on main `22674061`. All eight storage task files remain byte-identical to `63122b5c`; only the CI-blocking test correction below was added.

- Historical focused evidence before this base integration: 35 focused tests, formatting, maintainability, blocking and strict Clippy passed on the earlier candidate.
- Historical timing-fix evidence before integration into this PR: 200 exact test executions passed (100 default + 100 speech-enabled) on the earlier isolated staged change.
- Independent local code review and full combined-diff review completed with no actionable findings.
- All eight final validation tiers passed on `5d6544e9`: formatting, maintainability, version sync, default and speech-enabled workspace suites, and blocking/strict/advisory Clippy. The corrected inspection test passed in both full workspace suites.
- A fresh CLI build from exact head `5d6544e9` passed 18 cases on qualified ext4 and 18 on unsupported tmpfs, including malformed requests, unsafe/missing roots, output failure and filesystem non-mutation. The binary was built offline inside the retained runtime and mounted read-only for testing. The three exact exited test/build containers were removed, and their absence was independently verified; synthetic host fixtures and logs were retained.
- Hosted review and CI must run again on the refreshed head; the previous `63122b5c` run failed the timing assertion documented below.

## CI blocker correction

The prior Linux CI run failed `disappeared_database_is_not_recreated_by_task_catalog_or_inventory_reads` at an immediate `is_pending()` assertion. The action starts the inspection and then drains completed work in the same call, so a fast expected failure may already be consumed. Remove only that intermediate timing assertion and retain the settling step plus every final error, stale-observation, no-recreation, database-byte and runtime-state assertion. This is a test-only correction; no application behavior changes. The original failed run and logs are retained, and no retry was used to bypass it.

No provider, UI runtime, configuration-default, dependency, image-publication or release changes in this patch. This is not cloud acceptance.

Scope: 338 source/test changed lines across eight files, plus 21 documentation lines.
