### PR TITLE
feat(remote): inspect retained worker storage over pinned SSH

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -30,6 +30,7 @@ mod remote_worker_inspection;
 #[cfg(target_os = "linux")]
 mod remote_worker_ssh;
 pub mod remote_worker_status;
+pub mod remote_worker_storage;
 pub mod remote_workspace;
 pub mod remote_workspace_recovery;
 pub mod remote_workspace_setup;

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -49,12 +49,21 @@ pub(crate) fn prepared_intake(
     )
 }
 
+pub(crate) fn prepared_storage_status(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<Command, Error> {
+    command_for(identity, known_hosts, endpoint, Operation::StorageStatus)
+}
+
 #[derive(Clone, Copy)]
 enum Operation<'a> {
     Request,
     PackStatus,
     Intake,
     IntakeStatus,
+    StorageStatus,
     Attach { runtime: CloudJobId, panel: &'a str },
 }
 
@@ -69,7 +78,11 @@ fn command_for(
     }
     let mut command = Command::new("ssh");
     let terminal_mode = match operation {
-        Operation::Request | Operation::PackStatus | Operation::Intake | Operation::IntakeStatus => "-T",
+        Operation::Request
+        | Operation::PackStatus
+        | Operation::Intake
+        | Operation::IntakeStatus
+        | Operation::StorageStatus => "-T",
         Operation::Attach { panel, .. } if valid_local_id(panel) => "-tt",
         Operation::Attach { .. } => return Err(Error::UnknownPanel),
     };
@@ -121,6 +134,7 @@ fn command_for(
         Operation::PackStatus => "/usr/local/bin/horizon-repository pack-status".into(),
         Operation::Intake => "/usr/local/bin/horizon-repository intake".into(),
         Operation::IntakeStatus => "/usr/local/bin/horizon-repository intake-status".into(),
+        Operation::StorageStatus => "/usr/local/bin/horizon-repository storage-status".into(),
         Operation::Attach { runtime, panel } => {
             format!("/usr/local/bin/horizon-panel-session attach -- {runtime} {panel}")
         }
@@ -184,6 +198,30 @@ mod tests {
     use super::*;
     use crate::{HorizonHome, cloud_run::CloudWorkflowId, remote_ssh_identity::RemoteSshIdentityStore};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    #[test]
+    fn storage_status_only_changes_the_fixed_remote_command() {
+        use base64::Engine as _;
+        let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+        blob.extend_from_slice(&[1; 32]);
+        let endpoint = InteractiveWorkerSshEndpoint {
+            host: "127.0.0.1".into(),
+            port: 2222,
+            username: "root".into(),
+            host_key: format!("ssh-ed25519 {}", base64::engine::general_purpose::STANDARD.encode(blob)),
+        };
+        let identity = Path::new("/private/client key");
+        let trust = Path::new("/private/known hosts");
+        let baseline = prepared_command(identity, trust, &endpoint).expect("query");
+        let storage = prepared_storage_status(identity, trust, &endpoint).expect("storage query");
+        let mut expected: Vec<_> = baseline.get_args().map(std::ffi::OsStr::to_os_string).collect();
+        *expected.last_mut().expect("fixed command") = "/usr/local/bin/horizon-repository storage-status".into();
+        assert_eq!(storage.get_args().collect::<Vec<_>>(), expected);
+        assert_eq!(
+            storage.get_envs().collect::<Vec<_>>(),
+            baseline.get_envs().collect::<Vec<_>>()
+        );
+    }
 
     #[test]
     fn interactive_mode_shares_all_isolation_options_and_owns_unique_private_trust() {

--- a/crates/horizon-core/src/remote_worker_storage.rs
+++ b/crates/horizon-core/src/remote_worker_storage.rs
@@ -1,0 +1,101 @@
+//! Read-only fixed-root storage observation through an already retained SSH pin.
+
+#[cfg(target_os = "linux")]
+mod protocol;
+
+use crate::{
+    cloud_run::CloudWorkflowStore, remote_worker_status::RemotePanelStatusError,
+    remote_workspace_recovery::RecoveredRemoteWorkspace,
+    repository_overlay::intake::storage_status::WorkerStorageStatus,
+};
+
+/// Inspect the existing fixed worker root after owned, non-creating recovery.
+/// Both complete allocation snapshots, management state, current lifetime and
+/// retained worker/client/host identities are checked before and after the query.
+/// The caller owns active-session selection and fresh provider/cost admission.
+/// No root initialization, permission repair, setup, task, retry, cleanup or saved
+/// state mutation occurs. A qualified observation grants no operation and proves
+/// neither capacity, successful fsync, hardware health nor remote data retention.
+/// Run off the render thread. The 15-second pipe deadline excludes spawn/reap;
+/// local teardown does not stop the remote worker or independent tasks.
+/// # Errors
+/// Refuses unsupported client platforms, stale/unsafe ownership or identity,
+/// unavailable SSH, incomplete input, timeout and malformed/inconsistent output.
+/// A failed query is unknown, never an observed unsupported or unavailable root.
+pub fn inspect_remote_worker_storage(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+) -> Result<WorkerStorageStatus, RemoteStorageInspectionError> {
+    #[cfg(target_os = "linux")]
+    {
+        inspect_with(store, recovered, query)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, recovered);
+        Err(RemoteStorageInspectionError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_with(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    execute: impl FnOnce(
+        &crate::remote_ssh_identity::RemoteSshIdentity,
+        &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+    ) -> Result<crate::remote_worker_ssh::query::Exchange, RemoteStorageInspectionError>,
+) -> Result<WorkerStorageStatus, RemoteStorageInspectionError> {
+    use crate::remote_worker_inspection::validate_current;
+    let endpoint = validate_current(store, recovered, None)?;
+    let response = execute(recovered.identity(), endpoint)?;
+    let status = protocol::response(&response)?;
+    validate_current(store, recovered, None)?;
+    Ok(status)
+}
+
+#[cfg(target_os = "linux")]
+fn query(
+    identity: &crate::remote_ssh_identity::RemoteSshIdentity,
+    endpoint: &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+) -> Result<crate::remote_worker_ssh::query::Exchange, RemoteStorageInspectionError> {
+    use crate::remote_worker_ssh::{known_hosts, prepared_storage_status};
+    let trust = known_hosts(identity, endpoint)?;
+    let command = prepared_storage_status(identity.private_key_path(), trust.path(), endpoint)?;
+    exchange(command, std::time::Duration::from_secs(15))
+}
+
+#[cfg(target_os = "linux")]
+fn exchange(
+    command: std::process::Command,
+    timeout: std::time::Duration,
+) -> Result<crate::remote_worker_ssh::query::Exchange, RemoteStorageInspectionError> {
+    use crate::remote_worker_ssh::query;
+    // Valid negative observations exit 1: retain their output, unlike success-only queries.
+    let mut input = protocol::REQUEST;
+    query::exchange(command, &mut input, timeout, protocol::RESPONSE_LIMIT, || false, None).map_err(|error| match error
+    {
+        query::Error::ClientUnavailable => RemotePanelStatusError::ClientUnavailable.into(),
+        query::Error::QueryFailed => RemoteStorageInspectionError::QueryFailed,
+        query::Error::Deadline => RemoteStorageInspectionError::Deadline,
+        query::Error::OutputLimit => RemoteStorageInspectionError::InvalidResponse,
+    })
+}
+
+/// Diagnostics omit private paths, worker coordinates, keys and subprocess data.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteStorageInspectionError {
+    #[error(transparent)]
+    Admission(#[from] RemotePanelStatusError),
+    #[error("remote storage query failed; no storage state was established")]
+    QueryFailed,
+    #[error("remote storage query exceeded its deadline; storage state is unknown")]
+    Deadline,
+    #[error("remote storage observation is invalid or exceeds its size limit")]
+    InvalidResponse,
+    #[error("protected remote storage inspection is not yet supported on this platform")]
+    UnsupportedPlatform,
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_worker_storage/protocol.rs
+++ b/crates/horizon-core/src/remote_worker_storage/protocol.rs
@@ -1,0 +1,49 @@
+use super::{RemoteStorageInspectionError as Error, WorkerStorageStatus};
+use crate::remote_worker_ssh::query::{Exchange, InputProgress};
+use serde::Deserialize;
+
+pub(super) const REQUEST: &[u8] = b"{\"version\":1}\n";
+pub(super) const RESPONSE_LIMIT: usize = 1024;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Response {
+    version: u8,
+    status: Status,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Qualified,
+    Unsupported,
+    Unavailable,
+    Rejected,
+}
+
+pub(super) fn response(exchange: &Exchange) -> Result<WorkerStorageStatus, Error> {
+    // This immutable request has a known exact length. A child may finish after
+    // those bytes are written but before the exchange loop observes source EOF.
+    if !matches!(exchange.input, InputProgress::Complete(n) | InputProgress::Incomplete(n)
+        if n == REQUEST.len() as u64)
+    {
+        return Err(Error::QueryFailed);
+    }
+    let code = exchange.status.code();
+    if !matches!(code, Some(0..=2)) {
+        return Err(Error::QueryFailed);
+    }
+    if exchange.output.len() > RESPONSE_LIMIT {
+        return Err(Error::InvalidResponse);
+    }
+    let response: Response = serde_json::from_slice(&exchange.output).map_err(|_| Error::InvalidResponse)?;
+    if response.version != 1 {
+        return Err(Error::InvalidResponse);
+    }
+    match (response.status, code) {
+        (Status::Qualified, Some(0)) => Ok(WorkerStorageStatus::Qualified),
+        (Status::Unsupported, Some(1)) => Ok(WorkerStorageStatus::Unsupported),
+        (Status::Unavailable, Some(1)) => Ok(WorkerStorageStatus::Unavailable),
+        _ => Err(Error::InvalidResponse),
+    }
+}

--- a/crates/horizon-core/src/remote_worker_storage/tests.rs
+++ b/crates/horizon-core/src/remote_worker_storage/tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+use crate::{
+    cloud_run::interactive_worker::InteractiveWorkerLifecycle,
+    remote_repository_pack::tests::Fixture,
+    remote_worker_ssh::query::{Exchange, InputProgress},
+};
+use std::os::unix::process::ExitStatusExt;
+
+mod transport;
+
+fn wire(bytes: &[u8], code: i32) -> Exchange {
+    Exchange {
+        status: std::process::ExitStatus::from_raw(code << 8),
+        input: InputProgress::Complete(protocol::REQUEST.len() as u64),
+        output: bytes.to_vec(),
+    }
+}
+
+fn reply(status: &str, code: i32) -> Exchange {
+    wire(format!("{{\"version\":1,\"status\":\"{status}\"}}\n").as_bytes(), code)
+}
+
+#[test]
+fn zero_panel_storage_observations_preserve_allocation_and_client_identity() {
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let before = fixture.current();
+    let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+    assert!(before.workspace().state().spec.panels.is_empty());
+    for (name, code, expected) in [
+        ("qualified", 0, WorkerStorageStatus::Qualified),
+        ("unsupported", 1, WorkerStorageStatus::Unsupported),
+        ("unavailable", 1, WorkerStorageStatus::Unavailable),
+    ] {
+        let observed = inspect_with(&fixture.store, &fixture.recovered, |identity, endpoint| {
+            assert_eq!(identity.public_key(), fixture.recovered.identity().public_key());
+            assert_eq!(
+                Some(endpoint),
+                fixture.recovered.observation().and_then(|value| value.ssh.as_ref())
+            );
+            Ok(reply(name, code))
+        });
+        assert_eq!(observed, Ok(expected));
+        assert_eq!(fixture.current(), before);
+        assert_eq!(
+            std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+            key
+        );
+    }
+}
+
+#[test]
+fn missing_nonready_or_foreign_worker_refuses_before_transport() {
+    for lifecycle in [
+        None,
+        Some(InteractiveWorkerLifecycle::Stopped),
+        Some(InteractiveWorkerLifecycle::Unknown),
+    ] {
+        let fixture = Fixture::new(lifecycle);
+        assert_eq!(
+            inspect_with(&fixture.store, &fixture.recovered, |_, _| panic!("no SSH")),
+            Err(RemoteStorageInspectionError::Admission(
+                RemotePanelStatusError::WorkerUnavailable
+            )),
+        );
+    }
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let foreign = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    assert_eq!(
+        inspect_with(&foreign.store, &fixture.recovered, |_, _| panic!("no foreign query")),
+        Err(RemoteStorageInspectionError::Admission(
+            RemotePanelStatusError::StateChanged
+        )),
+    );
+}
+
+#[test]
+fn snapshot_and_management_changes_before_or_during_query_reject_results() {
+    for stop in [false, true] {
+        for during in [false, true] {
+            let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+            if !during {
+                fixture.edit(stop);
+            }
+            assert_eq!(
+                inspect_with(&fixture.store, &fixture.recovered, |_, _| {
+                    assert!(during, "stale admission must not query");
+                    fixture.edit(stop);
+                    Ok(reply("qualified", 0))
+                }),
+                Err(RemoteStorageInspectionError::Admission(
+                    RemotePanelStatusError::StateChanged
+                )),
+            );
+        }
+    }
+}
+
+#[test]
+fn missing_database_before_or_during_query_is_not_recreated() {
+    for during in [false, true] {
+        let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let path = fixture.store.path();
+        let retained = path.with_file_name("retained.sqlite3");
+        let before = std::fs::read(path).expect("database");
+        if !during {
+            std::fs::rename(path, &retained).expect("retain");
+        }
+        assert_eq!(
+            inspect_with(&fixture.store, &fixture.recovered, |_, _| {
+                assert!(during, "missing store must not query");
+                std::fs::rename(path, &retained).expect("retain");
+                Ok(reply("qualified", 0))
+            }),
+            Err(RemoteStorageInspectionError::Admission(
+                RemotePanelStatusError::StorageUnavailable
+            )),
+        );
+        assert!(!path.exists());
+        assert_eq!(std::fs::read(retained).expect("preserved bytes"), before);
+    }
+}
+
+#[test]
+fn wire_requires_complete_exact_input_and_matching_status_exit_pairs() {
+    for (name, expected_code, status) in [
+        ("qualified", 0, WorkerStorageStatus::Qualified),
+        ("unsupported", 1, WorkerStorageStatus::Unsupported),
+        ("unavailable", 1, WorkerStorageStatus::Unavailable),
+    ] {
+        for code in 0..=2 {
+            let expected = if code == expected_code {
+                Ok(status)
+            } else {
+                Err(RemoteStorageInspectionError::InvalidResponse)
+            };
+            assert_eq!(protocol::response(&reply(name, code)), expected);
+            let mut early = reply(name, code);
+            early.input = InputProgress::Incomplete(protocol::REQUEST.len() as u64);
+            assert_eq!(protocol::response(&early), expected);
+        }
+    }
+    for code in [0, 1, 2] {
+        assert_eq!(
+            protocol::response(&reply("rejected", code)),
+            Err(RemoteStorageInspectionError::InvalidResponse)
+        );
+    }
+    for input in [
+        InputProgress::Incomplete(0),
+        InputProgress::Incomplete(protocol::REQUEST.len() as u64 - 1),
+        InputProgress::Incomplete(protocol::REQUEST.len() as u64 + 1),
+        InputProgress::Complete(0),
+        InputProgress::Complete(protocol::REQUEST.len() as u64 - 1),
+        InputProgress::Complete(protocol::REQUEST.len() as u64 + 1),
+    ] {
+        let mut result = reply("qualified", 0);
+        result.input = input;
+        assert_eq!(
+            protocol::response(&result),
+            Err(RemoteStorageInspectionError::QueryFailed)
+        );
+    }
+    for code in [3, 7, 255] {
+        assert_eq!(
+            protocol::response(&reply("qualified", code)),
+            Err(RemoteStorageInspectionError::QueryFailed)
+        );
+    }
+    let mut result = reply("qualified", 0);
+    result.status = std::process::ExitStatus::from_raw(9);
+    assert_eq!(
+        protocol::response(&result),
+        Err(RemoteStorageInspectionError::QueryFailed)
+    );
+}
+
+#[test]
+fn malformed_or_excessive_output_never_invents_storage_state() {
+    for bytes in [
+        b"".as_slice(),
+        b"{}",
+        b"{\"version\":2,\"status\":\"qualified\"}",
+        b"{\"version\":1,\"status\":\"unknown\"}",
+        b"{\"version\":1,\"status\":\"qualified\",\"path\":\"private\"}",
+        b"{\"version\":1,\"version\":1,\"status\":\"qualified\"}",
+        b"{\"version\":1,\"status\":\"qualified\",\"status\":\"qualified\"}",
+        b"{\"version\":1,\"status\":\"qualified\"}{}",
+    ] {
+        assert_eq!(
+            protocol::response(&wire(bytes, 0)),
+            Err(RemoteStorageInspectionError::InvalidResponse)
+        );
+    }
+    let mut oversized = reply("qualified", 0);
+    oversized.output.resize(protocol::RESPONSE_LIMIT + 1, b' ');
+    assert_eq!(
+        protocol::response(&oversized),
+        Err(RemoteStorageInspectionError::InvalidResponse)
+    );
+}
+
+#[test]
+fn failed_queries_leave_saved_state_and_identity_untouched() {
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let before = fixture.current();
+    let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+    for error in [
+        RemoteStorageInspectionError::QueryFailed,
+        RemoteStorageInspectionError::Deadline,
+        RemoteStorageInspectionError::InvalidResponse,
+        RemotePanelStatusError::ClientUnavailable.into(),
+    ] {
+        let diagnostic = error.to_string();
+        let result = inspect_with(&fixture.store, &fixture.recovered, |_, _| Err(error)).expect_err("query error");
+        assert_eq!(result.to_string(), diagnostic);
+        assert!(!diagnostic.contains("synthetic-worker"));
+        assert_eq!(fixture.current(), before);
+        assert_eq!(
+            std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+            key
+        );
+    }
+}

--- a/crates/horizon-core/src/remote_worker_storage/tests/transport.rs
+++ b/crates/horizon-core/src/remote_worker_storage/tests/transport.rs
@@ -1,0 +1,79 @@
+use super::*;
+use std::{process::Command, time::Duration};
+
+fn shell(script: &str) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", script]);
+    command
+}
+
+#[test]
+fn real_child_receives_fixed_request_and_retains_valid_nonzero_responses() {
+    for (status, code, expected) in [
+        ("qualified", 0, WorkerStorageStatus::Qualified),
+        ("unsupported", 1, WorkerStorageStatus::Unsupported),
+        ("unavailable", 1, WorkerStorageStatus::Unavailable),
+    ] {
+        let script = format!(
+            "read -r request; [ \"$request\" = '{{\"version\":1}}' ] || exit 9; \
+             [ -z \"$(cat)\" ] || exit 8; printf '%s\\n' '{{\"version\":1,\"status\":\"{status}\"}}'; exit {code}"
+        );
+        assert_eq!(
+            exchange(shell(&script), Duration::from_secs(2)).and_then(|response| protocol::response(&response)),
+            Ok(expected)
+        );
+    }
+}
+
+#[test]
+fn real_child_can_reply_after_the_fixed_request_without_waiting_for_eof() {
+    for (status, code, expected) in [
+        ("qualified", 0, WorkerStorageStatus::Qualified),
+        ("unsupported", 1, WorkerStorageStatus::Unsupported),
+        ("unavailable", 1, WorkerStorageStatus::Unavailable),
+    ] {
+        let script = format!(
+            "read -r request; [ \"$request\" = '{{\"version\":1}}' ] || exit 9; \
+             printf '%s\\n' '{{\"version\":1,\"status\":\"{status}\"}}'; exit {code}"
+        );
+        assert_eq!(
+            exchange(shell(&script), Duration::from_secs(2)).and_then(|response| protocol::response(&response)),
+            Ok(expected)
+        );
+    }
+}
+
+#[test]
+fn real_child_failures_preserve_transport_error_categories() {
+    assert!(matches!(
+        exchange(
+            Command::new("/nonexistent-storage-query-client"),
+            Duration::from_secs(1)
+        ),
+        Err(RemoteStorageInspectionError::Admission(
+            RemotePanelStatusError::ClientUnavailable
+        ))
+    ));
+    for (script, deadline, expected) in [
+        (
+            "cat >/dev/null; exit 255",
+            Duration::from_secs(2),
+            RemoteStorageInspectionError::QueryFailed,
+        ),
+        (
+            "cat >/dev/null; exec sleep 5",
+            Duration::from_millis(30),
+            RemoteStorageInspectionError::Deadline,
+        ),
+        (
+            "cat >/dev/null; head -c 1025 /dev/zero",
+            Duration::from_secs(2),
+            RemoteStorageInspectionError::InvalidResponse,
+        ),
+    ] {
+        assert_eq!(
+            exchange(shell(script), deadline).and_then(|response| protocol::response(&response)),
+            Err(expected)
+        );
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -145,6 +145,12 @@ back into large multi-purpose modules.
   the fixed pinned worker command; its protocol leaf binds bounded paths and exact
   identity to the saved repository base. It neither uploads nor grants source,
   publication, synchronization or checkout-readiness authority.
+- `remote_worker_storage.rs` reuses the owned-worker fence for read-only fixed-root
+  qualification over pinned SSH, including zero-panel workspaces. Its protocol
+  leaf requires complete request delivery and exact bounded status/exit pairs;
+  valid negative observations are distinct from transport or protocol errors.
+  It reuses the worker's storage status type without initialization, provider
+  selection, persistence or task authority.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
   wire types; `ssh.rs` owns the query's private host-pin lifetime and retains the

--- a/docs/remote-repository-intake.md
+++ b/docs/remote-repository-intake.md
@@ -66,6 +66,17 @@ capacity, successful fsync, healthy hardware, remote durability, backup nor prov
 Stop/Delete retention. Later operations still perform their own admission checks.
 Run inspection off the UI thread; filesystem operations have no hard deadline.
 
+`remote_worker_storage::inspect_remote_worker_storage(store, recovered)` queries
+that same fixed command through an already retained SSH pin. It supports task-free
+workspaces, rechecks both owned allocation snapshots and current worker/lifetime
+before and after I/O, and never persists an observation. The caller still owns
+active-session selection and fresh provider/cost admission. The 15-second pipe
+deadline excludes spawn/reap; response output is limited to 1 KiB. Only matching
+status/exit pairs return a storage status: SSH failure, incomplete input, rejected
+requests and malformed replies are errors, not an observed unavailable root.
+Unsupported client platforms return a separate error without I/O. No root is
+created or repaired, and none of this adds provider discovery or setup authority.
+
 ## Fixed roots and replay barrier
 
 Production uses only the existing `/workspace/.horizon-worker` parent. It must be


### PR DESCRIPTION
## Purpose

Advance #473 and #383 by inspecting an already retained worker's storage through its pinned SSH identity. This connects the read-only worker CLI from #506 to the owned-workspace client boundary, including workspaces with no task panels.

## Behavior

- Add `remote_worker_storage::inspect_remote_worker_storage(store, recovered)` for the existing fixed worker root.
- Recheck the complete saved allocation, management state, worker lifetime and retained identities before and after the query. Refuse stale or foreign state without granting task authority.
- Reuse the protected noninteractive SSH options and temporary private known-host pin; invoke only `/usr/local/bin/horizon-repository storage-status` with the fixed version-1 request.
- Bound response output to 1 KiB and the pipe exchange to 15 seconds, excluding process spawn/reap. Require exact request-byte delivery and matching status/exit-code pairs; preserve valid negative observations returned with exit 1.
- Keep transport failure, timeout, malformed responses and unsupported client platforms separate from observed worker storage states. Never turn a failed query into a qualified or unavailable-root observation.

This is a Linux-client prerequisite; unsupported client platforms refuse without I/O. The caller still owns active-session selection and fresh provider/cost admission. Existing worker bootstrap already creates the private worker root; this client neither initializes nor repairs it. It does not persist observations, discover trust, allocate workers, upload repositories, start setup/tasks or perform cleanup. Qualification is point-in-time information, not write permission, durability, capacity or retention proof. Run it off the render thread.

## Review correction

A child can consume the entire fixed request and reply before the shared exchange observes source EOF. Accept either input-progress state only when its written count exactly matches the immutable request length. Zero, short and overlong counts still fail. Tests cover both progress states across all status/exit pairs and a real child that replies after reading the request line without waiting for EOF.

## Validation

Candidate `b36c08dc747c45ce6fd49174ac4d9f10f916d227` on #506 squash `313bbdfe`.

- The exact review correction passed all 10 focused client tests, formatting, maintainability, blocking and strict Clippy before commit. The original candidate's broader 61-test focused pass is historical evidence.
- Independent full-diff and correction review completed with no remaining actionable local findings.
- All eight final validation tiers passed in the exact committed worktree: formatting, maintainability, version sync, default and speech-enabled workspace suites, and blocking/strict/advisory Clippy. Both full suites include the early-response regression.
- The rebuilt candidate client passed six fresh disposable native cases against the exact packaged worker CLI over loopback pinned SSH: temporarily absent synthetic root, existing qualified root, unsafe mode, restored qualification, an incorrect pin using the same authorized client identity, and a valid unsupported tmpfs response. The standalone driver used workspace-matching dependency versions and checksums. Both task containers were removed; private synthetic fixtures and logs were retained.

The native fixture uses a synthetic provider and harness-supplied endpoint/public pin; it does not validate real provider allocation, product trust discovery, cloud image access, retention or PC-off operation. No UI runtime, provider, dependency, configuration-default, image-publication or release changes. Fresh hosted checks and independent review are required after publishing this amended head.

Scope: 493 source/test changed lines across six files, plus 17 documentation lines.
