### PR TITLE
feat(cloud): add Azure worker identity and deployment plan

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -1,17 +1,23 @@
-//! Azure Linux VM worker foundations for #474: operator profile, lifecycle mapping,
-//! credential source, typed errors and the bounded Resource Manager transport. The
-//! worker identity and the provider are separate slices; nothing is wired into
-//! configuration or UI.
-use super::{CloudProvider, WorkerTarget, interactive_worker::valid_worker_target};
+//! Azure Linux VM worker foundations for #474: operator profile, exact worker
+//! identity, lifecycle mapping, credential source, typed errors, the bounded Resource
+//! Manager transport and the deployment plan. The provider is a separate slice;
+//! nothing is wired into configuration or UI.
+use super::{
+    CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget,
+    interactive_worker::{InteractiveWorkerLifetime, valid_worker_target},
+    validation::valid_immutable_worker_image,
+};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use thiserror::Error;
 mod credential;
+pub mod deployment;
 #[cfg(test)]
 mod tests;
 mod transport;
 
 pub use credential::{AzureAccessToken, AzureCliCredential, AzureCredentialSource};
+pub use deployment::AzureDeploymentPlan;
 pub use transport::{
     AzureArmHttp, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport, AzureVmView,
 };
@@ -24,6 +30,8 @@ pub const DEPLOYMENT_API_VERSION: &str = "2022-09-01";
 pub const COMPUTE_API_VERSION: &str = "2024-03-01";
 pub(crate) const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
+/// Every worker lives in its own resource group named from its exact identity.
+pub const RESOURCE_GROUP_PREFIX: &str = "horizon-ws-";
 /// Constant VM name inside a worker's resource group; the group carries the identity.
 pub const WORKER_VM_NAME: &str = "worker";
 
@@ -38,7 +46,7 @@ pub struct AzureProfile {
     pub subscription_id: String,
     /// Lowercase region name such as `northeurope`.
     pub location: String,
-    /// Exact VM size such as `Standard_D4s_v3`.
+    /// Exact VM size from [`SUPPORTED_VM_SIZES`], such as `Standard_D4s_v3`.
     pub vm_size: String,
     /// Resource ID of the user-assigned identity that may pull the worker image. It must
     /// live in `subscription_id`: workers never borrow identities across subscriptions.
@@ -47,6 +55,36 @@ pub struct AzureProfile {
     pub declared_hourly_cost_micros: u64,
     /// Registry login server the image must belong to, such as `example.azurecr.io`.
     pub registry_login_server: String,
+    /// Managed-disk SKU for the OS and data disks; every allowlisted size supports both.
+    #[serde(default)]
+    pub disk_sku: AzureDiskSku,
+}
+
+/// Managed-disk SKUs the adapter offers; the wire names are Azure's own.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum AzureDiskSku {
+    #[default]
+    #[serde(rename = "StandardSSD_LRS")]
+    StandardSsdLrs,
+    #[serde(rename = "Premium_LRS")]
+    PremiumLrs,
+}
+
+impl AzureDiskSku {
+    /// Both offered SKUs are supported by every allowlisted size; kept as a hook for
+    /// SKUs whose support varies (for example zone-redundant disks).
+    #[must_use]
+    pub const fn is_supported(self) -> bool {
+        matches!(self, Self::StandardSsdLrs | Self::PremiumLrs)
+    }
+
+    #[must_use]
+    pub const fn as_azure_name(self) -> &'static str {
+        match self {
+            Self::StandardSsdLrs => "StandardSSD_LRS",
+            Self::PremiumLrs => "Premium_LRS",
+        }
+    }
 }
 
 impl AzureProfile {
@@ -59,7 +97,8 @@ impl AzureProfile {
             && valid_vm_size(&self.vm_size)
             && valid_identity_id(&self.image_pull_identity_id, &self.subscription_id)
             && self.declared_hourly_cost_micros > 0
-            && valid_registry_login_server(&self.registry_login_server);
+            && valid_registry_login_server(&self.registry_login_server)
+            && self.disk_sku.is_supported();
         valid.then_some(()).ok_or(AzureError::InvalidProfile)
     }
 
@@ -84,6 +123,72 @@ impl AzureProfile {
             }),
             _ => Ok(()),
         }
+    }
+}
+
+/// Deterministic, identity-derived resource group name for one worker.
+#[must_use]
+pub fn resource_group_name(workflow_id: CloudWorkflowId, job_id: CloudJobId) -> String {
+    format!("{RESOURCE_GROUP_PREFIX}{workflow_id}-{job_id}")
+}
+
+/// Exact identity of one Azure worker: the resource group is the unit of ownership and
+/// deletion, and its ARM resource ID is the provider handle. Decoding runs `validate`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "AzureWorkerSnapshot")]
+pub struct AzureWorker {
+    pub workflow_id: CloudWorkflowId,
+    pub job_id: CloudJobId,
+    pub subscription_id: String,
+    pub resource_group: String,
+    /// Group-level ARM resource ID, taken from Azure's creation response and never
+    /// constructed from a name; the VM inside is always [`WORKER_VM_NAME`].
+    pub group_id: String,
+    pub image: String,
+    pub lifetime: InteractiveWorkerLifetime,
+}
+
+impl AzureWorker {
+    /// Validate a handle before any provider call. Only the persistent lifetime is
+    /// accepted, matching the deployment plan; a well-formed lease is still refused.
+    /// # Errors
+    pub fn validate(&self) -> Result<(), AzureError> {
+        let valid = valid_subscription_id(&self.subscription_id)
+            && self.resource_group == resource_group_name(self.workflow_id, self.job_id)
+            && valid_resource_group_id(&self.group_id, &self.subscription_id, &self.resource_group)
+            && valid_immutable_worker_image(&self.image)
+            && self.lifetime == InteractiveWorkerLifetime::Persistent;
+        valid.then_some(()).ok_or(AzureError::InvalidPersistedWorker)
+    }
+}
+
+/// Wire shape of [`AzureWorker`]; decoding runs [`AzureWorker::validate`].
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AzureWorkerSnapshot {
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    subscription_id: String,
+    resource_group: String,
+    group_id: String,
+    image: String,
+    lifetime: InteractiveWorkerLifetime,
+}
+
+impl TryFrom<AzureWorkerSnapshot> for AzureWorker {
+    type Error = AzureError;
+
+    fn try_from(value: AzureWorkerSnapshot) -> Result<Self, Self::Error> {
+        let worker = Self {
+            workflow_id: value.workflow_id,
+            job_id: value.job_id,
+            subscription_id: value.subscription_id,
+            resource_group: value.resource_group,
+            group_id: value.group_id,
+            image: value.image,
+            lifetime: value.lifetime,
+        };
+        worker.validate().map(|()| worker)
     }
 }
 
