### PR TITLE
feat(cloud): inspect exact persistent network volumes

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -14,6 +14,7 @@ mod host_key;
 mod http;
 mod interactive;
 mod models;
+mod network_volume;
 mod stop;
 #[cfg(test)]
 mod tests;
@@ -25,6 +26,7 @@ pub use models::{
     RunPodCleanup, RunPodEnsure, RunPodError, RunPodLifecycle, RunPodProfile, RunPodSshEndpoint, RunPodWorker,
     RunPodWorkerStatus,
 };
+pub use network_volume::{RunPodNetworkVolume, RunPodNetworkVolumeExpectation};
 
 const WORKFLOW_ENV: &str = "HORIZON_WORKFLOW_ID";
 const JOB_ENV: &str = "HORIZON_JOB_ID";
@@ -383,6 +385,7 @@ impl RunPodClient {
     }
 }
 trait Transport: Send + Sync {
+    fn network_volume(&self, volume_id: &str) -> Result<Option<network_volume::ApiNetworkVolume>, RunPodError>;
     fn list_by_name(&self, name: &str) -> Result<Vec<ApiPod>, RunPodError>;
     fn create(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError>;
     fn get(&self, pod_id: &str) -> Result<Option<ApiPod>, RunPodError>;

--- a/crates/horizon-core/src/cloud_run/runpod/diagnostics/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/diagnostics/tests.rs
@@ -298,6 +298,12 @@ fn provider_ensure_emits_once_without_changing_the_error_or_issuing_cleanup() {
 
     struct RejectedCreate(Arc<AtomicUsize>);
     impl Transport for RejectedCreate {
+        fn network_volume(
+            &self,
+            _: &str,
+        ) -> Result<Option<super::super::network_volume::ApiNetworkVolume>, RunPodError> {
+            panic!("unexpected network volume inspection")
+        }
         fn list_by_name(&self, _: &str) -> Result<Vec<ApiPod>, RunPodError> {
             Ok(Vec::new())
         }
@@ -342,6 +348,12 @@ fn invalid_requests_emit_once_without_any_provider_operation() {
 
     struct NoProviderCalls;
     impl Transport for NoProviderCalls {
+        fn network_volume(
+            &self,
+            _: &str,
+        ) -> Result<Option<super::super::network_volume::ApiNetworkVolume>, RunPodError> {
+            panic!("unexpected network volume inspection")
+        }
         fn list_by_name(&self, _: &str) -> Result<Vec<ApiPod>, RunPodError> {
             panic!("unexpected lookup")
         }

--- a/crates/horizon-core/src/cloud_run/runpod/http.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http.rs
@@ -1,5 +1,6 @@
 use super::{ApiPod, CreatePodRequest, RunPodApiKey, RunPodCleanup, RunPodError, Transport, valid_provider_id};
 use std::{thread, time::Duration};
+mod network_volume;
 const PODS_URL: &str = "https://api.runpod.io/v2/pods";
 const GRAPHQL_URL: &str = "https://api.runpod.io/graphql";
 const CREATE_MUTATION: &str =
@@ -88,6 +89,9 @@ impl RunPodHttp {
     }
 }
 impl Transport for RunPodHttp {
+    fn network_volume(&self, volume_id: &str) -> Result<Option<super::network_volume::ApiNetworkVolume>, RunPodError> {
+        self.get_network_volume(volume_id)
+    }
     fn list_by_name(&self, name: &str) -> Result<Vec<ApiPod>, RunPodError> {
         let response = self
             .agent

--- a/crates/horizon-core/src/cloud_run/runpod/http/network_volume.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http/network_volume.rs
@@ -1,0 +1,22 @@
+use super::super::network_volume::ApiNetworkVolume;
+use super::{RunPodError, RunPodHttp, decode_json, valid_provider_id};
+
+const OPERATION: &str = "network volume inspection";
+
+impl RunPodHttp {
+    pub(super) fn get_network_volume(&self, volume_id: &str) -> Result<Option<ApiNetworkVolume>, RunPodError> {
+        if !valid_provider_id(volume_id) {
+            return Err(RunPodError::InvalidTarget);
+        }
+        let response = self
+            .agent
+            .get(format!("https://api.runpod.io/v2/network-volumes/{volume_id}"))
+            .header("Authorization", &self.authorization)
+            .call()
+            .map_err(|_| RunPodError::RequestFailed { operation: OPERATION })?;
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        decode_json(response, 200, OPERATION).map(Some)
+    }
+}

--- a/crates/horizon-core/src/cloud_run/runpod/network_volume.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_volume.rs
@@ -1,0 +1,79 @@
+//! Read-only, exact-ID provider observations; never volume ownership or attachment authority.
+
+use super::{RunPodClient, RunPodError, valid_provider_id};
+use serde::Deserialize;
+
+const MIN_VOLUME_GB: u32 = 10;
+const MAX_VOLUME_GB: u32 = 4_096;
+
+/// Caller-selected constraints for one provider network-volume observation.
+/// These values do not establish ownership, exclusive attachment or a durable binding.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunPodNetworkVolumeExpectation {
+    pub volume_id: String,
+    pub data_center_id: String,
+    /// Provider-reported allocated GB, not measured free space.
+    pub minimum_size_gb: u32,
+}
+
+/// Point-in-time metadata for a matching High-Performance network volume.
+///
+/// This is not proof of ownership, exclusivity, mount permissions, filesystem
+/// durability or available capacity. It does not authorize attach, Stop or Delete.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunPodNetworkVolume {
+    pub volume_id: String,
+    pub data_center_id: String,
+    pub size_gb: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ApiNetworkVolume {
+    id: String,
+    data_center: String,
+    size: u32,
+    #[serde(rename = "type")]
+    storage_type: String,
+}
+
+impl RunPodClient {
+    /// Observe one exact network volume without listing, creating or modifying resources.
+    ///
+    /// `None` means the provider returned 404. A present response must match the
+    /// requested ID, data center and minimum size, with tier `HIGH_PERFORMANCE`.
+    /// A successful observation is not a persisted storage-identity binding.
+    ///
+    /// # Errors
+    /// Rejects invalid expectations before I/O, mismatched metadata, malformed or
+    /// oversized responses, transport failures and non-404 unsuccessful statuses.
+    pub fn inspect_high_performance_volume(
+        &self,
+        expected: &RunPodNetworkVolumeExpectation,
+    ) -> Result<Option<RunPodNetworkVolume>, RunPodError> {
+        if !valid_provider_id(&expected.volume_id)
+            || !valid_provider_id(&expected.data_center_id)
+            || !(MIN_VOLUME_GB..=MAX_VOLUME_GB).contains(&expected.minimum_size_gb)
+        {
+            return Err(RunPodError::InvalidTarget);
+        }
+        let Some(volume) = self.transport.network_volume(&expected.volume_id)? else {
+            return Ok(None);
+        };
+        if volume.id != expected.volume_id
+            || volume.data_center != expected.data_center_id
+            || volume.storage_type != "HIGH_PERFORMANCE"
+            || !(expected.minimum_size_gb..=MAX_VOLUME_GB).contains(&volume.size)
+        {
+            return Err(RunPodError::ResourceIdentityMismatch);
+        }
+        Ok(Some(RunPodNetworkVolume {
+            volume_id: volume.id,
+            data_center_id: volume.data_center,
+            size_gb: volume.size,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/runpod/network_volume/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_volume/tests.rs
@@ -1,0 +1,188 @@
+use super::super::http::RunPodHttp;
+use super::*;
+use serde_json::{Value, json};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use ureq::{
+    Body, SendBody,
+    http::{Request, Response},
+    middleware::MiddlewareNext,
+};
+
+const OPERATION: &str = "network volume inspection";
+const PRIVATE_SENTINEL: &str = "private-provider-response-never-disclosed";
+
+fn expectation() -> RunPodNetworkVolumeExpectation {
+    RunPodNetworkVolumeExpectation {
+        volume_id: "volume_exact".into(),
+        data_center_id: "EU-TEST-1".into(),
+        minimum_size_gb: 10,
+    }
+}
+
+fn metadata() -> Value {
+    // Documented v2 GET shape: id, name, size, dataCenter and immutable type.
+    json!({"id": "volume_exact", "name": PRIVATE_SENTINEL, "size": 10,
+        "dataCenter": "EU-TEST-1", "type": "HIGH_PERFORMANCE"})
+}
+
+fn client(status: u16, body: String) -> (RunPodClient, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&calls);
+    let agent = ureq::Agent::config_builder()
+        .middleware(move |request: Request<SendBody>, _: MiddlewareNext| {
+            count.fetch_add(1, Ordering::SeqCst);
+            // Any list, Pod inspection, create, Stop or Delete call fails here.
+            assert_eq!(request.method(), "GET");
+            assert_eq!(request.uri(), "https://api.runpod.io/v2/network-volumes/volume_exact");
+            assert_eq!(request.headers()["Authorization"], "Bearer synthetic-credential");
+            Ok(Response::builder()
+                .status(status)
+                .body(Body::builder().data(body.clone()))
+                .expect("response"))
+        })
+        .build()
+        .new_agent();
+    (RunPodClient::with_transport(RunPodHttp::mock(agent)), calls)
+}
+
+#[test]
+fn matching_hps_metadata_is_one_exact_read_not_ownership_or_free_space() {
+    for size in [10, 64, 4_096] {
+        let mut body = metadata();
+        body["size"] = json!(size);
+        let (client, calls) = client(200, body.to_string());
+        let observed = client
+            .inspect_high_performance_volume(&expectation())
+            .expect("observation")
+            .expect("present");
+        assert_eq!(
+            observed,
+            RunPodNetworkVolume {
+                volume_id: "volume_exact".into(),
+                data_center_id: "EU-TEST-1".into(),
+                size_gb: size,
+            }
+        );
+        assert!(!format!("{observed:?}").contains(PRIVATE_SENTINEL));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn invalid_expectations_do_not_send_any_request() {
+    let mut invalid = Vec::new();
+    for value in ["", "../foreign", "volume?secret", "line\nbreak"] {
+        invalid.push(RunPodNetworkVolumeExpectation {
+            volume_id: value.into(),
+            ..expectation()
+        });
+        invalid.push(RunPodNetworkVolumeExpectation {
+            data_center_id: value.into(),
+            ..expectation()
+        });
+    }
+    invalid.push(RunPodNetworkVolumeExpectation {
+        volume_id: "x".repeat(192),
+        ..expectation()
+    });
+    invalid.push(RunPodNetworkVolumeExpectation {
+        data_center_id: "x".repeat(192),
+        ..expectation()
+    });
+    for size in [0, 9, 4_097, u32::MAX] {
+        invalid.push(RunPodNetworkVolumeExpectation {
+            minimum_size_gb: size,
+            ..expectation()
+        });
+    }
+    for expected in invalid {
+        let (client, calls) = client(200, metadata().to_string());
+        assert_eq!(
+            client.inspect_high_performance_volume(&expected),
+            Err(RunPodError::InvalidTarget)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn different_identity_location_tier_or_size_cannot_be_adopted() {
+    for (field, value) in [
+        ("id", json!("other_volume")),
+        ("dataCenter", json!("OTHER-DC")),
+        ("type", json!("STANDARD")),
+        ("type", json!("UNKNOWN")),
+        ("size", json!(9)),
+        ("size", json!(4_097)),
+    ] {
+        let mut body = metadata();
+        body[field] = value;
+        let (client, calls) = client(200, body.to_string());
+        assert_eq!(
+            client.inspect_high_performance_volume(&expectation()),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+    let (client, _) = client(200, metadata().to_string());
+    assert_eq!(
+        client.inspect_high_performance_volume(&RunPodNetworkVolumeExpectation {
+            minimum_size_gb: 11,
+            ..expectation()
+        }),
+        Err(RunPodError::ResourceIdentityMismatch)
+    );
+}
+
+#[test]
+fn missing_invalid_and_oversized_responses_remain_redacted() {
+    let mut invalid = vec![
+        PRIVATE_SENTINEL.into(),
+        format!("{{\"padding\":\"{}\"}}", "x".repeat(2 * 1024 * 1024)),
+    ];
+    for field in ["id", "size", "dataCenter", "type"] {
+        let mut body = metadata();
+        body.as_object_mut().expect("object").remove(field);
+        invalid.push(body.to_string());
+        let mut body = metadata();
+        body[field] = Value::Null;
+        invalid.push(body.to_string());
+    }
+    for size in [json!(-1), json!(1.5), json!("10"), json!(u64::MAX)] {
+        let mut body = metadata();
+        body["size"] = size;
+        invalid.push(body.to_string());
+    }
+    for body in invalid {
+        let (client, calls) = client(200, body);
+        let error = client
+            .inspect_high_performance_volume(&expectation())
+            .expect_err("invalid response");
+        assert_eq!(error, RunPodError::InvalidResponse { operation: OPERATION });
+        assert!(!error.to_string().contains(PRIVATE_SENTINEL));
+        assert!(!format!("{error:?}").contains(PRIVATE_SENTINEL));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn only_404_is_absence_and_status_errors_do_not_expose_bodies() {
+    for status in [200, 204, 302, 401, 403, 404, 429, 500] {
+        let (client, calls) = client(status, PRIVATE_SENTINEL.into());
+        let expected = match status {
+            404 => Ok(None),
+            200 => Err(RunPodError::InvalidResponse { operation: OPERATION }),
+            _ => Err(RunPodError::UnexpectedStatus {
+                operation: OPERATION,
+                status,
+            }),
+        };
+        let actual = client.inspect_high_performance_volume(&expectation());
+        assert_eq!(actual, expected);
+        assert!(!format!("{actual:?}").contains(PRIVATE_SENTINEL));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -49,6 +49,9 @@ impl FakeTransport {
     }
 }
 impl Transport for FakeTransport {
+    fn network_volume(&self, _: &str) -> Result<Option<network_volume::ApiNetworkVolume>, RunPodError> {
+        panic!("existing Pod operations must not inspect network volumes")
+    }
     fn list_by_name(&self, _name: &str) -> Result<Vec<ApiPod>, RunPodError> {
         let mut state = self.0.lock().expect("state");
         state.list_calls += 1;

--- a/docs/architecture/remote-worker-host-identity.md
+++ b/docs/architecture/remote-worker-host-identity.md
@@ -90,6 +90,14 @@ separate ext4-only repository importer contract. Actual worker bootstrap,
 Stop/restart persistence, provider-volume ownership and unchanged client pin
 still require exact-source integration and live verification.
 
+The RunPod client can read one exact network-volume ID and require the expected
+data center, allocated size and `HIGH_PERFORMANCE` tier from the
+[v2 metadata response](https://docs.runpod.io/api-reference-v2/network-volumes/get-a-network-volume).
+This point-in-time observation neither creates nor attaches storage and does not
+establish ownership, exclusive access, mount safety or a durable identity binding.
+Those remain separate prerequisites for provisioning, Stop and recovery; editing
+a named profile must not silently replace a retained volume.
+
 Remaining actions: integrate provider-retained volumes and remote backups;
 preserve task/agent state and session markers; implement explicit Stop/recovery;
 complete exact-head cloud acceptance without touching unrelated resources.


### PR DESCRIPTION
## Purpose

Advance #473 and #383 with a read-only verification boundary for an explicitly selected persistent network volume. This is a prerequisite for binding storage to a workspace generation, not automatic provisioning or cloud acceptance.

## Behavior

- Inspect exactly one selected volume through the authenticated provider API; never list, create, attach, stop or delete resources.
- Require the exact volume ID and data center, the requested minimum allocated size, and the high-performance storage tier. Invalid expectations fail before network access; only HTTP 404 means absence.
- Reuse bounded response parsing, request timeouts and disabled redirects. Errors omit response bodies; ignored descriptive metadata is not retained.
- Preserve all existing Pod operations and configuration. An observation proves neither ownership nor exclusive access, mount safety, free space or durable identity binding.

The response model follows the [documented v2 volume endpoint](https://docs.runpod.io/api-reference-v2/network-volumes/get-a-network-volume). There are no new dependencies, UI changes, saved-state migration or provider mutations. Attachment, generation-bound identity, retained Stop, remote Git and client-off acceptance remain separate work.

## Validation

Candidate: `5546ad976faaede11bc04b1695547b55c140015f`, based on `ebf33e7f998b45a75618e5ce290afee7caee15a5`.

- Independent local full-diff review completed with no actionable in-scope findings.
- All 61 focused provider tests passed, including five new tests with multiple positive and negative cases.
- Synthetic HTTP coverage verifies one exact authenticated GET, zero unrelated provider operations, pre-I/O rejection, identity/location/tier/size mismatches, malformed and oversized data, HTTP absence versus errors, and response-body redaction.
- All eight final gates passed on the exact committed source: formatting, maintainability, version sync, default and speech-enabled workspace tests, and blocking, strict and advisory Clippy. The source and lockfile remained unchanged; no reruns were needed.

No real credentials or cloud resources were used in these tests. This controller-side read API does not change UI or worker runtime behavior and does not establish cloud durability or client-off acceptance.

Scope: 311 source/test additions across seven files, plus eight architecture-note lines.
