### PR TITLE
feat(worker): add an optional shell-only image flavor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 **
 !Cargo.toml
 !Cargo.lock
+!LICENSE
 !crates/
 !crates/*/
 crates/*/**

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p crates/horizon-browser-cli/src crates/horizon-browser-mcp/src \
 FROM ${WORKER_BASE_IMAGE}
 
 ARG WORKER_BASE_IMAGE
+ARG WORKER_AGENT_TOOLS=full
 ARG CODEX_VERSION=0.153.2
 ARG CLAUDE_VERSION=2.1.260
 ARG GEMINI_VERSION=0.58.0
@@ -48,6 +49,11 @@ ENV RUSTUP_HOME=/usr/local/rustup
 ENV RUSTUP_TOOLCHAIN=1.95.0
 ENV PATH="/usr/local/cargo/bin:${PATH}"
 
+RUN case "${WORKER_AGENT_TOOLS}" in \
+        full|shell) ;; \
+        *) echo "WORKER_AGENT_TOOLS must be full or shell" >&2; exit 64 ;; \
+    esac
+
 RUN case "${WORKER_BASE_IMAGE}" in \
         *@sha256:*) base_digest="${WORKER_BASE_IMAGE##*@sha256:}" ;; \
         *) echo "WORKER_BASE_IMAGE must be pinned by sha256 digest" >&2; exit 64 ;; \
@@ -63,12 +69,14 @@ RUN case "${WORKER_BASE_IMAGE}" in \
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-runtime /usr/local/include/node/ /usr/local/include/node/
 COPY --from=node-runtime /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+COPY --from=node-runtime /usr/local/LICENSE /usr/local/share/licenses/node/LICENSE
 
 RUN ln -sfn node /usr/local/bin/nodejs \
     && ln -sfn ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack \
     && ln -sfn ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -sfn ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
+# Do not retain installation-generated SSH keys in an earlier image layer.
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         build-essential \
@@ -94,16 +102,20 @@ RUN apt-get update \
         python3 \
         rsync \
         tar \
+    && rm -f /etc/ssh/ssh_host_* \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tmux-runtime /opt/horizon-tmux/bin/tmux /usr/local/bin/tmux
+COPY --from=tmux-runtime /opt/horizon-tmux/share/licenses/tmux/COPYING /usr/local/share/licenses/tmux/COPYING
+COPY LICENSE /usr/local/share/licenses/horizon/LICENSE
 
 RUN rustup toolchain install 1.95.0 --profile minimal \
     && rustup component add --toolchain 1.95.0 rustfmt clippy
 
 # Keep this explicit: npm must fail if a new dependency adds an unreviewed
 # lifecycle script instead of silently skipping or running it.
-RUN npm install --global --no-audit --no-fund --strict-allow-scripts \
+RUN if [ "${WORKER_AGENT_TOOLS}" = full ]; then \
+    npm install --global --no-audit --no-fund --strict-allow-scripts \
         --allow-scripts="@anthropic-ai/claude-code,@kilocode/cli,opencode-ai,@github/keytar,node-pty,@google/genai,protobufjs" \
         "@openai/codex@${CODEX_VERSION}" \
         "@anthropic-ai/claude-code@${CLAUDE_VERSION}" \
@@ -111,9 +123,11 @@ RUN npm install --global --no-audit --no-fund --strict-allow-scripts \
         "opencode-ai@${OPENCODE_VERSION}" \
         "@kilocode/cli@${KILO_VERSION}" \
         "@earendil-works/pi-coding-agent@${PI_VERSION}" \
-    && npm cache clean --force
+    && npm cache clean --force; \
+    fi
 
-RUN case "${TARGETARCH}" in \
+RUN if [ "${WORKER_AGENT_TOOLS}" = full ]; then \
+    case "${TARGETARCH}" in \
         amd64) grok_arch=x86_64; grok_sha256="${GROK_AMD64_SHA256}" ;; \
         arm64) grok_arch=aarch64; grok_sha256="${GROK_ARM64_SHA256}" ;; \
         *) echo "Unsupported Grok target architecture: ${TARGETARCH}" >&2; exit 64 ;; \
@@ -122,17 +136,11 @@ RUN case "${TARGETARCH}" in \
         "https://x.ai/cli/grok-${GROK_VERSION}-linux-${grok_arch}" \
         --output /usr/local/bin/grok \
     && printf '%s  %s\n' "${grok_sha256}" /usr/local/bin/grok | sha256sum --check --strict - \
