### PR TITLE
feat(cloud): add Azure worker provider

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -1,7 +1,7 @@
-//! Azure Linux VM worker foundations for #474: operator profile, exact worker
-//! identity, lifecycle mapping, credential source, typed errors, the bounded Resource
-//! Manager transport and the deployment plan. The provider is a separate slice;
-//! nothing is wired into configuration or UI.
+//! Azure Linux VM worker adapter for #474: operator profile, exact worker identity,
+//! lifecycle mapping, credential source, typed errors, the bounded Resource Manager
+//! transport, the deployment plan and the provider. Nothing is wired into
+//! configuration or UI yet.
 use super::{
     CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget,
     interactive_worker::{InteractiveWorkerLifetime, valid_worker_target},
@@ -12,12 +12,14 @@ use std::time::Duration;
 use thiserror::Error;
 mod credential;
 pub mod deployment;
+mod provider;
 #[cfg(test)]
 mod tests;
 mod transport;
 
 pub use credential::{AzureAccessToken, AzureCliCredential, AzureCredentialSource};
 pub use deployment::AzureDeploymentPlan;
+pub use provider::{AzureClient, AzureCreationFence};
 pub use transport::{
     AzureArmHttp, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport, AzureVmView,
 };
@@ -249,6 +251,21 @@ pub enum AzureError {
     InvalidResponse { operation: &'static str },
     #[error("Azure returned an invalid or mismatched resource identity")]
     ResourceIdentityMismatch,
+    #[error("durable creation claim could not be read or recorded")]
+    CreationFenceFailed,
+    #[error("the worker's VM size or location no longer matches the profile")]
+    PlacementMismatch,
+    #[error(
+        "the worker resource group could not be resolved during ensure (claim held elsewhere, or the group vanished); retry ensure"
+    )]
+    CreationUnresolved,
+    #[error("worker resource group exists but its deployment submission is unconfirmed; retry ensure")]
+    CreationIncomplete {
+        #[source]
+        cause: Box<AzureError>,
+    },
+    #[error("worker stop did not reach a verified retained inactive state")]
+    StopUnverified,
 }
 
 /// Parsed `/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{kind}/{name}`.

