### PR TITLE
fix(worker): prepare empty storage before repository creation

### DIFF
--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -185,7 +185,7 @@ RUN mkdir -p \
     && cargo fetch --locked \
     && rm -rf /opt/horizon-dependency-cache
 
-WORKDIR /workspace/horizon
+WORKDIR /
 
 COPY --from=repository-builder /opt/horizon-repository /usr/local/bin/horizon-repository
 COPY containers/remote-worker/entrypoint.sh /usr/local/bin/horizon-worker-entrypoint
@@ -224,7 +224,7 @@ RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-a
         /root/.pi \
         /root/.rustup \
         /root/.ssh \
-    && mkdir -p /run/sshd /workspace/horizon /var/lib/horizon \
+    && mkdir -p /run/sshd /workspace /var/lib/horizon \
     && chmod 0700 /var/lib/horizon
 
 ARG WORKER_IMAGE_VERSION=0.1.0

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -120,6 +120,10 @@ fi
 
 /usr/local/bin/horizon-worker-host-identity
 
+# Keep a newly attached mount empty until storage and retained identity pass.
+mkdir -p /workspace/horizon
+cd /workspace/horizon
+
 if [ -n "${deadline_epoch}" ]; then
     now_epoch=$(date +%s)
     lease_seconds=$((deadline_epoch - now_epoch))

--- a/containers/remote-worker/host-identity.py
+++ b/containers/remote-worker/host-identity.py
@@ -68,11 +68,6 @@ def workspace_identity(descriptor):
 
 
 def prepare_fresh_workspace():
-    try:
-        trusted_directory(WORKSPACE)
-        return
-    except IdentityError:
-        pass
     # Provider ownership/exclusive attachment is a caller precondition, not
     # established by bootstrap metadata or by an empty directory observation.
     if os.geteuid() != 0:
@@ -102,6 +97,16 @@ def prepare_fresh_workspace():
                     fail()
             finally:
                 os.close(visible)
+
+        mode = stat.S_IMODE(os.fstat(descriptor).st_mode)
+        verify(mode)
+        try:
+            trusted_directory(WORKSPACE)
+        except IdentityError:
+            pass
+        else:
+            verify(mode)
+            return
 
         verify(0o777)
         with os.scandir(descriptor) as entries:

--- a/containers/remote-worker/host-identity.py
+++ b/containers/remote-worker/host-identity.py
@@ -26,6 +26,8 @@ BOOTSTRAP_ENV = "HORIZON_HOST_KEY_BOOTSTRAP_VERSION"
 BOOTSTRAP_VERSION = 1
 BOOTSTRAP_PREFIX = "horizon-worker-host-key "
 BOOTSTRAP_LIMIT = 1024
+WORKSPACE = Path("/workspace")
+DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_NONBLOCK
 
 
 class IdentityError(Exception):
@@ -48,6 +50,73 @@ def trusted_directory(path, private=False):
     info = path.lstat()
     if private and (info.st_uid != os.geteuid() or info.st_mode & 0o077):
         fail()
+
+
+def mount_id(descriptor):
+    with open(f"/proc/self/fdinfo/{descriptor}", "rb") as stream:
+        value = stream.read(4097)
+    identifiers = [line[7:].strip() for line in value.splitlines() if line.startswith(b"mnt_id:")]
+    if len(value) > 4096 or len(identifiers) != 1 or not identifiers[0].isdigit():
+        fail()
+    return int(identifiers[0])
+
+
+def workspace_identity(descriptor):
+    info = os.fstat(descriptor)
+    return (info.st_dev, info.st_ino, info.st_uid, info.st_gid,
+            stat.S_IFMT(info.st_mode), mount_id(descriptor))
+
+
+def prepare_fresh_workspace():
+    try:
+        trusted_directory(WORKSPACE)
+        return
+    except IdentityError:
+        pass
+    # Provider ownership/exclusive attachment is a caller precondition, not
+    # established by bootstrap metadata or by an empty directory observation.
+    if os.geteuid() != 0:
+        fail()
+    trusted_directory(WORKSPACE.parent)
+    descriptor = os.open(WORKSPACE, DIRECTORY_FLAGS)
+    try:
+        original = workspace_identity(descriptor)
+        parent = os.open(WORKSPACE.parent, DIRECTORY_FLAGS)
+        try:
+            parent_info = os.fstat(parent)
+            if (parent_info.st_uid != 0 or parent_info.st_mode & 0o022
+                    or original[-1] == mount_id(parent)):
+                fail()
+        finally:
+            os.close(parent)
+
+        def verify(mode):
+            current = os.fstat(descriptor)
+            if (current.st_uid != 0 or stat.S_IMODE(current.st_mode) != mode
+                    or workspace_identity(descriptor) != original):
+                fail()
+            visible = os.open(WORKSPACE, DIRECTORY_FLAGS)
+            try:
+                if (workspace_identity(visible) != original
+                        or stat.S_IMODE(os.fstat(visible).st_mode) != mode):
+                    fail()
+            finally:
+                os.close(visible)
+
+        verify(0o777)
+        with os.scandir(descriptor) as entries:
+            if next(entries, None) is not None:
+                fail()
+        verify(0o777)
+        os.fchmod(descriptor, 0o700)
+        verify(0o700)
+        os.fsync(descriptor)
+        with os.scandir(descriptor) as entries:
+            if next(entries, None) is not None:
+                fail()
+        verify(0o700)
+    finally:
+        os.close(descriptor)
 
 
 def read_file(path, private=True):
