### PR TITLE
feat(cloud): add Azure worker profile, lifecycle and CLI credential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "git2",
  "horizon-browser",
  "libc",
+ "process-wrap",
  "profiling",
  "regex",
  "rusqlite",

--- a/crates/horizon-core/Cargo.toml
+++ b/crates/horizon-core/Cargo.toml
@@ -36,6 +36,9 @@ sha2.workspace = true
 regex.workspace = true
 atomicwrites.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+process-wrap.workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 flate2.workspace = true
 rustix.workspace = true

--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -4,6 +4,7 @@ use std::{collections::HashSet, fmt};
 use thiserror::Error;
 use uuid::Uuid;
 mod artifact_digest;
+pub mod azure;
 pub mod interactive_worker;
 pub mod interactive_worker_stop;
 pub mod local_docker;

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -1,0 +1,216 @@
+//! Azure Linux VM worker foundations for #474: operator profile, lifecycle mapping,
+//! credential source and typed errors. The worker identity, the Resource Manager
+//! transport and the provider are separate slices; nothing is wired into config or UI.
+use super::{CloudProvider, WorkerTarget, interactive_worker::valid_worker_target};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+mod credential;
+#[cfg(test)]
+mod tests;
+
+pub use credential::{AzureAccessToken, AzureCliCredential, AzureCredentialSource};
+
+/// Public Azure Resource Manager endpoint; tokens are requested for this audience only.
+pub const MANAGEMENT_ENDPOINT: &str = "https://management.azure.com";
+
+/// Operator-declared placement for Azure CPU workers. Prices are declared, not
+/// discovered: ARM does not return an hourly rate for a VM, so the cost limit in a
+/// target is compared with this declared figure before any provider call.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AzureProfile {
+    pub name: String,
+    /// Exact subscription UUID; never a display name and never the CLI default.
+    pub subscription_id: String,
+    /// Lowercase region name such as `northeurope`.
+    pub location: String,
+    /// Exact VM size such as `Standard_D4s_v3`.
+    pub vm_size: String,
+    /// Resource ID of the user-assigned identity that may pull the worker image. It must
+    /// live in `subscription_id`: workers never borrow identities across subscriptions.
+    pub image_pull_identity_id: String,
+    /// Declared hourly price of `vm_size` in this region, in micro-units of the billing currency.
+    pub declared_hourly_cost_micros: u64,
+    /// Registry login server the image must belong to, such as `example.azurecr.io`.
+    pub registry_login_server: String,
+}
+
+impl AzureProfile {
+    /// Validate the profile shape before any provider call.
+    /// # Errors
+    pub fn validate(&self) -> Result<(), AzureError> {
+        let valid = valid_profile_name(&self.name)
+            && valid_subscription_id(&self.subscription_id)
+            && valid_location(&self.location)
+            && valid_vm_size(&self.vm_size)
+            && valid_identity_id(&self.image_pull_identity_id, &self.subscription_id)
+            && self.declared_hourly_cost_micros > 0
+            && valid_registry_login_server(&self.registry_login_server);
+        valid.then_some(()).ok_or(AzureError::InvalidProfile)
+    }
+
+    /// Reject a target that this profile cannot serve, before any provider I/O. The
+    /// provider-neutral contract is applied first so this never accepts what it rejects.
+    /// # Errors
+    pub fn validate_target(&self, target: &WorkerTarget) -> Result<(), AzureError> {
+        self.validate()?;
+        let on_declared_registry = target
+            .image
+            .split_once('/')
+            .is_some_and(|(server, _)| server == self.registry_login_server);
+        let valid =
+            valid_worker_target(target, CloudProvider::Azure) && target.profile == self.name && on_declared_registry;
+        if !valid {
+            return Err(AzureError::InvalidTarget);
+        }
+        match target.max_hourly_cost_micros {
+            Some(maximum) if maximum < self.declared_hourly_cost_micros => Err(AzureError::DeclaredCostExceedsLimit {
+                declared: self.declared_hourly_cost_micros,
+                maximum,
+            }),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Provider-side lifecycle observed from the VM provisioning and power states.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AzureLifecycle {
+    /// Being created, updated, started or deallocated.
+    Transitioning,
+    Running,
+    /// Guest OS stopped but compute still allocated and billed; not a retained stop.
+    StoppedAllocated,
+    /// Compute released, disks retained; the only state that counts as stopped.
+    Deallocated,
+    Failed,
+    Deleting,
+    Unknown,
+}
+
+impl AzureLifecycle {
+    /// Map ARM instance-view codes to the provider lifecycle.
+    #[must_use]
+    pub fn from_states(provisioning_state: Option<&str>, power_state: Option<&str>) -> Self {
+        match (provisioning_state, power_state) {
+            (Some("Deleting"), _) => Self::Deleting,
+            (Some("Failed" | "Canceled"), _) => Self::Failed,
+            (Some("Creating" | "Updating"), _)
+            | (Some("Succeeded"), Some("PowerState/starting" | "PowerState/deallocating" | "PowerState/stopping")) => {
+                Self::Transitioning
+            }
+            (Some("Succeeded"), Some("PowerState/running")) => Self::Running,
+            (Some("Succeeded"), Some("PowerState/stopped")) => Self::StoppedAllocated,
+            (Some("Succeeded"), Some("PowerState/deallocated")) => Self::Deallocated,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Static-message errors; no Azure payload or identifier can leak through them.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum AzureError {
+    #[error("Azure profile is invalid")]
+    InvalidProfile,
+    #[error("Azure worker target does not fit the profile")]
+    InvalidTarget,
+    #[error("declared hourly cost {declared} exceeds the target limit {maximum}")]
+    DeclaredCostExceedsLimit { declared: u64, maximum: u64 },
+    #[error("Azure credential is unavailable: {reason}")]
+    CredentialUnavailable { reason: &'static str },
+}
+
+/// Parsed `/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{kind}/{name}`.
+struct ResourceIdParts<'a> {
+    provider: &'a str,
+    kind: &'a str,
+    name: &'a str,
+}
+
+pub(crate) fn valid_subscription_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 36
+        && bytes.iter().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => *byte == b'-',
+            _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
+        })
+}
+
+pub(crate) fn valid_location(value: &str) -> bool {
+    (2..=64).contains(&value.len())
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+/// Exact size names, including constrained-vCPU sizes such as `Standard_E4-2s_v3`.
+pub(crate) fn valid_vm_size(value: &str) -> bool {
+    value.len() <= 48
+        && value.strip_prefix("Standard_").is_some_and(|rest| {
+            !rest.is_empty()
+                && rest
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'))
+        })
+}
+
+fn valid_profile_name(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 191 && value.trim() == value && !value.chars().any(char::is_control)
+}
+
+pub(crate) fn valid_resource_group_name(value: &str) -> bool {
+    (1..=90).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'(' | b')'))
+        && !value.ends_with('.')
+}
+
+/// Leaf resource names as ARM accepts them for compute and identity resources:
+/// 1 to 128 characters of alphanumerics, hyphens and underscores.
+pub(crate) fn valid_resource_name(value: &str) -> bool {
+    (1..=128).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+/// User-assigned identity names are 3 to 128 characters and start alphanumeric.
+fn valid_identity_name(value: &str) -> bool {
+    valid_resource_name(value) && value.len() >= 3 && value.as_bytes()[0].is_ascii_alphanumeric()
+}
+
+pub(crate) fn valid_identity_id(value: &str, subscription_id: &str) -> bool {
+    resource_id_parts(value, subscription_id).is_some_and(|parts| {
+        parts.provider.eq_ignore_ascii_case("Microsoft.ManagedIdentity")
+            && parts.kind.eq_ignore_ascii_case("userAssignedIdentities")
+            && valid_identity_name(parts.name)
+    })
+}
+
+/// Subscription and group segments compare case-insensitively, as ARM does.
+fn resource_id_parts<'a>(value: &'a str, subscription_id: &str) -> Option<ResourceIdParts<'a>> {
+    if value.len() > 512 || value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return None;
+    }
+    let mut parts = value.strip_prefix('/')?.split('/');
+    (parts.next()? == "subscriptions" && parts.next()?.eq_ignore_ascii_case(subscription_id)).then_some(())?;
+    parts.next()?.eq_ignore_ascii_case("resourceGroups").then_some(())?;
+    parts.next().filter(|group| valid_resource_group_name(group))?;
+    (parts.next()? == "providers").then_some(())?;
+    let provider = parts.next()?;
+    let kind = parts.next()?;
+    let name = parts.next().filter(|name| valid_resource_name(name))?;
+    parts
+        .next()
+        .is_none()
+        .then_some(ResourceIdParts { provider, kind, name })
+}
+
+/// `<registry>.azurecr.io` where the registry name is 5 to 50 lowercase alphanumerics.
+fn valid_registry_login_server(value: &str) -> bool {
+    value.strip_suffix(".azurecr.io").is_some_and(|registry| {
+        (5..=50).contains(&registry.len()) && registry.bytes().all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    })
+}

