### PR TITLE
feat(scripts): add bounded Azure VM workspace spike harness and results

### DIFF
--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -210,8 +210,9 @@ co-location is not a crash-safe bound; a probe confirmed Azure rejects a schedul
 VM that does not exist yet (`ComputeVmNotFound`). Two defense-in-depth layers were
 added next: a built-in power-only role for the worker identity on the sample group,
 granted before the deployment, and a guest systemd timer armed by cloud-init as its
-first `runcmd` step (54 s after boot in sample 14, before Docker or the pull) that
-deallocates the VM through ARM at the deadline. Neither is a pre-creation bound: the
+first `runcmd` step (54 s after boot in sample 14, after the package module has
+installed Docker but before the workspace bootstrap and the pull) that deallocates
+the VM through ARM at the deadline. Neither is a pre-creation bound: the
 role only authorizes, and the timer depends on cloud-init reaching `runcmd`. Sample 13
 tried to arm that timer from `bootcmd`; the early-boot `systemctl` call deadlocked the
 guest (no endpoint, no run-command response), the run was interrupted by hand and

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -167,7 +167,7 @@ Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 and 5 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4, 5 and 6 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -230,7 +230,7 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 and 5).
+      control (samples 4, 5 and 6).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and unchanged inventory.

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 8 to 10 minutes for samples 1, 2, 3 and 5 to 10, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
+Bound: 120 minutes per sample; actual 8 to 11 minutes for samples 1, 2, 3 and 5 to 12, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -133,6 +133,8 @@ resource-group delete.
 | 8 (final harness, see below) | 37.5 | 203.1 | 235.8 | 203.8 | 31.9 | 75.3 | 122.4 |
 | 9 (final harness, see below) | 66.5 | 245.4 | 278.0 | 246.0 | 32.5 | 75.0 | 183.0 |
 | 10 (final harness) | 38.1 | 210.6 | 243.7 | 211.2 | 32.4 | 74.4 | 183.4 |
+| 11 (single deployment) | 35.9 | 188.4 | 221.0 | 189.0 | 32.9 | 75.3 | 182.9 |
+| 12 (exact PR head 436fb9ed) | 37.5 | 184.0 | 247.7 | 184.7 | 32.0 | 105.6 | 242.8 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -150,6 +152,8 @@ cross-clock noise):
 | 8 | 25.9 | 85.0 | 87.4 | 88.5 | 195.4 | 200.5 |
 | 9 | 35.4 | 90.0 | 92.3 | 93.1 | 220.8 | 243.3 |
 | 10 | 25.9 | 83.9 | 86.1 | 87.0 | 180.4 | 206.0 |
+| 11 | 27.8 | 84.5 | 86.8 | 87.8 | 176.5 | 183.1 |
+| 12 | 26.2 | 82.4 | 84.7 | 85.6 | 173.9 | 179.7 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -187,15 +191,21 @@ sample is rerun. Sample 10, run with that final rule, passed every gate with a f
 proven deletion (`leftover` empty, `removed_outside_group` empty); it was invoked as
 `--sample 1` because the harness then accepted single digits, so its tags and journal
 directory carry sample number 1 (`sample-1-20260910T174441Z`). Samples 1 to 10 predate
-the `--preflight-report` requirement; the live `vm` preflight for `northeurope` /
-`Standard_D4s_v3` (status `no_blockers_observed`) was run earlier the same day and is
-referenced in the decision above.
+the `--preflight-report` requirement. Samples 11 and 12 ran with a digest-bound live
+`vm` preflight report (observed 2026-09-10T18:29:37Z, `no_blockers_observed`) journaled
+in their `start` events, and created the network, VM and DevTestLab auto-shutdown
+schedule in **one server-side deployment** (36 to 37 s) so a controller lost during
+creation cannot leave compute without the platform-side stop. Sample 12's journal
+records harness commit `436fb9ed` with no uncommitted changes, which is the exact head
+this document describes apart from this paragraph; the run-command host-key read took
+63 s in that sample (31 to 32 s in every other), which is why its verified-SSH time is
+higher than its endpoint time suggests.
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 10 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 12 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -210,21 +220,24 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10;
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 12;
   sample 8 differed only by an unrelated concurrent addition (proof still holds) and
   sample 9 by that resource's later removal by its own lane (proof unverified).
-- No provider was registered and no Container Apps Job was created.
+- No provider was registered and no Container Apps Job was created. From sample 8 on,
+  every VM carried a DevTestLab auto-shutdown schedule one minute after its lifetime
+  deadline as the platform-side stop; from sample 11 on it was created in the same
+  deployment as the VM.
 
-Cost actually incurred: ten VMs for 8 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: twelve VMs for 8 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the ten samples the slowest verified
-key-only SSH session came 278.0 s after `T0` (246.0 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 203.4 s. Eight of ten
-samples also missed the boundary for endpoint-open alone (sample 6 by 0.8 s), and
-the best endpoint time was 170.9 s. The measured budget splits
+**Not met with this configuration.** Across the twelve samples the slowest verified
+key-only SSH session came 278.0 s after `T0` (246.0 s excluding the out-of-band
+host-key read); even the fastest sample needed 203.4 s. Ten of twelve samples also
+missed the boundary for endpoint-open alone (sample 6 by 0.8 s, sample 12 by 4.0 s),
+and the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
 
@@ -240,7 +253,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 to 8 and 10; sample 9 held every gate except that its deletion proof is
+2, 3, 5 to 8 and 10 to 12; sample 9 held every gate except that its deletion proof is
 unverified because of concurrent activity, as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
 and mount were not verified; the harness change responsible was reverted before
@@ -261,11 +274,11 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 10).
+      control (samples 4 to 12).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10;
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 12;
       sample 9 is recorded as unverified because another lane deleted its own registry
       during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -99,8 +99,11 @@ disk bound at `/workspace`. Reasons recorded at decision time:
 
 Supporting infrastructure created under the same decision (persistent, outside any
 sample resource group): resource group `horizon-worker-registry` in `northeurope`
-with a Standard-SKU container registry (admin user disabled) and the user-assigned
-identity `horizon-worker-puller` holding `AcrPull` only. The worker image built from
+with a Standard-SKU container registry (admin user disabled), the user-assigned
+identity `horizon-worker-puller` holding `AcrPull` only, and the Automation account
+`horizon-spike-reaper` whose system identity holds the built-in power-only role
+`Desktop Virtualization Power On Off Contributor` at subscription scope and runs the
+spike reaper every 15 minutes (Basic tier; about 100 short jobs per day). The worker image built from
 commit `22674061` was pushed as `horizon-remote-worker:0.1.0-22674061` with digest
 `sha256:20cc03ef2530336b7374cc35412c8583b1422726c630ec6e6cd1450d690a74f6`
 (1.66 GB uncompressed, 31 layers). No automated publication workflow exists yet.
@@ -114,7 +117,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample (60 for samples 14 and 15); actual 8 to 12 minutes for samples 1, 2, 3, 5 to 12, 14 and 15, 17 minutes for sample 4 (failed restart wait) and 30 minutes for sample 13 (stalled guest, interrupted by hand). Journals are private.
+Bound: 120 minutes per sample (60 for samples 14 and 15, 90 for sample 16); actual 8 to 12 minutes for samples 1, 2, 3, 5 to 12, 14 and 15, 17 minutes for sample 4 (failed restart wait), 30 minutes for sample 13 (stalled guest, interrupted by hand) and 26 minutes for sample 16 (includes the 14-minute reaper wait). Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -138,6 +141,7 @@ resource-group delete.
 | 13 (early-boot timer, interrupted) | 40.0 | never | never | never | not reached | not reached | 243.4 |
 | 14 (guest lifetime bound) | 56.4 | 191.8 | 224.4 | 192.5 | 32.5 | 75.8 | 243.1 |
 | 15 (timer verified before firing) | 38.7 | 194.2 | 226.8 | 194.8 | 32.5 | 75.5 | 243.0 |
+| 16 (reaper proof, `--prove-reaper`) | 52.1 | 189.4 | 222.5 | 190.0 | 32.5 | 74.6 | 212.8 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -159,6 +163,7 @@ cross-clock noise):
 | 12 | 26.2 | 82.4 | 84.7 | 85.6 | 173.9 | 179.7 |
 | 14 | 25.9 | 79.2 | 81.5 | 82.4 | 175.0 | 191.2 |
 | 15 | 27.3 | 79.4 | 81.6 | 82.4 | 180.5 | 189.4 |
+| 16 | 39.7 | 92.9 | 95.2 | 96.0 | 175.4 | 184.5 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -202,25 +207,43 @@ in their `start` events, and created the network, VM and DevTestLab auto-shutdow
 schedule in one server-side deployment (36 to 37 s). Hosted review then pointed out
 that ARM deployments are not transactional and the schedule depends on the VM, so
 co-location is not a crash-safe bound; a probe confirmed Azure rejects a schedule for a
-VM that does not exist yet (`ComputeVmNotFound`). The bound now enforced **before any
-compute exists** is a built-in power-only role for the worker identity on the sample
-group plus a guest systemd timer, armed by cloud-init as its first step (54 s after
-boot in sample 14, before Docker or the pull), that deallocates the VM through ARM at
-the deadline. Sample 13 tried to arm that timer from `bootcmd`; the early-boot
-`systemctl` call deadlocked the guest (no endpoint, no run-command response), the run
-was interrupted and deleted cleanly with a proven inventory (exit 130, 17 minutes).
+VM that does not exist yet (`ComputeVmNotFound`). Two defense-in-depth layers were
+added next: a built-in power-only role for the worker identity on the sample group,
+granted before the deployment, and a guest systemd timer armed by cloud-init as its
+first `runcmd` step (54 s after boot in sample 14, before Docker or the pull) that
+deallocates the VM through ARM at the deadline. Neither is a pre-creation bound: the
+role only authorizes, and the timer depends on cloud-init reaching `runcmd`. Sample 13
+tried to arm that timer from `bootcmd`; the early-boot `systemctl` call deadlocked the
+guest (no endpoint, no run-command response), the run was interrupted by hand and
+deleted cleanly with a proven inventory (exit 130, 30 minutes).
 Sample 14 armed the timer from the first `runcmd` step and passed every gate,
 including the new one: firing the guest service once took the VM to
 `PowerState/deallocated`. Sample 15 additionally verified through run-command that the
 timer unit was `enabled` and `active` (waiting) before the service was fired, which
-the gate now requires together with the observed deallocation. The run-command host-key read took 63 s in sample 12
+the gate now requires together with the observed deallocation.
+
+The bound that genuinely exists **before any spike compute** is the subscription-side
+reaper created once by `scripts/azure-workspace-spike/setup-spike-reaper.sh`: an Azure
+Automation runbook (`horizon-spike-deadline-reaper` in account `horizon-spike-reaper`,
+resource group `horizon-worker-registry`) that runs every 15 minutes with a
+power-only system identity and deallocates every VM tagged
+`purpose=horizon-azure-vm-spike` whose `deadline` tag has passed. Each spike VM
+carries both tags in the same create call, the harness refuses to create anything
+unless that schedule is present and enabled, and a manual job run on 2026-09-10
+completed with `reaper done: 0 deallocation request(s)` on a subscription with no
+expired spike VMs. Sample 16 proved it end to end: after the restart checks the
+harness moved the VM's `deadline` tag two minutes into the past and waited; the
+reaper alone deallocated the VM 866 s later (one 15-minute interval), after which the
+sample restarted the VM, proved the guest timer as well, and deleted the group with a
+proven inventory. Maximum compute exposure after a lost controller is therefore the
+deadline plus one reaper interval plus the deallocation time. The run-command host-key read took 63 s in sample 12
 (31 to 32 s in every other sample).
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 12, 14 and 15 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 to 16 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -235,24 +258,25 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 15;
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 16;
   sample 8 differed only by an unrelated concurrent addition (proof still holds) and
   sample 9 by that resource's later removal by its own lane (proof unverified).
 - No provider was registered and no Container Apps Job was created. From sample 8 on,
   every VM carried a DevTestLab auto-shutdown schedule one minute after its lifetime
   deadline; from sample 11 on it was created in the same deployment as the VM; from
-  sample 14 on the primary bound is the pre-creation power-only role plus the guest
-  self-deallocate timer, proven by firing it.
+  sample 14 on the guest self-deallocate timer (with the power-only role) was proven
+  by firing it; from sample 16 on the subscription-side reaper is the primary,
+  pre-existing bound and the others are defense in depth.
 
-Cost actually incurred: fifteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
+Cost actually incurred: sixteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the fourteen samples that reached an
+**Not met with this configuration.** Across the fifteen samples that reached an
 endpoint, the slowest verified key-only SSH session came 278.0 s after `T0` (246.0 s
 excluding the out-of-band host-key read); even the fastest sample needed 203.4 s.
-Twelve of fourteen also missed the boundary for endpoint-open alone (sample 6 by
+Thirteen of fifteen also missed the boundary for endpoint-open alone (sample 6 by
 0.8 s, sample 12 by 4.0 s), and the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
@@ -269,7 +293,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 to 8, 10 to 12, 14 and 15; sample 9 held every gate except that its deletion proof
+2, 3, 5 to 8, 10 to 12 and 14 to 16; sample 9 held every gate except that its deletion proof
 is unverified because of concurrent activity, and sample 13 never reached its gates,
 as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
@@ -291,11 +315,11 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 12, 14 and 15).
+      control (samples 4 to 12 and 14 to 16).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 15;
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 16;
       sample 9 is recorded as unverified because another lane deleted its own registry
       during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -116,21 +116,30 @@ IMDS token exchanged at the registry (no registry password), host key read out o
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
 Bound: 120 minutes per sample; actual 9 to 10 minutes each. Journals are private.
 
-Timings in seconds from `T0` (the resource-group create call), controller side:
+Controller-side timings in seconds. The first four columns are offsets from `T0`
+(the resource-group create call); the last three are self-anchored durations of
+the deallocate call, the start call until a verified SSH session, and the
+resource-group delete.
 
-| Sample | Create ack | Endpoint open | SSH verified | SSH verified excl. run-command | Deallocate | Start to SSH | Delete |
+| Sample | Create ack (from T0) | Endpoint open (from T0) | SSH verified (from T0) | SSH verified excl. run-command (from T0) | Deallocate duration | Start to SSH duration | Delete duration |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | 36.4 | 203.3 | 235.4 | 204.0 | 32.1 | 74.7 | 188.5 |
 | 2 | 39.1 | 178.6 | 210.7 | 179.2 | 33.6 | 74.8 | 187.5 |
 | 3 | 38.4 | 238.7 | 270.8 | 239.3 | 32.1 | 74.2 | 187.8 |
+| 4 (revised harness, see below) | 67.9 | 241.6 | 274.2 | 242.2 | 31.5 | restart gate failed | 183.3 |
+| 5 (revised harness) | 38.8 | 243.0 | 275.6 | 243.7 | 31.5 | 74.3 | 182.9 |
 
-Guest-side stamps (seconds from `T0`):
+Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
+sync to host time, but treat sub-second differences between the two tables as
+cross-clock noise):
 
 | Sample | Boot | Docker installed | Data disk ready | Registry login | Image pulled | Container started |
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | 23.5 | 67.4 | 69.3 | 70.4 | 160.3 | 201.9 |
 | 2 | 25.0 | 73.2 | 75.0 | 76.0 | 169.2 | 174.0 |
 | 3 | 26.9 | 76.8 | 79.1 | 80.1 | 229.1 | 235.0 |
+| 4 | 33.4 | 101.5 | 103.7 | 104.6 | 221.4 | 237.3 |
+| 5 | 28.7 | 77.1 | 79.3 | 80.2 | 216.2 | 239.6 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -139,34 +148,50 @@ Standard before sample 2 did not change pull time, and sample 3 pulled 60 s slow
 than the others, so pull time is dominated by image size and VM-side extraction,
 not registry tier.
 
-Functional results, identical in all three samples:
+Samples 4 and 5 ran the harness after the independent review: `EXIT`-trapped
+cleanup, negative results journaled instead of aborting, the host key re-read and
+compared after restart, a docker `RequiresMountsFor` drop-in, and the worker's
+authoritative qualifier executed over SSH. Sample 4's first iteration also removed
+`nofail` from the data-disk fstab entry and added `x-systemd.required-by=docker.service`;
+after `az vm start` the worker endpoint never returned within the 10-minute restart
+bound, the sample exited 7 with the retention gate failed, and it was still deleted
+with an unchanged inventory. The root cause was not captured (the harness now records
+guest diagnostics out of band when the restart gate fails); restoring `defaults,nofail`
+while keeping the docker drop-in restarted cleanly in sample 5.
 
-- Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`, sysfs path
-  resolvable from inside the container); kernel options include `rw`, `barrier`,
-  exactly one `data=ordered` and no `ro`/`nobarrier`, so a shell mirror of the Rust
-  qualifier passes. **The authoritative Rust qualifier has not been executed on the
-  worker yet**; that remains a gate for the adapter's first real repository setup.
+Functional results, identical in every sample unless stated:
+
+- Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
+  include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
+  shell mirror of the Rust qualifier passes. In samples 4 and 5 the **authoritative
+  qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
+  0700 retained root on the data disk returned `status: absent` (qualified storage,
+  no claim), and the same request against a 0700 root on the container's overlay
+  filesystem returned `status: error` with "retained setup requires supported
+  journaled storage and confinement", so the check discriminates as intended.
 - Detach independence: a tmux heartbeat kept writing while no client was connected.
 - Explicit Stop with retained data: `az vm deallocate` reached
   `PowerState/deallocated`; after `az vm start` the marker file was present, the
-  public IP was unchanged, the pinned host key matched (it lives on the data disk),
-  and the tmux session was gone because the container restarted. Data survives Stop;
-  in-container sessions do not.
+  public IP was unchanged, the host key re-read from the restarted worker equalled
+  the pinned key (it lives on the data disk), the data disk was mounted inside the
+  container, and the tmux session was gone because the container restarted. Data
+  survives Stop; in-container sessions do not. Sample 4's failed restart is described
+  above.
 - Exact deletion: the resource group was absent and the subscription resource
   inventory was byte-identical to the pre-sample snapshot after every sample.
 - No provider was registered and no Container Apps Job was created.
 
-Cost actually incurred: three VMs for about 10 minutes each plus 32 GiB disks, well
+Cost actually incurred: five VMs for 9 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** The slowest sample reached a verified key-only
-SSH session 270.8 s after `T0` (239.3 s excluding the 31 s out-of-band host-key read);
-even the fastest sample needed 210.7 s. Two of three samples also missed the boundary
-for endpoint-open alone. The measured budget splits into roughly 25 s VM boot, 45 to
-50 s Docker installation from apt, 90 to 150 s image pull and extraction, and 31 s
-for `run-command`. Levers that the measurements point to, in order of impact:
+**Not met with this configuration.** Across the five samples the slowest verified
+key-only SSH session came 275.6 s after `T0` (243.7 s excluding the 31 to 32 s
+out-of-band host-key read); even the fastest sample needed 210.7 s. Four of five
+samples also missed the boundary for endpoint-open alone. The measured budget splits
+into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
+image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
 
 1. A smaller worker image or a VM image with the worker image pre-pulled (removes
    most of the 90 to 150 s pull).
@@ -194,12 +219,13 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] User-assigned managed identity with pull-only registry rights.
 - [x] `T0`, create, pull, endpoint, SSH-ready and delete timing per sample.
 - [x] Host key verified out of band and pinned before the first connection.
-- [x] Kernel ext4 option lines recorded from the worker; shell mirror passes.
-      **Not executed:** the Rust qualifier itself on the worker.
+- [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
+      authoritative Rust qualifier accepted the data disk and rejected the overlay
+      control (samples 4 and 5).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and unchanged inventory.
-- [x] Slowest sample compared with the 180-second boundary: **not met** (270.8 s).
+- [x] Slowest sample compared with the 180-second boundary: **not met** (275.6 s).
 - [x] Cost recorded against the bound.
 - [ ] **Not executed:** PC-off task progress over hours, three independent panels on
       one worker, verified-loss recovery, opt-in budget policy, and the adapter's own

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -117,7 +117,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample (60 for samples 14 and 15, 90 for samples 16 and 17); actual 8 to 13 minutes for samples 1, 2, 3, 5 to 12, 14, 15 and 17, 17 minutes for sample 4 (failed restart wait), 30 minutes for sample 13 (stalled guest, interrupted by hand) and 26 minutes for sample 16 (includes the 14-minute reaper wait). Journals are private.
+Bound: 120 minutes per sample (60 for samples 14 and 15, 90 for samples 16 to 18); actual 8 to 13 minutes for samples 1, 2, 3, 5 to 12, 14, 15, 17 and 18, 17 minutes for sample 4 (failed restart wait), 30 minutes for sample 13 (stalled guest, interrupted by hand) and 26 minutes for sample 16 (includes the 14-minute reaper wait). Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -142,7 +142,8 @@ resource-group delete.
 | 14 (guest lifetime bound) | 56.4 | 191.8 | 224.4 | 192.5 | 32.5 | 75.8 | 243.1 |
 | 15 (timer verified before firing) | 38.7 | 194.2 | 226.8 | 194.8 | 32.5 | 75.5 | 243.0 |
 | 16 (reaper proof, `--prove-reaper`) | 52.1 | 189.4 | 222.5 | 190.0 | 32.5 | 74.6 | 212.8 |
-| 17 (exact final harness head fb5ed0a3, `--prove-reaper`) | 40.3 | 186.7 | 219.8 | 187.4 | 32.0 | 75.7 | 243.2 |
+| 17 (harness head fb5ed0a3, `--prove-reaper`) | 40.3 | 186.7 | 219.8 | 187.4 | 32.0 | 75.7 | 243.2 |
+| 18 (exact final harness head b3b3d926, subscription-pinned reaper, `--prove-reaper`) | 39.9 | 189.3 | 222.4 | 189.9 | 32.9 | 74.8 | 182.8 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -166,6 +167,7 @@ cross-clock noise):
 | 15 | 27.3 | 79.4 | 81.6 | 82.4 | 180.5 | 189.4 |
 | 16 | 39.7 | 92.9 | 95.2 | 96.0 | 175.4 | 184.5 |
 | 17 | 27.5 | 86.4 | 89.5 | 94.4 | 174.6 | 183.7 |
+| 18 | 35.1 | 87.1 | 89.4 | 90.3 | 179.9 | 184.9 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -238,11 +240,18 @@ expired spike VMs. Sample 16 proved it end to end: after the restart checks the
 harness moved the VM's `deadline` tag two minutes into the past and waited; the
 reaper alone deallocated the VM 866 s later (one 15-minute interval), after which the
 sample restarted the VM, proved the guest timer as well, and deleted the group with a
-proven inventory. Sample 17 repeated the full path on the final harness commit
-`fb5ed0a3` (journaled with no uncommitted changes; every later commit on the branch
-touches only this document): all gates held, the reaper deallocated the VM 56 s after
-the tag change because a scheduled run was imminent, the guest timer was verified and
-fired, and the deletion was proven. Maximum compute exposure after a lost controller is
+proven inventory. Sample 17 repeated the full path on harness commit `fb5ed0a3`: all
+gates held, the reaper deallocated the VM 56 s after the tag change because a
+scheduled run was imminent, the guest timer was verified and fired, and the deletion
+was proven. Hosted review then asked for the reaper to be pinned to the configured
+subscription: the runbook now takes a mandatory `SubscriptionId`, connects and sets
+its Az context to it and asserts the result, the job link supplies it, and the
+harness requires that pinned link (reading links individually, because the list API
+omits parameters and Azure re-cases the key to `SubscriptionID`). Sample 18 ran the
+full path with `--prove-reaper` on the final harness commit `b3b3d926` (journaled with
+no uncommitted changes; every later commit on the branch touches only this document):
+all gates held and the scheduled, subscription-pinned reaper deallocated the VM 103 s
+after the tag change. Maximum compute exposure after a lost controller is
 therefore the deadline plus one reaper interval plus the deallocation time. The run-command host-key read took 63 s in sample 12
 (31 to 32 s in every other sample).
 
@@ -250,7 +259,7 @@ Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 to 17 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 to 18 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -265,7 +274,7 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 17;
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 18;
   sample 8 differed only by an unrelated concurrent addition (proof still holds) and
   sample 9 by that resource's later removal by its own lane (proof unverified).
 - No provider was registered and no Container Apps Job was created. From sample 8 on,
@@ -275,15 +284,15 @@ Functional results, identical in every sample unless stated:
   by firing it; from sample 16 on the subscription-side reaper is the primary,
   pre-existing bound and the others are defense in depth.
 
-Cost actually incurred: seventeen VMs for 8 to 30 minutes each plus 32 GiB disks, well
+Cost actually incurred: eighteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the sixteen samples that reached an
+**Not met with this configuration.** Across the seventeen samples that reached an
 endpoint, the slowest verified key-only SSH session came 278.0 s after `T0` (246.0 s
 excluding the out-of-band host-key read); even the fastest sample needed 203.4 s.
-Fourteen of sixteen also missed the boundary for endpoint-open alone (sample 6 by
+Fifteen of seventeen also missed the boundary for endpoint-open alone (sample 6 by
 0.8 s, sample 12 by 4.0 s), and the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
@@ -300,7 +309,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 to 8, 10 to 12 and 14 to 17; sample 9 held every gate except that its deletion proof
+2, 3, 5 to 8, 10 to 12 and 14 to 18; sample 9 held every gate except that its deletion proof
 is unverified because of concurrent activity, and sample 13 never reached its gates,
 as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
@@ -322,11 +331,11 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 12 and 14 to 17).
+      control (samples 4 to 12 and 14 to 18).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 17;
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 18;
       sample 9 is recorded as unverified because another lane deleted its own registry
       during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -4,16 +4,17 @@ Permanent operator guidance for the Azure CPU lane of
 [#474](https://github.com/peters/horizon/issues/474) under
 [#383](https://github.com/peters/horizon/issues/383). It records the dated
 official-source comparison behind `scripts/azure-workspace-preflight/preflight.py`,
-the qualification gates that no API read can close, and the **future**
-three-sample spike checklist. Nothing in this document is cloud evidence. No
-Azure resource has been created, started, stopped or deleted for it, and no
-candidate has been selected. Container Apps Jobs are excluded from this lane by
+the qualification gates that no API read can close, the maintainer's
+revalidation decision, and the results of the three-sample Linux VM spike executed
+on 2026-09-10 with `scripts/azure-workspace-spike`. Spike resources were created
+under a stated bound and deleted with inventory proof; the persistent registry and
+pull identity are listed below. Container Apps Jobs are excluded from this lane by
 the issue contract and are not compared.
 
 Status legend used below: **documented** means stated by the linked official
 page on the date given; **not verified in this pass** means the author did not
 locate an official statement and the spike must measure or confirm it;
-**not executed** marks spike steps that have never been run.
+**not executed** marks steps that have never been run.
 
 ## Product contract the candidates are measured against
 
@@ -79,56 +80,131 @@ dynamic sessions and other ephemeral sandboxes (no persistent identity).
 5. Record the report path, `observed_at`, tool version and commit in the resource
    journal that the spike will use.
 
-## Future three-sample spike checklist (not executed)
+## Revalidation decision (2026-09-10)
 
-Every item below is **not executed** as of 2026-09-10. Paid creation is approved
-by #474 only within a bounded cost and lifetime, after the read-only preflight
-above, with explicit approval before any provider registration.
+Maintainer decision, taken after the official-source comparison above and the live
+read-only preflight of the maintainer's subscription: the Azure CPU candidate for
+the spike and the adapter is a **Linux virtual machine with an ext4-formatted
+managed data disk**, running the compact worker image under Docker with the data
+disk bound at `/workspace`. Reasons recorded at decision time:
 
-Before the first sample:
+- Container Instances: Stop does not preserve container state, the only durable
+  volume type is CIFS (cannot satisfy the ext4 qualifier by construction), and
+  `Microsoft.ContainerInstance` is not registered in the subscription (live
+  preflight: `blocked`, `unregistered_provider`).
+- Container Apps: storage is ephemeral or Azure Files; external TCP ingress needs a
+  VNet-integrated environment; core quota is per environment.
+- Linux VM: deallocate retains disks, needs no new provider registration, and the
+  live preflight reported no blockers for `Standard_D4s_v3` in `northeurope`.
 
-- [ ] Candidate revalidation note referencing this comparison and the live
-      preflight reports, signed off by the lead.
-- [ ] Exact candidate image: registry, repository, tag and immutable digest of
-      the compact worker image; confirm it is x64 and includes `sshd`.
-- [ ] Bounded cost and lifetime: maximum hourly cost, maximum wall-clock lifetime
-      per sample, and the hard deadline for cleanup, written down before creation.
-- [ ] Resource ownership journal: one task-owned resource group per sample with a
-      unique name, tags recording issue, sample number and creation time, plus a
-      pre-creation inventory snapshot of the subscription so "unchanged
-      pre-existing resources" can be proven afterward.
-- [ ] Fresh client key pair generated for the spike only; the public key is the
-      only identity installed; no password authentication anywhere.
-- [ ] User-assigned managed identity with pull-only registry rights created under
-      the same ownership journal; no registry password or admin user enabled.
+Supporting infrastructure created under the same decision (persistent, outside any
+sample resource group): resource group `horizon-worker-registry` in `northeurope`
+with a Standard-SKU container registry (admin user disabled) and the user-assigned
+identity `horizon-worker-puller` holding `AcrPull` only. The worker image built from
+commit `22674061` was pushed as `horizon-remote-worker:0.1.0-22674061` with digest
+`sha256:20cc03ef2530336b7374cc35412c8583b1422726c630ec6e6cd1450d690a74f6`
+(1.66 GB uncompressed, 31 layers). No automated publication workflow exists yet.
 
-Per sample (three samples, sequential, one exact resource each):
+## Three-sample spike (executed 2026-09-10)
 
-- [ ] Record `T0` before the create call; record create acknowledged, image pull
-      complete, endpoint published, first successful key-only SSH handshake, and
-      delete complete, each as UTC timestamps and elapsed seconds from `T0`.
-- [ ] Verify the SSH host key out of band and pin it; reject any prompt-based
-      trust.
-- [ ] Run the on-worker storage qualification against the intended repository
-      root and record the raw kernel option lines; a failure here is a candidate
-      blocker regardless of timing.
-- [ ] Prove independent execution: start a long-running process, disconnect the
-      client, wait, reconnect and observe it still running.
-- [ ] Prove explicit Stop with retained data: write a marker file, perform the
-      candidate's documented stop, start again, confirm the marker survives and
-      record whether the endpoint changed.
-- [ ] Prove exact deletion: delete only the sample's resources, then confirm
-      absence by identity and confirm the pre-creation inventory is unchanged.
+Harness: [`scripts/azure-workspace-spike/run-vm-spike.sh`](../../scripts/azure-workspace-spike/README.md).
+Configuration for all samples: `northeurope`, `Standard_D4s_v3`,
+`Canonical:ubuntu-24_04-lts:server:latest`, 32 GiB data disk, Standard static public
+IP, VM port 2222 opened only from the operator's egress address, key-only SSH with a
+fresh Ed25519 key per sample, image pulled by digest through the managed identity's
+IMDS token exchanged at the registry (no registry password), host key read out of band
+through ARM-authenticated `az vm run-command` and pinned before the first SSH.
+Bound: 120 minutes per sample; actual 9 to 10 minutes each. Journals are private.
 
-After the three samples:
+Timings in seconds from `T0` (the resource-group create call), controller side:
 
-- [ ] Compare all three timing records against the 180-second boundary; report
-      the slowest sample, not the average.
-- [ ] Record cost actually incurred against the bound.
-- [ ] Attach cleanup proof (absence checks and unchanged inventory) to the journal.
-- [ ] Only then update #474 with the revalidated compute and storage decision.
-      Until that update exists, no Azure adapter, identity integration or UI work
-      should assume a platform.
+| Sample | Create ack | Endpoint open | SSH verified | SSH verified excl. run-command | Deallocate | Start to SSH | Delete |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 36.4 | 203.3 | 235.4 | 204.0 | 32.1 | 74.7 | 188.5 |
+| 2 | 39.1 | 178.6 | 210.7 | 179.2 | 33.6 | 74.8 | 187.5 |
+| 3 | 38.4 | 238.7 | 270.8 | 239.3 | 32.1 | 74.2 | 187.8 |
+
+Guest-side stamps (seconds from `T0`):
+
+| Sample | Boot | Docker installed | Data disk ready | Registry login | Image pulled | Container started |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 23.5 | 67.4 | 69.3 | 70.4 | 160.3 | 201.9 |
+| 2 | 25.0 | 73.2 | 75.0 | 76.0 | 169.2 | 174.0 |
+| 3 | 26.9 | 76.8 | 79.1 | 80.1 | 229.1 | 235.0 |
+
+Sample 1's 42 s between pull and container start did not recur once the harness
+split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
+it is recorded as an unexplained one-off. Raising the registry from Basic to
+Standard before sample 2 did not change pull time, and sample 3 pulled 60 s slower
+than the others, so pull time is dominated by image size and VM-side extraction,
+not registry tier.
+
+Functional results, identical in all three samples:
+
+- Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`, sysfs path
+  resolvable from inside the container); kernel options include `rw`, `barrier`,
+  exactly one `data=ordered` and no `ro`/`nobarrier`, so a shell mirror of the Rust
+  qualifier passes. **The authoritative Rust qualifier has not been executed on the
+  worker yet**; that remains a gate for the adapter's first real repository setup.
+- Detach independence: a tmux heartbeat kept writing while no client was connected.
+- Explicit Stop with retained data: `az vm deallocate` reached
+  `PowerState/deallocated`; after `az vm start` the marker file was present, the
+  public IP was unchanged, the pinned host key matched (it lives on the data disk),
+  and the tmux session was gone because the container restarted. Data survives Stop;
+  in-container sessions do not.
+- Exact deletion: the resource group was absent and the subscription resource
+  inventory was byte-identical to the pre-sample snapshot after every sample.
+- No provider was registered and no Container Apps Job was created.
+
+Cost actually incurred: three VMs for about 10 minutes each plus 32 GiB disks, well
+under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
+
+### Verdict against the 180-second boundary
+
+**Not met with this configuration.** The slowest sample reached a verified key-only
+SSH session 270.8 s after `T0` (239.3 s excluding the 31 s out-of-band host-key read);
+even the fastest sample needed 210.7 s. Two of three samples also missed the boundary
+for endpoint-open alone. The measured budget splits into roughly 25 s VM boot, 45 to
+50 s Docker installation from apt, 90 to 150 s image pull and extraction, and 31 s
+for `run-command`. Levers that the measurements point to, in order of impact:
+
+1. A smaller worker image or a VM image with the worker image pre-pulled (removes
+   most of the 90 to 150 s pull).
+2. A prebaked VM image (Azure Compute Gallery) with Docker installed (removes the
+   45 to 50 s apt step).
+3. A faster authenticated host-key channel than `run-command`, for example the
+   worker publishing its bootstrap record to the serial console read through boot
+   diagnostics, or the adapter accepting the retained key from the data disk on
+   reconnect (removes up to 31 s from the first connection only).
+
+None of these are approved or implemented; they are the next decision for #474.
+The functional contract (key-only SSH, managed-identity pull, ext4 storage,
+detach independence, Stop with retained data, exact deletion) held in every sample.
+
+## Spike checklist status
+
+Executed on 2026-09-10 unless marked otherwise.
+
+- [x] Candidate revalidation note (above).
+- [x] Exact candidate image by digest (above).
+- [x] Bounded cost and lifetime (120 minutes per sample, $10 total).
+- [x] Resource ownership journal: one tagged resource group per sample, pre- and
+      post-inventory snapshots, private journals.
+- [x] Fresh client key per sample; key-only SSH; no password authentication.
+- [x] User-assigned managed identity with pull-only registry rights.
+- [x] `T0`, create, pull, endpoint, SSH-ready and delete timing per sample.
+- [x] Host key verified out of band and pinned before the first connection.
+- [x] Kernel ext4 option lines recorded from the worker; shell mirror passes.
+      **Not executed:** the Rust qualifier itself on the worker.
+- [x] Independent execution across a disconnect.
+- [x] Explicit Stop with retained data, endpoint retention recorded.
+- [x] Exact deletion with absence check and unchanged inventory.
+- [x] Slowest sample compared with the 180-second boundary: **not met** (270.8 s).
+- [x] Cost recorded against the bound.
+- [ ] **Not executed:** PC-off task progress over hours, three independent panels on
+      one worker, verified-loss recovery, opt-in budget policy, and the adapter's own
+      create-once and reconcile behaviour. These are #474 acceptance items for the
+      adapter and integration PRs, not for this spike.
 
 ## Maintenance
 

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 8 to 10 minutes for samples 1, 2, 3 and 5 to 9, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
+Bound: 120 minutes per sample; actual 8 to 10 minutes for samples 1, 2, 3 and 5 to 10, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -132,6 +132,7 @@ resource-group delete.
 | 7 (final harness) | 37.0 | 170.9 | 203.4 | 171.5 | 31.9 | 77.1 | 212.8 |
 | 8 (final harness, see below) | 37.5 | 203.1 | 235.8 | 203.8 | 31.9 | 75.3 | 122.4 |
 | 9 (final harness, see below) | 66.5 | 245.4 | 278.0 | 246.0 | 32.5 | 75.0 | 183.0 |
+| 10 (final harness) | 38.1 | 210.6 | 243.7 | 211.2 | 32.4 | 74.4 | 183.4 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -148,6 +149,7 @@ cross-clock noise):
 | 7 | 21.3 | 73.8 | 76.1 | 76.9 | 162.1 | 167.8 |
 | 8 | 25.9 | 85.0 | 87.4 | 88.5 | 195.4 | 200.5 |
 | 9 | 35.4 | 90.0 | 92.3 | 93.1 | 220.8 | 243.3 |
+| 10 | 25.9 | 83.9 | 86.1 | 87.0 | 180.4 | 206.0 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -176,17 +178,19 @@ exited 6 because the subscription inventory was not byte-identical afterwards: a
 unrelated registry had been created concurrently by another lane. The proof rule was
 then corrected to "no pre-existing resource removed and nothing left under the sample
 group, additions by other actors counted", which sample 8's snapshots satisfy.
-Sample 9 (all gates held, verified SSH at 278.0 s) then exposed the symmetric case:
-the same unrelated registry was deleted by its own lane during the run, so the rule
-now proves only what the harness controls (group gone, nothing left under it) and
-journals concurrent additions and removals outside the group for cross-checking
-against the activity log.
+Sample 9 (all functional gates held, verified SSH at 278.0 s) then exposed the
+symmetric case: the same unrelated registry was deleted by its own lane during the
+run. Because #474 asks for unchanged pre-existing resources and the inventory cannot
+attribute a disappearance, the final rule reports such a sample as **unverified**
+(exit 6, `unverified_concurrent_removal_outside_group`) rather than proven, and the
+sample is rerun. Sample 10, run with that final rule, passed every gate with a fully
+proven deletion (`leftover` empty, `removed_outside_group` empty).
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 9 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 10 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -201,19 +205,19 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7; samples
-  8 and 9 differed only by an unrelated registry created and later deleted by another
-  lane (see above).
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10;
+  sample 8 differed only by an unrelated concurrent addition (proof still holds) and
+  sample 9 by that resource's later removal by its own lane (proof unverified).
 - No provider was registered and no Container Apps Job was created.
 
-Cost actually incurred: nine VMs for 8 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: ten VMs for 8 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the nine samples the slowest verified
+**Not met with this configuration.** Across the ten samples the slowest verified
 key-only SSH session came 278.0 s after `T0` (246.0 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 203.4 s. Six of nine
+out-of-band host-key read); even the fastest sample needed 203.4 s. Seven of ten
 samples also missed the boundary for endpoint-open alone, and the best endpoint
 time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
@@ -231,7 +235,8 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3 and 5 to 9. Sample 4 held every gate up to the restart, then failed the retention
+2, 3, 5 to 8 and 10; sample 9 held every gate except that its deletion proof is
+unverified because of concurrent activity, as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
 and mount were not verified; the harness change responsible was reverted before
 sample 5.
@@ -251,12 +256,13 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 9).
+      control (samples 4 to 10).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it; concurrent additions and removals elsewhere in the shared subscription
-      journaled for cross-checking, as in samples 8 and 9).
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10;
+      sample 9 is recorded as unverified because another lane deleted its own registry
+      during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).
 - [x] Cost recorded against the bound.
 - [ ] **Not executed:** PC-off task progress over hours, three independent panels on

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 8 to 11 minutes for samples 1, 2, 3 and 5 to 12, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
+Bound: 120 minutes per sample (60 for sample 14); actual 8 to 11 minutes for samples 1, 2, 3, 5 to 12 and 14, 17 minutes for sample 4 (failed restart wait) and 30 minutes for sample 13 (stalled guest, interrupted by hand). Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -135,6 +135,8 @@ resource-group delete.
 | 10 (final harness) | 38.1 | 210.6 | 243.7 | 211.2 | 32.4 | 74.4 | 183.4 |
 | 11 (single deployment) | 35.9 | 188.4 | 221.0 | 189.0 | 32.9 | 75.3 | 182.9 |
 | 12 (exact PR head 436fb9ed) | 37.5 | 184.0 | 247.7 | 184.7 | 32.0 | 105.6 | 242.8 |
+| 13 (early-boot timer, interrupted) | 40.0 | never | never | never | not reached | not reached | 243.4 |
+| 14 (guest lifetime bound) | 56.4 | 191.8 | 224.4 | 192.5 | 32.5 | 75.8 | 243.1 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -154,6 +156,7 @@ cross-clock noise):
 | 10 | 25.9 | 83.9 | 86.1 | 87.0 | 180.4 | 206.0 |
 | 11 | 27.8 | 84.5 | 86.8 | 87.8 | 176.5 | 183.1 |
 | 12 | 26.2 | 82.4 | 84.7 | 85.6 | 173.9 | 179.7 |
+| 14 | 25.9 | 79.2 | 81.5 | 82.4 | 175.0 | 191.2 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -194,18 +197,26 @@ directory carry sample number 1 (`sample-1-20260910T174441Z`). Samples 1 to 10 p
 the `--preflight-report` requirement. Samples 11 and 12 ran with a digest-bound live
 `vm` preflight report (observed 2026-09-10T18:29:37Z, `no_blockers_observed`) journaled
 in their `start` events, and created the network, VM and DevTestLab auto-shutdown
-schedule in **one server-side deployment** (36 to 37 s) so a controller lost during
-creation cannot leave compute without the platform-side stop. Sample 12's journal
-records harness commit `436fb9ed` with no uncommitted changes, which is the exact head
-this document describes apart from this paragraph; the run-command host-key read took
-63 s in that sample (31 to 32 s in every other), which is why its verified-SSH time is
-higher than its endpoint time suggests.
+schedule in one server-side deployment (36 to 37 s). Hosted review then pointed out
+that ARM deployments are not transactional and the schedule depends on the VM, so
+co-location is not a crash-safe bound; a probe confirmed Azure rejects a schedule for a
+VM that does not exist yet (`ComputeVmNotFound`). The bound now enforced **before any
+compute exists** is a built-in power-only role for the worker identity on the sample
+group plus a guest systemd timer, armed by cloud-init as its first step (54 s after
+boot in sample 14, before Docker or the pull), that deallocates the VM through ARM at
+the deadline. Sample 13 tried to arm that timer from `bootcmd`; the early-boot
+`systemctl` call deadlocked the guest (no endpoint, no run-command response), the run
+was interrupted and deleted cleanly with a proven inventory (exit 130, 17 minutes).
+Sample 14 armed the timer from the first `runcmd` step and passed every gate,
+including the new one: firing the guest service once took the VM to
+`PowerState/deallocated`. The run-command host-key read took 63 s in sample 12
+(31 to 32 s in every other sample).
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 12 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -220,24 +231,25 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 12;
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 14;
   sample 8 differed only by an unrelated concurrent addition (proof still holds) and
   sample 9 by that resource's later removal by its own lane (proof unverified).
 - No provider was registered and no Container Apps Job was created. From sample 8 on,
   every VM carried a DevTestLab auto-shutdown schedule one minute after its lifetime
-  deadline as the platform-side stop; from sample 11 on it was created in the same
-  deployment as the VM.
+  deadline; from sample 11 on it was created in the same deployment as the VM; from
+  sample 14 on the primary bound is the pre-creation power-only role plus the guest
+  self-deallocate timer, proven by firing it.
 
-Cost actually incurred: twelve VMs for 8 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: fourteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the twelve samples the slowest verified
-key-only SSH session came 278.0 s after `T0` (246.0 s excluding the out-of-band
-host-key read); even the fastest sample needed 203.4 s. Ten of twelve samples also
-missed the boundary for endpoint-open alone (sample 6 by 0.8 s, sample 12 by 4.0 s),
-and the best endpoint time was 170.9 s. The measured budget splits
+**Not met with this configuration.** Across the thirteen samples that reached an
+endpoint, the slowest verified key-only SSH session came 278.0 s after `T0` (246.0 s
+excluding the out-of-band host-key read); even the fastest sample needed 203.4 s.
+Eleven of thirteen also missed the boundary for endpoint-open alone (sample 6 by
+0.8 s, sample 12 by 4.0 s), and the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
 
@@ -253,8 +265,9 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 to 8 and 10 to 12; sample 9 held every gate except that its deletion proof is
-unverified because of concurrent activity, as described above. Sample 4 held every gate up to the restart, then failed the retention
+2, 3, 5 to 8, 10 to 12 and 14; sample 9 held every gate except that its deletion proof
+is unverified because of concurrent activity, and sample 13 never reached its gates,
+as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
 and mount were not verified; the harness change responsible was reverted before
 sample 5.
@@ -274,11 +287,11 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 12).
+      control (samples 4 to 12 and 14).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 12;
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 14;
       sample 9 is recorded as unverified because another lane deleted its own registry
       during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample (60 for sample 14); actual 8 to 11 minutes for samples 1, 2, 3, 5 to 12 and 14, 17 minutes for sample 4 (failed restart wait) and 30 minutes for sample 13 (stalled guest, interrupted by hand). Journals are private.
+Bound: 120 minutes per sample (60 for samples 14 and 15); actual 8 to 12 minutes for samples 1, 2, 3, 5 to 12, 14 and 15, 17 minutes for sample 4 (failed restart wait) and 30 minutes for sample 13 (stalled guest, interrupted by hand). Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -137,6 +137,7 @@ resource-group delete.
 | 12 (exact PR head 436fb9ed) | 37.5 | 184.0 | 247.7 | 184.7 | 32.0 | 105.6 | 242.8 |
 | 13 (early-boot timer, interrupted) | 40.0 | never | never | never | not reached | not reached | 243.4 |
 | 14 (guest lifetime bound) | 56.4 | 191.8 | 224.4 | 192.5 | 32.5 | 75.8 | 243.1 |
+| 15 (timer verified before firing) | 38.7 | 194.2 | 226.8 | 194.8 | 32.5 | 75.5 | 243.0 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -157,6 +158,7 @@ cross-clock noise):
 | 11 | 27.8 | 84.5 | 86.8 | 87.8 | 176.5 | 183.1 |
 | 12 | 26.2 | 82.4 | 84.7 | 85.6 | 173.9 | 179.7 |
 | 14 | 25.9 | 79.2 | 81.5 | 82.4 | 175.0 | 191.2 |
+| 15 | 27.3 | 79.4 | 81.6 | 82.4 | 180.5 | 189.4 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -209,14 +211,16 @@ the deadline. Sample 13 tried to arm that timer from `bootcmd`; the early-boot
 was interrupted and deleted cleanly with a proven inventory (exit 130, 17 minutes).
 Sample 14 armed the timer from the first `runcmd` step and passed every gate,
 including the new one: firing the guest service once took the VM to
-`PowerState/deallocated`. The run-command host-key read took 63 s in sample 12
+`PowerState/deallocated`. Sample 15 additionally verified through run-command that the
+timer unit was `enabled` and `active` (waiting) before the service was fired, which
+the gate now requires together with the observed deallocation. The run-command host-key read took 63 s in sample 12
 (31 to 32 s in every other sample).
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 12, 14 and 15 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -231,7 +235,7 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 14;
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 15;
   sample 8 differed only by an unrelated concurrent addition (proof still holds) and
   sample 9 by that resource's later removal by its own lane (proof unverified).
 - No provider was registered and no Container Apps Job was created. From sample 8 on,
@@ -240,15 +244,15 @@ Functional results, identical in every sample unless stated:
   sample 14 on the primary bound is the pre-creation power-only role plus the guest
   self-deallocate timer, proven by firing it.
 
-Cost actually incurred: fourteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
+Cost actually incurred: fifteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the thirteen samples that reached an
+**Not met with this configuration.** Across the fourteen samples that reached an
 endpoint, the slowest verified key-only SSH session came 278.0 s after `T0` (246.0 s
 excluding the out-of-band host-key read); even the fastest sample needed 203.4 s.
-Eleven of thirteen also missed the boundary for endpoint-open alone (sample 6 by
+Twelve of fourteen also missed the boundary for endpoint-open alone (sample 6 by
 0.8 s, sample 12 by 4.0 s), and the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
@@ -265,7 +269,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 to 8, 10 to 12 and 14; sample 9 held every gate except that its deletion proof
+2, 3, 5 to 8, 10 to 12, 14 and 15; sample 9 held every gate except that its deletion proof
 is unverified because of concurrent activity, and sample 13 never reached its gates,
 as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
@@ -287,11 +291,11 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 12 and 14).
+      control (samples 4 to 12, 14 and 15).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 14;
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 15;
       sample 9 is recorded as unverified because another lane deleted its own registry
       during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -246,7 +246,9 @@ Executed on 2026-09-10 unless marked otherwise.
       control (samples 4 to 8).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
-- [x] Exact deletion with absence check and unchanged inventory.
+- [x] Exact deletion with absence check and inventory proof (no pre-existing resource
+      removed, nothing left under the sample group; concurrent additions by other
+      actors counted, as in sample 8).
 - [x] Slowest sample compared with the 180-second boundary: **not met** (275.6 s).
 - [x] Cost recorded against the bound.
 - [ ] **Not executed:** PC-off task progress over hours, three independent panels on

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 9 to 10 minutes each. Journals are private.
+Bound: 120 minutes per sample; actual 9 to 10 minutes for samples 1, 2, 3, 5 and 6, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -128,6 +128,7 @@ resource-group delete.
 | 3 | 38.4 | 238.7 | 270.8 | 239.3 | 32.1 | 74.2 | 187.8 |
 | 4 (revised harness, see below) | 67.9 | 241.6 | 274.2 | 242.2 | 31.5 | restart gate failed | 183.3 |
 | 5 (revised harness) | 38.8 | 243.0 | 275.6 | 243.7 | 31.5 | 74.3 | 182.9 |
+| 6 (final harness) | 37.6 | 180.8 | 213.5 | 181.5 | 31.9 | 105.9 | 183.1 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -140,6 +141,7 @@ cross-clock noise):
 | 3 | 26.9 | 76.8 | 79.1 | 80.1 | 229.1 | 235.0 |
 | 4 | 33.4 | 101.5 | 103.7 | 104.6 | 221.4 | 237.3 |
 | 5 | 28.7 | 77.1 | 79.3 | 80.2 | 216.2 | 239.6 |
+| 6 | 27.9 | 84.3 | 86.6 | 87.5 | 173.5 | 178.1 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -157,7 +159,9 @@ after `az vm start` the worker endpoint never returned within the 10-minute rest
 bound, the sample exited 7 with the retention gate failed, and it was still deleted
 with an unchanged inventory. The root cause was not captured (the harness now records
 guest diagnostics out of band when the restart gate fails); restoring `defaults,nofail`
-while keeping the docker drop-in restarted cleanly in sample 5.
+while keeping the docker drop-in restarted cleanly in sample 5. Sample 6 ran the
+final harness (hosted-review fixes: hard lifetime bound on every CLI call, overlay
+control gated, unproven deletion outranking other exit codes) and passed every gate.
 
 Functional results, identical in every sample unless stated:
 
@@ -181,15 +185,16 @@ Functional results, identical in every sample unless stated:
   inventory was byte-identical to the pre-sample snapshot after every sample.
 - No provider was registered and no Container Apps Job was created.
 
-Cost actually incurred: five VMs for 9 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: six VMs for 9 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the five samples the slowest verified
+**Not met with this configuration.** Across the six samples the slowest verified
 key-only SSH session came 275.6 s after `T0` (243.7 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 210.7 s. Four of five
-samples also missed the boundary for endpoint-open alone. The measured budget splits
+out-of-band host-key read); even the fastest sample needed 210.7 s. Four of six
+samples also missed the boundary for endpoint-open alone, and the two that met it
+did so by less than two seconds. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
 
@@ -204,7 +209,11 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
-detach independence, Stop with retained data, exact deletion) held in every sample.
+detach independence, Stop with retained data, exact deletion) held in samples 1,
+2, 3, 5 and 6. Sample 4 held every gate up to the restart, then failed the retention
+gate because the worker endpoint never returned, so its retained marker, host key
+and mount were not verified; the harness change responsible was reverted before
+sample 5.
 
 ## Spike checklist status
 

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 9 to 10 minutes for samples 1, 2, 3, 5 and 6, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
+Bound: 120 minutes per sample; actual 9 to 10 minutes for samples 1, 2, 3, 5, 6 and 7, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -129,6 +129,7 @@ resource-group delete.
 | 4 (revised harness, see below) | 67.9 | 241.6 | 274.2 | 242.2 | 31.5 | restart gate failed | 183.3 |
 | 5 (revised harness) | 38.8 | 243.0 | 275.6 | 243.7 | 31.5 | 74.3 | 182.9 |
 | 6 (final harness) | 37.6 | 180.8 | 213.5 | 181.5 | 31.9 | 105.9 | 183.1 |
+| 7 (final harness) | 37.0 | 170.9 | 203.4 | 171.5 | 31.9 | 77.1 | 212.8 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -142,6 +143,7 @@ cross-clock noise):
 | 4 | 33.4 | 101.5 | 103.7 | 104.6 | 221.4 | 237.3 |
 | 5 | 28.7 | 77.1 | 79.3 | 80.2 | 216.2 | 239.6 |
 | 6 | 27.9 | 84.3 | 86.6 | 87.5 | 173.5 | 178.1 |
+| 7 | 21.3 | 73.8 | 76.1 | 76.9 | 162.1 | 167.8 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -161,13 +163,15 @@ with an unchanged inventory. The root cause was not captured (the harness now re
 guest diagnostics out of band when the restart gate fails); restoring `defaults,nofail`
 while keeping the docker drop-in restarted cleanly in sample 5. Sample 6 ran the
 final harness (hosted-review fixes: hard lifetime bound on every CLI call, overlay
-control gated, unproven deletion outranking other exit codes) and passed every gate.
+control gated, unproven deletion outranking other exit codes) and passed every gate,
+as did sample 7 after the last review round (bounded SSH, verified-absent group
+name, JSON-forced CLI output, journaled deallocate/start failures).
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4, 5 and 6 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 7 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -185,16 +189,16 @@ Functional results, identical in every sample unless stated:
   inventory was byte-identical to the pre-sample snapshot after every sample.
 - No provider was registered and no Container Apps Job was created.
 
-Cost actually incurred: six VMs for 9 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: seven VMs for 9 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the six samples the slowest verified
+**Not met with this configuration.** Across the seven samples the slowest verified
 key-only SSH session came 275.6 s after `T0` (243.7 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 210.7 s. Four of six
-samples also missed the boundary for endpoint-open alone, and the two that met it
-did so by less than two seconds. The measured budget splits
+out-of-band host-key read); even the fastest sample needed 203.4 s. Four of seven
+samples also missed the boundary for endpoint-open alone, and the best endpoint
+time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
 
@@ -210,7 +214,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 and 6. Sample 4 held every gate up to the restart, then failed the retention
+2, 3, 5, 6 and 7. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
 and mount were not verified; the harness change responsible was reverted before
 sample 5.
@@ -230,7 +234,7 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4, 5 and 6).
+      control (samples 4 to 7).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and unchanged inventory.

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -184,7 +184,12 @@ run. Because #474 asks for unchanged pre-existing resources and the inventory ca
 attribute a disappearance, the final rule reports such a sample as **unverified**
 (exit 6, `unverified_concurrent_removal_outside_group`) rather than proven, and the
 sample is rerun. Sample 10, run with that final rule, passed every gate with a fully
-proven deletion (`leftover` empty, `removed_outside_group` empty).
+proven deletion (`leftover` empty, `removed_outside_group` empty); it was invoked as
+`--sample 1` because the harness then accepted single digits, so its tags and journal
+directory carry sample number 1 (`sample-1-20260910T174441Z`). Samples 1 to 10 predate
+the `--preflight-report` requirement; the live `vm` preflight for `northeurope` /
+`Standard_D4s_v3` (status `no_blockers_observed`) was run earlier the same day and is
+referenced in the decision above.
 
 Functional results, identical in every sample unless stated:
 

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -222,9 +222,9 @@ under the $10 bound; the persistent registry costs about $0.67 per day at Standa
 
 **Not met with this configuration.** Across the ten samples the slowest verified
 key-only SSH session came 278.0 s after `T0` (246.0 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 203.4 s. Seven of ten
-samples also missed the boundary for endpoint-open alone, and the best endpoint
-time was 170.9 s. The measured budget splits
+out-of-band host-key read); even the fastest sample needed 203.4 s. Eight of ten
+samples also missed the boundary for endpoint-open alone (sample 6 by 0.8 s), and
+the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
 

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 9 to 10 minutes for samples 1, 2, 3, 5, 6 and 7, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
+Bound: 120 minutes per sample; actual 8 to 10 minutes for samples 1, 2, 3 and 5 to 8, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -130,6 +130,7 @@ resource-group delete.
 | 5 (revised harness) | 38.8 | 243.0 | 275.6 | 243.7 | 31.5 | 74.3 | 182.9 |
 | 6 (final harness) | 37.6 | 180.8 | 213.5 | 181.5 | 31.9 | 105.9 | 183.1 |
 | 7 (final harness) | 37.0 | 170.9 | 203.4 | 171.5 | 31.9 | 77.1 | 212.8 |
+| 8 (final harness, see below) | 37.5 | 203.1 | 235.8 | 203.8 | 31.9 | 75.3 | 122.4 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -144,6 +145,7 @@ cross-clock noise):
 | 5 | 28.7 | 77.1 | 79.3 | 80.2 | 216.2 | 239.6 |
 | 6 | 27.9 | 84.3 | 86.6 | 87.5 | 173.5 | 178.1 |
 | 7 | 21.3 | 73.8 | 76.1 | 76.9 | 162.1 | 167.8 |
+| 8 | 25.9 | 85.0 | 87.4 | 88.5 | 195.4 | 200.5 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -164,14 +166,20 @@ guest diagnostics out of band when the restart gate fails); restoring `defaults,
 while keeping the docker drop-in restarted cleanly in sample 5. Sample 6 ran the
 final harness (hosted-review fixes: hard lifetime bound on every CLI call, overlay
 control gated, unproven deletion outranking other exit codes) and passed every gate,
-as did sample 7 after the last review round (bounded SSH, verified-absent group
-name, JSON-forced CLI output, journaled deallocate/start failures).
+as did sample 7 after the next review round (bounded SSH, verified-absent group
+name, JSON-forced CLI output, journaled deallocate/start failures). Sample 8 added
+the platform-side safety net (Azure VM auto-shutdown scheduled one minute after the
+lifetime deadline, journaled as scheduled) and passed every functional gate, but
+exited 6 because the subscription inventory was not byte-identical afterwards: an
+unrelated registry had been created concurrently by another lane. The proof rule was
+then corrected to "no pre-existing resource removed and nothing left under the sample
+group, additions by other actors counted", which sample 8's snapshots satisfy.
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 7 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 8 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -185,18 +193,19 @@ Functional results, identical in every sample unless stated:
   container, and the tmux session was gone because the container restarted. Data
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
-- Exact deletion: the resource group was absent and the subscription resource
-  inventory was byte-identical to the pre-sample snapshot after every sample.
+- Exact deletion: the resource group was absent after every sample; the subscription
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7, and in
+  sample 8 differed only by an unrelated concurrent addition (see above).
 - No provider was registered and no Container Apps Job was created.
 
-Cost actually incurred: seven VMs for 9 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: eight VMs for 8 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the seven samples the slowest verified
+**Not met with this configuration.** Across the eight samples the slowest verified
 key-only SSH session came 275.6 s after `T0` (243.7 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 203.4 s. Four of seven
+out-of-band host-key read); even the fastest sample needed 203.4 s. Five of eight
 samples also missed the boundary for endpoint-open alone, and the best endpoint
 time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
@@ -214,7 +223,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5, 6 and 7. Sample 4 held every gate up to the restart, then failed the retention
+2, 3 and 5 to 8. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
 and mount were not verified; the harness change responsible was reverted before
 sample 5.
@@ -234,7 +243,7 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 7).
+      control (samples 4 to 8).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and unchanged inventory.

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -117,7 +117,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample (60 for samples 14 and 15, 90 for sample 16); actual 8 to 12 minutes for samples 1, 2, 3, 5 to 12, 14 and 15, 17 minutes for sample 4 (failed restart wait), 30 minutes for sample 13 (stalled guest, interrupted by hand) and 26 minutes for sample 16 (includes the 14-minute reaper wait). Journals are private.
+Bound: 120 minutes per sample (60 for samples 14 and 15, 90 for samples 16 and 17); actual 8 to 13 minutes for samples 1, 2, 3, 5 to 12, 14, 15 and 17, 17 minutes for sample 4 (failed restart wait), 30 minutes for sample 13 (stalled guest, interrupted by hand) and 26 minutes for sample 16 (includes the 14-minute reaper wait). Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -142,6 +142,7 @@ resource-group delete.
 | 14 (guest lifetime bound) | 56.4 | 191.8 | 224.4 | 192.5 | 32.5 | 75.8 | 243.1 |
 | 15 (timer verified before firing) | 38.7 | 194.2 | 226.8 | 194.8 | 32.5 | 75.5 | 243.0 |
 | 16 (reaper proof, `--prove-reaper`) | 52.1 | 189.4 | 222.5 | 190.0 | 32.5 | 74.6 | 212.8 |
+| 17 (exact final harness head fb5ed0a3, `--prove-reaper`) | 40.3 | 186.7 | 219.8 | 187.4 | 32.0 | 75.7 | 243.2 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -164,6 +165,7 @@ cross-clock noise):
 | 14 | 25.9 | 79.2 | 81.5 | 82.4 | 175.0 | 191.2 |
 | 15 | 27.3 | 79.4 | 81.6 | 82.4 | 180.5 | 189.4 |
 | 16 | 39.7 | 92.9 | 95.2 | 96.0 | 175.4 | 184.5 |
+| 17 | 27.5 | 86.4 | 89.5 | 94.4 | 174.6 | 183.7 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -236,15 +238,19 @@ expired spike VMs. Sample 16 proved it end to end: after the restart checks the
 harness moved the VM's `deadline` tag two minutes into the past and waited; the
 reaper alone deallocated the VM 866 s later (one 15-minute interval), after which the
 sample restarted the VM, proved the guest timer as well, and deleted the group with a
-proven inventory. Maximum compute exposure after a lost controller is therefore the
-deadline plus one reaper interval plus the deallocation time. The run-command host-key read took 63 s in sample 12
+proven inventory. Sample 17 repeated the full path on the final harness commit
+`fb5ed0a3` (journaled with no uncommitted changes; every later commit on the branch
+touches only this document): all gates held, the reaper deallocated the VM 56 s after
+the tag change because a scheduled run was imminent, the guest timer was verified and
+fired, and the deletion was proven. Maximum compute exposure after a lost controller is
+therefore the deadline plus one reaper interval plus the deallocation time. The run-command host-key read took 63 s in sample 12
 (31 to 32 s in every other sample).
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 to 16 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 12 and 14 to 17 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -259,7 +265,7 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 16;
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7 and 10 to 17;
   sample 8 differed only by an unrelated concurrent addition (proof still holds) and
   sample 9 by that resource's later removal by its own lane (proof unverified).
 - No provider was registered and no Container Apps Job was created. From sample 8 on,
@@ -269,15 +275,15 @@ Functional results, identical in every sample unless stated:
   by firing it; from sample 16 on the subscription-side reaper is the primary,
   pre-existing bound and the others are defense in depth.
 
-Cost actually incurred: sixteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
+Cost actually incurred: seventeen VMs for 8 to 30 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the fifteen samples that reached an
+**Not met with this configuration.** Across the sixteen samples that reached an
 endpoint, the slowest verified key-only SSH session came 278.0 s after `T0` (246.0 s
 excluding the out-of-band host-key read); even the fastest sample needed 203.4 s.
-Thirteen of fifteen also missed the boundary for endpoint-open alone (sample 6 by
+Fourteen of sixteen also missed the boundary for endpoint-open alone (sample 6 by
 0.8 s, sample 12 by 4.0 s), and the best endpoint time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
 image pull and extraction, and 31 s for `run-command`. Levers that the measurements point to, in order of impact:
@@ -294,7 +300,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3, 5 to 8, 10 to 12 and 14 to 16; sample 9 held every gate except that its deletion proof
+2, 3, 5 to 8, 10 to 12 and 14 to 17; sample 9 held every gate except that its deletion proof
 is unverified because of concurrent activity, and sample 13 never reached its gates,
 as described above. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
@@ -316,11 +322,11 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 12 and 14 to 16).
+      control (samples 4 to 12 and 14 to 17).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
 - [x] Exact deletion with absence check and inventory proof (group gone, nothing left
-      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 16;
+      under it, no pre-existing resource missing). Proven in samples 1 to 8 and 10 to 17;
       sample 9 is recorded as unverified because another lane deleted its own registry
       during the run.
 - [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -114,7 +114,7 @@ IP, VM port 2222 opened only from the operator's egress address, key-only SSH wi
 fresh Ed25519 key per sample, image pulled by digest through the managed identity's
 IMDS token exchanged at the registry (no registry password), host key read out of band
 through ARM-authenticated `az vm run-command` and pinned before the first SSH.
-Bound: 120 minutes per sample; actual 8 to 10 minutes for samples 1, 2, 3 and 5 to 8, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
+Bound: 120 minutes per sample; actual 8 to 10 minutes for samples 1, 2, 3 and 5 to 9, and 17 minutes for sample 4 because of its failed 10-minute restart wait. Journals are private.
 
 Controller-side timings in seconds. The first four columns are offsets from `T0`
 (the resource-group create call); the last three are self-anchored durations of
@@ -131,6 +131,7 @@ resource-group delete.
 | 6 (final harness) | 37.6 | 180.8 | 213.5 | 181.5 | 31.9 | 105.9 | 183.1 |
 | 7 (final harness) | 37.0 | 170.9 | 203.4 | 171.5 | 31.9 | 77.1 | 212.8 |
 | 8 (final harness, see below) | 37.5 | 203.1 | 235.8 | 203.8 | 31.9 | 75.3 | 122.4 |
+| 9 (final harness, see below) | 66.5 | 245.4 | 278.0 | 246.0 | 32.5 | 75.0 | 183.0 |
 
 Guest-side stamps, in seconds after `T0` using the VM's own clock (Azure guests
 sync to host time, but treat sub-second differences between the two tables as
@@ -146,6 +147,7 @@ cross-clock noise):
 | 6 | 27.9 | 84.3 | 86.6 | 87.5 | 173.5 | 178.1 |
 | 7 | 21.3 | 73.8 | 76.1 | 76.9 | 162.1 | 167.8 |
 | 8 | 25.9 | 85.0 | 87.4 | 88.5 | 195.4 | 200.5 |
+| 9 | 35.4 | 90.0 | 92.3 | 93.1 | 220.8 | 243.3 |
 
 Sample 1's 42 s between pull and container start did not recur once the harness
 split `docker create` from `docker start` (4 to 6 s and 0.4 s in samples 2 and 3);
@@ -174,12 +176,17 @@ exited 6 because the subscription inventory was not byte-identical afterwards: a
 unrelated registry had been created concurrently by another lane. The proof rule was
 then corrected to "no pre-existing resource removed and nothing left under the sample
 group, additions by other actors counted", which sample 8's snapshots satisfy.
+Sample 9 (all gates held, verified SSH at 278.0 s) then exposed the symmetric case:
+the same unrelated registry was deleted by its own lane during the run, so the rule
+now proves only what the harness controls (group gone, nothing left under it) and
+journals concurrent additions and removals outside the group for cross-checking
+against the activity log.
 
 Functional results, identical in every sample unless stated:
 
 - Storage: `/workspace` is the bound ext4 data disk (`/dev/sdc`); kernel options
   include `rw`, `barrier`, exactly one `data=ordered` and no `ro`/`nobarrier`, so a
-  shell mirror of the Rust qualifier passes. In samples 4 to 8 the **authoritative
+  shell mirror of the Rust qualifier passes. In samples 4 to 9 the **authoritative
   qualifier ran on the worker**: `horizon-repository setup-status` against a fresh
   0700 retained root on the data disk returned `status: absent` (qualified storage,
   no claim), and the same request against a 0700 root on the container's overlay
@@ -194,18 +201,19 @@ Functional results, identical in every sample unless stated:
   survives Stop; in-container sessions do not. Sample 4's failed restart is described
   above.
 - Exact deletion: the resource group was absent after every sample; the subscription
-  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7, and in
-  sample 8 differed only by an unrelated concurrent addition (see above).
+  inventory was byte-identical to the pre-sample snapshot in samples 1 to 7; samples
+  8 and 9 differed only by an unrelated registry created and later deleted by another
+  lane (see above).
 - No provider was registered and no Container Apps Job was created.
 
-Cost actually incurred: eight VMs for 8 to 17 minutes each plus 32 GiB disks, well
+Cost actually incurred: nine VMs for 8 to 17 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
 ### Verdict against the 180-second boundary
 
-**Not met with this configuration.** Across the eight samples the slowest verified
-key-only SSH session came 275.6 s after `T0` (243.7 s excluding the 31 to 32 s
-out-of-band host-key read); even the fastest sample needed 203.4 s. Five of eight
+**Not met with this configuration.** Across the nine samples the slowest verified
+key-only SSH session came 278.0 s after `T0` (246.0 s excluding the 31 to 32 s
+out-of-band host-key read); even the fastest sample needed 203.4 s. Six of nine
 samples also missed the boundary for endpoint-open alone, and the best endpoint
 time was 170.9 s. The measured budget splits
 into roughly 25 to 33 s VM boot, 45 to 70 s Docker installation from apt, 90 to 150 s
@@ -223,7 +231,7 @@ image pull and extraction, and 31 s for `run-command`. Levers that the measureme
 None of these are approved or implemented; they are the next decision for #474.
 The functional contract (key-only SSH, managed-identity pull, ext4 storage,
 detach independence, Stop with retained data, exact deletion) held in samples 1,
-2, 3 and 5 to 8. Sample 4 held every gate up to the restart, then failed the retention
+2, 3 and 5 to 9. Sample 4 held every gate up to the restart, then failed the retention
 gate because the worker endpoint never returned, so its retained marker, host key
 and mount were not verified; the harness change responsible was reverted before
 sample 5.
@@ -243,13 +251,13 @@ Executed on 2026-09-10 unless marked otherwise.
 - [x] Host key verified out of band and pinned before the first connection.
 - [x] Kernel ext4 option lines recorded from the worker; shell mirror passes; the
       authoritative Rust qualifier accepted the data disk and rejected the overlay
-      control (samples 4 to 8).
+      control (samples 4 to 9).
 - [x] Independent execution across a disconnect.
 - [x] Explicit Stop with retained data, endpoint retention recorded.
-- [x] Exact deletion with absence check and inventory proof (no pre-existing resource
-      removed, nothing left under the sample group; concurrent additions by other
-      actors counted, as in sample 8).
-- [x] Slowest sample compared with the 180-second boundary: **not met** (275.6 s).
+- [x] Exact deletion with absence check and inventory proof (group gone, nothing left
+      under it; concurrent additions and removals elsewhere in the shared subscription
+      journaled for cross-checking, as in samples 8 and 9).
+- [x] Slowest sample compared with the 180-second boundary: **not met** (278.0 s).
 - [x] Cost recorded against the bound.
 - [ ] **Not executed:** PC-off task progress over hours, three independent panels on
       one worker, verified-loss recovery, opt-in budget policy, and the adapter's own

--- a/scripts/azure-workspace-preflight/README.md
+++ b/scripts/azure-workspace-preflight/README.md
@@ -109,8 +109,10 @@ Provider namespaces per candidate: `aci` requires `Microsoft.ContainerInstance`;
 `vm` requires `Microsoft.Compute` and `Microsoft.Network`; `container-apps`
 requires `Microsoft.App` and `Microsoft.Network`. `Microsoft.ContainerRegistry`
 and `Microsoft.ManagedIdentity` are checked for every candidate because image
-access must go through a managed identity, and `Microsoft.Storage` or
-`Microsoft.OperationalInsights` where the candidate's documented setup needs them.
+access must go through a managed identity, `Microsoft.DevTestLab` for `vm` because
+the spike's platform-side auto-shutdown is a DevTestLab schedule, and
+`Microsoft.Storage` or `Microsoft.OperationalInsights` where the candidate's
+documented setup needs them.
 An unregistered provider is reported as a blocker; registering it is a separate
 approval, not something this tool does.
 

--- a/scripts/azure-workspace-preflight/README.md
+++ b/scripts/azure-workspace-preflight/README.md
@@ -109,8 +109,8 @@ Provider namespaces per candidate: `aci` requires `Microsoft.ContainerInstance`;
 `vm` requires `Microsoft.Compute` and `Microsoft.Network`; `container-apps`
 requires `Microsoft.App` and `Microsoft.Network`. `Microsoft.ContainerRegistry`
 and `Microsoft.ManagedIdentity` are checked for every candidate because image
-access must go through a managed identity, `Microsoft.DevTestLab` for `vm` because
-the spike's platform-side auto-shutdown is a DevTestLab schedule, and
+access must go through a managed identity, `Microsoft.DevTestLab` and `Microsoft.Automation` for `vm` because
+the spike's lifetime bounds are an Automation reaper and a DevTestLab schedule, and
 `Microsoft.Storage` or `Microsoft.OperationalInsights` where the candidate's
 documented setup needs them.
 An unregistered provider is reported as a blocker; registering it is a separate

--- a/scripts/azure-workspace-preflight/README.md
+++ b/scripts/azure-workspace-preflight/README.md
@@ -119,7 +119,10 @@ approval, not something this tool does.
 ## Report
 
 The JSON report is versioned (`schema_version` 1) and contains `observed_at`,
-`candidate`, `region`, the redacted `subscription`, one entry per check with
+`candidate`, `region`, the redacted `subscription`, a `subscription_digest` (the
+first 16 hex characters of SHA-256 over `horizon-preflight:<subscription-uuid>`,
+so a downstream tool such as the spike harness can bind a report to the
+subscription it was asked about without the identifier itself), one entry per check with
 `role` (`required` or `supporting`), `outcome`, `reason` and safe `details`, the
 `blockers` list, `unverified_gates` and an overall `status`. The overall status
 folds every check the same way (`blocked` beats `unknown` beats

--- a/scripts/azure-workspace-preflight/preflight.py
+++ b/scripts/azure-workspace-preflight/preflight.py
@@ -53,7 +53,7 @@ CANDIDATES: Dict[str, Dict[str, Any]] = {
             "required": ["Microsoft.ContainerInstance"],
             "supporting": _IDENTITY + ["Microsoft.Storage", "Microsoft.Network"]},
     "vm": {"name": "Azure Linux virtual machine with managed disk (candidate, not selected)",
-           "required": ["Microsoft.Compute", "Microsoft.Network"], "supporting": _IDENTITY},
+           "required": ["Microsoft.Compute", "Microsoft.Network"], "supporting": _IDENTITY + ["Microsoft.DevTestLab"]},
     "container-apps": {"name": "Azure Container Apps long-running app (candidate, not selected; Jobs excluded)",
                        "required": ["Microsoft.App", "Microsoft.Network"],
                        "supporting": _IDENTITY + ["Microsoft.Storage", "Microsoft.OperationalInsights"]},

--- a/scripts/azure-workspace-preflight/preflight.py
+++ b/scripts/azure-workspace-preflight/preflight.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import dataclasses
 import datetime as _dt
+import hashlib
 import json
 import os
 import re
@@ -24,19 +25,14 @@ import time
 from typing import Any, Callable, Dict, List, Optional
 
 TOOL_VERSION = "0.1.0"
-REPORT_SCHEMA = "horizon.azure-workspace-preflight.report"
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA, REPORT_SCHEMA_VERSION = "horizon.azure-workspace-preflight.report", 1
 ARM = "https://management.azure.com"
-API_LOCATIONS = "2022-12-01"
-API_ACI = "2026-07-01"
-API_APP = "2025-07-01"
-DEFAULT_TIMEOUT_SECONDS = 150  # az vm list-skus filters client-side and needs about a minute
-MAX_TIMEOUT_SECONDS = 600
+API_LOCATIONS, API_ACI, API_APP = "2022-12-01", "2026-07-01", "2025-07-01"
+DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS = 150, 600  # az vm list-skus filters client-side for about a minute
 OUTPUT_LIMIT_BYTES = 4 * 1024 * 1024
 
 UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
-REGION_RE = re.compile(r"^[a-z][a-z0-9]{1,63}$")
-VM_SIZE_RE = re.compile(r"^Standard_[A-Za-z0-9_-]{1,40}$")
+REGION_RE, VM_SIZE_RE = re.compile(r"^[a-z][a-z0-9]{1,63}$"), re.compile(r"^Standard_[A-Za-z0-9_-]{1,40}$")
 ERROR_CODE_RE = re.compile(r"^[A-Za-z0-9_.-]{1,80}$")
 # The only ARM read endpoints az rest may target; the planner and the allowlist share this definition.
 REST_URL_RE = re.compile(re.escape(ARM) + r"/subscriptions/[0-9a-f-]{36}(?:/locations|/providers/Microsoft\."
@@ -234,7 +230,9 @@ def plan_checks(request: Request) -> List[PlannedCheck]:
         checks.append(PlannedCheck(
             "vm_regional_quota", "Compute regional vCPU and family usage versus quota", "required",
             _az(request, "vm", "list-usage", "--location", request.region, *sub),
-            interpret_vm_usage, (*regional, "vm_sku_availability")))
+            lambda payload, o: interpret_usage(payload, [(name, o["vm_sku_availability"].details["vcpus"]) for name in
+                                                        ("cores", o["vm_sku_availability"].details["family"])]),
+            (*regional, "vm_sku_availability")))
     else:
         checks.append(PlannedCheck(
             "container_apps_regional_quota", "Container Apps regional usage versus quota", "required",
@@ -450,11 +448,6 @@ def interpret_vm_sku(payload: Any, request: Request) -> Outcome:
     return Outcome("blocked", "sku_unavailable_in_region", {"listed_skus": len(payload)})
 
 
-def interpret_vm_usage(payload: Any, outcomes: Dict[str, Outcome]) -> Outcome:
-    sku = outcomes["vm_sku_availability"].details
-    return interpret_usage(payload, [("cores", sku["vcpus"]), (sku["family"], sku["vcpus"])])
-
-
 def evaluate(check: PlannedCheck, result: CommandResult, outcomes: Dict[str, Outcome]) -> Outcome:
     if not result.executed or result.launch_failed or result.timed_out or result.oversized or result.exit_code != 0:
         return classify_failure(result)
@@ -462,6 +455,10 @@ def evaluate(check: PlannedCheck, result: CommandResult, outcomes: Dict[str, Out
         return check.interpret(json.loads(result.stdout), outcomes)
     except Exception:  # noqa: BLE001 - any unexpected payload shape fails closed as missing evidence
         return Outcome("unknown", "malformed_response")
+
+
+def subscription_digest(subscription: str) -> str:  # stable, non-identifying binding for downstream tools
+    return hashlib.sha256(f"horizon-preflight:{subscription.lower()}".encode()).hexdigest()[:16]
 
 
 def redact(value: Any, subscription: str) -> Any:
@@ -503,6 +500,7 @@ def run_preflight(request: Request, executor: Optional[Executor]) -> Dict[str, A
         "candidate": {"id": request.candidate, "name": CANDIDATES[request.candidate]["name"],
                       "vm_size": request.vm_size, "cpu_cores": request.cpu_cores, "memory_gb": request.memory_gb},
         "region": request.region, "subscription": "<subscription>", "status": status,
+        "subscription_digest": subscription_digest(request.subscription),
         "checks": [{"id": c.id, "title": c.title, "role": c.role, "operation": " ".join(c.argv[1:]),
                     **dataclasses.asdict(outcomes[c.id])} for c in plan],
         "blockers": [f"{c.id}: {outcomes[c.id].reason}" for c in plan if outcomes[c.id].outcome == "blocked"],

--- a/scripts/azure-workspace-preflight/preflight.py
+++ b/scripts/azure-workspace-preflight/preflight.py
@@ -49,12 +49,12 @@ FORBIDDEN_TOKENS = frozenset({"create", "delete", "start", "stop", "restart", "r
                               "set", "extension", "configure", "deployment", "update", "exec", "attach", "run-command"})
 _IDENTITY = ["Microsoft.ContainerRegistry", "Microsoft.ManagedIdentity"]
 CANDIDATES: Dict[str, Dict[str, Any]] = {
-    "aci": {"name": "Azure Container Instances container group (candidate, not selected)",
+    "aci": {"name": "Azure Container Instances container group (not selected 2026-09-10)",
             "required": ["Microsoft.ContainerInstance"],
             "supporting": _IDENTITY + ["Microsoft.Storage", "Microsoft.Network"]},
-    "vm": {"name": "Azure Linux virtual machine with managed disk (candidate, not selected)",
+    "vm": {"name": "Azure Linux VM with managed disk (revalidated candidate 2026-09-10; acceptance open)",
            "required": ["Microsoft.Compute", "Microsoft.Network"], "supporting": _IDENTITY + ["Microsoft.DevTestLab"]},
-    "container-apps": {"name": "Azure Container Apps long-running app (candidate, not selected; Jobs excluded)",
+    "container-apps": {"name": "Azure Container Apps long-running app (not selected 2026-09-10; Jobs excluded)",
                        "required": ["Microsoft.App", "Microsoft.Network"],
                        "supporting": _IDENTITY + ["Microsoft.Storage", "Microsoft.OperationalInsights"]},
 }

--- a/scripts/azure-workspace-preflight/preflight.py
+++ b/scripts/azure-workspace-preflight/preflight.py
@@ -49,7 +49,7 @@ CANDIDATES: Dict[str, Dict[str, Any]] = {
             "required": ["Microsoft.ContainerInstance"],
             "supporting": _IDENTITY + ["Microsoft.Storage", "Microsoft.Network"]},
     "vm": {"name": "Azure Linux VM with managed disk (revalidated candidate 2026-09-10; acceptance open)",
-           "required": ["Microsoft.Compute", "Microsoft.Network"], "supporting": _IDENTITY + ["Microsoft.DevTestLab"]},
+           "required": ["Microsoft.Compute", "Microsoft.Network"], "supporting": _IDENTITY + ["Microsoft.DevTestLab", "Microsoft.Automation"]},
     "container-apps": {"name": "Azure Container Apps long-running app (not selected 2026-09-10; Jobs excluded)",
                        "required": ["Microsoft.App", "Microsoft.Network"],
                        "supporting": _IDENTITY + ["Microsoft.Storage", "Microsoft.OperationalInsights"]},

--- a/scripts/azure-workspace-preflight/tests/test_preflight.py
+++ b/scripts/azure-workspace-preflight/tests/test_preflight.py
@@ -228,6 +228,8 @@ class InterpretationTests(Harness):
                 self.assertIn(word, gates)
             self.assertNotIn("ready", report["status"])
             self.assertEqual(report["subscription"], "<subscription>")
+            self.assertEqual((report["subscription_digest"], SUB[:8] in report["subscription_digest"]),
+                             (preflight.subscription_digest(SUB), False))
             self.assertEqual(report["schema_version"], preflight.REPORT_SCHEMA_VERSION)
             self.assertIsNotNone(report["observed_at"])
         self.popen.assert_not_called()

--- a/scripts/azure-workspace-preflight/tests/test_preflight.py
+++ b/scripts/azure-workspace-preflight/tests/test_preflight.py
@@ -3,6 +3,7 @@
 Every test uses synthetic fixtures or an injected executor. Nothing here invokes
 the Azure CLI, needs credentials or inspects the operator's account.
 """
+import hashlib
 import io
 import json
 import os
@@ -90,8 +91,7 @@ class Harness(unittest.TestCase):
         self.assertEqual(err, "")
         return code, json.loads(out)
 
-    def check(self, report, check_id):
-        return next(c for c in report["checks"] if c["id"] == check_id)
+    def check(self, report, check_id): return next(c for c in report["checks"] if c["id"] == check_id)  # noqa: E704
 
 
 class OfflineAndInputTests(Harness):
@@ -229,7 +229,7 @@ class InterpretationTests(Harness):
             self.assertNotIn("ready", report["status"])
             self.assertEqual(report["subscription"], "<subscription>")
             self.assertEqual((report["subscription_digest"], SUB[:8] in report["subscription_digest"]),
-                             (preflight.subscription_digest(SUB), False))
+                             (hashlib.sha256(f"horizon-preflight:{SUB}".encode()).hexdigest()[:16], False))
             self.assertEqual(report["schema_version"], preflight.REPORT_SCHEMA_VERSION)
             self.assertIsNotNone(report["observed_at"])
         self.popen.assert_not_called()

--- a/scripts/azure-workspace-preflight/tests/test_preflight.py
+++ b/scripts/azure-workspace-preflight/tests/test_preflight.py
@@ -91,7 +91,8 @@ class Harness(unittest.TestCase):
         self.assertEqual(err, "")
         return code, json.loads(out)
 
-    def check(self, report, check_id): return next(c for c in report["checks"] if c["id"] == check_id)  # noqa: E704
+    def check(self, report, check_id):
+        return next(c for c in report["checks"] if c["id"] == check_id)
 
 
 class OfflineAndInputTests(Harness):
@@ -174,9 +175,7 @@ class PlanningTests(Harness):
 
 
 @unittest.skipUnless(os.name == "posix", "the live executor is POSIX-only by design")
-class ExecutorTests(unittest.TestCase):
-    """Real subprocess boundary, exercised with the Python interpreter instead of the Azure CLI."""
-
+class ExecutorTests(unittest.TestCase):  # real subprocess boundary, driven with the Python interpreter, not az
     def test_arguments_pass_without_shell_expansion_and_time_and_output_are_bounded(self):
         run = preflight.subprocess_executor
         literal = run([sys.executable, "-c", "import sys; print(sys.argv[1])", "$HOME `id` ; touch x"], 20)

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -3,8 +3,8 @@
 Bounded, journaled, self-cleaning spike harness for the Azure CPU lane of
 [#474](https://github.com/peters/horizon/issues/474). It creates **one exact
 task-owned resource group per sample**, measures the timings #474 asks for, checks
-the on-worker storage and retention behaviour, deletes the sample and proves the
-subscription inventory is unchanged. Run
+the on-worker storage and retention behaviour, deletes the sample and proves that
+no pre-existing resource disappeared and nothing remains under the sample group. Run
 [`scripts/azure-workspace-preflight`](../azure-workspace-preflight/README.md) first.
 
 `--max-minutes` (default 120) bounds the **active phase**: every blocking call runs
@@ -58,7 +58,8 @@ leaves the sample resource group for manual inspection; delete it yourself.
    `00000000-0000-0000-0000-000000000000` user; pulls the image by digest; creates and
    starts the worker container with the data disk bound at `/workspace` and the client
    public key in `HORIZON_SSH_PUBLIC_KEY`, publishing container port 22 on VM port 2222.
-   Right after creation it schedules Azure VM auto-shutdown at the lifetime deadline.
+   Right after creation it schedules Azure VM auto-shutdown at the lifetime deadline;
+   if that cannot be scheduled the sample is deleted immediately (even with `--keep`).
 4. Opens VM port 2222 only from the caller's egress address (or `--allow-ssh-from`).
 5. Waits for the endpoint, reads the worker's Ed25519 host key **out of band** through
    ARM-authenticated `az vm run-command` from the retained

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -13,6 +13,8 @@ never publishes an image and touches nothing outside the sample resource group.
 
 ## Prerequisites
 
+- A GNU/Linux controller (the harness uses GNU `timeout`, `date -d` and millisecond
+  `%N` timestamps; stock macOS tools do not provide them).
 - `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `ssh-keyscan`, `nc`, `jq`, `curl`.
 - A worker image published by digest to an Azure Container Registry in the same
   subscription. The image build is documented in

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -18,7 +18,10 @@ runbook running every 15 minutes with a power-only identity that deallocates eve
 VM tagged `purpose=horizon-azure-vm-spike` whose `deadline` tag (UTC) has passed.
 Every spike VM carries both tags in the same create call, so a VM cannot exist
 without them, and the harness refuses to create anything unless the reaper's
-schedule is present and enabled (journaled as `reaper_present`). `--prove-reaper`
+15-minute schedule is enabled with a future run, its identity holds the power-only
+role, and the published runbook is byte-identical to
+[`reaper-runbook.ps1`](reaper-runbook.ps1) (journaled as `reaper_present` with the
+content hash). `--prove-reaper`
 moves a sample's deadline tag into the past after the restart checks and requires
 the reaper alone to deallocate the VM within 25 minutes (gate `reaper_bound`).
 Maximum compute exposure after a lost controller is therefore the deadline plus one

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -11,16 +11,28 @@ the group is gone with nothing left under it and no pre-existing resource missin
 under the remaining time and, once it expires, the harness stops measuring, deletes
 the sample and exits 4. Two exceptions extend exposure and must be included when
 calculating the maximum: cleanup has its own fixed 25-minute bound, and `--keep`
-skips deletion entirely. Compute is additionally bounded without this controller:
-before any compute exists the harness grants the worker identity the built-in
-power-only role `Desktop Virtualization Power On Off Contributor` on the sample
-group (the assignment lives and dies with the group), and the VM's own cloud-init
-arms a systemd timer as its first step, before Docker or the image pull, that
-deallocates the VM through ARM one minute after the deadline. Each sample proves this
-by firing that service once and observing `PowerState/deallocated`. The deployment
-also creates an Azure VM auto-shutdown schedule at the same time as a second stop;
-it is created after the VM, so it is a backstop, not the primary bound. In every
-case disks and the static IP persist until the tagged resource group
+skips deletion entirely. Compute is bounded independently of this controller by a
+mechanism that exists **before** any spike VM does: the subscription-side reaper
+created once by [`setup-spike-reaper.sh`](setup-spike-reaper.sh), an Azure Automation
+runbook running every 15 minutes with a power-only identity that deallocates every
+VM tagged `purpose=horizon-azure-vm-spike` whose `deadline` tag (UTC) has passed.
+Every spike VM carries both tags in the same create call, so a VM cannot exist
+without them, and the harness refuses to create anything unless the reaper's
+schedule is present and enabled (journaled as `reaper_present`). `--prove-reaper`
+moves a sample's deadline tag into the past after the restart checks and requires
+the reaper alone to deallocate the VM within 25 minutes (gate `reaper_bound`).
+Maximum compute exposure after a lost controller is therefore the deadline plus one
+reaper interval plus the deallocate time.
+
+Two further layers are defense in depth, not the primary bound: the VM's identity
+gets the built-in power-only role `Desktop Virtualization Power On Off Contributor`
+on the sample group before the deployment and the VM's cloud-init arms a systemd
+timer as its first `runcmd` step (before Docker or the pull) that deallocates the VM
+one minute after the deadline, proven per sample by verifying the timer is enabled
+and active, firing it once and observing `PowerState/deallocated` (gate
+`guest_lifetime_bound`); and the deployment also creates an Azure VM auto-shutdown
+schedule, which depends on the VM and is therefore only a backstop. In every case
+disks and the static IP persist until the tagged resource group
 (`horizon-spike-474-*`, tag `deadline`) is deleted by hand. It never registers a provider, never publishes
 an image and touches nothing outside the sample resource group.
 
@@ -29,8 +41,13 @@ an image and touches nothing outside the sample resource group.
 - A GNU/Linux controller (the harness uses GNU `timeout`, `date -d` and millisecond
   `%N` timestamps; stock macOS tools do not provide them).
 - `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `ssh-keyscan`, `nc`, `jq`, `curl`, `timeout`.
+- The subscription-side reaper, created once with
+  `scripts/azure-workspace-spike/setup-spike-reaper.sh --subscription <uuid>` (Automation
+  account `horizon-spike-reaper` in `horizon-worker-registry` by default; override with
+  `--reaper-resource-group` and `--reaper-account`). It needs `Microsoft.Automation`
+  registered and rights to assign the power-only role at subscription scope.
 - `Microsoft.DevTestLab` registered in the subscription (read-only check; the harness never
-  registers providers), because the platform-side auto-shutdown is a DevTestLab schedule.
+  registers providers), because the backstop auto-shutdown is a DevTestLab schedule.
 - A worker image published by digest to an Azure Container Registry in the same
   subscription. The image build is documented in
   [`containers/remote-worker/README.md`](../../containers/remote-worker/README.md).
@@ -75,7 +92,8 @@ because the deletion gate was skipped. `--sample` accepts
    the caller's egress address only), virtual network, Standard static public IP, NIC,
    the Linux VM (`Canonical:ubuntu-24_04-lts:server`, key-only SSH, the pull identity
    assigned, a 32 GiB data disk) and the DevTestLab auto-shutdown schedule set one
-   minute after the lifetime deadline. Before that deployment the power-only role
+   minute after the lifetime deadline. The VM is tagged `purpose=horizon-azure-vm-spike`
+   and `deadline=<UTC>` in that same call. Before the deployment the power-only role
    above is granted on the group. The VM's cloud-init first arms the self-deallocate
    timer, then formats and mounts the data
    disk as ext4 at `/mnt/horizon-workspace`; installs Docker; exchanges the identity's
@@ -109,11 +127,10 @@ because the deletion gate was skipped. `--sample` accepts
    failure after creation still deletes the sample.
 
 Exit codes: `0` every gate held; `1` a setup or provider failure before the gates (for
-example `Microsoft.DevTestLab` not registered, so the platform-side stop cannot be
-scheduled; cleanup still runs); `3` usage; `4` lifetime bound reached; `5` the worker
+example the reaper missing or `Microsoft.DevTestLab` not registered; cleanup still runs); `3` usage; `4` lifetime bound reached; `5` the worker
 never published a host key; `6` deletion not proven; `7` a functional gate failed
 (storage qualifier, storage negative control, detach independence, deallocate, retention,
-guest lifetime bound)
+guest lifetime bound, and reaper bound when `--prove-reaper` is given)
 with evidence journaled; `130` interrupted (cleanup still runs). Any other status is
 normalized to `1`. Any failure after the active-phase bound expired reports `4`, and an
 unproven deletion always wins: exit `6` replaces any other code. Every blocking `az` and

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -11,11 +11,17 @@ the group is gone with nothing left under it and no pre-existing resource missin
 under the remaining time and, once it expires, the harness stops measuring, deletes
 the sample and exits 4. Two exceptions extend exposure and must be included when
 calculating the maximum: cleanup has its own fixed 25-minute bound, and `--keep`
-skips deletion entirely. As an independent safety net the deployment that creates
-the VM also creates an Azure VM auto-shutdown schedule one minute after the deadline,
-so compute is deallocated by the platform even if this controller process dies; disks and the
-static IP then persist until the tagged resource group (`horizon-spike-474-*`,
-tag `deadline`) is deleted by hand. It never registers a provider, never publishes
+skips deletion entirely. Compute is additionally bounded without this controller:
+before any compute exists the harness grants the worker identity the built-in
+power-only role `Desktop Virtualization Power On Off Contributor` on the sample
+group (the assignment lives and dies with the group), and the VM's own cloud-init
+arms a systemd timer as its first step, before Docker or the image pull, that
+deallocates the VM through ARM one minute after the deadline. Each sample proves this
+by firing that service once and observing `PowerState/deallocated`. The deployment
+also creates an Azure VM auto-shutdown schedule at the same time as a second stop;
+it is created after the VM, so it is a backstop, not the primary bound. In every
+case disks and the static IP persist until the tagged resource group
+(`horizon-spike-474-*`, tag `deadline`) is deleted by hand. It never registers a provider, never publishes
 an image and touches nothing outside the sample resource group.
 
 ## Prerequisites
@@ -69,8 +75,9 @@ because the deletion gate was skipped. `--sample` accepts
    the caller's egress address only), virtual network, Standard static public IP, NIC,
    the Linux VM (`Canonical:ubuntu-24_04-lts:server`, key-only SSH, the pull identity
    assigned, a 32 GiB data disk) and the DevTestLab auto-shutdown schedule set one
-   minute after the lifetime deadline, so a controller that dies mid-creation cannot
-   leave compute without the platform-side stop. The VM's cloud-init formats and mounts the data
+   minute after the lifetime deadline. Before that deployment the power-only role
+   above is granted on the group. The VM's cloud-init first arms the self-deallocate
+   timer, then formats and mounts the data
    disk as ext4 at `/mnt/horizon-workspace`; installs Docker; exchanges the identity's
    IMDS token for a registry refresh token and logs in with the documented
    `00000000-0000-0000-0000-000000000000` user; pulls the image by digest; creates and
@@ -94,7 +101,9 @@ because the deletion gate was skipped. `--sample` accepts
    the marker, the public IP, that the data disk is mounted in the container, and
    whether the tmux session survived (it does not: the container restarts; that is
    recorded, not hidden). A failed restart is journaled and guest diagnostics are
-   captured out of band; the phase is bounded to 10 minutes.
+   captured out of band; the phase is bounded to 10 minutes. It then fires the
+   guest's self-deallocate service once and requires the VM to reach
+   `PowerState/deallocated` (gate `guest_lifetime_bound`).
 9. Deletes the resource group (`--no-wait` plus `group wait --deleted`), confirms
    absence and evaluates the inventory proof above. Cleanup runs from an `EXIT` trap, so any
    failure after creation still deletes the sample.
@@ -103,7 +112,8 @@ Exit codes: `0` every gate held; `1` a setup or provider failure before the gate
 example `Microsoft.DevTestLab` not registered, so the platform-side stop cannot be
 scheduled; cleanup still runs); `3` usage; `4` lifetime bound reached; `5` the worker
 never published a host key; `6` deletion not proven; `7` a functional gate failed
-(storage qualifier, storage negative control, detach independence, deallocate, retention)
+(storage qualifier, storage negative control, detach independence, deallocate, retention,
+guest lifetime bound)
 with evidence journaled; `130` interrupted (cleanup still runs). Any other status is
 normalized to `1`. Any failure after the active-phase bound expired reports `4`, and an
 unproven deletion always wins: exit `6` replaces any other code. Every blocking `az` and
@@ -113,8 +123,8 @@ unproven deletion always wins: exit `6` replaces any other code. Every blocking 
 
 Everything lands under `--journal-dir/sample-<n>-<run-id>/` with mode 0700: the
 private client key, `cloud-init.yaml`, `deployment.json`, `deployment-result.json`, `run-command-hostkey.txt`, `qualifier-output.txt`,
-`guest-timing.jsonl` (boot, bootstrap, disk, registry login, pull, container create
-and start stamps from inside the VM), `storage-evidence.txt`, heartbeat counts and
+`guest-timing.jsonl` (boot, deadline timer armed, bootstrap, disk, registry login, pull,
+container create and start stamps from inside the VM), `self-deallocate.txt`, `storage-evidence.txt`, heartbeat counts and
 `journal.jsonl` with every controller-side event and millisecond offsets from `T0`
 (the resource-group create call). Journals contain the public IP and subscription
 scoped resource ids; keep them private and quote only redacted summaries.

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -7,9 +7,16 @@ the on-worker storage and retention behaviour, deletes the sample and proves the
 subscription inventory is unchanged. Run
 [`scripts/azure-workspace-preflight`](../azure-workspace-preflight/README.md) first.
 
-Paid creation is bounded by `--max-minutes` (default 120); when the bound is
-reached the harness deletes the sample and exits 4. It never registers a provider,
-never publishes an image and touches nothing outside the sample resource group.
+`--max-minutes` (default 120) bounds the **active phase**: every blocking call runs
+under the remaining time and, once it expires, the harness stops measuring, deletes
+the sample and exits 4. Two exceptions extend exposure and must be included when
+calculating the maximum: cleanup has its own fixed 25-minute bound, and `--keep`
+skips deletion entirely. As an independent safety net the harness schedules Azure
+VM auto-shutdown one minute after the deadline right after creation, so compute is
+deallocated by the platform even if this controller process dies; disks and the
+static IP then persist until the tagged resource group (`horizon-spike-474-*`,
+tag `deadline`) is deleted by hand. It never registers a provider, never publishes
+an image and touches nothing outside the sample resource group.
 
 ## Prerequisites
 
@@ -39,9 +46,11 @@ leaves the sample resource group for manual inspection; delete it yourself.
 
 ## What one sample does
 
-1. Snapshots the subscription resource inventory (`az resource list`).
+1. Snapshots the subscription resource inventory (`az resource list`), used at the end to
+   prove that no pre-existing resource disappeared and nothing remains under the sample
+   group; resources added meanwhile by other actors are counted, not blamed on the sample.
 2. Generates a fresh Ed25519 client key used only for this sample.
-3. Creates the resource group, then a Linux VM (`Canonical:ubuntu-24_04-lts:server`,
+3. Verifies the random group name is absent, creates the resource group, then a Linux VM (`Canonical:ubuntu-24_04-lts:server`,
    key-only SSH, Standard static public IP, no default NSG rules, the pull identity
    assigned, a 32 GiB data disk) with cloud-init that: formats and mounts the data
    disk as ext4 at `/mnt/horizon-workspace`; installs Docker; exchanges the identity's
@@ -49,6 +58,7 @@ leaves the sample resource group for manual inspection; delete it yourself.
    `00000000-0000-0000-0000-000000000000` user; pulls the image by digest; creates and
    starts the worker container with the data disk bound at `/workspace` and the client
    public key in `HORIZON_SSH_PUBLIC_KEY`, publishing container port 22 on VM port 2222.
+   Right after creation it schedules Azure VM auto-shutdown at the lifetime deadline.
 4. Opens VM port 2222 only from the caller's egress address (or `--allow-ssh-from`).
 5. Waits for the endpoint, reads the worker's Ed25519 host key **out of band** through
    ARM-authenticated `az vm run-command` from the retained
@@ -68,15 +78,15 @@ leaves the sample resource group for manual inspection; delete it yourself.
    recorded, not hidden). A failed restart is journaled and guest diagnostics are
    captured out of band; the phase is bounded to 10 minutes.
 9. Deletes the resource group (`--no-wait` plus `group wait --deleted`), confirms
-   absence and compares the inventory. Cleanup runs from an `EXIT` trap, so any
+   absence and evaluates the inventory proof above. Cleanup runs from an `EXIT` trap, so any
    failure after creation still deletes the sample.
 
 Exit codes: `0` every gate held; `3` usage; `4` lifetime bound reached; `5` the worker
 never published a host key; `6` deletion not proven; `7` a functional gate failed
 (storage qualifier, storage negative control, detach independence, deallocate, retention)
-with evidence journaled. An unproven deletion always wins: exit `6` replaces any other code.
-Every blocking `az` call runs under `timeout` with the remaining lifetime bound; cleanup has
-its own fixed 25-minute bound.
+with evidence journaled. Any failure after the active-phase bound expired reports `4`, and
+an unproven deletion always wins: exit `6` replaces any other code. Every blocking `az` and
+`ssh` call runs under `timeout` with the remaining bound.
 
 ## Journal
 

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -4,8 +4,7 @@ Bounded, journaled, self-cleaning spike harness for the Azure CPU lane of
 [#474](https://github.com/peters/horizon/issues/474). It creates **one exact
 task-owned resource group per sample**, measures the timings #474 asks for, checks
 the on-worker storage and retention behaviour, deletes the sample and proves that
-the group is gone with nothing left under it, journaling any concurrent changes
-made elsewhere in the shared subscription for cross-checking. Run
+the group is gone with nothing left under it and no pre-existing resource missing. Run
 [`scripts/azure-workspace-preflight`](../azure-workspace-preflight/README.md) first.
 
 `--max-minutes` (default 120) bounds the **active phase**: every blocking call runs
@@ -50,10 +49,11 @@ leaves the sample resource group for manual inspection; delete it yourself.
 ## What one sample does
 
 1. Snapshots the subscription resource inventory (`az resource list`), used at the end to
-   prove that nothing remains under the sample group. Every mutating call in the harness
-   names the sample group, so additions or removals elsewhere during the run belong to
-   other actors sharing the subscription; they are journaled (`inventory_proof`) for
-   cross-checking against the subscription activity log, not blamed on the sample.
+   prove #474's criterion: nothing remains under the sample group and no pre-existing
+   resource disappeared. Every mutating call names the sample group, so a disappearance
+   elsewhere is almost certainly another actor in a shared subscription, but the
+   inventory cannot attribute it; the proof is then reported as unverified (exit `6`,
+   `inventory_proof.reason`) and the sample must be rerun. Additions elsewhere are counted.
 2. Generates a fresh Ed25519 client key used only for this sample.
 3. Verifies the random group name is absent, creates the resource group, then a Linux VM (`Canonical:ubuntu-24_04-lts:server`,
    key-only SSH, Standard static public IP, no default NSG rules, the pull identity

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -39,12 +39,19 @@ scripts/azure-workspace-spike/run-vm-spike.sh \
   --image <registry>.azurecr.io/horizon-remote-worker@sha256:<digest> \
   --puller-identity-id /subscriptions/<subscription-uuid>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name> \
   --journal-dir /private/path/spike-journal \
+  --preflight-report /private/path/vm-northeurope.json \
   --sample 1 [--region northeurope] [--vm-size Standard_D4s_v3] [--max-minutes 120] \
   [--allow-ssh-from <cidr>] [--dry-run] [--keep]
 ```
 
-`--dry-run` renders the cloud-init and exits without creating anything. `--keep`
-leaves the sample resource group for manual inspection; delete it yourself.
+`--preflight-report` is the JSON written by `scripts/azure-workspace-preflight/preflight.py
+--candidate vm --live --report ...` for the same region and VM size; the harness
+refuses to create anything unless that report is a live `vm` report with
+`no_blockers_observed`, and it journals the report path, `observed_at`, tool version
+and its own git commit in the `start` event. `--dry-run` renders the cloud-init and
+exits without creating anything (the report is then optional). `--keep` leaves the
+sample resource group for manual inspection; delete it yourself. `--sample` accepts
+1 to 99 and only tags and names the journal.
 
 ## What one sample does
 

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -71,7 +71,10 @@ leaves the sample resource group for manual inspection; delete it yourself.
 
 Exit codes: `0` every gate held; `3` usage; `4` lifetime bound reached; `5` the worker
 never published a host key; `6` deletion not proven; `7` a functional gate failed
-(storage qualifier, detach independence, deallocate, retention) with evidence journaled.
+(storage qualifier, storage negative control, detach independence, deallocate, retention)
+with evidence journaled. An unproven deletion always wins: exit `6` replaces any other code.
+Every blocking `az` call runs under `timeout` with the remaining lifetime bound; cleanup has
+its own fixed 25-minute bound.
 
 ## Journal
 

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -22,7 +22,9 @@ an image and touches nothing outside the sample resource group.
 
 - A GNU/Linux controller (the harness uses GNU `timeout`, `date -d` and millisecond
   `%N` timestamps; stock macOS tools do not provide them).
-- `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `ssh-keyscan`, `nc`, `jq`, `curl`.
+- `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `ssh-keyscan`, `nc`, `jq`, `curl`, `timeout`.
+- `Microsoft.DevTestLab` registered in the subscription (read-only check; the harness never
+  registers providers), because the platform-side auto-shutdown is a DevTestLab schedule.
 - A worker image published by digest to an Azure Container Registry in the same
   subscription. The image build is documented in
   [`containers/remote-worker/README.md`](../../containers/remote-worker/README.md).
@@ -82,11 +84,14 @@ leaves the sample resource group for manual inspection; delete it yourself.
    absence and evaluates the inventory proof above. Cleanup runs from an `EXIT` trap, so any
    failure after creation still deletes the sample.
 
-Exit codes: `0` every gate held; `3` usage; `4` lifetime bound reached; `5` the worker
+Exit codes: `0` every gate held; `1` a setup or provider failure before the gates (for
+example `Microsoft.DevTestLab` not registered, so the platform-side stop cannot be
+scheduled; cleanup still runs); `3` usage; `4` lifetime bound reached; `5` the worker
 never published a host key; `6` deletion not proven; `7` a functional gate failed
 (storage qualifier, storage negative control, detach independence, deallocate, retention)
-with evidence journaled. Any failure after the active-phase bound expired reports `4`, and
-an unproven deletion always wins: exit `6` replaces any other code. Every blocking `az` and
+with evidence journaled; `130` interrupted (cleanup still runs). Any other status is
+normalized to `1`. Any failure after the active-phase bound expired reports `4`, and an
+unproven deletion always wins: exit `6` replaces any other code. Every blocking `az` and
 `ssh` call runs under `timeout` with the remaining bound.
 
 ## Journal

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -47,7 +47,7 @@ scripts/azure-workspace-spike/run-vm-spike.sh \
 `--preflight-report` is the JSON written by `scripts/azure-workspace-preflight/preflight.py
 --candidate vm --live --report ...` for the same region and VM size; the harness
 refuses to create anything unless that report is a live `vm` report with
-`no_blockers_observed`, and it journals the report path, `observed_at`, tool version
+`no_blockers_observed` whose `subscription_digest` matches `--subscription`, and it journals the report path, `observed_at`, tool version
 and its own git commit in the `start` event. `--dry-run` renders the cloud-init and
 exits without creating anything (the report is then optional). `--keep` leaves the
 sample resource group for manual inspection; delete it yourself. `--sample` accepts

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -4,7 +4,8 @@ Bounded, journaled, self-cleaning spike harness for the Azure CPU lane of
 [#474](https://github.com/peters/horizon/issues/474). It creates **one exact
 task-owned resource group per sample**, measures the timings #474 asks for, checks
 the on-worker storage and retention behaviour, deletes the sample and proves that
-no pre-existing resource disappeared and nothing remains under the sample group. Run
+the group is gone with nothing left under it, journaling any concurrent changes
+made elsewhere in the shared subscription for cross-checking. Run
 [`scripts/azure-workspace-preflight`](../azure-workspace-preflight/README.md) first.
 
 `--max-minutes` (default 120) bounds the **active phase**: every blocking call runs
@@ -49,8 +50,10 @@ leaves the sample resource group for manual inspection; delete it yourself.
 ## What one sample does
 
 1. Snapshots the subscription resource inventory (`az resource list`), used at the end to
-   prove that no pre-existing resource disappeared and nothing remains under the sample
-   group; resources added meanwhile by other actors are counted, not blamed on the sample.
+   prove that nothing remains under the sample group. Every mutating call in the harness
+   names the sample group, so additions or removals elsewhere during the run belong to
+   other actors sharing the subscription; they are journaled (`inventory_proof`) for
+   cross-checking against the subscription activity log, not blamed on the sample.
 2. Generates a fresh Ed25519 client key used only for this sample.
 3. Verifies the random group name is absent, creates the resource group, then a Linux VM (`Canonical:ubuntu-24_04-lts:server`,
    key-only SSH, Standard static public IP, no default NSG rules, the pull identity

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -1,0 +1,81 @@
+# Azure Linux VM workspace spike
+
+Bounded, journaled, self-cleaning spike harness for the Azure CPU lane of
+[#474](https://github.com/peters/horizon/issues/474). It creates **one exact
+task-owned resource group per sample**, measures the timings #474 asks for, checks
+the on-worker storage and retention behaviour, deletes the sample and proves the
+subscription inventory is unchanged. Run
+[`scripts/azure-workspace-preflight`](../azure-workspace-preflight/README.md) first.
+
+Paid creation is bounded by `--max-minutes` (default 120); when the bound is
+reached the harness deletes the sample and exits 4. It never registers a provider,
+never publishes an image and touches nothing outside the sample resource group.
+
+## Prerequisites
+
+- `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `nc`, `jq`, `curl`.
+- A worker image published by digest to an Azure Container Registry in the same
+  subscription. The image build is documented in
+  [`containers/remote-worker/README.md`](../../containers/remote-worker/README.md).
+- A user-assigned managed identity with `AcrPull` on that registry (pull-only; no
+  registry password or admin user). The harness assigns it to each sample VM.
+
+## Usage
+
+```bash
+scripts/azure-workspace-spike/run-vm-spike.sh \
+  --subscription <subscription-uuid> \
+  --image <registry>.azurecr.io/horizon-remote-worker@sha256:<digest> \
+  --puller-identity-id /subscriptions/<subscription-uuid>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name> \
+  --journal-dir /private/path/spike-journal \
+  --sample 1 [--region northeurope] [--vm-size Standard_D4s_v3] [--max-minutes 120] \
+  [--allow-ssh-from <cidr>] [--dry-run] [--keep]
+```
+
+`--dry-run` renders the cloud-init and exits without creating anything. `--keep`
+leaves the sample resource group for manual inspection; delete it yourself.
+
+## What one sample does
+
+1. Snapshots the subscription resource inventory (`az resource list`).
+2. Generates a fresh Ed25519 client key used only for this sample.
+3. Creates the resource group, then a Linux VM (`Canonical:ubuntu-24_04-lts:server`,
+   key-only SSH, Standard static public IP, no default NSG rules, the pull identity
+   assigned, a 32 GiB data disk) with cloud-init that: formats and mounts the data
+   disk as ext4 at `/mnt/horizon-workspace`; installs Docker; exchanges the identity's
+   IMDS token for a registry refresh token and logs in with the documented
+   `00000000-0000-0000-0000-000000000000` user; pulls the image by digest; creates and
+   starts the worker container with the data disk bound at `/workspace` and the client
+   public key in `HORIZON_SSH_PUBLIC_KEY`, publishing container port 22 on VM port 2222.
+4. Opens VM port 2222 only from the caller's egress address (or `--allow-ssh-from`).
+5. Waits for the endpoint, reads the worker's Ed25519 host key **out of band** through
+   ARM-authenticated `az vm run-command` from the retained
+   `/workspace/.horizon-worker/ssh` directory, pins it, and verifies key-only SSH with
+   `StrictHostKeyChecking=yes`.
+6. Records `/proc/fs/ext4/<device>/options`, the mount line and sysfs path for the
+   worker's `/workspace`, and applies a shell mirror of the Rust qualifier's rules
+   (`rw`, `barrier`, exactly one accepted `data=`, no `ro`/`nobarrier`). The Rust
+   qualifier remains authoritative; the mirror only classifies evidence.
+7. Starts a tmux heartbeat, disconnects for 20 s, reconnects and checks progress.
+8. Writes a marker, `az vm deallocate`, `az vm start`, reconnects with the same
+   pinned host key and checks the marker, the public IP and whether the tmux session
+   survived (it does not: the container restarts; that is recorded, not hidden).
+9. Deletes the resource group, waits for absence and compares the inventory.
+
+## Journal
+
+Everything lands under `--journal-dir/sample-<n>-<run-id>/` with mode 0700: the
+private client key, `cloud-init.yaml`, `vm-create.json`, `run-command-hostkey.json`,
+`guest-timing.jsonl` (boot, bootstrap, disk, registry login, pull, container create
+and start stamps from inside the VM), `storage-evidence.txt`, heartbeat counts and
+`journal.jsonl` with every controller-side event and millisecond offsets from `T0`
+(the resource-group create call). Journals contain the public IP and subscription
+scoped resource ids; keep them private and quote only redacted summaries.
+
+## What a passing sample does not prove
+
+A sample proves the measured path for that VM at that time. It does not prove
+regional capacity, that a different VM size or region behaves the same, that the
+worker's own sessions survive a Stop (they do not; only data does), PC-off task
+progress over hours, or the Horizon adapter's own create-once and reconcile
+behaviour. Those remain the acceptance items in #474.

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -27,8 +27,9 @@ reaper interval plus the deallocate time.
 Two further layers are defense in depth, not the primary bound: the VM's identity
 gets the built-in power-only role `Desktop Virtualization Power On Off Contributor`
 on the sample group before the deployment and the VM's cloud-init arms a systemd
-timer as its first `runcmd` step (before Docker or the pull) that deallocates the VM
-one minute after the deadline, proven per sample by verifying the timer is enabled
+timer as its first `runcmd` step (after the package module has installed Docker,
+before the workspace bootstrap and the image pull) that deallocates the VM one minute
+after the deadline, proven per sample by verifying the timer is enabled
 and active, firing it once and observing `PowerState/deallocated` (gate
 `guest_lifetime_bound`); and the deployment also creates an Azure VM auto-shutdown
 schedule, which depends on the VM and is therefore only a backstop. In every case
@@ -64,13 +65,18 @@ scripts/azure-workspace-spike/run-vm-spike.sh \
   --journal-dir /private/path/spike-journal \
   --preflight-report /private/path/vm-northeurope.json \
   --sample 1 [--region northeurope] [--vm-size Standard_D4s_v3] [--max-minutes 120] \
-  [--allow-ssh-from <cidr>] [--dry-run] [--keep]
+  [--allow-ssh-from <ipv4-cidr>] [--reaper-resource-group <rg>] [--reaper-account <name>] \
+  [--prove-reaper] [--dry-run] [--keep]
 ```
+
+`--allow-ssh-from` must be a specific IPv4 network (prefix `/8` or longer); `*`,
+service tags and the whole internet are rejected before anything is created.
 
 `--preflight-report` is the JSON written by `scripts/azure-workspace-preflight/preflight.py
 --candidate vm --live --report ...` for the same region and VM size; the harness
 refuses to create anything unless that report is a live `vm` report with
-`no_blockers_observed` whose `subscription_digest` matches `--subscription`, and it journals the report path, `observed_at`, tool version
+`no_blockers_observed`, schema version 1, a `subscription_digest` matching
+`--subscription`, and an `observed_at` at most 24 hours old, and it journals the report path, `observed_at`, tool version
 and its own git commit (plus whether the harness directory had uncommitted changes) in
 the `start` event. `--dry-run` renders the cloud-init and
 exits without creating anything (the report is then optional). `--keep` leaves the
@@ -94,9 +100,9 @@ because the deletion gate was skipped. `--sample` accepts
    assigned, a 32 GiB data disk) and the DevTestLab auto-shutdown schedule set one
    minute after the lifetime deadline. The VM is tagged `purpose=horizon-azure-vm-spike`
    and `deadline=<UTC>` in that same call. Before the deployment the power-only role
-   above is granted on the group. The VM's cloud-init first arms the self-deallocate
-   timer, then formats and mounts the data
-   disk as ext4 at `/mnt/horizon-workspace`; installs Docker; exchanges the identity's
+   above is granted on the group. The VM's cloud-init installs Docker (package module),
+   arms the self-deallocate timer as the first `runcmd` step, then formats and mounts
+   the data disk as ext4 at `/mnt/horizon-workspace`; exchanges the identity's
    IMDS token for a registry refresh token and logs in with the documented
    `00000000-0000-0000-0000-000000000000` user; pulls the image by digest; creates and
    starts the worker container with the data disk bound at `/workspace` and the client
@@ -138,7 +144,7 @@ unproven deletion always wins: exit `6` replaces any other code. Every blocking 
 
 ## Journal
 
-Everything lands under `--journal-dir/sample-<n>-<run-id>/` with mode 0700: the
+Everything lands under `--journal-dir/sample-<n>-<run-id>-<token>/` with mode 0700: the
 private client key, `cloud-init.yaml`, `deployment.json`, `deployment-result.json`, `run-command-hostkey.txt`, `qualifier-output.txt`,
 `guest-timing.jsonl` (boot, deadline timer armed, bootstrap, disk, registry login, pull,
 container create and start stamps from inside the VM), `self-deallocate.txt`, `storage-evidence.txt`, heartbeat counts and

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -11,9 +11,9 @@ the group is gone with nothing left under it and no pre-existing resource missin
 under the remaining time and, once it expires, the harness stops measuring, deletes
 the sample and exits 4. Two exceptions extend exposure and must be included when
 calculating the maximum: cleanup has its own fixed 25-minute bound, and `--keep`
-skips deletion entirely. As an independent safety net the harness schedules Azure
-VM auto-shutdown one minute after the deadline right after creation, so compute is
-deallocated by the platform even if this controller process dies; disks and the
+skips deletion entirely. As an independent safety net the deployment that creates
+the VM also creates an Azure VM auto-shutdown schedule one minute after the deadline,
+so compute is deallocated by the platform even if this controller process dies; disks and the
 static IP then persist until the tagged resource group (`horizon-spike-474-*`,
 tag `deadline`) is deleted by hand. It never registers a provider, never publishes
 an image and touches nothing outside the sample resource group.
@@ -48,7 +48,8 @@ scripts/azure-workspace-spike/run-vm-spike.sh \
 --candidate vm --live --report ...` for the same region and VM size; the harness
 refuses to create anything unless that report is a live `vm` report with
 `no_blockers_observed` whose `subscription_digest` matches `--subscription`, and it journals the report path, `observed_at`, tool version
-and its own git commit in the `start` event. `--dry-run` renders the cloud-init and
+and its own git commit (plus whether the harness directory had uncommitted changes) in
+the `start` event. `--dry-run` renders the cloud-init and
 exits without creating anything (the report is then optional). `--keep` leaves the
 sample resource group for manual inspection; delete it yourself, and expect exit `6`
 because the deletion gate was skipped. `--sample` accepts
@@ -63,17 +64,20 @@ because the deletion gate was skipped. `--sample` accepts
    inventory cannot attribute it; the proof is then reported as unverified (exit `6`,
    `inventory_proof.reason`) and the sample must be rerun. Additions elsewhere are counted.
 2. Generates a fresh Ed25519 client key used only for this sample.
-3. Verifies the random group name is absent, creates the resource group, then a Linux VM (`Canonical:ubuntu-24_04-lts:server`,
-   key-only SSH, Standard static public IP, no default NSG rules, the pull identity
-   assigned, a 32 GiB data disk) with cloud-init that: formats and mounts the data
+3. Verifies the random group name is absent, creates the resource group, then submits
+   **one server-side deployment** containing the network security group (port 2222 from
+   the caller's egress address only), virtual network, Standard static public IP, NIC,
+   the Linux VM (`Canonical:ubuntu-24_04-lts:server`, key-only SSH, the pull identity
+   assigned, a 32 GiB data disk) and the DevTestLab auto-shutdown schedule set one
+   minute after the lifetime deadline, so a controller that dies mid-creation cannot
+   leave compute without the platform-side stop. The VM's cloud-init formats and mounts the data
    disk as ext4 at `/mnt/horizon-workspace`; installs Docker; exchanges the identity's
    IMDS token for a registry refresh token and logs in with the documented
    `00000000-0000-0000-0000-000000000000` user; pulls the image by digest; creates and
    starts the worker container with the data disk bound at `/workspace` and the client
    public key in `HORIZON_SSH_PUBLIC_KEY`, publishing container port 22 on VM port 2222.
-   Right after creation it schedules Azure VM auto-shutdown at the lifetime deadline;
-   if that cannot be scheduled the sample is deleted immediately (even with `--keep`).
-4. Opens VM port 2222 only from the caller's egress address (or `--allow-ssh-from`).
+4. (Port 2222 is opened by the deployment's security rule, from the caller's egress
+   address or `--allow-ssh-from`; nothing is opened afterwards.)
 5. Waits for the endpoint, reads the worker's Ed25519 host key **out of band** through
    ARM-authenticated `az vm run-command` from the retained
    `/workspace/.horizon-worker/ssh` directory, pins it, and verifies key-only SSH with
@@ -108,7 +112,7 @@ unproven deletion always wins: exit `6` replaces any other code. Every blocking 
 ## Journal
 
 Everything lands under `--journal-dir/sample-<n>-<run-id>/` with mode 0700: the
-private client key, `cloud-init.yaml`, `vm-create.json`, `run-command-hostkey.txt`, `qualifier-output.txt`,
+private client key, `cloud-init.yaml`, `deployment.json`, `deployment-result.json`, `run-command-hostkey.txt`, `qualifier-output.txt`,
 `guest-timing.jsonl` (boot, bootstrap, disk, registry login, pull, container create
 and start stamps from inside the VM), `storage-evidence.txt`, heartbeat counts and
 `journal.jsonl` with every controller-side event and millisecond offsets from `T0`

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -50,7 +50,8 @@ refuses to create anything unless that report is a live `vm` report with
 `no_blockers_observed` whose `subscription_digest` matches `--subscription`, and it journals the report path, `observed_at`, tool version
 and its own git commit in the `start` event. `--dry-run` renders the cloud-init and
 exits without creating anything (the report is then optional). `--keep` leaves the
-sample resource group for manual inspection; delete it yourself. `--sample` accepts
+sample resource group for manual inspection; delete it yourself, and expect exit `6`
+because the deletion gate was skipped. `--sample` accepts
 1 to 99 and only tags and names the journal.
 
 ## What one sample does

--- a/scripts/azure-workspace-spike/README.md
+++ b/scripts/azure-workspace-spike/README.md
@@ -13,7 +13,7 @@ never publishes an image and touches nothing outside the sample resource group.
 
 ## Prerequisites
 
-- `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `nc`, `jq`, `curl`.
+- `az` logged in to the target subscription; `ssh`, `ssh-keygen`, `ssh-keyscan`, `nc`, `jq`, `curl`.
 - A worker image published by digest to an Azure Container Registry in the same
   subscription. The image build is documented in
   [`containers/remote-worker/README.md`](../../containers/remote-worker/README.md).
@@ -52,20 +52,31 @@ leaves the sample resource group for manual inspection; delete it yourself.
    ARM-authenticated `az vm run-command` from the retained
    `/workspace/.horizon-worker/ssh` directory, pins it, and verifies key-only SSH with
    `StrictHostKeyChecking=yes`.
-6. Records `/proc/fs/ext4/<device>/options`, the mount line and sysfs path for the
-   worker's `/workspace`, and applies a shell mirror of the Rust qualifier's rules
-   (`rw`, `barrier`, exactly one accepted `data=`, no `ro`/`nobarrier`). The Rust
-   qualifier remains authoritative; the mirror only classifies evidence.
+6. Records `/proc/fs/ext4/<device>/options` and the mount line for the worker's
+   `/workspace`, applies a shell mirror of the qualifier's rules for the journal, and
+   runs the **authoritative** qualifier: `horizon-repository setup-status` against a
+   fresh 0700 retained root on the data disk (expected `status: absent`) and, as a
+   negative control, against a root on the container's overlay filesystem (expected
+   `status: error`). The storage gate passes only on the authoritative result.
 7. Starts a tmux heartbeat, disconnects for 20 s, reconnects and checks progress.
-8. Writes a marker, `az vm deallocate`, `az vm start`, reconnects with the same
-   pinned host key and checks the marker, the public IP and whether the tmux session
-   survived (it does not: the container restarts; that is recorded, not hidden).
-9. Deletes the resource group, waits for absence and compares the inventory.
+8. Writes a marker, `az vm deallocate`, `az vm start`, re-reads the host key with
+   `ssh-keyscan` and compares it with the pinned key before reconnecting, then checks
+   the marker, the public IP, that the data disk is mounted in the container, and
+   whether the tmux session survived (it does not: the container restarts; that is
+   recorded, not hidden). A failed restart is journaled and guest diagnostics are
+   captured out of band; the phase is bounded to 10 minutes.
+9. Deletes the resource group (`--no-wait` plus `group wait --deleted`), confirms
+   absence and compares the inventory. Cleanup runs from an `EXIT` trap, so any
+   failure after creation still deletes the sample.
+
+Exit codes: `0` every gate held; `3` usage; `4` lifetime bound reached; `5` the worker
+never published a host key; `6` deletion not proven; `7` a functional gate failed
+(storage qualifier, detach independence, deallocate, retention) with evidence journaled.
 
 ## Journal
 
 Everything lands under `--journal-dir/sample-<n>-<run-id>/` with mode 0700: the
-private client key, `cloud-init.yaml`, `vm-create.json`, `run-command-hostkey.json`,
+private client key, `cloud-init.yaml`, `vm-create.json`, `run-command-hostkey.txt`, `qualifier-output.txt`,
 `guest-timing.jsonl` (boot, bootstrap, disk, registry login, pull, container create
 and start stamps from inside the VM), `storage-evidence.txt`, heartbeat counts and
 `journal.jsonl` with every controller-side event and millisecond offsets from `T0`

--- a/scripts/azure-workspace-spike/reaper-runbook.ps1
+++ b/scripts/azure-workspace-spike/reaper-runbook.ps1
@@ -1,6 +1,10 @@
+param([Parameter(Mandatory = $true)][string]$SubscriptionId)
 $ErrorActionPreference = 'Stop'
+if ($SubscriptionId -notmatch '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') { throw "SubscriptionId must be a UUID" }
 Disable-AzContextAutosave -Scope Process | Out-Null
-Connect-AzAccount -Identity | Out-Null
+Connect-AzAccount -Identity -Subscription $SubscriptionId | Out-Null
+$context = Set-AzContext -Subscription $SubscriptionId
+if ($context.Subscription.Id -ne $SubscriptionId) { throw "Az context is $($context.Subscription.Id), expected $SubscriptionId" }
 $now = (Get-Date).ToUniversalTime()
 $acted = 0
 foreach ($vm in Get-AzVM -Status) {

--- a/scripts/azure-workspace-spike/reaper-runbook.ps1
+++ b/scripts/azure-workspace-spike/reaper-runbook.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+Disable-AzContextAutosave -Scope Process | Out-Null
+Connect-AzAccount -Identity | Out-Null
+$now = (Get-Date).ToUniversalTime()
+$acted = 0
+foreach ($vm in Get-AzVM -Status) {
+  if ($null -eq $vm.Tags -or $vm.Tags['purpose'] -ne 'horizon-azure-vm-spike' -or -not $vm.Tags['deadline']) { continue }
+  try { $deadline = [datetime]::Parse($vm.Tags['deadline'], $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal) } catch { Write-Output "skip $($vm.Name): unparsable deadline"; continue }
+  if ($now -le $deadline) { continue }
+  if ($vm.PowerState -eq 'VM deallocated' -or $vm.PowerState -eq 'VM deallocating') { continue }
+  Write-Output "deallocating $($vm.ResourceGroupName)/$($vm.Name) (deadline $($deadline.ToString('u')), now $($now.ToString('u')))"
+  try { Stop-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force -NoWait | Out-Null; $acted++ }
+  catch { Write-Output "failed to deallocate $($vm.ResourceGroupName)/$($vm.Name): $($_.Exception.Message)" }
+}
+Write-Output "reaper done: $acted deallocation request(s)"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -55,7 +55,7 @@ done
 [[ $REGION =~ ^[a-z][a-z0-9]{1,63}$ ]] || { echo "--region must be a lowercase region name" >&2; exit 3; }
 [[ $VM_SIZE =~ ^Standard_[A-Za-z0-9_-]+$ ]] || { echo "--vm-size must look like Standard_D4s_v3" >&2; exit 3; }
 [[ $SAMPLE =~ ^[1-9]$ ]] || { echo "--sample must be 1-9" >&2; exit 3; }
-[[ $MAX_MINUTES =~ ^[0-9]{1,3}$ ]] && [ "$MAX_MINUTES" -ge 10 ] || { echo "--max-minutes must be 10-999" >&2; exit 3; }
+[[ $MAX_MINUTES =~ ^[1-9][0-9]{1,2}$ ]] || { echo "--max-minutes must be 10-999 without leading zeros" >&2; exit 3; }
 [ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
 for tool in az ssh ssh-keygen ssh-keyscan nc jq curl; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
 
@@ -81,11 +81,17 @@ remaining_seconds() {
   if [ "$CLEANED" = 1 ]; then echo $(( CLEANUP_DEADLINE - $(date +%s) )); else echo $(( DEADLINE_EPOCH - $(date +%s) )); fi
 }
 bounded() {
-  local remaining; remaining=$(remaining_seconds)
+  local remaining rc; remaining=$(remaining_seconds)
   if [ "$remaining" -lt 1 ]; then say "bound reached before: $1 $2 $3"; return 124; fi
-  timeout -k 15 "$remaining" "$@"
+  timeout -k 15 "$remaining" "$@" && return 0 || rc=$?
+  [ "$rc" != 124 ] || say "bound reached during: $1 $2 $3"
+  return "$rc"
 }
-azc() { bounded az "$@" --subscription "$SUBSCRIPTION" --only-show-errors; }
+# Machine-consumed output is always JSON unless the caller asks for tsv explicitly.
+azc() {
+  case " $* " in *" -o "*|*" --output "*) ;; *) set -- "$@" --output json ;; esac
+  bounded az "$@" --subscription "$SUBSCRIPTION" --only-show-errors
+}
 now() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
 epoch_ms() { date +%s%3N; }
 journal() { local data=${2:-'{}'}; jq -cn --arg at "$(now)" --arg event "$1" --argjson data "$data" '{at:$at,event:$event,data:$data}' >>"$JOURNAL"; }
@@ -138,6 +144,7 @@ finish() {
   trap - EXIT
   cleanup
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
+  if [ "$code" != 0 ] && [ "$(date +%s)" -ge "$DEADLINE_EPOCH" ]; then code=4; fi  # any failure past the bound is a bound expiry
   if [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven delete outranks every other outcome
   journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"
   say "sample $SAMPLE finished with exit $code${GATE_FAILURES[*]:+ (failed gates: ${GATE_FAILURES[*]})}; journal $JOURNAL"
@@ -307,18 +314,18 @@ MARKER="spike-$RUN_ID-$TOKEN"
 ssh_worker "$IP" "printf '%s\n' '$MARKER' > /workspace/spike-marker; sync" || true
 deadline_check
 T_STOP=$(epoch_ms)
-azc vm deallocate --resource-group "$RG" --name "$VM" >/dev/null
+STOP_OK=true; azc vm deallocate --resource-group "$RG" --name "$VM" >/dev/null || STOP_OK=false
 T_STOPPED=$(epoch_ms)
-POWER=$(azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv)
-journal deallocated "$(jq -cn --argjson ms $((T_STOPPED - T_STOP)) --arg power "$POWER" '{stop_ms:$ms,power_state:$power}')"
-gate deallocated "$([ "$POWER" = PowerState/deallocated ] && echo true || echo false)"
+POWER=$(azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null || echo unknown)
+journal deallocated "$(jq -cn --argjson ms $((T_STOPPED - T_STOP)) --argjson ok $STOP_OK --arg power "$POWER" '{stop_ms:$ms,call_succeeded:$ok,power_state:$power}')"
+gate deallocated "$([ "$STOP_OK" = true ] && [ "$POWER" = PowerState/deallocated ] && echo true || echo false)"
 T_START=$(epoch_ms)
-azc vm start --resource-group "$RG" --name "$VM" >/dev/null
-IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv)
+START_OK=true; azc vm start --resource-group "$RG" --name "$VM" >/dev/null || START_OK=false
+IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv 2>/dev/null || echo unknown)
 IP_SAME=false; [ "$IP" = "$IP_AFTER" ] && IP_SAME=true
 KEY_SAME=false SESSION=unknown RETAINED_MARKER=false HEARTBEAT=0 MOUNTED=false
 RESTART_DEADLINE=$(( $(date +%s) + RESTART_WAIT_SECONDS ))
-if wait_for "$RESTART_WAIT_SECONDS" nc -z -w 3 "$IP_AFTER" 2222; then
+if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for "$RESTART_WAIT_SECONDS" nc -z -w 3 "$IP_AFTER" 2222; then
   SCANNED=$(ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
   [ "$SCANNED" = "$HOST_KEY" ] && KEY_SAME=true
   if [ "$KEY_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) ssh_worker "$IP_AFTER" true; then
@@ -332,7 +339,7 @@ if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != 
   say "restart verification failed; capturing guest diagnostics out of band"
   run_command 'systemctl is-system-running; systemctl list-units --failed --no-legend; systemctl status docker --no-pager | head -20; findmnt /mnt/horizon-workspace; docker ps -a; docker logs --tail 20 horizon-worker 2>&1; journalctl -b -u docker --no-pager | tail -20' >"$SAMPLE_DIR/restart-diagnostics.txt" 2>&1 || true
 fi
-journal restarted "$(jq -cn --argjson ms $((T_RESTARTED - T_START)) --argjson ip $IP_SAME --argjson key $KEY_SAME --argjson marker $RETAINED_MARKER --arg session "$SESSION" --argjson hb "${HEARTBEAT:-0}" --argjson mounted $MOUNTED '{start_to_verified_ms:$ms,public_ip_unchanged:$ip,same_pinned_host_key:$key,marker_retained:$marker,session_after_restart:$session,heartbeat_lines:$hb,data_disk_mounted:$mounted}')"
+journal restarted "$(jq -cn --argjson ms $((T_RESTARTED - T_START)) --argjson started $START_OK --argjson ip $IP_SAME --argjson key $KEY_SAME --argjson marker $RETAINED_MARKER --arg session "$SESSION" --argjson hb "${HEARTBEAT:-0}" --argjson mounted $MOUNTED '{start_to_verified_ms:$ms,start_call_succeeded:$started,public_ip_unchanged:$ip,same_pinned_host_key:$key,marker_retained:$marker,session_after_restart:$session,heartbeat_lines:$hb,data_disk_mounted:$mounted}')"
 gate retention "$([ "$KEY_SAME" = true ] && [ "$RETAINED_MARKER" = true ] && [ "$MOUNTED" = true ] && echo true || echo false)"
 say "after deallocate/start: ip_unchanged=$IP_SAME host_key_same=$KEY_SAME marker_retained=$RETAINED_MARKER mounted=$MOUNTED session=$SESSION"
 journal timings_complete "$(jq -cn --argjson total $(( $(epoch_ms) - T0 )) '{ms_from_t0:$total}')"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -208,37 +208,40 @@ package_update: true
 packages: [docker.io]
 bootcmd:
   - [ sh, -c, 'printf "{\"event\":\"boot\",\"at\":\"%s\"}\n" "\$(date -u +%FT%T.%3NZ)" >> /var/log/horizon-spike-timing.jsonl' ]
-  # Guest-side lifetime bound, armed on every boot before anything else: at the deadline the VM
-  # deallocates itself through ARM with its own identity (power-only role granted before creation).
-  - |
-    cat > /usr/local/sbin/horizon-spike-deadline.sh <<'SH'
-    #!/bin/sh
-    set -eu
-    T=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&client_id=${CLIENT_ID}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
-    I=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" | python3 -c 'import json,sys; print(json.load(sys.stdin)["resourceId"])')
-    curl -sf -X POST -H "Authorization: Bearer \$T" -H "Content-Length: 0" "https://management.azure.com\$I/deallocate?api-version=2024-03-01"
-    SH
-    chmod 0700 /usr/local/sbin/horizon-spike-deadline.sh
-    cat > /etc/systemd/system/horizon-spike-deadline.service <<'UNIT'
-    [Unit]
-    Description=Horizon spike lifetime bound: deallocate this VM
-    [Service]
-    Type=oneshot
-    ExecStart=/usr/local/sbin/horizon-spike-deadline.sh
-    UNIT
-    cat > /etc/systemd/system/horizon-spike-deadline.timer <<'UNIT'
-    [Unit]
-    Description=Horizon spike lifetime bound
-    [Timer]
-    OnCalendar=${GUEST_DEADLINE}
-    Persistent=true
-    AccuracySec=1s
-    [Install]
-    WantedBy=timers.target
-    UNIT
-    systemctl daemon-reload
-    systemctl enable --now horizon-spike-deadline.timer
 write_files:
+  # Guest-side lifetime bound: at the deadline the VM deallocates itself through ARM with its own
+  # identity (power-only role granted before creation). Armed as the first runcmd step, before
+  # Docker or the image pull, once systemd is fully up (an early-boot systemctl call deadlocks).
+  - path: /usr/local/sbin/horizon-spike-deadline.sh
+    permissions: '0700'
+    owner: root:root
+    content: |
+      #!/bin/sh
+      set -eu
+      T=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&client_id=${CLIENT_ID}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+      I=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" | python3 -c 'import json,sys; print(json.load(sys.stdin)["resourceId"])')
+      curl -sf -X POST -H "Authorization: Bearer \$T" -H "Content-Length: 0" "https://management.azure.com\$I/deallocate?api-version=2024-03-01"
+  - path: /etc/systemd/system/horizon-spike-deadline.service
+    permissions: '0644'
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Horizon spike lifetime bound: deallocate this VM
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/horizon-spike-deadline.sh
+  - path: /etc/systemd/system/horizon-spike-deadline.timer
+    permissions: '0644'
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Horizon spike lifetime bound
+      [Timer]
+      OnCalendar=${GUEST_DEADLINE}
+      Persistent=true
+      AccuracySec=1s
+      [Install]
+      WantedBy=timers.target
   - path: /etc/systemd/system/docker.service.d/horizon-workspace.conf
     permissions: '0644'
     owner: root:root
@@ -282,6 +285,9 @@ write_files:
       stamp container_started
       docker logout ${REGISTRY} >/dev/null 2>&1 || true
 runcmd:
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, enable, --now, horizon-spike-deadline.timer ]
+  - [ sh, -c, 'printf "{\"event\":\"deadline_timer_armed\",\"at\":\"%s\"}\n" "\$(date -u +%FT%T.%3NZ)" >> /var/log/horizon-spike-timing.jsonl' ]
   - [ bash, /usr/local/sbin/horizon-spike-bootstrap.sh ]
 EOF
 

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -59,7 +59,8 @@ done
 
 [[ $SUBSCRIPTION =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || { echo "--subscription must be a UUID" >&2; exit 3; }
 [[ $IMAGE =~ ^[a-z0-9.-]+\.azurecr\.io/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$ ]] || { echo "--image must be an ACR digest reference" >&2; exit 3; }
-[[ $PULLER_ID =~ ^/subscriptions/[0-9a-f-]{36}/resource[Gg]roups/[^/]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[A-Za-z0-9_-]+$ ]] || { echo "--puller-identity-id must be a user-assigned identity resource id" >&2; exit 3; }
+[[ $PULLER_ID =~ ^/subscriptions/([0-9a-f-]{36})/resource[Gg]roups/[^/]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[A-Za-z0-9_-]+$ ]] || { echo "--puller-identity-id must be a user-assigned identity resource id" >&2; exit 3; }
+[ "${BASH_REMATCH[1],,}" = "$SUBSCRIPTION" ] || { echo "--puller-identity-id must belong to --subscription" >&2; exit 3; }
 [[ $REGION =~ ^[a-z][a-z0-9]{1,63}$ ]] || { echo "--region must be a lowercase region name" >&2; exit 3; }
 [[ $VM_SIZE =~ ^Standard_[A-Za-z0-9_-]+$ ]] || { echo "--vm-size must look like Standard_D4s_v3" >&2; exit 3; }
 [[ $SAMPLE =~ ^[1-9][0-9]?$ ]] || { echo "--sample must be 1-99 without leading zeros" >&2; exit 3; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -261,7 +261,9 @@ SHUTDOWN_AT=$(date -u -d @"$(( DEADLINE_EPOCH + 60 ))" +%H%M)
 if azc vm auto-shutdown --resource-group "$RG" --name "$VM" --time "$SHUTDOWN_AT" >/dev/null 2>&1; then
   journal auto_shutdown_scheduled "$(jq -cn --arg at "$SHUTDOWN_AT" '{utc_hhmm:$at}')"
 else
-  journal auto_shutdown_not_scheduled '{}'; say "warning: cloud-side auto-shutdown could not be scheduled"
+  # Without the platform-side bound the sample may not continue and may not be kept.
+  journal auto_shutdown_not_scheduled '{}'; say "fatal: cloud-side auto-shutdown could not be scheduled; deleting the sample"
+  KEEP=0; exit 1
 fi
 
 NSG=$(azc network nsg list --resource-group "$RG" --query "[0].name" -o tsv)

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -518,8 +518,12 @@ if [ "$PROVE_REAPER" = 1 ] && [ "$KEY_SAME" = true ]; then
   journal reaper_proof "$(jq -cn --argjson ok $REAPED --argjson ms $(( $(epoch_ms) - T_REAP )) '{vm_deallocated_by_reaper:$ok,wait_ms:$ms}')"
   gate reaper_bound "$REAPED"
   say "reaper proof: vm_deallocated_by_reaper=$REAPED after $(( ($(epoch_ms) - T_REAP) / 1000 )) s"
-  # Restore the real deadline before restarting so the guest-timer proof below is isolated from the reaper.
-  azc tag update --resource-id "$VM_ID" --operation merge --tags deadline="$DEADLINE_TAG" >/dev/null || true
+  # Restore the real deadline before restarting so the guest-timer proof below is isolated from the
+  # reaper; if that cannot be confirmed the proof would be ambiguous, so the sample ends here.
+  RESTORED=false
+  for _ in 1 2 3; do azc tag update --resource-id "$VM_ID" --operation merge --tags deadline="$DEADLINE_TAG" >/dev/null 2>&1 && RESTORED=true && break; bounded sleep 5 || break; done
+  [ "$(azc tag list --resource-id "$VM_ID" --query "properties.tags.deadline" -o tsv 2>/dev/null)" = "$DEADLINE_TAG" ] || RESTORED=false
+  [ "$RESTORED" = true ] || { journal deadline_restore_failed '{}'; say "could not restore the deadline tag; ending the sample without the guest proof"; exit 1; }
   if [ "$REAPED" = true ]; then azc vm start --resource-group "$RG" --name "$VM" >/dev/null || true; wait_for 600 ssh_worker "$IP_AFTER" true || true; fi
 fi
 # Prove the guest-side bound: confirm the timer is armed, fire its service once, expect deallocation.

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Bounded three-sample Azure Linux VM spike for issue #474.
+#
+# One exact task-owned resource group per sample. Measures create, image pull,
+# endpoint, verified key-only SSH and delete timing; records on-worker ext4 kernel
+# options, detach independence, deallocate/start data retention and exact deletion
+# with an unchanged-inventory proof. Every timestamp is UTC and journaled privately.
+# Nothing here registers a provider, publishes an image or touches resources outside
+# the sample resource group. Run the read-only preflight first.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: run-vm-spike.sh --subscription <uuid> --image <registry/repo@sha256:...> \
+         --puller-identity-id <user-assigned-identity-resource-id> --journal-dir <private-dir> \
+         [--region northeurope] [--vm-size Standard_D4s_v3] [--sample 1] [--max-minutes 120] \
+         [--allow-ssh-from <cidr>] [--keep] [--dry-run]
+
+Requires: az (logged in), ssh, ssh-keygen, nc, jq, curl. Paid creation is bounded by
+--max-minutes; the sample resource group is deleted at the end unless --keep is given.
+EOF
+}
+
+SUBSCRIPTION="" IMAGE="" PULLER_ID="" JOURNAL_DIR="" REGION=northeurope VM_SIZE=Standard_D4s_v3
+SAMPLE=1 MAX_MINUTES=120 ALLOW_SSH_FROM="" KEEP=0 DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --subscription) SUBSCRIPTION=$2; shift 2 ;;
+    --image) IMAGE=$2; shift 2 ;;
+    --puller-identity-id) PULLER_ID=$2; shift 2 ;;
+    --journal-dir) JOURNAL_DIR=$2; shift 2 ;;
+    --region) REGION=$2; shift 2 ;;
+    --vm-size) VM_SIZE=$2; shift 2 ;;
+    --sample) SAMPLE=$2; shift 2 ;;
+    --max-minutes) MAX_MINUTES=$2; shift 2 ;;
+    --allow-ssh-from) ALLOW_SSH_FROM=$2; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 3 ;;
+  esac
+done
+
+[[ $SUBSCRIPTION =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || { echo "--subscription must be a UUID" >&2; exit 3; }
+[[ $IMAGE =~ ^[a-z0-9.-]+\.azurecr\.io/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$ ]] || { echo "--image must be an ACR digest reference" >&2; exit 3; }
+[[ $PULLER_ID =~ ^/subscriptions/[0-9a-f-]{36}/resource[Gg]roups/[^/]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[A-Za-z0-9_-]+$ ]] || { echo "--puller-identity-id must be a user-assigned identity resource id" >&2; exit 3; }
+[[ $REGION =~ ^[a-z][a-z0-9]{1,63}$ ]] || { echo "--region must be a lowercase region name" >&2; exit 3; }
+[[ $VM_SIZE =~ ^Standard_[A-Za-z0-9_-]+$ ]] || { echo "--vm-size must look like Standard_D4s_v3" >&2; exit 3; }
+[[ $SAMPLE =~ ^[1-9]$ ]] || { echo "--sample must be 1-9" >&2; exit 3; }
+[[ $MAX_MINUTES =~ ^[0-9]{1,3}$ ]] && [ "$MAX_MINUTES" -ge 10 ] || { echo "--max-minutes must be 10-999" >&2; exit 3; }
+[ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
+for tool in az ssh ssh-keygen nc jq curl; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
+
+REGISTRY=${IMAGE%%/*}
+RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
+TOKEN=$(head -c 3 /dev/urandom | od -An -tx1 | tr -d ' \n')
+RG="horizon-spike-474-s${SAMPLE}-${TOKEN}"
+VM="worker-s${SAMPLE}"
+DEADLINE_EPOCH=$(( $(date +%s) + MAX_MINUTES * 60 ))
+umask 077
+mkdir -p "$JOURNAL_DIR"
+SAMPLE_DIR="$JOURNAL_DIR/sample-${SAMPLE}-${RUN_ID}"
+mkdir "$SAMPLE_DIR"
+JOURNAL="$SAMPLE_DIR/journal.jsonl"
+KEY="$SAMPLE_DIR/client-ed25519"
+KNOWN_HOSTS="$SAMPLE_DIR/known_hosts"
+
+azc() { az "$@" --subscription "$SUBSCRIPTION" --only-show-errors; }
+now() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
+epoch_ms() { date +%s%3N; }
+journal() { local data=${2:-'{}'}; jq -cn --arg at "$(now)" --arg event "$1" --argjson data "$data" '{at:$at,event:$event,data:$data}' >>"$JOURNAL"; }
+say() { printf '[%s] %s\n' "$(now)" "$*"; }
+deadline_check() { [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || { say "lifetime bound reached; forcing cleanup"; cleanup; exit 4; }; }
+
+cleanup() {
+  local started finished exists
+  if [ "$KEEP" = 1 ]; then say "--keep given; leaving $RG in place (delete it yourself)"; journal kept '{"resource_group":"'"$RG"'"}'; return; fi
+  if [ "$DRY_RUN" = 1 ]; then return; fi
+  started=$(epoch_ms)
+  say "deleting resource group $RG"
+  azc group delete --name "$RG" --yes >/dev/null 2>&1 || true
+  for _ in $(seq 1 60); do
+    exists=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)
+    [ "$exists" = false ] && break
+    sleep 10
+  done
+  finished=$(epoch_ms)
+  azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json"
+  local unchanged=false
+  cmp -s "$SAMPLE_DIR/inventory-before.json" "$SAMPLE_DIR/inventory-after.json" && unchanged=true
+  journal deleted "$(jq -cn --arg exists "$exists" --argjson ms $((finished - started)) --argjson unchanged $unchanged '{group_exists:$exists,delete_ms:$ms,inventory_unchanged:$unchanged}')"
+  say "resource group exists=$exists inventory_unchanged=$unchanged delete_ms=$((finished - started))"
+}
+
+say "sample $SAMPLE run $RUN_ID journal $SAMPLE_DIR"
+journal start "$(jq -cn --arg region "$REGION" --arg size "$VM_SIZE" --arg image "$IMAGE" --arg rg "$RG" --argjson max "$MAX_MINUTES" '{region:$region,vm_size:$size,image:$image,resource_group:$rg,max_minutes:$max}')"
+
+ssh-keygen -q -t ed25519 -N "" -C "horizon-spike-474-s${SAMPLE}" -f "$KEY"
+PUBKEY=$(cat "$KEY.pub")
+CLIENT_ID=$(azc identity show --ids "$PULLER_ID" --query clientId -o tsv)
+
+CLOUD_INIT="$SAMPLE_DIR/cloud-init.yaml"
+cat >"$CLOUD_INIT" <<EOF
+#cloud-config
+package_update: true
+packages: [docker.io]
+bootcmd:
+  - [ sh, -c, 'printf "{\"event\":\"boot\",\"at\":\"%s\"}\n" "\$(date -u +%FT%T.%3NZ)" >> /var/log/horizon-spike-timing.jsonl' ]
+write_files:
+  - path: /usr/local/sbin/horizon-spike-bootstrap.sh
+    permissions: '0700'
+    owner: root:root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      J=/var/log/horizon-spike-timing.jsonl
+      stamp() { printf '{"event":"%s","at":"%s"}\n' "\$1" "\$(date -u +%FT%T.%3NZ)" >> "\$J"; }
+      stamp bootstrap_start
+      DISK=/dev/disk/azure/scsi1/lun0
+      for _ in \$(seq 1 90); do [ -e "\$DISK" ] && break; sleep 1; done
+      [ -e "\$DISK" ] || { stamp data_disk_missing; exit 1; }
+      if [ "\$(blkid -o value -s TYPE "\$DISK" || true)" != ext4 ]; then mkfs.ext4 -q -L horizonws "\$DISK"; fi
+      mkdir -p /mnt/horizon-workspace
+      UUID=\$(blkid -o value -s UUID "\$DISK")
+      grep -q "\$UUID" /etc/fstab || echo "UUID=\$UUID /mnt/horizon-workspace ext4 defaults,nofail 0 2" >> /etc/fstab
+      mountpoint -q /mnt/horizon-workspace || mount /mnt/horizon-workspace
+      chown root:root /mnt/horizon-workspace && chmod 0755 /mnt/horizon-workspace
+      stamp data_disk_ready
+      systemctl enable --now docker
+      field() { python3 -c 'import json,sys; print(json.load(sys.stdin)[sys.argv[1]])' "\$1"; }
+      AAD=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&client_id=${CLIENT_ID}" | field access_token)
+      REFRESH=\$(curl -sf -X POST "https://${REGISTRY}/oauth2/exchange" --data-urlencode grant_type=access_token --data-urlencode service=${REGISTRY} --data-urlencode "access_token=\$AAD" | field refresh_token)
+      printf '%s' "\$REFRESH" | docker login ${REGISTRY} -u 00000000-0000-0000-0000-000000000000 --password-stdin >/dev/null
+      unset AAD REFRESH
+      stamp registry_login
+      docker pull -q ${IMAGE} >/dev/null
+      stamp image_pulled
+      docker create --name horizon-worker --restart unless-stopped -p 2222:22 \\
+        --mount type=bind,src=/mnt/horizon-workspace,dst=/workspace \\
+        -e "HORIZON_SSH_PUBLIC_KEY=${PUBKEY}" ${IMAGE} >/dev/null
+      stamp container_created
+      docker start horizon-worker >/dev/null
+      stamp container_started
+      docker logout ${REGISTRY} >/dev/null 2>&1 || true
+runcmd:
+  - [ bash, /usr/local/sbin/horizon-spike-bootstrap.sh ]
+EOF
+
+if [ "$DRY_RUN" = 1 ]; then
+  say "dry run: would create $RG in $REGION with $VM_SIZE, image $IMAGE, cloud-init at $CLOUD_INIT"
+  journal dry_run '{}'
+  exit 0
+fi
+
+trap 'say "interrupted; cleaning up"; cleanup' INT TERM
+
+azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
+journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
+
+T0=$(epoch_ms)
+azc group create --name "$RG" --location "$REGION" \
+  --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
+journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
+
+CREATE_JSON="$SAMPLE_DIR/vm-create.json"
+azc vm create --resource-group "$RG" --name "$VM" --location "$REGION" --size "$VM_SIZE" \
+  --image Canonical:ubuntu-24_04-lts:server:latest --admin-username azureuser \
+  --authentication-type ssh --ssh-key-values "$KEY.pub" \
+  --public-ip-sku Standard --public-ip-address-allocation static --nsg-rule NONE \
+  --assign-identity "$PULLER_ID" --os-disk-size-gb 30 --data-disk-sizes-gb 32 \
+  --custom-data "$CLOUD_INIT" --tags issue=474 sample="$SAMPLE" run="$RUN_ID" >"$CREATE_JSON"
+T_CREATE=$(epoch_ms)
+IP=$(jq -r .publicIpAddress "$CREATE_JSON")
+journal vm_created "$(jq -cn --argjson ms $((T_CREATE - T0)) --arg ip "$IP" '{ms_from_t0:$ms,public_ip:$ip}')"
+say "vm created in $((T_CREATE - T0)) ms"
+
+NSG=$(azc network nsg list --resource-group "$RG" --query "[0].name" -o tsv)
+SOURCE=${ALLOW_SSH_FROM:-$(curl -s --max-time 10 https://ifconfig.me)/32}
+azc network nsg rule create --resource-group "$RG" --nsg-name "$NSG" --name worker-ssh --priority 100 \
+  --direction Inbound --access Allow --protocol Tcp --source-address-prefixes "$SOURCE" \
+  --destination-port-ranges 2222 >/dev/null
+journal nsg_rule "$(jq -cn --arg src "$SOURCE" '{source:$src,port:2222}')"
+
+say "waiting for worker endpoint on $IP:2222"
+until nc -z -w 3 "$IP" 2222 2>/dev/null; do deadline_check; sleep 3; done
+T_PORT=$(epoch_ms)
+journal endpoint_open "$(jq -cn --argjson ms $((T_PORT - T0)) '{ms_from_t0:$ms}')"
+say "endpoint open in $((T_PORT - T0)) ms"
+
+say "reading worker host key out of band through run-command"
+RC_START=$(epoch_ms)
+RC_JSON="$SAMPLE_DIR/run-command-hostkey.json"
+azc vm run-command invoke --resource-group "$RG" --name "$VM" --command-id RunShellScript \
+  --scripts 'cat /mnt/horizon-workspace/.horizon-worker/ssh/*.pub 2>/dev/null; echo ---TIMING---; cat /var/log/horizon-spike-timing.jsonl' >"$RC_JSON"
+RC_END=$(epoch_ms)
+RC_TEXT=$(jq -r '.value[0].message' "$RC_JSON")
+HOST_KEY=$(printf '%s\n' "$RC_TEXT" | grep -m1 '^ssh-ed25519 ' || true)
+printf '%s\n' "$RC_TEXT" | sed -n '/---TIMING---/,$p' | grep '^{' >"$SAMPLE_DIR/guest-timing.jsonl" || true
+[ -n "$HOST_KEY" ] || { journal host_key_missing '{}'; say "no ed25519 host key published yet; aborting sample"; cleanup; exit 5; }
+printf '[%s]:2222 %s\n' "$IP" "$HOST_KEY" >"$KNOWN_HOSTS"
+journal host_key_pinned "$(jq -cn --argjson ms $((RC_END - RC_START)) --arg fp "$(ssh-keygen -lf "$KNOWN_HOSTS" | awk '{print $2}')" '{run_command_ms:$ms,fingerprint:$fp}')"
+
+SSH=(ssh -p 2222 -i "$KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$KNOWN_HOSTS" -o PasswordAuthentication=no -o ConnectTimeout=10 -o BatchMode=yes "root@$IP")
+until "${SSH[@]}" true 2>/dev/null; do deadline_check; sleep 3; done
+T_SSH=$(epoch_ms)
+journal ssh_verified "$(jq -cn --argjson ms $((T_SSH - T0)) --argjson excl $((T_SSH - T0 - (RC_END - RC_START))) '{ms_from_t0:$ms,ms_excluding_run_command:$excl}')"
+say "key-only SSH verified in $((T_SSH - T0)) ms (excluding run-command: $((T_SSH - T0 - (RC_END - RC_START))) ms)"
+
+say "collecting on-worker storage evidence"
+"${SSH[@]}" 'set -e; echo "fs_type=$(stat -f -c %T /workspace)"; DEV=$(df --output=source /workspace | tail -1); echo "device=$DEV"; NAME=$(basename "$(readlink -f "$DEV")"); echo "kernel_options_path=/proc/fs/ext4/$NAME/options"; echo "---OPTIONS---"; cat /proc/fs/ext4/$NAME/options; echo "---MOUNT---"; grep " /workspace " /proc/self/mounts; echo "---SYSFS---"; readlink /sys/dev/block/$(stat -c %d /workspace | awk "{printf \"%d:%d\", int(\$1/256), \$1%256}") 2>&1 || true' >"$SAMPLE_DIR/storage-evidence.txt" 2>&1 || true
+OPTIONS=$(sed -n '/---OPTIONS---/,/---MOUNT---/p' "$SAMPLE_DIR/storage-evidence.txt" | grep -v -- '---')
+QUALIFIES=false
+if grep -qx rw <<<"$OPTIONS" && grep -qx barrier <<<"$OPTIONS" && ! grep -qx ro <<<"$OPTIONS" && ! grep -qx nobarrier <<<"$OPTIONS" \
+   && [ "$(grep -c '^data=' <<<"$OPTIONS")" = 1 ] && grep -qxE 'data=(ordered|journal)' <<<"$OPTIONS" && grep -q 'fs_type=ext2/ext3' "$SAMPLE_DIR/storage-evidence.txt"; then QUALIFIES=true; fi
+journal storage_evidence "$(jq -cn --argjson q $QUALIFIES --arg opts "$OPTIONS" '{shell_mirror_of_qualifier_passes:$q,kernel_options:($opts|split("\n"))}')"
+say "ext4 kernel options mirror check: $QUALIFIES (authoritative qualifier is the Rust code, not this script)"
+
+say "detach independence: start a heartbeat, disconnect, reconnect"
+"${SSH[@]}" 'tmux new-session -d -s spike "while true; do date -u +%FT%TZ >> /workspace/spike-heartbeat; sleep 2; done"; sleep 1; wc -l < /workspace/spike-heartbeat' >"$SAMPLE_DIR/heartbeat-before.txt"
+sleep 20
+"${SSH[@]}" 'tmux has-session -t spike && wc -l < /workspace/spike-heartbeat' >"$SAMPLE_DIR/heartbeat-after.txt"
+journal detach_independence "$(jq -cn --arg b "$(cat "$SAMPLE_DIR/heartbeat-before.txt")" --arg a "$(cat "$SAMPLE_DIR/heartbeat-after.txt")" '{lines_before:($b|tonumber),lines_after:($a|tonumber),progressed:(($a|tonumber)>($b|tonumber))}')"
+
+say "retention: marker, deallocate, start, verify"
+MARKER="spike-$RUN_ID-$TOKEN"
+"${SSH[@]}" "printf '%s\n' '$MARKER' > /workspace/spike-marker; sync"
+deadline_check
+T_STOP=$(epoch_ms)
+azc vm deallocate --resource-group "$RG" --name "$VM" >/dev/null
+POWER=$(azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv)
+T_STOPPED=$(epoch_ms)
+journal deallocated "$(jq -cn --argjson ms $((T_STOPPED - T_STOP)) --arg power "$POWER" '{stop_ms:$ms,power_state:$power}')"
+T_START=$(epoch_ms)
+azc vm start --resource-group "$RG" --name "$VM" >/dev/null
+IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv)
+until nc -z -w 3 "$IP" 2222 2>/dev/null; do deadline_check; sleep 3; done
+until "${SSH[@]}" true 2>/dev/null; do deadline_check; sleep 3; done
+T_RESTARTED=$(epoch_ms)
+RETAINED=$("${SSH[@]}" "cat /workspace/spike-marker 2>/dev/null; tmux has-session -t spike 2>/dev/null && echo session-alive || echo session-gone; wc -l < /workspace/spike-heartbeat")
+journal restarted "$(jq -cn --argjson ms $((T_RESTARTED - T_START)) --arg ip_same "$([ "$IP" = "$IP_AFTER" ] && echo true || echo false)" --arg out "$RETAINED" --arg marker "$MARKER" '{start_to_ssh_ms:$ms,public_ip_unchanged:($ip_same=="true"),marker_retained:($out|split("\n")[0]==$marker),session_after_restart:($out|split("\n")[1]),heartbeat_lines:($out|split("\n")[2]|tonumber),same_pinned_host_key:true}')"
+say "after deallocate/start: $(tr '\n' ' ' <<<"$RETAINED")"
+
+cleanup
+journal end "$(jq -cn --argjson total $(( $(epoch_ms) - T0 )) '{total_ms:$total}')"
+say "sample $SAMPLE complete; journal at $JOURNAL"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -320,7 +320,11 @@ journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before
 # (scripts/azure-workspace-spike/setup-spike-reaper.sh) deallocates every VM tagged
 # purpose=horizon-azure-vm-spike whose deadline tag has passed. Read-only check, journaled.
 REAPER_BASE="https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$REAPER_RG/providers/Microsoft.Automation/automationAccounts/$REAPER_ACCOUNT"
-REAPER_FACTS=$(azc rest --method get --url "$REAPER_BASE/jobSchedules?api-version=2023-11-01" --query "value[?properties.runbook.name=='horizon-spike-deadline-reaper'] | [0].properties.schedule.name" -o tsv 2>/dev/null || true)
+REAPER_FACTS=""
+for link_id in $(azc rest --method get --url "$REAPER_BASE/jobSchedules?api-version=2023-11-01" --query "value[?properties.runbook.name=='horizon-spike-deadline-reaper'].properties.jobScheduleId" -o tsv 2>/dev/null); do
+  LINK_JSON=$(azc rest --method get --url "$REAPER_BASE/jobSchedules/$link_id?api-version=2023-11-01" 2>/dev/null || echo null)  # the list omits parameters
+  [ "$(jq -r '(.properties.parameters // {}) | to_entries | map(select(.key | ascii_downcase == "subscriptionid")) | .[0].value // empty | ascii_downcase' <<<"$LINK_JSON")" = "$SUBSCRIPTION" ] && REAPER_FACTS=$(jq -r '.properties.schedule.name' <<<"$LINK_JSON") && break
+done
 REAPER_SCHEDULE=$(azc rest --method get --url "$REAPER_BASE/schedules/${REAPER_FACTS:-none}?api-version=2023-11-01" --query "{enabled:properties.isEnabled,next_run:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" 2>/dev/null || echo null)
 REAPER_NEXT=$(date -u -d "$(jq -r '.next_run // empty' <<<"$REAPER_SCHEDULE")" +%s 2>/dev/null || echo 0)
 [ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$REAPER_SCHEDULE")" = ok ] && [ "$REAPER_NEXT" -gt "$(date +%s)" ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present, not enabled, not the 15-minute schedule or has no future run; run setup-spike-reaper.sh first (nothing created)"; exit 1; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -182,7 +182,7 @@ finish() {
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
   if [ "$code" != 0 ] && [ "$expired" = 1 ]; then code=4; fi  # any failure past the active-phase bound is a bound expiry
   case "$code" in 0|3|4|5|6|7|130) ;; *) code=1 ;; esac
-  if [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven delete outranks every other outcome
+  if [ "$CREATED" = 1 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven (or --keep skipped) delete outranks every other outcome
   journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"
   say "sample $SAMPLE finished with exit $code${GATE_FAILURES[*]:+ (failed gates: ${GATE_FAILURES[*]})}; journal $JOURNAL"
   exit "$code"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -133,18 +133,27 @@ cleanup() {
     exists=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)
   fi
   finished=$(epoch_ms)
-  azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json" 2>/dev/null || echo '"unavailable"' >"$SAMPLE_DIR/inventory-after.json"
-  cmp -s "$SAMPLE_DIR/inventory-before.json" "$SAMPLE_DIR/inventory-after.json" && unchanged=true
+  azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json" 2>/dev/null || echo 'null' >"$SAMPLE_DIR/inventory-after.json"
+  # Proof: every pre-existing resource still exists and nothing remains under the sample group.
+  # Resources added meanwhile by other actors are counted, not treated as this sample's fault.
+  local verdict
+  verdict=$(jq -cn --arg rg "/resourceGroups/$RG/" --slurpfile before "$SAMPLE_DIR/inventory-before.json" --slurpfile after "$SAMPLE_DIR/inventory-after.json" \
+    '($before[0] // null) as $b | ($after[0] // null) as $a
+     | if ($b|type) != "array" or ($a|type) != "array" then {proven:false,reason:"inventory_unavailable"}
+       else {removed:($b - $a), leftover:[$a[] | select(ascii_downcase | contains($rg|ascii_downcase))], added_by_others:(($a - $b)|length)}
+            | .proven = ((.removed|length)==0 and (.leftover|length)==0) end')
+  [ "$(jq -r .proven <<<"$verdict")" = true ] && unchanged=true
   [ "$exists" = false ] && [ "$unchanged" = true ] && DELETE_PROVEN=1
-  journal deleted "$(jq -cn --arg exists "$exists" --argjson ms $((finished - started)) --argjson unchanged $unchanged '{group_exists:$exists,delete_ms:$ms,inventory_unchanged:$unchanged}')"
-  say "resource group exists=$exists inventory_unchanged=$unchanged delete_ms=$((finished - started))"
+  journal deleted "$(jq -cn --arg exists "$exists" --argjson ms $((finished - started)) --argjson v "$verdict" '{group_exists:$exists,delete_ms:$ms,inventory_proof:$v}')"
+  say "resource group exists=$exists inventory_proof=$(jq -c 'del(.removed,.leftover)' <<<"$verdict") delete_ms=$((finished - started))"
 }
 finish() {
-  local code=$?
+  local code=$? expired=0
   trap - EXIT
+  [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || expired=1  # decided before cleanup spends its own bound
   cleanup
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
-  if [ "$code" != 0 ] && [ "$(date +%s)" -ge "$DEADLINE_EPOCH" ]; then code=4; fi  # any failure past the bound is a bound expiry
+  if [ "$code" != 0 ] && [ "$expired" = 1 ]; then code=4; fi  # any failure past the active-phase bound is a bound expiry
   if [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven delete outranks every other outcome
   journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"
   say "sample $SAMPLE finished with exit $code${GATE_FAILURES[*]:+ (failed gates: ${GATE_FAILURES[*]})}; journal $JOURNAL"
@@ -156,7 +165,11 @@ journal start "$(jq -cn --arg region "$REGION" --arg size "$VM_SIZE" --arg image
 
 ssh-keygen -q -t ed25519 -N "" -C "horizon-spike-474-s${SAMPLE}" -f "$KEY"
 PUBKEY=$(cat "$KEY.pub")
-CLIENT_ID=$(azc identity show --ids "$PULLER_ID" --query clientId -o tsv)
+if [ "$DRY_RUN" = 1 ]; then CLIENT_ID=00000000-0000-0000-0000-000000000000; else
+  trap finish EXIT
+  trap 'exit 130' INT TERM
+  CLIENT_ID=$(azc identity show --ids "$PULLER_ID" --query clientId -o tsv)
+fi
 
 CLOUD_INIT="$SAMPLE_DIR/cloud-init.yaml"
 cat >"$CLOUD_INIT" <<EOF
@@ -218,9 +231,7 @@ if [ "$DRY_RUN" = 1 ]; then
   exit 0
 fi
 
-trap finish EXIT
-trap 'exit 130' INT TERM
-
+# finish() already covers every bounded call; nothing paid exists until CREATED=1.
 azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
 journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
 
@@ -244,6 +255,14 @@ IP=$(jq -r .publicIpAddress "$CREATE_JSON")
 [[ $IP =~ ^[0-9.]+$ ]] || { journal vm_create_no_ip '{}'; say "vm create returned no public IP"; exit 1; }
 journal vm_created "$(jq -cn --argjson ms $((T_CREATE - T0)) --arg ip "$IP" '{ms_from_t0:$ms,public_ip:$ip}')"
 say "vm created in $((T_CREATE - T0)) ms"
+# Independent cloud-side stop: Azure deallocates the VM at the lifetime deadline even if this
+# controller dies. Disks and the public IP remain until the tagged group is deleted by hand.
+SHUTDOWN_AT=$(date -u -d @"$(( DEADLINE_EPOCH + 60 ))" +%H%M)
+if azc vm auto-shutdown --resource-group "$RG" --name "$VM" --time "$SHUTDOWN_AT" >/dev/null 2>&1; then
+  journal auto_shutdown_scheduled "$(jq -cn --arg at "$SHUTDOWN_AT" '{utc_hhmm:$at}')"
+else
+  journal auto_shutdown_not_scheduled '{}'; say "warning: cloud-side auto-shutdown could not be scheduled"
+fi
 
 NSG=$(azc network nsg list --resource-group "$RG" --query "[0].name" -o tsv)
 SOURCE=${ALLOW_SSH_FROM:-}

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -314,7 +314,10 @@ REAPER_BASE="https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGr
 REAPER_FACTS=$(azc rest --method get --url "$REAPER_BASE/jobSchedules?api-version=2023-11-01" --query "value[?properties.runbook.name=='horizon-spike-deadline-reaper'] | [0].properties.schedule.name" -o tsv 2>/dev/null || true)
 REAPER_SCHEDULE=$(azc rest --method get --url "$REAPER_BASE/schedules/${REAPER_FACTS:-none}?api-version=2023-11-01" --query "{enabled:properties.isEnabled,next_run:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" 2>/dev/null || echo null)
 [ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$REAPER_SCHEDULE")" = ok ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present, not enabled or not the 15-minute schedule; run setup-spike-reaper.sh first (nothing created)"; exit 1; }
-journal reaper_present "$(jq -c --arg acct "$REAPER_ACCOUNT" '. + {account:$acct}' <<<"$REAPER_SCHEDULE")"
+REAPER_PRINCIPAL=$(azc rest --method get --url "$REAPER_BASE?api-version=2023-11-01" --query identity.principalId -o tsv 2>/dev/null || true)
+REAPER_ROLES=$(azc role assignment list --assignee "${REAPER_PRINCIPAL:-00000000-0000-0000-0000-000000000000}" --role "Desktop Virtualization Power On Off Contributor" --scope "/subscriptions/$SUBSCRIPTION" --query "length(@)" -o tsv 2>/dev/null || echo 0)
+[ "$REAPER_ROLES" != 0 ] || { journal reaper_role_missing '{}'; say "the reaper identity lacks the subscription-scoped power-only role; rerun setup-spike-reaper.sh (nothing created)"; exit 1; }
+journal reaper_present "$(jq -c --arg acct "$REAPER_ACCOUNT" '. + {account:$acct,power_role_assigned:true}' <<<"$REAPER_SCHEDULE")"
 # Read-only provider preflight for the auto-shutdown schedule; registration is a separate approval.
 DEVTESTLAB=$(azc provider show --namespace Microsoft.DevTestLab --query registrationState -o tsv 2>/dev/null || echo unknown)
 [ "$DEVTESTLAB" = Registered ] || { journal devtestlab_not_registered "$(jq -cn --arg s "$DEVTESTLAB" '{registration_state:$s}')"; say "Microsoft.DevTestLab is $DEVTESTLAB; the platform-side stop cannot be scheduled, so nothing is created"; exit 1; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -189,7 +189,8 @@ finish() {
 
 say "sample $SAMPLE run $RUN_ID journal $SAMPLE_DIR"
 HARNESS_COMMIT=$(git -C "$(dirname "$0")" rev-parse HEAD 2>/dev/null || echo unknown)
-journal start "$(jq -cn --arg region "$REGION" --arg size "$VM_SIZE" --arg image "$IMAGE" --arg rg "$RG" --argjson max "$MAX_MINUTES" --arg commit "$HARNESS_COMMIT" --arg pf "${PREFLIGHT:-}" --argjson facts "${PREFLIGHT_FACTS:-null}" '{region:$region,vm_size:$size,image:$image,resource_group:$rg,max_minutes:$max,harness_commit:$commit,preflight_report:$pf,preflight:$facts}')"
+HARNESS_DIRTY=$([ -n "$(git -C "$(dirname "$0")" status --porcelain -- . 2>/dev/null)" ] && echo true || echo false)
+journal start "$(jq -cn --arg region "$REGION" --arg size "$VM_SIZE" --arg image "$IMAGE" --arg rg "$RG" --argjson max "$MAX_MINUTES" --arg commit "$HARNESS_COMMIT" --argjson dirty "$HARNESS_DIRTY" --arg pf "${PREFLIGHT:-}" --argjson facts "${PREFLIGHT_FACTS:-null}" '{region:$region,vm_size:$size,image:$image,resource_group:$rg,max_minutes:$max,harness_commit:$commit,harness_uncommitted_changes:$dirty,preflight_report:$pf,preflight:$facts}')"
 
 ssh-keygen -q -t ed25519 -N "" -C "horizon-spike-474-s${SAMPLE}" -f "$KEY"
 PUBKEY=$(cat "$KEY.pub")
@@ -274,40 +275,84 @@ azc group create --name "$RG" --location "$REGION" \
   --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
 
-CREATE_JSON="$SAMPLE_DIR/vm-create.json"
-azc vm create --resource-group "$RG" --name "$VM" --location "$REGION" --size "$VM_SIZE" \
-  --image Canonical:ubuntu-24_04-lts:server:latest --admin-username azureuser \
-  --authentication-type ssh --ssh-key-values "$KEY.pub" \
-  --public-ip-sku Standard --public-ip-address-allocation static --nsg-rule NONE \
-  --assign-identity "$PULLER_ID" --os-disk-size-gb 30 --data-disk-sizes-gb 32 \
-  --custom-data "$CLOUD_INIT" --tags issue=474 sample="$SAMPLE" run="$RUN_ID" >"$CREATE_JSON"
-T_CREATE=$(epoch_ms)
-IP=$(jq -r .publicIpAddress "$CREATE_JSON")
-[[ $IP =~ ^[0-9.]+$ ]] || { journal vm_create_no_ip '{}'; say "vm create returned no public IP"; exit 1; }
-journal vm_created "$(jq -cn --argjson ms $((T_CREATE - T0)) --arg ip "$IP" '{ms_from_t0:$ms,public_ip:$ip}')"
-say "vm created in $((T_CREATE - T0)) ms"
-# Independent cloud-side stop: Azure deallocates the VM at the lifetime deadline even if this
-# controller dies. Disks and the public IP remain until the tagged group is deleted by hand.
-SHUTDOWN_AT=$(date -u -d @"$(( DEADLINE_EPOCH + 60 ))" +%H%M)
-if azc vm auto-shutdown --resource-group "$RG" --name "$VM" --time "$SHUTDOWN_AT" >/dev/null 2>&1; then
-  journal auto_shutdown_scheduled "$(jq -cn --arg at "$SHUTDOWN_AT" '{utc_hhmm:$at}')"
-else
-  # Without the platform-side bound the sample may not continue and may not be kept.
-  journal auto_shutdown_not_scheduled '{}'; say "fatal: cloud-side auto-shutdown could not be scheduled; deleting the sample"
-  KEEP=0; exit 1
-fi
-
-NSG=$(azc network nsg list --resource-group "$RG" --query "[0].name" -o tsv)
 SOURCE=${ALLOW_SSH_FROM:-}
 if [ -z "$SOURCE" ]; then
   EGRESS=$(bounded curl -s --max-time 10 https://ifconfig.me || true)
   [[ $EGRESS =~ ^[0-9.]+$ ]] || { journal egress_unknown '{}'; say "could not learn the egress address; pass --allow-ssh-from"; exit 1; }
   SOURCE="$EGRESS/32"
 fi
-azc network nsg rule create --resource-group "$RG" --nsg-name "$NSG" --name worker-ssh --priority 100 \
-  --direction Inbound --access Allow --protocol Tcp --source-address-prefixes "$SOURCE" \
-  --destination-port-ranges 2222 >/dev/null
-journal nsg_rule "$(jq -cn --arg src "$SOURCE" '{source:$src,port:2222}')"
+# One server-side deployment creates the network, the VM and the DevTestLab auto-shutdown
+# schedule together, so a controller that dies mid-creation cannot leave compute without the
+# platform-side stop. Azure deallocates the VM at the lifetime deadline even if nothing else runs;
+# disks and the public IP remain until the tagged group is deleted by hand.
+SHUTDOWN_AT=$(date -u -d @"$(( DEADLINE_EPOCH + 60 ))" +%H%M)
+TEMPLATE="$SAMPLE_DIR/deployment.json"
+cat >"$TEMPLATE" <<'EOF'
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmName": {"type": "string"}, "vmSize": {"type": "string"}, "adminPublicKey": {"type": "string"},
+    "customData": {"type": "string"}, "identityId": {"type": "string"}, "sourceCidr": {"type": "string"},
+    "shutdownTime": {"type": "string"}, "tags": {"type": "object"},
+    "location": {"type": "string", "defaultValue": "[resourceGroup().location]"}
+  },
+  "variables": {"nic": "[concat(parameters('vmName'), '-nic')]", "pip": "[concat(parameters('vmName'), '-pip')]",
+                "nsg": "[concat(parameters('vmName'), '-nsg')]", "vnet": "[concat(parameters('vmName'), '-vnet')]"},
+  "resources": [
+    {"type": "Microsoft.Network/networkSecurityGroups", "apiVersion": "2023-11-01", "name": "[variables('nsg')]",
+     "location": "[parameters('location')]", "tags": "[parameters('tags')]",
+     "properties": {"securityRules": [{"name": "worker-ssh", "properties": {"priority": 100, "direction": "Inbound",
+       "access": "Allow", "protocol": "Tcp", "sourceAddressPrefix": "[parameters('sourceCidr')]", "sourcePortRange": "*",
+       "destinationAddressPrefix": "*", "destinationPortRange": "2222"}}]}},
+    {"type": "Microsoft.Network/virtualNetworks", "apiVersion": "2023-11-01", "name": "[variables('vnet')]",
+     "location": "[parameters('location')]", "tags": "[parameters('tags')]",
+     "dependsOn": ["[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg'))]"],
+     "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name": "workers",
+       "properties": {"addressPrefix": "10.0.0.0/24",
+         "networkSecurityGroup": {"id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg'))]"}}}]}},
+    {"type": "Microsoft.Network/publicIPAddresses", "apiVersion": "2023-11-01", "name": "[variables('pip')]",
+     "location": "[parameters('location')]", "tags": "[parameters('tags')]", "sku": {"name": "Standard"},
+     "properties": {"publicIPAllocationMethod": "Static", "publicIPAddressVersion": "IPv4"}},
+    {"type": "Microsoft.Network/networkInterfaces", "apiVersion": "2023-11-01", "name": "[variables('nic')]",
+     "location": "[parameters('location')]", "tags": "[parameters('tags')]",
+     "dependsOn": ["[resourceId('Microsoft.Network/virtualNetworks', variables('vnet'))]",
+                   "[resourceId('Microsoft.Network/publicIPAddresses', variables('pip'))]"],
+     "properties": {"ipConfigurations": [{"name": "primary", "properties": {"privateIPAllocationMethod": "Dynamic",
+       "subnet": {"id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnet'), 'workers')]"},
+       "publicIPAddress": {"id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('pip'))]"}}}]}},
+    {"type": "Microsoft.Compute/virtualMachines", "apiVersion": "2024-03-01", "name": "[parameters('vmName')]",
+     "location": "[parameters('location')]", "tags": "[parameters('tags')]",
+     "dependsOn": ["[resourceId('Microsoft.Network/networkInterfaces', variables('nic'))]"],
+     "identity": {"type": "UserAssigned", "userAssignedIdentities": {"[parameters('identityId')]": {}}},
+     "properties": {"hardwareProfile": {"vmSize": "[parameters('vmSize')]"},
+       "storageProfile": {"imageReference": {"publisher": "Canonical", "offer": "ubuntu-24_04-lts", "sku": "server", "version": "latest"},
+         "osDisk": {"createOption": "FromImage", "diskSizeGB": 30, "managedDisk": {"storageAccountType": "Premium_LRS"}},
+         "dataDisks": [{"lun": 0, "createOption": "Empty", "diskSizeGB": 32, "managedDisk": {"storageAccountType": "Premium_LRS"}}]},
+       "osProfile": {"computerName": "[parameters('vmName')]", "adminUsername": "azureuser", "customData": "[parameters('customData')]",
+         "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/azureuser/.ssh/authorized_keys",
+           "keyData": "[parameters('adminPublicKey')]"}]}}},
+       "networkProfile": {"networkInterfaces": [{"id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic'))]"}]}}},
+    {"type": "Microsoft.DevTestLab/schedules", "apiVersion": "2018-09-15", "name": "[concat('shutdown-computevm-', parameters('vmName'))]",
+     "location": "[parameters('location')]", "tags": "[parameters('tags')]",
+     "dependsOn": ["[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]"],
+     "properties": {"status": "Enabled", "taskType": "ComputeVmShutdownTask", "timeZoneId": "UTC",
+       "dailyRecurrence": {"time": "[parameters('shutdownTime')]"}, "notificationSettings": {"status": "Disabled"},
+       "targetResourceId": "[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]"}}
+  ],
+  "outputs": {"publicIp": {"type": "string", "value": "[reference(variables('pip')).ipAddress]"}}
+}
+EOF
+CREATE_JSON="$SAMPLE_DIR/deployment-result.json"
+TAGS=$(jq -cn --arg s "$SAMPLE" --arg r "$RUN_ID" '{issue:"474",sample:$s,run:$r,purpose:"horizon-azure-vm-spike"}')
+azc deployment group create --resource-group "$RG" --name "worker-s${SAMPLE}" --template-file "$TEMPLATE" \
+  --parameters vmName="$VM" vmSize="$VM_SIZE" adminPublicKey="$PUBKEY" customData="$(base64 -w0 "$CLOUD_INIT")" \
+  identityId="$PULLER_ID" sourceCidr="$SOURCE" shutdownTime="$SHUTDOWN_AT" tags="$TAGS" >"$CREATE_JSON"
+T_CREATE=$(epoch_ms)
+IP=$(jq -r '.properties.outputs.publicIp.value // empty' "$CREATE_JSON")
+[[ $IP =~ ^[0-9.]+$ ]] || { journal vm_create_no_ip '{}'; say "deployment returned no public IP"; exit 1; }
+journal vm_created "$(jq -cn --argjson ms $((T_CREATE - T0)) --arg ip "$IP" --arg at "$SHUTDOWN_AT" --arg src "$SOURCE" '{ms_from_t0:$ms,public_ip:$ip,auto_shutdown_utc_hhmm:$at,ssh_source:$src,deployment:"vm+network+shutdown schedule in one deployment"}')"
+say "deployment complete in $((T_CREATE - T0)) ms (VM, network and auto-shutdown schedule together)"
 
 say "waiting for worker endpoint on port 2222"
 wait_for $(( DEADLINE_EPOCH - $(date +%s) )) bounded nc -z -w 3 "$IP" 2222 || { journal endpoint_never_opened '{}'; exit 4; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -87,9 +87,9 @@ remaining_seconds() {
 }
 bounded() {
   local remaining rc; remaining=$(remaining_seconds)
-  if [ "$remaining" -lt 1 ]; then say "bound reached before: $1 $2 $3"; return 124; fi
+  if [ "$remaining" -lt 1 ]; then say "bound reached before: ${*:1:3}"; return 124; fi
   timeout -k 15 "$remaining" "$@" && return 0 || rc=$?
-  [ "$rc" != 124 ] || say "bound reached during: $1 $2 $3"
+  [ "$rc" != 124 ] || say "bound reached during: ${*:1:3}"
   return "$rc"
 }
 # Machine-consumed output is always JSON unless the caller asks for tsv explicitly.
@@ -109,7 +109,7 @@ wait_for() {
   until "$@" >/dev/null 2>&1; do
     deadline_check
     [ "$(date +%s)" -lt "$until_epoch" ] || return 1
-    sleep 3
+    bounded sleep 3 || return 1
   done
 }
 # run_command <script>: ARM-authenticated shell on the VM; retries while the extension is still installing.
@@ -120,7 +120,7 @@ run_command() {
       printf '%s\n' "$output"; return 0
     fi
     grep -qi "in progress\|Conflict\|please wait" <<<"$output" || { printf '%s\n' "$output" >&2; return 1; }
-    say "run-command busy (attempt $attempt); retrying"; sleep 10
+    say "run-command busy (attempt $attempt); retrying"; bounded sleep 10 || return 1
   done
   return 1
 }
@@ -157,6 +157,7 @@ cleanup() {
 finish() {
   local code=$? expired=0
   trap - EXIT
+  trap '' INT TERM  # a second interrupt must not cut the cleanup attempt short
   [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || expired=1  # decided before cleanup spends its own bound
   cleanup
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
@@ -335,7 +336,7 @@ say "rust qualifier on data disk: ${DATA_STATUS:-none} (overlay control: ${OVERL
 
 say "detach independence: start a heartbeat, disconnect, reconnect"
 BEFORE=$(ssh_worker "$IP" 'tmux new-session -d -s spike "while true; do date -u +%FT%TZ >> /workspace/spike-heartbeat; sleep 2; done"; sleep 1; wc -l < /workspace/spike-heartbeat' 2>/dev/null || echo 0)
-sleep 20
+bounded sleep 20 || true
 AFTER=$(ssh_worker "$IP" 'tmux has-session -t spike 2>/dev/null && wc -l < /workspace/spike-heartbeat' 2>/dev/null || echo 0)
 PROGRESSED=false; [ "${AFTER:-0}" -gt "${BEFORE:-0}" ] 2>/dev/null && PROGRESSED=true
 journal detach_independence "$(jq -cn --argjson b "${BEFORE:-0}" --argjson a "${AFTER:-0}" --argjson p $PROGRESSED '{lines_before:$b,lines_after:$a,progressed:$p}')"
@@ -359,7 +360,7 @@ IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps 
 IP_SAME=false; [ "$IP" = "$IP_AFTER" ] && IP_SAME=true
 KEY_SAME=false SESSION=unknown RETAINED_MARKER=false HEARTBEAT=0 MOUNTED=false
 if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) nc -z -w 3 "$IP_AFTER" 2222; then
-  SCANNED=$(ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
+  SCANNED=$(bounded ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
   [ "$SCANNED" = "$HOST_KEY" ] && KEY_SAME=true
   if [ "$KEY_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) ssh_worker "$IP_AFTER" true; then
     OUT=$(ssh_worker "$IP_AFTER" "cat /workspace/spike-marker 2>/dev/null || echo missing; tmux has-session -t spike 2>/dev/null && echo session-alive || echo session-gone; wc -l < /workspace/spike-heartbeat 2>/dev/null || echo 0; grep -q ' /workspace ' /proc/self/mounts && echo mounted || echo unmounted" 2>/dev/null || printf 'missing\nunknown\n0\nunknown\n')

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -8,9 +8,10 @@
 # journaled privately. Nothing here registers a provider, publishes an image or
 # touches resources outside the sample resource group. Run the read-only preflight first.
 #
-# Exit codes: 0 every gate held; 3 usage; 4 lifetime bound reached (cleanup attempted);
-# 5 worker never published a host key; 6 deletion not proven; 7 a functional gate failed
-# (evidence journaled, resources deleted).
+# Exit codes: 0 every gate held; 1 setup or provider failure before the gates (cleanup attempted);
+# 3 usage; 4 lifetime bound reached (cleanup attempted); 5 worker never published a host key;
+# 6 deletion not proven; 7 a functional gate failed (evidence journaled, resources deleted);
+# 130 interrupted (cleanup attempted). Any other status is normalized to 1.
 set -euo pipefail
 
 usage() {
@@ -57,7 +58,7 @@ done
 [[ $SAMPLE =~ ^[1-9]$ ]] || { echo "--sample must be 1-9" >&2; exit 3; }
 [[ $MAX_MINUTES =~ ^[1-9][0-9]{1,2}$ ]] || { echo "--max-minutes must be 10-999 without leading zeros" >&2; exit 3; }
 [ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
-for tool in az ssh ssh-keygen ssh-keyscan nc jq curl; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
+for tool in az ssh ssh-keygen ssh-keyscan nc jq curl timeout; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
 
 REGISTRY=${IMAGE%%/*}
 RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
@@ -74,11 +75,15 @@ JOURNAL="$SAMPLE_DIR/journal.jsonl"
 KEY="$SAMPLE_DIR/client-ed25519"
 KNOWN_HOSTS="$SAMPLE_DIR/known_hosts"
 GATE_FAILURES=()
-CREATED=0 CLEANED=0 DELETE_PROVEN=0 CLEANUP_DEADLINE=0
+CREATED=0 CLEANED=0 DELETE_PROVEN=0 CLEANUP_DEADLINE=0 PHASE_DEADLINE=0
 
 # Every blocking call runs under the remaining lifetime bound; cleanup shares one fixed 25-minute deadline.
 remaining_seconds() {
-  if [ "$CLEANED" = 1 ]; then echo $(( CLEANUP_DEADLINE - $(date +%s) )); else echo $(( DEADLINE_EPOCH - $(date +%s) )); fi
+  local now limit; now=$(date +%s)
+  if [ "$CLEANED" = 1 ]; then echo $(( CLEANUP_DEADLINE - now )); return; fi
+  limit=$DEADLINE_EPOCH
+  [ "$PHASE_DEADLINE" -gt 0 ] && [ "$PHASE_DEADLINE" -lt "$limit" ] && limit=$PHASE_DEADLINE
+  echo $(( limit - now ))
 }
 bounded() {
   local remaining rc; remaining=$(remaining_seconds)
@@ -154,6 +159,7 @@ finish() {
   cleanup
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
   if [ "$code" != 0 ] && [ "$expired" = 1 ]; then code=4; fi  # any failure past the active-phase bound is a bound expiry
+  case "$code" in 0|3|4|5|6|7|130) ;; *) code=1 ;; esac
   if [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven delete outranks every other outcome
   journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"
   say "sample $SAMPLE finished with exit $code${GATE_FAILURES[*]:+ (failed gates: ${GATE_FAILURES[*]})}; journal $JOURNAL"
@@ -235,6 +241,9 @@ fi
 azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
 journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
 
+# Read-only provider preflight for the auto-shutdown schedule; registration is a separate approval.
+DEVTESTLAB=$(azc provider show --namespace Microsoft.DevTestLab --query registrationState -o tsv 2>/dev/null || echo unknown)
+[ "$DEVTESTLAB" = Registered ] || { journal devtestlab_not_registered "$(jq -cn --arg s "$DEVTESTLAB" '{registration_state:$s}')"; say "Microsoft.DevTestLab is $DEVTESTLAB; the platform-side stop cannot be scheduled, so nothing is created"; exit 1; }
 EXISTS=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)
 [ "$EXISTS" = false ] || { journal group_name_not_free "$(jq -cn --arg e "$EXISTS" '{group_exists:$e}')"; say "refusing to claim $RG (exists=$EXISTS)"; exit 1; }
 T0=$(epoch_ms)
@@ -341,12 +350,13 @@ POWER=$(azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "in
 journal deallocated "$(jq -cn --argjson ms $((T_STOPPED - T_STOP)) --argjson ok $STOP_OK --arg power "$POWER" '{stop_ms:$ms,call_succeeded:$ok,power_state:$power}')"
 gate deallocated "$([ "$STOP_OK" = true ] && [ "$POWER" = PowerState/deallocated ] && echo true || echo false)"
 T_START=$(epoch_ms)
+# The whole restart phase (start call, lookup, both polls, evidence) shares one 10-minute bound.
+RESTART_DEADLINE=$(( $(date +%s) + RESTART_WAIT_SECONDS )); PHASE_DEADLINE=$RESTART_DEADLINE
 START_OK=true; azc vm start --resource-group "$RG" --name "$VM" >/dev/null || START_OK=false
 IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv 2>/dev/null || echo unknown)
 IP_SAME=false; [ "$IP" = "$IP_AFTER" ] && IP_SAME=true
 KEY_SAME=false SESSION=unknown RETAINED_MARKER=false HEARTBEAT=0 MOUNTED=false
-RESTART_DEADLINE=$(( $(date +%s) + RESTART_WAIT_SECONDS ))
-if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for "$RESTART_WAIT_SECONDS" nc -z -w 3 "$IP_AFTER" 2222; then
+if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) nc -z -w 3 "$IP_AFTER" 2222; then
   SCANNED=$(ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
   [ "$SCANNED" = "$HOST_KEY" ] && KEY_SAME=true
   if [ "$KEY_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) ssh_worker "$IP_AFTER" true; then
@@ -356,6 +366,7 @@ if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for "$RESTART_WAIT_SE
   fi
 fi
 T_RESTARTED=$(epoch_ms)
+PHASE_DEADLINE=0
 if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != true ]; then
   say "restart verification failed; capturing guest diagnostics out of band"
   run_command 'systemctl is-system-running; systemctl list-units --failed --no-legend; systemctl status docker --no-pager | head -20; findmnt /mnt/horizon-workspace; docker ps -a; docker logs --tail 20 horizon-worker 2>&1; journalctl -b -u docker --no-pager | tail -20' >"$SAMPLE_DIR/restart-diagnostics.txt" 2>&1 || true

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -139,18 +139,20 @@ cleanup() {
   fi
   finished=$(epoch_ms)
   azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json" 2>/dev/null || echo 'null' >"$SAMPLE_DIR/inventory-after.json"
-  # Proof: every pre-existing resource still exists and nothing remains under the sample group.
-  # Resources added meanwhile by other actors are counted, not treated as this sample's fault.
+  # Proof: the group is gone and nothing remains under it. Every mutating call in this script
+  # names the sample group, so changes outside it belong to other actors sharing the
+  # subscription; they are journaled for cross-checking against the activity log, not blamed.
   local verdict
   verdict=$(jq -cn --arg rg "/resourceGroups/$RG/" --slurpfile before "$SAMPLE_DIR/inventory-before.json" --slurpfile after "$SAMPLE_DIR/inventory-after.json" \
     '($before[0] // null) as $b | ($after[0] // null) as $a
      | if ($b|type) != "array" or ($a|type) != "array" then {proven:false,reason:"inventory_unavailable"}
-       else {removed:($b - $a), leftover:[$a[] | select(ascii_downcase | contains($rg|ascii_downcase))], added_by_others:(($a - $b)|length)}
-            | .proven = ((.removed|length)==0 and (.leftover|length)==0) end')
+       else {leftover:[$a[] | select(ascii_downcase | contains($rg|ascii_downcase))],
+             concurrent_removals_outside_group:($b - $a), concurrent_additions_outside_group:(($a - $b)|length)}
+            | .proven = ((.leftover|length)==0) end')
   [ "$(jq -r .proven <<<"$verdict")" = true ] && unchanged=true
   [ "$exists" = false ] && [ "$unchanged" = true ] && DELETE_PROVEN=1
   journal deleted "$(jq -cn --arg exists "$exists" --argjson ms $((finished - started)) --argjson v "$verdict" '{group_exists:$exists,delete_ms:$ms,inventory_proof:$v}')"
-  say "resource group exists=$exists inventory_proof=$(jq -c 'del(.removed,.leftover)' <<<"$verdict") delete_ms=$((finished - started))"
+  say "resource group exists=$exists inventory_proof=$(jq -c '{proven,leftover:(.leftover|length),concurrent_removals_outside_group:(.concurrent_removals_outside_group|length),concurrent_additions_outside_group}' <<<"$verdict") delete_ms=$((finished - started))"
 }
 finish() {
   local code=$? expired=0

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -180,7 +180,7 @@ finish() {
   [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || expired=1  # decided before cleanup spends its own bound
   cleanup
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
-  if [ "$code" != 0 ] && [ "$expired" = 1 ]; then code=4; fi  # any failure past the active-phase bound is a bound expiry
+  if [ "$expired" = 1 ]; then code=4; fi  # crossing the active-phase bound is never a success, whatever else happened
   case "$code" in 0|3|4|5|6|7|130) ;; *) code=1 ;; esac
   if [ "$CREATED" = 1 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven (or --keep skipped) delete outranks every other outcome
   journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -300,9 +300,11 @@ say "endpoint open in $((T_PORT - T0)) ms"
 
 say "reading worker host key out of band through run-command"
 RC_START=$(epoch_ms)
-RC_TEXT=$(run_command 'cat /mnt/horizon-workspace/.horizon-worker/ssh/*.pub 2>/dev/null; echo ---TIMING---; cat /var/log/horizon-spike-timing.jsonl') || RC_TEXT=""
+RC_OK=true
+RC_TEXT=$(run_command 'cat /mnt/horizon-workspace/.horizon-worker/ssh/*.pub 2>/dev/null; echo ---TIMING---; cat /var/log/horizon-spike-timing.jsonl' 2>&1) || RC_OK=false
 RC_END=$(epoch_ms)
 printf '%s\n' "$RC_TEXT" >"$SAMPLE_DIR/run-command-hostkey.txt"
+[ "$RC_OK" = true ] || { journal run_command_failed "$(jq -cn --argjson ms $((RC_END - RC_START)) '{run_command_ms:$ms}')"; say "run-command failed; see run-command-hostkey.txt"; exit 1; }
 HOST_KEY=$(printf '%s\n' "$RC_TEXT" | grep -m1 '^ssh-ed25519 ' | awk '{print $1" "$2}' || true)
 printf '%s\n' "$RC_TEXT" | sed -n '/---TIMING---/,$p' | grep '^{' >"$SAMPLE_DIR/guest-timing.jsonl" || true
 [ -n "$HOST_KEY" ] || { journal host_key_missing "$(jq -cn --argjson ms $((RC_END - RC_START)) '{run_command_ms:$ms}')"; say "no ed25519 host key published yet; aborting sample"; exit 5; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -70,7 +70,7 @@ if [ "$DRY_RUN" = 0 ] || [ -n "$PREFLIGHT" ]; then
   PREFLIGHT_FACTS=$(jq -c --arg region "$REGION" --arg size "$VM_SIZE" --arg digest "$SUB_DIGEST" '
     if .schema == "horizon.azure-workspace-preflight.report" and .candidate.id == "vm" and .region == $region
        and .candidate.vm_size == $size and .mode == "live" and .status == "no_blockers_observed"
-       and .subscription_digest == $digest
+       and .subscription_digest == $digest and .schema_version == 1
     then {observed_at, tool_version, status, schema_version, subscription_digest} else empty end' "$PREFLIGHT" 2>/dev/null || true)
   [ -n "$PREFLIGHT_FACTS" ] || { echo "--preflight-report is not a live vm preflight for this subscription, $REGION and $VM_SIZE with no blockers observed" >&2; exit 3; }
 fi
@@ -489,18 +489,20 @@ T_RESTARTED=$(epoch_ms)
 PHASE_DEADLINE=0
 # Prove the guest-side bound: confirm the timer is armed, fire its service once, expect deallocation.
 SELF_STOP=false TIMER_ARMED=false
-grep -q '"event":"deadline_timer_armed"' "$SAMPLE_DIR/guest-timing.jsonl" 2>/dev/null && TIMER_ARMED=true  # stamped by runcmd before Docker
 if [ "$KEY_SAME" = true ]; then
-  # The deallocation usually preempts the run-command response itself; the power state is the evidence.
-  TIMER_TEXT=$(run_command 'systemctl list-timers horizon-spike-deadline.timer --no-legend; systemctl start --no-block horizon-spike-deadline.service' 2>&1 || true)
+  # First prove the automatic timer is enabled and waiting, then fire its service by hand; the
+  # deallocation usually preempts the run-command response itself, so the power state is the evidence.
+  TIMER_TEXT=$(run_command 'systemctl is-enabled horizon-spike-deadline.timer; systemctl is-active horizon-spike-deadline.timer; systemctl list-timers horizon-spike-deadline.timer --no-legend' 2>&1 || true)
   printf '%s\n' "$TIMER_TEXT" >"$SAMPLE_DIR/self-deallocate.txt"
+  grep -qx enabled <<<"$TIMER_TEXT" && grep -qx active <<<"$TIMER_TEXT" && TIMER_ARMED=true
+  run_command 'systemctl start --no-block horizon-spike-deadline.service' >>"$SAMPLE_DIR/self-deallocate.txt" 2>&1 || true
   PHASE_DEADLINE=$(( $(date +%s) + 300 ))
   vm_deallocated() { azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null | grep -qx PowerState/deallocated; }
   wait_for 300 vm_deallocated && SELF_STOP=true
   PHASE_DEADLINE=0
 fi
 journal self_deallocate "$(jq -cn --argjson armed $TIMER_ARMED --argjson stopped $SELF_STOP '{timer_armed:$armed,vm_deallocated_by_guest:$stopped}')"
-gate guest_lifetime_bound "$SELF_STOP"
+gate guest_lifetime_bound "$([ "$TIMER_ARMED" = true ] && [ "$SELF_STOP" = true ] && echo true || echo false)"
 say "guest-side bound: timer_armed=$TIMER_ARMED vm_deallocated_by_guest=$SELF_STOP"
 if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != true ]; then
   say "restart verification failed; capturing guest diagnostics out of band"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -139,20 +139,22 @@ cleanup() {
   fi
   finished=$(epoch_ms)
   azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json" 2>/dev/null || echo 'null' >"$SAMPLE_DIR/inventory-after.json"
-  # Proof: the group is gone and nothing remains under it. Every mutating call in this script
-  # names the sample group, so changes outside it belong to other actors sharing the
-  # subscription; they are journaled for cross-checking against the activity log, not blamed.
+  # Proof (#474: exact absence and unchanged pre-existing resources): nothing remains under the
+  # sample group and no pre-existing resource disappeared. A disappearance outside the group is
+  # most likely another actor in the shared subscription, but the inventory cannot attribute it,
+  # so the proof is reported as unverified and the sample must be rerun. Additions are counted.
   local verdict
   verdict=$(jq -cn --arg rg "/resourceGroups/$RG/" --slurpfile before "$SAMPLE_DIR/inventory-before.json" --slurpfile after "$SAMPLE_DIR/inventory-after.json" \
     '($before[0] // null) as $b | ($after[0] // null) as $a
      | if ($b|type) != "array" or ($a|type) != "array" then {proven:false,reason:"inventory_unavailable"}
        else {leftover:[$a[] | select(ascii_downcase | contains($rg|ascii_downcase))],
-             concurrent_removals_outside_group:($b - $a), concurrent_additions_outside_group:(($a - $b)|length)}
-            | .proven = ((.leftover|length)==0) end')
+             removed_outside_group:($b - $a), added_outside_group:(($a - $b)|length)}
+            | .proven = ((.leftover|length)==0 and (.removed_outside_group|length)==0)
+            | if .proven then . else .reason = (if (.leftover|length)>0 then "resources_left_under_group" else "unverified_concurrent_removal_outside_group" end) end end')
   [ "$(jq -r .proven <<<"$verdict")" = true ] && unchanged=true
   [ "$exists" = false ] && [ "$unchanged" = true ] && DELETE_PROVEN=1
   journal deleted "$(jq -cn --arg exists "$exists" --argjson ms $((finished - started)) --argjson v "$verdict" '{group_exists:$exists,delete_ms:$ms,inventory_proof:$v}')"
-  say "resource group exists=$exists inventory_proof=$(jq -c '{proven,leftover:(.leftover|length),concurrent_removals_outside_group:(.concurrent_removals_outside_group|length),concurrent_additions_outside_group}' <<<"$verdict") delete_ms=$((finished - started))"
+  say "resource group exists=$exists inventory_proof=$(jq -c '{proven,reason,leftover:(.leftover|length),removed_outside_group:(.removed_outside_group|length),added_outside_group}' <<<"$verdict") delete_ms=$((finished - started))"
 }
 finish() {
   local code=$? expired=0
@@ -281,7 +283,7 @@ fi
 NSG=$(azc network nsg list --resource-group "$RG" --query "[0].name" -o tsv)
 SOURCE=${ALLOW_SSH_FROM:-}
 if [ -z "$SOURCE" ]; then
-  EGRESS=$(curl -s --max-time 10 https://ifconfig.me || true)
+  EGRESS=$(bounded curl -s --max-time 10 https://ifconfig.me || true)
   [[ $EGRESS =~ ^[0-9.]+$ ]] || { journal egress_unknown '{}'; say "could not learn the egress address; pass --allow-ssh-from"; exit 1; }
   SOURCE="$EGRESS/32"
 fi
@@ -291,7 +293,7 @@ azc network nsg rule create --resource-group "$RG" --nsg-name "$NSG" --name work
 journal nsg_rule "$(jq -cn --arg src "$SOURCE" '{source:$src,port:2222}')"
 
 say "waiting for worker endpoint on port 2222"
-wait_for $(( DEADLINE_EPOCH - $(date +%s) )) nc -z -w 3 "$IP" 2222 || { journal endpoint_never_opened '{}'; exit 4; }
+wait_for $(( DEADLINE_EPOCH - $(date +%s) )) bounded nc -z -w 3 "$IP" 2222 || { journal endpoint_never_opened '{}'; exit 4; }
 T_PORT=$(epoch_ms)
 journal endpoint_open "$(jq -cn --argjson ms $((T_PORT - T0)) '{ms_from_t0:$ms}')"
 say "endpoint open in $((T_PORT - T0)) ms"
@@ -359,7 +361,7 @@ START_OK=true; azc vm start --resource-group "$RG" --name "$VM" >/dev/null || ST
 IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv 2>/dev/null || echo unknown)
 IP_SAME=false; [ "$IP" = "$IP_AFTER" ] && IP_SAME=true
 KEY_SAME=false SESSION=unknown RETAINED_MARKER=false HEARTBEAT=0 MOUNTED=false
-if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) nc -z -w 3 "$IP_AFTER" 2222; then
+if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) bounded nc -z -w 3 "$IP_AFTER" 2222; then
   SCANNED=$(bounded ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
   [ "$SCANNED" = "$HOST_KEY" ] && KEY_SAME=true
   if [ "$KEY_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) ssh_worker "$IP_AFTER" true; then

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -151,9 +151,8 @@ cleanup() {
   local started finished exists=unknown unchanged=false
   started=$(epoch_ms)
   say "deleting resource group $RG"
-  if azc group delete --name "$RG" --yes --no-wait >/dev/null 2>&1 && azc group wait --name "$RG" --deleted --timeout 1200 >/dev/null 2>&1; then
-    exists=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)
-  fi
+  azc group delete --name "$RG" --yes --no-wait >/dev/null 2>&1 && azc group wait --name "$RG" --deleted --timeout 1200 >/dev/null 2>&1 || true
+  exists=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)  # final Azure state decides, not the call statuses
   finished=$(epoch_ms)
   azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json" 2>/dev/null || echo 'null' >"$SAMPLE_DIR/inventory-after.json"
   # Proof (#474: exact absence and unchanged pre-existing resources): nothing remains under the

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -65,11 +65,14 @@ for tool in az ssh ssh-keygen ssh-keyscan nc jq curl timeout; do command -v "$to
 # region and size, with no blockers, and carry its provenance into the sample journal.
 if [ "$DRY_RUN" = 0 ] || [ -n "$PREFLIGHT" ]; then
   [ -n "$PREFLIGHT" ] && [ -r "$PREFLIGHT" ] || { echo "--preflight-report must point at a readable preflight JSON report" >&2; exit 3; }
-  PREFLIGHT_FACTS=$(jq -c --arg region "$REGION" --arg size "$VM_SIZE" '
+  # The report carries a stable digest of its subscription instead of the identifier itself.
+  SUB_DIGEST=$(printf 'horizon-preflight:%s' "$SUBSCRIPTION" | sha256sum | cut -c1-16)
+  PREFLIGHT_FACTS=$(jq -c --arg region "$REGION" --arg size "$VM_SIZE" --arg digest "$SUB_DIGEST" '
     if .schema == "horizon.azure-workspace-preflight.report" and .candidate.id == "vm" and .region == $region
        and .candidate.vm_size == $size and .mode == "live" and .status == "no_blockers_observed"
-    then {observed_at, tool_version, status, schema_version} else empty end' "$PREFLIGHT" 2>/dev/null || true)
-  [ -n "$PREFLIGHT_FACTS" ] || { echo "--preflight-report is not a live vm preflight for $REGION/$VM_SIZE with no blockers observed" >&2; exit 3; }
+       and .subscription_digest == $digest
+    then {observed_at, tool_version, status, schema_version, subscription_digest} else empty end' "$PREFLIGHT" 2>/dev/null || true)
+  [ -n "$PREFLIGHT_FACTS" ] || { echo "--preflight-report is not a live vm preflight for this subscription, $REGION and $VM_SIZE with no blockers observed" >&2; exit 3; }
 fi
 
 REGISTRY=${IMAGE%%/*}
@@ -343,9 +346,10 @@ QUALIFIER_REQUEST='{"version":1,"retained_root":"%s","workspace_local_id":"works
 QUALIFIER_OUT=$(ssh_worker "$IP" "set -e; mkdir -p -m 0755 /workspace/spike-input/objects /workspace/spike-input/bundles; mkdir -p -m 0700 /workspace/spike-retained /root/spike-overlay; printf '$QUALIFIER_REQUEST' /workspace/spike-retained | /usr/local/bin/horizon-repository setup-status; echo; echo ---OVERLAY---; printf '$QUALIFIER_REQUEST' /root/spike-overlay | /usr/local/bin/horizon-repository setup-status || true; echo" 2>&1 || true)
 printf '%s\n' "$QUALIFIER_OUT" >"$SAMPLE_DIR/qualifier-output.txt"
 DATA_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed '/---OVERLAY---/,$d' | jq -r '.status // empty' 2>/dev/null | head -1 || true)
-OVERLAY_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed -n '/---OVERLAY---/,$p' | grep -v -- '---' | jq -r '.status // empty' 2>/dev/null | head -1 || true)
+OVERLAY_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed -n '/---OVERLAY---/,$p' | grep -v -- '---' | jq -r '"\(.status // "none"):\(.reason // "")"' 2>/dev/null | head -1 || true)
 QUALIFIED=false; [ "$DATA_STATUS" = absent ] && QUALIFIED=true
-CONTROL_REJECTED=false; case "${OVERLAY_STATUS:-none}" in error|rejected) CONTROL_REJECTED=true ;; esac
+# Only the storage discriminator's own refusal counts; a decoding "rejected" or another error does not.
+CONTROL_REJECTED=false; [ "$OVERLAY_STATUS" = "error:retained setup requires supported journaled storage and confinement" ] && CONTROL_REJECTED=true
 journal storage_evidence "$(jq -cn --argjson mirror $MIRROR --argjson q $QUALIFIED --argjson c $CONTROL_REJECTED --arg ds "${DATA_STATUS:-none}" --arg os "${OVERLAY_STATUS:-none}" --arg opts "$OPTIONS" '{shell_mirror_passes:$mirror,rust_qualifier_status_on_data_disk:$ds,rust_qualifier_status_on_overlay:$os,rust_qualifier_accepts_data_disk:$q,overlay_control_rejected:$c,kernel_options:($opts|split("\n")|map(select(length>0)))}')"
 gate storage_qualifier "$QUALIFIED"
 gate storage_negative_control "$CONTROL_REJECTED"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -29,6 +29,10 @@ SUBSCRIPTION="" IMAGE="" PULLER_ID="" JOURNAL_DIR="" REGION=northeurope VM_SIZE=
 SAMPLE=1 MAX_MINUTES=120 ALLOW_SSH_FROM="" KEEP=0 DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
+    --subscription|--image|--puller-identity-id|--journal-dir|--region|--vm-size|--sample|--max-minutes|--allow-ssh-from)
+      [ $# -ge 2 ] || { echo "$1 requires a value" >&2; usage; exit 3; } ;;
+  esac
+  case "$1" in
     --subscription) SUBSCRIPTION=$2; shift 2 ;;
     --image) IMAGE=$2; shift 2 ;;
     --puller-identity-id) PULLER_ID=$2; shift 2 ;;
@@ -70,15 +74,18 @@ JOURNAL="$SAMPLE_DIR/journal.jsonl"
 KEY="$SAMPLE_DIR/client-ed25519"
 KNOWN_HOSTS="$SAMPLE_DIR/known_hosts"
 GATE_FAILURES=()
-CREATED=0 CLEANED=0 DELETE_PROVEN=0
+CREATED=0 CLEANED=0 DELETE_PROVEN=0 CLEANUP_DEADLINE=0
 
-# Every blocking CLI call runs under the remaining lifetime bound; cleanup gets its own fixed bound.
-azc() {
-  local remaining
-  if [ "$CLEANED" = 1 ]; then remaining=1500; else remaining=$(( DEADLINE_EPOCH - $(date +%s) )); fi
-  if [ "$remaining" -lt 1 ]; then say "lifetime bound reached before: az $1 $2"; return 124; fi
-  timeout -k 15 "$remaining" az "$@" --subscription "$SUBSCRIPTION" --only-show-errors
+# Every blocking call runs under the remaining lifetime bound; cleanup shares one fixed 25-minute deadline.
+remaining_seconds() {
+  if [ "$CLEANED" = 1 ]; then echo $(( CLEANUP_DEADLINE - $(date +%s) )); else echo $(( DEADLINE_EPOCH - $(date +%s) )); fi
 }
+bounded() {
+  local remaining; remaining=$(remaining_seconds)
+  if [ "$remaining" -lt 1 ]; then say "bound reached before: $1 $2 $3"; return 124; fi
+  timeout -k 15 "$remaining" "$@"
+}
+azc() { bounded az "$@" --subscription "$SUBSCRIPTION" --only-show-errors; }
 now() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
 epoch_ms() { date +%s%3N; }
 journal() { local data=${2:-'{}'}; jq -cn --arg at "$(now)" --arg event "$1" --argjson data "$data" '{at:$at,event:$event,data:$data}' >>"$JOURNAL"; }
@@ -110,6 +117,7 @@ run_command() {
 cleanup() {
   [ "$CLEANED" = 0 ] || return 0
   CLEANED=1
+  CLEANUP_DEADLINE=$(( $(date +%s) + 1500 ))
   [ "$CREATED" = 1 ] || return 0
   if [ "$KEEP" = 1 ]; then say "--keep given; leaving $RG in place (delete it yourself)"; journal kept "$(jq -cn --arg rg "$RG" '{resource_group:$rg}')"; return 0; fi
   local started finished exists=unknown unchanged=false
@@ -209,8 +217,10 @@ trap 'exit 130' INT TERM
 azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
 journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
 
+EXISTS=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)
+[ "$EXISTS" = false ] || { journal group_name_not_free "$(jq -cn --arg e "$EXISTS" '{group_exists:$e}')"; say "refusing to claim $RG (exists=$EXISTS)"; exit 1; }
 T0=$(epoch_ms)
-CREATED=1  # cleanup owns the uniquely named group from this point, even if the create response is lost
+CREATED=1  # cleanup owns the verified-absent group from this point, even if the create response is lost
 azc group create --name "$RG" --location "$REGION" \
   --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
@@ -257,7 +267,7 @@ printf '%s\n' "$RC_TEXT" | sed -n '/---TIMING---/,$p' | grep '^{' >"$SAMPLE_DIR/
 printf '[%s]:2222 %s\n' "$IP" "$HOST_KEY" >"$KNOWN_HOSTS"
 journal host_key_pinned "$(jq -cn --argjson ms $((RC_END - RC_START)) --arg fp "$(ssh-keygen -lf "$KNOWN_HOSTS" | awk '{print $2}')" '{run_command_ms:$ms,fingerprint:$fp}')"
 
-ssh_worker() { ssh -T -F /dev/null -p 2222 -i "$KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$KNOWN_HOSTS" \
+ssh_worker() { bounded ssh -T -F /dev/null -p 2222 -i "$KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$KNOWN_HOSTS" \
   -o PasswordAuthentication=no -o KbdInteractiveAuthentication=no -o ConnectTimeout=10 -o BatchMode=yes "root@$1" "${@:2}"; }
 wait_for $(( DEADLINE_EPOCH - $(date +%s) )) ssh_worker "$IP" true || { journal ssh_never_verified '{}'; exit 4; }
 T_SSH=$(epoch_ms)

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -326,7 +326,12 @@ REAPER_NEXT=$(date -u -d "$(jq -r '.next_run // empty' <<<"$REAPER_SCHEDULE")" +
 REAPER_PRINCIPAL=$(azc rest --method get --url "$REAPER_BASE?api-version=2023-11-01" --query identity.principalId -o tsv 2>/dev/null || true)
 REAPER_ROLES=$(azc role assignment list --assignee "${REAPER_PRINCIPAL:-00000000-0000-0000-0000-000000000000}" --role "Desktop Virtualization Power On Off Contributor" --scope "/subscriptions/$SUBSCRIPTION" --query "length(@)" -o tsv 2>/dev/null || echo 0)
 [ "$REAPER_ROLES" != 0 ] || { journal reaper_role_missing '{}'; say "the reaper identity lacks the subscription-scoped power-only role; rerun setup-spike-reaper.sh (nothing created)"; exit 1; }
-journal reaper_present "$(jq -c --arg acct "$REAPER_ACCOUNT" '. + {account:$acct,power_role_assigned:true}' <<<"$REAPER_SCHEDULE")"
+# The published runbook must be exactly the reviewed reaper-runbook.ps1 next to this script.
+EXPECTED_SHA=$(sha256sum "$(dirname "$0")/reaper-runbook.ps1" | cut -c1-64)
+PUBLISHED_SHA=$( { azc rest --method get --url "$REAPER_BASE/runbooks/horizon-spike-deadline-reaper/content?api-version=2023-11-01" 2>/dev/null || true; } | tr -d '\r' | sha256sum | cut -c1-64)
+REAPER_STATE=$(azc rest --method get --url "$REAPER_BASE/runbooks/horizon-spike-deadline-reaper?api-version=2023-11-01" --query properties.state -o tsv 2>/dev/null || echo unknown)
+[ "$REAPER_STATE" = Published ] && [ "$PUBLISHED_SHA" = "$EXPECTED_SHA" ] || { journal reaper_content_mismatch "$(jq -cn --arg st "$REAPER_STATE" --arg e "$EXPECTED_SHA" --arg p "$PUBLISHED_SHA" '{state:$st,expected_sha256:$e,published_sha256:$p}')"; say "the published reaper runbook is not the reviewed content (state $REAPER_STATE); rerun setup-spike-reaper.sh (nothing created)"; exit 1; }
+journal reaper_present "$(jq -c --arg acct "$REAPER_ACCOUNT" --arg sha "$EXPECTED_SHA" '. + {account:$acct,power_role_assigned:true,runbook_sha256:$sha}' <<<"$REAPER_SCHEDULE")"
 # Read-only provider preflight for the auto-shutdown schedule; registration is a separate approval.
 DEVTESTLAB=$(azc provider show --namespace Microsoft.DevTestLab --query registrationState -o tsv 2>/dev/null || echo unknown)
 [ "$DEVTESTLAB" = Registered ] || { journal devtestlab_not_registered "$(jq -cn --arg s "$DEVTESTLAB" '{registration_state:$s}')"; say "Microsoft.DevTestLab is $DEVTESTLAB; the platform-side stop cannot be scheduled, so nothing is created"; exit 1; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -109,7 +109,9 @@ bounded() {
 }
 # Machine-consumed output is always JSON unless the caller asks for tsv explicitly.
 azc() {
-  case " $* " in *" -o "*|*" --output "*) ;; *) set -- "$@" --output json ;; esac
+  local arg explicit=0
+  for arg in "$@"; do case "$arg" in -o|--output) explicit=1 ;; esac; done
+  [ "$explicit" = 1 ] || set -- "$@" --output json
   bounded az "$@" --subscription "$SUBSCRIPTION" --only-show-errors
 }
 now() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -313,7 +313,7 @@ journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before
 REAPER_BASE="https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$REAPER_RG/providers/Microsoft.Automation/automationAccounts/$REAPER_ACCOUNT"
 REAPER_FACTS=$(azc rest --method get --url "$REAPER_BASE/jobSchedules?api-version=2023-11-01" --query "value[?properties.runbook.name=='horizon-spike-deadline-reaper'] | [0].properties.schedule.name" -o tsv 2>/dev/null || true)
 REAPER_SCHEDULE=$(azc rest --method get --url "$REAPER_BASE/schedules/${REAPER_FACTS:-none}?api-version=2023-11-01" --query "{enabled:properties.isEnabled,next_run:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" 2>/dev/null || echo null)
-[ "$(jq -r '.enabled // false' <<<"$REAPER_SCHEDULE")" = true ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present or not enabled; run setup-spike-reaper.sh first (nothing created)"; exit 1; }
+[ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$REAPER_SCHEDULE")" = ok ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present, not enabled or not the 15-minute schedule; run setup-spike-reaper.sh first (nothing created)"; exit 1; }
 journal reaper_present "$(jq -c --arg acct "$REAPER_ACCOUNT" '. + {account:$acct}' <<<"$REAPER_SCHEDULE")"
 # Read-only provider preflight for the auto-shutdown schedule; registration is a separate approval.
 DEVTESTLAB=$(azc provider show --namespace Microsoft.DevTestLab --query registrationState -o tsv 2>/dev/null || echo unknown)
@@ -518,6 +518,8 @@ if [ "$PROVE_REAPER" = 1 ] && [ "$KEY_SAME" = true ]; then
   journal reaper_proof "$(jq -cn --argjson ok $REAPED --argjson ms $(( $(epoch_ms) - T_REAP )) '{vm_deallocated_by_reaper:$ok,wait_ms:$ms}')"
   gate reaper_bound "$REAPED"
   say "reaper proof: vm_deallocated_by_reaper=$REAPED after $(( ($(epoch_ms) - T_REAP) / 1000 )) s"
+  # Restore the real deadline before restarting so the guest-timer proof below is isolated from the reaper.
+  azc tag update --resource-id "$VM_ID" --operation merge --tags deadline="$DEADLINE_TAG" >/dev/null || true
   if [ "$REAPED" = true ]; then azc vm start --resource-group "$RG" --name "$VM" >/dev/null || true; wait_for 600 ssh_worker "$IP_AFTER" true || true; fi
 fi
 # Prove the guest-side bound: confirm the timer is armed, fire its service once, expect deallocation.

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -2,11 +2,15 @@
 # Bounded three-sample Azure Linux VM spike for issue #474.
 #
 # One exact task-owned resource group per sample. Measures create, image pull,
-# endpoint, verified key-only SSH and delete timing; records on-worker ext4 kernel
-# options, detach independence, deallocate/start data retention and exact deletion
-# with an unchanged-inventory proof. Every timestamp is UTC and journaled privately.
-# Nothing here registers a provider, publishes an image or touches resources outside
-# the sample resource group. Run the read-only preflight first.
+# endpoint, verified key-only SSH and delete timing; runs the worker's authoritative
+# storage qualifier; records detach independence, deallocate/start data retention
+# and exact deletion with an unchanged-inventory proof. Every timestamp is UTC and
+# journaled privately. Nothing here registers a provider, publishes an image or
+# touches resources outside the sample resource group. Run the read-only preflight first.
+#
+# Exit codes: 0 every gate held; 3 usage; 4 lifetime bound reached (cleanup attempted);
+# 5 worker never published a host key; 6 deletion not proven; 7 a functional gate failed
+# (evidence journaled, resources deleted).
 set -euo pipefail
 
 usage() {
@@ -16,8 +20,8 @@ usage: run-vm-spike.sh --subscription <uuid> --image <registry/repo@sha256:...> 
          [--region northeurope] [--vm-size Standard_D4s_v3] [--sample 1] [--max-minutes 120] \
          [--allow-ssh-from <cidr>] [--keep] [--dry-run]
 
-Requires: az (logged in), ssh, ssh-keygen, nc, jq, curl. Paid creation is bounded by
---max-minutes; the sample resource group is deleted at the end unless --keep is given.
+Requires: az (logged in), ssh, ssh-keygen, ssh-keyscan, nc, jq, curl. Paid creation is
+bounded by --max-minutes; the sample resource group is deleted at the end unless --keep.
 EOF
 }
 
@@ -49,7 +53,7 @@ done
 [[ $SAMPLE =~ ^[1-9]$ ]] || { echo "--sample must be 1-9" >&2; exit 3; }
 [[ $MAX_MINUTES =~ ^[0-9]{1,3}$ ]] && [ "$MAX_MINUTES" -ge 10 ] || { echo "--max-minutes must be 10-999" >&2; exit 3; }
 [ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
-for tool in az ssh ssh-keygen nc jq curl; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
+for tool in az ssh ssh-keygen ssh-keyscan nc jq curl; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
 
 REGISTRY=${IMAGE%%/*}
 RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
@@ -57,6 +61,7 @@ TOKEN=$(head -c 3 /dev/urandom | od -An -tx1 | tr -d ' \n')
 RG="horizon-spike-474-s${SAMPLE}-${TOKEN}"
 VM="worker-s${SAMPLE}"
 DEADLINE_EPOCH=$(( $(date +%s) + MAX_MINUTES * 60 ))
+RESTART_WAIT_SECONDS=600
 umask 077
 mkdir -p "$JOURNAL_DIR"
 SAMPLE_DIR="$JOURNAL_DIR/sample-${SAMPLE}-${RUN_ID}"
@@ -64,32 +69,65 @@ mkdir "$SAMPLE_DIR"
 JOURNAL="$SAMPLE_DIR/journal.jsonl"
 KEY="$SAMPLE_DIR/client-ed25519"
 KNOWN_HOSTS="$SAMPLE_DIR/known_hosts"
+GATE_FAILURES=()
+CREATED=0 CLEANED=0 DELETE_PROVEN=0
 
 azc() { az "$@" --subscription "$SUBSCRIPTION" --only-show-errors; }
 now() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
 epoch_ms() { date +%s%3N; }
 journal() { local data=${2:-'{}'}; jq -cn --arg at "$(now)" --arg event "$1" --argjson data "$data" '{at:$at,event:$event,data:$data}' >>"$JOURNAL"; }
 say() { printf '[%s] %s\n' "$(now)" "$*"; }
-deadline_check() { [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || { say "lifetime bound reached; forcing cleanup"; cleanup; exit 4; }; }
+gate() { local name=$1 ok=$2; [ "$ok" = true ] || GATE_FAILURES+=("$name"); }
+deadline_check() { [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || { say "lifetime bound reached; forcing cleanup"; exit 4; }; }
+# wait_for <max-seconds> <command...>: poll every 3 s under the lifetime bound; returns 1 on the phase bound.
+wait_for() {
+  local until_epoch=$(( $(date +%s) + $1 )); shift
+  until "$@" >/dev/null 2>&1; do
+    deadline_check
+    [ "$(date +%s)" -lt "$until_epoch" ] || return 1
+    sleep 3
+  done
+}
+# run_command <script>: ARM-authenticated shell on the VM; retries while the extension is still installing.
+run_command() {
+  local attempt output
+  for attempt in $(seq 1 12); do
+    if output=$(azc vm run-command invoke --resource-group "$RG" --name "$VM" --command-id RunShellScript --scripts "$1" --query 'value[0].message' -o tsv 2>&1); then
+      printf '%s\n' "$output"; return 0
+    fi
+    grep -qi "in progress\|Conflict\|please wait" <<<"$output" || { printf '%s\n' "$output" >&2; return 1; }
+    say "run-command busy (attempt $attempt); retrying"; sleep 10
+  done
+  return 1
+}
 
 cleanup() {
-  local started finished exists
-  if [ "$KEEP" = 1 ]; then say "--keep given; leaving $RG in place (delete it yourself)"; journal kept '{"resource_group":"'"$RG"'"}'; return; fi
-  if [ "$DRY_RUN" = 1 ]; then return; fi
+  [ "$CLEANED" = 0 ] || return 0
+  CLEANED=1
+  [ "$CREATED" = 1 ] || return 0
+  if [ "$KEEP" = 1 ]; then say "--keep given; leaving $RG in place (delete it yourself)"; journal kept "$(jq -cn --arg rg "$RG" '{resource_group:$rg}')"; return 0; fi
+  local started finished exists=unknown unchanged=false
   started=$(epoch_ms)
   say "deleting resource group $RG"
-  azc group delete --name "$RG" --yes >/dev/null 2>&1 || true
-  for _ in $(seq 1 60); do
+  if azc group delete --name "$RG" --yes --no-wait >/dev/null 2>&1 && azc group wait --name "$RG" --deleted --timeout 1200 >/dev/null 2>&1; then
     exists=$(azc group exists --name "$RG" -o tsv 2>/dev/null || echo unknown)
-    [ "$exists" = false ] && break
-    sleep 10
-  done
+  fi
   finished=$(epoch_ms)
-  azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json"
-  local unchanged=false
+  azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-after.json" 2>/dev/null || echo '"unavailable"' >"$SAMPLE_DIR/inventory-after.json"
   cmp -s "$SAMPLE_DIR/inventory-before.json" "$SAMPLE_DIR/inventory-after.json" && unchanged=true
+  [ "$exists" = false ] && [ "$unchanged" = true ] && DELETE_PROVEN=1
   journal deleted "$(jq -cn --arg exists "$exists" --argjson ms $((finished - started)) --argjson unchanged $unchanged '{group_exists:$exists,delete_ms:$ms,inventory_unchanged:$unchanged}')"
   say "resource group exists=$exists inventory_unchanged=$unchanged delete_ms=$((finished - started))"
+}
+finish() {
+  local code=$?
+  trap - EXIT
+  cleanup
+  if [ "$code" = 0 ] && [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi
+  if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
+  journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"
+  say "sample $SAMPLE finished with exit $code${GATE_FAILURES[*]:+ (failed gates: ${GATE_FAILURES[*]})}; journal $JOURNAL"
+  exit "$code"
 }
 
 say "sample $SAMPLE run $RUN_ID journal $SAMPLE_DIR"
@@ -107,6 +145,12 @@ packages: [docker.io]
 bootcmd:
   - [ sh, -c, 'printf "{\"event\":\"boot\",\"at\":\"%s\"}\n" "\$(date -u +%FT%T.%3NZ)" >> /var/log/horizon-spike-timing.jsonl' ]
 write_files:
+  - path: /etc/systemd/system/docker.service.d/horizon-workspace.conf
+    permissions: '0644'
+    owner: root:root
+    content: |
+      [Unit]
+      RequiresMountsFor=/mnt/horizon-workspace
   - path: /usr/local/sbin/horizon-spike-bootstrap.sh
     permissions: '0700'
     owner: root:root
@@ -115,6 +159,7 @@ write_files:
       set -euo pipefail
       J=/var/log/horizon-spike-timing.jsonl
       stamp() { printf '{"event":"%s","at":"%s"}\n' "\$1" "\$(date -u +%FT%T.%3NZ)" >> "\$J"; }
+      field() { python3 -c 'import json,sys; print(json.load(sys.stdin)[sys.argv[1]])' "\$1"; }
       stamp bootstrap_start
       DISK=/dev/disk/azure/scsi1/lun0
       for _ in \$(seq 1 90); do [ -e "\$DISK" ] && break; sleep 1; done
@@ -123,11 +168,11 @@ write_files:
       mkdir -p /mnt/horizon-workspace
       UUID=\$(blkid -o value -s UUID "\$DISK")
       grep -q "\$UUID" /etc/fstab || echo "UUID=\$UUID /mnt/horizon-workspace ext4 defaults,nofail 0 2" >> /etc/fstab
+      systemctl daemon-reload
       mountpoint -q /mnt/horizon-workspace || mount /mnt/horizon-workspace
       chown root:root /mnt/horizon-workspace && chmod 0755 /mnt/horizon-workspace
       stamp data_disk_ready
       systemctl enable --now docker
-      field() { python3 -c 'import json,sys; print(json.load(sys.stdin)[sys.argv[1]])' "\$1"; }
       AAD=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&client_id=${CLIENT_ID}" | field access_token)
       REFRESH=\$(curl -sf -X POST "https://${REGISTRY}/oauth2/exchange" --data-urlencode grant_type=access_token --data-urlencode service=${REGISTRY} --data-urlencode "access_token=\$AAD" | field refresh_token)
       printf '%s' "\$REFRESH" | docker login ${REGISTRY} -u 00000000-0000-0000-0000-000000000000 --password-stdin >/dev/null
@@ -152,7 +197,8 @@ if [ "$DRY_RUN" = 1 ]; then
   exit 0
 fi
 
-trap 'say "interrupted; cleaning up"; cleanup' INT TERM
+trap finish EXIT
+trap 'exit 130' INT TERM
 
 azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
 journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
@@ -160,6 +206,7 @@ journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before
 T0=$(epoch_ms)
 azc group create --name "$RG" --location "$REGION" \
   --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
+CREATED=1
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
 
 CREATE_JSON="$SAMPLE_DIR/vm-create.json"
@@ -171,75 +218,102 @@ azc vm create --resource-group "$RG" --name "$VM" --location "$REGION" --size "$
   --custom-data "$CLOUD_INIT" --tags issue=474 sample="$SAMPLE" run="$RUN_ID" >"$CREATE_JSON"
 T_CREATE=$(epoch_ms)
 IP=$(jq -r .publicIpAddress "$CREATE_JSON")
+[[ $IP =~ ^[0-9.]+$ ]] || { journal vm_create_no_ip '{}'; say "vm create returned no public IP"; exit 1; }
 journal vm_created "$(jq -cn --argjson ms $((T_CREATE - T0)) --arg ip "$IP" '{ms_from_t0:$ms,public_ip:$ip}')"
 say "vm created in $((T_CREATE - T0)) ms"
 
 NSG=$(azc network nsg list --resource-group "$RG" --query "[0].name" -o tsv)
-SOURCE=${ALLOW_SSH_FROM:-$(curl -s --max-time 10 https://ifconfig.me)/32}
+SOURCE=${ALLOW_SSH_FROM:-}
+if [ -z "$SOURCE" ]; then
+  EGRESS=$(curl -s --max-time 10 https://ifconfig.me || true)
+  [[ $EGRESS =~ ^[0-9.]+$ ]] || { journal egress_unknown '{}'; say "could not learn the egress address; pass --allow-ssh-from"; exit 1; }
+  SOURCE="$EGRESS/32"
+fi
 azc network nsg rule create --resource-group "$RG" --nsg-name "$NSG" --name worker-ssh --priority 100 \
   --direction Inbound --access Allow --protocol Tcp --source-address-prefixes "$SOURCE" \
   --destination-port-ranges 2222 >/dev/null
 journal nsg_rule "$(jq -cn --arg src "$SOURCE" '{source:$src,port:2222}')"
 
-say "waiting for worker endpoint on $IP:2222"
-until nc -z -w 3 "$IP" 2222 2>/dev/null; do deadline_check; sleep 3; done
+say "waiting for worker endpoint on port 2222"
+wait_for $(( DEADLINE_EPOCH - $(date +%s) )) nc -z -w 3 "$IP" 2222 || { journal endpoint_never_opened '{}'; exit 4; }
 T_PORT=$(epoch_ms)
 journal endpoint_open "$(jq -cn --argjson ms $((T_PORT - T0)) '{ms_from_t0:$ms}')"
 say "endpoint open in $((T_PORT - T0)) ms"
 
 say "reading worker host key out of band through run-command"
 RC_START=$(epoch_ms)
-RC_JSON="$SAMPLE_DIR/run-command-hostkey.json"
-azc vm run-command invoke --resource-group "$RG" --name "$VM" --command-id RunShellScript \
-  --scripts 'cat /mnt/horizon-workspace/.horizon-worker/ssh/*.pub 2>/dev/null; echo ---TIMING---; cat /var/log/horizon-spike-timing.jsonl' >"$RC_JSON"
+RC_TEXT=$(run_command 'cat /mnt/horizon-workspace/.horizon-worker/ssh/*.pub 2>/dev/null; echo ---TIMING---; cat /var/log/horizon-spike-timing.jsonl') || RC_TEXT=""
 RC_END=$(epoch_ms)
-RC_TEXT=$(jq -r '.value[0].message' "$RC_JSON")
-HOST_KEY=$(printf '%s\n' "$RC_TEXT" | grep -m1 '^ssh-ed25519 ' || true)
+printf '%s\n' "$RC_TEXT" >"$SAMPLE_DIR/run-command-hostkey.txt"
+HOST_KEY=$(printf '%s\n' "$RC_TEXT" | grep -m1 '^ssh-ed25519 ' | awk '{print $1" "$2}' || true)
 printf '%s\n' "$RC_TEXT" | sed -n '/---TIMING---/,$p' | grep '^{' >"$SAMPLE_DIR/guest-timing.jsonl" || true
-[ -n "$HOST_KEY" ] || { journal host_key_missing '{}'; say "no ed25519 host key published yet; aborting sample"; cleanup; exit 5; }
+[ -n "$HOST_KEY" ] || { journal host_key_missing "$(jq -cn --argjson ms $((RC_END - RC_START)) '{run_command_ms:$ms}')"; say "no ed25519 host key published yet; aborting sample"; exit 5; }
 printf '[%s]:2222 %s\n' "$IP" "$HOST_KEY" >"$KNOWN_HOSTS"
 journal host_key_pinned "$(jq -cn --argjson ms $((RC_END - RC_START)) --arg fp "$(ssh-keygen -lf "$KNOWN_HOSTS" | awk '{print $2}')" '{run_command_ms:$ms,fingerprint:$fp}')"
 
-SSH=(ssh -p 2222 -i "$KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$KNOWN_HOSTS" -o PasswordAuthentication=no -o ConnectTimeout=10 -o BatchMode=yes "root@$IP")
-until "${SSH[@]}" true 2>/dev/null; do deadline_check; sleep 3; done
+ssh_worker() { ssh -T -F /dev/null -p 2222 -i "$KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$KNOWN_HOSTS" \
+  -o PasswordAuthentication=no -o KbdInteractiveAuthentication=no -o ConnectTimeout=10 -o BatchMode=yes "root@$1" "${@:2}"; }
+wait_for $(( DEADLINE_EPOCH - $(date +%s) )) ssh_worker "$IP" true || { journal ssh_never_verified '{}'; exit 4; }
 T_SSH=$(epoch_ms)
 journal ssh_verified "$(jq -cn --argjson ms $((T_SSH - T0)) --argjson excl $((T_SSH - T0 - (RC_END - RC_START))) '{ms_from_t0:$ms,ms_excluding_run_command:$excl}')"
 say "key-only SSH verified in $((T_SSH - T0)) ms (excluding run-command: $((T_SSH - T0 - (RC_END - RC_START))) ms)"
 
-say "collecting on-worker storage evidence"
-"${SSH[@]}" 'set -e; echo "fs_type=$(stat -f -c %T /workspace)"; DEV=$(df --output=source /workspace | tail -1); echo "device=$DEV"; NAME=$(basename "$(readlink -f "$DEV")"); echo "kernel_options_path=/proc/fs/ext4/$NAME/options"; echo "---OPTIONS---"; cat /proc/fs/ext4/$NAME/options; echo "---MOUNT---"; grep " /workspace " /proc/self/mounts; echo "---SYSFS---"; readlink /sys/dev/block/$(stat -c %d /workspace | awk "{printf \"%d:%d\", int(\$1/256), \$1%256}") 2>&1 || true' >"$SAMPLE_DIR/storage-evidence.txt" 2>&1 || true
-OPTIONS=$(sed -n '/---OPTIONS---/,/---MOUNT---/p' "$SAMPLE_DIR/storage-evidence.txt" | grep -v -- '---')
-QUALIFIES=false
-if grep -qx rw <<<"$OPTIONS" && grep -qx barrier <<<"$OPTIONS" && ! grep -qx ro <<<"$OPTIONS" && ! grep -qx nobarrier <<<"$OPTIONS" \
-   && [ "$(grep -c '^data=' <<<"$OPTIONS")" = 1 ] && grep -qxE 'data=(ordered|journal)' <<<"$OPTIONS" && grep -q 'fs_type=ext2/ext3' "$SAMPLE_DIR/storage-evidence.txt"; then QUALIFIES=true; fi
-journal storage_evidence "$(jq -cn --argjson q $QUALIFIES --arg opts "$OPTIONS" '{shell_mirror_of_qualifier_passes:$q,kernel_options:($opts|split("\n"))}')"
-say "ext4 kernel options mirror check: $QUALIFIES (authoritative qualifier is the Rust code, not this script)"
+say "collecting on-worker storage evidence and running the authoritative qualifier"
+ssh_worker "$IP" 'set -e; echo "fs_type=$(stat -f -c %T /workspace)"; DEV=$(df --output=source /workspace | tail -1); echo "device=$DEV"; NAME=$(basename "$(readlink -f "$DEV")"); echo "---OPTIONS---"; cat "/proc/fs/ext4/$NAME/options"; echo "---MOUNT---"; grep " /workspace " /proc/self/mounts' >"$SAMPLE_DIR/storage-evidence.txt" 2>&1 || true
+OPTIONS=$(sed -n '/---OPTIONS---/,/---MOUNT---/p' "$SAMPLE_DIR/storage-evidence.txt" | grep -v -- '---' || true)
+MIRROR=false
+if [ -n "$OPTIONS" ] && grep -qx rw <<<"$OPTIONS" && grep -qx barrier <<<"$OPTIONS" && ! grep -qx ro <<<"$OPTIONS" && ! grep -qx nobarrier <<<"$OPTIONS" \
+   && [ "$(grep -c '^data=' <<<"$OPTIONS")" = 1 ] && grep -qxE 'data=(ordered|journal)' <<<"$OPTIONS" && grep -q 'fs_type=ext2/ext3' "$SAMPLE_DIR/storage-evidence.txt"; then MIRROR=true; fi
+# The image's horizon-repository binary runs storage::qualify read-only on the retained root:
+# "absent" means qualified storage with no claim; an overlay root is the negative control.
+QUALIFIER_REQUEST='{"version":1,"retained_root":"%s","workspace_local_id":"workspace_1","objects_directory":"/workspace/spike-input/objects","bundle_store":"/workspace/spike-input/bundles","bundle_manifest":"0000000000000000000000000000000000000000000000000000000000000000","destination":"repository"}'
+QUALIFIER_OUT=$(ssh_worker "$IP" "set -e; mkdir -p -m 0755 /workspace/spike-input/objects /workspace/spike-input/bundles; mkdir -p -m 0700 /workspace/spike-retained /root/spike-overlay; printf '$QUALIFIER_REQUEST' /workspace/spike-retained | /usr/local/bin/horizon-repository setup-status; echo; echo ---OVERLAY---; printf '$QUALIFIER_REQUEST' /root/spike-overlay | /usr/local/bin/horizon-repository setup-status || true; echo" 2>&1 || true)
+printf '%s\n' "$QUALIFIER_OUT" >"$SAMPLE_DIR/qualifier-output.txt"
+DATA_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed '/---OVERLAY---/,$d' | jq -r '.status // empty' 2>/dev/null | head -1 || true)
+OVERLAY_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed -n '/---OVERLAY---/,$p' | grep -v -- '---' | jq -r '.status // empty' 2>/dev/null | head -1 || true)
+QUALIFIED=false; [ "$DATA_STATUS" = absent ] && QUALIFIED=true
+journal storage_evidence "$(jq -cn --argjson mirror $MIRROR --argjson q $QUALIFIED --arg ds "${DATA_STATUS:-none}" --arg os "${OVERLAY_STATUS:-none}" --arg opts "$OPTIONS" '{shell_mirror_passes:$mirror,rust_qualifier_status_on_data_disk:$ds,rust_qualifier_status_on_overlay:$os,rust_qualifier_accepts_data_disk:$q,kernel_options:($opts|split("\n")|map(select(length>0)))}')"
+gate storage_qualifier "$QUALIFIED"
+say "rust qualifier on data disk: ${DATA_STATUS:-none} (overlay control: ${OVERLAY_STATUS:-none}); shell mirror: $MIRROR"
 
 say "detach independence: start a heartbeat, disconnect, reconnect"
-"${SSH[@]}" 'tmux new-session -d -s spike "while true; do date -u +%FT%TZ >> /workspace/spike-heartbeat; sleep 2; done"; sleep 1; wc -l < /workspace/spike-heartbeat' >"$SAMPLE_DIR/heartbeat-before.txt"
+BEFORE=$(ssh_worker "$IP" 'tmux new-session -d -s spike "while true; do date -u +%FT%TZ >> /workspace/spike-heartbeat; sleep 2; done"; sleep 1; wc -l < /workspace/spike-heartbeat' 2>/dev/null || echo 0)
 sleep 20
-"${SSH[@]}" 'tmux has-session -t spike && wc -l < /workspace/spike-heartbeat' >"$SAMPLE_DIR/heartbeat-after.txt"
-journal detach_independence "$(jq -cn --arg b "$(cat "$SAMPLE_DIR/heartbeat-before.txt")" --arg a "$(cat "$SAMPLE_DIR/heartbeat-after.txt")" '{lines_before:($b|tonumber),lines_after:($a|tonumber),progressed:(($a|tonumber)>($b|tonumber))}')"
+AFTER=$(ssh_worker "$IP" 'tmux has-session -t spike 2>/dev/null && wc -l < /workspace/spike-heartbeat' 2>/dev/null || echo 0)
+PROGRESSED=false; [ "${AFTER:-0}" -gt "${BEFORE:-0}" ] 2>/dev/null && PROGRESSED=true
+journal detach_independence "$(jq -cn --argjson b "${BEFORE:-0}" --argjson a "${AFTER:-0}" --argjson p $PROGRESSED '{lines_before:$b,lines_after:$a,progressed:$p}')"
+gate detach_independence "$PROGRESSED"
 
 say "retention: marker, deallocate, start, verify"
 MARKER="spike-$RUN_ID-$TOKEN"
-"${SSH[@]}" "printf '%s\n' '$MARKER' > /workspace/spike-marker; sync"
+ssh_worker "$IP" "printf '%s\n' '$MARKER' > /workspace/spike-marker; sync" || true
 deadline_check
 T_STOP=$(epoch_ms)
 azc vm deallocate --resource-group "$RG" --name "$VM" >/dev/null
-POWER=$(azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv)
 T_STOPPED=$(epoch_ms)
+POWER=$(azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv)
 journal deallocated "$(jq -cn --argjson ms $((T_STOPPED - T_STOP)) --arg power "$POWER" '{stop_ms:$ms,power_state:$power}')"
+gate deallocated "$([ "$POWER" = PowerState/deallocated ] && echo true || echo false)"
 T_START=$(epoch_ms)
 azc vm start --resource-group "$RG" --name "$VM" >/dev/null
 IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv)
-until nc -z -w 3 "$IP" 2222 2>/dev/null; do deadline_check; sleep 3; done
-until "${SSH[@]}" true 2>/dev/null; do deadline_check; sleep 3; done
+IP_SAME=false; [ "$IP" = "$IP_AFTER" ] && IP_SAME=true
+KEY_SAME=false SESSION=unknown RETAINED_MARKER=false HEARTBEAT=0 MOUNTED=false
+if wait_for "$RESTART_WAIT_SECONDS" nc -z -w 3 "$IP_AFTER" 2222; then
+  SCANNED=$(ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
+  [ "$SCANNED" = "$HOST_KEY" ] && KEY_SAME=true
+  if [ "$KEY_SAME" = true ] && wait_for "$RESTART_WAIT_SECONDS" ssh_worker "$IP_AFTER" true; then
+    OUT=$(ssh_worker "$IP_AFTER" "cat /workspace/spike-marker 2>/dev/null || echo missing; tmux has-session -t spike 2>/dev/null && echo session-alive || echo session-gone; wc -l < /workspace/spike-heartbeat 2>/dev/null || echo 0; grep -q ' /workspace ' /proc/self/mounts && echo mounted || echo unmounted" 2>/dev/null || printf 'missing\nunknown\n0\nunknown\n')
+    [ "$(sed -n 1p <<<"$OUT")" = "$MARKER" ] && RETAINED_MARKER=true
+    SESSION=$(sed -n 2p <<<"$OUT"); HEARTBEAT=$(sed -n 3p <<<"$OUT"); [ "$(sed -n 4p <<<"$OUT")" = mounted ] && MOUNTED=true
+  fi
+fi
 T_RESTARTED=$(epoch_ms)
-RETAINED=$("${SSH[@]}" "cat /workspace/spike-marker 2>/dev/null; tmux has-session -t spike 2>/dev/null && echo session-alive || echo session-gone; wc -l < /workspace/spike-heartbeat")
-journal restarted "$(jq -cn --argjson ms $((T_RESTARTED - T_START)) --arg ip_same "$([ "$IP" = "$IP_AFTER" ] && echo true || echo false)" --arg out "$RETAINED" --arg marker "$MARKER" '{start_to_ssh_ms:$ms,public_ip_unchanged:($ip_same=="true"),marker_retained:($out|split("\n")[0]==$marker),session_after_restart:($out|split("\n")[1]),heartbeat_lines:($out|split("\n")[2]|tonumber),same_pinned_host_key:true}')"
-say "after deallocate/start: $(tr '\n' ' ' <<<"$RETAINED")"
-
-cleanup
-journal end "$(jq -cn --argjson total $(( $(epoch_ms) - T0 )) '{total_ms:$total}')"
-say "sample $SAMPLE complete; journal at $JOURNAL"
+if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != true ]; then
+  say "restart verification failed; capturing guest diagnostics out of band"
+  run_command 'systemctl is-system-running; systemctl list-units --failed --no-legend; systemctl status docker --no-pager | head -20; findmnt /mnt/horizon-workspace; docker ps -a; docker logs --tail 20 horizon-worker 2>&1; journalctl -b -u docker --no-pager | tail -20' >"$SAMPLE_DIR/restart-diagnostics.txt" 2>&1 || true
+fi
+journal restarted "$(jq -cn --argjson ms $((T_RESTARTED - T_START)) --argjson ip $IP_SAME --argjson key $KEY_SAME --argjson marker $RETAINED_MARKER --arg session "$SESSION" --argjson hb "${HEARTBEAT:-0}" --argjson mounted $MOUNTED '{start_to_verified_ms:$ms,public_ip_unchanged:$ip,same_pinned_host_key:$key,marker_retained:$marker,session_after_restart:$session,heartbeat_lines:$hb,data_disk_mounted:$mounted}')"
+gate retention "$([ "$KEY_SAME" = true ] && [ "$RETAINED_MARKER" = true ] && [ "$MOUNTED" = true ] && echo true || echo false)"
+say "after deallocate/start: ip_unchanged=$IP_SAME host_key_same=$KEY_SAME marker_retained=$RETAINED_MARKER mounted=$MOUNTED session=$SESSION"
+journal timings_complete "$(jq -cn --argjson total $(( $(epoch_ms) - T0 )) '{ms_from_t0:$total}')"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -18,6 +18,7 @@ usage() {
   cat <<'EOF'
 usage: run-vm-spike.sh --subscription <uuid> --image <registry/repo@sha256:...> \
          --puller-identity-id <user-assigned-identity-resource-id> --journal-dir <private-dir> \
+         --preflight-report <json from scripts/azure-workspace-preflight --candidate vm --live> \
          [--region northeurope] [--vm-size Standard_D4s_v3] [--sample 1] [--max-minutes 120] \
          [--allow-ssh-from <cidr>] [--keep] [--dry-run]
 
@@ -26,11 +27,11 @@ bounded by --max-minutes; the sample resource group is deleted at the end unless
 EOF
 }
 
-SUBSCRIPTION="" IMAGE="" PULLER_ID="" JOURNAL_DIR="" REGION=northeurope VM_SIZE=Standard_D4s_v3
+SUBSCRIPTION="" IMAGE="" PULLER_ID="" JOURNAL_DIR="" PREFLIGHT="" REGION=northeurope VM_SIZE=Standard_D4s_v3
 SAMPLE=1 MAX_MINUTES=120 ALLOW_SSH_FROM="" KEEP=0 DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --subscription|--image|--puller-identity-id|--journal-dir|--region|--vm-size|--sample|--max-minutes|--allow-ssh-from)
+    --subscription|--image|--puller-identity-id|--journal-dir|--preflight-report|--region|--vm-size|--sample|--max-minutes|--allow-ssh-from)
       [ $# -ge 2 ] || { echo "$1 requires a value" >&2; usage; exit 3; } ;;
   esac
   case "$1" in
@@ -38,6 +39,7 @@ while [ $# -gt 0 ]; do
     --image) IMAGE=$2; shift 2 ;;
     --puller-identity-id) PULLER_ID=$2; shift 2 ;;
     --journal-dir) JOURNAL_DIR=$2; shift 2 ;;
+    --preflight-report) PREFLIGHT=$2; shift 2 ;;
     --region) REGION=$2; shift 2 ;;
     --vm-size) VM_SIZE=$2; shift 2 ;;
     --sample) SAMPLE=$2; shift 2 ;;
@@ -55,10 +57,20 @@ done
 [[ $PULLER_ID =~ ^/subscriptions/[0-9a-f-]{36}/resource[Gg]roups/[^/]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[A-Za-z0-9_-]+$ ]] || { echo "--puller-identity-id must be a user-assigned identity resource id" >&2; exit 3; }
 [[ $REGION =~ ^[a-z][a-z0-9]{1,63}$ ]] || { echo "--region must be a lowercase region name" >&2; exit 3; }
 [[ $VM_SIZE =~ ^Standard_[A-Za-z0-9_-]+$ ]] || { echo "--vm-size must look like Standard_D4s_v3" >&2; exit 3; }
-[[ $SAMPLE =~ ^[1-9]$ ]] || { echo "--sample must be 1-9" >&2; exit 3; }
+[[ $SAMPLE =~ ^[1-9][0-9]?$ ]] || { echo "--sample must be 1-99 without leading zeros" >&2; exit 3; }
 [[ $MAX_MINUTES =~ ^[1-9][0-9]{1,2}$ ]] || { echo "--max-minutes must be 10-999 without leading zeros" >&2; exit 3; }
 [ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
 for tool in az ssh ssh-keygen ssh-keyscan nc jq curl timeout; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
+# The read-only preflight must precede paid creation: require its report for this exact candidate,
+# region and size, with no blockers, and carry its provenance into the sample journal.
+if [ "$DRY_RUN" = 0 ] || [ -n "$PREFLIGHT" ]; then
+  [ -n "$PREFLIGHT" ] && [ -r "$PREFLIGHT" ] || { echo "--preflight-report must point at a readable preflight JSON report" >&2; exit 3; }
+  PREFLIGHT_FACTS=$(jq -c --arg region "$REGION" --arg size "$VM_SIZE" '
+    if .schema == "horizon.azure-workspace-preflight.report" and .candidate.id == "vm" and .region == $region
+       and .candidate.vm_size == $size and .mode == "live" and .status == "no_blockers_observed"
+    then {observed_at, tool_version, status, schema_version} else empty end' "$PREFLIGHT" 2>/dev/null || true)
+  [ -n "$PREFLIGHT_FACTS" ] || { echo "--preflight-report is not a live vm preflight for $REGION/$VM_SIZE with no blockers observed" >&2; exit 3; }
+fi
 
 REGISTRY=${IMAGE%%/*}
 RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
@@ -172,7 +184,8 @@ finish() {
 }
 
 say "sample $SAMPLE run $RUN_ID journal $SAMPLE_DIR"
-journal start "$(jq -cn --arg region "$REGION" --arg size "$VM_SIZE" --arg image "$IMAGE" --arg rg "$RG" --argjson max "$MAX_MINUTES" '{region:$region,vm_size:$size,image:$image,resource_group:$rg,max_minutes:$max}')"
+HARNESS_COMMIT=$(git -C "$(dirname "$0")" rev-parse HEAD 2>/dev/null || echo unknown)
+journal start "$(jq -cn --arg region "$REGION" --arg size "$VM_SIZE" --arg image "$IMAGE" --arg rg "$RG" --argjson max "$MAX_MINUTES" --arg commit "$HARNESS_COMMIT" --arg pf "${PREFLIGHT:-}" --argjson facts "${PREFLIGHT_FACTS:-null}" '{region:$region,vm_size:$size,image:$image,resource_group:$rg,max_minutes:$max,harness_commit:$commit,preflight_report:$pf,preflight:$facts}')"
 
 ssh-keygen -q -t ed25519 -N "" -C "horizon-spike-474-s${SAMPLE}" -f "$KEY"
 PUBKEY=$(cat "$KEY.pub")

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -72,7 +72,13 @@ KNOWN_HOSTS="$SAMPLE_DIR/known_hosts"
 GATE_FAILURES=()
 CREATED=0 CLEANED=0 DELETE_PROVEN=0
 
-azc() { az "$@" --subscription "$SUBSCRIPTION" --only-show-errors; }
+# Every blocking CLI call runs under the remaining lifetime bound; cleanup gets its own fixed bound.
+azc() {
+  local remaining
+  if [ "$CLEANED" = 1 ]; then remaining=1500; else remaining=$(( DEADLINE_EPOCH - $(date +%s) )); fi
+  if [ "$remaining" -lt 1 ]; then say "lifetime bound reached before: az $1 $2"; return 124; fi
+  timeout -k 15 "$remaining" az "$@" --subscription "$SUBSCRIPTION" --only-show-errors
+}
 now() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
 epoch_ms() { date +%s%3N; }
 journal() { local data=${2:-'{}'}; jq -cn --arg at "$(now)" --arg event "$1" --argjson data "$data" '{at:$at,event:$event,data:$data}' >>"$JOURNAL"; }
@@ -81,7 +87,7 @@ gate() { local name=$1 ok=$2; [ "$ok" = true ] || GATE_FAILURES+=("$name"); }
 deadline_check() { [ "$(date +%s)" -lt "$DEADLINE_EPOCH" ] || { say "lifetime bound reached; forcing cleanup"; exit 4; }; }
 # wait_for <max-seconds> <command...>: poll every 3 s under the lifetime bound; returns 1 on the phase bound.
 wait_for() {
-  local until_epoch=$(( $(date +%s) + $1 )); shift
+  local until_epoch=$(( $(date +%s) + ( $1 > 0 ? $1 : 0 ) )); shift
   until "$@" >/dev/null 2>&1; do
     deadline_check
     [ "$(date +%s)" -lt "$until_epoch" ] || return 1
@@ -123,8 +129,8 @@ finish() {
   local code=$?
   trap - EXIT
   cleanup
-  if [ "$code" = 0 ] && [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi
   if [ "$code" = 0 ] && [ "${#GATE_FAILURES[@]}" -gt 0 ]; then code=7; fi
+  if [ "$CREATED" = 1 ] && [ "$KEEP" = 0 ] && [ "$DELETE_PROVEN" = 0 ]; then code=6; fi  # an unproven delete outranks every other outcome
   journal end "$(jq -cn --argjson code "$code" --arg gates "${GATE_FAILURES[*]:-}" '{exit_code:$code,failed_gates:($gates|split(" ")|map(select(length>0)))}')"
   say "sample $SAMPLE finished with exit $code${GATE_FAILURES[*]:+ (failed gates: ${GATE_FAILURES[*]})}; journal $JOURNAL"
   exit "$code"
@@ -204,9 +210,9 @@ azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
 journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
 
 T0=$(epoch_ms)
+CREATED=1  # cleanup owns the uniquely named group from this point, even if the create response is lost
 azc group create --name "$RG" --location "$REGION" \
   --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
-CREATED=1
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
 
 CREATE_JSON="$SAMPLE_DIR/vm-create.json"
@@ -272,8 +278,10 @@ printf '%s\n' "$QUALIFIER_OUT" >"$SAMPLE_DIR/qualifier-output.txt"
 DATA_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed '/---OVERLAY---/,$d' | jq -r '.status // empty' 2>/dev/null | head -1 || true)
 OVERLAY_STATUS=$(printf '%s\n' "$QUALIFIER_OUT" | sed -n '/---OVERLAY---/,$p' | grep -v -- '---' | jq -r '.status // empty' 2>/dev/null | head -1 || true)
 QUALIFIED=false; [ "$DATA_STATUS" = absent ] && QUALIFIED=true
-journal storage_evidence "$(jq -cn --argjson mirror $MIRROR --argjson q $QUALIFIED --arg ds "${DATA_STATUS:-none}" --arg os "${OVERLAY_STATUS:-none}" --arg opts "$OPTIONS" '{shell_mirror_passes:$mirror,rust_qualifier_status_on_data_disk:$ds,rust_qualifier_status_on_overlay:$os,rust_qualifier_accepts_data_disk:$q,kernel_options:($opts|split("\n")|map(select(length>0)))}')"
+CONTROL_REJECTED=false; case "${OVERLAY_STATUS:-none}" in error|rejected) CONTROL_REJECTED=true ;; esac
+journal storage_evidence "$(jq -cn --argjson mirror $MIRROR --argjson q $QUALIFIED --argjson c $CONTROL_REJECTED --arg ds "${DATA_STATUS:-none}" --arg os "${OVERLAY_STATUS:-none}" --arg opts "$OPTIONS" '{shell_mirror_passes:$mirror,rust_qualifier_status_on_data_disk:$ds,rust_qualifier_status_on_overlay:$os,rust_qualifier_accepts_data_disk:$q,overlay_control_rejected:$c,kernel_options:($opts|split("\n")|map(select(length>0)))}')"
 gate storage_qualifier "$QUALIFIED"
+gate storage_negative_control "$CONTROL_REJECTED"
 say "rust qualifier on data disk: ${DATA_STATUS:-none} (overlay control: ${OVERLAY_STATUS:-none}); shell mirror: $MIRROR"
 
 say "detach independence: start a heartbeat, disconnect, reconnect"
@@ -299,10 +307,11 @@ azc vm start --resource-group "$RG" --name "$VM" >/dev/null
 IP_AFTER=$(azc vm show -d --resource-group "$RG" --name "$VM" --query publicIps -o tsv)
 IP_SAME=false; [ "$IP" = "$IP_AFTER" ] && IP_SAME=true
 KEY_SAME=false SESSION=unknown RETAINED_MARKER=false HEARTBEAT=0 MOUNTED=false
+RESTART_DEADLINE=$(( $(date +%s) + RESTART_WAIT_SECONDS ))
 if wait_for "$RESTART_WAIT_SECONDS" nc -z -w 3 "$IP_AFTER" 2222; then
   SCANNED=$(ssh-keyscan -p 2222 -t ed25519 -T 10 "$IP_AFTER" 2>/dev/null | awk '{print $2" "$3}' | head -1 || true)
   [ "$SCANNED" = "$HOST_KEY" ] && KEY_SAME=true
-  if [ "$KEY_SAME" = true ] && wait_for "$RESTART_WAIT_SECONDS" ssh_worker "$IP_AFTER" true; then
+  if [ "$KEY_SAME" = true ] && wait_for $(( RESTART_DEADLINE - $(date +%s) )) ssh_worker "$IP_AFTER" true; then
     OUT=$(ssh_worker "$IP_AFTER" "cat /workspace/spike-marker 2>/dev/null || echo missing; tmux has-session -t spike 2>/dev/null && echo session-alive || echo session-gone; wc -l < /workspace/spike-heartbeat 2>/dev/null || echo 0; grep -q ' /workspace ' /proc/self/mounts && echo mounted || echo unmounted" 2>/dev/null || printf 'missing\nunknown\n0\nunknown\n')
     [ "$(sed -n 1p <<<"$OUT")" = "$MARKER" ] && RETAINED_MARKER=true
     SESSION=$(sed -n 2p <<<"$OUT"); HEARTBEAT=$(sed -n 3p <<<"$OUT"); [ "$(sed -n 4p <<<"$OUT")" = mounted ] && MOUNTED=true

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -200,6 +200,7 @@ if [ "$DRY_RUN" = 1 ]; then CLIENT_ID=00000000-0000-0000-0000-000000000000; else
   CLIENT_ID=$(azc identity show --ids "$PULLER_ID" --query clientId -o tsv)
 fi
 
+GUEST_DEADLINE=$(date -u -d @"$(( DEADLINE_EPOCH + 60 ))" +"%Y-%m-%d %H:%M:%S UTC")
 CLOUD_INIT="$SAMPLE_DIR/cloud-init.yaml"
 cat >"$CLOUD_INIT" <<EOF
 #cloud-config
@@ -207,6 +208,36 @@ package_update: true
 packages: [docker.io]
 bootcmd:
   - [ sh, -c, 'printf "{\"event\":\"boot\",\"at\":\"%s\"}\n" "\$(date -u +%FT%T.%3NZ)" >> /var/log/horizon-spike-timing.jsonl' ]
+  # Guest-side lifetime bound, armed on every boot before anything else: at the deadline the VM
+  # deallocates itself through ARM with its own identity (power-only role granted before creation).
+  - |
+    cat > /usr/local/sbin/horizon-spike-deadline.sh <<'SH'
+    #!/bin/sh
+    set -eu
+    T=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&client_id=${CLIENT_ID}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+    I=\$(curl -sf -H Metadata:true "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" | python3 -c 'import json,sys; print(json.load(sys.stdin)["resourceId"])')
+    curl -sf -X POST -H "Authorization: Bearer \$T" -H "Content-Length: 0" "https://management.azure.com\$I/deallocate?api-version=2024-03-01"
+    SH
+    chmod 0700 /usr/local/sbin/horizon-spike-deadline.sh
+    cat > /etc/systemd/system/horizon-spike-deadline.service <<'UNIT'
+    [Unit]
+    Description=Horizon spike lifetime bound: deallocate this VM
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/local/sbin/horizon-spike-deadline.sh
+    UNIT
+    cat > /etc/systemd/system/horizon-spike-deadline.timer <<'UNIT'
+    [Unit]
+    Description=Horizon spike lifetime bound
+    [Timer]
+    OnCalendar=${GUEST_DEADLINE}
+    Persistent=true
+    AccuracySec=1s
+    [Install]
+    WantedBy=timers.target
+    UNIT
+    systemctl daemon-reload
+    systemctl enable --now horizon-spike-deadline.timer
 write_files:
   - path: /etc/systemd/system/docker.service.d/horizon-workspace.conf
     permissions: '0644'
@@ -274,6 +305,19 @@ CREATED=1  # cleanup owns the verified-absent group from this point, even if the
 azc group create --name "$RG" --location "$REGION" \
   --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
+# Independent lifetime bound, enforced before any compute exists: the VM's identity may only
+# power VMs inside this sample group (built-in power-only role, assignment lives and dies with
+# the group), and the VM's own early boot arms a timer that deallocates it at the deadline.
+PULLER_PRINCIPAL=$(azc identity show --ids "$PULLER_ID" --query principalId -o tsv)
+GROUP_ID=$(azc group show --name "$RG" --query id -o tsv)
+ROLE_OK=false
+for _ in $(seq 1 6); do
+  if azc role assignment create --assignee-object-id "$PULLER_PRINCIPAL" --assignee-principal-type ServicePrincipal \
+       --role "Desktop Virtualization Power On Off Contributor" --scope "$GROUP_ID" >/dev/null 2>&1; then ROLE_OK=true; break; fi
+  bounded sleep 10 || break
+done
+[ "$ROLE_OK" = true ] || { journal power_role_not_granted '{}'; say "could not grant the power-only role before creation; nothing created"; exit 1; }
+journal power_role_granted "$(jq -cn --arg deadline "$GUEST_DEADLINE" '{role:"Desktop Virtualization Power On Off Contributor",scope:"sample resource group",guest_deadline:$deadline}')"
 
 SOURCE=${ALLOW_SSH_FROM:-}
 if [ -z "$SOURCE" ]; then
@@ -437,6 +481,20 @@ if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for $(( RESTART_DEADL
 fi
 T_RESTARTED=$(epoch_ms)
 PHASE_DEADLINE=0
+# Prove the guest-side bound: confirm the timer is armed, fire its service once, expect deallocation.
+SELF_STOP=false TIMER_ARMED=false
+if [ "$KEY_SAME" = true ]; then
+  TIMER_TEXT=$(run_command 'systemctl list-timers horizon-spike-deadline.timer --no-legend; systemctl start horizon-spike-deadline.service; systemctl is-active horizon-spike-deadline.service || systemctl status horizon-spike-deadline.service --no-pager | tail -3' 2>&1 || true)
+  printf '%s\n' "$TIMER_TEXT" >"$SAMPLE_DIR/self-deallocate.txt"
+  grep -q 'horizon-spike-deadline.timer' <<<"$TIMER_TEXT" && TIMER_ARMED=true
+  PHASE_DEADLINE=$(( $(date +%s) + 300 ))
+  vm_deallocated() { azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null | grep -qx PowerState/deallocated; }
+  wait_for 300 vm_deallocated && SELF_STOP=true
+  PHASE_DEADLINE=0
+fi
+journal self_deallocate "$(jq -cn --argjson armed $TIMER_ARMED --argjson stopped $SELF_STOP '{timer_armed:$armed,vm_deallocated_by_guest:$stopped}')"
+gate guest_lifetime_bound "$SELF_STOP"
+say "guest-side bound: timer_armed=$TIMER_ARMED vm_deallocated_by_guest=$SELF_STOP"
 if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != true ]; then
   say "restart verification failed; capturing guest diagnostics out of band"
   run_command 'systemctl is-system-running; systemctl list-units --failed --no-legend; systemctl status docker --no-pager | head -20; findmnt /mnt/horizon-workspace; docker ps -a; docker logs --tail 20 horizon-worker 2>&1; journalctl -b -u docker --no-pager | tail -20' >"$SAMPLE_DIR/restart-diagnostics.txt" 2>&1 || true

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -489,10 +489,11 @@ T_RESTARTED=$(epoch_ms)
 PHASE_DEADLINE=0
 # Prove the guest-side bound: confirm the timer is armed, fire its service once, expect deallocation.
 SELF_STOP=false TIMER_ARMED=false
+grep -q '"event":"deadline_timer_armed"' "$SAMPLE_DIR/guest-timing.jsonl" 2>/dev/null && TIMER_ARMED=true  # stamped by runcmd before Docker
 if [ "$KEY_SAME" = true ]; then
-  TIMER_TEXT=$(run_command 'systemctl list-timers horizon-spike-deadline.timer --no-legend; systemctl start horizon-spike-deadline.service; systemctl is-active horizon-spike-deadline.service || systemctl status horizon-spike-deadline.service --no-pager | tail -3' 2>&1 || true)
+  # The deallocation usually preempts the run-command response itself; the power state is the evidence.
+  TIMER_TEXT=$(run_command 'systemctl list-timers horizon-spike-deadline.timer --no-legend; systemctl start --no-block horizon-spike-deadline.service' 2>&1 || true)
   printf '%s\n' "$TIMER_TEXT" >"$SAMPLE_DIR/self-deallocate.txt"
-  grep -q 'horizon-spike-deadline.timer' <<<"$TIMER_TEXT" && TIMER_ARMED=true
   PHASE_DEADLINE=$(( $(date +%s) + 300 ))
   vm_deallocated() { azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null | grep -qx PowerState/deallocated; }
   wait_for 300 vm_deallocated && SELF_STOP=true

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -20,7 +20,8 @@ usage: run-vm-spike.sh --subscription <uuid> --image <registry/repo@sha256:...> 
          --puller-identity-id <user-assigned-identity-resource-id> --journal-dir <private-dir> \
          --preflight-report <json from scripts/azure-workspace-preflight --candidate vm --live> \
          [--region northeurope] [--vm-size Standard_D4s_v3] [--sample 1] [--max-minutes 120] \
-         [--allow-ssh-from <cidr>] [--keep] [--dry-run]
+         [--allow-ssh-from <cidr>] [--reaper-resource-group horizon-worker-registry] \
+         [--reaper-account horizon-spike-reaper] [--prove-reaper] [--keep] [--dry-run]
 
 Requires: az (logged in), ssh, ssh-keygen, ssh-keyscan, nc, jq, curl. Paid creation is
 bounded by --max-minutes; the sample resource group is deleted at the end unless --keep.
@@ -28,10 +29,11 @@ EOF
 }
 
 SUBSCRIPTION="" IMAGE="" PULLER_ID="" JOURNAL_DIR="" PREFLIGHT="" REGION=northeurope VM_SIZE=Standard_D4s_v3
-SAMPLE=1 MAX_MINUTES=120 ALLOW_SSH_FROM="" KEEP=0 DRY_RUN=0
+SAMPLE=1 MAX_MINUTES=120 ALLOW_SSH_FROM="" KEEP=0 DRY_RUN=0 PROVE_REAPER=0
+REAPER_RG=horizon-worker-registry REAPER_ACCOUNT=horizon-spike-reaper
 while [ $# -gt 0 ]; do
   case "$1" in
-    --subscription|--image|--puller-identity-id|--journal-dir|--preflight-report|--region|--vm-size|--sample|--max-minutes|--allow-ssh-from)
+    --subscription|--image|--puller-identity-id|--journal-dir|--preflight-report|--region|--vm-size|--sample|--max-minutes|--allow-ssh-from|--reaper-resource-group|--reaper-account)
       [ $# -ge 2 ] || { echo "$1 requires a value" >&2; usage; exit 3; } ;;
   esac
   case "$1" in
@@ -45,6 +47,9 @@ while [ $# -gt 0 ]; do
     --sample) SAMPLE=$2; shift 2 ;;
     --max-minutes) MAX_MINUTES=$2; shift 2 ;;
     --allow-ssh-from) ALLOW_SSH_FROM=$2; shift 2 ;;
+    --reaper-resource-group) REAPER_RG=$2; shift 2 ;;
+    --reaper-account) REAPER_ACCOUNT=$2; shift 2 ;;
+    --prove-reaper) PROVE_REAPER=1; shift ;;
     --keep) KEEP=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -60,6 +65,7 @@ done
 [[ $SAMPLE =~ ^[1-9][0-9]?$ ]] || { echo "--sample must be 1-99 without leading zeros" >&2; exit 3; }
 [[ $MAX_MINUTES =~ ^[1-9][0-9]{1,2}$ ]] || { echo "--max-minutes must be 10-999 without leading zeros" >&2; exit 3; }
 [ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
+[[ $REAPER_RG =~ ^[A-Za-z0-9._-]{1,90}$ ]] && [[ $REAPER_ACCOUNT =~ ^[A-Za-z][A-Za-z0-9-]{4,48}$ ]] || { echo "invalid reaper names" >&2; exit 3; }
 for tool in az ssh ssh-keygen ssh-keyscan nc jq curl timeout; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
 # The read-only preflight must precede paid creation: require its report for this exact candidate,
 # region and size, with no blockers, and carry its provenance into the sample journal.
@@ -301,6 +307,14 @@ fi
 azc resource list --query "sort([].id)" >"$SAMPLE_DIR/inventory-before.json"
 journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before.json")"
 
+# Subscription-side lifetime bound that already exists before any compute: the reaper runbook
+# (scripts/azure-workspace-spike/setup-spike-reaper.sh) deallocates every VM tagged
+# purpose=horizon-azure-vm-spike whose deadline tag has passed. Read-only check, journaled.
+REAPER_BASE="https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$REAPER_RG/providers/Microsoft.Automation/automationAccounts/$REAPER_ACCOUNT"
+REAPER_FACTS=$(azc rest --method get --url "$REAPER_BASE/jobSchedules?api-version=2023-11-01" --query "value[?properties.runbook.name=='horizon-spike-deadline-reaper'] | [0].properties.schedule.name" -o tsv 2>/dev/null || true)
+REAPER_SCHEDULE=$(azc rest --method get --url "$REAPER_BASE/schedules/${REAPER_FACTS:-none}?api-version=2023-11-01" --query "{enabled:properties.isEnabled,next_run:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" 2>/dev/null || echo null)
+[ "$(jq -r '.enabled // false' <<<"$REAPER_SCHEDULE")" = true ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present or not enabled; run setup-spike-reaper.sh first (nothing created)"; exit 1; }
+journal reaper_present "$(jq -c --arg acct "$REAPER_ACCOUNT" '. + {account:$acct}' <<<"$REAPER_SCHEDULE")"
 # Read-only provider preflight for the auto-shutdown schedule; registration is a separate approval.
 DEVTESTLAB=$(azc provider show --namespace Microsoft.DevTestLab --query registrationState -o tsv 2>/dev/null || echo unknown)
 [ "$DEVTESTLAB" = Registered ] || { journal devtestlab_not_registered "$(jq -cn --arg s "$DEVTESTLAB" '{registration_state:$s}')"; say "Microsoft.DevTestLab is $DEVTESTLAB; the platform-side stop cannot be scheduled, so nothing is created"; exit 1; }
@@ -311,9 +325,9 @@ CREATED=1  # cleanup owns the verified-absent group from this point, even if the
 azc group create --name "$RG" --location "$REGION" \
   --tags issue=474 sample="$SAMPLE" run="$RUN_ID" purpose=horizon-azure-vm-spike deadline="$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)" >/dev/null
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
-# Independent lifetime bound, enforced before any compute exists: the VM's identity may only
-# power VMs inside this sample group (built-in power-only role, assignment lives and dies with
-# the group), and the VM's own early boot arms a timer that deallocates it at the deadline.
+# Defense in depth behind the reaper: the VM's identity may only power VMs inside this sample
+# group (built-in power-only role, assignment lives and dies with the group), and the VM's own
+# cloud-init arms a timer that deallocates it at the deadline.
 PULLER_PRINCIPAL=$(azc identity show --ids "$PULLER_ID" --query principalId -o tsv)
 GROUP_ID=$(azc group show --name "$RG" --query id -o tsv)
 ROLE_OK=false
@@ -331,10 +345,10 @@ if [ -z "$SOURCE" ]; then
   [[ $EGRESS =~ ^[0-9.]+$ ]] || { journal egress_unknown '{}'; say "could not learn the egress address; pass --allow-ssh-from"; exit 1; }
   SOURCE="$EGRESS/32"
 fi
-# One server-side deployment creates the network, the VM and the DevTestLab auto-shutdown
-# schedule together, so a controller that dies mid-creation cannot leave compute without the
-# platform-side stop. Azure deallocates the VM at the lifetime deadline even if nothing else runs;
-# disks and the public IP remain until the tagged group is deleted by hand.
+# One server-side deployment creates the network, the VM (tagged with its deadline, so the reaper
+# can act on it from the moment it exists) and a DevTestLab auto-shutdown schedule as a further
+# backstop. Deployments are not transactional and the schedule depends on the VM, so the schedule
+# is not the primary bound. Disks and the public IP remain until the tagged group is deleted.
 SHUTDOWN_AT=$(date -u -d @"$(( DEADLINE_EPOCH + 60 ))" +%H%M)
 TEMPLATE="$SAMPLE_DIR/deployment.json"
 cat >"$TEMPLATE" <<'EOF'
@@ -394,7 +408,8 @@ cat >"$TEMPLATE" <<'EOF'
 }
 EOF
 CREATE_JSON="$SAMPLE_DIR/deployment-result.json"
-TAGS=$(jq -cn --arg s "$SAMPLE" --arg r "$RUN_ID" '{issue:"474",sample:$s,run:$r,purpose:"horizon-azure-vm-spike"}')
+DEADLINE_TAG=$(date -u -d @"$DEADLINE_EPOCH" +%FT%TZ)
+TAGS=$(jq -cn --arg s "$SAMPLE" --arg r "$RUN_ID" --arg d "$DEADLINE_TAG" '{issue:"474",sample:$s,run:$r,purpose:"horizon-azure-vm-spike",deadline:$d}')
 azc deployment group create --resource-group "$RG" --name "worker-s${SAMPLE}" --template-file "$TEMPLATE" \
   --parameters vmName="$VM" vmSize="$VM_SIZE" adminPublicKey="$PUBKEY" customData="$(base64 -w0 "$CLOUD_INIT")" \
   identityId="$PULLER_ID" sourceCidr="$SOURCE" shutdownTime="$SHUTDOWN_AT" tags="$TAGS" >"$CREATE_JSON"
@@ -487,6 +502,24 @@ if [ "$START_OK" = true ] && [ "$IP_SAME" = true ] && wait_for $(( RESTART_DEADL
 fi
 T_RESTARTED=$(epoch_ms)
 PHASE_DEADLINE=0
+if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != true ]; then
+  say "restart verification failed; capturing guest diagnostics out of band"
+  run_command 'systemctl is-system-running; systemctl list-units --failed --no-legend; systemctl status docker --no-pager | head -20; findmnt /mnt/horizon-workspace; docker ps -a; docker logs --tail 20 horizon-worker 2>&1; journalctl -b -u docker --no-pager | tail -20' >"$SAMPLE_DIR/restart-diagnostics.txt" 2>&1 || true
+fi
+# Optional proof of the subscription-side reaper alone: move this VM's deadline tag into the past
+# and wait for the reaper (every 15 minutes) to deallocate it; the guest timer keeps its later time.
+if [ "$PROVE_REAPER" = 1 ] && [ "$KEY_SAME" = true ]; then
+  VM_ID=$(azc vm show --resource-group "$RG" --name "$VM" --query id -o tsv)
+  azc tag update --resource-id "$VM_ID" --operation merge --tags deadline="$(date -u -d '-2 minutes' +%FT%TZ)" >/dev/null
+  T_REAP=$(epoch_ms); PHASE_DEADLINE=$(( $(date +%s) + 1500 ))
+  vm_deallocated() { azc vm get-instance-view --resource-group "$RG" --name "$VM" --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null | grep -qx PowerState/deallocated; }
+  REAPED=false; wait_for 1500 vm_deallocated && REAPED=true
+  PHASE_DEADLINE=0
+  journal reaper_proof "$(jq -cn --argjson ok $REAPED --argjson ms $(( $(epoch_ms) - T_REAP )) '{vm_deallocated_by_reaper:$ok,wait_ms:$ms}')"
+  gate reaper_bound "$REAPED"
+  say "reaper proof: vm_deallocated_by_reaper=$REAPED after $(( ($(epoch_ms) - T_REAP) / 1000 )) s"
+  if [ "$REAPED" = true ]; then azc vm start --resource-group "$RG" --name "$VM" >/dev/null || true; wait_for 600 ssh_worker "$IP_AFTER" true || true; fi
+fi
 # Prove the guest-side bound: confirm the timer is armed, fire its service once, expect deallocation.
 SELF_STOP=false TIMER_ARMED=false
 if [ "$KEY_SAME" = true ]; then
@@ -504,10 +537,6 @@ fi
 journal self_deallocate "$(jq -cn --argjson armed $TIMER_ARMED --argjson stopped $SELF_STOP '{timer_armed:$armed,vm_deallocated_by_guest:$stopped}')"
 gate guest_lifetime_bound "$([ "$TIMER_ARMED" = true ] && [ "$SELF_STOP" = true ] && echo true || echo false)"
 say "guest-side bound: timer_armed=$TIMER_ARMED vm_deallocated_by_guest=$SELF_STOP"
-if [ "$KEY_SAME" != true ] || [ "$RETAINED_MARKER" != true ] || [ "$MOUNTED" != true ]; then
-  say "restart verification failed; capturing guest diagnostics out of band"
-  run_command 'systemctl is-system-running; systemctl list-units --failed --no-legend; systemctl status docker --no-pager | head -20; findmnt /mnt/horizon-workspace; docker ps -a; docker logs --tail 20 horizon-worker 2>&1; journalctl -b -u docker --no-pager | tail -20' >"$SAMPLE_DIR/restart-diagnostics.txt" 2>&1 || true
-fi
 journal restarted "$(jq -cn --argjson ms $((T_RESTARTED - T_START)) --argjson started $START_OK --argjson ip $IP_SAME --argjson key $KEY_SAME --argjson marker $RETAINED_MARKER --arg session "$SESSION" --argjson hb "${HEARTBEAT:-0}" --argjson mounted $MOUNTED '{start_to_verified_ms:$ms,start_call_succeeded:$started,public_ip_unchanged:$ip,same_pinned_host_key:$key,marker_retained:$marker,session_after_restart:$session,heartbeat_lines:$hb,data_disk_mounted:$mounted}')"
 gate retention "$([ "$KEY_SAME" = true ] && [ "$RETAINED_MARKER" = true ] && [ "$MOUNTED" = true ] && echo true || echo false)"
 say "after deallocate/start: ip_unchanged=$IP_SAME host_key_same=$KEY_SAME marker_retained=$RETAINED_MARKER mounted=$MOUNTED session=$SESSION"

--- a/scripts/azure-workspace-spike/run-vm-spike.sh
+++ b/scripts/azure-workspace-spike/run-vm-spike.sh
@@ -66,6 +66,10 @@ done
 [[ $MAX_MINUTES =~ ^[1-9][0-9]{1,2}$ ]] || { echo "--max-minutes must be 10-999 without leading zeros" >&2; exit 3; }
 [ -n "$JOURNAL_DIR" ] || { echo "--journal-dir is required" >&2; exit 3; }
 [[ $REAPER_RG =~ ^[A-Za-z0-9._-]{1,90}$ ]] && [[ $REAPER_ACCOUNT =~ ^[A-Za-z][A-Za-z0-9-]{4,48}$ ]] || { echo "invalid reaper names" >&2; exit 3; }
+if [ -n "$ALLOW_SSH_FROM" ]; then  # a specific IPv4 network only; never "*", service tags or the whole internet
+  python3 -c 'import ipaddress,sys; n=ipaddress.IPv4Network(sys.argv[1], strict=True); sys.exit(0 if n.prefixlen >= 8 else 1)' "$ALLOW_SSH_FROM" 2>/dev/null \
+    || { echo "--allow-ssh-from must be an IPv4 CIDR with a prefix of at least /8" >&2; exit 3; }
+fi
 for tool in az ssh ssh-keygen ssh-keyscan nc jq curl timeout; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
 # The read-only preflight must precede paid creation: require its report for this exact candidate,
 # region and size, with no blockers, and carry its provenance into the sample journal.
@@ -79,6 +83,9 @@ if [ "$DRY_RUN" = 0 ] || [ -n "$PREFLIGHT" ]; then
        and .subscription_digest == $digest and .schema_version == 1
     then {observed_at, tool_version, status, schema_version, subscription_digest} else empty end' "$PREFLIGHT" 2>/dev/null || true)
   [ -n "$PREFLIGHT_FACTS" ] || { echo "--preflight-report is not a live vm preflight for this subscription, $REGION and $VM_SIZE with no blockers observed" >&2; exit 3; }
+  # The preflight must be recent: at most 24 hours old and not from the future (5 minutes of skew).
+  PREFLIGHT_AGE=$(( $(date +%s) - $(date -u -d "$(jq -r .observed_at <<<"$PREFLIGHT_FACTS")" +%s 2>/dev/null || echo 0) ))
+  [ "$PREFLIGHT_AGE" -ge -300 ] && [ "$PREFLIGHT_AGE" -le 86400 ] || { echo "--preflight-report is older than 24 hours or timestamped in the future; rerun the live preflight" >&2; exit 3; }
 fi
 
 REGISTRY=${IMAGE%%/*}
@@ -90,7 +97,7 @@ DEADLINE_EPOCH=$(( $(date +%s) + MAX_MINUTES * 60 ))
 RESTART_WAIT_SECONDS=600
 umask 077
 mkdir -p "$JOURNAL_DIR"
-SAMPLE_DIR="$JOURNAL_DIR/sample-${SAMPLE}-${RUN_ID}"
+SAMPLE_DIR="$JOURNAL_DIR/sample-${SAMPLE}-${RUN_ID}-${TOKEN}"
 mkdir "$SAMPLE_DIR"
 JOURNAL="$SAMPLE_DIR/journal.jsonl"
 KEY="$SAMPLE_DIR/client-ed25519"
@@ -216,8 +223,9 @@ bootcmd:
   - [ sh, -c, 'printf "{\"event\":\"boot\",\"at\":\"%s\"}\n" "\$(date -u +%FT%T.%3NZ)" >> /var/log/horizon-spike-timing.jsonl' ]
 write_files:
   # Guest-side lifetime bound: at the deadline the VM deallocates itself through ARM with its own
-  # identity (power-only role granted before creation). Armed as the first runcmd step, before
-  # Docker or the image pull, once systemd is fully up (an early-boot systemctl call deadlocks).
+  # identity (power-only role granted before creation). Armed as the first runcmd step, after the
+  # packages module has installed Docker but before the workspace bootstrap and the image pull,
+  # once systemd is fully up (an early-boot systemctl call deadlocks).
   - path: /usr/local/sbin/horizon-spike-deadline.sh
     permissions: '0700'
     owner: root:root
@@ -313,7 +321,8 @@ journal inventory_before "$(jq -c '{count:length}' "$SAMPLE_DIR/inventory-before
 REAPER_BASE="https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$REAPER_RG/providers/Microsoft.Automation/automationAccounts/$REAPER_ACCOUNT"
 REAPER_FACTS=$(azc rest --method get --url "$REAPER_BASE/jobSchedules?api-version=2023-11-01" --query "value[?properties.runbook.name=='horizon-spike-deadline-reaper'] | [0].properties.schedule.name" -o tsv 2>/dev/null || true)
 REAPER_SCHEDULE=$(azc rest --method get --url "$REAPER_BASE/schedules/${REAPER_FACTS:-none}?api-version=2023-11-01" --query "{enabled:properties.isEnabled,next_run:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" 2>/dev/null || echo null)
-[ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$REAPER_SCHEDULE")" = ok ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present, not enabled or not the 15-minute schedule; run setup-spike-reaper.sh first (nothing created)"; exit 1; }
+REAPER_NEXT=$(date -u -d "$(jq -r '.next_run // empty' <<<"$REAPER_SCHEDULE")" +%s 2>/dev/null || echo 0)
+[ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$REAPER_SCHEDULE")" = ok ] && [ "$REAPER_NEXT" -gt "$(date +%s)" ] || { journal reaper_missing "$(jq -cn --arg s "$REAPER_SCHEDULE" '{schedule:$s}')"; say "the subscription-side reaper is not present, not enabled, not the 15-minute schedule or has no future run; run setup-spike-reaper.sh first (nothing created)"; exit 1; }
 REAPER_PRINCIPAL=$(azc rest --method get --url "$REAPER_BASE?api-version=2023-11-01" --query identity.principalId -o tsv 2>/dev/null || true)
 REAPER_ROLES=$(azc role assignment list --assignee "${REAPER_PRINCIPAL:-00000000-0000-0000-0000-000000000000}" --role "Desktop Virtualization Power On Off Contributor" --scope "/subscriptions/$SUBSCRIPTION" --query "length(@)" -o tsv 2>/dev/null || echo 0)
 [ "$REAPER_ROLES" != 0 ] || { journal reaper_role_missing '{}'; say "the reaper identity lacks the subscription-scoped power-only role; rerun setup-spike-reaper.sh (nothing created)"; exit 1; }
@@ -330,7 +339,8 @@ azc group create --name "$RG" --location "$REGION" \
 journal group_created "$(jq -cn --argjson ms $(( $(epoch_ms) - T0 )) '{ms_from_t0:$ms}')"
 # Defense in depth behind the reaper: the VM's identity may only power VMs inside this sample
 # group (built-in power-only role, assignment lives and dies with the group), and the VM's own
-# cloud-init arms a timer that deallocates it at the deadline.
+# cloud-init arms a timer (after package installation, before the workspace bootstrap and image
+# pull) that deallocates it at the deadline.
 PULLER_PRINCIPAL=$(azc identity show --ids "$PULLER_ID" --query principalId -o tsv)
 GROUP_ID=$(azc group show --name "$RG" --query id -o tsv)
 ROLE_OK=false

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -44,13 +44,17 @@ azr --method put --url "$BASE?api-version=$API" --body "$(jq -cn --arg loc "$REG
 PRINCIPAL=$(azr --method get --url "$BASE?api-version=$API" --query identity.principalId -o tsv)
 
 say "subscription-scoped power-only role for the reaper identity"
-for attempt in $(seq 1 6); do
-  if az role assignment create --assignee-object-id "$PRINCIPAL" --assignee-principal-type ServicePrincipal \
-       --role "Desktop Virtualization Power On Off Contributor" --scope "/subscriptions/$SUBSCRIPTION" \
-       --subscription "$SUBSCRIPTION" --only-show-errors -o none 2>/dev/null; then break; fi
-  [ "$attempt" -lt 6 ] || { echo "role assignment failed" >&2; exit 1; }
-  sleep 10
-done
+ROLE="Desktop Virtualization Power On Off Contributor"
+if [ "$(az role assignment list --assignee "$PRINCIPAL" --role "$ROLE" --scope "/subscriptions/$SUBSCRIPTION" --subscription "$SUBSCRIPTION" --only-show-errors --query "length(@)" -o tsv 2>/dev/null || echo 0)" != 0 ]; then
+  say "role assignment already present (kept)"
+else
+  for attempt in $(seq 1 6); do
+    if az role assignment create --assignee-object-id "$PRINCIPAL" --assignee-principal-type ServicePrincipal \
+         --role "$ROLE" --scope "/subscriptions/$SUBSCRIPTION" --subscription "$SUBSCRIPTION" --only-show-errors -o none 2>/dev/null; then break; fi
+    [ "$attempt" -lt 6 ] || { echo "role assignment failed" >&2; exit 1; }
+    sleep 10  # the new identity may not have replicated yet
+  done
+fi
 
 RUNBOOK=horizon-spike-deadline-reaper
 say "runbook $RUNBOOK (PowerShell 7.2)"
@@ -74,11 +78,16 @@ Write-Output "reaper done: $acted deallocation request(s)"
 PS1
 )
 azr --method put --url "$BASE/runbooks/$RUNBOOK/draft/content?api-version=$API" --headers "Content-Type=text/powershell" --body "$SCRIPT" >/dev/null
-azr --method post --url "$BASE/runbooks/$RUNBOOK/publish?api-version=$API" >/dev/null 2>&1 || true
-for _ in $(seq 1 12); do
-  [ "$(azr --method get --url "$BASE/runbooks/$RUNBOOK?api-version=$API" --query properties.state -o tsv)" = Published ] && break
+azr --method post --url "$BASE/runbooks/$RUNBOOK/publish?api-version=$API" >/dev/null
+STATE=""
+for _ in $(seq 1 24); do
+  STATE=$(azr --method get --url "$BASE/runbooks/$RUNBOOK?api-version=$API" --query properties.state -o tsv)
+  [ "$STATE" = Published ] && break
   sleep 5
 done
+[ "$STATE" = Published ] || { echo "runbook did not reach Published (state: $STATE)" >&2; exit 1; }
+PUBLISHED=$(azr --method get --url "$BASE/runbooks/$RUNBOOK/content?api-version=$API" 2>/dev/null || true)
+[ "$(printf '%s' "$PUBLISHED" | tr -d '\r')" = "$(printf '%s' "$SCRIPT")" ] || { echo "published runbook content does not match this script" >&2; exit 1; }
 
 SCHEDULE=every-15-minutes
 say "schedule $SCHEDULE and job link"

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -102,7 +102,8 @@ say "verifying"
 LINKED=$(azr --method get --url "$BASE/jobSchedules?api-version=$API" --query "length(value[?properties.runbook.name=='$RUNBOOK' && properties.schedule.name=='$SCHEDULE'])" -o tsv)
 SCHED=$(azr --method get --url "$BASE/schedules/$SCHEDULE?api-version=$API" --query "{enabled:properties.isEnabled,next:properties.nextRun,interval:properties.interval,frequency:properties.frequency}")
 printf '%s\n' "$SCHED" | jq -c .
-if [ "$LINKED" != 1 ] || [ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$SCHED")" != ok ]; then
+NEXT=$(date -u -d "$(jq -r '.next // empty' <<<"$SCHED")" +%s 2>/dev/null || echo 0)
+if [ "$LINKED" != 1 ] || [ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$SCHED")" != ok ] || [ "$NEXT" -le "$(date +%s)" ]; then
   echo "reaper is NOT ready: runbook link count $LINKED, schedule $SCHED" >&2; exit 1
 fi
 say "reaper ready: VMs tagged purpose=horizon-azure-vm-spike with a past deadline tag are deallocated within about 15 minutes"

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -71,8 +71,8 @@ foreach ($vm in Get-AzVM -Status) {
   if ($now -le $deadline) { continue }
   if ($vm.PowerState -eq 'VM deallocated' -or $vm.PowerState -eq 'VM deallocating') { continue }
   Write-Output "deallocating $($vm.ResourceGroupName)/$($vm.Name) (deadline $($deadline.ToString('u')), now $($now.ToString('u')))"
-  Stop-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force -NoWait | Out-Null
-  $acted++
+  try { Stop-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force -NoWait | Out-Null; $acted++ }
+  catch { Write-Output "failed to deallocate $($vm.ResourceGroupName)/$($vm.Name): $($_.Exception.Message)" }
 }
 Write-Output "reaper done: $acted deallocation request(s)"
 PS1

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -59,24 +59,7 @@ fi
 RUNBOOK=horizon-spike-deadline-reaper
 say "runbook $RUNBOOK (PowerShell 7.2)"
 azr --method put --url "$BASE/runbooks/$RUNBOOK?api-version=$API" --body "$(jq -cn --arg loc "$REGION" '{location:$loc,properties:{runbookType:"PowerShell72",logProgress:false,logVerbose:false,description:"Deallocate horizon-azure-vm-spike VMs whose deadline tag has passed."}}')" >/dev/null
-SCRIPT=$(cat <<'PS1'
-$ErrorActionPreference = 'Stop'
-Disable-AzContextAutosave -Scope Process | Out-Null
-Connect-AzAccount -Identity | Out-Null
-$now = (Get-Date).ToUniversalTime()
-$acted = 0
-foreach ($vm in Get-AzVM -Status) {
-  if ($null -eq $vm.Tags -or $vm.Tags['purpose'] -ne 'horizon-azure-vm-spike' -or -not $vm.Tags['deadline']) { continue }
-  try { $deadline = [datetime]::Parse($vm.Tags['deadline'], $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal) } catch { Write-Output "skip $($vm.Name): unparsable deadline"; continue }
-  if ($now -le $deadline) { continue }
-  if ($vm.PowerState -eq 'VM deallocated' -or $vm.PowerState -eq 'VM deallocating') { continue }
-  Write-Output "deallocating $($vm.ResourceGroupName)/$($vm.Name) (deadline $($deadline.ToString('u')), now $($now.ToString('u')))"
-  try { Stop-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force -NoWait | Out-Null; $acted++ }
-  catch { Write-Output "failed to deallocate $($vm.ResourceGroupName)/$($vm.Name): $($_.Exception.Message)" }
-}
-Write-Output "reaper done: $acted deallocation request(s)"
-PS1
-)
+SCRIPT=$(cat "$(dirname "$0")/reaper-runbook.ps1")
 azr --method put --url "$BASE/runbooks/$RUNBOOK/draft/content?api-version=$API" --headers "Content-Type=text/powershell" --body "$SCRIPT" >/dev/null
 azr --method post --url "$BASE/runbooks/$RUNBOOK/publish?api-version=$API" >/dev/null
 STATE=""

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -66,7 +66,7 @@ Connect-AzAccount -Identity | Out-Null
 $now = (Get-Date).ToUniversalTime()
 $acted = 0
 foreach ($vm in Get-AzVM -Status) {
-  if ($vm.Tags['purpose'] -ne 'horizon-azure-vm-spike' -or -not $vm.Tags['deadline']) { continue }
+  if ($null -eq $vm.Tags -or $vm.Tags['purpose'] -ne 'horizon-azure-vm-spike' -or -not $vm.Tags['deadline']) { continue }
   try { $deadline = [datetime]::Parse($vm.Tags['deadline'], $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal) } catch { Write-Output "skip $($vm.Name): unparsable deadline"; continue }
   if ($now -le $deadline) { continue }
   if ($vm.PowerState -eq 'VM deallocated' -or $vm.PowerState -eq 'VM deallocating') { continue }
@@ -99,6 +99,10 @@ azr --method put --url "$BASE/jobSchedules/$LINK?api-version=$API" --body "$(jq 
   || say "job schedule already linked (kept)"
 
 say "verifying"
-azr --method get --url "$BASE/jobSchedules?api-version=$API" --query "value[].{runbook:properties.runbook.name,schedule:properties.schedule.name}" -o table
-azr --method get --url "$BASE/schedules/$SCHEDULE?api-version=$API" --query "{enabled:properties.isEnabled,next:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" -o table
+LINKED=$(azr --method get --url "$BASE/jobSchedules?api-version=$API" --query "length(value[?properties.runbook.name=='$RUNBOOK' && properties.schedule.name=='$SCHEDULE'])" -o tsv)
+SCHED=$(azr --method get --url "$BASE/schedules/$SCHEDULE?api-version=$API" --query "{enabled:properties.isEnabled,next:properties.nextRun,interval:properties.interval,frequency:properties.frequency}")
+printf '%s\n' "$SCHED" | jq -c .
+if [ "$LINKED" != 1 ] || [ "$(jq -r 'if .enabled == true and .frequency == "Minute" and .interval == 15 then "ok" else "bad" end' <<<"$SCHED")" != ok ]; then
+  echo "reaper is NOT ready: runbook link count $LINKED, schedule $SCHED" >&2; exit 1
+fi
 say "reaper ready: VMs tagged purpose=horizon-azure-vm-spike with a past deadline tag are deallocated within about 15 minutes"

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -77,12 +77,30 @@ say "schedule $SCHEDULE and job link"
 START=$(python3 -c 'import datetime as d; t=d.datetime.now(d.timezone.utc)+d.timedelta(minutes=7); print(t.replace(second=0,microsecond=0).strftime("%Y-%m-%dT%H:%M:%S+00:00"))')
 azr --method put --url "$BASE/schedules/$SCHEDULE?api-version=$API" --body "$(jq -cn --arg start "$START" '{name:"every-15-minutes",properties:{startTime:$start,frequency:"Minute",interval:15,timeZone:"UTC"}}')" >/dev/null 2>&1 \
   || say "schedule already exists (kept)"
-LINK=$(python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_URL, "horizon-spike-deadline-reaper/every-15-minutes"))')
-azr --method put --url "$BASE/jobSchedules/$LINK?api-version=$API" --body "$(jq -cn --arg rb "$RUNBOOK" --arg sc "$SCHEDULE" '{properties:{runbook:{name:$rb},schedule:{name:$sc}}}')" >/dev/null 2>&1 \
-  || say "job schedule already linked (kept)"
+# The job link pins the subscription the runbook scans. The list endpoint omits parameters, so each
+# link is read individually; a link with a different or missing subscription is replaced.
+pinned_link_count() {
+  local count=0 id
+  for id in $(azr --method get --url "$BASE/jobSchedules?api-version=$API" --query "value[?properties.runbook.name=='$RUNBOOK' && properties.schedule.name=='$SCHEDULE'].properties.jobScheduleId" -o tsv 2>/dev/null); do
+    # Azure returns parameter keys with its own casing (SubscriptionID), so compare case-insensitively.
+    if [ "$(azr --method get --url "$BASE/jobSchedules/$id?api-version=$API" 2>/dev/null | jq -r '(.properties.parameters // {}) | to_entries | map(select(.key | ascii_downcase == "subscriptionid")) | .[0].value // empty | ascii_downcase')" = "$SUBSCRIPTION" ]; then
+      count=$((count + 1))
+    else
+      say "replacing job link $id (subscription not pinned to this one)" >&2
+      azr --method delete --url "$BASE/jobSchedules/$id?api-version=$API" >/dev/null 2>&1 || true
+    fi
+  done
+  echo "$count"
+}
+if [ "$(pinned_link_count)" = 0 ]; then
+  sleep 5
+  azr --method put --url "$BASE/jobSchedules/$(python3 -c 'import uuid; print(uuid.uuid4())')?api-version=$API" --body "$(jq -cn --arg rb "$RUNBOOK" --arg sc "$SCHEDULE" --arg sub "$SUBSCRIPTION" '{properties:{runbook:{name:$rb},schedule:{name:$sc},parameters:{SubscriptionId:$sub}}}')" >/dev/null
+else
+  say "job schedule already linked with this subscription (kept)"
+fi
 
 say "verifying"
-LINKED=$(azr --method get --url "$BASE/jobSchedules?api-version=$API" --query "length(value[?properties.runbook.name=='$RUNBOOK' && properties.schedule.name=='$SCHEDULE'])" -o tsv)
+LINKED=$(pinned_link_count)
 SCHED=$(azr --method get --url "$BASE/schedules/$SCHEDULE?api-version=$API" --query "{enabled:properties.isEnabled,next:properties.nextRun,interval:properties.interval,frequency:properties.frequency}")
 printf '%s\n' "$SCHED" | jq -c .
 NEXT=$(date -u -d "$(jq -r '.next // empty' <<<"$SCHED")" +%s 2>/dev/null || echo 0)

--- a/scripts/azure-workspace-spike/setup-spike-reaper.sh
+++ b/scripts/azure-workspace-spike/setup-spike-reaper.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# One-time, idempotent setup of the subscription-side lifetime reaper for the Azure VM spike.
+#
+# An Azure Automation runbook runs every 15 minutes with the account's system identity and
+# deallocates every VM tagged purpose=horizon-azure-vm-spike whose deadline tag (RFC 3339 UTC)
+# has passed. It exists before any spike VM does, and a spike VM cannot exist without those tags
+# (they are part of the same create call), so compute is bounded even if the controller that
+# created it never runs again. It touches nothing untagged and never deletes anything.
+#
+# Requires: az logged in with rights to create an Automation account and a subscription-scoped
+# role assignment (the built-in power-only role "Desktop Virtualization Power On Off Contributor").
+set -euo pipefail
+
+usage() { echo "usage: setup-spike-reaper.sh --subscription <uuid> [--region northeurope] [--resource-group horizon-worker-registry] [--account horizon-spike-reaper]" >&2; }
+SUBSCRIPTION="" REGION=northeurope RG=horizon-worker-registry ACCOUNT=horizon-spike-reaper
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --subscription|--region|--resource-group|--account) [ $# -ge 2 ] || { usage; exit 3; } ;;
+  esac
+  case "$1" in
+    --subscription) SUBSCRIPTION=$2; shift 2 ;;
+    --region) REGION=$2; shift 2 ;;
+    --resource-group) RG=$2; shift 2 ;;
+    --account) ACCOUNT=$2; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 3 ;;
+  esac
+done
+[[ $SUBSCRIPTION =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || { usage; exit 3; }
+[[ $REGION =~ ^[a-z][a-z0-9]{1,63}$ ]] && [[ $RG =~ ^[A-Za-z0-9._-]{1,90}$ ]] && [[ $ACCOUNT =~ ^[A-Za-z][A-Za-z0-9-]{4,48}$ ]] || { usage; exit 3; }
+for tool in az jq python3; do command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 3; }; done
+
+ARM=https://management.azure.com
+BASE="$ARM/subscriptions/$SUBSCRIPTION/resourceGroups/$RG/providers/Microsoft.Automation/automationAccounts/$ACCOUNT"
+API=2023-11-01
+azr() { az rest --subscription "$SUBSCRIPTION" --only-show-errors "$@"; }
+say() { printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+az group show --name "$RG" --subscription "$SUBSCRIPTION" --only-show-errors -o none 2>/dev/null \
+  || az group create --name "$RG" --location "$REGION" --tags purpose=horizon-worker-images issue=474 --subscription "$SUBSCRIPTION" --only-show-errors -o none
+
+say "automation account $ACCOUNT (system identity, Basic)"
+azr --method put --url "$BASE?api-version=$API" --body "$(jq -cn --arg loc "$REGION" '{location:$loc,identity:{type:"SystemAssigned"},tags:{purpose:"horizon-azure-vm-spike-reaper",issue:"474"},properties:{sku:{name:"Basic"},publicNetworkAccess:true}}')" >/dev/null
+PRINCIPAL=$(azr --method get --url "$BASE?api-version=$API" --query identity.principalId -o tsv)
+
+say "subscription-scoped power-only role for the reaper identity"
+for attempt in $(seq 1 6); do
+  if az role assignment create --assignee-object-id "$PRINCIPAL" --assignee-principal-type ServicePrincipal \
+       --role "Desktop Virtualization Power On Off Contributor" --scope "/subscriptions/$SUBSCRIPTION" \
+       --subscription "$SUBSCRIPTION" --only-show-errors -o none 2>/dev/null; then break; fi
+  [ "$attempt" -lt 6 ] || { echo "role assignment failed" >&2; exit 1; }
+  sleep 10
+done
+
+RUNBOOK=horizon-spike-deadline-reaper
+say "runbook $RUNBOOK (PowerShell 7.2)"
+azr --method put --url "$BASE/runbooks/$RUNBOOK?api-version=$API" --body "$(jq -cn --arg loc "$REGION" '{location:$loc,properties:{runbookType:"PowerShell72",logProgress:false,logVerbose:false,description:"Deallocate horizon-azure-vm-spike VMs whose deadline tag has passed."}}')" >/dev/null
+SCRIPT=$(cat <<'PS1'
+$ErrorActionPreference = 'Stop'
+Disable-AzContextAutosave -Scope Process | Out-Null
+Connect-AzAccount -Identity | Out-Null
+$now = (Get-Date).ToUniversalTime()
+$acted = 0
+foreach ($vm in Get-AzVM -Status) {
+  if ($vm.Tags['purpose'] -ne 'horizon-azure-vm-spike' -or -not $vm.Tags['deadline']) { continue }
+  try { $deadline = [datetime]::Parse($vm.Tags['deadline'], $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal) } catch { Write-Output "skip $($vm.Name): unparsable deadline"; continue }
+  if ($now -le $deadline) { continue }
+  if ($vm.PowerState -eq 'VM deallocated' -or $vm.PowerState -eq 'VM deallocating') { continue }
+  Write-Output "deallocating $($vm.ResourceGroupName)/$($vm.Name) (deadline $($deadline.ToString('u')), now $($now.ToString('u')))"
+  Stop-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force -NoWait | Out-Null
+  $acted++
+}
+Write-Output "reaper done: $acted deallocation request(s)"
+PS1
+)
+azr --method put --url "$BASE/runbooks/$RUNBOOK/draft/content?api-version=$API" --headers "Content-Type=text/powershell" --body "$SCRIPT" >/dev/null
+azr --method post --url "$BASE/runbooks/$RUNBOOK/publish?api-version=$API" >/dev/null 2>&1 || true
+for _ in $(seq 1 12); do
+  [ "$(azr --method get --url "$BASE/runbooks/$RUNBOOK?api-version=$API" --query properties.state -o tsv)" = Published ] && break
+  sleep 5
+done
+
+SCHEDULE=every-15-minutes
+say "schedule $SCHEDULE and job link"
+START=$(python3 -c 'import datetime as d; t=d.datetime.now(d.timezone.utc)+d.timedelta(minutes=7); print(t.replace(second=0,microsecond=0).strftime("%Y-%m-%dT%H:%M:%S+00:00"))')
+azr --method put --url "$BASE/schedules/$SCHEDULE?api-version=$API" --body "$(jq -cn --arg start "$START" '{name:"every-15-minutes",properties:{startTime:$start,frequency:"Minute",interval:15,timeZone:"UTC"}}')" >/dev/null 2>&1 \
+  || say "schedule already exists (kept)"
+LINK=$(python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_URL, "horizon-spike-deadline-reaper/every-15-minutes"))')
+azr --method put --url "$BASE/jobSchedules/$LINK?api-version=$API" --body "$(jq -cn --arg rb "$RUNBOOK" --arg sc "$SCHEDULE" '{properties:{runbook:{name:$rb},schedule:{name:$sc}}}')" >/dev/null 2>&1 \
+  || say "job schedule already linked (kept)"
+
+say "verifying"
+azr --method get --url "$BASE/jobSchedules?api-version=$API" --query "value[].{runbook:properties.runbook.name,schedule:properties.schedule.name}" -o table
+azr --method get --url "$BASE/schedules/$SCHEDULE?api-version=$API" --query "{enabled:properties.isEnabled,next:properties.nextRun,interval:properties.interval,frequency:properties.frequency}" -o table
+say "reaper ready: VMs tagged purpose=horizon-azure-vm-spike with a past deadline tag are deallocated within about 15 minutes"


### PR DESCRIPTION
## Purpose

Part of #474 (parent #383). Adds the bounded, journaled, self-cleaning Azure Linux VM spike harness and records the maintainer's revalidation decision plus the executed spike results in the readiness document. This is the paid three-creation spike that #474 required before any Azure adapter work. It does not add an adapter, config or UI, and it does not complete #474.

## Behavior impact

No Rust, Cargo, CI, container image or UI changes. Files:

- `scripts/azure-workspace-spike/run-vm-spike.sh` (new): one exact task-owned resource group per sample; Linux VM with key-only SSH and a fresh Ed25519 key per sample, Standard static public IP, no default NSG rules, a 32 GiB ext4 data disk bound into the worker at `/workspace`; image pulled by digest through a user-assigned managed identity's IMDS token exchanged at the registry (no registry password); host key read out of band through ARM-authenticated `run-command` and pinned before the first SSH; a compute lifetime bound that exists before any spike VM does: a subscription-side Azure Automation reaper (new `setup-spike-reaper.sh`, run once) that deallocates every VM tagged for the spike once its `deadline` tag has passed, with both tags applied in the VM's own create call and the harness refusing to create anything unless that schedule is enabled; behind it, as defense in depth, a power-only role on the sample group plus a guest systemd timer armed before Docker (proven per sample by firing it) and a DevTestLab auto-shutdown schedule created in the same deployment as the VM; a digest-bound live preflight report required and journaled before anything is created; the worker's authoritative storage qualifier (`horizon-repository setup-status`) run against the data disk with an overlay negative control; detach independence; `deallocate`/`start` retention with the host key re-read and compared; deletion with `group wait --deleted` and an unchanged-inventory proof from an `EXIT` trap. Negative results are journaled, not hidden; distinct exit codes report gate failures. Everything is bounded by `--max-minutes`.
- `scripts/azure-workspace-preflight/preflight.py`, its README and tests (small changes): `Microsoft.DevTestLab` listed as a supporting provider for `vm`, a stable `subscription_digest` added to reports so the harness can bind a report to the requested subscription, and candidate names updated for the recorded decision.
- `scripts/azure-workspace-spike/setup-spike-reaper.sh` and `reaper-runbook.ps1` (new): idempotent one-time setup of the reaper (Automation account with system identity, subscription-scoped power-only role, the PowerShell 7.2 runbook from the checked-in file, 15-minute schedule whose job link pins the runbook to the configured subscription) through `az rest`, asserting Published state, matching content, the pinned job link and a future next run; rerunning is idempotent. The harness verifies all of that again, including the runbook's SHA-256, before creating anything.
- `scripts/azure-workspace-spike/README.md` (new): usage, per-sample steps, journal contents, exit codes, what a passing sample does not prove.
- `docs/testing/azure-workspace-readiness.md`: revalidation decision (Linux VM with managed ext4 data disk; reasons recorded), persistent supporting infrastructure (registry resource group, Standard registry with admin user disabled, pull-only identity, image digest), five executed samples with controller and guest timing tables, functional results, verdict against the 180-second boundary, and the checklist status.

## Evidence

Executed 2026-09-10 in `northeurope` with `Standard_D4s_v3`; journals are private, summaries are in the document. Eighteen samples in total: three with the initial harness, one failed restart on the first review-hardened iteration (sample 4), three clean passes with the hardened harness (samples 5 to 7), sample 8 (all gates held, one unrelated concurrent addition), sample 9 (all functional gates held, deletion proof recorded as unverified because another lane deleted its own registry during the run), sample 10 (fully proven pass), samples 11 and 12 (digest-bound preflight report journaled, network, VM and DevTestLab schedule in one deployment; sample 12 on exact harness commit `436fb9ed`), sample 13 (an early-boot `systemctl` in `bootcmd` deadlocked the guest; interrupted by hand, deleted with proven inventory, exit 130) and sample 14 (the crash-safe lifetime bound: power-only role granted on the group before creation plus a guest self-deallocate timer armed as the first `runcmd` step, proven by firing it and observing `PowerState/deallocated`), sample 15 (the timer verified enabled and active before firing; all gates held), and sample 16 with `--prove-reaper`: the subscription-side reaper alone deallocated the VM 866 s after its deadline tag was moved into the past, then the guest timer was proven too and the group deleted with a proven inventory; and sample 17, the same full path with `--prove-reaper` on harness commit `fb5ed0a3`: all gates held; and sample 18, the same full path with `--prove-reaper` on the exact final harness commit `b3b3d926` after the reaper was pinned to the configured subscription (journaled with no uncommitted changes; later commits are documentation only): all gates held, the scheduled reaper deallocated the VM 103 s after the tag change.

- Functional contract held in every completed sample except sample 4's restart: key-only SSH with a pinned out-of-band host key, managed-identity pull, authoritative qualifier `absent` on the data disk and `error` on the overlay control, heartbeat progressed while disconnected, marker and pinned host key retained across deallocate/start on the same IP, resource group absent after deletion with the inventory proof (nothing left under the group, no pre-existing resource missing) holding in every sample except 9, which is recorded as unverified.
- 180-second boundary **not met**: verified SSH at 235.4, 210.7, 270.8, 274.2, 275.6, 213.5, 203.4, 235.8, 278.0, 243.7, 221.0, 247.7, 224.4 and 226.8, 222.5, 219.8 and 222.4 s from T0 (204.0, 179.2, 239.3, 242.2, 243.7, 181.5, 171.5, 203.8, 246.0, 211.2, 189.0, 184.7, 192.5 and 194.8, 190.0, 187.4 and 189.9 s excluding the run-command read); sample 13 never reached an endpoint. Budget: 25 to 33 s boot, 45 to 70 s apt Docker install, 90 to 150 s image pull and extraction, 31 s run-command. Levers listed in the document (smaller or pre-pulled image, prebaked VM image, faster host-key channel); none implemented or approved here.
- Sample 4, the first run of the review-hardened harness, failed the restart gate when the fstab entry lost `nofail`; it still deleted cleanly with exit 7. Restoring `nofail` restarted cleanly in sample 5. The harness now captures guest diagnostics out of band on a failed restart.
- Cost: eighteen VMs for 8 to 30 minutes each plus disks, well under the $10 bound; the Automation account adds about 100 short jobs per day.

## Validation on the pushed head

- `cargo fmt --all -- --check`, `./scripts/check-maintainability.sh`, `./scripts/check-version-sync.sh`: pass
- `RUSTFLAGS="-D warnings" cargo test --workspace` and `--features speech`: pass
- blocking, strict and pedantic clippy tiers: pass (Rust surface unchanged)
- One run of the speech test tier on the final docs-only commit hit a pre-existing timing-sensitive failure in `remote_worker_ssh::query::tests::streaming::broken_pipe_preserves_output_for_draining`; the tier passed on immediate rerun (1196 passed) and passed on every other head of this PR. Follow-up candidate, not introduced here.
- preflight Python tests: 17 passed
- Independent local review: eight verified findings on the first harness (no `EXIT` trap, crashing negative paths, unbounded restart wait with a hard-coded host-key claim, authoritative qualifier available but unused, a defeated `|| true`, gate failures not affecting exit code, docker/mount ordering, mislabeled timing columns) all addressed in the second commit and re-proven by sample 5.

## Notes

No provider was registered and no Container Apps Job was created. Persistent resources created under the maintainer's decision and left in place: resource group `horizon-worker-registry` (registry, pull identity, and the `horizon-spike-reaper` Automation account whose identity holds the built-in power-only role at subscription scope). The Azure adapter (typed models, identity, bounded transport, synthetic tests) follows in a separate PR without config or UI wiring.

https://claude.ai/code/session_01MnceMNTuvpWkyD8EXh35or
