### PR TITLE
fix(worker): consume credentials on demand

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ containers/remote-worker/**
 !containers/remote-worker/host-identity.py
 !containers/remote-worker/rust-path.sh
 !containers/remote-worker/session.sh
+!containers/remote-worker/github-credentials.py
 !containers/remote-worker/panel-session.py
 !containers/remote-worker/setup-launch.py
 !containers/remote-worker/tmux.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Verify detached setup handoff contract
         run: python3 -B containers/remote-worker/test_setup_launch.py -v
+      - name: Verify on-demand GitHub credentials
+        run: python3 -B containers/remote-worker/test_github_credentials.py -v
       - name: Verify source allowlist and excluded-file controls
         run: python3 -B containers/remote-worker/test_repository_packaging.py --docker-host unix:///var/run/docker.sock
 

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -191,6 +191,7 @@ COPY --from=repository-builder /opt/horizon-repository /usr/local/bin/horizon-re
 COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entrypoint
 COPY containers/remote-worker/host-identity.py /usr/local/bin/horizon-worker-host-identity
 COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session
+COPY containers/remote-worker/github-credentials.py /usr/local/bin/horizon-github-credential
 COPY containers/remote-worker/panel-session.py /usr/local/bin/horizon-panel-session
 COPY containers/remote-worker/setup-launch.py /usr/local/bin/horizon-setup-launch
 COPY containers/remote-worker/tmux.conf /etc/horizon/tmux.conf
@@ -198,9 +199,11 @@ COPY containers/remote-worker/rust-path.sh /etc/profile.d/horizon-rust.sh
 COPY containers/remote-worker/sshd_config /etc/ssh/sshd_config.d/99-horizon-worker.conf
 
 RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-agent-session \
+    /usr/local/bin/horizon-github-credential \
     /usr/local/bin/horizon-panel-session \
     /usr/local/bin/horizon-setup-launch \
     /usr/local/bin/horizon-worker-host-identity \
+    && ln -s horizon-github-credential /usr/local/bin/gh \
     && chmod 0644 /etc/profile.d/horizon-rust.sh /etc/ssh/sshd_config.d/99-horizon-worker.conf \
     && git lfs install --system \
     && rm -f /etc/ssh/ssh_host_* \

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -218,8 +218,8 @@ At startup the entrypoint:
 
 1. validates any supplied expiry, the public key, and optional secret file;
 2. installs only the supplied public key for root login;
-3. copies the optional token to a root-only runtime file and configures shared
-   Git authentication once, before SSH accepts concurrent sessions;
+3. copies the optional token to a root-only runtime file and configures a
+   token-free Git credential helper once, without contacting GitHub;
 4. prepares or strictly recovers the workspace-retained Ed25519 host identity
    and materializes its verified runtime files before SSH starts; and
 5. starts a termination watchdog only when an explicit expiry was supplied.
@@ -234,9 +234,31 @@ running; losing the client reference neither revokes access nor stops compute.
 
 `/workspace/horizon` starts empty. The controller checks out the requested
 repository and task after host-key verification. Remote commands should run
-through `horizon-agent-session`, which exposes the Rust toolchain, marks the
-session with `HORIZON=1`, and configures GitHub authentication only when the
-runtime token file exists. tmux provides reconnectable interactive sessions.
+through `horizon-agent-session`, which exposes the Rust toolchain and marks the
+session with `HORIZON=1`. It does not export a token into shells or agents.
+tmux provides reconnectable interactive sessions.
+
+Ordinary HTTPS Git requests for exactly `github.com` use the protected runtime
+token file through `horizon-github-credential`. Other hosts/protocols receive no
+credentials; store/erase requests never modify the file. The installed `gh`
+wrapper reads that same file and supplies `GH_TOKEN` only to the packaged CLI
+process, not its parent session. It does not run login or persist the token in
+Git/CLI configuration. It rejects foreign `GH_HOST` and API host overrides;
+other commands retain the packaged CLI's host-scoped authentication behavior.
+It does not use an ambient CLI login. Worker root can already read the file:
+this limits ambient token inheritance, not intentional credential retrieval or
+the packaged CLI's development-host aliases. Missing, malformed or insecure credentials fail the
+GitHub operation, not the worker; expiration and repository permissions are
+reported by GitHub normally. Help/version remain usable without a token.
+Supply a fine-grained PAT restricted to the required repositories and permissions;
+creation, rotation and provider delivery of that token remain separate work.
+Retained repository setup remains offline and does not acquire credentials.
+
+Run the credential regressions without network or real credentials:
+
+```bash
+python3 -B containers/remote-worker/test_github_credentials.py -v
+```
 
 The provider or operator must supply retained storage at `/workspace`; the image
 cannot prove that the backing storage is durable. The named volume in the example

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -109,11 +109,12 @@ if [ -n "${github_token_file}" ]; then
     fi
     install -m 0600 "${github_token_file}" /run/horizon/github-token
 
-    git config --global --replace-all credential.https://github.com.helper ''
-    git config --global --add credential.https://github.com.helper /usr/local/bin/horizon-github-credential
     git config --global --replace-all url.https://github.com/.insteadOf git@github.com:
     git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
 fi
+
+git config --global --replace-all credential.https://github.com.helper ''
+git config --global --add credential.https://github.com.helper /usr/local/bin/horizon-github-credential
 
 /usr/local/bin/horizon-worker-host-identity
 

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -109,11 +109,8 @@ if [ -n "${github_token_file}" ]; then
     fi
     install -m 0600 "${github_token_file}" /run/horizon/github-token
 
-    GITHUB_TOKEN=$(cat /run/horizon/github-token)
-    export GITHUB_TOKEN
-    GH_TOKEN=${GITHUB_TOKEN}
-    export GH_TOKEN
-    gh auth setup-git
+    git config --global --replace-all credential.https://github.com.helper ''
+    git config --global --add credential.https://github.com.helper /usr/local/bin/horizon-github-credential
     git config --global --replace-all url.https://github.com/.insteadOf git@github.com:
     git config --global --add url.https://github.com/.insteadOf ssh://git@github.com/
 fi

--- a/containers/remote-worker/github-credentials.py
+++ b/containers/remote-worker/github-credentials.py
@@ -131,7 +131,7 @@ def api_target(arguments):
 
 def run_gh(arguments):
     environment = gh_environment(os.environ)
-    if arguments == ['--version'] or arguments[:1] == ['help'] or '--help' in arguments:
+    if arguments in (['--version'], ['version']) or arguments[:1] == ['help'] or '--help' in arguments:
         os.execve(GH, [GH, *arguments], environment)
     require(environment.get('GH_HOST', 'github.com') == 'github.com')
     # Explicit GH_HOST also filters inferred Git remotes, preventing a different
@@ -157,6 +157,9 @@ def main(arguments):
         raise CredentialError()
     except (OSError, ValueError, CredentialError):
         print('horizon-worker: GitHub credential unavailable or request rejected', file=sys.stderr)
+        if Path(sys.argv[0]).name != 'gh' and arguments == ['get']:
+            sys.stdout.write('quit=true\n\n')
+            return 0
         return 1
 
 

--- a/containers/remote-worker/github-credentials.py
+++ b/containers/remote-worker/github-credentials.py
@@ -131,7 +131,8 @@ def api_target(arguments):
 
 def run_gh(arguments):
     environment = gh_environment(os.environ)
-    if arguments in (['--version'], ['version']) or arguments[:1] == ['help'] or '--help' in arguments:
+    if (arguments in (['--version'], ['version']) or arguments[:1] == ['help']
+            or any(flag in arguments for flag in ('--help', '-h'))):
         os.execve(GH, [GH, *arguments], environment)
     require(environment.get('GH_HOST', 'github.com') == 'github.com')
     # Explicit GH_HOST also filters inferred Git remotes, preventing a different

--- a/containers/remote-worker/github-credentials.py
+++ b/containers/remote-worker/github-credentials.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python3 -I
+"""Consume the worker's protected runtime token without persisting credentials."""
+
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+from urllib.parse import urlsplit
+
+RUNTIME = Path('/run/horizon')
+GH = '/usr/bin/gh'
+MAX_TOKEN = 16384
+MAX_REQUEST = 65536
+TOKEN_VARIABLES = ('GH_TOKEN', 'GITHUB_TOKEN', 'GH_ENTERPRISE_TOKEN',
+                   'GITHUB_ENTERPRISE_TOKEN', 'HORIZON_GITHUB_TOKEN')
+DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_NONBLOCK
+
+
+class CredentialError(Exception):
+    pass
+
+
+def require(condition):
+    if not condition:
+        raise CredentialError()
+
+
+def identity(info):
+    return (info.st_dev, info.st_ino, info.st_uid, info.st_gid, info.st_mode,
+            info.st_nlink, info.st_size, info.st_mtime_ns, info.st_ctime_ns)
+
+
+def read_token():
+    try:
+        directory = os.open(RUNTIME, DIRECTORY_FLAGS)
+    except FileNotFoundError:
+        return None
+    try:
+        parent = os.fstat(directory)
+        require(parent.st_uid == os.geteuid() and stat.S_IMODE(parent.st_mode) == 0o700)
+        try:
+            descriptor = os.open('github-token', os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                                 dir_fd=directory)
+        except FileNotFoundError:
+            return None
+        try:
+            before = os.fstat(descriptor)
+            require(stat.S_ISREG(before.st_mode) and before.st_uid == os.geteuid()
+                    and stat.S_IMODE(before.st_mode) == 0o600 and before.st_nlink == 1
+                    and 1 <= before.st_size <= MAX_TOKEN)
+            raw = os.read(descriptor, MAX_TOKEN + 1)
+            require(len(raw) == before.st_size and identity(os.fstat(descriptor)) == identity(before))
+            require(identity(os.stat('github-token', dir_fd=directory, follow_symlinks=False))
+                    == identity(before))
+            require(identity(os.stat(RUNTIME, follow_symlinks=False)) == identity(parent))
+        finally:
+            os.close(descriptor)
+    finally:
+        os.close(directory)
+    # Fine-grained and classic PATs use this alphabet. Permit one file-ending LF,
+    # never whitespace/control characters that could inject credential fields.
+    value = raw.removesuffix(b'\n')
+    require(re.fullmatch(rb'[A-Za-z0-9_]+', value) is not None)
+    return value.decode('ascii')
+
+
+def credential_request(stream):
+    fields = {}
+    total = 0
+    while True:
+        line = stream.readline(MAX_REQUEST + 1)
+        total += len(line)
+        require(total <= MAX_REQUEST)
+        if line in (b'', b'\n'):
+            return fields
+        require(line.endswith(b'\n') and b'\0' not in line and b'\r' not in line)
+        key, separator, value = line[:-1].partition(b'=')
+        require(separator and key and key not in fields)
+        fields[key] = value
+
+
+def git_credential(operation, stream, output):
+    # Read-only helper: Git's store/erase input must never replace the mounted PAT.
+    if operation != 'get':
+        return 0
+    fields = credential_request(stream)
+    if fields.get(b'protocol') != b'https' or fields.get(b'host') != b'github.com':
+        return 0
+    token = read_token()
+    if token is None:
+        output.write('quit=true\n\n')
+    else:
+        output.write('username=x-access-token\npassword=' + token + '\n\n')
+    return 0
+
+
+def gh_environment(environment):
+    result = {key: value for key, value in environment.items()
+              if key not in TOKEN_VARIABLES and key not in ('GH_DEBUG', 'DEBUG')}
+    # No fallback to the user's normal hosts.yml or interactive login. The file
+    # above is the only automatically supplied credential source on this worker.
+    result.update(GH_CONFIG_DIR='/run/horizon/github-cli', GH_PROMPT_DISABLED='1')
+    return result
+
+
+def api_target(arguments):
+    if arguments[:1] != ['api']:
+        return
+    # Parse only API target/options, never PR/issue text or API field values.
+    # Unknown flags are left for gh, which rejects them before making a request.
+    valued = {'--hostname', '--cache', '--field', '--raw-field', '--header', '--input',
+              '--jq', '--method', '--template', '--preview', '-F', '-f', '-H', '-q', '-X', '-t', '-p'}
+    remaining = iter(arguments[1:])
+    for argument in remaining:
+        flag = argument.split('=', 1)[0]
+        if flag in valued:
+            value = argument.split('=', 1)[1] if '=' in argument else next(remaining, None)
+            require(value is not None)
+            if flag == '--hostname':
+                require(value == 'github.com')
+        elif argument.startswith('-') and argument != '--':
+            continue
+        else:
+            endpoint = next(remaining, '') if argument == '--' else argument
+            if '://' in endpoint:
+                url = urlsplit(endpoint)
+                require(url.scheme == 'https' and url.hostname in ('github.com', 'api.github.com')
+                        and url.port in (None, 443) and url.username is None and url.password is None)
+
+
+def run_gh(arguments):
+    environment = gh_environment(os.environ)
+    if arguments == ['--version'] or arguments[:1] == ['help'] or '--help' in arguments:
+        os.execve(GH, [GH, *arguments], environment)
+    require(environment.get('GH_HOST', 'github.com') == 'github.com')
+    # Explicit GH_HOST also filters inferred Git remotes, preventing a different
+    # host in the working repository from receiving GitHub's environment token.
+    environment['GH_HOST'] = 'github.com'
+    api_target(arguments)
+    token = read_token()
+    require(token is not None)
+    # A missing config gives packaged gh a valid empty config. Do not admit a
+    # corrupt/unreadable config (or a second stored credential source).
+    require(not os.path.lexists(environment['GH_CONFIG_DIR']))
+    environment['GH_TOKEN'] = token
+    os.execve(GH, [GH, *arguments], environment)
+
+
+def main(arguments):
+    try:
+        if Path(sys.argv[0]).name == 'gh':
+            run_gh(arguments)
+            return 0
+        if len(arguments) == 1:
+            return git_credential(arguments[0], sys.stdin.buffer, sys.stdout)
+        raise CredentialError()
+    except (OSError, ValueError, CredentialError):
+        print('horizon-worker: GitHub credential unavailable or request rejected', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/containers/remote-worker/session.sh
+++ b/containers/remote-worker/session.sh
@@ -8,12 +8,9 @@ fi
 
 export PATH="/usr/local/cargo/bin:${PATH}"
 
-if [ -f /run/horizon/github-token ]; then
-    GITHUB_TOKEN=$(cat /run/horizon/github-token)
-    export GITHUB_TOKEN
-    GH_TOKEN=${GITHUB_TOKEN}
-    export GH_TOKEN
-fi
+# Only the Git credential helper and gh child consume the protected token.
+# Ordinary shells, agents and their unrelated children must not inherit it.
+unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN HORIZON_GITHUB_TOKEN
 
 export HORIZON=1
 exec "$@"

--- a/containers/remote-worker/test_github_credentials.py
+++ b/containers/remote-worker/test_github_credentials.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Synthetic-only worker credentials; no network, local login or real tokens."""
+
+import concurrent.futures
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location('credentials', HERE / 'github-credentials.py')
+C = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(C)
+TOKEN = 'github_pat_SYNTHETIC_NOT_A_CREDENTIAL'
+
+
+class CredentialsTests(unittest.TestCase):
+    def setUp(self):
+        self.fixture = tempfile.TemporaryDirectory(prefix='horizon-github-credentials-')
+        self.root = Path(self.fixture.name)
+        self.runtime = self.root / 'runtime'
+        self.runtime.mkdir(mode=0o700)
+        self.token = self.runtime / 'github-token'
+        self.token.write_text(TOKEN + '\n')
+        self.token.chmod(0o600)
+        self.runtime_patch = patch.object(C, 'RUNTIME', self.runtime)
+        self.runtime_patch.start()
+
+    def tearDown(self):
+        self.runtime_patch.stop()
+        self.fixture.cleanup()
+
+    def get(self, request=b'protocol=https\nhost=github.com\n\n', operation='get'):
+        output = io.StringIO()
+        C.git_credential(operation, io.BytesIO(request), output)
+        return output.getvalue()
+
+    def test_valid_token_and_single_optional_file_newline(self):
+        for value in (TOKEN, TOKEN + '\n'):
+            self.token.write_text(value)
+            self.assertEqual(TOKEN, C.read_token())
+            self.assertEqual('username=x-access-token\npassword=' + TOKEN + '\n\n', self.get())
+
+    def test_bad_token_shapes_are_rejected_without_output(self):
+        for value in ('', TOKEN + '\n\n', TOKEN + '\r\n', 'private secret', 'x\0y', 'x' * 16385):
+            self.token.write_text(value)
+            with self.assertRaises(C.CredentialError):
+                self.get()
+
+    def test_missing_token_is_noninteractive_and_never_recreated(self):
+        self.token.unlink()
+        self.assertIsNone(C.read_token())
+        self.assertEqual('quit=true\n\n', self.get())
+        self.assertFalse(self.token.exists())
+
+    def test_protected_directory_and_file_modes(self):
+        for mode in (0o644, 0o666, 0o777):
+            self.token.chmod(mode)
+            with self.assertRaises(C.CredentialError):
+                C.read_token()
+        self.token.chmod(0o600)
+        self.runtime.chmod(0o755)
+        with self.assertRaises(C.CredentialError):
+            C.read_token()
+        self.runtime.chmod(0o700)
+        with patch.object(C.os, 'geteuid', return_value=os.geteuid() + 1):
+            with self.assertRaises(C.CredentialError):
+                C.read_token()
+
+    def test_link_fifo_and_directory_tokens_rejected(self):
+        self.token.unlink()
+        target = self.root / 'target'
+        target.write_text(TOKEN)
+        target.chmod(0o600)
+        self.token.symlink_to(target)
+        with self.assertRaises(OSError):
+            C.read_token()
+        self.token.unlink()
+        os.link(target, self.token)
+        with self.assertRaises(C.CredentialError):
+            C.read_token()
+        self.token.unlink()
+        os.mkfifo(self.token, 0o600)
+        with self.assertRaises(C.CredentialError):
+            C.read_token()
+        self.token.unlink()
+        self.token.mkdir(mode=0o700)
+        with self.assertRaises(C.CredentialError):
+            C.read_token()
+
+    def test_runtime_directory_symlink_rejected(self):
+        link = self.root / 'runtime-link'
+        link.symlink_to(self.runtime, target_is_directory=True)
+        with patch.object(C, 'RUNTIME', link):
+            with self.assertRaises(OSError):
+                C.read_token()
+
+    def test_replacement_during_read_rejected(self):
+        read = os.read
+        def replace(descriptor, size):
+            data = read(descriptor, size)
+            self.token.unlink()
+            self.token.write_text(TOKEN)
+            self.token.chmod(0o600)
+            return data
+        with patch.object(C.os, 'read', side_effect=replace):
+            with self.assertRaises(C.CredentialError):
+                C.read_token()
+
+    def test_other_hosts_protocols_and_lookalikes_never_read_token(self):
+        with patch.object(C, 'read_token', side_effect=AssertionError('must not read token')):
+            for protocol, host in [('http', 'github.com'), ('https', 'github.com.evil'),
+                                   ('https', 'gitlab.com'), ('https', 'github.com:443'),
+                                   ('ssh', 'github.com'), ('https', 'user@github.com')]:
+                self.assertEqual('', self.get(f'protocol={protocol}\nhost={host}\n\n'.encode()))
+
+    def test_invalid_protocol_input_is_bounded_and_not_echoed(self):
+        for value in (b'host=github.com\nhost=other\n\n', b'bad-line\n', b'host=x\0y\n',
+                      b'host=github.com\r\n', b'x=' + b'x' * 65536 + b'\n'):
+            with self.assertRaises(C.CredentialError):
+                self.get(value)
+        self.assertEqual('', self.get(b'\n'))
+
+    def test_store_erase_and_unknown_operations_are_noops(self):
+        before = self.token.read_bytes()
+        with patch.object(C, 'read_token', side_effect=AssertionError('must not read token')):
+            for operation in ('store', 'erase', 'future-operation'):
+                self.assertEqual('', self.get(b'password=other-secret\n\n', operation))
+        self.assertEqual(before, self.token.read_bytes())
+
+    def test_gh_exec_has_only_file_token_in_child_environment(self):
+        argv = ['api', 'user', '--jq', '.login']
+        parent = {'PATH': '/usr/bin:/bin', 'GH_TOKEN': 'ambient-secret', 'GITHUB_TOKEN': 'other',
+                  'GH_ENTERPRISE_TOKEN': 'enterprise', 'GH_DEBUG': 'api', 'GH_CONFIG_DIR': '/unrelated'}
+        with patch.dict(C.os.environ, parent, clear=True), patch.object(C.os, 'execve') as execute:
+            C.run_gh(argv)
+            self.assertEqual('ambient-secret', os.environ['GH_TOKEN'])
+        binary, arguments, environment = execute.call_args.args
+        self.assertEqual('/usr/bin/gh', binary)
+        self.assertEqual(['/usr/bin/gh', *argv], arguments)
+        self.assertEqual(TOKEN, environment['GH_TOKEN'])
+        self.assertEqual('github.com', environment['GH_HOST'])
+        self.assertEqual('/run/horizon/github-cli', environment['GH_CONFIG_DIR'])
+        self.assertNotIn('GITHUB_TOKEN', environment)
+        self.assertNotIn('GH_ENTERPRISE_TOKEN', environment)
+        self.assertNotIn('GH_DEBUG', environment)
+        self.assertNotIn(TOKEN, ' '.join(arguments))
+
+    def test_foreign_gh_targets_refused_before_secret_read(self):
+        with patch.dict(C.os.environ, {}, clear=True), patch.object(C, 'read_token', side_effect=AssertionError('must not read token')):
+            for args in (['api', '--hostname', 'evil.ghe.com'], ['api', '--hostname=evil.com'],
+                         ['api', 'https://evil.com/user'], ['api', 'http://github.com/user']):
+                with self.assertRaises(C.CredentialError):
+                    C.run_gh(args)
+            with patch.dict(C.os.environ, GH_HOST='evil.ghe.com'):
+                with self.assertRaises(C.CredentialError):
+                    C.run_gh(['api', 'user'])
+
+    def test_gh_content_is_not_interpreted_as_host_flags(self):
+        for args in (['pr', 'create', '--body', 'See https://example.com'],
+                     ['issue', 'create', '--title', '--hostname=example.com'],
+                     ['api', '-f', 'url=https://example.com', 'repos/a/b/issues'],
+                     ['api', 'repos/a/b/issues', '--field', 'body=See https://example.com']):
+            with patch.dict(C.os.environ, {}, clear=True), patch.object(C.os, 'execve') as execute:
+                C.run_gh(args)
+                self.assertEqual([C.GH, *args], execute.call_args.args[1])
+
+    def test_existing_gh_config_is_not_an_alternative_credential_source(self):
+        with patch.dict(C.os.environ, {}, clear=True), patch.object(C.os.path, 'lexists', return_value=True):
+            with self.assertRaises(C.CredentialError):
+                C.run_gh(['api', 'user'])
+
+    def test_missing_token_keeps_help_but_fails_authenticated_operation(self):
+        self.token.unlink()
+        with patch.dict(C.os.environ, {}, clear=True), patch.object(C.os, 'execve') as execute:
+            # execve does not return in production; emulate that control flow.
+            execute.side_effect = SystemExit(0)
+            for args in (['--version'], ['help'], ['repo', 'view', '--help']):
+                with self.assertRaises(SystemExit):
+                    C.run_gh(args)
+                self.assertNotIn('GH_TOKEN', execute.call_args.args[2])
+            with self.assertRaises(C.CredentialError):
+                C.run_gh(['api', 'user'])
+
+    def test_session_does_not_export_any_token_and_preserves_literal_argv(self):
+        value = 'literal ; $(false) argument'
+        code = 'import os,sys,json; print(json.dumps([sys.argv[1],os.environ.get("HORIZON"),[x for x in os.environ if x in '+repr(C.TOKEN_VARIABLES)+']]))'
+        environment = {'PATH': '/usr/bin:/bin', **{key: TOKEN for key in C.TOKEN_VARIABLES}}
+        result = subprocess.run(['/bin/sh', str(HERE / 'session.sh'), '/usr/bin/python3', '-c', code, value],
+                                env=environment, capture_output=True, timeout=5, check=True)
+        self.assertEqual([value, '1', []], json.loads(result.stdout))
+        self.assertNotIn(TOKEN.encode(), result.stderr)
+
+    def test_gh_authentication_failure_only_exits_its_child(self):
+        fake = self.root / 'packaged-gh'
+        fake.write_text('#!/usr/bin/python3\nimport os,sys\n'
+                        + 'assert os.environ["GH_TOKEN"] == ' + repr(TOKEN) + '\n'
+                        + 'assert "GITHUB_TOKEN" not in os.environ\n'
+                        + 'print("synthetic authentication rejected", file=sys.stderr)\nsys.exit(42)\n')
+        fake.chmod(0o700)
+        wrapper = self.root / 'gh'
+        source = (HERE / 'github-credentials.py').read_text()
+        wrapper.write_text(source.replace("RUNTIME = Path('/run/horizon')", 'RUNTIME = Path(' + repr(str(self.runtime)) + ')')
+                           .replace("GH = '/usr/bin/gh'", 'GH = ' + repr(str(fake))))
+        environment = {'PATH': '/usr/bin:/bin', 'GITHUB_TOKEN': 'ignored-ambient-secret'}
+        before = set(self.root.iterdir())
+        result = subprocess.run(['/usr/bin/python3', '-I', str(wrapper), 'api', 'user'],
+                                env=environment, capture_output=True, timeout=5, check=False)
+        self.assertEqual(42, result.returncode)
+        self.assertEqual(b'', result.stdout)
+        self.assertEqual(b'synthetic authentication rejected\n', result.stderr)
+        self.assertNotIn(TOKEN.encode(), result.stdout + result.stderr)
+        self.assertEqual(before, set(self.root.iterdir()))
+        self.assertEqual(TOKEN + '\n', self.token.read_text())
+
+    def test_image_and_startup_contract_uses_absolute_readonly_helper(self):
+        dockerfile = (HERE / 'Dockerfile').read_text()
+        entrypoint = (HERE / 'entrypoint.sh').read_text()
+        self.assertIn('COPY containers/remote-worker/github-credentials.py /usr/local/bin/horizon-github-credential', dockerfile)
+        self.assertIn('ln -s horizon-github-credential /usr/local/bin/gh', dockerfile)
+        self.assertIn('credential.https://github.com.helper /usr/local/bin/horizon-github-credential', entrypoint)
+        self.assertNotIn('gh auth setup-git', entrypoint)
+        self.assertNotIn('$(cat /run/horizon/github-token)', entrypoint)
+        self.assertIn('!containers/remote-worker/github-credentials.py', (HERE.parents[1] / '.dockerignore').read_text())
+        smoke = (HERE.parents[1] / 'scripts/run-remote-worker-smoke.sh').read_text()
+        self.assertIn('slow-identity,dst=/usr/local/bin/horizon-worker-host-identity,readonly', smoke)
+        self.assertNotIn('slow-gh', smoke)
+
+    def test_real_git_fill_concurrent_no_config_or_secret_storage(self):
+        helper = self.root / 'helper.py'
+        source = (HERE / 'github-credentials.py').read_text()
+        helper.write_text(source.replace("RUNTIME = Path('/run/horizon')", 'RUNTIME = Path(' + repr(str(self.runtime)) + ')'))
+        environment = {'PATH': '/usr/bin:/bin', 'LC_ALL': 'C', 'HOME': str(self.root),
+                       'GIT_CONFIG_GLOBAL': '/dev/null', 'GIT_CONFIG_NOSYSTEM': '1', 'GIT_TERMINAL_PROMPT': '0'}
+        command = ['/usr/bin/git', '-c', 'credential.helper=', '-c',
+                   'credential.https://github.com.helper=/usr/bin/python3 -I ' + str(helper), 'credential', 'fill']
+        def fill(_):
+            result = subprocess.run(command, input=b'protocol=https\nhost=github.com\n\n',
+                                    env=environment, capture_output=True, timeout=5, check=True)
+            self.assertIn(('password=' + TOKEN).encode(), result.stdout)
+            self.assertEqual(b'', result.stderr)
+        before = set(self.root.iterdir())
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(fill, range(8)))
+        for operation in ('approve', 'reject'):
+            result = subprocess.run([*command[:-1], operation],
+                input=b'protocol=https\nhost=github.com\nusername=x-access-token\npassword=synthetic_other\n\n',
+                env=environment, capture_output=True, timeout=5, check=True)
+            self.assertEqual(b'', result.stdout + result.stderr)
+        self.assertEqual(TOKEN + '\n', self.token.read_text())
+        self.assertEqual(before, set(self.root.iterdir()))
+        self.assertFalse((self.root / '.gitconfig').exists())
+        self.assertFalse((self.root / '.git-credentials').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/containers/remote-worker/test_github_credentials.py
+++ b/containers/remote-worker/test_github_credentials.py
@@ -180,7 +180,7 @@ class CredentialsTests(unittest.TestCase):
         with patch.dict(C.os.environ, {}, clear=True), patch.object(C.os, 'execve') as execute:
             # execve does not return in production; emulate that control flow.
             execute.side_effect = SystemExit(0)
-            for args in (['--version'], ['help'], ['repo', 'view', '--help']):
+            for args in (['--version'], ['version'], ['help'], ['repo', 'view', '--help']):
                 with self.assertRaises(SystemExit):
                     C.run_gh(args)
                 self.assertNotIn('GH_TOKEN', execute.call_args.args[2])
@@ -256,6 +256,47 @@ class CredentialsTests(unittest.TestCase):
         self.assertEqual(before, set(self.root.iterdir()))
         self.assertFalse((self.root / '.gitconfig').exists())
         self.assertFalse((self.root / '.git-credentials').exists())
+
+    def test_failed_get_stops_real_git_before_later_helper_or_prompt(self):
+        helper = self.root / 'helper.py'
+        source = (HERE / 'github-credentials.py').read_text()
+        helper.write_text(source.replace("RUNTIME = Path('/run/horizon')", 'RUNTIME = Path(' + repr(str(self.runtime)) + ')'))
+        marker, later = self.root / 'fallback-called', self.root / 'fallback'
+        later.write_text('#!/usr/bin/python3\nfrom pathlib import Path\n'
+                         + 'Path(' + repr(str(marker)) + ').write_text("called")\n'
+                         + 'print("username=fallback\\npassword=fallback\\n")\n')
+        later.chmod(0o700)
+        environment = {'PATH': '/usr/bin:/bin', 'LC_ALL': 'C', 'HOME': str(self.root),
+                       'GIT_CONFIG_GLOBAL': '/dev/null', 'GIT_CONFIG_NOSYSTEM': '1',
+                       'GIT_ASKPASS': str(later), 'GIT_TERMINAL_PROMPT': '0'}
+        command = ['/usr/bin/git', '-c', 'credential.helper=', '-c',
+                   'credential.helper=/usr/bin/python3 -I ' + str(helper), '-c',
+                   'credential.helper=' + str(later), 'credential', 'fill']
+        request = b'protocol=https\nhost=github.com\n\n'
+        for value, mode in ((TOKEN, 0o644), ('malformed private sentinel', 0o600)):
+            self.token.write_text(value)
+            self.token.chmod(mode)
+            result = subprocess.run(command, input=request, env=environment,
+                                    capture_output=True, timeout=5, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertEqual(b'', result.stdout)
+            self.assertIn(b'GitHub credential unavailable or request rejected', result.stderr)
+            self.assertNotIn(value.encode(), result.stderr)
+            self.assertFalse(marker.exists())
+            direct = subprocess.run(['/usr/bin/python3', '-I', str(helper), 'get'],
+                input=request, env=environment, capture_output=True, timeout=5, check=False)
+            self.assertEqual(0, direct.returncode)
+            self.assertEqual(b'quit=true\n\n', direct.stdout)
+            self.assertEqual(b'horizon-worker: GitHub credential unavailable or request rejected\n', direct.stderr)
+
+    def test_wrapper_credential_failure_remains_nonzero(self):
+        self.token.write_text('malformed private sentinel')
+        diagnostics, output = io.StringIO(), io.StringIO()
+        with patch.dict(C.os.environ, {}, clear=True), patch.object(C.sys, 'argv', ['gh']), \
+                patch.object(C.sys, 'stdout', output), patch.object(C.sys, 'stderr', diagnostics):
+            self.assertEqual(1, C.main(['api', 'user']))
+        self.assertEqual('', output.getvalue())
+        self.assertEqual('horizon-worker: GitHub credential unavailable or request rejected\n', diagnostics.getvalue())
 
 
 if __name__ == '__main__':

--- a/containers/remote-worker/test_github_credentials.py
+++ b/containers/remote-worker/test_github_credentials.py
@@ -180,7 +180,8 @@ class CredentialsTests(unittest.TestCase):
         with patch.dict(C.os.environ, {}, clear=True), patch.object(C.os, 'execve') as execute:
             # execve does not return in production; emulate that control flow.
             execute.side_effect = SystemExit(0)
-            for args in (['--version'], ['version'], ['help'], ['repo', 'view', '--help']):
+            for args in (['--version'], ['version'], ['help'], ['-h'], ['repo', 'view', '-h'],
+                         ['repo', 'view', '--help']):
                 with self.assertRaises(SystemExit):
                     C.run_gh(args)
                 self.assertNotIn('GH_TOKEN', execute.call_args.args[2])
@@ -230,6 +231,13 @@ class CredentialsTests(unittest.TestCase):
         smoke = (HERE.parents[1] / 'scripts/run-remote-worker-smoke.sh').read_text()
         self.assertIn('slow-identity,dst=/usr/local/bin/horizon-worker-host-identity,readonly', smoke)
         self.assertNotIn('slow-gh', smoke)
+
+    def test_tokenless_startup_installs_helper_outside_token_gate(self):
+        entrypoint = (HERE / 'entrypoint.sh').read_text()
+        before_identity = entrypoint.split('\n/usr/local/bin/horizon-worker-host-identity', 1)[0]
+        unconditional = before_identity.rsplit('\nfi\n', 1)[1]
+        self.assertIn("git config --global --replace-all credential.https://github.com.helper ''", unconditional)
+        self.assertIn('git config --global --add credential.https://github.com.helper /usr/local/bin/horizon-github-credential', unconditional)
 
     def test_real_git_fill_concurrent_no_config_or_secret_storage(self):
         helper = self.root / 'helper.py'

--- a/containers/remote-worker/test_repository_packaging.py
+++ b/containers/remote-worker/test_repository_packaging.py
@@ -14,7 +14,7 @@ import tempfile
 
 CRATES = ("horizon-repository", "horizon-core", "horizon-browser", "horizon-browser-protocol")
 WORKER_FILES = {"Dockerfile", "build-tmux.sh", "entrypoint.sh", "host-identity.py", "rust-path.sh",
-                "session.sh", "panel-session.py", "setup-launch.py", "tmux.conf", "sshd_config"}
+                "session.sh", "github-credentials.py", "panel-session.py", "setup-launch.py", "tmux.conf", "sshd_config"}
 AGENT_PATHS = tuple("usr/local/bin/" + tool for tool in
                     ("codex", "claude", "gemini", "opencode", "kilo", "pi", "grok")) + tuple(
     "usr/local/lib/node_modules/" + package for package in

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -387,6 +387,29 @@ docker run --detach \
 
 worker_a_port=$(wait_for_host_key "${worker_a}" "${temp_dir}/worker-a-known-hosts")
 worker_b_port=$(wait_for_host_key "${worker_b}" "${temp_dir}/worker-b-known-hosts")
+docker exec "${worker_b}" python3 -c '
+import os, pathlib, subprocess, tempfile
+assert not pathlib.Path("/run/horizon/github-token").exists()
+before = pathlib.Path("/root/.gitconfig").read_bytes()
+with tempfile.TemporaryDirectory(prefix="horizon-tokenless-credentials-") as temporary:
+    root = pathlib.Path(temporary)
+    marker, fallback = root / "fallback-called", root / "fallback"
+    fallback.write_text("#!/usr/bin/python3\nfrom pathlib import Path\n"
+        + "Path(" + repr(str(marker)) + ").write_text(\"called\")\n"
+        + "print(\"username=fallback\\npassword=fallback\\n\")\n")
+    fallback.chmod(0o700)
+    result = subprocess.run(["git", "-c", "credential.https://github.com.helper=" + str(fallback),
+        "credential", "fill"], input=b"protocol=https\nhost=github.com\n\n",
+        env=dict(os.environ, GIT_ASKPASS=str(fallback), GIT_TERMINAL_PROMPT="0"),
+        capture_output=True, timeout=10, check=False)
+    assert result.returncode != 0 and not result.stdout
+    assert b"told us to quit" in result.stderr and not marker.exists()
+assert pathlib.Path("/root/.gitconfig").read_bytes() == before
+assert not pathlib.Path("/run/horizon/github-token").exists()
+for arguments in (["gh", "-h"], ["gh", "repo", "view", "-h"]):
+    subprocess.run(arguments, capture_output=True, timeout=10, check=True)
+print("PASS tokenless installed helper stops Git fallback and prompts; short help remains available")
+'
 # Before any task starts, PID 1 may have only SSH children, never a watchdog shell.
 persistent_startup_processes=$(docker exec "${worker_b}" ps -eo ppid=,comm=) ||
   fail "could not inspect persistent worker startup processes"

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -259,7 +259,7 @@ ssh-keygen -q -t ed25519 -N '' -f "${temp_dir}/wrong-client"
 ssh-keygen -q -t rsa -b 2048 -N '' -f "${temp_dir}/unsupported-client"
 client_public_key=$(<"${temp_dir}/client.pub")
 unsupported_public_key=$(<"${temp_dir}/unsupported-client.pub")
-fake_token="ghp_horizon_worker_smoke_${smoke_id}_not_real"
+fake_token="ghp_horizon_worker_smoke_${smoke_id//-/_}_not_real"
 printf '%s' "${fake_token}" >"${temp_dir}/github-token"
 chmod 0600 "${temp_dir}/github-token"
 head -c 16385 /dev/zero | tr '\0' x >"${temp_dir}/oversized-token"
@@ -332,8 +332,8 @@ expect_usage_failure \
   --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/github-token" \
   --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token
 
-printf '%s\n' '#!/bin/sh' 'sleep 7' 'exit 0' >"${temp_dir}/slow-gh"
-chmod 0755 "${temp_dir}/slow-gh"
+printf '%s\n' '#!/bin/sh' 'sleep 7' 'exit 0' >"${temp_dir}/slow-identity"
+chmod 0755 "${temp_dir}/slow-identity"
 startup_expiry_worker="${smoke_id}-startup-expiry"
 record_container "${startup_expiry_worker}"
 docker run --detach \
@@ -343,7 +343,7 @@ docker run --detach \
   --env "HORIZON_TERMINATE_AFTER=$(deadline_after 5)" \
   --mount "type=bind,src=${temp_dir}/github-token,dst=/run/secrets/github-token,readonly" \
   --env HORIZON_GITHUB_TOKEN_FILE=/run/secrets/github-token \
-  --mount "type=bind,src=${temp_dir}/slow-gh,dst=/usr/bin/gh,readonly" \
+  --mount "type=bind,src=${temp_dir}/slow-identity,dst=/usr/local/bin/horizon-worker-host-identity,readonly" \
   "${image}" >/dev/null
 startup_expired=false
 for _ in {1..20}; do
@@ -465,6 +465,25 @@ set -e
 git_config_after=$(docker exec "${worker_a}" sha256sum /root/.gitconfig | awk '{print $1}')
 [[ "${git_config_after}" == "${git_config_before}" ]] ||
   fail "token-backed agent sessions changed shared Git configuration"
+docker exec "${worker_a}" python3 -c '
+import os, pathlib, subprocess
+token = pathlib.Path("/run/horizon/github-token").read_bytes().rstrip(b"\n")
+result = subprocess.run(["git", "credential", "fill"],
+    input=b"protocol=https\nhost=github.com\n\n", capture_output=True,
+    env=dict(os.environ, GIT_TERMINAL_PROMPT="0"), timeout=10, check=True)
+assert b"password=" + token + b"\n" in result.stdout and not result.stderr
+for _ in range(2):
+    result = subprocess.run(["gh", "auth", "token", "--hostname", "github.com"],
+        capture_output=True, timeout=10, check=True)
+    assert result.stdout.strip() == token and not result.stderr
+result = subprocess.run(["horizon-agent-session", "/usr/bin/env"],
+    capture_output=True, timeout=10, check=True)
+assert token not in result.stdout and token not in result.stderr
+assert not any(line.startswith((b"GH_TOKEN=", b"GITHUB_TOKEN=")) for line in result.stdout.splitlines())
+assert not pathlib.Path("/root/.git-credentials").exists()
+assert not pathlib.Path("/root/.config/gh/hosts.yml").exists()
+print("PASS installed Git/gh file credentials and token-free task environment")
+'
 git_rewrites=$(
   docker exec "${worker_a}" \
     git config --global --get-all url.https://github.com/.insteadOf


### PR DESCRIPTION
## Purpose

Advance #470 and #383 by consuming the worker's protected token only when Git or the packaged CLI needs it. This is a credential-handling prerequisite, not the complete remote Git workflow.

## Behavior

- Replace startup authentication with an offline, token-free Git helper configuration on both token-backed and tokenless workers. HTTPS credential requests for exactly `github.com` read the protected runtime file; other hosts and protocols receive no credentials, and store/erase never rewrite it. Missing credentials stop fallback without blocking anonymous public Git operations.
- Add a CLI wrapper that supplies the file token to its child process only, prevents ambient stored-login fallback and rejects foreign host overrides. Ordinary task shells and agents no longer inherit token environment variables.
- Validate file ownership, permissions, links, size and replacement during reads; reject malformed credentials without printing them. Missing credentials fail the requested operation, while help/version and the worker remain available.
- Add synthetic regressions to CI and extend the installed-image smoke and build-context allowlist. Invalid credential reads explicitly stop Git fallback, and both CLI version forms remain token-free.

The worker runs trusted tasks as root: this reduces ambient inheritance, not intentional credential access by those tasks. The CLI retains its documented host-scoped behavior; this is not a general-purpose CLI sandbox. Provider token delivery, repository clone/push/PR wiring, UI and cloud persistence are unchanged. No dependency, default configuration, release or publication change.

## Validation

Candidate `5a9e680bb775abb54b090c9e611cc41d4f2c5c44`, based on `89ba63dea20e4afc0876fd3996acb7bd17c4df30`.

- Independent local full-diff review completed with no actionable in-scope findings.
- All eight final validation gates passed on the exact committed source: formatting, maintainability, version sync, default and speech workspace tests, and blocking, strict and advisory Clippy.
- All 22 synthetic credential regressions passed, including real Git concurrent fill, read-only approve/reject operations and failure cases proving that neither a later helper nor an askpass prompt runs. No real credentials or network authentication were used. The installed image also passed tokenless Git refusal without fallback/prompting, both short-help forms and the token-free CLI `version` subcommand.
- The full worker image built from this commit and passed the local runtime smoke: installed Git/CLI file-token consumption, token-free task environments, pinned SSH and rejection cases, disconnected task progress, same-session reconnect, and explicit Stop retaining task data. Task-created containers were removed; pre-existing containers were preserved.
- Packaging audit passed: Docker admitted exactly 420 expected inputs and excluded synthetic sensitive-file controls; all 37 final image layers passed source/key exclusion and exact repository-helper and license-notice provenance checks. Extraction containers and temporary audit archives were removed; images remain local.

Earlier full-suite attempts exposed two failures in unchanged browser timing/concurrency tests. Those failures are retained in local evidence; focused confirmations and one fresh complete final matrix passed without source changes. No root cause is asserted.

Local Docker proof does not establish provider storage retention, client-off acceptance, or a successful authenticated remote clone/push/PR. Hosted CI and the required independent review remain to run.

Scope: 554 source/test/config changed lines across nine files, plus 32 README lines.