--- a/crates/horizon-core/src/cloud_run/azure/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/deployment.rs
@@ -9,7 +9,10 @@ use super::{AzureError, AzureProfile, COMPUTE_API_VERSION, WORKER_VM_NAME, resou
 /// Network and disk resource API versions used inside the template.
 const NETWORK_API_VERSION: &str = "2023-11-01";
 const DISK_API_VERSION: &str = "2023-10-02";
-use crate::cloud_run::{CLOUD_RUN_PROTOCOL_VERSION, WorkerLifetime, interactive_worker::InteractiveWorkerRequest};
+use crate::cloud_run::{
+    CLOUD_RUN_PROTOCOL_VERSION, CloudJobId, CloudWorkflowId, WorkerLifetime, WorkerTarget,
+    interactive_worker::InteractiveWorkerRequest,
+};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use sha2::{Digest as _, Sha256};
 use std::collections::BTreeMap;
@@ -27,6 +30,12 @@ pub const TAG_PROTOCOL: &str = "horizon-cloud-protocol-version";
 pub const TAG_LIFETIME: &str = "horizon-worker-lifetime";
 pub const TAG_IMAGE_DIGEST: &str = "horizon-worker-image-digest";
 pub const TAG_CLIENT_KEY_DIGEST: &str = "horizon-client-key-sha256";
+pub const TAG_DISK_GIB: &str = "horizon-worker-disk-gib";
+/// SHA-256 of the profile name: tag-safe regardless of the characters a name contains.
+pub const TAG_PROFILE: &str = "horizon-worker-profile-sha256";
+/// SHA-256 of the complete image reference (registry, repository and digest), so two
+/// repositories sharing one manifest digest never pass as the same worker.
+pub const TAG_IMAGE_REF_DIGEST: &str = "horizon-worker-image-ref-sha256";
 const LIFETIME_PERSISTENT: &str = "persistent";
 const ADMIN_USERNAME: &str = "azureuser";
 const OS_DISK_GIB: u32 = 30;
@@ -84,23 +93,42 @@ impl AzureDeploymentPlan {
 }
 
 /// Identity tags: exact workflow and job, protocol version, lifetime policy, image
-/// digest and the SHA-256 of the client key, so ownership is provable without
-/// reading the guest.
+/// digest, the SHA-256 of the client key, the data disk size, the profile name and the
+/// SHA-256 of the full image reference, so ownership and the complete target are
+/// provable without reading the guest.
 #[must_use]
 pub fn worker_tags(request: &InteractiveWorkerRequest) -> BTreeMap<String, String> {
-    let digest = request
-        .target
+    identity_tags(
+        request.workflow_id,
+        request.job_id,
+        &request.target,
+        &request.ssh_public_key,
+    )
+}
+
+/// The same tags computed from a persisted handle's parts, for ownership checks.
+#[must_use]
+pub fn identity_tags(
+    workflow_id: CloudWorkflowId,
+    job_id: CloudJobId,
+    target: &WorkerTarget,
+    ssh_public_key: &str,
+) -> BTreeMap<String, String> {
+    let digest = target
         .image
         .rsplit_once("@sha256:")
         .map(|(_, digest)| digest)
         .unwrap_or_default();
     [
-        (TAG_WORKFLOW, request.workflow_id.to_string()),
-        (TAG_JOB, request.job_id.to_string()),
+        (TAG_WORKFLOW, workflow_id.to_string()),
+        (TAG_JOB, job_id.to_string()),
         (TAG_PROTOCOL, CLOUD_RUN_PROTOCOL_VERSION.to_string()),
         (TAG_LIFETIME, LIFETIME_PERSISTENT.to_string()),
         (TAG_IMAGE_DIGEST, digest.to_string()),
-        (TAG_CLIENT_KEY_DIGEST, client_key_digest(&request.ssh_public_key)),
+        (TAG_CLIENT_KEY_DIGEST, client_key_digest(ssh_public_key)),
+        (TAG_DISK_GIB, target.disk_gib.to_string()),
+        (TAG_PROFILE, sha256_hex(&target.profile)),
+        (TAG_IMAGE_REF_DIGEST, sha256_hex(&target.image)),
     ]
     .into_iter()
     .map(|(key, value)| (key.to_string(), value))
@@ -110,7 +138,11 @@ pub fn worker_tags(request: &InteractiveWorkerRequest) -> BTreeMap<String, Strin
 /// Lowercase hex SHA-256 of the exact client public key string.
 #[must_use]
 pub fn client_key_digest(ssh_public_key: &str) -> String {
-    Sha256::digest(ssh_public_key.as_bytes())
+    sha256_hex(ssh_public_key)
+}
+
+fn sha256_hex(value: &str) -> String {
+    Sha256::digest(value.as_bytes())
         .iter()
         .fold(String::with_capacity(64), |mut hex, byte| {
             use std::fmt::Write as _;

--- a/crates/horizon-core/src/cloud_run/azure/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider.rs
@@ -1,0 +1,473 @@
+//! The Azure provider behind the common interactive-worker contract: create once
+//! behind a durable fence, recover and inspect without creating, and delete exactly
+//! the owned resource group. SSH readiness (host-key attestation) and explicit Stop
+//! are the next slice.
+use super::{
+    AzureDeploymentPlan, AzureError, AzureGroupInfo, AzureLifecycle, AzureManagementTransport, AzureProfile,
+    AzureVmView, AzureWorker, WORKER_VM_NAME,
+    deployment::{DEPLOYMENT_NAME, identity_tags, worker_tags},
+    resource_group_name,
+};
+use crate::cloud_run::{
+    CloudJobId, CloudProvider, CloudWorkflowId, WorkerTarget,
+    interactive_worker::{
+        InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+        InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest,
+        InteractiveWorkerStatus,
+    },
+};
+use std::collections::BTreeMap;
+
+/// Durable, cross-controller compare-and-set whose claim survives process exit. A
+/// resource group name may return `true` at most once. The workflow store implements
+/// it where the production client is assembled.
+pub trait AzureCreationFence: Send + Sync {
+    /// # Errors
+    /// Returns [`AzureError::CreationFenceFailed`] when the durable claim cannot be read
+    /// or recorded; the underlying cause stays with the adapter, never in this error.
+    fn claim_once(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        resource_group: &str,
+    ) -> Result<bool, AzureError>;
+}
+
+impl<F> AzureCreationFence for F
+where
+    F: Fn(CloudWorkflowId, CloudJobId, &WorkerTarget, &str) -> Result<bool, AzureError> + Send + Sync,
+{
+    fn claim_once(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        resource_group: &str,
+    ) -> Result<bool, AzureError> {
+        self(workflow_id, job_id, target, resource_group)
+    }
+}
+
+/// Provider for persistent Azure CPU workers.
+pub struct AzureClient {
+    profile: AzureProfile,
+    transport: Box<dyn AzureManagementTransport>,
+    fence: Box<dyn AzureCreationFence>,
+}
+
+/// Whether an observation must also match the current profile's VM size and location.
+/// Request-driven paths enforce it; persisted-handle paths stay policy-independent.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Placement {
+    Enforce,
+    Ignore,
+}
+
+/// How `ensure` came by the worker's group.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Origin {
+    /// Found before the fence: this controller's earlier work, repairable.
+    Existing,
+    /// Created by this call, repairable.
+    Created,
+    /// Appeared during the claim: another controller's work, observed only.
+    Adopted,
+}
+
+/// One worker's exact handle plus what the control plane currently shows.
+#[derive(Debug)]
+struct Observation {
+    worker: AzureWorker,
+    lifecycle: AzureLifecycle,
+    /// Neither a deployment nor a VM exists yet: the only state repair may act on.
+    bare: bool,
+}
+
+impl AzureClient {
+    /// Client over any management transport; the HTTPS production constructor arrives
+    /// with the configuration wiring that first needs it.
+    /// # Errors
+    /// Rejects an invalid profile.
+    pub fn with_transport(
+        profile: AzureProfile,
+        transport: impl AzureManagementTransport + 'static,
+        fence: impl AzureCreationFence + 'static,
+    ) -> Result<Self, AzureError> {
+        profile.validate()?;
+        // A transport for another subscription would create in the wrong place and then
+        // reject every handle it produced.
+        if transport.subscription_id() != profile.subscription_id {
+            return Err(AzureError::InvalidProfile);
+        }
+        Ok(Self {
+            profile,
+            transport: Box::new(transport),
+            fence: Box::new(fence),
+        })
+    }
+
+    /// The persisted handle, shape-checked before any I/O. Cost and placement policy are
+    /// not re-applied, so a handle stays inspectable and deletable after profile changes,
+    /// with one deliberate exception: a handle is bound to the profile's subscription,
+    /// and a profile pointed at another subscription cannot address it.
+    fn handle(&self, worker: &InteractiveWorker) -> Result<AzureWorker, AzureError> {
+        if !worker.is_valid_for(CloudProvider::Azure) {
+            return Err(AzureError::InvalidPersistedWorker);
+        }
+        let handle = AzureWorker {
+            workflow_id: worker.identity.workflow_id,
+            job_id: worker.identity.job_id,
+            subscription_id: self.profile.subscription_id.clone(),
+            resource_group: resource_group_name(worker.identity.workflow_id, worker.identity.job_id),
+            group_id: worker.identity.resource_id.clone(),
+            image: worker.target.image.clone(),
+            lifetime: worker.lifetime.clone(),
+        };
+        handle.validate().map(|()| handle)
+    }
+
+    /// Every identity tag must match on the group itself.
+    fn owned_group(
+        &self,
+        group: &str,
+        expected: &BTreeMap<String, String>,
+    ) -> Result<Option<AzureGroupInfo>, AzureError> {
+        let Some(info) = self.transport.get_resource_group(group)? else {
+            return Ok(None);
+        };
+        if expected.iter().any(|(key, value)| info.tags.get(key) != Some(value)) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
+        Ok(Some(info))
+    }
+
+    fn worker_for(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        group: &AzureGroupInfo,
+        image: &str,
+    ) -> AzureWorker {
+        AzureWorker {
+            workflow_id,
+            job_id,
+            subscription_id: self.profile.subscription_id.clone(),
+            resource_group: group.name.clone(),
+            group_id: group.id.clone(),
+            image: image.to_string(),
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        }
+    }
+
+    /// What the control plane shows for an owned group: the VM when it exists, else the
+    /// deployment that should produce it. `resubmit` lets `ensure` repair a group whose
+    /// deployment was never recorded; recovery never resubmits; a deleting group is left alone.
+    fn observe(
+        &self,
+        worker: AzureWorker,
+        group: &AzureGroupInfo,
+        expected: &BTreeMap<String, String>,
+        resubmit: Option<&AzureDeploymentPlan>,
+        placement: Placement,
+    ) -> Result<Option<Observation>, AzureError> {
+        if group.provisioning_state == "Deleting" {
+            // Re-prove before reporting: the snapshot may predate a retag or removal.
+            return Ok(self
+                .owned_group(&worker.resource_group, expected)?
+                .map(|_| Observation {
+                    worker,
+                    lifecycle: AzureLifecycle::Deleting,
+                    bare: false,
+                }));
+        }
+        // The group's region is immutable; a profile moved to another region under the
+        // same name must never repair into, or serve, a group in the old one.
+        if placement == Placement::Enforce && group.location != self.profile.location {
+            return Err(AzureError::PlacementMismatch);
+        }
+        let deployment = self.transport.get_deployment(&worker.resource_group, DEPLOYMENT_NAME)?;
+        let deployment_state = deployment.as_ref().map(|state| state.provisioning_state.as_str());
+        let host = deployment
+            .as_ref()
+            .filter(|state| state.provisioning_state == "Succeeded")
+            .and_then(|state| state.outputs.get("publicIp").cloned())
+            .filter(|host| host.parse::<std::net::IpAddr>().is_ok_and(routable));
+        let vm = self.transport.get_vm(&worker.resource_group, WORKER_VM_NAME)?;
+        let lifecycle = match &vm {
+            Some(vm) => {
+                if expected.iter().any(|(key, value)| vm.tags.get(key) != Some(value)) {
+                    return Err(AzureError::ResourceIdentityMismatch);
+                }
+                // A terminal deployment failure wins over everything the leftover VM shows.
+                if matches!(deployment_state, Some("Failed" | "Canceled")) {
+                    AzureLifecycle::Failed
+                } else if placement == Placement::Enforce
+                    && (vm.vm_size != self.profile.vm_size || vm.location != self.profile.location)
+                {
+                    // A profile edited under the same name, or a VM resized out of band,
+                    // must not be served as the requested target on request-driven paths.
+                    return Err(AzureError::PlacementMismatch);
+                } else {
+                    match vm_lifecycle(vm) {
+                        // Running but unreachable by design: neither ready nor provisioning.
+                        AzureLifecycle::Running if host.is_none() && deployment_state == Some("Succeeded") => {
+                            AzureLifecycle::Unknown
+                        }
+                        lifecycle => lifecycle,
+                    }
+                }
+            }
+            None => match (deployment_state, resubmit) {
+                (Some("Failed" | "Canceled"), _) => AzureLifecycle::Failed,
+                // A finished deployment without its VM, or a group with no deployment
+                // that recovery may not repair: ambiguous, never treated as retained.
+                (Some("Succeeded"), _) | (None, None) => AzureLifecycle::Unknown,
+                (Some(_), _) => AzureLifecycle::Transitioning,
+                // Repair only after a complete fresh observation right before the PUT: the
+                // group must still be owned and not deleting, and neither a deployment nor
+                // a VM may have appeared; anything that did is observed through the same
+                // identity, placement and lifecycle checks instead of being written over.
+                (None, Some(plan)) => match self.owned_group(&plan.resource_group, expected)? {
+                    Some(current) => match self.observe(worker.clone(), &current, expected, None, placement)? {
+                        Some(fresh) if fresh.bare && fresh.lifecycle != AzureLifecycle::Deleting => {
+                            self.submit(plan)?
+                        }
+                        fresh => return Ok(fresh),
+                    },
+                    None => return Ok(None),
+                },
+            },
+        };
+        // The reads above took time; a deletion or retag that began meanwhile must not be
+        // reported as a live state, and a group that vanished is absent, not a status.
+        let lifecycle = match self.owned_group(&worker.resource_group, expected)? {
+            Some(current) if current.provisioning_state == "Deleting" => AzureLifecycle::Deleting,
+            Some(current) if placement == Placement::Enforce && current.location != self.profile.location => {
+                return Err(AzureError::PlacementMismatch);
+            }
+            Some(_) => lifecycle,
+            None => return Ok(None),
+        };
+        let bare = vm.is_none() && deployment.is_none() && resubmit.is_none();
+        Ok(Some(Observation {
+            worker,
+            lifecycle,
+            bare,
+        }))
+    }
+
+    /// Submit the deployment; ARM may complete the PUT synchronously, even as failed. A
+    /// synchronous success means the VM now exists but was not yet observed, so the
+    /// worker is provisioning until the next observation, never `Unknown`.
+    fn submit(&self, plan: &AzureDeploymentPlan) -> Result<AzureLifecycle, AzureError> {
+        let state = self
+            .transport
+            .put_deployment(&plan.resource_group, DEPLOYMENT_NAME, &plan.template, &plan.parameters)
+            .map_err(|cause| AzureError::CreationIncomplete { cause: Box::new(cause) })?;
+        Ok(match state.provisioning_state.as_str() {
+            "Failed" | "Canceled" => AzureLifecycle::Failed,
+            _ => AzureLifecycle::Transitioning,
+        })
+    }
+
+    /// Common status for an observation. `Ready` requires a pinned host key, which the
+    /// readiness slice supplies; until then a running worker is reported `Provisioning`.
+    fn status(observation: Observation, target: &WorkerTarget, ssh_public_key: &str) -> InteractiveWorkerStatus {
+        let worker = AzureWorker {
+            image: target.image.clone(),
+            ..observation.worker
+        };
+        let lifecycle = match observation.lifecycle {
+            AzureLifecycle::Running | AzureLifecycle::Transitioning => InteractiveWorkerLifecycle::Provisioning,
+            AzureLifecycle::Deallocated => InteractiveWorkerLifecycle::Stopped,
+            AzureLifecycle::Failed => InteractiveWorkerLifecycle::Failed,
+            AzureLifecycle::Deleting => InteractiveWorkerLifecycle::Deleting,
+            // Guest halted but compute still billed: not a retained stop, not ready.
+            AzureLifecycle::StoppedAllocated | AzureLifecycle::Unknown => InteractiveWorkerLifecycle::Unknown,
+        };
+        InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::Azure,
+                    workflow_id: worker.workflow_id,
+                    job_id: worker.job_id,
+                    resource_id: worker.group_id,
+                },
+                target: target.clone(),
+                ssh_public_key: ssh_public_key.to_string(),
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            lifecycle,
+            ssh: None,
+        }
+    }
+
+    /// Create the group behind the durable fence. ARM is consulted again right before
+    /// the PUT: a group left by an earlier attempt or a concurrent controller is adopted
+    /// through the tag proof (or refused), never overwritten.
+    fn create(
+        &self,
+        plan: &AzureDeploymentPlan,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<(AzureGroupInfo, Origin), AzureError> {
+        let claimed = self.fence.claim_once(
+            request.workflow_id,
+            request.job_id,
+            &request.target,
+            &plan.resource_group,
+        )?;
+        // The group PUT is an upsert, so look once more immediately before it: anything
+        // that appeared since the first lookup must pass the same ownership proof and is
+        // then observed rather than overwritten.
+        match (claimed, self.owned_group(&plan.resource_group, &plan.tags)?) {
+            (_, Some(group)) => Ok((group, Origin::Adopted)),
+            (false, None) => Err(AzureError::CreationUnresolved),
+            (true, None) => {
+                let group = self
+                    .transport
+                    .create_resource_group(&plan.resource_group, &plan.location, &plan.tags)?;
+                Ok((group, Origin::Created))
+            }
+        }
+    }
+}
+
+/// A public address the worker can actually be reached on: no unspecified, loopback,
+/// multicast, link-local, private or unique-local values.
+fn routable(address: std::net::IpAddr) -> bool {
+    // An IPv4-mapped IPv6 value is judged by the IPv4 rules it represents.
+    let address = match address {
+        std::net::IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(address, std::net::IpAddr::V4),
+        v4 @ std::net::IpAddr::V4(_) => v4,
+    };
+    match address {
+        std::net::IpAddr::V4(v4) => {
+            !(v4.is_unspecified()
+                || v4.is_loopback()
+                || v4.is_multicast()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_private())
+        }
+        std::net::IpAddr::V6(v6) => {
+            !(v6.is_unspecified()
+                || v6.is_loopback()
+                || v6.is_multicast()
+                || v6.is_unicast_link_local()
+                || v6.is_unique_local())
+        }
+    }
+}
+
+fn vm_lifecycle(vm: &AzureVmView) -> AzureLifecycle {
+    AzureLifecycle::from_states(Some(&vm.provisioning_state), vm.power_state.as_deref())
+}
+
+impl InteractiveWorkerProvider for AzureClient {
+    type Error = AzureError;
+
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::Azure
+    }
+
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        let plan = AzureDeploymentPlan::new(&self.profile, request)?;
+        let expected = worker_tags(request);
+        let (group, origin) = match self.owned_group(&plan.resource_group, &expected)? {
+            Some(group) => (group, Origin::Existing),
+            None => self.create(&plan, request)?,
+        };
+        let worker = self.worker_for(request.workflow_id, request.job_id, &group, &request.target.image);
+        // A group that raced in during the claim is only observed; repair is reserved
+        // for groups this controller found before the fence or created itself.
+        let repair = (origin != Origin::Adopted).then_some(&plan);
+        // Creation and repair share one path: the deployment PUT happens only after the
+        // group is re-proven owned and not deleting, and never over a deployment that
+        // appeared in the meantime.
+        // Vanishing during creation's own observation is a lost worker, not an absence.
+        let observation = self
+            .observe(worker, &group, &expected, repair, Placement::Enforce)?
+            .ok_or(AzureError::CreationUnresolved)?;
+        let status = Self::status(observation, &request.target, &request.ssh_public_key);
+        Ok(if origin == Origin::Created {
+            InteractiveWorkerEnsure::Created(status)
+        } else {
+            InteractiveWorkerEnsure::Reused(status)
+        })
+    }
+
+    fn reconcile_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let plan = AzureDeploymentPlan::new(&self.profile, request)?;
+        let expected = worker_tags(request);
+        let Some(group) = self.owned_group(&plan.resource_group, &expected)? else {
+            return Ok(None);
+        };
+        let worker = self.worker_for(request.workflow_id, request.job_id, &group, &request.target.image);
+        let observation = self.observe(worker, &group, &expected, None, Placement::Enforce)?;
+        Ok(observation.map(|observation| Self::status(observation, &request.target, &request.ssh_public_key)))
+    }
+
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let Some((handle, group, expected)) = self.owned_handle(worker)? else {
+            return Ok(None);
+        };
+        let observation = self.observe(handle, &group, &expected, None, Placement::Ignore)?;
+        Ok(observation.map(|observation| Self::status(observation, &worker.target, &worker.ssh_public_key)))
+    }
+
+    /// `Deleted` means ARM accepted (202) or completed the deletion of exactly the owned
+    /// group; the group may keep answering `Deleting` for a while afterwards.
+    /// Resource groups carry no entity tag, so the ownership proof cannot be made atomic with
+    /// the DELETE; it is repeated immediately before the call, and the name itself is
+    /// derived from this worker's own identifiers, so a foreign replacement inside the
+    /// remaining window would need the same two UUIDs.
+    fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        let Some((handle, _, expected)) = self.owned_handle(worker)? else {
+            return Ok(InteractiveWorkerCleanup::AlreadyAbsent);
+        };
+        match self.owned_group(&handle.resource_group, &expected)? {
+            // An earlier accepted deletion is still in flight: nothing more to request.
+            Some(current) if current.id.eq_ignore_ascii_case(&handle.group_id) => {
+                if current.provisioning_state == "Deleting" {
+                    return Ok(InteractiveWorkerCleanup::Deleted);
+                }
+            }
+            Some(_) => return Err(AzureError::ResourceIdentityMismatch),
+            None => return Ok(InteractiveWorkerCleanup::AlreadyAbsent),
+        }
+        match self.transport.delete_resource_group(&handle.resource_group) {
+            Ok(_accepted_or_completed) => Ok(InteractiveWorkerCleanup::Deleted),
+            // Removed between the ownership check and this call: a retry stays idempotent.
+            Err(AzureError::UnexpectedStatus { status: 404, .. }) => Ok(InteractiveWorkerCleanup::AlreadyAbsent),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+/// A persisted handle proven against the live group.
+type OwnedHandle = (AzureWorker, AzureGroupInfo, BTreeMap<String, String>);
+
+impl AzureClient {
+    /// Shape, every identity tag, and the group ID recorded at creation (ARM compares
+    /// IDs case-insensitively) must all agree before any mutation.
+    fn owned_handle(&self, worker: &InteractiveWorker) -> Result<Option<OwnedHandle>, AzureError> {
+        let handle = self.handle(worker)?;
+        let expected = identity_tags(
+            handle.workflow_id,
+            handle.job_id,
+            &worker.target,
+            &worker.ssh_public_key,
+        );
+        let Some(group) = self.owned_group(&handle.resource_group, &expected)? else {
+            return Ok(None);
+        };
+        if !group.id.eq_ignore_ascii_case(&handle.group_id) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
+        Ok(Some((handle, group, expected)))
+    }
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::cloud_run::{CloudProvider, WorkerLifetime, WorkerTarget};
 mod deployment;
 mod identity;
+mod provider;
 mod transport;
 use std::time::Duration;
 
@@ -360,7 +361,16 @@ fn cli_credential_invokes_the_executable_without_a_shell_and_enforces_its_bounds
         format!("sleep 30 &\necho $! > '{}'\nexit 0\n", orphan_pid.display()),
     );
     let credential = AzureCliCredential::with_executable(good, SUB).expect("credential");
-    let first = credential.token().expect("token");
+    // Another test thread may fork while the script file is still open for writing, which
+    // makes the first exec fail with "text file busy"; that window closes within milliseconds.
+    let first = (0..20)
+        .find_map(|_| {
+            credential.token().ok().or_else(|| {
+                std::thread::sleep(Duration::from_millis(25));
+                None
+            })
+        })
+        .expect("token");
     let second = credential.token().expect("cached token");
     assert_eq!(first.authorization_header(), second.authorization_header());
     assert_eq!(first.authorization_header(), "Bearer synthetic-token-value");

--- a/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
@@ -1,8 +1,8 @@
 use super::super::{
     AzureDeploymentPlan, AzureError, RESOURCE_GROUP_PREFIX,
     deployment::{
-        SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_IMAGE_DIGEST, TAG_JOB, TAG_LIFETIME, TAG_PROTOCOL, TAG_WORKFLOW,
-        client_key_digest, worker_tags,
+        SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_DISK_GIB, TAG_IMAGE_DIGEST, TAG_IMAGE_REF_DIGEST, TAG_JOB, TAG_LIFETIME,
+        TAG_PROFILE, TAG_PROTOCOL, TAG_WORKFLOW, client_key_digest, worker_tags,
     },
 };
 use super::{IMAGE, ed25519_key, profile, target};
@@ -68,7 +68,29 @@ fn plan_derives_identity_parameters_and_tags_from_validated_inputs() {
         client_key_digest("abc"),
         "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
     );
-    assert_eq!(plan.tags.len(), 6);
+    assert_eq!(plan.tags[TAG_DISK_GIB], "32");
+    assert_eq!(
+        plan.tags[TAG_PROFILE],
+        client_key_digest("cpu-north"),
+        "profile name hashed, tag-safe"
+    );
+    assert_eq!(
+        plan.tags[TAG_IMAGE_REF_DIGEST],
+        client_key_digest(IMAGE),
+        "sha256 of the full reference"
+    );
+    let mut other_repository = request.clone();
+    other_repository.target.image = IMAGE.replace("horizon-remote-worker", "other-worker");
+    assert_ne!(
+        worker_tags(&other_repository)[TAG_IMAGE_REF_DIGEST],
+        plan.tags[TAG_IMAGE_REF_DIGEST]
+    );
+    assert_eq!(
+        worker_tags(&other_repository)[TAG_IMAGE_DIGEST],
+        plan.tags[TAG_IMAGE_DIGEST],
+        "same manifest digest"
+    );
+    assert_eq!(plan.tags.len(), 9);
     assert!(
         plan.tags
             .values()

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -1,0 +1,276 @@
+pub(super) use super::super::{
+    AzureClient, AzureDeploymentState, AzureError, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
+    AzureVmView,
+    deployment::{DEPLOYMENT_NAME, TAG_CLIENT_KEY_DIGEST, TAG_JOB, worker_tags},
+    resource_group_name,
+};
+pub(super) use super::{OTHER_SUB, SUB, ed25519_key, profile, target};
+pub(super) use crate::cloud_run::{
+    CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime, WorkerTarget,
+    interactive_worker::{
+        InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+        InteractiveWorkerLifecycle as Lifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider,
+        InteractiveWorkerRequest, InteractiveWorkerStatus,
+    },
+};
+pub(super) use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+/// Every management call the provider makes, in order, with its arguments.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum Call {
+    GetGroup(String),
+    CreateGroup(String, BTreeMap<String, String>),
+    DeleteGroup(String),
+    PutDeployment(String, String, serde_json::Value),
+    GetDeployment(String),
+    GetVm(String),
+}
+
+#[derive(Default)]
+pub(super) struct Plane {
+    pub(super) group: Option<AzureGroupInfo>,
+    pub(super) deployment: Option<AzureDeploymentState>,
+    pub(super) vm_states: Vec<Option<AzureVmView>>,
+    pub(super) fail_deployment: bool,
+    pub(super) submitted_state: Option<&'static str>,
+    pub(super) appear_on_second_lookup: Option<AzureGroupInfo>,
+    /// Replaces the group after the first lookup, as a concurrent retag or deletion would.
+    pub(super) group_after_first_lookup: Option<AzureGroupInfo>,
+    pub(super) group_after_create: Option<AzureGroupInfo>,
+    pub(super) deployment_on_second_read: Option<AzureDeploymentState>,
+    pub(super) vanish_after_first_lookup: bool,
+    pub(super) delete_status: Option<u16>,
+    pub(super) calls: Vec<Call>,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct Fake(pub(super) Arc<Mutex<Plane>>);
+
+impl Fake {
+    pub(super) fn lock(&self) -> std::sync::MutexGuard<'_, Plane> {
+        self.0.lock().expect("plane")
+    }
+
+    pub(super) fn calls(&self) -> Vec<Call> {
+        self.lock().calls.clone()
+    }
+
+    pub(super) fn mutations(&self) -> Vec<Call> {
+        self.calls()
+            .into_iter()
+            .filter(|call| !matches!(call, Call::GetGroup(_) | Call::GetDeployment(_) | Call::GetVm(_)))
+            .collect()
+    }
+
+    pub(super) fn script(
+        &self,
+        group: Option<AzureGroupInfo>,
+        deployment: Option<AzureDeploymentState>,
+        vm_states: Vec<Option<AzureVmView>>,
+    ) {
+        let mut plane = self.lock();
+        plane.group = group;
+        plane.deployment = deployment;
+        plane.vm_states = vm_states;
+        plane.calls.clear();
+    }
+}
+
+impl AzureManagementTransport for Fake {
+    fn subscription_id(&self) -> &str {
+        SUB
+    }
+
+    fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::GetGroup(name.into()));
+        let found = plane.group.clone().filter(|group| group.name == name);
+        if found.is_none() {
+            plane.group = plane.appear_on_second_lookup.take();
+        } else if let Some(next) = plane.group_after_first_lookup.take() {
+            plane.group = Some(next);
+        } else if std::mem::take(&mut plane.vanish_after_first_lookup) {
+            plane.group = None;
+        }
+        Ok(found)
+    }
+
+    fn create_resource_group(
+        &self,
+        name: &str,
+        location: &str,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<AzureGroupInfo, AzureError> {
+        let mut plane = self.lock();
+        assert_eq!(location, "northeurope");
+        plane.calls.push(Call::CreateGroup(name.into(), tags.clone()));
+        let info = group_info(name, tags.clone(), "Succeeded");
+        plane.group = Some(plane.group_after_create.take().unwrap_or_else(|| info.clone()));
+        Ok(info)
+    }
+
+    fn delete_resource_group(&self, name: &str) -> Result<AzureLongRunningState, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::DeleteGroup(name.into()));
+        if let Some(status) = plane.delete_status {
+            return Err(AzureError::UnexpectedStatus {
+                operation: "resource group deletion",
+                status,
+            });
+        }
+        plane.group = None;
+        Ok(AzureLongRunningState::Accepted)
+    }
+
+    fn put_deployment(
+        &self,
+        group: &str,
+        name: &str,
+        _template: &serde_json::Value,
+        parameters: &serde_json::Value,
+    ) -> Result<AzureDeploymentState, AzureError> {
+        let mut plane = self.lock();
+        plane
+            .calls
+            .push(Call::PutDeployment(group.into(), name.into(), parameters.clone()));
+        if plane.fail_deployment {
+            return Err(AzureError::UnexpectedStatus {
+                operation: "deployment submission",
+                status: 429,
+            });
+        }
+        let state = AzureDeploymentState {
+            provisioning_state: plane.submitted_state.unwrap_or("Accepted").into(),
+            outputs: BTreeMap::new(),
+        };
+        plane.deployment = Some(state.clone());
+        Ok(state)
+    }
+
+    fn get_deployment(&self, group: &str, _name: &str) -> Result<Option<AzureDeploymentState>, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::GetDeployment(group.into()));
+        let current = plane.deployment.clone();
+        if let Some(next) = plane.deployment_on_second_read.take() {
+            plane.deployment = Some(next);
+        }
+        Ok(current)
+    }
+
+    fn get_vm(&self, group: &str, _name: &str) -> Result<Option<AzureVmView>, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::GetVm(group.into()));
+        Ok(if plane.vm_states.len() > 1 {
+            plane.vm_states.remove(0)
+        } else {
+            plane.vm_states.first().cloned().flatten()
+        })
+    }
+}
+
+pub(super) fn group_info(name: &str, tags: BTreeMap<String, String>, state: &str) -> AzureGroupInfo {
+    AzureGroupInfo {
+        id: format!("/subscriptions/{SUB}/resourceGroups/{name}"),
+        name: name.into(),
+        location: "northeurope".into(),
+        provisioning_state: state.into(),
+        tags,
+    }
+}
+
+pub(super) fn vm(power: &str, tags: &BTreeMap<String, String>) -> AzureVmView {
+    AzureVmView {
+        id: format!("/subscriptions/{SUB}/resourceGroups/g/providers/Microsoft.Compute/virtualMachines/worker"),
+        name: "worker".into(),
+        location: "northeurope".into(),
+        vm_size: "Standard_D4s_v3".into(),
+        provisioning_state: "Succeeded".into(),
+        power_state: Some(format!("PowerState/{power}")),
+        tags: tags.clone(),
+    }
+}
+
+pub(super) fn deployment(state: &str, host: &str) -> AzureDeploymentState {
+    AzureDeploymentState {
+        provisioning_state: state.into(),
+        outputs: [("publicIp".to_string(), host.to_string())].into(),
+    }
+}
+
+pub(super) struct Scenario {
+    pub(super) request: InteractiveWorkerRequest,
+    pub(super) group: String,
+    pub(super) group_id: String,
+    pub(super) tags: BTreeMap<String, String>,
+    pub(super) plane: Fake,
+}
+
+impl Scenario {
+    pub(super) fn new() -> Self {
+        let request = InteractiveWorkerRequest {
+            workflow_id: CloudWorkflowId::new(),
+            job_id: CloudJobId::new(),
+            target: target(),
+            ssh_public_key: ed25519_key(7, "client"),
+        };
+        let group = resource_group_name(request.workflow_id, request.job_id);
+        Self {
+            group_id: format!("/subscriptions/{SUB}/resourceGroups/{group}"),
+            group,
+            tags: worker_tags(&request),
+            plane: Fake::default(),
+            request,
+        }
+    }
+
+    /// A client whose fence answers `claim` for exactly this request.
+    pub(super) fn client(&self, claim: bool) -> AzureClient {
+        let (expected, group) = (self.persisted(), self.group.clone());
+        let fence = move |w: CloudWorkflowId, j: CloudJobId, t: &WorkerTarget, g: &str| {
+            assert_eq!(
+                (w, j, t, g),
+                (
+                    expected.identity.workflow_id,
+                    expected.identity.job_id,
+                    &expected.target,
+                    group.as_str()
+                )
+            );
+            Ok(claim)
+        };
+        AzureClient::with_transport(profile(), self.plane.clone(), fence).expect("client")
+    }
+
+    pub(super) fn persisted(&self) -> InteractiveWorker {
+        InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::Azure,
+                workflow_id: self.request.workflow_id,
+                job_id: self.request.job_id,
+                resource_id: self.group_id.clone(),
+            },
+            target: self.request.target.clone(),
+            ssh_public_key: self.request.ssh_public_key.clone(),
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        }
+    }
+
+    pub(super) fn reconcile(&self) -> InteractiveWorkerStatus {
+        self.client(false)
+            .reconcile_worker(&self.request)
+            .expect("reconcile")
+            .expect("present")
+    }
+}
+
+pub(super) fn owned(s: &Scenario) -> AzureGroupInfo {
+    group_info(&s.group, s.tags.clone(), "Succeeded")
+}
+
+pub(super) const MISMATCH: AzureError = AzureError::ResourceIdentityMismatch;
+
+mod creation;
+mod observation;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/creation.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/creation.rs
@@ -1,0 +1,268 @@
+use super::*;
+
+#[test]
+fn ensure_creates_once_behind_the_fence_and_then_reuses() {
+    let s = Scenario::new();
+    let created = s.client(true).ensure_worker(&s.request).expect("created");
+    let InteractiveWorkerEnsure::Created(status) = &created else {
+        panic!("first ensure creates: {created:?}");
+    };
+    assert_eq!(status.lifecycle, Lifecycle::Provisioning);
+    assert_eq!(status.worker.identity.resource_id, s.group_id);
+    assert_eq!(
+        (&status.worker.target, &status.worker.lifetime),
+        (&s.request.target, &InteractiveWorkerLifetime::Persistent)
+    );
+    let calls = s.plane.calls();
+    let lookup = Call::GetGroup(s.group.clone());
+    assert_eq!(
+        &calls[..3],
+        [
+            lookup.clone(),
+            lookup.clone(),
+            Call::CreateGroup(s.group.clone(), s.tags.clone())
+        ]
+    );
+    let put = calls
+        .iter()
+        .position(|call| matches!(call, Call::PutDeployment(..)))
+        .expect("submission");
+    let Call::PutDeployment(group, name, parameters) = &calls[put] else {
+        unreachable!()
+    };
+    assert_eq!((group.as_str(), name.as_str()), (s.group.as_str(), DEPLOYMENT_NAME));
+    assert_eq!(parameters["adminPublicKey"]["value"], s.request.ssh_public_key);
+    let fresh = [
+        Call::GetDeployment(s.group.clone()),
+        Call::GetVm(s.group.clone()),
+        lookup.clone(),
+    ];
+    assert!(
+        calls[3..put].ends_with(&fresh),
+        "a complete observation immediately precedes the submission: {calls:?}"
+    );
+    assert_eq!(&calls[put + 1..], [lookup], "a final re-read follows the submission");
+    assert_eq!(s.plane.mutations().len(), 2, "one creation, one submission");
+    s.plane.lock().calls.clear();
+    let reused = s.client(false).ensure_worker(&s.request).expect("reused");
+    assert!(matches!(reused, InteractiveWorkerEnsure::Reused(_)));
+    assert_eq!(
+        reused.status().lifecycle,
+        Lifecycle::Provisioning,
+        "deployment accepted, VM pending"
+    );
+    assert!(s.plane.mutations().is_empty(), "{:?}", s.plane.calls());
+}
+
+#[test]
+fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
+    // A claim lost to a crash before the group appeared: a second look at ARM, then unresolved.
+    let s = Scenario::new();
+    assert_eq!(
+        s.client(false).ensure_worker(&s.request),
+        Err(AzureError::CreationUnresolved)
+    );
+    assert_eq!(
+        s.plane.calls(),
+        [Call::GetGroup(s.group.clone()), Call::GetGroup(s.group.clone())]
+    );
+    // A claim lost after the group appeared is adopted through the same tag proof.
+    s.plane.script(Some(owned(&s)), None, vec![None]);
+    let adopted = s.client(true).ensure_worker(&s.request).expect("adopted");
+    assert!(matches!(adopted, InteractiveWorkerEnsure::Reused(_)));
+    assert!(
+        matches!(s.plane.mutations().as_slice(), [Call::PutDeployment(..)]),
+        "only the missing deployment"
+    );
+    // A group that appears between the first lookup and a denied claim is observed, not re-created.
+    let raced = Scenario::new();
+    raced.plane.lock().deployment = Some(deployment("Succeeded", "203.0.113.9"));
+    raced.plane.lock().vm_states = vec![Some(vm("running", &raced.tags))];
+    raced.plane.lock().appear_on_second_lookup = Some(owned(&raced));
+    let observed = raced.client(false).ensure_worker(&raced.request).expect("observed");
+    assert!(matches!(observed, InteractiveWorkerEnsure::Reused(_)), "{observed:?}");
+    assert_eq!(observed.status().lifecycle, Lifecycle::Provisioning);
+    assert!(
+        raced.plane.mutations().is_empty(),
+        "nothing is resubmitted for a finished worker"
+    );
+    // The same race with a granted claim: the group is adopted, never overwritten by the upsert.
+    let granted = Scenario::new();
+    granted.plane.lock().deployment = Some(deployment("Succeeded", "203.0.113.9"));
+    granted.plane.lock().vm_states = vec![Some(vm("running", &granted.tags))];
+    granted.plane.lock().appear_on_second_lookup = Some(owned(&granted));
+    let adopted = granted.client(true).ensure_worker(&granted.request).expect("adopted");
+    assert!(matches!(adopted, InteractiveWorkerEnsure::Reused(_)), "{adopted:?}");
+    assert!(
+        granted.plane.mutations().is_empty(),
+        "no PUT over a group that appeared: {:?}",
+        granted.plane.calls()
+    );
+    // A foreign group that appears in the window is refused, never overwritten.
+    let foreign = Scenario::new();
+    let mut other_tags = foreign.tags.clone();
+    other_tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    foreign.plane.lock().appear_on_second_lookup = Some(AzureGroupInfo {
+        tags: other_tags,
+        ..owned(&foreign)
+    });
+    assert_eq!(foreign.client(true).ensure_worker(&foreign.request), Err(MISMATCH));
+    assert!(foreign.plane.mutations().is_empty());
+    // A throttled submission keeps the owned group; the next ensure repairs it.
+    let t = Scenario::new();
+    t.plane.lock().fail_deployment = true;
+    let error = t.client(true).ensure_worker(&t.request).expect_err("submission");
+    assert!(
+        matches!(&error, AzureError::CreationIncomplete { cause } if matches!(**cause, AzureError::UnexpectedStatus { status: 429, .. }))
+    );
+    assert!(
+        std::error::Error::source(&error).is_some(),
+        "the transport failure stays reachable as the error source"
+    );
+    t.plane.lock().fail_deployment = false;
+    t.plane.lock().calls.clear();
+    let repaired = t.client(false).ensure_worker(&t.request).expect("repaired");
+    assert!(matches!(repaired, InteractiveWorkerEnsure::Reused(_)));
+    assert!(matches!(t.plane.mutations().as_slice(), [Call::PutDeployment(..)]));
+}
+
+#[test]
+fn ensure_never_deploys_into_a_group_that_changed_under_it() {
+    // A group that starts deleting, or is retagged, between observation and repair is never deployed into.
+    let racing = Scenario::new();
+    racing.plane.lock().group = Some(owned(&racing));
+    racing.plane.lock().group_after_first_lookup = Some(AzureGroupInfo {
+        provisioning_state: "Deleting".into(),
+        ..owned(&racing)
+    });
+    let observed = racing.client(false).ensure_worker(&racing.request).expect("observed");
+    assert_eq!(observed.status().lifecycle, Lifecycle::Deleting);
+    assert!(
+        racing.plane.mutations().is_empty(),
+        "no submission into a deleting group"
+    );
+    let mut foreign_tags = racing.tags.clone();
+    foreign_tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    racing.plane.script(Some(owned(&racing)), None, vec![None]);
+    racing.plane.lock().group_after_first_lookup = Some(AzureGroupInfo {
+        tags: foreign_tags,
+        ..owned(&racing)
+    });
+    assert_eq!(racing.client(false).ensure_worker(&racing.request), Err(MISMATCH));
+    assert!(
+        racing.plane.mutations().is_empty(),
+        "no submission into a retagged group"
+    );
+    // A deployment that appears between the observation reads and the repair is observed, not overwritten.
+    let appeared = Scenario::new();
+    appeared.plane.lock().group = Some(owned(&appeared));
+    appeared.plane.lock().deployment_on_second_read = Some(deployment("Running", ""));
+    let observed = appeared
+        .client(false)
+        .ensure_worker(&appeared.request)
+        .expect("observed");
+    assert_eq!(observed.status().lifecycle, Lifecycle::Provisioning);
+    assert!(appeared.plane.mutations().is_empty(), "no second deployment upsert");
+    // A group that vanishes during the reads is absent for the non-creating APIs.
+    let vanished = Scenario::new();
+    vanished.plane.script(
+        Some(owned(&vanished)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![Some(vm("running", &vanished.tags))],
+    );
+    vanished.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(vanished.client(false).reconcile_worker(&vanished.request), Ok(None));
+    vanished.plane.script(Some(owned(&vanished)), None, vec![None]);
+    vanished.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(vanished.client(false).inspect_worker(&vanished.persisted()), Ok(None));
+    vanished.plane.script(Some(owned(&vanished)), None, vec![None]);
+    vanished.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(
+        vanished.client(false).ensure_worker(&vanished.request),
+        Err(AzureError::CreationUnresolved),
+        "a lost worker during ensure is not an absence"
+    );
+    assert!(vanished.plane.mutations().is_empty());
+    // A VM that appears between the observation reads and the repair is observed, never written over.
+    let vm_appeared = Scenario::new();
+    vm_appeared.plane.lock().group = Some(owned(&vm_appeared));
+    let mut foreign_vm = vm("running", &vm_appeared.tags);
+    foreign_vm.tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    vm_appeared.plane.lock().vm_states = vec![None, Some(foreign_vm)];
+    assert_eq!(
+        vm_appeared.client(false).ensure_worker(&vm_appeared.request),
+        Err(MISMATCH)
+    );
+    assert!(
+        vm_appeared.plane.mutations().is_empty(),
+        "no submission over a VM with foreign tags"
+    );
+    // A failed deployment behind a VM does not hide a deletion that began during the reads.
+    let failed_then_deleting = Scenario::new();
+    failed_then_deleting.plane.script(
+        Some(owned(&failed_then_deleting)),
+        Some(deployment("Failed", "")),
+        vec![Some(vm("running", &failed_then_deleting.tags))],
+    );
+    failed_then_deleting.plane.lock().group_after_first_lookup = Some(AzureGroupInfo {
+        provisioning_state: "Deleting".into(),
+        ..owned(&failed_then_deleting)
+    });
+    assert_eq!(failed_then_deleting.reconcile().lifecycle, Lifecycle::Deleting);
+}
+
+#[test]
+fn ensure_never_deploys_into_a_group_changed_right_after_creation() {
+    // A deleting group whose tags change before the re-proof is a mismatch, not Deleting.
+    let retagged = Scenario::new();
+    let mut deleting = owned(&retagged);
+    deleting.provisioning_state = "Deleting".into();
+    let mut foreign = deleting.clone();
+    foreign.tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    retagged.plane.script(Some(deleting), None, vec![None]);
+    retagged.plane.lock().group_after_first_lookup = Some(foreign);
+    assert_eq!(
+        retagged.client(false).reconcile_worker(&retagged.request),
+        Err(MISMATCH)
+    );
+    // A group retagged or deleting right after creation is never deployed into either.
+    let stolen = Scenario::new();
+    let mut other_tags = stolen.tags.clone();
+    other_tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    stolen.plane.lock().group_after_create = Some(AzureGroupInfo {
+        tags: other_tags,
+        ..owned(&stolen)
+    });
+    assert_eq!(stolen.client(true).ensure_worker(&stolen.request), Err(MISMATCH));
+    assert!(
+        !stolen
+            .plane
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::PutDeployment(..)))
+    );
+    // A submission that ARM completes synchronously in a failed state is Failed, not Provisioning.
+    let sync_failed = Scenario::new();
+    sync_failed.plane.lock().submitted_state = Some("Failed");
+    let failed = sync_failed
+        .client(true)
+        .ensure_worker(&sync_failed.request)
+        .expect("created");
+    assert!(matches!(failed, InteractiveWorkerEnsure::Created(_)));
+    assert_eq!(failed.status().lifecycle, Lifecycle::Failed);
+    let sync_ok = Scenario::new();
+    sync_ok.plane.lock().submitted_state = Some("Succeeded");
+    let created = sync_ok.client(true).ensure_worker(&sync_ok.request).expect("created");
+    assert_eq!(
+        created.status().lifecycle,
+        Lifecycle::Provisioning,
+        "a synchronous success is provisioning, not unknown"
+    );
+    // A group ARM is deleting is reported, never repaired or resubmitted.
+    let t = sync_failed;
+    t.plane
+        .script(Some(group_info(&t.group, t.tags.clone(), "Deleting")), None, vec![None]);
+    let deleting = t.client(false).ensure_worker(&t.request).expect("observed");
+    assert_eq!(deleting.status().lifecycle, Lifecycle::Deleting);
+    assert!(t.plane.mutations().is_empty());
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/observation.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/observation.rs
@@ -1,0 +1,272 @@
+use super::*;
+
+#[test]
+fn recovery_maps_every_observed_state_without_creating() {
+    let s = Scenario::new();
+    let up = || Some(deployment("Succeeded", "203.0.113.9"));
+    let dep = |state: &str| Some(deployment(state, ""));
+    let power = |state: &str| Some(vm(state, &s.tags));
+    let cases = [
+        (up(), power("deallocated"), Lifecycle::Stopped, "deallocated"),
+        (
+            up(),
+            power("stopped"),
+            Lifecycle::Unknown,
+            "billed halt is never a retained stop",
+        ),
+        (
+            dep("Failed"),
+            power("running"),
+            Lifecycle::Failed,
+            "a VM left behind a failed deployment",
+        ),
+        (
+            dep("Canceled"),
+            power("deallocated"),
+            Lifecycle::Failed,
+            "a VM left behind a canceled deployment",
+        ),
+        (
+            dep("Running"),
+            power("running"),
+            Lifecycle::Provisioning,
+            "deployment still running",
+        ),
+        (dep("Failed"), None, Lifecycle::Failed, "failed deployment"),
+        (dep("Canceled"), None, Lifecycle::Failed, "canceled deployment"),
+        (up(), None, Lifecycle::Unknown, "finished deployment without its VM"),
+        (
+            None,
+            None,
+            Lifecycle::Unknown,
+            "owned group with nothing in it: recovery never submits",
+        ),
+    ];
+    for (deployment, vm_state, lifecycle, label) in cases {
+        s.plane.script(Some(owned(&s)), deployment, vec![vm_state]);
+        assert_eq!(s.reconcile().lifecycle, lifecycle, "{label}");
+        assert!(s.plane.mutations().is_empty(), "{label}");
+    }
+    s.plane.script(None, None, vec![None]);
+    assert_eq!(s.client(false).reconcile_worker(&s.request), Ok(None));
+}
+#[test]
+fn recovery_treats_unusable_addresses_as_unknown() {
+    let s = Scenario::new();
+    for address in [
+        "not-an-ip",
+        "0.0.0.0",
+        "127.0.0.1",
+        "::",
+        "fe80::1",
+        "169.254.1.1",
+        "10.0.0.1",
+        "fd00::1",
+        "::ffff:10.0.0.1",
+    ] {
+        s.plane.script(
+            Some(owned(&s)),
+            Some(deployment("Succeeded", address)),
+            vec![Some(vm("running", &s.tags))],
+        );
+        assert_eq!(s.reconcile().lifecycle, Lifecycle::Unknown, "{address}");
+        assert!(s.plane.mutations().is_empty(), "{address}");
+    }
+}
+
+#[test]
+fn foreign_or_tampered_resources_are_rejected_before_any_mutation() {
+    let s = Scenario::new();
+    let mut other_client = s.tags.clone();
+    other_client.insert(TAG_CLIENT_KEY_DIGEST.into(), "0".repeat(64));
+    s.plane
+        .script(Some(group_info(&s.group, other_client, "Succeeded")), None, vec![None]);
+    let client = s.client(true);
+    let worker = s.persisted();
+    assert_eq!(client.ensure_worker(&s.request), Err(MISMATCH));
+    assert_eq!(client.reconcile_worker(&s.request), Err(MISMATCH));
+    assert_eq!(client.inspect_worker(&worker), Err(MISMATCH));
+    assert_eq!(client.delete_worker(&worker), Err(MISMATCH));
+    assert!(
+        s.plane.calls().iter().all(|call| matches!(call, Call::GetGroup(_))),
+        "{:?}",
+        s.plane.calls()
+    );
+    let mut other_job = s.tags.clone();
+    other_job.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("running", &other_job))]);
+    assert_eq!(client.reconcile_worker(&s.request), Err(MISMATCH), "VM tags disagree");
+    let mut recased = worker.clone();
+    recased.identity.resource_id = format!("/subscriptions/{SUB}/resourcegroups/{}", s.group.to_ascii_uppercase());
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("running", &s.tags))]);
+    assert!(
+        client.inspect_worker(&recased).expect("inspect").is_some(),
+        "ARM ids compare case-insensitively"
+    );
+    let mut limited = s.request.clone();
+    limited.target.lifetime = WorkerLifetime::TimeLimited { seconds: 600 };
+    assert_eq!(client.ensure_worker(&limited), Err(AzureError::UnsupportedLifetime));
+    let mut bad_key = s.request.clone();
+    bad_key.ssh_public_key = "ssh-rsa AAAA".into();
+    assert_eq!(client.ensure_worker(&bad_key), Err(AzureError::InvalidTarget));
+    let mut moved = owned(&s);
+    moved.location = "westeurope".into();
+    s.plane.script(Some(moved), None, vec![None]);
+    assert_eq!(
+        client.ensure_worker(&s.request),
+        Err(AzureError::PlacementMismatch),
+        "group in another region is never repaired"
+    );
+    assert_eq!(client.reconcile_worker(&s.request), Err(AzureError::PlacementMismatch));
+    assert!(s.plane.mutations().is_empty());
+}
+
+#[test]
+fn placement_and_subscription_policy_apply_to_request_paths_only() {
+    let s = Scenario::new();
+    let client = s.client(false);
+    let worker = s.persisted();
+    let mut other_subscription = profile();
+    other_subscription.subscription_id = OTHER_SUB.into();
+    other_subscription.image_pull_identity_id = profile().image_pull_identity_id.replace(SUB, OTHER_SUB);
+    let never = |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| Ok(false);
+    assert!(
+        AzureClient::with_transport(other_subscription, s.plane.clone(), never).is_err(),
+        "transport bound to the profile's subscription"
+    );
+    let mut relocated = owned(&s);
+    relocated.location = "westeurope".into();
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![Some(vm("running", &s.tags))],
+    );
+    s.plane.lock().group_after_first_lookup = Some(relocated);
+    assert_eq!(
+        client.reconcile_worker(&s.request),
+        Err(AzureError::PlacementMismatch),
+        "recreated elsewhere mid-read"
+    );
+    let mut resized = vm("running", &s.tags);
+    resized.vm_size = "Standard_D8s_v3".into();
+    s.plane.script(Some(owned(&s)), None, vec![Some(resized)]);
+    assert_eq!(
+        client.reconcile_worker(&s.request),
+        Err(AzureError::PlacementMismatch),
+        "resized out of band"
+    );
+    assert_eq!(client.ensure_worker(&s.request), Err(AzureError::PlacementMismatch));
+    assert!(
+        client.inspect_worker(&worker).expect("inspect").is_some(),
+        "the persisted handle stays inspectable"
+    );
+    let mut resized = vm("running", &s.tags);
+    resized.vm_size = "Standard_D8s_v3".into();
+    s.plane
+        .script(Some(owned(&s)), Some(deployment("Failed", "")), vec![Some(resized)]);
+    assert_eq!(
+        client
+            .reconcile_worker(&s.request)
+            .map(|status| status.map(|status| status.lifecycle)),
+        Ok(Some(Lifecycle::Failed)),
+        "a failed deployment is reported before any placement verdict on its leftovers"
+    );
+    assert!(s.plane.mutations().is_empty());
+    let mut bigger = s.request.clone();
+    bigger.target.disk_gib = 64;
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("running", &s.tags))]);
+    assert_eq!(
+        client.ensure_worker(&bigger),
+        Err(MISMATCH),
+        "a different disk size is another worker, never adopted"
+    );
+    assert_eq!(client.reconcile_worker(&bigger), Err(MISMATCH));
+    let mut renamed = worker.clone();
+    renamed.target.profile = "cpu-north-b".into();
+    let mut other_profile = profile();
+    other_profile.name = "cpu-north-b".into();
+    let never = |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| Ok(false);
+    let other = AzureClient::with_transport(other_profile, s.plane.clone(), never).expect("client");
+    assert_eq!(
+        other.inspect_worker(&renamed),
+        Err(MISMATCH),
+        "a handle under another profile name is not this worker"
+    );
+    assert!(s.plane.mutations().is_empty());
+}
+
+#[test]
+fn inspect_and_delete_act_only_on_the_exact_owned_group() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false);
+    assert_eq!(client.inspect_worker(&worker), Ok(None));
+    assert_eq!(
+        client.delete_worker(&worker),
+        Ok(InteractiveWorkerCleanup::AlreadyAbsent)
+    );
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![Some(vm("running", &s.tags))],
+    );
+    let status = client.inspect_worker(&worker).expect("inspect").expect("present");
+    assert_eq!(
+        (status.lifecycle, status.worker),
+        (Lifecycle::Provisioning, worker.clone())
+    );
+    assert!(s.plane.mutations().is_empty());
+    s.plane.script(Some(owned(&s)), None, vec![None]);
+    assert_eq!(client.delete_worker(&worker), Ok(InteractiveWorkerCleanup::Deleted));
+    let lookup = Call::GetGroup(s.group.clone());
+    assert_eq!(
+        s.plane.calls(),
+        [lookup.clone(), lookup, Call::DeleteGroup(s.group.clone())],
+        "proof, re-proof, delete"
+    );
+    assert_eq!(
+        client.delete_worker(&worker),
+        Ok(InteractiveWorkerCleanup::AlreadyAbsent)
+    );
+    assert_eq!(client.inspect_worker(&worker), Ok(None));
+    s.plane.script(Some(owned(&s)), None, vec![None]);
+    s.plane.lock().delete_status = Some(404);
+    assert_eq!(
+        client.delete_worker(&worker),
+        Ok(InteractiveWorkerCleanup::AlreadyAbsent),
+        "removed concurrently"
+    );
+    s.plane.lock().delete_status = Some(409);
+    assert!(matches!(
+        client.delete_worker(&worker),
+        Err(AzureError::UnexpectedStatus { status: 409, .. })
+    ));
+    s.plane.lock().delete_status = None;
+    let mut other_tags = s.tags.clone();
+    other_tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    s.plane.script(Some(owned(&s)), None, vec![None]);
+    s.plane.lock().group_after_first_lookup = Some(AzureGroupInfo {
+        tags: other_tags,
+        ..owned(&s)
+    });
+    assert_eq!(
+        client.delete_worker(&worker),
+        Err(MISMATCH),
+        "replaced between proof and delete"
+    );
+    assert!(!s.plane.calls().iter().any(|call| matches!(call, Call::DeleteGroup(_))));
+    s.plane
+        .script(Some(group_info(&s.group, s.tags.clone(), "Deleting")), None, vec![None]);
+    assert_eq!(
+        client.delete_worker(&worker),
+        Ok(InteractiveWorkerCleanup::Deleted),
+        "an accepted deletion in flight"
+    );
+    assert!(
+        s.plane.mutations().is_empty(),
+        "no second DELETE while ARM is still deleting"
+    );
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -283,7 +283,34 @@ fn deployments_are_submitted_incrementally_and_read_back_with_string_outputs() {
             None,
         ),
         expect("GET", url.clone(), 404, "", None),