--- a/crates/horizon-core/src/cloud_run/azure/credential.rs
+++ b/crates/horizon-core/src/cloud_run/azure/credential.rs
@@ -1,0 +1,302 @@
+//! Azure identity through the official Azure CLI: the token stays in memory, is never
+//! persisted or logged, and is refreshed by asking the CLI again. No OAuth is hand-rolled.
+use super::{AzureError, MANAGEMENT_ENDPOINT, valid_subscription_id};
+#[cfg(not(windows))]
+use std::process::Child;
+use std::{
+    fmt,
+    io::Read as _,
+    path::PathBuf,
+    process::{Command, Stdio},
+    sync::{Mutex, mpsc},
+    time::{Duration, Instant},
+};
+
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+const CLI_OUTPUT_LIMIT: usize = 64 * 1024;
+const REFRESH_MARGIN: Duration = Duration::from_secs(300);
+const MAX_TOKEN_BYTES: usize = 16 * 1024;
+const READER_GRACE: Duration = Duration::from_secs(2);
+#[cfg(windows)]
+const DEFAULT_EXECUTABLE: &str = "az.cmd";
+#[cfg(not(windows))]
+const DEFAULT_EXECUTABLE: &str = "az";
+
+/// A bearer token for Azure Resource Manager and the instant it stops being usable.
+#[derive(Clone)]
+pub struct AzureAccessToken {
+    secret: String,
+    expires_at: Instant,
+}
+
+impl AzureAccessToken {
+    /// # Errors
+    /// Rejects empty, oversized or non-printable tokens and an expiry beyond the clock range.
+    pub fn new(secret: impl Into<String>, valid_for: Duration) -> Result<Self, AzureError> {
+        let secret = secret.into();
+        let valid =
+            !secret.is_empty() && secret.len() <= MAX_TOKEN_BYTES && secret.bytes().all(|b| b.is_ascii_graphic());
+        if !valid {
+            return Err(AzureError::CredentialUnavailable {
+                reason: "token has an invalid shape",
+            });
+        }
+        let expires_at = Instant::now()
+            .checked_add(valid_for)
+            .ok_or(AzureError::CredentialUnavailable {
+                reason: "token expiry is out of range",
+            })?;
+        Ok(Self { secret, expires_at })
+    }
+
+    #[must_use]
+    pub fn needs_refresh(&self) -> bool {
+        Instant::now() + REFRESH_MARGIN >= self.expires_at
+    }
+
+    /// The `Authorization` header value; the only way the secret leaves this type.
+    #[must_use]
+    pub fn authorization_header(&self) -> String {
+        format!("Bearer {}", self.secret)
+    }
+}
+
+impl fmt::Debug for AzureAccessToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AzureAccessToken(<redacted>)")
+    }
+}
+
+/// Source of Resource Manager tokens for one explicit subscription.
+pub trait AzureCredentialSource: Send + Sync {
+    /// # Errors
+    /// Returns a redacted error when no usable token can be obtained.
+    fn token(&self) -> Result<AzureAccessToken, AzureError>;
+}
+
+impl<F> AzureCredentialSource for F
+where
+    F: Fn() -> Result<AzureAccessToken, AzureError> + Send + Sync,
+{
+    fn token(&self) -> Result<AzureAccessToken, AzureError> {
+        self()
+    }
+}
+
+/// Tokens from `az account get-access-token` (CLI 2.54 or newer) for the configured
+/// subscription: argument array, no shell, time and output bounds, explicit
+/// subscription so the operator's default is never used, in-memory cache until expiry.
+pub struct AzureCliCredential {
+    executable: PathBuf,
+    subscription_id: String,
+    timeout: Duration,
+    output_limit: usize,
+    cached: Mutex<Option<AzureAccessToken>>,
+}
+
+impl AzureCliCredential {
+    /// # Errors
+    /// Rejects a malformed subscription identifier.
+    pub fn new(subscription_id: impl Into<String>) -> Result<Self, AzureError> {
+        Self::with_executable(PathBuf::from(DEFAULT_EXECUTABLE), subscription_id)
+    }
+
+    /// # Errors
+    /// Rejects a malformed subscription identifier.
+    pub fn with_executable(executable: PathBuf, subscription_id: impl Into<String>) -> Result<Self, AzureError> {
+        let subscription_id = subscription_id.into();
+        if !valid_subscription_id(&subscription_id) {
+            return Err(AzureError::InvalidProfile);
+        }
+        Ok(Self {
+            executable,
+            subscription_id,
+            timeout: CLI_TIMEOUT,
+            output_limit: CLI_OUTPUT_LIMIT,
+            cached: Mutex::new(None),
+        })
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) fn with_bounds(mut self, timeout: Duration, output_limit: usize) -> Self {
+        self.timeout = timeout;
+        self.output_limit = output_limit;
+        self
+    }
+
+    fn fetch(&self) -> Result<AzureAccessToken, AzureError> {
+        let unavailable = |reason| AzureError::CredentialUnavailable { reason };
+        let started = Instant::now();
+        let mut command = Command::new(&self.executable);
+        command
+            .args([
+                "account",
+                "get-access-token",
+                "--resource",
+                &format!("{MANAGEMENT_ENDPOINT}/"),
+                "--subscription",
+                &self.subscription_id,
+                "--output",
+                "json",
+                "--only-show-errors",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        // The CLI is a launcher; its own process group lets a timeout end the whole tree.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+            command.process_group(0);
+        }
+        let mut child = OwnedChild(spawn_tree(command).map_err(|_| unavailable("Azure CLI could not be started"))?);
+        let stdout = child.take_stdout().ok_or(unavailable("Azure CLI produced no output"))?;
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let limit = self.output_limit as u64 + 1;
+        std::thread::Builder::new()
+            .name("azure-cli-output".into())
+            .spawn(move || {
+                let mut output = Vec::new();
+                let result = stdout.take(limit).read_to_end(&mut output).map(|_| output);
+                let _ = sender.send(result);
+            })
+            .map_err(|_| unavailable("Azure CLI output could not be read"))?;
+        let status = loop {
+            if let Some(status) = child
+                .0
+                .try_wait()
+                .map_err(|_| unavailable("Azure CLI could not be waited on"))?
+            {
+                break status;
+            }
+            if started.elapsed() >= self.timeout {
+                return Err(abandon(child, &receiver));
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        // A descendant that inherited stdout can outlive the leader; the same bound applies.
+        let output = match receiver.recv_timeout(self.timeout.saturating_sub(started.elapsed())) {
+            Ok(Ok(output)) => output,
+            Ok(Err(_)) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(unavailable("Azure CLI output could not be read"));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => return Err(abandon(child, &receiver)),
+        };
+        if !status.success() || output.len() > self.output_limit {
+            return Err(unavailable("Azure CLI did not return a token"));
+        }
+        parse_cli_token(&output)
+    }
+}
+
+impl AzureCredentialSource for AzureCliCredential {
+    fn token(&self) -> Result<AzureAccessToken, AzureError> {
+        let mut cached = self.cached.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(token) = cached.as_ref().filter(|token| !token.needs_refresh()) {
+            return Ok(token.clone());
+        }
+        let token = self.fetch()?;
+        *cached = Some(token.clone());
+        Ok(token)
+    }
+}
+
+/// Only the executable's file name is shown; a configured path could carry a user name.
+impl fmt::Debug for AzureCliCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AzureCliCredential")
+            .field("executable", &self.executable.file_name().unwrap_or_default())
+            .finish_non_exhaustive()
+    }
+}
+
+/// End the tree, then let the reader thread finish: killing every member closes the
+/// pipe writers, so the reader returns on its own within the grace period.
+fn abandon(child: OwnedChild, receiver: &mpsc::Receiver<std::io::Result<Vec<u8>>>) -> AzureError {
+    drop(child);
+    let _ = receiver.recv_timeout(READER_GRACE);
+    AzureError::CredentialUnavailable {
+        reason: "Azure CLI timed out",
+    }
+}
+
+/// The CLI leader plus every descendant: a process group on Unix (the group id stays
+/// valid after the leader exits) and a Job Object on Windows.
+#[cfg(windows)]
+type CliChild = Box<dyn process_wrap::std::ChildWrapper>;
+#[cfg(not(windows))]
+type CliChild = Child;
+
+fn spawn_tree(command: Command) -> std::io::Result<CliChild> {
+    #[cfg(windows)]
+    {
+        let mut command = process_wrap::std::CommandWrap::from(command);
+        command.wrap(process_wrap::std::JobObject);
+        command.spawn()
+    }
+    #[cfg(not(windows))]
+    {
+        let mut command = command;
+        command.spawn()
+    }
+}
+
+/// Ends and reaps the whole CLI process tree when the caller gives up on it, whether or
+/// not the leader has already exited.
+struct OwnedChild(CliChild);
+
+impl OwnedChild {
+    fn take_stdout(&mut self) -> Option<std::process::ChildStdout> {
+        #[cfg(windows)]
+        {
+            self.0.stdout().take()
+        }
+        #[cfg(not(windows))]
+        {
+            self.0.stdout.take()
+        }
+    }
+}
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        // `--` keeps the negative (process group) id from being read as an option.
+        #[cfg(unix)]
+        let _ = Command::new("/bin/kill")
+            .args(["-KILL", "--", &format!("-{}", self.0.id())])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        // On Windows this terminates the Job Object, which covers descendants.
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Parse the CLI's JSON: `accessToken` plus `expires_on` (POSIX seconds, the field the
+/// CLI documents as authoritative). A missing or past expiry is rejected so a broken
+/// CLI cannot turn every call into a fresh process spawn.
+pub(crate) fn parse_cli_token(output: &[u8]) -> Result<AzureAccessToken, AzureError> {
+    let unavailable = |reason| AzureError::CredentialUnavailable { reason };
+    let value: serde_json::Value =
+        serde_json::from_slice(output).map_err(|_| unavailable("Azure CLI token response was malformed"))?;
+    let secret = value
+        .get("accessToken")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(unavailable("Azure CLI token response was malformed"))?;
+    let expires_on = value
+        .get("expires_on")
+        .and_then(|raw| raw.as_u64().or_else(|| raw.as_str().and_then(|text| text.parse().ok())))
+        .ok_or(unavailable("Azure CLI token response lacked an expiry"))?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or_default();
+    let remaining = expires_on
+        .checked_sub(now)
+        .filter(|remaining| *remaining > REFRESH_MARGIN.as_secs())
+        .ok_or(unavailable("Azure CLI returned an expired token"))?;
+    AzureAccessToken::new(secret, Duration::from_secs(remaining))
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -1,0 +1,382 @@
+use super::{
+    AzureAccessToken, AzureCliCredential, AzureError, AzureLifecycle, AzureProfile, credential::parse_cli_token,
+    valid_identity_id, valid_location, valid_registry_login_server, valid_vm_size,
+};
+use crate::cloud_run::{CloudProvider, WorkerLifetime, WorkerTarget};
+use std::time::Duration;
+
+const SUB: &str = "0f0e0d0c-0b0a-4908-8706-050403020100";
+const OTHER_SUB: &str = "9a8b7c6d-5e4f-4a3b-9c2d-1e0f9a8b7c6d";
+const IMAGE: &str =
+    "example.azurecr.io/horizon-remote-worker@sha256:20cc03ef2530336b7374cc35412c8583b1422726c630ec6e6cd1450d690a74f6";
+
+fn profile() -> AzureProfile {
+    AzureProfile {
+        name: "cpu-north".into(),
+        subscription_id: SUB.into(),
+        location: "northeurope".into(),
+        vm_size: "Standard_D4s_v3".into(),
+        image_pull_identity_id: format!(
+            "/subscriptions/{SUB}/resourceGroups/horizon-worker-registry/providers/Microsoft.ManagedIdentity/userAssignedIdentities/puller"
+        ),
+        declared_hourly_cost_micros: 200_000,
+        registry_login_server: "example.azurecr.io".into(),
+    }
+}
+
+fn target() -> WorkerTarget {
+    WorkerTarget {
+        provider: CloudProvider::Azure,
+        profile: "cpu-north".into(),
+        image: IMAGE.into(),
+        disk_gib: 32,
+        lifetime: WorkerLifetime::Persistent,
+        max_hourly_cost_micros: Some(500_000),
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs()
+}
+
+#[test]
+fn profile_and_target_validation_reject_before_any_provider_call() {
+    assert_eq!(profile().validate(), Ok(()));
+    assert_eq!(profile().validate_target(&target()), Ok(()));
+    let profile_mutations: [fn(&mut AzureProfile); 10] = [
+        |p| p.subscription_id = "Finter As".into(),
+        |p| p.subscription_id = SUB.to_ascii_uppercase(),
+        |p| p.location = "North Europe".into(),
+        |p| p.vm_size = "D4s_v3".into(),
+        |p| p.vm_size = "Standard_".into(),
+        |p| p.image_pull_identity_id = p.image_pull_identity_id.replace(SUB, OTHER_SUB),
+        |p| p.image_pull_identity_id = "/subscriptions/x".into(),
+        |p| p.declared_hourly_cost_micros = 0,
+        |p| p.registry_login_server = "example.docker.io".into(),
+        |p| p.name = " cpu ".into(),
+    ];
+    for mutate in profile_mutations {
+        let mut profile = profile();
+        mutate(&mut profile);
+        assert_eq!(profile.validate(), Err(AzureError::InvalidProfile));
+        assert_eq!(profile.validate_target(&target()), Err(AzureError::InvalidProfile));
+    }
+    let target_mutations: [fn(&mut WorkerTarget); 7] = [
+        |t| t.provider = CloudProvider::RunPod,
+        |t| t.profile = "other".into(),
+        |t| t.disk_gib = 0,
+        |t| t.image = "example.azurecr.io/horizon-remote-worker:latest".into(),
+        |t| t.image = IMAGE.replace("example.azurecr.io", "other.azurecr.io"),
+        |t| t.image = IMAGE.replace("example.azurecr.io/", ""),
+        |t| t.lifetime = WorkerLifetime::TimeLimited { seconds: 0 },
+    ];
+    for mutate in target_mutations {
+        let mut target = target();
+        mutate(&mut target);
+        assert_eq!(profile().validate_target(&target), Err(AzureError::InvalidTarget));
+    }
+    let mut cheap = target();
+    cheap.max_hourly_cost_micros = Some(100_000);
+    assert_eq!(
+        profile().validate_target(&cheap),
+        Err(AzureError::DeclaredCostExceedsLimit {
+            declared: 200_000,
+            maximum: 100_000
+        })
+    );
+    let mut exact = target();
+    exact.max_hourly_cost_micros = Some(200_000);
+    assert_eq!(profile().validate_target(&exact), Ok(()));
+    let mut unlimited = target();
+    unlimited.max_hourly_cost_micros = None;
+    assert_eq!(profile().validate_target(&unlimited), Ok(()));
+}
+
+#[test]
+fn validators_follow_azure_naming_rules() {
+    let identity = profile().image_pull_identity_id;
+    assert!(valid_identity_id(&identity, SUB));
+    assert!(valid_identity_id(
+        &identity.replace(SUB, &SUB.to_ascii_uppercase()),
+        SUB
+    ));
+    assert!(valid_identity_id(
+        &identity.replace("resourceGroups", "resourcegroups"),
+        SUB
+    ));
+    assert!(valid_identity_id(&identity.replace("puller", &"n".repeat(128)), SUB));
+    assert!(!valid_identity_id(&identity, OTHER_SUB));
+    for (bad, label) in [
+        (identity.replace("puller", "_puller"), "leading underscore"),
+        (identity.replace("puller", "ab"), "too short"),
+        (identity.replace("puller", &"n".repeat(129)), "too long"),
+        (
+            identity.replace("Microsoft.ManagedIdentity", "Microsoft.Compute"),
+            "provider",
+        ),
+        (format!("{identity}/extra"), "trailing segments"),
+        (
+            identity.replace("/subscriptions/", "/Subscriptions/"),
+            "fixed segment casing",
+        ),
+        (format!("{identity} "), "whitespace"),
+    ] {
+        assert!(!valid_identity_id(&bad, SUB), "{label}");
+    }
+    for size in [
+        "Standard_D4s_v3",
+        "Standard_E4-2s_v3",
+        "Standard_M8-2ms",
+        "Standard_B1ls",
+    ] {
+        assert!(valid_vm_size(size), "{size}");
+    }
+    for size in [
+        "Standard_",
+        "Basic_A1",
+        "Standard_D4s v3",
+        "standard_d4s_v3",
+        &format!("Standard_{}", "x".repeat(40)),
+    ] {
+        assert!(!valid_vm_size(size), "{size}");
+    }
+    for location in ["northeurope", "eastus2", "swedencentral"] {
+        assert!(valid_location(location), "{location}");
+    }
+    for location in ["", "x", "North Europe", "north-europe", "2northeurope", &"a".repeat(65)] {
+        assert!(!valid_location(location), "{location}");
+    }
+    for server in [
+        "example.azurecr.io",
+        "horizonworkersa898ee.azurecr.io",
+        "abc12.azurecr.io",
+    ] {
+        assert!(valid_registry_login_server(server), "{server}");
+    }
+    for server in [
+        "Example.azurecr.io",
+        "my-reg.azurecr.io",
+        "abcd.azurecr.io",
+        "example.azurecr.cn",
+        "azurecr.io",
+        "docker.io",
+    ] {
+        assert!(!valid_registry_login_server(server), "{server}");
+    }
+}
+
+#[test]
+fn lifecycle_mapping_keeps_billed_stop_apart_from_deallocated() {
+    let map = AzureLifecycle::from_states;
+    assert_eq!(
+        map(Some("Succeeded"), Some("PowerState/running")),
+        AzureLifecycle::Running
+    );
+    assert_eq!(
+        map(Some("Succeeded"), Some("PowerState/deallocated")),
+        AzureLifecycle::Deallocated
+    );
+    assert_eq!(
+        map(Some("Succeeded"), Some("PowerState/stopped")),
+        AzureLifecycle::StoppedAllocated
+    );
+    assert_eq!(
+        map(Some("Succeeded"), Some("PowerState/starting")),
+        AzureLifecycle::Transitioning
+    );
+    assert_eq!(
+        map(Some("Succeeded"), Some("PowerState/deallocating")),
+        AzureLifecycle::Transitioning
+    );
+    assert_eq!(map(Some("Succeeded"), None), AzureLifecycle::Unknown);
+    assert_eq!(map(Some("Creating"), None), AzureLifecycle::Transitioning);
+    assert_eq!(map(Some("Failed"), Some("PowerState/running")), AzureLifecycle::Failed);
+    assert_eq!(map(Some("Canceled"), None), AzureLifecycle::Failed);
+    assert_eq!(
+        map(Some("Deleting"), Some("PowerState/running")),
+        AzureLifecycle::Deleting
+    );
+    assert_eq!(map(None, Some("PowerState/running")), AzureLifecycle::Unknown);
+    assert_eq!(
+        map(Some("Succeeded"), Some("PowerState/unknown")),
+        AzureLifecycle::Unknown
+    );
+}
+
+#[test]
+fn tokens_are_redacted_bounded_and_refreshed_near_expiry() {
+    let token = AzureAccessToken::new("synthetic-token-value", Duration::from_secs(3_600)).expect("token");
+    assert!(!token.needs_refresh());
+    assert_eq!(format!("{token:?}"), "AzureAccessToken(<redacted>)");
+    assert_eq!(token.authorization_header(), "Bearer synthetic-token-value");
+    assert!(
+        AzureAccessToken::new("synthetic", Duration::from_secs(60))
+            .expect("token")
+            .needs_refresh()
+    );
+    for bad in ["", " spaced token", "tab\tin", &"x".repeat(16 * 1024 + 1)] {
+        assert!(AzureAccessToken::new(bad, Duration::from_secs(60)).is_err());
+    }
+    assert_eq!(
+        AzureAccessToken::new("synthetic", Duration::MAX).expect_err("no overflow panic"),
+        AzureError::CredentialUnavailable {
+            reason: "token expiry is out of range"
+        }
+    );
+    let later = unix_now() + 3_600;
+    let numeric = format!(r#"{{"accessToken":"synthetic-token-value","expires_on":{later}}}"#);
+    assert!(!parse_cli_token(numeric.as_bytes()).expect("parse").needs_refresh());
+    let stringy = format!(r#"{{"accessToken":"synthetic-token-value","expires_on":"{later}"}}"#);
+    assert!(!parse_cli_token(stringy.as_bytes()).expect("parse").needs_refresh());
+    let expired = format!(
+        r#"{{"accessToken":"synthetic-token-value","expires_on":{}}}"#,
+        unix_now() + 60
+    );
+    let far_future = r#"{"accessToken":"synthetic-token-value","expires_on":18446744073709551615}"#;
+    for (payload, reason) in [
+        (&b"not json"[..], "Azure CLI token response was malformed"),
+        (br#"{"expires_on":1}"#, "Azure CLI token response was malformed"),
+        (
+            br#"{"accessToken":"synthetic-token-value"}"#,
+            "Azure CLI token response lacked an expiry",
+        ),
+        (expired.as_bytes(), "Azure CLI returned an expired token"),
+        (far_future.as_bytes(), "token expiry is out of range"),
+        (
+            br#"{"accessToken":"","expires_on":9999999999}"#,
+            "token has an invalid shape",
+        ),
+    ] {
+        let error = parse_cli_token(payload).expect_err("rejected");
+        assert_eq!(error, AzureError::CredentialUnavailable { reason });
+        assert!(!format!("{error:?} {error}").contains("synthetic"));
+    }
+    assert_eq!(
+        AzureCliCredential::new("not-a-uuid").err(),
+        Some(AzureError::InvalidProfile)
+    );
+    let custom = std::path::PathBuf::from("/home/operator-name/bin/az");
+    let credential = AzureCliCredential::with_executable(custom, SUB).expect("credential");
+    let shown = format!("{credential:?}");
+    assert!(!shown.contains(SUB), "subscription id stays out of Debug output");
+    assert!(
+        !shown.contains("operator-name"),
+        "configured path stays out of Debug output"
+    );
+    assert!(shown.contains("\"az\""), "{shown}");
+}
+
+/// True once the process whose id is recorded in `pid_file` no longer accepts signals.
+#[cfg(unix)]
+fn gone_after_bound(pid_file: &std::path::Path) -> bool {
+    let pid = std::fs::read_to_string(pid_file).expect("pid file").trim().to_string();
+    assert!(pid.parse::<u32>().is_ok(), "{pid}");
+    (0..60).any(|_| {
+        std::thread::sleep(Duration::from_millis(50));
+        let alive = std::process::Command::new("/bin/kill")
+            .args(["-0", "--", &pid])
+            .stderr(std::process::Stdio::null())
+            .status();
+        !alive.is_ok_and(|status| status.success())
+    })
+}
+
+#[cfg(unix)]
+#[test]
+fn cli_credential_invokes_the_executable_without_a_shell_and_enforces_its_bounds() {
+    use super::AzureCredentialSource as _;
+    use std::os::unix::fs::PermissionsExt as _;
+    let directory = tempfile::tempdir().expect("temp dir");
+    let calls = directory.path().join("calls");
+    let write_script = |name: &str, body: String| {
+        let path = directory.path().join(name);
+        std::fs::write(
+            &path,
+            format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n{body}", calls.display()),
+        )
+        .expect("script");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        path
+    };
+    let token_json = format!(
+        r#"{{"accessToken":"synthetic-token-value","expires_on":{}}}"#,
+        unix_now() + 3_600
+    );
+    let good = write_script("fake-az", format!("printf '%s' '{token_json}'\n"));
+    let failing = write_script("fake-az-fail", format!("printf '%s' '{token_json}'\nexit 1\n"));
+    let sleep_pid = directory.path().join("sleep-pid");
+    let slow = write_script(
+        "fake-az-slow",
+        format!("sleep 30 &\necho $! > '{}'\nwait $!\n", sleep_pid.display()),
+    );
+    let verbose = write_script("fake-az-verbose", "head -c 70000 /dev/zero | tr '\\0' a\n".into());
+    let orphan_pid = directory.path().join("orphan-pid");
+    let orphaning = write_script(
+        "fake-az-orphaning",
+        format!("sleep 30 &\necho $! > '{}'\nexit 0\n", orphan_pid.display()),
+    );
+    let credential = AzureCliCredential::with_executable(good, SUB).expect("credential");
+    let first = credential.token().expect("token");
+    let second = credential.token().expect("cached token");
+    assert_eq!(first.authorization_header(), second.authorization_header());
+    assert_eq!(first.authorization_header(), "Bearer synthetic-token-value");
+    let recorded = std::fs::read_to_string(&calls).expect("calls");
+    assert_eq!(
+        recorded.lines().count(),
+        1,
+        "second call served from the in-memory cache"
+    );
+    assert_eq!(
+        recorded.trim(),
+        format!(
+            "account get-access-token --resource https://management.azure.com/ --subscription {SUB} --output json --only-show-errors"
+        )
+    );
+    let unavailable = |reason| AzureError::CredentialUnavailable { reason };
+    let token = |path, timeout, limit| {
+        AzureCliCredential::with_executable(path, SUB)
+            .expect("credential")
+            .with_bounds(timeout, limit)
+            .token()
+            .expect_err("bounded failure")
+    };
+    assert_eq!(
+        token(failing, Duration::from_secs(30), 64 * 1024),
+        unavailable("Azure CLI did not return a token")
+    );
+    let started = std::time::Instant::now();
+    assert_eq!(
+        token(slow, Duration::from_millis(300), 64 * 1024),
+        unavailable("Azure CLI timed out")
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(4),
+        "the slow CLI is killed at the bound, not awaited"
+    );
+    let gone = gone_after_bound(&sleep_pid);
+    assert!(gone, "the launcher's own child is ended with the process group");
+    let started = std::time::Instant::now();
+    assert_eq!(
+        token(orphaning, Duration::from_millis(300), 64 * 1024),
+        unavailable("Azure CLI timed out")
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(4),
+        "an exited leader does not extend the bound"
+    );
+    assert!(
+        gone_after_bound(&orphan_pid),
+        "a descendant holding stdout is ended after the leader exited"
+    );
+    assert_eq!(
+        token(verbose, Duration::from_secs(30), 64 * 1024),
+        unavailable("Azure CLI did not return a token")
+    );
+    assert_eq!(
+        token(directory.path().join("absent"), Duration::from_secs(30), 64 * 1024),
+        unavailable("Azure CLI could not be started")
+    );
+}

--- a/crates/horizon-core/src/cloud_run/interactive_worker.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker.rs
@@ -347,7 +347,7 @@ pub trait InteractiveWorkerProvider: Send + Sync {
 pub(crate) fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider) -> bool {
     target.provider == provider
         && valid_worker_profile_name(&target.profile)
-        && valid_immutable_image(&target.image)
+        && super::validation::valid_immutable_worker_image(&target.image)
         && target.disk_gib > 0
         && target.lifetime.is_valid()
         && target
@@ -359,13 +359,6 @@ pub(crate) fn valid_worker_target(target: &WorkerTarget, provider: CloudProvider
 
 pub(crate) fn valid_worker_profile_name(name: &str) -> bool {
     !name.trim().is_empty() && name.trim() == name && name.len() <= 191 && !name.chars().any(char::is_control)
-}
-
-fn valid_immutable_image(value: &str) -> bool {
-    super::validation::valid_worker_image(value)
-        && value
-            .rsplit_once("@sha256:")
-            .is_some_and(|(_, digest)| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
 pub(crate) fn valid_single_token(value: &str, maximum_length: usize) -> bool {

--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -4,7 +4,7 @@ use super::{
     interactive_worker::{
         InteractiveWorkerLease, InteractiveWorkerLifetime, InteractiveWorkerRequest, valid_ssh_public_key,
     },
-    validation::valid_worker_image,
+    validation::valid_immutable_worker_image,
 };
 use serde::{Deserialize, Deserializer, de};
 use std::{collections::BTreeMap, env, fmt};
@@ -542,12 +542,6 @@ fn termination_deadline(lease_seconds: u32) -> Result<String, RunPodError> {
 fn valid_provider_id(value: &str) -> bool {
     let valid_byte = |byte: u8| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_');
     !value.is_empty() && value.len() <= 191 && value.bytes().all(valid_byte)
-}
-fn valid_immutable_worker_image(value: &str) -> bool {
-    valid_worker_image(value)
-        && value
-            .rsplit_once("@sha256:")
-            .is_some_and(|(_, digest)| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 fn deserialize_hourly_cost<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where

--- a/crates/horizon-core/src/cloud_run/validation.rs
+++ b/crates/horizon-core/src/cloud_run/validation.rs
@@ -315,6 +315,13 @@ pub(super) fn valid_worker_image(value: &str) -> bool {
     let registry = !explicit || Url::parse(&format!("https://{value}")).is_ok_and(usable);
     OCI_REF.as_ref().is_some_and(|pattern| pattern.is_match(value)) && digest && registry
 }
+/// A worker image reference pinned to a full `sha256` digest.
+pub(super) fn valid_immutable_worker_image(value: &str) -> bool {
+    valid_worker_image(value)
+        && value
+            .rsplit_once("@sha256:")
+            .is_some_and(|(_, digest)| ArtifactDigest::parse_sha256(digest).is_ok())
+}
 impl GitSource {
     /// Validate the credential-free repository identity and optional branch.
     /// # Errors


### PR DESCRIPTION
## Summary

First isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open; the worker identity, the transport, the provider and the wiring follow as separate slices).

This adds `cloud_run::azure` with no configuration, dispatcher or UI wiring:

- `AzureProfile`: operator-declared placement (exact subscription UUID, lowercase region, exact VM size including constrained-vCPU names, image-pull identity resource ID in the same subscription, declared hourly price, ACR login server). `validate()` and `validate_target()` reject unusable input before any provider call: the provider-neutral worker target contract is applied first (digest-pinned image, 30-day lease maximum, positive disk, non-zero cost cap), then the target must name this profile, use an image on the declared registry, and its cost limit must cover the declared price (`DeclaredCostExceedsLimit` otherwise).
- `AzureLifecycle::from_states()`: maps ARM provisioning and power states. `PowerState/deallocated` is the retained stop; `PowerState/stopped` (guest halted, compute still allocated and billed) gets its own `StoppedAllocated` state so a reconcile loop can act on it and never mistakes it for a safe stop. `Canceled` provisioning is a failure.
- `AzureError`: typed errors with static messages only; no response bodies, tokens or identifiers can be echoed. Transport failure variants arrive with the transport slice.
- `AzureCliCredential` and `AzureAccessToken`: tokens come from `az account get-access-token` for the explicit subscription. The CLI runs as an argument array without a shell (`az.cmd` on Windows), in its own process group on Unix and a Job Object on Windows (via the `process-wrap` dependency the browser crate already uses), under a 60 s bound that covers both the leader and any descendant holding the output pipe, with a 64 KiB output cap. The whole tree is ended and reaped on every give-up path, including after the leader has exited, and the reader thread is given a bounded grace to finish. A missing, past or out-of-range `expires_on` is rejected rather than degraded. The token type has a redacted `Debug` and the secret only leaves it through `authorization_header()`; the credential's `Debug` shows only the executable file name.
- The digest-pinned image check that the worker contract and RunPod each carried moves to `cloud_run::validation` (one copy).

## Why this shape

Follows the decision recorded in `docs/testing/azure-workspace-readiness.md` (Linux VM plus managed ext4 data disk), the 2026-09-11 remote-only scope update, and the RunPod adapter conventions: validators that reject rather than normalise, injected dependencies for tests, redacted errors.

## Tests

`cloud_run::azure::tests` (5 tests): profile and target rejection matrix on top of the shared contract, Azure naming rules (constrained-vCPU sizes, regions, ACR login servers, identity resource IDs with casing, foreign subscription, trailing segments and whitespace), lifecycle mapping, token redaction, overflow-safe expiry and CLI JSON parsing, and the CLI credential exercised against fake executables in a temp dir: exact argument vector, cache hit, non-zero exit, oversized output, missing executable, a slow leader killed at the bound together with its child, and an exited leader whose child still holds stdout ended within the bound. No test touches the real `az` binary or the network.

## Validation

Full matrix run on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict (`unwrap_used`/`expect_used`), clippy pedantic.

## Follow-ups (separate slices)

1. Persisted worker identity (`AzureWorker`, deterministic resource group, validate-on-deserialise) together with the bounded ARM transport and middleware-mocked tests.
2. Provider implementing `InteractiveWorkerProvider` with the create-once fence, single-deployment lifecycle and ACR managed-identity pulls.
3. Wiring into `remote_provider_config`, dispatchers and UI once the common provider boundary settles.