@@ -237,6 +306,8 @@ def bootstrap_context(environment):
 
 def prepare_for_startup(store, environment, output):
     record = bootstrap_context(environment)
+    if record is not None and store.workspace == WORKSPACE:
+        prepare_fresh_workspace()
     host_public_key = store.prepare()
     if record is not None:
         digest = hashlib.sha256(public_key(read_file(store.access_key)).encode()).hexdigest()

--- a/containers/remote-worker/test_host_identity.py
+++ b/containers/remote-worker/test_host_identity.py
@@ -2,6 +2,7 @@
 
 import base64
 import concurrent.futures
+from contextlib import contextmanager
 import importlib.util
 import io
 import json
@@ -9,6 +10,7 @@ import os
 from pathlib import Path
 import shutil
 import tempfile
+from types import SimpleNamespace
 import unittest
 from unittest import mock
 
@@ -52,6 +54,19 @@ class HostIdentityTests(unittest.TestCase):
         return {identity.BOOTSTRAP_ENV: "1", "HORIZON_CLOUD_PROTOCOL_VERSION": "1", "RUNPOD_POD_ID": "pod_synthetic",
                 "HORIZON_WORKFLOW_ID": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
                 "HORIZON_JOB_ID": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"}
+
+    def test_image_does_not_populate_workspace_before_identity_validation(self):
+        directory = Path(__file__).parent
+        dockerfile = (directory / "Dockerfile").read_text()
+        entrypoint = (directory / "entrypoint.sh").read_text()
+        self.assertEqual("WORKDIR /", [line for line in dockerfile.splitlines()
+                                      if line.startswith("WORKDIR ")][-1])
+        self.assertNotIn("/workspace/horizon", dockerfile)
+        prepare = entrypoint.index("\n/usr/local/bin/horizon-worker-host-identity\n")
+        create = entrypoint.index("\nmkdir -p /workspace/horizon\n")
+        enter = entrypoint.index("\ncd /workspace/horizon\n")
+        self.assertLess(prepare, create)
+        self.assertLess(create, enter)
 
     def test_bootstrap_record_is_emitted_only_after_retained_key_materialization(self):
         output = io.StringIO()
@@ -352,6 +367,157 @@ class HostIdentityTests(unittest.TestCase):
             self.store.prepare()
         self.assertTrue(self.store.marker.exists())
         self.assertIn((self.store.directory, True), observed)
+
+
+    @contextmanager
+    def fresh_mount(self):
+        # Only authority/mount topology are simulated; chmod, fsync, directory
+        # enumeration and path replacement operate on disposable real files.
+        self.workspace.chmod(0o777)
+        actual_fstat, actual_trusted, uid = os.fstat, identity.trusted_directory, os.geteuid()
+
+        def fstat(descriptor):
+            info = actual_fstat(descriptor)
+            return SimpleNamespace(st_dev=info.st_dev, st_ino=info.st_ino,
+                                   st_uid=0, st_gid=info.st_gid, st_mode=info.st_mode)
+
+        def trusted(path, private=False):
+            with mock.patch.object(identity.os, "geteuid", return_value=uid):
+                actual_trusted(path, private)
+
+        def mount(descriptor):
+            return 2 if os.readlink(f"/proc/self/fd/{descriptor}") == str(self.workspace) else 1
+
+        with mock.patch.object(identity, "WORKSPACE", self.workspace), \
+                mock.patch.object(identity.os, "geteuid", return_value=0), \
+                mock.patch.object(identity.os, "fstat", side_effect=fstat), \
+                mock.patch.object(identity, "trusted_directory", side_effect=trusted), \
+                mock.patch.object(identity, "mount_id", side_effect=mount):
+            yield
+
+    def test_fresh_mount_is_private_and_synced_before_identity_preparation(self):
+        actual_sync, observed = os.fsync, []
+
+        def sync(descriptor):
+            self.assertEqual(0o700, self.workspace.stat().st_mode & 0o777)
+            self.assertEqual([], list(self.workspace.iterdir()))
+            observed.append("synced")
+            actual_sync(descriptor)
+
+        def prepare():
+            self.assertEqual(["synced"], observed)
+            raise identity.IdentityError()
+
+        with self.fresh_mount(), mock.patch.object(identity.os, "fsync", side_effect=sync), \
+                mock.patch.object(self.store, "prepare", side_effect=prepare) as start:
+            with self.assertRaises(identity.IdentityError):
+                identity.prepare_for_startup(self.store, self.bootstrap_environment(), io.StringIO())
+            start.assert_called_once()
+        self.assertFalse(self.store.parent.exists())
+
+    def test_missing_or_invalid_bootstrap_never_prepares_unsafe_mount(self):
+        with self.fresh_mount(), mock.patch.object(identity.os, "fchmod") as chmod:
+            for environment in ({}, {identity.BOOTSTRAP_ENV: "invalid"}):
+                with self.assertRaises(identity.IdentityError):
+                    identity.prepare_for_startup(self.store, environment, io.StringIO())
+            chmod.assert_not_called()
+        self.assertFalse(self.store.parent.exists())
+
+    def test_existing_protected_mount_and_nonworkspace_store_are_unchanged(self):
+        with self.fresh_mount(), mock.patch.object(identity.os, "fchmod") as chmod:
+            self.workspace.chmod(0o700)
+            (self.workspace / "retained").write_bytes(b"synthetic")
+            identity.prepare_fresh_workspace()
+            chmod.assert_not_called()
+        with mock.patch.object(identity, "prepare_fresh_workspace") as prepare:
+            identity.prepare_for_startup(self.store, self.bootstrap_environment(), io.StringIO())
+            prepare.assert_not_called()
+
+    def test_nonempty_unsafe_mount_never_repairs_or_deletes_entries(self):
+        for filename in ("retained", ".hidden"):
+            path = self.workspace / filename
+            path.write_bytes(b"synthetic")
+            with self.fresh_mount(), mock.patch.object(identity.os, "fchmod") as chmod:
+                with self.assertRaises(identity.IdentityError):
+                    identity.prepare_fresh_workspace()
+                chmod.assert_not_called()
+            self.assertEqual(b"synthetic", path.read_bytes())
+            path.unlink()
+
+    def test_noop_chmod_and_sync_failure_refuse_without_creating_state(self):
+        with self.fresh_mount(), mock.patch.object(identity.os, "fchmod"):
+            with self.assertRaises(identity.IdentityError):
+                identity.prepare_fresh_workspace()
+        with self.fresh_mount(), mock.patch.object(identity.os, "fsync", side_effect=OSError):
+            with self.assertRaises(OSError):
+                identity.prepare_fresh_workspace()
+        self.assertEqual([], list(self.workspace.iterdir()))
+
+    def test_mount_id_parser_is_bounded_and_unambiguous(self):
+        with mock.patch("builtins.open", return_value=io.BytesIO(b"mnt_id:\t123\n")):
+            self.assertEqual(123, identity.mount_id(1))
+        for value in (b"", b"mnt_id: x\n", b"mnt_id: 1\nmnt_id: 2\n", b"x" * 4097):
+            with mock.patch("builtins.open", return_value=io.BytesIO(value)):
+                with self.assertRaises(identity.IdentityError):
+                    identity.mount_id(1)
+
+    def test_post_chmod_mode_or_mount_change_is_rejected(self):
+        actual_chmod = os.fchmod
+        with self.fresh_mount(), mock.patch.object(identity.os, "fchmod",
+                side_effect=lambda descriptor, mode: actual_chmod(descriptor, 0o755)):
+            with self.assertRaises(identity.IdentityError):
+                identity.prepare_fresh_workspace()
+        with self.fresh_mount():
+            mount = identity.mount_id.side_effect
+            def changed_mount(descriptor):
+                value = mount(descriptor)
+                return 3 if value == 2 and self.workspace.stat().st_mode & 0o777 == 0o700 else value
+            with mock.patch.object(identity, "mount_id", side_effect=changed_mount):
+                with self.assertRaises(identity.IdentityError):
+                    identity.prepare_fresh_workspace()
+        self.assertFalse(self.store.parent.exists())
+
+    def test_insertion_or_path_replacement_after_chmod_refuses_without_cleanup(self):
+        actual_chmod = os.fchmod
+        for replace in (False, True):
+            def race(descriptor, mode):
+                actual_chmod(descriptor, mode)
+                if replace:
+                    self.workspace.rename(self.root / "original")
+                    self.workspace.mkdir(mode=0o700)
+                else:
+                    (self.workspace / ".concurrent").write_bytes(b"synthetic")
+            with self.fresh_mount(), mock.patch.object(identity.os, "fchmod", side_effect=race):
+                with self.assertRaises(identity.IdentityError):
+                    identity.prepare_fresh_workspace()
+            if not replace:
+                self.assertEqual(b"synthetic", (self.workspace / ".concurrent").read_bytes())
+                (self.workspace / ".concurrent").unlink()
+            else:
+                self.assertTrue((self.root / "original").is_dir())
+        self.assertFalse(self.store.parent.exists())
+
+    def test_wrong_owner_nonmount_unsafe_parent_and_symlink_refuse(self):
+        with self.fresh_mount():
+            for target, value in (("geteuid", 1), ("fstat", SimpleNamespace(
+                    st_dev=1, st_ino=1, st_uid=1, st_gid=1, st_mode=0o40777))):
+                with mock.patch.object(identity.os, target, return_value=value), \
+                        mock.patch.object(identity.os, "fchmod") as chmod:
+                    with self.assertRaises(identity.IdentityError):
+                        identity.prepare_fresh_workspace()
+                    chmod.assert_not_called()
+            with mock.patch.object(identity, "mount_id", return_value=1):
+                with self.assertRaises(identity.IdentityError):
+                    identity.prepare_fresh_workspace()
+            self.root.chmod(0o777)
+            with self.assertRaises(identity.IdentityError):
+                identity.prepare_fresh_workspace()
+            self.root.chmod(0o700)
+            self.workspace.rmdir()
+            self.workspace.symlink_to(self.runtime, target_is_directory=True)
+            with self.assertRaises((identity.IdentityError, OSError)):
+                identity.prepare_fresh_workspace()
+        self.assertEqual([], list(self.runtime.iterdir()))
 
 
 if __name__ == "__main__":

--- a/containers/remote-worker/test_host_identity.py
+++ b/containers/remote-worker/test_host_identity.py
@@ -379,7 +379,8 @@ class HostIdentityTests(unittest.TestCase):
         def fstat(descriptor):
             info = actual_fstat(descriptor)
             return SimpleNamespace(st_dev=info.st_dev, st_ino=info.st_ino,
-                                   st_uid=0, st_gid=info.st_gid, st_mode=info.st_mode)
+                                   st_uid=0, st_gid=info.st_gid, st_mode=info.st_mode,
+                                   st_size=info.st_size)
 
         def trusted(path, private=False):
             with mock.patch.object(identity.os, "geteuid", return_value=uid):