-        expect("GET", url, 200, r#"{"properties":{}}"#, None),
+        expect("GET", url.clone(), 200, r#"{"properties":{}}"#, None),
+        expect(
+            "PUT",
+            url.clone(),
+            202,
+            "",
+            Some(
+                serde_json::json!({"properties":{"mode":"Incremental","template":{"resources":[]},"parameters":{"vmName":{"value":"worker"}}}}),
+            ),
+        ),
+        expect(
+            "PUT",
+            url.clone(),
+            202,
+            r#"{"status":"InProgress"}"#,
+            Some(
+                serde_json::json!({"properties":{"mode":"Incremental","template":{"resources":[]},"parameters":{"vmName":{"value":"worker"}}}}),
+            ),
+        ),
+        expect(
+            "PUT",
+            url,
+            202,
+            "private-garbage",
+            Some(
+                serde_json::json!({"properties":{"mode":"Incremental","template":{"resources":[]},"parameters":{"vmName":{"value":"worker"}}}}),
+            ),
+        ),
     ]);
     let accepted = transport
         .put_deployment(GROUP, "worker", &template, &parameters)
@@ -309,7 +336,36 @@ fn deployments_are_submitted_incrementally_and_read_back_with_string_outputs() {
             operation: "deployment lookup"
         })
     );