-    && chmod 0755 /usr/local/bin/grok
+    && chmod 0755 /usr/local/bin/grok; \
+    fi
 
 RUN node --version \
     && npm --version \
-    && codex --version \
-    && claude --version \
-    && gemini --version \
-    && opencode --version \
-    && kilo --version \
-    && pi --version \
-    && grok --version \
     && rustc --version \
     && cargo --version \
     && git --version \
@@ -141,6 +149,16 @@ RUN node --version \
     && rsync --version \
     && tar --version \
     && tmux -V
+
+RUN if [ "${WORKER_AGENT_TOOLS}" = full ]; then \
+    codex --version \
+    && claude --version \
+    && gemini --version \
+    && opencode --version \
+    && kilo --version \
+    && pi --version \
+    && grok --version; \
+    fi
 
 WORKDIR /opt/horizon-dependency-cache
 COPY --from=repository-builder /opt/horizon-manifests/ ./
@@ -215,7 +233,8 @@ RUN if [ -z "${WORKER_IMAGE_VERSION}" ]; then \
     fi
 LABEL org.opencontainers.image.title="Horizon remote worker" \
       org.opencontainers.image.description="Provider-neutral interactive coding worker for Horizon" \
-      org.opencontainers.image.version="${WORKER_IMAGE_VERSION}"
+      org.opencontainers.image.version="${WORKER_IMAGE_VERSION}" \
+      io.horizon.worker.agent-tools="${WORKER_AGENT_TOOLS}"
 ENV HORIZON_WORKER_IMAGE_VERSION=${WORKER_IMAGE_VERSION}
 
 EXPOSE 22

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -46,9 +46,34 @@ Version tags make development builds understandable, but provider profiles must
 use a registry digest after publication. This slice does not publish an image
 or change any provider configuration.
 
+### Shell-only flavor
+
+`WORKER_AGENT_TOOLS` accepts exactly `full` (the unchanged default) or `shell`.
+The shell flavor omits all bundled coding-agent CLIs, including Grok, while
+retaining Rust, Node/npm, Git/Git LFS, SSH, tmux and the repository, setup and panel
+helpers. It supports explicit Linux/Shell work; it does not install an agent at
+startup or make other panel types available.
+
+```bash
+docker build --file containers/remote-worker/Dockerfile \
+  --build-arg WORKER_AGENT_TOOLS=shell \
+  --build-arg WORKER_IMAGE_VERSION=0.1.0-shell \
+  --tag horizon-remote-worker:0.1.0-shell .
+```
+
+The `io.horizon.worker.agent-tools` image label records the selected flavor.
+Both flavors include Horizon's MIT notice, the pinned tmux source's `COPYING`
+and the pinned Node image's aggregate `LICENSE` under `/usr/local/share/licenses/`.
+SSH host keys generated during package
+installation are removed in that same image layer; runtime retained host-identity
+preparation is unchanged. Omitting agents is not a license, security or public
+redistribution clearance: dependencies, notices and final layers still need
+review. Publication and provider allocation remain separate explicit actions.
+
 The helper is compiled with the pinned Rust toolchain in a separate build stage.
-The context admits workspace manifests, the lockfile, reviewed worker scripts and
-only Rust source under the repository, core, browser and browser-protocol crates.
+The context admits workspace manifests, the lockfile, Horizon's license, reviewed
+worker scripts and only Rust source under the repository, core, browser and
+browser-protocol crates.
 Build from a trusted clean checkout: the source allowlist is not a secret scanner.
 Unrelated application source, local configuration, SSH material and credentials
 remain excluded. Only the executable crosses into the final runtime; the existing
@@ -107,8 +132,19 @@ replay, unsafe result preflight and status after output loss. The claim-only cas
 is a synthetic state fixture, not proof of surviving an actual interruption.
 It uses no network or credentials and removes only its owned containers/fixtures.
 The second checks the real Docker context filter with positive source controls and