@@ -443,6 +444,47 @@ class HostIdentityTests(unittest.TestCase):
                 chmod.assert_not_called()
             self.assertEqual(b"synthetic", path.read_bytes())
             path.unlink()
+
+    def test_provider_bootstrap_rejects_trusted_nonmount_before_key_generation(self):
+        for mode in (0o700, 0o755):
+            with self.subTest(mode=mode), self.fresh_mount(), \
+                    mock.patch.object(identity, "mount_id", return_value=1), \
+                    mock.patch.object(self.store, "prepare", side_effect=AssertionError(
+                        "identity preparation must not run without a mount")) as prepare, \
+                    mock.patch.object(identity, "keygen") as keygen:
+                self.workspace.chmod(mode)
+                output = io.StringIO()
+                with self.assertRaises(identity.IdentityError):
+                    identity.prepare_for_startup(self.store, self.bootstrap_environment(), output)
+                keygen.assert_not_called()
+                prepare.assert_not_called()
+                self.assertEqual("", output.getvalue())
+                self.assertFalse(self.store.parent.exists())
+                self.assertEqual(mode, self.workspace.stat().st_mode & 0o777)
+
+    def test_provider_bootstrap_preserves_trusted_mounted_identity_bytes(self):
+        public = self.store.prepare()
+        before = self.snapshot()
+        for mode in (0o700, 0o755):
+            with self.subTest(mode=mode), self.fresh_mount(), \
+                    mock.patch.object(identity.os, "fchmod") as chmod:
+                self.workspace.chmod(mode)
+                output = io.StringIO()
+                self.assertEqual(public, identity.prepare_for_startup(
+                    self.store, self.bootstrap_environment(), output))
+                chmod.assert_not_called()
+                self.assertEqual(before, self.snapshot())
+                self.assertEqual(mode, self.workspace.stat().st_mode & 0o777)
+                self.assertTrue(output.getvalue().startswith(identity.BOOTSTRAP_PREFIX))
+
+    def test_nonprovider_startup_does_not_require_a_mount(self):
+        with mock.patch.object(identity, "WORKSPACE", self.workspace), \
+                mock.patch.object(identity, "prepare_fresh_workspace") as prepare:
+            output = io.StringIO()
+            identity.prepare_for_startup(self.store, {}, output)
+            prepare.assert_not_called()
+            self.assertEqual("", output.getvalue())
+            self.assertTrue(self.store.marker.is_file())
 
     def test_noop_chmod_and_sync_failure_refuse_without_creating_state(self):
         with self.fresh_mount(), mock.patch.object(identity.os, "fchmod"):