-    assert_eq!(calls.load(Ordering::SeqCst), 4);
+    let accepted = transport
+        .put_deployment(GROUP, "worker", &template, &parameters)
+        .expect("asynchronous acceptance");
+    assert_eq!(
+        (accepted.provisioning_state.as_str(), accepted.outputs.len()),
+        ("Accepted", 0),
+        "a bodiless 202 is accepted"
+    );
+    let envelope = transport
+        .put_deployment(GROUP, "worker", &template, &parameters)
+        .expect("async envelope");
+    assert_eq!(
+        envelope.provisioning_state, "Accepted",
+        "a 202 without the deployment shape is still accepted"
+    );
+    let garbage = transport.put_deployment(GROUP, "worker", &template, &parameters);
+    assert_eq!(
+        garbage,
+        Err(AzureError::InvalidResponse {
+            operation: "deployment submission"
+        }),
+        "a malformed 202 body is not accepted"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 7);
+}
+
+#[test]
+fn deployment_operations_reject_invalid_segments_before_any_request() {
+    let (transport, calls) = http(vec![]);
+    let (template, parameters) = (serde_json::json!({}), serde_json::json!({}));
     for (group, name) in [
         ("bad/group", "worker"),
         (GROUP, "worker/../other"),
@@ -327,7 +383,7 @@ fn deployments_are_submitted_incrementally_and_read_back_with_string_outputs() {
     }
     assert_eq!(
         calls.load(Ordering::SeqCst),
-        4,
+        0,
         "invalid segments never reach the network"
     );
 }

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -55,6 +55,8 @@ pub enum AzureLongRunningState {
 
 /// Narrow set of management operations the adapter is allowed to perform.
 pub trait AzureManagementTransport: Send + Sync {
+    /// The single subscription every request of this transport addresses.
+    fn subscription_id(&self) -> &str;
     /// # Errors
     fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError>;
     /// # Errors
@@ -224,8 +226,30 @@ impl AzureArmHttp {
         if !decode_body {
             return Ok((status, serde_json::Value::Null));
         }
+        // An asynchronous acceptance may carry no body at all; the caller treats Null as
+        // accepted. A body that is present must still be well-formed JSON within bounds.
+        if status == 202 {
+            return decode_json_or_empty(response, operation).map(|value| (status, value));
+        }
         decode_json(response, accepted, operation).map(|value| (status, value))
     }
+}
+
+/// Bounded read of a 202 body: empty is `Null`, anything else must parse as JSON.
+fn decode_json_or_empty(
+    mut response: ureq::http::Response<ureq::Body>,
+    operation: &'static str,
+) -> Result<serde_json::Value, AzureError> {
+    let text = response
+        .body_mut()
+        .with_config()
+        .limit(RESPONSE_LIMIT_BYTES)
+        .read_to_string()
+        .map_err(|_| AzureError::InvalidResponse { operation })?;
+    if text.trim().is_empty() {
+        return Ok(serde_json::Value::Null);
+    }
+    serde_json::from_str(&text).map_err(|_| AzureError::InvalidResponse { operation })
 }
 
 fn decode_json(
@@ -243,6 +267,14 @@ fn decode_json(
         .limit(RESPONSE_LIMIT_BYTES)
         .read_json()
         .map_err(|_| AzureError::InvalidResponse { operation })
+}
+
+fn long_running(status: u16) -> AzureLongRunningState {
+    if status == 202 {
+        AzureLongRunningState::Accepted
+    } else {
+        AzureLongRunningState::Completed
+    }
 }
 
 fn text(value: &serde_json::Value, pointer: &str) -> Option<String> {
@@ -305,6 +337,10 @@ fn deployment_state(value: &serde_json::Value, operation: &'static str) -> Resul
 }
 
 impl AzureManagementTransport for AzureArmHttp {
+    fn subscription_id(&self) -> &str {
+        &self.subscription_id
+    }
+
     fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError> {
         let operation = "resource group lookup";
         self.get_json(&self.group_url(name, RESOURCE_GROUP_API_VERSION)?, operation)?
@@ -344,11 +380,7 @@ impl AzureManagementTransport for AzureArmHttp {
             false,
             operation,
         )?;
-        Ok(if status == 202 {
-            AzureLongRunningState::Accepted
-        } else {
-            AzureLongRunningState::Completed
-        })
+        Ok(long_running(status))
     }
 
     fn put_deployment(
@@ -367,7 +399,15 @@ impl AzureManagementTransport for AzureArmHttp {
             "",
         )?;
         let body = serde_json::json!({ "properties": { "mode": "Incremental", "template": template, "parameters": parameters } });
-        let (_, value) = self.send_json("PUT", &url, Some(&body), &[200, 201], true, operation)?;
+        let (status, value) = self.send_json("PUT", &url, Some(&body), &[200, 201, 202], true, operation)?;
+        // An asynchronous acceptance is an acceptance whatever its body carries; the
+        // deployment shape is parsed only when the body has it.
+        if status == 202 && value.pointer("/properties/provisioningState").is_none() {
+            return Ok(AzureDeploymentState {
+                provisioning_state: "Accepted".into(),
+                outputs: BTreeMap::new(),
+            });
+        }
         deployment_state(&value, operation)
     }
 


### PR DESCRIPTION
## Summary

Fourth isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open; SSH readiness with host-key attestation, explicit Stop and the wiring follow). No configuration, dispatcher or UI wiring.

`AzureClient` implements `InteractiveWorkerProvider` for persistent Azure CPU workers on top of the merged profile, transport and deployment plan:

- **ensure_worker**: validates the request against the profile and the deployment plan, then looks up the deterministic resource group. An existing group is adopted only if every identity tag (workflow, job, protocol version, lifetime, image manifest digest, SHA-256 of the full image reference, client-key digest, data disk size, SHA-256 of the profile name) matches; otherwise `ResourceIdentityMismatch`, so a request for a different disk size or under another profile name is another worker and is never adopted. An absent group is created only after the durable creation fence (`AzureCreationFence`; the workflow store implements it where the production client is assembled) grants the single claim; the group is tagged on creation, its returned group-level ID becomes the handle, and the deployment is submitted straight away. Because the group PUT is an upsert, ARM is checked once more immediately before it, whether or not the claim was granted: a group that appeared in the meantime (an earlier attempt or a concurrent controller) must pass the same tag proof and is then observed and reported `Reused`, never overwritten or resubmitted; a foreign group is refused; a denied claim with no group is `CreationUnresolved`. A group that exists with neither VM nor deployment (crash or throttling after group creation; the cause is kept in `CreationIncomplete`) is repaired by resubmitting the idempotent deployment; only `ensure` may do this, and never for a group ARM reports as `Deleting`.
- **Placement**: on the request-driven paths (`ensure`, `reconcile`) the observed VM must still match the profile's size and location, so a profile edited under the same name or a VM resized out of band is `PlacementMismatch` rather than served as the requested target; `inspect` and `delete` stay policy-independent.
- **reconcile_worker / inspect_worker**: non-creating. Absence is `None`; a matching group yields the observed state without ever submitting, restarting or deleting anything. `inspect` validates the persisted handle's shape only (cost and placement policy are not re-applied, so a handle stays inspectable after a profile change) and requires its group ID to equal the observed one (case-insensitively, as ARM compares IDs).
- **Lifecycle**: `PowerState/deallocated` is `Stopped`; a guest halt that is still billed (`PowerState/stopped`) is `Unknown`, never a retained stop; a failed or canceled deployment is `Failed` even when ARM left a VM behind; a group being deleted is `Deleting`; a running VM whose finished deployment carries no usable public address (unparseable, unspecified, loopback, multicast, link-local, private or unique-local) is `Unknown`. A running VM is reported `Provisioning` until the readiness slice adds host-key attestation; `Ready` is never claimed without a pinned key.
- **delete_worker**: after the same ownership proof, deletes exactly the owned resource group (accepted asynchronously); absent is `AlreadyAbsent`, including a group removed between the ownership check and the delete call.
- **Lifetime**: persistent only; a time-limited request is refused before any I/O.

Also adds the disk size to the identity tags and shares the identity-tag computation with the deployment plan.

## Tests

`cloud_run::azure::tests::provider` (5 tests) drive the real client through a scripted fake transport recording every call and the submitted parameters: create-once behind the fence with the exact call sequence and the client key in the deployment parameters, reuse without recreation, a lost claim re-checked then unresolved, adoption of an owned group, a group appearing between lookup and denied claim observed as `Reused` without resubmission, a throttled submission kept and repaired by the next ensure, a deleting group left alone; a full table of observed states mapped without any mutation, including VMs left behind failed or canceled deployments; foreign client key, VM tag disagreement, re-cased handle ID, different disk size, different profile name, time-limited lifetime and bad key handled before any mutation; inspect and delete only on the exact owned group, with a concurrent removal reported as already absent.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.

## Follow-ups

1. SSH readiness: host-key attestation through the ARM run command and the `Ready` endpoint, plus explicit Stop (`InteractiveWorkerStopProvider` by deallocation with verified retained state).
2. HTTPS production constructor, the workflow-store fence implementation, then wiring into configuration, dispatchers and UI once the common provider boundary settles.
3. Coordinate on #474: the worker image's provider-bootstrap path requires a RunPod pod ID; Azure uses the plain startup path until generalised.
