### PR TITLE
feat(cloud): add bounded Azure Resource Manager transport

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -1,17 +1,31 @@
 //! Azure Linux VM worker foundations for #474: operator profile, lifecycle mapping,
-//! credential source and typed errors. The worker identity, the Resource Manager
-//! transport and the provider are separate slices; nothing is wired into config or UI.
+//! credential source, typed errors and the bounded Resource Manager transport. The
+//! worker identity and the provider are separate slices; nothing is wired into
+//! configuration or UI.
 use super::{CloudProvider, WorkerTarget, interactive_worker::valid_worker_target};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use thiserror::Error;
 mod credential;
 #[cfg(test)]
 mod tests;
+mod transport;
 
 pub use credential::{AzureAccessToken, AzureCliCredential, AzureCredentialSource};
+pub use transport::{
+    AzureArmHttp, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport, AzureVmView,
+};
 
 /// Public Azure Resource Manager endpoint; tokens are requested for this audience only.
 pub const MANAGEMENT_ENDPOINT: &str = "https://management.azure.com";
+/// Explicit ARM API versions; the transport never lets Azure pick a version.
+pub const RESOURCE_GROUP_API_VERSION: &str = "2022-09-01";
+pub const DEPLOYMENT_API_VERSION: &str = "2022-09-01";
+pub const COMPUTE_API_VERSION: &str = "2024-03-01";
+pub(crate) const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
+/// Constant VM name inside a worker's resource group; the group carries the identity.
+pub const WORKER_VM_NAME: &str = "worker";
 
 /// Operator-declared placement for Azure CPU workers. Prices are declared, not
 /// discovered: ARM does not return an hourly rate for a VM, so the cost limit in a
@@ -118,10 +132,19 @@ pub enum AzureError {
     DeclaredCostExceedsLimit { declared: u64, maximum: u64 },
     #[error("Azure credential is unavailable: {reason}")]
     CredentialUnavailable { reason: &'static str },
+    #[error("Azure request failed during {operation}")]
+    RequestFailed { operation: &'static str },
+    #[error("Azure returned HTTP {status} during {operation}")]
+    UnexpectedStatus { operation: &'static str, status: u16 },
+    #[error("Azure returned a malformed response during {operation}")]
+    InvalidResponse { operation: &'static str },
+    #[error("Azure returned an invalid or mismatched resource identity")]
+    ResourceIdentityMismatch,
 }
 
 /// Parsed `/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{kind}/{name}`.
 struct ResourceIdParts<'a> {
+    group: &'a str,
     provider: &'a str,
     kind: &'a str,
     name: &'a str,
@@ -189,6 +212,36 @@ pub(crate) fn valid_identity_id(value: &str, subscription_id: &str) -> bool {
     })
 }
 
+/// `/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{name}`
+/// for exactly the requested subscription, group and VM name.
+pub(crate) fn valid_vm_resource_id(value: &str, subscription_id: &str, resource_group: &str, name: &str) -> bool {
+    resource_id_parts(value, subscription_id).is_some_and(|parts| {
+        parts.group.eq_ignore_ascii_case(resource_group)
+            && parts.provider.eq_ignore_ascii_case("Microsoft.Compute")
+            && parts.kind.eq_ignore_ascii_case("virtualMachines")
+            && parts.name == name
+    })
+}
+
+/// `/subscriptions/{sub}/resourceGroups/{rg}` for exactly the requested subscription and group.
+pub(crate) fn valid_resource_group_id(value: &str, subscription_id: &str, resource_group: &str) -> bool {
+    if value.len() > 512 || value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return false;
+    }
+    let mut parts = value.strip_prefix('/').unwrap_or_default().split('/');
+    parts.next() == Some("subscriptions")
+        && parts
+            .next()
+            .is_some_and(|sub| sub.eq_ignore_ascii_case(subscription_id))
+        && parts
+            .next()
+            .is_some_and(|segment| segment.eq_ignore_ascii_case("resourceGroups"))
+        && parts
+            .next()
+            .is_some_and(|group| group.eq_ignore_ascii_case(resource_group))
+        && parts.next().is_none()
+}
+
 /// Subscription and group segments compare case-insensitively, as ARM does.
 fn resource_id_parts<'a>(value: &'a str, subscription_id: &str) -> Option<ResourceIdParts<'a>> {
     if value.len() > 512 || value.chars().any(|c| c.is_control() || c.is_whitespace()) {
@@ -197,15 +250,17 @@ fn resource_id_parts<'a>(value: &'a str, subscription_id: &str) -> Option<Resour
     let mut parts = value.strip_prefix('/')?.split('/');
     (parts.next()? == "subscriptions" && parts.next()?.eq_ignore_ascii_case(subscription_id)).then_some(())?;
     parts.next()?.eq_ignore_ascii_case("resourceGroups").then_some(())?;
-    parts.next().filter(|group| valid_resource_group_name(group))?;
+    let group = parts.next().filter(|group| valid_resource_group_name(group))?;
     (parts.next()? == "providers").then_some(())?;
     let provider = parts.next()?;
     let kind = parts.next()?;
     let name = parts.next().filter(|name| valid_resource_name(name))?;