--- a/docs/architecture/remote-worker-host-identity.md
+++ b/docs/architecture/remote-worker-host-identity.md
@@ -29,6 +29,28 @@ The provider/coordinator must still verify those identities. A missing entire
 volume cannot be distinguished from a fresh volume by this helper; recovery must
 not silently accept a new server key in that case.
 
+For a validated provider-bootstrap request, first initialization may restrict an
+empty, root-owned `/workspace` mount from exactly `0777` to `0700`. This is
+fixed-root preparation, not permission repair or volume adoption. It requires a
+safe parent and a real mount boundary, holds a no-follow directory descriptor,
+and rechecks path/inode/owner/mount identity and effective mode around chmod,
+directory synchronization and a second emptiness check before creating identity
+state. Already trusted storage is unchanged; nonempty unsafe storage is refused.
+The image starts in `/` and leaves `/workspace` empty. Only after retained
+identity validation does the entrypoint create and enter `/workspace/horizon`.
+Using that repository directory as the image working directory would let the
+container runtime populate a fresh mount before the emptiness check.
+A chmod that silently does nothing is refused. If chmod succeeds but a concurrent
+entry or identity change is detected, startup fails without deleting that entry
+or attempting a rollback/repair.
+
+The provider must establish fresh-volume ownership and exclusive attachment
+before requesting this operation; valid bootstrap environment fields and an empty
+directory do not prove either. The helper cannot exclude another authorized
+mount writer or make chmod and emptiness checks crash-atomic. A crash after chmod
+can leave a restricted mount without an identity claim; existing provider identity
+and client pin checks remain necessary on recovery, including whole-volume loss.
+
 ## Alternatives and trade-offs
 
 - Container-only keys are simple but fail verified reconnect when the runtime