-excluded synthetic files. Add `--image` and `--expected-binary-sha256` from a separate
-`repository-builder` target to audit every final image layer and executable provenance.
+excluded synthetic files, plus shell-only flavor selection with mocked tools.
+Use `--static-only` without `--docker-host` to run only those no-Docker checks.
+To audit every final image layer, pass `--image`, `--expected-agent-tools full|shell`,
+`--expected-binary-sha256` from a separate `repository-builder` target,
+`--expected-tmux-notice-sha256` from `COPYING` in the checksum-verified tmux source,
+and `--expected-node-notice-sha256` from `/usr/local/LICENSE` in the pinned
+`node-runtime` target. The Node aggregate notice is bounded to 1 MiB; the Horizon
+and tmux notices remain bounded to 16 KiB each.
+That audit verifies the flavor label, exact notices and helper provenance, rejects
+SSH host-key files in any layer, and checks known agent executable/package paths:
+absent in shell (including symlink entries and whiteouts), present in full.
+It is not a general secret scanner or a complete dependency-license audit;
+separate runtime checks still verify the final installed filesystem and tools.
 These tests retain images and fail, rather than claim success, on unsupported storage.
 
 To exercise independent setup through local SSH with a fresh synthetic client key,

--- a/containers/remote-worker/build-tmux.sh
+++ b/containers/remote-worker/build-tmux.sh
@@ -31,4 +31,5 @@ make -j2
 mkdir -m 0755 -- "${tmux_prefix}"
 mkdir -m 0755 -- "${tmux_prefix}/bin"
 install -m 0755 tmux "${tmux_prefix}/bin/tmux"
+install -D -m 0644 COPYING "${tmux_prefix}/share/licenses/tmux/COPYING"
 test "$("${tmux_prefix}/bin/tmux" -V)" = "tmux ${tmux_version}"

--- a/containers/remote-worker/test_repository_packaging.py
+++ b/containers/remote-worker/test_repository_packaging.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import json
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tarfile
@@ -14,6 +15,38 @@ import tempfile
 CRATES = ("horizon-repository", "horizon-core", "horizon-browser", "horizon-browser-protocol")
 WORKER_FILES = {"Dockerfile", "build-tmux.sh", "entrypoint.sh", "host-identity.py", "rust-path.sh",
                 "session.sh", "panel-session.py", "setup-launch.py", "tmux.conf", "sshd_config"}
+AGENT_PATHS = tuple("usr/local/bin/" + tool for tool in
+                    ("codex", "claude", "gemini", "opencode", "kilo", "pi", "grok")) + tuple(
+    "usr/local/lib/node_modules/" + package for package in
+    ("@openai/codex", "@anthropic-ai/claude-code", "@google/gemini-cli", "opencode-ai",
+     "@kilocode/cli", "@earendil-works/pi-coding-agent"))
+
+
+def agent_member(name):
+    """Match shipped agent paths, including whiteouts that hide their ancestors."""
+    name = name.removeprefix("./")
+    parent, _, leaf = name.rpartition("/")
+    whiteout = leaf.startswith(".wh.")
+    if whiteout:
+        name = parent if leaf == ".wh..wh..opq" else (parent + "/" if parent else "") + leaf[4:]
+    return any(name == path or name.startswith(path + "/")
+               or whiteout and (not name or path.startswith(name + "/")) for path in AGENT_PATHS)
+
+
+def agent_path_test():
+    for path in AGENT_PATHS:
+        parent, _, leaf = path.rpartition("/")
+        for member in (path, "./" + path, path + "/child", parent + "/.wh." + leaf):
+            assert agent_member(member), member
+        for member in (path + "-unrelated", "other/" + path):
+            assert not agent_member(member), member
+    assert agent_member("usr/local/lib/node_modules/.wh.@openai")
+    assert agent_member("usr/local/bin/.wh..wh..opq")
+    assert agent_member(".wh.usr")
+    assert agent_member(".wh..wh..opq")
+    assert not agent_member("usr/local/lib/node_modules/npm/package.json")
+    assert not agent_member("usr/local/bin/.wh.node")
+    assert not agent_member("etc/.wh.ssh")
 
 
 def execute(argv, **kwargs):
@@ -22,11 +55,73 @@ def execute(argv, **kwargs):
 
 def admitted(path):
     parts = path.parts