-    parts
-        .next()
-        .is_none()
-        .then_some(ResourceIdParts { provider, kind, name })
+    parts.next().is_none().then_some(ResourceIdParts {
+        group,
+        provider,
+        kind,
+        name,
+    })
 }
 
 /// `<registry>.azurecr.io` where the registry name is 5 to 50 lowercase alphanumerics.

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -3,11 +3,13 @@ use super::{
     valid_identity_id, valid_location, valid_registry_login_server, valid_vm_size,
 };
 use crate::cloud_run::{CloudProvider, WorkerLifetime, WorkerTarget};
+mod transport;
 use std::time::Duration;
 
-const SUB: &str = "0f0e0d0c-0b0a-4908-8706-050403020100";
-const OTHER_SUB: &str = "9a8b7c6d-5e4f-4a3b-9c2d-1e0f9a8b7c6d";
-const IMAGE: &str =
+pub(super) const SUB: &str = "0f0e0d0c-0b0a-4908-8706-050403020100";
+pub(super) const OTHER_SUB: &str = "9a8b7c6d-5e4f-4a3b-9c2d-1e0f9a8b7c6d";
+pub(super) const GROUP: &str = "horizon-ws-sample";
+pub(super) const IMAGE: &str =
     "example.azurecr.io/horizon-remote-worker@sha256:20cc03ef2530336b7374cc35412c8583b1422726c630ec6e6cd1450d690a74f6";
 
 fn profile() -> AzureProfile {

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -1,0 +1,464 @@
+use super::super::{
+    AzureAccessToken, AzureArmHttp, AzureCliCredential, AzureDeploymentState, AzureError, AzureLongRunningState,
+    AzureManagementTransport, REQUEST_TIMEOUT, valid_vm_resource_id,
+};
+use super::{GROUP, OTHER_SUB, SUB};
+use std::{
+    collections::BTreeMap,
+    io::Read as _,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use ureq::{
+    Body, SendBody,
+    http::{Request, Response},
+    middleware::MiddlewareNext,
+};
+
+struct Expectation {
+    method: &'static str,
+    url: String,
+    status: u16,
+    body: String,
+    request_body: Option<serde_json::Value>,
+}
+
+fn expect(
+    method: &'static str,
+    url: String,
+    status: u16,
+    body: &str,
+    request_body: Option<serde_json::Value>,
+) -> Expectation {
+    Expectation {
+        method,
+        url,
+        status,
+        body: body.to_string(),
+        request_body,
+    }
+}
+
+fn http(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&calls);
+    let queue = Arc::new(Mutex::new(expectations));
+    let agent = ureq::Agent::config_builder()
+        .middleware(move |request: Request<SendBody>, _: MiddlewareNext| {
+            let index = count.fetch_add(1, Ordering::SeqCst);
+            let expectation = queue.lock().expect("queue").remove(0);
+            assert_eq!(request.method(), expectation.method, "call {index}");
+            assert_eq!(request.uri().to_string(), expectation.url, "call {index}");
+            assert_eq!(request.headers()["Authorization"], "Bearer synthetic-token-value");
+            let mut payload = String::new();
+            request
+                .into_body()
+                .into_reader()
+                .read_to_string(&mut payload)
+                .expect("payload");
+            match expectation.request_body {
+                Some(expected) => assert_eq!(
+                    serde_json::from_str::<serde_json::Value>(&payload).expect("json"),
+                    expected
+                ),
+                None => assert!(payload.is_empty(), "unexpected body on call {index}"),
+            }
+            Ok(Response::builder()
+                .status(expectation.status)
+                .body(Body::builder().data(expectation.body))
+                .expect("response"))
+        })
+        .build()
+        .new_agent();
+    let credential = || AzureAccessToken::new("synthetic-token-value", Duration::from_secs(3_600));
+    (
+        AzureArmHttp::with_agent(agent, SUB, credential).expect("transport"),
+        calls,
+    )
+}
+
+fn group_url(name: &str) -> String {
+    format!("https://management.azure.com/subscriptions/{SUB}/resourcegroups/{name}?api-version=2022-09-01")
+}
+
+fn resource_url(provider_path: &str, name: &str, api: &str) -> String {
+    format!(
+        "https://management.azure.com/subscriptions/{SUB}/resourcegroups/{GROUP}/providers/{provider_path}/{name}?api-version={api}"
+    )
+}
+
+fn vm_url(suffix: &str) -> String {
+    resource_url(
+        "Microsoft.Compute/virtualMachines",
+        &format!("worker{suffix}"),
+        "2024-03-01",
+    )
+}
+
+fn vm_body(power: &str, name: &str, group: &str) -> String {
+    format!(
+        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{group}/providers/Microsoft.Compute/virtualMachines/worker","name":"{name}","location":"northeurope","tags":{{"horizon-job-id":"j"}},"properties":{{"provisioningState":"Succeeded","hardwareProfile":{{"vmSize":"Standard_D4s_v3"}},"instanceView":{{"statuses":[{{"code":"ProvisioningState/succeeded"}},{{"code":"PowerState/{power}"}}]}}}}}}"#
+    )
+}
+
+#[test]
+fn resource_group_reads_are_typed_bounded_and_identity_checked() {
+    let present = format!(
+        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{GROUP}","name":"{GROUP}","location":"northeurope","properties":{{"provisioningState":"Succeeded"}},"tags":{{"horizon-job-id":"j","numeric":1}}}}"#
+    );
+    let foreign = format!(
+        r#"{{"id":"/subscriptions/{OTHER_SUB}/resourceGroups/{GROUP}","name":"{GROUP}","location":"northeurope"}}"#
+    );
+    let nameless = format!(r#"{{"name":"{GROUP}","location":"northeurope"}}"#);
+    let oversized = format!(
+        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{GROUP}","name":"{GROUP}","padding":"{}"}}"#,
+        "x".repeat(2 * 1024 * 1024)
+    );
+    let (transport, calls) = http(vec![
+        expect("GET", group_url(GROUP), 404, "", None),
+        expect("GET", group_url(GROUP), 200, &present, None),
+        expect(
+            "GET",
+            group_url(GROUP),
+            200,
+            r#"{"id":"/subscriptions/x/resourceGroups/HORIZON-WS-other","name":"HORIZON-WS-other","location":"northeurope"}"#,
+            None,
+        ),
+        expect("GET", group_url(GROUP), 200, &foreign, None),
+        expect("GET", group_url(GROUP), 200, &nameless, None),
+        expect("GET", group_url(GROUP), 200, "private-malformed", None),
+        expect("GET", group_url(GROUP), 200, &oversized, None),
+        expect("GET", group_url(GROUP), 302, "private-redirect", None),
+    ]);
+    assert_eq!(transport.get_resource_group(GROUP), Ok(None));
+    let info = transport.get_resource_group(GROUP).expect("group").expect("present");
+    assert_eq!(
+        (
+            info.name.as_str(),
+            info.location.as_str(),
+            info.provisioning_state.as_str()
+        ),
+        (GROUP, "northeurope", "Succeeded")
+    );
+    assert_eq!(
+        info.tags,
+        [("horizon-job-id".to_string(), "j".to_string())].into(),
+        "non-string tags are dropped"
+    );
+    assert_eq!(
+        transport.get_resource_group(GROUP),
+        Err(AzureError::ResourceIdentityMismatch),
+        "renamed"
+    );
+    assert_eq!(
+        transport.get_resource_group(GROUP),
+        Err(AzureError::ResourceIdentityMismatch),
+        "foreign subscription id"
+    );
+    assert_eq!(
+        transport.get_resource_group(GROUP),
+        Err(AzureError::InvalidResponse {
+            operation: "resource group lookup"
+        }),
+        "a group without its resource id is not trusted"
+    );
+    let malformed = Err(AzureError::InvalidResponse {
+        operation: "resource group lookup",
+    });
+    assert_eq!(transport.get_resource_group(GROUP), malformed);
+    assert_eq!(
+        transport.get_resource_group(GROUP),
+        malformed,
+        "oversized body is rejected"
+    );
+    let redirect = transport
+        .get_resource_group(GROUP)
+        .expect_err("redirects are not followed");
+    assert_eq!(
+        redirect,
+        AzureError::UnexpectedStatus {
+            operation: "resource group lookup",
+            status: 302
+        }
+    );
+    assert!(!format!("{redirect:?} {redirect}").contains("private-"));
+    assert_eq!(calls.load(Ordering::SeqCst), 8);
+    for invalid in ["", "bad/name", "name?x=1", &"g".repeat(91), "trailing."] {
+        assert_eq!(
+            transport.get_resource_group(invalid),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            transport.delete_resource_group(invalid),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+    }
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        8,
+        "invalid input never reaches the network"
+    );
+}
+
+#[test]
+fn resource_group_writes_send_exact_bodies_and_map_long_running_states() {
+    let tags: BTreeMap<String, String> = [("horizon-job-id".to_string(), "j".to_string())].into();
+    let created = format!(
+        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{GROUP}","name":"{GROUP}","location":"northeurope","tags":{{"horizon-job-id":"j"}}}}"#
+    );
+    let (transport, calls) = http(vec![
+        expect(
+            "PUT",
+            group_url(GROUP),
+            201,
+            &created,
+            Some(serde_json::json!({"location":"northeurope","tags":{"horizon-job-id":"j"}})),
+        ),
+        expect("DELETE", group_url(GROUP), 202, "", None),
+        expect("DELETE", group_url(GROUP), 200, "", None),
+        expect("DELETE", group_url(GROUP), 409, "private-conflict-payload", None),
+    ]);
+    let info = transport
+        .create_resource_group(GROUP, "northeurope", &tags)
+        .expect("created");
+    assert_eq!((info.name.as_str(), info.tags), (GROUP, tags.clone()));
+    assert_eq!(
+        transport.delete_resource_group(GROUP),
+        Ok(AzureLongRunningState::Accepted)
+    );
+    assert_eq!(
+        transport.delete_resource_group(GROUP),
+        Ok(AzureLongRunningState::Completed),
+        "empty 200 body"
+    );
+    let conflict = transport.delete_resource_group(GROUP);
+    assert_eq!(
+        conflict,
+        Err(AzureError::UnexpectedStatus {
+            operation: "resource group deletion",
+            status: 409
+        })
+    );
+    assert!(!format!("{conflict:?}").contains("private-"));
+    assert_eq!(
+        transport.create_resource_group(GROUP, "North Europe", &tags),
+        Err(AzureError::InvalidProfile)
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        4,
+        "an invalid location never reaches the network"
+    );
+}
+
+#[test]
+fn deployments_are_submitted_incrementally_and_read_back_with_string_outputs() {
+    let url = resource_url("Microsoft.Resources/deployments", "worker", "2022-09-01");
+    let template = serde_json::json!({"resources": []});
+    let parameters = serde_json::json!({"vmName": {"value": "worker"}});
+    let (transport, calls) = http(vec![
+        expect(
+            "PUT",
+            url.clone(),
+            201,
+            r#"{"properties":{"provisioningState":"Accepted"}}"#,
+            Some(
+                serde_json::json!({"properties":{"mode":"Incremental","template":{"resources":[]},"parameters":{"vmName":{"value":"worker"}}}}),
+            ),
+        ),
+        expect(
+            "GET",
+            url.clone(),
+            200,
+            r#"{"properties":{"provisioningState":"Succeeded","outputs":{"publicIp":{"type":"String","value":"203.0.113.9"},"count":{"type":"Int","value":2}}}}"#,
+            None,
+        ),
+        expect("GET", url.clone(), 404, "", None),
+        expect("GET", url, 200, r#"{"properties":{}}"#, None),
+    ]);
+    let accepted = transport
+        .put_deployment(GROUP, "worker", &template, &parameters)
+        .expect("deployment");
+    assert_eq!(accepted.provisioning_state, "Accepted");
+    assert!(!accepted.is_terminal());
+    let done = transport
+        .get_deployment(GROUP, "worker")
+        .expect("lookup")
+        .expect("present");
+    assert_eq!(
+        done,
+        AzureDeploymentState {
+            provisioning_state: "Succeeded".into(),
+            outputs: [("publicIp".to_string(), "203.0.113.9".to_string())].into(),
+        }
+    );
+    assert!(done.is_terminal());
+    assert_eq!(transport.get_deployment(GROUP, "worker"), Ok(None));
+    assert_eq!(
+        transport.get_deployment(GROUP, "worker"),
+        Err(AzureError::InvalidResponse {
+            operation: "deployment lookup"
+        })
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+    for (group, name) in [
+        ("bad/group", "worker"),
+        (GROUP, "worker/../other"),
+        (GROUP, ""),
+        (GROUP, "name with space"),
+    ] {
+        assert_eq!(
+            transport.get_deployment(group, name),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            transport.put_deployment(group, name, &template, &parameters),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+    }
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        4,
+        "invalid segments never reach the network"
+    );
+}
+
+#[test]
+fn virtual_machine_views_verify_the_returned_identity() {
+    let expanded = format!("{}&$expand=instanceView", vm_url(""));
+    let (transport, calls) = http(vec![
+        expect("GET", expanded.clone(), 200, &vm_body("running", "worker", GROUP), None),
+        expect("GET", expanded.clone(), 200, &vm_body("running", "other", GROUP), None),
+        expect(
+            "GET",
+            expanded.clone(),
+            200,
+            &vm_body("running", "worker", "horizon-ws-foreign"),
+            None,
+        ),
+        expect("GET", expanded.clone(), 200, r#"{"name":"worker"}"#, None),
+        expect("GET", expanded, 404, "", None),
+    ]);
+    let vm = transport.get_vm(GROUP, "worker").expect("vm").expect("present");
+    assert_eq!(
+        (vm.name.as_str(), vm.vm_size.as_str(), vm.location.as_str()),
+        ("worker", "Standard_D4s_v3", "northeurope")
+    );
+    assert!(vm.id.ends_with("/virtualMachines/worker"));
+    assert_eq!(
+        (vm.provisioning_state.as_str(), vm.power_state.as_deref()),
+        ("Succeeded", Some("PowerState/running"))
+    );
+    assert_eq!(vm.tags.get("horizon-job-id").map(String::as_str), Some("j"));
+    assert_eq!(
+        transport.get_vm(GROUP, "worker"),
+        Err(AzureError::ResourceIdentityMismatch),
+        "renamed VM"
+    );
+    assert_eq!(
+        transport.get_vm(GROUP, "worker"),
+        Err(AzureError::ResourceIdentityMismatch),
+        "foreign group id"
+    );
+    assert_eq!(
+        transport.get_vm(GROUP, "worker"),
+        Err(AzureError::InvalidResponse {
+            operation: "virtual machine lookup"
+        }),
+        "missing id"
+    );
+    assert_eq!(transport.get_vm(GROUP, "worker"), Ok(None));
+    assert_eq!(calls.load(Ordering::SeqCst), 5);
+    assert_eq!(
+        transport.get_vm(GROUP, "worker/../other"),
+        Err(AzureError::ResourceIdentityMismatch)
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 5);
+}
+
+#[test]
+fn vm_resource_ids_are_matched_exactly() {
+    let vm_id =
+        format!("/subscriptions/{SUB}/resourceGroups/{GROUP}/providers/Microsoft.Compute/virtualMachines/worker");
+    assert!(valid_vm_resource_id(&vm_id, SUB, GROUP, "worker"));
+    assert!(valid_vm_resource_id(
+        &vm_id.replace("resourceGroups", "resourcegroups"),
+        SUB,
+        GROUP,
+        "worker"
+    ));
+    assert!(valid_vm_resource_id(&vm_id, SUB, &GROUP.to_ascii_uppercase(), "worker"));
+    assert!(valid_vm_resource_id(
+        &vm_id.replace("/worker", "/other"),
+        SUB,
+        GROUP,
+        "other"
+    ));
+    assert!(!valid_vm_resource_id(&vm_id, SUB, GROUP, "other"));
+    let group_id = format!("/subscriptions/{SUB}/resourceGroups/{GROUP}");
+    assert!(super::super::valid_resource_group_id(&group_id, SUB, GROUP));
+    assert!(super::super::valid_resource_group_id(
+        &group_id.replace("resourceGroups", "resourcegroups"),
+        SUB,
+        GROUP
+    ));
+    assert!(super::super::valid_resource_group_id(
+        &group_id,
+        SUB,
+        &GROUP.to_ascii_uppercase()
+    ));
+    for bad in [
+        group_id.replace(SUB, OTHER_SUB),
+        group_id.replace(GROUP, "horizon-ws-other"),
+        format!("{group_id}/providers/x"),
+        format!("{group_id} "),
+        String::new(),
+    ] {
+        assert!(!super::super::valid_resource_group_id(&bad, SUB, GROUP), "{bad}");
+    }
+    for (bad, label) in [
+        (vm_id.replace("/worker", "/Worker"), "vm name casing"),
+        (vm_id.replace("/worker", "/other"), "vm name"),
+        (vm_id.replace(GROUP, "horizon-ws-other"), "group"),
+        (vm_id.replace(SUB, OTHER_SUB), "subscription"),
+        (format!("{vm_id}/extensions/x"), "trailing segments"),
+        (vm_id.replace("Microsoft.Compute", "Microsoft.Storage"), "provider"),
+    ] {
+        assert!(!valid_vm_resource_id(&bad, SUB, GROUP, "worker"), "{label}");
+    }
+}
+#[test]
+fn credential_failures_stop_before_any_request_and_production_agent_is_pinned() {
+    let agent = ureq::Agent::config_builder()
+        .middleware(
+            |_: Request<SendBody>, _: MiddlewareNext| -> Result<Response<Body>, ureq::Error> {
+                panic!("no request may be sent without a credential")
+            },
+        )
+        .build()
+        .new_agent();
+    let unavailable = || -> Result<AzureAccessToken, AzureError> {
+        Err(AzureError::CredentialUnavailable {
+            reason: "Azure CLI did not return a token",
+        })
+    };
+    let transport = AzureArmHttp::with_agent(agent, SUB, unavailable).expect("transport");
+    assert_eq!(
+        transport.get_resource_group(GROUP),
+        Err(unavailable().expect_err("error"))
+    );
+    assert_eq!(
+        transport.delete_resource_group(GROUP),
+        Err(unavailable().expect_err("error"))
+    );
+    let rejected = AzureArmHttp::with_agent(ureq::Agent::new_with_defaults(), "bad", unavailable);
+    assert_eq!(rejected.err(), Some(AzureError::InvalidProfile));
+    let production = AzureArmHttp::new(SUB, AzureCliCredential::new(SUB).expect("credential")).expect("transport");
+    assert!(production.config().https_only());
+    assert_eq!(production.config().max_redirects(), 0);
+    assert_eq!(production.config().timeouts().global, Some(REQUEST_TIMEOUT));
+    assert!(!production.config().http_status_as_error());
+}

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -1,0 +1,420 @@
+//! Bounded, narrowly typed Azure Resource Manager requests. Every URL is built from
+//! validated segments with an explicit API version; responses are size-limited,
+//! decoded into small typed views, and never echoed into errors.
+use super::{
+    AzureCredentialSource, AzureError, COMPUTE_API_VERSION, DEPLOYMENT_API_VERSION, MANAGEMENT_ENDPOINT,
+    REQUEST_TIMEOUT, RESOURCE_GROUP_API_VERSION, RESPONSE_LIMIT_BYTES, valid_resource_group_name,
+    valid_subscription_id,
+};
+use std::collections::BTreeMap;
+
+/// Resource group as observed from ARM.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AzureGroupInfo {
+    pub name: String,
+    pub location: String,
+    pub provisioning_state: String,
+    pub tags: BTreeMap<String, String>,
+}
+
+/// Deployment state plus its string outputs (for example the public IP).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AzureDeploymentState {
+    pub provisioning_state: String,
+    pub outputs: BTreeMap<String, String>,
+}
+
+impl AzureDeploymentState {
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.provisioning_state.as_str(), "Succeeded" | "Failed" | "Canceled")
+    }
+}
+
+/// The subset of a VM resource plus instance view that the lifecycle needs.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AzureVmView {
+    pub id: String,
+    pub name: String,
+    pub location: String,
+    pub vm_size: String,
+    pub provisioning_state: String,
+    pub power_state: Option<String>,
+    pub tags: BTreeMap<String, String>,
+}
+
+/// Outcome of a request that ARM may complete asynchronously.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AzureLongRunningState {
+    Accepted,
+    Completed,
+}
+
+/// Narrow set of management operations the adapter is allowed to perform.
+pub trait AzureManagementTransport: Send + Sync {
+    /// # Errors
+    fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError>;
+    /// # Errors
+    fn create_resource_group(
+        &self,
+        name: &str,
+        location: &str,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<AzureGroupInfo, AzureError>;
+    /// # Errors
+    fn delete_resource_group(&self, name: &str) -> Result<AzureLongRunningState, AzureError>;
+    /// # Errors
+    fn put_deployment(
+        &self,
+        group: &str,
+        name: &str,
+        template: &serde_json::Value,
+        parameters: &serde_json::Value,
+    ) -> Result<AzureDeploymentState, AzureError>;
+    /// # Errors
+    fn get_deployment(&self, group: &str, name: &str) -> Result<Option<AzureDeploymentState>, AzureError>;
+    /// # Errors
+    fn get_vm(&self, group: &str, name: &str) -> Result<Option<AzureVmView>, AzureError>;
+}
+
+/// HTTPS transport pinned to the public Azure Resource Manager endpoint.
+pub struct AzureArmHttp {
+    agent: ureq::Agent,
+    credential: Box<dyn AzureCredentialSource>,
+    subscription_id: String,
+}
+
+impl AzureArmHttp {
+    /// # Errors
+    /// Rejects a malformed subscription identifier.
+    pub fn new(
+        subscription_id: impl Into<String>,
+        credential: impl AzureCredentialSource + 'static,
+    ) -> Result<Self, AzureError> {
+        let config = ureq::Agent::config_builder()
+            .https_only(true)
+            .http_status_as_error(false)
+            .max_redirects(0)
+            .timeout_global(Some(REQUEST_TIMEOUT))
+            .user_agent(concat!("horizon/", env!("CARGO_PKG_VERSION")))
+            .build();
+        Self::with_agent(ureq::Agent::new_with_config(config), subscription_id, credential)
+    }
+
+    pub(crate) fn with_agent(
+        agent: ureq::Agent,
+        subscription_id: impl Into<String>,
+        credential: impl AzureCredentialSource + 'static,
+    ) -> Result<Self, AzureError> {
+        let subscription_id = subscription_id.into();
+        if !valid_subscription_id(&subscription_id) {
+            return Err(AzureError::InvalidProfile);
+        }
+        Ok(Self {
+            agent,
+            credential: Box::new(credential),
+            subscription_id,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn config(&self) -> &ureq::config::Config {
+        self.agent.config()
+    }
+
+    fn group_url(&self, name: &str, api_version: &str) -> Result<String, AzureError> {
+        valid_resource_group_name(name)
+            .then(|| {
+                format!(
+                    "{MANAGEMENT_ENDPOINT}/subscriptions/{}/resourcegroups/{name}?api-version={api_version}",
+                    self.subscription_id
+                )
+            })
+            .ok_or(AzureError::ResourceIdentityMismatch)
+    }
+
+    fn resource_url(
+        &self,
+        group: &str,
+        provider_path: &str,
+        name: &str,
+        api_version: &str,
+        suffix: &str,
+    ) -> Result<String, AzureError> {
+        (valid_resource_group_name(group) && super::valid_resource_name(name))
+            .then(|| {
+                format!(
+                    "{MANAGEMENT_ENDPOINT}/subscriptions/{}/resourcegroups/{group}/providers/{provider_path}/{name}{suffix}?api-version={api_version}",
+                    self.subscription_id
+                )
+            })
+            .ok_or(AzureError::ResourceIdentityMismatch)
+    }
+
+    fn authorization(&self) -> Result<String, AzureError> {
+        self.credential.token().map(|token| token.authorization_header())
+    }
+
+    fn get_json(&self, url: &str, operation: &'static str) -> Result<Option<serde_json::Value>, AzureError> {
+        let authorization = self.authorization()?;
+        let response = self
+            .agent
+            .get(url)
+            .header("Authorization", &authorization)
+            .call()
+            .map_err(|_| AzureError::RequestFailed { operation })?;
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        decode_json(response, &[200], operation).map(Some)
+    }
+
+    /// Send a mutating request. Long-running operations answer with a status and an
+    /// empty or unused body, so callers say whether the body must be decoded.
+    fn send_json(
+        &self,
+        method: &'static str,
+        url: &str,
+        body: Option<&serde_json::Value>,
+        accepted: &[u16],
+        decode_body: bool,
+        operation: &'static str,
+    ) -> Result<(u16, serde_json::Value), AzureError> {
+        let authorization = self.authorization()?;
+        let failed = |_| AzureError::RequestFailed { operation };
+        let response = match (method, body) {
+            ("DELETE", _) => self
+                .agent
+                .delete(url)
+                .header("Authorization", &authorization)
+                .call()
+                .map_err(failed)?,
+            ("PUT", Some(body)) => self
+                .agent
+                .put(url)
+                .header("Authorization", &authorization)
+                .send_json(body)
+                .map_err(failed)?,
+            ("PUT", None) => self
+                .agent
+                .put(url)
+                .header("Authorization", &authorization)
+                .send_empty()
+                .map_err(failed)?,
+            (_, Some(body)) => self
+                .agent
+                .post(url)
+                .header("Authorization", &authorization)
+                .send_json(body)
+                .map_err(failed)?,
+            (_, None) => self
+                .agent
+                .post(url)
+                .header("Authorization", &authorization)
+                .send_empty()
+                .map_err(failed)?,
+        };
+        let status = response.status().as_u16();
+        if !accepted.contains(&status) {
+            return Err(AzureError::UnexpectedStatus { operation, status });
+        }
+        if !decode_body {
+            return Ok((status, serde_json::Value::Null));
+        }
+        decode_json(response, accepted, operation).map(|value| (status, value))
+    }
+}
+
+fn decode_json(
+    mut response: ureq::http::Response<ureq::Body>,
+    accepted: &[u16],
+    operation: &'static str,
+) -> Result<serde_json::Value, AzureError> {
+    let status = response.status().as_u16();
+    if !accepted.contains(&status) {
+        return Err(AzureError::UnexpectedStatus { operation, status });
+    }
+    response
+        .body_mut()
+        .with_config()
+        .limit(RESPONSE_LIMIT_BYTES)
+        .read_json()
+        .map_err(|_| AzureError::InvalidResponse { operation })
+}
+
+fn text(value: &serde_json::Value, pointer: &str) -> Option<String> {
+    value
+        .pointer(pointer)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn tags(value: &serde_json::Value) -> BTreeMap<String, String> {
+    value
+        .get("tags")
+        .and_then(serde_json::Value::as_object)
+        .map(|tags| {
+            tags.iter()
+                .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn group_info(
+    value: &serde_json::Value,
+    subscription_id: &str,
+    expected_name: &str,
+    operation: &'static str,
+) -> Result<AzureGroupInfo, AzureError> {
+    let name = text(value, "/name").ok_or(AzureError::InvalidResponse { operation })?;
+    let id = text(value, "/id").ok_or(AzureError::InvalidResponse { operation })?;
+    if !name.eq_ignore_ascii_case(expected_name) || !super::valid_resource_group_id(&id, subscription_id, expected_name)
+    {
+        return Err(AzureError::ResourceIdentityMismatch);
+    }
+    Ok(AzureGroupInfo {
+        name,
+        location: text(value, "/location").unwrap_or_default(),
+        provisioning_state: text(value, "/properties/provisioningState").unwrap_or_default(),
+        tags: tags(value),
+    })
+}
+
+fn deployment_state(value: &serde_json::Value, operation: &'static str) -> Result<AzureDeploymentState, AzureError> {
+    let provisioning_state =
+        text(value, "/properties/provisioningState").ok_or(AzureError::InvalidResponse { operation })?;
+    let outputs = value
+        .pointer("/properties/outputs")
+        .and_then(serde_json::Value::as_object)
+        .map(|outputs| {
+            outputs
+                .iter()
+                .filter_map(|(key, output)| text(output, "/value").map(|value| (key.clone(), value)))
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(AzureDeploymentState {
+        provisioning_state,
+        outputs,
+    })
+}
+
+impl AzureManagementTransport for AzureArmHttp {
+    fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError> {
+        let operation = "resource group lookup";
+        self.get_json(&self.group_url(name, RESOURCE_GROUP_API_VERSION)?, operation)?
+            .map(|value| group_info(&value, &self.subscription_id, name, operation))
+            .transpose()
+    }
+
+    fn create_resource_group(
+        &self,
+        name: &str,
+        location: &str,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<AzureGroupInfo, AzureError> {
+        let operation = "resource group creation";
+        if !super::valid_location(location) {
+            return Err(AzureError::InvalidProfile);
+        }
+        let body = serde_json::json!({ "location": location, "tags": tags });
+        let (_, value) = self.send_json(
+            "PUT",
+            &self.group_url(name, RESOURCE_GROUP_API_VERSION)?,
+            Some(&body),
+            &[200, 201],
+            true,
+            operation,
+        )?;
+        group_info(&value, &self.subscription_id, name, operation)
+    }
+
+    fn delete_resource_group(&self, name: &str) -> Result<AzureLongRunningState, AzureError> {
+        let operation = "resource group deletion";
+        let (status, _) = self.send_json(
+            "DELETE",
+            &self.group_url(name, RESOURCE_GROUP_API_VERSION)?,
+            None,
+            &[200, 202, 204],
+            false,
+            operation,
+        )?;
+        Ok(if status == 202 {
+            AzureLongRunningState::Accepted
+        } else {
+            AzureLongRunningState::Completed
+        })
+    }
+
+    fn put_deployment(
+        &self,
+        group: &str,
+        name: &str,
+        template: &serde_json::Value,
+        parameters: &serde_json::Value,
+    ) -> Result<AzureDeploymentState, AzureError> {
+        let operation = "deployment submission";
+        let url = self.resource_url(
+            group,
+            "Microsoft.Resources/deployments",
+            name,
+            DEPLOYMENT_API_VERSION,
+            "",
+        )?;
+        let body = serde_json::json!({ "properties": { "mode": "Incremental", "template": template, "parameters": parameters } });
+        let (_, value) = self.send_json("PUT", &url, Some(&body), &[200, 201], true, operation)?;
+        deployment_state(&value, operation)
+    }
+
+    fn get_deployment(&self, group: &str, name: &str) -> Result<Option<AzureDeploymentState>, AzureError> {
+        let operation = "deployment lookup";
+        let url = self.resource_url(
+            group,
+            "Microsoft.Resources/deployments",
+            name,
+            DEPLOYMENT_API_VERSION,
+            "",
+        )?;
+        self.get_json(&url, operation)?
+            .map(|value| deployment_state(&value, operation))
+            .transpose()
+    }
+
+    fn get_vm(&self, group: &str, name: &str) -> Result<Option<AzureVmView>, AzureError> {
+        let operation = "virtual machine lookup";
+        let url = self.resource_url(
+            group,
+            "Microsoft.Compute/virtualMachines",
+            name,
+            COMPUTE_API_VERSION,
+            "",
+        )?;
+        let Some(value) = self.get_json(&format!("{url}&$expand=instanceView"), operation)? else {
+            return Ok(None);
+        };
+        let id = text(&value, "/id").ok_or(AzureError::InvalidResponse { operation })?;
+        let observed_name = text(&value, "/name").ok_or(AzureError::InvalidResponse { operation })?;
+        if !observed_name.eq_ignore_ascii_case(name)
+            || !super::valid_vm_resource_id(&id, &self.subscription_id, group, name)
+        {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
+        let power_state = value
+            .pointer("/properties/instanceView/statuses")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|status| text(status, "/code"))
+            .find(|code| code.starts_with("PowerState/"));
+        Ok(Some(AzureVmView {
+            id,
+            name: observed_name,
+            location: text(&value, "/location").unwrap_or_default(),
+            vm_size: text(&value, "/properties/hardwareProfile/vmSize").unwrap_or_default(),
+            provisioning_state: text(&value, "/properties/provisioningState").unwrap_or_default(),
+            power_state,
+            tags: tags(&value),
+        }))
+    }
+}


### PR DESCRIPTION
## Summary

Second isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open; the worker identity, the provider and the wiring follow as separate slices). Stacked on the foundations slice; no configuration, dispatcher or UI wiring.

Adds `AzureManagementTransport`, the narrow set of Resource Manager operations the provider is allowed to perform, and `AzureArmHttp`, its HTTPS implementation:

- **Operations**: resource group get, create (PUT with location and tags) and delete; incremental deployment PUT and get (provisioning state plus string outputs); VM get with `$expand=instanceView` (provisioning and power state, size, tags). Nothing else is reachable through the trait. Power operations (deallocate, start) arrive with the provider slice that defines Stop semantics; the worker's static address is read from the deployment outputs.
- **Exact URLs**: every path is built from a validated resource-group name and leaf name against the public `management.azure.com` endpoint with an explicit API version per resource type; invalid segments fail before any request.
- **Identity checks**: every resource group response must carry a group-level resource ID under the requested subscription and group, and every VM response a VM resource ID under the requested subscription, group and name; anything else is `ResourceIdentityMismatch`, never used.
- **Bounds and redaction**: 60 s request timeout, no redirects, HTTPS only, 2 MiB response limit, typed decoding of only the needed fields; long-running 200/202/204 answers are mapped to `Completed`/`Accepted` without decoding a body; errors carry the operation name and status only, never a payload.
- **Credential**: bearer tokens come from the `AzureCredentialSource` of the previous slice on each call; a credential failure stops before any request.

## Tests

`cloud_run::azure::tests::transport` (6 tests) drive the real client through `ureq` middleware mocks: exact method, URL, query and API version per operation; request bodies for group creation and deployment submission; 404 to `None`; malformed, oversized and redirected responses; renamed, foreign-subscription and ID-less group responses; renamed or foreign-group VM identities; long-running state mapping including an empty 200 body on delete; redaction of private payloads in errors; no network call for invalid segments; production agent pinned to HTTPS only, zero redirects and the request timeout. Plus strict VM and resource-group ID matching.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.

## Follow-ups (separate slices)

1. Persisted worker identity (`AzureWorker`, deterministic resource group, validate-on-deserialise) with the provider implementing `InteractiveWorkerProvider`: create-once fence, single deployment, non-creating inspect, exact delete, ACR managed-identity pulls.
2. Wiring into `remote_provider_config`, dispatchers and UI once the common provider boundary settles.