@@ -52,6 +74,18 @@ state and path permissions. A local SSH smoke destroys only its task-owned
 container filesystem while keeping its named volume and verifies the same host
 identity and repository data. This does not prove live cloud restart, persistence
 of agent/session state, volume-loss recovery or PC-off development.
+
+A disposable September 2026 High-Performance network-volume probe observed NFSv4:
+root chmod changed `0777` to `0700`, synthetic directories/files retained
+`0700`/`0600`, and an unprivileged child was denied listing, reading, creating and
+renaming within the protected root. Synthetic file/directory fsync, hard-link
+publication and rename/readback succeeded. This is one measured candidate, not a
+provider-wide guarantee or a durability certification. Separate sampled Pod and
+Standard network volumes exposed FUSE with ineffective permission changes and
+must remain rejected. The NFSv4 observation does not satisfy or change the
+separate ext4-only repository importer contract. Actual worker bootstrap,
+Stop/restart persistence, provider-volume ownership and unchanged client pin
+still require exact-source integration and live verification.
 
 Remaining actions: integrate provider-retained volumes and remote backups;
 preserve task/agent state and session markers; implement explicit Stop/recovery;

--- a/docs/architecture/remote-worker-host-identity.md
+++ b/docs/architecture/remote-worker-host-identity.md
@@ -35,7 +35,10 @@ fixed-root preparation, not permission repair or volume adoption. It requires a
 safe parent and a real mount boundary, holds a no-follow directory descriptor,
 and rechecks path/inode/owner/mount identity and effective mode around chmod,
 directory synchronization and a second emptiness check before creating identity