-    return (str(path) in ("Cargo.toml", "Cargo.lock")
+    return (str(path) in ("Cargo.toml", "Cargo.lock", "LICENSE")
             or len(parts) == 3 and parts[0] == "crates" and parts[2] == "Cargo.toml"
             or len(parts) >= 4 and parts[0] == "crates" and parts[1] in CRATES
             and parts[2] == "src" and path.suffix == ".rs"
             or len(parts) == 3 and parts[:2] == ("containers", "remote-worker") and parts[2] in WORKER_FILES)
+
+
+def flavor_test(root):
+    # Execute the real RUN bodies with no executable search path. Only the
+    # explicitly mocked tool functions can run; no downloads or installs occur.
+    agent_path_test()
+    dockerfile = (root / "containers/remote-worker/Dockerfile").read_text()
+    lines = dockerfile.replace("\\\n", "").splitlines()
+    arguments = dict(line[4:].split("=", 1) for line in lines if line.startswith("ARG ") and "=" in line)
+    assert arguments["WORKER_AGENT_TOOLS"] == "full"
+    assert sum(line.startswith("ARG WORKER_AGENT_TOOLS") for line in lines) == 1
+    runs = [line[4:] for line in lines if line.startswith("RUN ")]
+    validation = next(command for command in runs if command.startswith('case "${WORKER_AGENT_TOOLS}"'))
+    gated = [command for command in runs if command.startswith('if [ "${WORKER_AGENT_TOOLS}" = full ]')]
+    assert len(gated) == 3
+    assert runs.index(validation) < min(runs.index(command) for command in gated)
+    tools = ("npm", "curl", "sha256sum", "chmod", "codex", "claude", "gemini", "opencode", "kilo", "pi", "grok")
+    mocks = "\n".join(
+        f'{tool}() {{ printf "%s\\n" "{tool} $*"; [ "${{FAIL_TOOL-}}" != "{tool}" ]; }}'
+        for tool in tools)
+
+    def run(command, flavor, fail="", arch="amd64"):
+        return subprocess.run(["/bin/sh", "-c", mocks + "\n" + command],
+                              env=dict(arguments, PATH="/nonexistent", WORKER_AGENT_TOOLS=flavor,
+                                       FAIL_TOOL=fail, TARGETARCH=arch),
+                              stdin=subprocess.DEVNULL, capture_output=True, timeout=10, check=False)
+
+    for flavor in ("full", "shell"):
+        assert run(validation, flavor).returncode == 0
+    for flavor in ("", "Shell", "minimal", "full shell", "$(false)"):
+        result = run(validation, flavor)
+        assert result.returncode == 64 and b"must be full or shell" in result.stderr
+    for command in gated:
+        result = run(command, "shell")
+        assert result.returncode == 0 and not result.stdout and not result.stderr
+        result = run(command, arguments["WORKER_AGENT_TOOLS"])
+        assert result.returncode == 0 and result.stdout and not result.stderr
+    npm, grok, versions = gated
+    npm_output = run(npm, "full").stdout
+    for package in ("@openai/codex@", "@anthropic-ai/claude-code@", "@google/gemini-cli@",
+                    "opencode-ai@", "@kilocode/cli@", "@earendil-works/pi-coding-agent@"):
+        assert package.encode() in npm_output
+    assert b"--strict-allow-scripts" in npm_output and b"npm cache clean --force" in npm_output
+    assert run(npm, "full", fail="npm").returncode != 0
+    for arch, suffix in (("amd64", "x86_64"), ("arm64", "aarch64")):
+        result = run(grok, "full", arch=arch)
+        assert result.returncode == 0 and f"-linux-{suffix}".encode() in result.stdout
+        assert b"sha256sum --check --strict -" in result.stdout
+    assert run(grok, "full", arch="invalid").returncode == 64
+    for tool in ("curl", "sha256sum", "chmod"):
+        assert run(grok, "full", fail=tool).returncode != 0
+    assert run(versions, "full").stdout.splitlines() == [f"{tool} --version".encode() for tool in tools[4:]]
+    for tool in tools[4:]:
+        assert run(versions, "full", fail=tool).returncode != 0
+    apt = next(command for command in runs if "openssh-server" in command)
+    assert "&& rm -f /etc/ssh/ssh_host_*" in apt
+    assert "COPY LICENSE /usr/local/share/licenses/horizon/LICENSE" in lines
+    assert "COPY --from=node-runtime /usr/local/LICENSE /usr/local/share/licenses/node/LICENSE" in lines
+    assert "COPY --from=tmux-runtime /opt/horizon-tmux/share/licenses/tmux/COPYING /usr/local/share/licenses/tmux/COPYING" in lines
+    assert 'install -D -m 0644 COPYING "${tmux_prefix}/share/licenses/tmux/COPYING"' in (root / "containers/remote-worker/build-tmux.sh").read_text()
+    assert "!LICENSE" in (root / ".dockerignore").read_text().splitlines()
+    print("PASS static flavor contract: full default, shell omissions, invalid values, tool failures, notices and same-layer key removal", flush=True)
 
 
 def context_test(docker, root, fixture):
@@ -61,11 +156,15 @@ def context_test(docker, root, fixture):
     print(f"PASS actual Docker filter: {len(observed)} exact source/manifest/worker inputs; unrelated source and sentinels excluded", flush=True)
 
 
-def image_test(docker, image, fixture, expected_binary):
-    identity = json.loads(execute(docker + ["image", "inspect", image]))[0]["Id"]
+def image_test(docker, image, fixture, expected_binary, license_bytes, flavor, tmux_notice_hash, node_notice_hash):
+    metadata = json.loads(execute(docker + ["image", "inspect", image]))[0]
+    assert metadata["Config"]["Labels"]["io.horizon.worker.agent-tools"] == flavor
+    identity = metadata["Id"]
     archive = fixture / "image.tar"
     execute(docker + ["image", "save", "--output", str(archive), identity])
     binary_hashes = []
+    notices = {}
+    agent_paths = set()
     layers = 0
     with tarfile.open(archive) as outer:
         manifests = json.load(outer.extractfile("manifest.json"))
@@ -74,35 +173,69 @@ def image_test(docker, image, fixture, expected_binary):
             with tarfile.open(fileobj=outer.extractfile(layer_name), mode="r|*") as layer:
                 for item in layer:
                     name = item.name.removeprefix("./")
+                    if flavor == "shell":
+                        assert not agent_member(name), name
+                    elif name in AGENT_PATHS:
+                        assert item.isfile() or item.isdir() or item.issym(), name
+                        agent_paths.add(name)
                     assert not name.startswith("opt/horizon-repository-build/"), name
                     assert not name.startswith("opt/horizon-manifests/"), name
+                    assert not name.startswith("etc/ssh/ssh_host_"), name
                     if name.startswith("opt/horizon-dependency-cache/crates/"):
                         assert not item.isfile() or name.endswith("/Cargo.toml"), name
                     if name == "usr/local/bin/horizon-repository":
                         assert item.isfile() and item.mode & 0o111
                         binary_hashes.append(hashlib.sha256(layer.extractfile(item).read()).hexdigest())
+                    if name in ("usr/local/share/licenses/horizon/LICENSE", "usr/local/share/licenses/tmux/COPYING",
+                                "usr/local/share/licenses/node/LICENSE"):
+                        limit = 1024 * 1024 if name == "usr/local/share/licenses/node/LICENSE" else 16384
+                        assert item.isfile() and 0 < item.size <= limit and name not in notices, name
+                        notices[name] = layer.extractfile(item).read()
             layers += 1
     assert binary_hashes == [expected_binary], binary_hashes
-    print(f"PASS {layers} final image layers: no Horizon build/source tree; exactly the expected executable hash", flush=True)
+    if flavor == "full":
+        assert agent_paths == set(AGENT_PATHS), set(AGENT_PATHS) - agent_paths
+    assert notices["usr/local/share/licenses/horizon/LICENSE"] == license_bytes
+    assert hashlib.sha256(notices["usr/local/share/licenses/tmux/COPYING"]).hexdigest() == tmux_notice_hash
+    assert hashlib.sha256(notices["usr/local/share/licenses/node/LICENSE"]).hexdigest() == node_notice_hash
+    print(f"PASS {layers} final image layers: {flavor} agent paths, no Horizon build/source tree or SSH host keys; expected executable and exact notices", flush=True)
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--docker-host", required=True)
+    parser.add_argument("--docker-host")
+    parser.add_argument("--static-only", action="store_true")
     parser.add_argument("--image")
     parser.add_argument("--expected-binary-sha256")
+    parser.add_argument("--expected-agent-tools", choices=("full", "shell"))
+    parser.add_argument("--expected-tmux-notice-sha256")
+    parser.add_argument("--expected-node-notice-sha256")
     options = parser.parse_args()
-    if not options.docker_host.startswith("unix:///"):
+    expected = (options.expected_binary_sha256, options.expected_agent_tools,
+                options.expected_tmux_notice_sha256, options.expected_node_notice_sha256)
+    if options.static_only and (options.image or any(expected)):
+        parser.error("static-only mode does not audit an image")
+    if not options.static_only and (not options.docker_host or not options.docker_host.startswith("unix:///")):
         parser.error("an explicit local Unix Docker socket is required")
-    if options.image and (not options.expected_binary_sha256 or len(options.expected_binary_sha256) != 64):
-        parser.error("image audit requires the separately observed build-stage binary SHA-256")
-    docker = ["docker", "--host", options.docker_host]
+    if options.image and (not options.expected_agent_tools or any(
+            not value or not re.fullmatch("[0-9a-f]{64}", value)
+            for value in (options.expected_binary_sha256, options.expected_tmux_notice_sha256,
+                          options.expected_node_notice_sha256))):
+        parser.error("image audit requires expected flavor and separately observed binary/tmux/Node notice SHA-256 values")
+    if not options.image and any(expected):
+        parser.error("expected image values require --image")
     root = Path(__file__).resolve().parents[2]
+    flavor_test(root)
+    if options.static_only:
+        return
+    docker = ["docker", "--host", options.docker_host]
     with tempfile.TemporaryDirectory(prefix="horizon-repository-packaging-") as temporary:
         fixture = Path(temporary)
         context_test(docker, root, fixture)
         if options.image:
-            image_test(docker, options.image, fixture, options.expected_binary_sha256)
+            image_test(docker, options.image, fixture, options.expected_binary_sha256,
+                       (root / "LICENSE").read_bytes(), options.expected_agent_tools,
+                       options.expected_tmux_notice_sha256, options.expected_node_notice_sha256)
     print("Removed only temporary audit context, export and archive; images unchanged", flush=True)
 
 


### PR DESCRIPTION
## Purpose

Advance #473 and #383 with an explicit Shell-only worker image flavor, preserving the default full image. This is a packaging prerequisite for the first Linux/Shell cloud workflow, not cloud acceptance or permission to publish an image.

## Behavior

- Add `WORKER_AGENT_TOOLS=full|shell`, defaulting to `full`; reject every other value.
- The shell flavor skips bundled coding-agent installations and their version probes while retaining Rust, Node/npm, Git/Git LFS, SSH, tmux and repository/setup/panel helpers. It does not install agents at startup or enable unsupported panel types.
- Record the flavor in image metadata. Include the repository MIT notice, `COPYING` from the checksum-verified tmux source and the aggregate `LICENSE` from the digest-pinned Node image.
- Remove installation-generated SSH host keys in the same image layer as package installation. Runtime retained host-identity preparation remains unchanged.
- Extend packaging checks with no-download flavor/failure tests, exact notice provenance, all-layer SSH-key rejection and known agent-path checks, including symlinks and whiteouts. Keep the Docker context allowlist narrow, adding only the repository license.

No provider, UI, default configuration, dependency-version, runtime lifecycle or release changes. Omitting bundled agents is not a complete security or redistribution audit; publication and provider allocation remain separate actions.

## Validation

Final candidate `e15cd1569d4f9c24116c5b08f533887fec575683` on #507 squash `84f59898`.

- Independent full-diff review completed with no actionable source findings.
- All eight final validation tiers passed in the exact committed worktree: formatting, maintainability, version sync, default and speech-enabled workspace suites, and blocking/strict/advisory Clippy.
- Both full and shell images built from the exact candidate source.
- Each image passed six fresh native cases using the candidate client over loopback pinned SSH: absent synthetic root, qualified root, unsafe mode, restored qualification, wrong pin with the same authorized client identity, and unsupported tmpfs. Driver dependencies matched the workspace lock. All four journaled test containers were independently verified absent; private proof fixtures were retained.
- Fresh final-source build-stage extraction verified the exact repository-helper binary. Independent upstream tmux and Node notices were reused only after pinned-stage/script and artifact parity checks. Actual Docker filtering admitted exactly 417 expected inputs and excluded the synthetic sensitive-file controls.
- Both images passed all-layer audits (36 layers each): exact helper and three-notice provenance, no worker build/source trees or SSH host keys, known bundled-agent paths present in full and absent from shell. Read-only, no-network runtime checks verified shared tools/helpers, four exact hashes, empty initial workspace and each flavor's installed-tool contract. The stage-extraction and runtime-check containers were removed after passing; local images and private evidence were retained.

The native fixture uses a synthetic provider and supplied endpoint/public pin. It does not prove cloud allocation, image pull access, product trust discovery, retained cloud storage, independent PC-off progress or the complete cloud workflow. Hosted CI and independent review must run after the PR is opened.

Scope: 198 source/test/config changed lines across four files, plus 44 README lines.
