### PR TITLE
test(cloud): centralize provider fixture construction

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -378,9 +378,17 @@ impl RunPodClient {
     }
     #[cfg(test)]
     fn with_transport(transport: impl Transport + 'static) -> Self {
+        Self::with_transport_and_fence(transport, |_, _, _: &WorkerTarget, _: &str| Ok(true))
+    }
+
+    #[cfg(test)]
+    fn with_transport_and_fence(
+        transport: impl Transport + 'static,
+        creation_fence: impl RunPodCreationFence + 'static,
+    ) -> Self {
         Self {
             transport: Box::new(transport),
-            creation_fence: Box::new(|_, _, _: &WorkerTarget, _: &str| Ok(true)),
+            creation_fence: Box::new(creation_fence),
         }
     }
 }

--- a/crates/horizon-core/src/cloud_run/runpod/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests.rs
@@ -318,18 +318,16 @@ fn retries_reuse_one_exact_worker_and_reject_ambiguity() {
     let transport = FakeTransport::with_create_response(api_pod(workflow_id, job_id, &target, Some(420_000)));
     let observer = transport.clone();
     let expected_target = target.clone();
-    let client = RunPodClient {
-        transport: Box::new(transport),
-        creation_fence: Box::new(
-            move |actual_workflow, actual_job, actual_target: &WorkerTarget, name: &str| {
-                assert_eq!(actual_workflow, workflow_id);
-                assert_eq!(actual_job, job_id);
-                assert_eq!(actual_target, &expected_target);
-                assert_eq!(name, resource_name(workflow_id, job_id));
-                Ok(false)
-            },
-        ),
-    };
+    let client = RunPodClient::with_transport_and_fence(
+        transport,
+        move |actual_workflow, actual_job, actual_target: &WorkerTarget, name: &str| {
+            assert_eq!(actual_workflow, workflow_id);
+            assert_eq!(actual_job, job_id);
+            assert_eq!(actual_target, &expected_target);
+            assert_eq!(name, resource_name(workflow_id, job_id));
+            Ok(false)
+        },
+    );
     assert!(matches!(
         client.ensure_worker(workflow_id, job_id, &target, &profile()),
         Err(RunPodError::CreationUnresolved { .. })

--- a/crates/horizon-core/src/cloud_run/runpod/tests/noncreating.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/noncreating.rs
@@ -4,13 +4,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 fn read_only_provider(transport: FakeTransport) -> (RunPodInteractiveWorkerProvider, Arc<AtomicUsize>) {
     let claims = Arc::new(AtomicUsize::new(0));
     let calls = claims.clone();
-    let client = RunPodClient {
-        transport: Box::new(transport),
-        creation_fence: Box::new(move |_, _, _: &WorkerTarget, _: &str| {
-            calls.fetch_add(1, Ordering::SeqCst);
-            Ok(true)
-        }),
-    };
+    let client = RunPodClient::with_transport_and_fence(transport, move |_, _, _: &WorkerTarget, _: &str| {
+        calls.fetch_add(1, Ordering::SeqCst);
+        Ok(true)
+    });
     (
         RunPodInteractiveWorkerProvider::new(client, profile(), FakeHostKeySource::new(Some(ed25519_key(73)))),
         claims,

--- a/crates/horizon-core/src/cloud_run/runpod/tests/reconciliation.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/reconciliation.rs
@@ -45,10 +45,10 @@ impl Fixture {
 
     fn provider(&self, transport: FakeTransport) -> RunPodInteractiveWorkerProvider {
         RunPodInteractiveWorkerProvider::new(
-            RunPodClient {
-                transport: Box::new(transport),
-                creation_fence: Box::new(CloudWorkflowStore::open_path(self.store.path()).expect("reopen fence")),
-            },
+            RunPodClient::with_transport_and_fence(
+                transport,
+                CloudWorkflowStore::open_path(self.store.path()).expect("reopen fence"),
+            ),
             profile(),
             FakeHostKeySource::new(Some(ed25519_key(73))),
         )


### PR DESCRIPTION
## Purpose

Centralize test-only construction of a RunPod client with an explicit creation fence. This small prerequisite for #473 lets upcoming storage attachment enforcement extend client state in one place while preserving existing test behavior.

## Behavior impact

No production behavior changes. The helper and all changed call sites are compiled only for tests. Existing fence assertions, claim counters and reopened durable-store behavior are unchanged. Four files, 27 additions and 24 deletions.

## Validation

- Independent local full-diff review: clear.
- All 61 focused RunPod tests passed.
- Blocking and strict Clippy passed before committing.
- All eight local gates passed on `00474330009974198cdfc06d1d1cd82781a22d20`: formatting, maintainability, version sync, full workspace tests, full speech-enabled workspace tests, blocking Clippy, strict Clippy and advisory pedantic Clippy. The checkout remained clean throughout validation.
- No UI or runtime changes; live UI/cloud smoke is not applicable to this test-only prerequisite.

Part of #473; does not close the issue or demonstrate cloud storage attachment, retained Stop or end-to-end remote Git acceptance.