-state. Already trusted storage is unchanged; nonempty unsafe storage is refused.
+state. Already trusted mounted storage is unchanged; nonempty unsafe storage is
+refused. Every provider-bootstrap request also validates the real mount and
+root/path identity for already protected storage; an image-local directory is
+not a retained volume. Non-provider startup behavior is unchanged.
 The image starts in `/` and leaves `/workspace` empty. Only after retained
 identity validation does the entrypoint create and enter `/workspace/horizon`.
 Using that repository directory as the image working directory would let the

--- a/scripts/run-remote-worker-smoke.sh
+++ b/scripts/run-remote-worker-smoke.sh
@@ -233,7 +233,8 @@ if grep -Eq '(github_pat_|ghp_|rpa_)' <<<"${image_history}"; then
 fi
 
 docker run --rm --entrypoint /bin/sh "${image}" -eu -c '
-  test -z "$(find /workspace/horizon -mindepth 1 -print -quit)"
+  test "$(pwd)" = /
+  test -z "$(find /workspace -mindepth 1 -print -quit)"
   test ! -e /opt/horizon-dependency-cache
   test -z "$(find /etc/ssh -maxdepth 1 -name "ssh_host_*" -print -quit)"
   test ! -e /root/.ssh


### PR DESCRIPTION
## Purpose

Advance #473 and #383 with fail-closed first initialization of an empty, root-owned worker mount whose initial mode is `0777`. This is a worker startup prerequisite, not complete provider integration or cloud acceptance.

## Behavior

- Only a validated provider-bootstrap request for the fixed `/workspace` root may restrict an empty mount from exactly `0777` to `0700` before host-identity creation.
- Require a real mount boundary and safe parent, hold a no-follow directory descriptor, and recheck path, inode, owner, mount and effective permissions around chmod, fsync and a second emptiness check. Refuse ineffective chmod, unsafe/nonempty roots and observed races without deleting entries or attempting repair.
- Preserve already trusted mounted storage and existing retained-identity recovery rules. Provider bootstrap must verify the mount boundary and path identity even when permissions are already safe; an unmounted image-local directory is refused. Non-provider startup is unchanged.
- Start the image in `/`, with `/workspace` empty. Create and enter `/workspace/horizon` only after host-identity validation. The previous image working directory let Docker create that directory before startup, defeating the empty-mount check.
- Add regression coverage, update the image smoke's initial-state assertion and extend the existing host-identity architecture note.

Provider freshness and exclusive attachment remain caller preconditions: an empty directory and bootstrap metadata do not prove ownership. This does not add network-volume selection/provisioning, relax the separate repository importer's ext4 contract, or authorize adoption after volume loss.

## Local evidence

Candidate `0ce4c40009184f553427cb653f01fa3ca533128b`, based on `89ba63dea20e4afc0876fd3996acb7bd17c4df30`.

- Independent full-diff review and launch-order correction review passed.
- All 38 synthetic host-identity regressions passed, including ineffective chmod, nonempty roots, mount/path races, protected-but-unmounted refusal and retained-key preservation; shell syntax checks passed.
- All eight final validation gates passed on the exact committed source: formatting, maintainability, version sync, default and speech workspace tests, and blocking, strict and advisory Clippy. An initial sandbox metadata refusal occurred before any gate; the elevated run passed without test retries.
- A real Docker control reproduced directory prepopulation with the old working directory and an empty mount with `/`.
- The exact-source image passed four default-entrypoint cases: fresh `0777` mount becomes private, a replacement container retains the same host identity bytes, nonempty unsafe storage is rejected with its sentinel intact, and provider startup without a volume exits before publishing identity or creating workspace children. All task-created containers were removed; existing containers were preserved.
- The broader installed-image SSH/session smoke passed: pinned connection/rejection checks, independent task progress with no SSH clients, same-session reconnect and explicit Stop retaining task data. Its disconnected progress window was eight seconds, on local Docker only.
- Packaging passed actual Docker filtering of 419 expected inputs and exclusion controls, plus all 35 final layers with exact repository-helper and license provenance and no retained SSH keys or worker source/build trees. Only task-owned extraction containers and temporary audit artifacts were removed.

The High-Performance network-storage capability probe is prior, separate evidence—not proof that this image survives provider Stop/restart or client-off operation. Images remain local. No provider, UI, dependency, release or user configuration changes.

Scope: 295 source/test/script changed lines across five files, plus 37 architecture-note lines.