@@ -130,6 +235,10 @@ pub enum AzureError {
     InvalidTarget,
     #[error("declared hourly cost {declared} exceeds the target limit {maximum}")]
     DeclaredCostExceedsLimit { declared: u64, maximum: u64 },
+    #[error("persisted Azure worker identity is invalid")]
+    InvalidPersistedWorker,
+    #[error("Azure workers support only the persistent lifetime policy")]
+    UnsupportedLifetime,
     #[error("Azure credential is unavailable: {reason}")]
     CredentialUnavailable { reason: &'static str },
     #[error("Azure request failed during {operation}")]
@@ -168,14 +277,43 @@ pub(crate) fn valid_location(value: &str) -> bool {
 }
 
 /// Exact size names, including constrained-vCPU sizes such as `Standard_E4-2s_v3`.
+/// Exact VM sizes the adapter accepts: x64, Hyper-V generation 2 and premium-storage
+/// capable general-purpose, memory-optimised, compute-optimised and burstable sizes.
+/// Matched by equality, so no nonexistent family, version or vCPU combination can
+/// reach a paid call. `Standard_D4s_v3` is the live-validated candidate; extend the
+/// table only after a live check of the new size.
+pub const SUPPORTED_VM_SIZES: &[&str] = &[
+    "Standard_D2s_v3",
+    "Standard_D4s_v3",
+    "Standard_D8s_v3",
+    "Standard_D16s_v3",
+    "Standard_D2s_v5",
+    "Standard_D4s_v5",
+    "Standard_D8s_v5",
+    "Standard_D16s_v5",
+    "Standard_D2as_v5",
+    "Standard_D4as_v5",
+    "Standard_D8as_v5",
+    "Standard_D16as_v5",
+    "Standard_E2s_v5",
+    "Standard_E4s_v5",
+    "Standard_E8s_v5",
+    "Standard_E16s_v5",
+    "Standard_E4-2s_v5",
+    "Standard_E8-4s_v5",
+    "Standard_E16-8s_v5",
+    "Standard_F2s_v2",
+    "Standard_F4s_v2",
+    "Standard_F8s_v2",
+    "Standard_F16s_v2",
+    "Standard_B2s",
+    "Standard_B2ms",
+    "Standard_B4ms",
+    "Standard_B8ms",
+];
+
 pub(crate) fn valid_vm_size(value: &str) -> bool {
-    value.len() <= 48
-        && value.strip_prefix("Standard_").is_some_and(|rest| {
-            !rest.is_empty()
-                && rest
-                    .bytes()
-                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'))
-        })
+    SUPPORTED_VM_SIZES.contains(&value)
 }
 
 fn valid_profile_name(value: &str) -> bool {

--- a/crates/horizon-core/src/cloud_run/azure/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/deployment.rs
@@ -1,0 +1,324 @@
+//! The single ARM deployment that materialises one persistent Azure worker: a locked
+//! down network path to the container's SSH port, a static public address, an Ubuntu
+//! VM with the image-pull identity, a managed data disk that becomes `/workspace`,
+//! and cloud-init that logs in to the registry with that identity and starts the
+//! digest-pinned worker image. Everything is derived from validated inputs; nothing
+//! operator-controlled is interpolated into YAML or shell.
+use super::{AzureError, AzureProfile, COMPUTE_API_VERSION, WORKER_VM_NAME, resource_group_name};
+
+/// Network and disk resource API versions used inside the template.
+const NETWORK_API_VERSION: &str = "2023-11-01";
+const DISK_API_VERSION: &str = "2023-10-02";
+use crate::cloud_run::{CLOUD_RUN_PROTOCOL_VERSION, WorkerLifetime, interactive_worker::InteractiveWorkerRequest};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use sha2::{Digest as _, Sha256};
+use std::collections::BTreeMap;
+
+/// Deployment name inside the worker's resource group; one worker, one deployment.
+pub const DEPLOYMENT_NAME: &str = "worker";
+/// Public IP resource name; the provider reads the address back from it on reconnect.
+pub const PUBLIC_IP_NAME: &str = "worker-pip";
+/// Host port forwarded to the container's SSH daemon; the VM's own port 22 stays closed.
+pub const SSH_PORT: u16 = 2222;
+/// Tag keys that carry the worker identity on the resource group and every resource.
+pub const TAG_WORKFLOW: &str = "horizon-workflow-id";
+pub const TAG_JOB: &str = "horizon-job-id";
+pub const TAG_PROTOCOL: &str = "horizon-cloud-protocol-version";
+pub const TAG_LIFETIME: &str = "horizon-worker-lifetime";
+pub const TAG_IMAGE_DIGEST: &str = "horizon-worker-image-digest";
+pub const TAG_CLIENT_KEY_DIGEST: &str = "horizon-client-key-sha256";
+const LIFETIME_PERSISTENT: &str = "persistent";
+const ADMIN_USERNAME: &str = "azureuser";
+const OS_DISK_GIB: u32 = 30;
+const WORKSPACE_MOUNT: &str = "/mnt/horizon-workspace";
+const CLIENT_KEY_PATH: &str = "/etc/horizon-worker/client-key.pub";
+const MAX_DATA_DISK_GIB: u32 = 4_095;
+
+/// Everything the transport needs to submit the worker deployment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AzureDeploymentPlan {
+    pub resource_group: String,
+    pub location: String,
+    pub tags: BTreeMap<String, String>,
+    pub template: serde_json::Value,
+    pub parameters: serde_json::Value,
+}
+
+impl AzureDeploymentPlan {
+    /// Derive the deployment for one request against one profile.
+    /// # Errors
+    /// Rejects requests the profile cannot serve and any non-persistent lifetime: a
+    /// time-limited Azure worker needs a provider-side power bound that this adapter
+    /// does not provide yet, so it is refused rather than silently made persistent.
+    pub fn new(profile: &AzureProfile, request: &InteractiveWorkerRequest) -> Result<Self, AzureError> {
+        profile.validate_target(&request.target)?;
+        if !request.is_valid_for(crate::cloud_run::CloudProvider::Azure) || !shell_safe(&request.target.image) {
+            return Err(AzureError::InvalidTarget);
+        }
+        if request.target.lifetime != WorkerLifetime::Persistent {
+            return Err(AzureError::UnsupportedLifetime);
+        }
+        if request.target.disk_gib > MAX_DATA_DISK_GIB {
+            return Err(AzureError::InvalidTarget);
+        }
+        let tags = worker_tags(request);
+        let cloud_init = cloud_init(profile, request);
+        let parameters = serde_json::json!({
+            "vmName": { "value": WORKER_VM_NAME },
+            "vmSize": { "value": profile.vm_size },
+            "adminPublicKey": { "value": request.ssh_public_key },
+            "customData": { "value": STANDARD.encode(cloud_init) },
+            "identityId": { "value": profile.image_pull_identity_id },
+            "dataDiskGib": { "value": request.target.disk_gib },
+            "diskSku": { "value": profile.disk_sku.as_azure_name() },
+            "tags": { "value": tags },
+        });
+        Ok(Self {
+            resource_group: resource_group_name(request.workflow_id, request.job_id),
+            location: profile.location.clone(),
+            tags,
+            template: template(),
+            parameters,
+        })
+    }
+}
+
+/// Identity tags: exact workflow and job, protocol version, lifetime policy, image
+/// digest and the SHA-256 of the client key, so ownership is provable without
+/// reading the guest.
+#[must_use]
+pub fn worker_tags(request: &InteractiveWorkerRequest) -> BTreeMap<String, String> {
+    let digest = request
+        .target
+        .image
+        .rsplit_once("@sha256:")
+        .map(|(_, digest)| digest)
+        .unwrap_or_default();
+    [
+        (TAG_WORKFLOW, request.workflow_id.to_string()),
+        (TAG_JOB, request.job_id.to_string()),
+        (TAG_PROTOCOL, CLOUD_RUN_PROTOCOL_VERSION.to_string()),
+        (TAG_LIFETIME, LIFETIME_PERSISTENT.to_string()),
+        (TAG_IMAGE_DIGEST, digest.to_string()),
+        (TAG_CLIENT_KEY_DIGEST, client_key_digest(&request.ssh_public_key)),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_string(), value))
+    .collect()
+}
+
+/// Lowercase hex SHA-256 of the exact client public key string.
+#[must_use]
+pub fn client_key_digest(ssh_public_key: &str) -> String {
+    Sha256::digest(ssh_public_key.as_bytes())
+        .iter()
+        .fold(String::with_capacity(64), |mut hex, byte| {
+            use std::fmt::Write as _;
+            let _ = write!(hex, "{byte:02x}");
+            hex
+        })
+}
+
+/// Image references and registry names only ever contain these bytes; anything else
+/// is refused before it could reach a shell line.
+fn shell_safe(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'/' | b':' | b'@'))
+}
+
+/// cloud-init for a persistent worker: Docker from the distribution, a data disk that
+/// carries no signature at all formatted once as ext4 (a partition table or any other
+/// filesystem signature is refused, never overwritten) and
+/// mounted before Docker starts, a registry login through the VM's user-assigned
+/// identity kept in a temporary Docker config that an EXIT trap removes on every
+/// path, then the digest-pinned image started with the client key. The key arrives
+/// as a base64 root-only file, never inline. Before the container can start, the
+/// host is sealed against it: boot-persistent firewall rules drop container traffic
+/// to the instance metadata service (no fresh identity tokens from inside) and to
+/// the host's SSH port over the bridge, and host SSH is disabled outright, so the
+/// admin key required by the image is inert. The ARM run command remains the
+/// operator's path into the host.
+fn cloud_init(profile: &AzureProfile, request: &InteractiveWorkerRequest) -> String {
+    let registry = &profile.registry_login_server;
+    let image = &request.target.image;
+    let client_id_lookup = format!(
+        "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&msi_res_id={}",
+        percent_encode(&profile.image_pull_identity_id)
+    );
+    format!(
+        r#"#cloud-config
+package_update: true
+packages: [docker.io, iptables-persistent]
+write_files:
+  - path: {CLIENT_KEY_PATH}
+    permissions: '0600'
+    owner: root:root
+    encoding: b64
+    content: {key}
+  - path: /etc/systemd/system/docker.service.d/horizon-workspace.conf
+    permissions: '0644'
+    owner: root:root
+    content: |
+      [Unit]
+      RequiresMountsFor={WORKSPACE_MOUNT}
+  - path: /usr/local/sbin/horizon-worker-bootstrap.sh
+    permissions: '0700'
+    owner: root:root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      field() {{ python3 -c 'import json,sys; print(json.load(sys.stdin)[sys.argv[1]])' "$1"; }}
+      DISK=
+      for _ in $(seq 1 120); do
+        for candidate in /dev/disk/azure/data/by-lun/0 /dev/disk/azure/scsi1/lun0; do
+          if [ -e "$candidate" ]; then DISK=$candidate; break 2; fi
+        done
+        sleep 1
+      done
+      [ -n "$DISK" ]
+      SIGNATURES=$(wipefs --noheadings --output TYPE "$DISK" | sort -u | tr '\n' ' ')
+      case "$SIGNATURES" in
+        "") mkfs.ext4 -q -L horizonws "$DISK" ;;
+        "ext4 ") ;;
+        *) echo "refusing data disk with unexpected signatures: $SIGNATURES" >&2; exit 1 ;;
+      esac
+      mkdir -p {WORKSPACE_MOUNT}
+      UUID=$(blkid -o value -s UUID "$DISK")
+      grep -q "$UUID" /etc/fstab || echo "UUID=$UUID {WORKSPACE_MOUNT} ext4 defaults,nofail 0 2" >> /etc/fstab
+      systemctl daemon-reload
+      mountpoint -q {WORKSPACE_MOUNT} || mount {WORKSPACE_MOUNT}
+      chown root:root {WORKSPACE_MOUNT} && chmod 0755 {WORKSPACE_MOUNT}
+      systemctl enable --now docker
+      iptables -I DOCKER-USER -d 169.254.169.254 -j DROP
+      iptables -I INPUT -i docker0 -p tcp --dport 22 -j DROP
+      netfilter-persistent save
+      systemctl disable --now ssh.socket ssh.service
+      export DOCKER_CONFIG=$(mktemp -d /run/horizon-docker-login.XXXXXX)
+      trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+      CURL="curl -sf --max-time 20 --retry 5 --retry-delay 3 --retry-connrefused"
+      AAD=$($CURL -H Metadata:true '{client_id_lookup}' | field access_token)
+      REFRESH=$($CURL -X POST 'https://{registry}/oauth2/exchange' --data-urlencode grant_type=access_token --data-urlencode service={registry} --data-urlencode "access_token=$AAD" | field refresh_token)
+      printf '%s' "$REFRESH" | timeout 60 docker login {registry} -u 00000000-0000-0000-0000-000000000000 --password-stdin >/dev/null
+      unset AAD REFRESH
+      for attempt in 1 2 3 4 5; do
+        if PULL_ERROR=$(timeout 900 docker pull -q '{image}' 2>&1 >/dev/null); then break; fi
+        case "$PULL_ERROR" in
+          *unauthorized*|*denied*|*"authentication required"*|*"not found"*|*"manifest unknown"*) echo "$PULL_ERROR" >&2; exit 1 ;;
+        esac
+        [ "$attempt" = 5 ] && {{ echo "$PULL_ERROR" >&2; exit 1; }}
+        sleep $((attempt * 10))
+      done
+      docker logout {registry} >/dev/null 2>&1 || true
+      docker create --name horizon-worker --restart unless-stopped -p {SSH_PORT}:22 --mount type=bind,src={WORKSPACE_MOUNT},dst=/workspace -e "HORIZON_SSH_PUBLIC_KEY=$(cat {CLIENT_KEY_PATH})" '{image}' >/dev/null
+      docker start horizon-worker >/dev/null
+runcmd:
+  - [ systemctl, daemon-reload ]
+  - [ bash, /usr/local/sbin/horizon-worker-bootstrap.sh ]
+"#,
+        key = STANDARD.encode(&request.ssh_public_key),
+    )
+}
+
+/// Percent-encode a validated resource ID for the instance metadata query string.
+fn percent_encode(value: &str) -> String {
+    value
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => char::from(byte).to_string(),
+            _ => format!("%{byte:02X}"),
+        })
+        .collect()
+}
+
+fn arm_id(kind: &str, name_expression: &str) -> String {
+    format!("[resourceId('{kind}', {name_expression})]")
+}
+
+/// The ARM template. Names are fixed relative to the VM name so every resource of a
+/// worker is addressable from its identity alone. The data disk is a declared, tagged
+/// resource attached by ID and detached rather than deleted with the VM; the OS disk
+/// is created from the image (ARM cannot tag it at creation), is owned through the
+/// group, and is deleted with the VM.
+fn template() -> serde_json::Value {
+    let nsg = arm_id("Microsoft.Network/networkSecurityGroups", "variables('nsg')");
+    let vnet = arm_id("Microsoft.Network/virtualNetworks", "variables('vnet')");
+    let pip = arm_id("Microsoft.Network/publicIPAddresses", "variables('pip')");
+    let nic = arm_id("Microsoft.Network/networkInterfaces", "variables('nic')");
+    let data_disk = arm_id("Microsoft.Compute/disks", "variables('data')");
+    let subnet = "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnet'), 'workers')]";
+    let common = |kind: &str, api: &str, name: &str| {
+        serde_json::json!({
+            "type": kind, "apiVersion": api, "name": name,
+            "location": "[parameters('location')]", "tags": "[parameters('tags')]",
+        })
+    };
+    let with = |mut base: serde_json::Value, extra: serde_json::Value| {
+        if let (Some(base), Some(extra)) = (base.as_object_mut(), extra.as_object()) {
+            base.extend(extra.clone());
+        }
+        base
+    };
+    serde_json::json!({
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {
+            "vmName": { "type": "string" }, "vmSize": { "type": "string" },
+            "adminPublicKey": { "type": "securestring" }, "customData": { "type": "securestring" },
+            "identityId": { "type": "string" }, "dataDiskGib": { "type": "int", "minValue": 1, "maxValue": MAX_DATA_DISK_GIB },
+            "diskSku": { "type": "string", "allowedValues": ["StandardSSD_LRS", "Premium_LRS"] },
+            "tags": { "type": "object" },
+            "location": { "type": "string", "defaultValue": "[resourceGroup().location]" },
+        },
+        "variables": {
+            "nsg": "[concat(parameters('vmName'), '-nsg')]", "vnet": "[concat(parameters('vmName'), '-vnet')]",
+            "pip": "[concat(parameters('vmName'), '-pip')]",
+            "nic": "[concat(parameters('vmName'), '-nic')]",
+            "data": "[concat(parameters('vmName'), '-data')]",
+        },
+        "resources": [
+            with(common("Microsoft.Network/networkSecurityGroups", NETWORK_API_VERSION, "[variables('nsg')]"), serde_json::json!({
+                "properties": { "securityRules": [{ "name": "worker-ssh", "properties": {
+                    "priority": 100, "direction": "Inbound", "access": "Allow", "protocol": "Tcp",
+                    "sourceAddressPrefix": "Internet", "sourcePortRange": "*",
+                    "destinationAddressPrefix": "*", "destinationPortRange": SSH_PORT.to_string() } }] }
+            })),
+            with(common("Microsoft.Network/virtualNetworks", NETWORK_API_VERSION, "[variables('vnet')]"), serde_json::json!({
+                "dependsOn": [nsg],
+                "properties": { "addressSpace": { "addressPrefixes": ["10.0.0.0/16"] }, "subnets": [{ "name": "workers",
+                    "properties": { "addressPrefix": "10.0.0.0/24", "networkSecurityGroup": { "id": nsg } } }] }
+            })),
+            with(common("Microsoft.Network/publicIPAddresses", NETWORK_API_VERSION, "[variables('pip')]"), serde_json::json!({
+                "sku": { "name": "Standard" },
+                "properties": { "publicIPAllocationMethod": "Static", "publicIPAddressVersion": "IPv4" }
+            })),
+            with(common("Microsoft.Compute/disks", DISK_API_VERSION, "[variables('data')]"), serde_json::json!({
+                "sku": { "name": "[parameters('diskSku')]" },
+                "properties": { "creationData": { "createOption": "Empty" }, "diskSizeGB": "[parameters('dataDiskGib')]" }
+            })),
+            with(common("Microsoft.Network/networkInterfaces", NETWORK_API_VERSION, "[variables('nic')]"), serde_json::json!({
+                "dependsOn": [vnet, pip],
+                "properties": { "ipConfigurations": [{ "name": "primary", "properties": {
+                    "privateIPAllocationMethod": "Dynamic", "subnet": { "id": subnet }, "publicIPAddress": { "id": pip } } }] }
+            })),
+            with(common("Microsoft.Compute/virtualMachines", COMPUTE_API_VERSION, "[parameters('vmName')]"), serde_json::json!({
+                "dependsOn": [nic, data_disk],
+                "identity": { "type": "UserAssigned", "userAssignedIdentities": { "[parameters('identityId')]": {} } },
+                "properties": {
+                    "hardwareProfile": { "vmSize": "[parameters('vmSize')]" },
+                    "storageProfile": {
+                        "imageReference": { "publisher": "Canonical", "offer": "ubuntu-24_04-lts", "sku": "server", "version": "latest" },
+                        "osDisk": { "createOption": "FromImage", "diskSizeGB": OS_DISK_GIB, "deleteOption": "Delete",
+                            "managedDisk": { "storageAccountType": "[parameters('diskSku')]" } },
+                        "dataDisks": [{ "lun": 0, "createOption": "Attach", "deleteOption": "Detach",
+                            "managedDisk": { "id": data_disk } }] },
+                    "osProfile": { "computerName": "[parameters('vmName')]", "adminUsername": ADMIN_USERNAME,
+                        "customData": "[parameters('customData')]",
+                        "linuxConfiguration": { "disablePasswordAuthentication": true, "ssh": { "publicKeys": [{
+                            "path": format!("/home/{ADMIN_USERNAME}/.ssh/authorized_keys"), "keyData": "[parameters('adminPublicKey')]" }] } } },
+                    "networkProfile": { "networkInterfaces": [{ "id": nic }] } }
+            })),
+        ],
+        "outputs": { "publicIp": { "type": "string", "value": "[reference(variables('pip')).ipAddress]" } },
+    })
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -1,18 +1,33 @@
 use super::{
-    AzureAccessToken, AzureCliCredential, AzureError, AzureLifecycle, AzureProfile, credential::parse_cli_token,
-    valid_identity_id, valid_location, valid_registry_login_server, valid_vm_size,
+    AzureAccessToken, AzureCliCredential, AzureDiskSku, AzureError, AzureLifecycle, AzureProfile,
+    credential::parse_cli_token, valid_identity_id, valid_location, valid_registry_login_server, valid_vm_size,
 };
 use crate::cloud_run::{CloudProvider, WorkerLifetime, WorkerTarget};
+mod deployment;
+mod identity;
 mod transport;
 use std::time::Duration;
 
 pub(super) const SUB: &str = "0f0e0d0c-0b0a-4908-8706-050403020100";
 pub(super) const OTHER_SUB: &str = "9a8b7c6d-5e4f-4a3b-9c2d-1e0f9a8b7c6d";
 pub(super) const GROUP: &str = "horizon-ws-sample";
+const ED25519_BLOB_PREFIX: &[u8] = b"\0\0\0\x0bssh-ed25519\0\0\0\x20";
+
+/// A structurally valid Ed25519 public key whose 32 key bytes are all `byte`.
+pub(super) fn ed25519_key(byte: u8, comment: &str) -> String {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    let blob = [ED25519_BLOB_PREFIX, &[byte; 32]].concat();
+    let comment = if comment.is_empty() {
+        String::new()
+    } else {
+        format!(" {comment}")
+    };
+    format!("ssh-ed25519 {}{comment}", STANDARD.encode(blob))
+}
 pub(super) const IMAGE: &str =
     "example.azurecr.io/horizon-remote-worker@sha256:20cc03ef2530336b7374cc35412c8583b1422726c630ec6e6cd1450d690a74f6";
 
-fn profile() -> AzureProfile {
+pub(super) fn profile() -> AzureProfile {
     AzureProfile {
         name: "cpu-north".into(),
         subscription_id: SUB.into(),
@@ -23,10 +38,11 @@ fn profile() -> AzureProfile {
         ),
         declared_hourly_cost_micros: 200_000,
         registry_login_server: "example.azurecr.io".into(),
+        disk_sku: AzureDiskSku::PremiumLrs,
     }
 }
 
-fn target() -> WorkerTarget {
+pub(super) fn target() -> WorkerTarget {
     WorkerTarget {
         provider: CloudProvider::Azure,
         profile: "cpu-north".into(),
@@ -128,23 +144,6 @@ fn validators_follow_azure_naming_rules() {
     ] {
         assert!(!valid_identity_id(&bad, SUB), "{label}");
     }
-    for size in [
-        "Standard_D4s_v3",
-        "Standard_E4-2s_v3",
-        "Standard_M8-2ms",
-        "Standard_B1ls",
-    ] {
-        assert!(valid_vm_size(size), "{size}");
-    }
-    for size in [
-        "Standard_",
-        "Basic_A1",
-        "Standard_D4s v3",
-        "standard_d4s_v3",
-        &format!("Standard_{}", "x".repeat(40)),
-    ] {
-        assert!(!valid_vm_size(size), "{size}");
-    }
     for location in ["northeurope", "eastus2", "swedencentral"] {
         assert!(valid_location(location), "{location}");
     }
@@ -164,10 +163,50 @@ fn validators_follow_azure_naming_rules() {
         "abcd.azurecr.io",
         "example.azurecr.cn",
         "azurecr.io",
-        "docker.io",
     ] {
         assert!(!valid_registry_login_server(server), "{server}");
     }
+}
+
+#[test]
+fn vm_sizes_come_from_the_validated_allowlist() {
+    use super::SUPPORTED_VM_SIZES;
+    assert!(
+        SUPPORTED_VM_SIZES.contains(&"Standard_D4s_v3"),
+        "the live-validated candidate"
+    );
+    for size in SUPPORTED_VM_SIZES {
+        assert!(valid_vm_size(size), "{size}");
+        assert!(size.starts_with("Standard_") && !size.contains('p'), "{size}: x64 only");
+    }
+    for size in [
+        "Standard_D4_v3",
+        "Standard_A2_v2",
+        "Standard_DS3_v2",
+        "Standard_D4ps_v5",
+        "Standard_B96s",
+        "Standard_D0s_v3",
+        "Standard_D999s_v3",
+        "Standard_E4-8s_v5",
+        "Standard_D4s_v2",
+        "Standard_d4s_v3",
+        "Standard_D4s_v3 ",
+        "Standard_",
+        "Basic_A1",
+        "",
+    ] {
+        assert!(!valid_vm_size(size), "{size}");
+    }
+    let mut standard_disks = profile();
+    standard_disks.disk_sku = AzureDiskSku::StandardSsdLrs;
+    assert_eq!(standard_disks.validate(), Ok(()));
+    let decoded: AzureProfile = serde_json::from_str(
+        &serde_json::to_string(&profile())
+            .expect("encode")
+            .replace(",\"disk_sku\":\"Premium_LRS\"", ""),
+    )
+    .expect("decode");
+    assert_eq!(decoded.disk_sku, AzureDiskSku::StandardSsdLrs, "the default SKU");
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
@@ -1,0 +1,288 @@
+use super::super::{
+    AzureDeploymentPlan, AzureError, RESOURCE_GROUP_PREFIX,
+    deployment::{
+        SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_IMAGE_DIGEST, TAG_JOB, TAG_LIFETIME, TAG_PROTOCOL, TAG_WORKFLOW,
+        client_key_digest, worker_tags,
+    },
+};
+use super::{IMAGE, ed25519_key, profile, target};
+use crate::cloud_run::{
+    CLOUD_RUN_PROTOCOL_VERSION, CloudJobId, CloudWorkflowId, WorkerLifetime,
+    interactive_worker::InteractiveWorkerRequest,
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+fn request(comment: &str) -> InteractiveWorkerRequest {
+    InteractiveWorkerRequest {
+        workflow_id: CloudWorkflowId::new(),
+        job_id: CloudJobId::new(),
+        target: target(),
+        ssh_public_key: ed25519_key(7, comment),
+    }
+}
+
+fn decoded_cloud_init(plan: &AzureDeploymentPlan) -> String {
+    let encoded = plan.parameters["customData"]["value"].as_str().expect("customData");
+    String::from_utf8(STANDARD.decode(encoded).expect("base64")).expect("utf8")
+}
+
+#[test]
+fn plan_derives_identity_parameters_and_tags_from_validated_inputs() {
+    let request = request("operator@example");
+    let plan = AzureDeploymentPlan::new(&profile(), &request).expect("plan");
+    assert_eq!(
+        plan.resource_group,
+        format!("{RESOURCE_GROUP_PREFIX}{}-{}", request.workflow_id, request.job_id)
+    );
+    assert_eq!(plan.location, "northeurope");
+    let parameters = &plan.parameters;
+    assert_eq!(parameters["vmName"]["value"], "worker");
+    assert_eq!(parameters["vmSize"]["value"], "Standard_D4s_v3");
+    assert_eq!(parameters["adminPublicKey"]["value"], request.ssh_public_key);
+    assert_eq!(parameters["identityId"]["value"], profile().image_pull_identity_id);
+    assert_eq!(parameters["dataDiskGib"]["value"], 32);
+    assert_eq!(
+        parameters["tags"]["value"],
+        serde_json::to_value(&plan.tags).expect("tags")
+    );
+    let expected_tags = worker_tags(&request);
+    assert_eq!(plan.tags, expected_tags);
+    assert_eq!(plan.tags[TAG_WORKFLOW], request.workflow_id.to_string());
+    assert_eq!(plan.tags[TAG_JOB], request.job_id.to_string());
+    assert_eq!(plan.tags[TAG_PROTOCOL], CLOUD_RUN_PROTOCOL_VERSION.to_string());
+    assert_eq!(plan.tags[TAG_LIFETIME], "persistent");
+    assert_eq!(
+        plan.tags[TAG_IMAGE_DIGEST],
+        IMAGE.rsplit_once("@sha256:").expect("digest").1
+    );
+    assert_eq!(
+        plan.tags[TAG_CLIENT_KEY_DIGEST],
+        client_key_digest(&request.ssh_public_key)
+    );
+    assert_eq!(plan.tags[TAG_CLIENT_KEY_DIGEST].len(), 64);
+    assert_ne!(
+        client_key_digest(&request.ssh_public_key),
+        client_key_digest(&ed25519_key(8, ""))
+    );
+    assert_eq!(
+        client_key_digest("abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+    assert_eq!(plan.tags.len(), 6);
+    assert!(
+        plan.tags
+            .values()
+            .all(|value| value.len() <= 256 && !value.chars().any(char::is_control))
+    );
+}
+
+#[test]
+fn template_pins_api_versions_identity_disks_and_closed_network_path() {
+    let plan = AzureDeploymentPlan::new(&profile(), &request("")).expect("plan");
+    let template = &plan.template;
+    let resources = template["resources"].as_array().expect("resources");
+    let kinds: Vec<&str> = resources
+        .iter()
+        .filter_map(|resource| resource["type"].as_str())
+        .collect();
+    assert_eq!(
+        kinds,
+        [
+            "Microsoft.Network/networkSecurityGroups",
+            "Microsoft.Network/virtualNetworks",
+            "Microsoft.Network/publicIPAddresses",
+            "Microsoft.Compute/disks",
+            "Microsoft.Network/networkInterfaces",
+            "Microsoft.Compute/virtualMachines",
+        ]
+    );
+    for resource in resources {
+        assert_eq!(resource["tags"], "[parameters('tags')]", "{}", resource["type"]);
+        assert_eq!(resource["location"], "[parameters('location')]");
+        assert!(resource["apiVersion"].as_str().is_some_and(|api| api.starts_with("20")));
+    }
+    let rule = &resources[0]["properties"]["securityRules"][0]["properties"];
+    assert_eq!(rule["destinationPortRange"], SSH_PORT.to_string());
+    assert_eq!(rule["access"], "Allow");
+    assert_eq!(rule["protocol"], "Tcp");
+    assert_eq!(
+        resources[0]["properties"]["securityRules"].as_array().map(Vec::len),
+        Some(1),
+        "only the container SSH port"
+    );
+    assert_eq!(resources[2]["properties"]["publicIPAllocationMethod"], "Static");
+    assert_eq!(resources[2]["sku"]["name"], "Standard");
+    let disk = &resources[3];
+    assert_eq!(disk["properties"]["diskSizeGB"], "[parameters('dataDiskGib')]");
+    assert_eq!(disk["properties"]["creationData"]["createOption"], "Empty");
+    assert_eq!(disk["sku"]["name"], "[parameters('diskSku')]");
+    assert_eq!(plan.parameters["diskSku"]["value"], "Premium_LRS");
+    assert_eq!(
+        template["parameters"]["diskSku"]["allowedValues"],
+        serde_json::json!(["StandardSSD_LRS", "Premium_LRS"])
+    );
+    let vm = &resources[5];
+    assert_eq!(vm["apiVersion"], "2024-03-01");
+    assert_eq!(vm["identity"]["type"], "UserAssigned");
+    assert!(vm["identity"]["userAssignedIdentities"]["[parameters('identityId')]"].is_object());
+    let storage = &vm["properties"]["storageProfile"];
+    assert_eq!(storage["imageReference"]["offer"], "ubuntu-24_04-lts");
+    assert_eq!(storage["dataDisks"][0]["createOption"], "Attach");
+    assert_eq!(
+        storage["dataDisks"][0]["deleteOption"], "Detach",
+        "the data disk outlives the VM"
+    );
+    assert_eq!(
+        storage["dataDisks"][0]["managedDisk"]["id"],
+        "[resourceId('Microsoft.Compute/disks', variables('data'))]"
+    );
+    assert_eq!(storage["osDisk"]["deleteOption"], "Delete");
+    assert!(
+        vm["dependsOn"]
+            .as_array()
+            .expect("dependsOn")
+            .contains(&serde_json::json!(
+                "[resourceId('Microsoft.Compute/disks', variables('data'))]"
+            ))
+    );
+    let linux = &vm["properties"]["osProfile"]["linuxConfiguration"];
+    assert_eq!(linux["disablePasswordAuthentication"], true);
+    assert_eq!(
+        linux["ssh"]["publicKeys"][0]["keyData"],
+        "[parameters('adminPublicKey')]"
+    );
+    assert_eq!(
+        vm["properties"]["osProfile"]["customData"],
+        "[parameters('customData')]"
+    );
+    assert_eq!(template["parameters"]["adminPublicKey"]["type"], "securestring");
+    assert_eq!(template["parameters"]["customData"]["type"], "securestring");
+    assert_eq!(template["parameters"]["dataDiskGib"]["maxValue"], 4_095);
+    assert_eq!(
+        template["outputs"]["publicIp"]["value"],
+        "[reference(variables('pip')).ipAddress]"
+    );
+    assert_eq!(template["variables"]["pip"], "[concat(parameters('vmName'), '-pip')]");
+    assert!(
+        !template.to_string().contains("Microsoft.DevTestLab"),
+        "no schedule for persistent workers"
+    );
+}
+
+#[test]
+fn cloud_init_carries_the_key_as_a_file_and_never_interpolates_operator_text() {
+    let hostile = "operator'; rm -rf / #\"$(x)";
+    let request = request(hostile);
+    let plan = AzureDeploymentPlan::new(&profile(), &request).expect("plan");
+    let cloud_init = decoded_cloud_init(&plan);
+    assert!(cloud_init.starts_with("#cloud-config\n"));
+    assert!(
+        !cloud_init.contains(hostile),
+        "the raw key text never appears in cloud-init"
+    );
+    assert!(
+        !cloud_init.contains("ssh-ed25519"),
+        "the key travels only as a base64 file"
+    );
+    assert!(cloud_init.contains(&format!("content: {}", STANDARD.encode(&request.ssh_public_key))));
+    assert!(cloud_init.contains("path: /etc/horizon-worker/client-key.pub"));
+    assert!(cloud_init.contains("permissions: '0600'"));
+    assert!(cloud_init.contains(&format!("docker pull -q '{IMAGE}'")));
+    assert!(cloud_init.contains("-e \"HORIZON_SSH_PUBLIC_KEY=$(cat /etc/horizon-worker/client-key.pub)\""));
+    assert!(cloud_init.contains(&format!("-p {SSH_PORT}:22")));
+    assert!(cloud_init.contains("src=/mnt/horizon-workspace,dst=/workspace"));
+    assert!(
+        cloud_init.contains("wipefs --noheadings --output TYPE \"$DISK\""),
+        "every signature is inspected"
+    );
+    assert!(
+        cloud_init.contains("\"\") mkfs.ext4 -q -L horizonws \"$DISK\" ;;"),
+        "only a signature-free disk is formatted"
+    );
+    assert!(cloud_init.contains("\"ext4 \") ;;"), "a lone ext4 signature is reused");
+    assert!(cloud_init.contains("refusing data disk with unexpected signatures"));
+    assert!(cloud_init.contains("packages: [docker.io, iptables-persistent]"));
+    let bootstrap = cloud_init
+        .split("horizon-worker-bootstrap.sh")
+        .nth(1)
+        .expect("bootstrap script");
+    let position = |needle: &str| bootstrap.find(needle).unwrap_or_else(|| panic!("{needle}"));
+    assert!(position("iptables -I DOCKER-USER -d 169.254.169.254 -j DROP") < position("docker create"));
+    assert!(position("iptables -I INPUT -i docker0 -p tcp --dport 22 -j DROP") < position("docker create"));
+    assert!(position("netfilter-persistent save") < position("docker create"));
+    assert!(position("systemctl disable --now ssh.socket ssh.service") < position("docker create"));
+    assert!(position("systemctl enable --now docker") < position("iptables -I DOCKER-USER"));
+    assert!(
+        cloud_init.contains("CURL=\"curl -sf --max-time 20 --retry 5 --retry-delay 3 --retry-connrefused\""),
+        "bounded, retried metadata and registry calls"
+    );
+    assert!(cloud_init.contains("timeout 60 docker login"), "bounded login");
+    assert!(
+        cloud_init.contains("PULL_ERROR=$(timeout 900 docker pull -q"),
+        "bounded pull attempts"
+    );
+    assert!(cloud_init.contains("*unauthorized*|*denied*|*\"authentication required\"*|*\"not found\"*|*\"manifest unknown\"*) echo \"$PULL_ERROR\" >&2; exit 1 ;;"), "authentication and missing-image failures are not retried");
+    assert!(
+        cloud_init.contains("[ \"$attempt\" = 5 ] && { echo \"$PULL_ERROR\" >&2; exit 1; }"),
+        "bounded retries"
+    );
+    assert!(cloud_init.contains("export DOCKER_CONFIG=$(mktemp -d /run/horizon-docker-login.XXXXXX)"));
+    assert!(cloud_init.contains("trap 'rm -rf \"$DOCKER_CONFIG\"' EXIT"));
+    assert!(cloud_init.contains("RequiresMountsFor=/mnt/horizon-workspace"));
+    assert!(
+        cloud_init.contains("docker login example.azurecr.io -u 00000000-0000-0000-0000-000000000000 --password-stdin")
+    );
+    assert!(
+        cloud_init.contains("msi_res_id=%2Fsubscriptions%2F"),
+        "identity selected by resource id, percent-encoded"
+    );
+    assert!(
+        cloud_init.contains("/dev/disk/azure/data/by-lun/0 /dev/disk/azure/scsi1/lun0"),
+        "NVMe and SCSI data disk paths"
+    );
+    assert!(!cloud_init.contains("HORIZON_TERMINATE_AFTER"));
+    assert!(!cloud_init.contains("bootcmd"), "no early-boot systemctl calls");
+    for line in cloud_init.lines() {
+        assert!(!line.chars().any(char::is_control), "{line:?}");
+    }
+}
+
+#[test]
+fn plan_rejects_unsupported_lifetimes_and_targets_before_any_io() {
+    let mut limited = request("");
+    limited.target.lifetime = WorkerLifetime::TimeLimited { seconds: 3_600 };
+    assert_eq!(
+        AzureDeploymentPlan::new(&profile(), &limited),
+        Err(AzureError::UnsupportedLifetime)
+    );
+    let mut other_registry = request("");
+    other_registry.target.image = IMAGE.replace("example.azurecr.io", "other.azurecr.io");
+    assert_eq!(
+        AzureDeploymentPlan::new(&profile(), &other_registry),
+        Err(AzureError::InvalidTarget)
+    );
+    let mut bad_key = request("");
+    bad_key.ssh_public_key = "ssh-rsa AAAA".into();
+    assert_eq!(
+        AzureDeploymentPlan::new(&profile(), &bad_key),
+        Err(AzureError::InvalidTarget)
+    );
+    let mut huge = request("");
+    huge.target.disk_gib = 4_096;
+    assert_eq!(
+        AzureDeploymentPlan::new(&profile(), &huge),
+        Err(AzureError::InvalidTarget)
+    );
+    let mut costly = request("");
+    costly.target.max_hourly_cost_micros = Some(1);
+    assert!(matches!(
+        AzureDeploymentPlan::new(&profile(), &costly),
+        Err(AzureError::DeclaredCostExceedsLimit { .. })
+    ));
+    let mut bad_profile = profile();
+    bad_profile.location = "North Europe".into();
+    assert_eq!(
+        AzureDeploymentPlan::new(&bad_profile, &request("")),
+        Err(AzureError::InvalidProfile)
+    );
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/identity.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/identity.rs
@@ -1,0 +1,79 @@
+use super::super::{AzureError, AzureWorker, resource_group_name, valid_resource_group_id};
+use super::{IMAGE, OTHER_SUB, SUB};
+use crate::cloud_run::{
+    CloudJobId, CloudWorkflowId,
+    interactive_worker::{InteractiveWorkerLease, InteractiveWorkerLifetime},
+};
+
+#[test]
+fn worker_identity_is_exact_and_resource_ids_are_parsed_strictly() {
+    let (workflow_id, job_id) = (CloudWorkflowId::new(), CloudJobId::new());
+    let group = resource_group_name(workflow_id, job_id);
+    assert!(group.starts_with("horizon-ws-"));
+    assert_eq!(group.len(), 84);
+    let group_id = format!("/subscriptions/{SUB}/resourceGroups/{group}");
+    let worker = AzureWorker {
+        workflow_id,
+        job_id,
+        subscription_id: SUB.into(),
+        resource_group: group.clone(),
+        group_id: group_id.clone(),
+        image: IMAGE.into(),
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    };
+    assert_eq!(worker.validate(), Ok(()));
+    assert!(valid_resource_group_id(
+        &group_id.replace("resourceGroups", "resourcegroups"),
+        SUB,
+        &group
+    ));
+    assert!(valid_resource_group_id(
+        &group_id.replace(SUB, &SUB.to_ascii_uppercase()),
+        SUB,
+        &group
+    ));
+    for (bad_id, label) in [
+        (group_id.replace(&group, "horizon-ws-other"), "group"),
+        (group_id.replace(SUB, OTHER_SUB), "subscription"),
+        (
+            format!("{group_id}/providers/Microsoft.Compute/virtualMachines/worker"),
+            "trailing segments",
+        ),
+        (
+            group_id.replace("/subscriptions/", "/Subscriptions/"),
+            "fixed segment casing",
+        ),
+        (format!("{group_id} "), "whitespace"),
+        (String::new(), "empty"),
+    ] {
+        assert!(!valid_resource_group_id(&bad_id, SUB, &group), "{label}");
+        let mut broken = worker.clone();
+        broken.group_id = bad_id;
+        assert_eq!(broken.validate(), Err(AzureError::InvalidPersistedWorker), "{label}");
+    }
+    let mut renamed = worker.clone();
+    renamed.resource_group = "horizon-ws-renamed".into();
+    assert_eq!(renamed.validate(), Err(AzureError::InvalidPersistedWorker));
+    for terminate_after in ["tomorrow", "2030-01-01T00:00:00Z"] {
+        let mut leased = worker.clone();
+        leased.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+            terminate_after: terminate_after.into(),
+        });
+        assert_eq!(
+            leased.validate(),
+            Err(AzureError::InvalidPersistedWorker),
+            "{terminate_after}"
+        );
+        let encoded = serde_json::to_string(&leased).expect("encode");
+        assert!(
+            serde_json::from_str::<AzureWorker>(&encoded).is_err(),
+            "a lease never decodes: {terminate_after}"
+        );
+    }
+    let encoded = serde_json::to_string(&worker).expect("encode");
+    assert_eq!(serde_json::from_str::<AzureWorker>(&encoded).expect("decode"), worker);
+    assert!(serde_json::from_str::<AzureWorker>(&encoded.replace("\"image\"", "\"extra\":1,\"image\"")).is_err());
+    let tampered = encoded.replace(&group, "horizon-ws-other");
+    let error = serde_json::from_str::<AzureWorker>(&tampered).expect_err("tampered handle is rejected while decoding");
+    assert!(error.to_string().contains("persisted Azure worker identity is invalid"));
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -148,6 +148,7 @@ fn resource_group_reads_are_typed_bounded_and_identity_checked() {
         [("horizon-job-id".to_string(), "j".to_string())].into(),
         "non-string tags are dropped"
     );
+    assert_eq!(info.id, format!("/subscriptions/{SUB}/resourceGroups/{GROUP}"));
     assert_eq!(
         transport.get_resource_group(GROUP),
         Err(AzureError::ResourceIdentityMismatch),
@@ -225,6 +226,11 @@ fn resource_group_writes_send_exact_bodies_and_map_long_running_states() {
         .create_resource_group(GROUP, "northeurope", &tags)
         .expect("created");
     assert_eq!((info.name.as_str(), info.tags), (GROUP, tags.clone()));
+    assert_eq!(
+        info.id,
+        format!("/subscriptions/{SUB}/resourceGroups/{GROUP}"),
+        "the returned id is retained verbatim"
+    );
     assert_eq!(
         transport.delete_resource_group(GROUP),
         Ok(AzureLongRunningState::Accepted)

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -11,6 +11,9 @@ use std::collections::BTreeMap;
 /// Resource group as observed from ARM.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AzureGroupInfo {
+    /// Group-level ARM resource ID as returned, verified against the requested
+    /// subscription and group; the provider persists exactly this value.
+    pub id: String,
     pub name: String,
     pub location: String,
     pub provisioning_state: String,
@@ -274,6 +277,7 @@ fn group_info(
         return Err(AzureError::ResourceIdentityMismatch);
     }
     Ok(AzureGroupInfo {
+        id,
         name,
         location: text(value, "/location").unwrap_or_default(),
         provisioning_state: text(value, "/properties/provisioningState").unwrap_or_default(),


### PR DESCRIPTION
## Summary

Third isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open; the provider and the wiring follow). No configuration, dispatcher or UI wiring.

- **Worker identity** (`AzureWorker`, `resource_group_name`): one resource group per worker named `horizon-ws-<workflow>-<job>`; the handle carries the group-level ARM resource ID as Azure returned it on creation (the group is the unit of ownership and deletion, and its ID is known before the VM exists), checked against subscription and group. The VM inside is always the constant name. A persisted handle is validated while it is decoded (`try_from` snapshot) and only the persistent lifetime is accepted, so a tampered, renamed or leased handle never exists in memory.
- **Deployment plan** (`AzureDeploymentPlan::new(profile, request)`): the single incremental ARM deployment for a worker. Network security group allowing only TCP 2222 inbound, virtual network and subnet, a Standard static IPv4 address, a NIC, a declared managed data disk of `disk_gib`, and an Ubuntu 24.04 VM with the user-assigned image-pull identity and a 30 GiB OS disk. The profile accepts VM sizes only from an exact table (`SUPPORTED_VM_SIZES`: Dsv3, Dsv5, Dasv5, Esv5 including three constrained-vCPU forms, Fsv2 and B-series sizes, all x64, generation 2 and premium-capable) matched by equality, so no nonexistent, Arm64, generation 1 only or premium-incapable size can reach a paid call; the table is extended only after a live check of the new size. Both disks use the profile's `disk_sku` (default `StandardSSD_LRS`, or `Premium_LRS`). The data disk is attached by resource ID and detached rather than deleted with the VM; the OS disk is deleted with the VM. `adminPublicKey` and `customData` are `securestring` parameters. Every declared resource carries the identity tags (workflow, job, protocol version, lifetime, image digest, SHA-256 of the client key); the OS disk, which ARM creates from the image and cannot tag at creation, is owned through the group. Outputs the public address.
- **cloud-init**: Docker from the distribution, a blank data disk formatted once as ext4 (a disk carrying any other filesystem is refused, never reformatted) and mounted at `/mnt/horizon-workspace` before Docker starts (`RequiresMountsFor` drop-in, `nofail` fstab entry), registry login through the VM identity via the instance metadata service (identity selected by percent-encoded resource ID, token exchanged for a registry refresh token, every call time-bounded and retried on transient failures while authentication errors fail at once, credential kept in a temporary Docker config that an EXIT trap removes on success and every failure path), a pull retried with backoff, then the digest-pinned image started with `/workspace` bound to the disk, port 2222 forwarded to the container's SSH daemon, and `HORIZON_SSH_PUBLIC_KEY` read from a root-only file that cloud-init wrote from base64. Before the container can start the host is sealed against it: boot-persistent firewall rules (`iptables-persistent`) drop container traffic to the instance metadata service, so nothing inside can mint fresh identity tokens, and drop bridge traffic to the host's SSH port; host SSH is disabled outright, so the admin key the image format requires is inert. The ARM run command remains the operator's path into the host. No operator-controlled text is interpolated into YAML or shell; image and registry names are additionally restricted to a safe byte set.
- **Lifetime policy**: persistent only. A time-limited request is refused with `UnsupportedLifetime` rather than converted, as the provider contract requires. A correct time-limited bound on Azure needs either a power role for the VM identity or a scheduler design; that is a separate decision recorded for #474.

Compared with the spike harness this drops the DevTestLab schedule and the spike-only guest timer, uses the `Internet` service tag for the SSH rule (key-only authentication with a pinned host key; clients roam), and selects the identity by resource ID instead of a client ID.

## Tests

`cloud_run::azure::tests::identity` (1) and `::deployment` (4): exact identity and strict group-ID parsing including tampered persisted handles and syntactically valid leases that must not decode; parameters and tags derived from the request; template shape (resource order, API versions, tags and location on every resource, single NSG rule on 2222, static Standard IP, user-assigned identity, data disk from the parameter, password authentication disabled, secure parameters, no DevTestLab schedule); cloud-init content with a hostile key comment proving the raw key never appears, the base64 file is used, the pull is digest-pinned and no control characters leak; rejection of time-limited lifetime, foreign registry, non-Ed25519 key, oversized disk, cost cap and invalid profile before any I/O.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.

## Follow-ups

1. Provider implementing `InteractiveWorkerProvider`: create-once fence, submit this plan, non-creating reconcile and inspect, host key through run-command, exact delete, deallocate and start for Stop.
2. Coordinate on #474: the worker image's provider-bootstrap path currently requires a RunPod pod ID; Azure uses the plain startup path until that is generalised.
3. Wiring into configuration, dispatchers and UI once the common provider boundary settles.
