### PR TITLE
feat(cloud): enforce selected network volume attachments

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -14,6 +14,7 @@ mod host_key;
 mod http;
 mod interactive;
 mod models;
+mod network_attachment;
 mod network_volume;
 mod stop;
 #[cfg(test)]
@@ -108,6 +109,7 @@ impl RunPodCreationFence for super::CloudWorkflowStore {
 pub struct RunPodClient {
     transport: Box<dyn Transport>,
     creation_fence: Box<dyn RunPodCreationFence>,
+    network_binding: Option<network_attachment::NetworkBinding>,
 }
 impl RunPodClient {
     /// Build a production client pinned to `RunPod`'s HTTPS control planes.
@@ -115,6 +117,7 @@ impl RunPodClient {
         Self {
             transport: Box::new(http::RunPodHttp::new(api_key)),
             creation_fence: Box::new(creation_fence),
+            network_binding: None,
         }
     }
     /// Create a worker once, or adopt the single exact resource from an interrupted attempt.
@@ -149,17 +152,20 @@ impl RunPodClient {
         ssh_public_key: Option<&str>,
     ) -> Result<RunPodEnsure, RunPodError> {
         validate_target(target, profile)?;
+        self.check_network_request(workflow_id, job_id, target, ssh_public_key)?;
         if ssh_public_key.is_some_and(|key| !valid_ssh_public_key(key)) {
             return Err(RunPodError::InvalidTarget);
         }
         let name = resource_name(workflow_id, job_id);
         let matches = self.reconcile_by_name(&name)?;
+        self.verify_selected_volume()?;
         let may_create = !matches.is_empty() || self.creation_fence.claim_once(workflow_id, job_id, target, &name)?;
         let (pod, created, expected_deadline) = match matches.as_slice() {
             [] if !may_create => return Err(RunPodError::CreationUnresolved { name }),
             [] => {
-                let request =
+                let mut request =
                     CreatePodRequest::new(workflow_id, job_id, target, profile, name.clone(), ssh_public_key)?;
+                self.apply_network_selection(&mut request);
                 let expected_deadline = request.terminate_after.clone();
                 (self.create_worker(&request)?, true, expected_deadline)
             }
@@ -171,6 +177,7 @@ impl RunPodClient {
                 });
             }
         };
+        let pod = self.fresh_attachment(pod)?;
         let status = match status_from_pod(
             &pod,
             workflow_id,
@@ -237,6 +244,13 @@ impl RunPodClient {
             return Err(RunPodError::InvalidTarget);
         }
         validate_target(&request.target, profile)?;
+        self.check_network_request(
+            request.workflow_id,
+            request.job_id,
+            &request.target,
+            Some(&request.ssh_public_key),
+        )?;
+        self.verify_selected_volume()?;
         let name = resource_name(request.workflow_id, request.job_id);
         let matches = self.reconcile_by_name(&name)?;
         let pod = match matches.as_slice() {
@@ -255,6 +269,7 @@ impl RunPodClient {
         if current.id != pod.id {
             return Err(RunPodError::ResourceIdentityMismatch);
         }
+        self.verify_attachment(&current)?;
         let status = status_from_pod(
             &current,
             request.workflow_id,
@@ -297,10 +312,14 @@ impl RunPodClient {
     /// Inspect an exact persisted worker, returning `None` after provider deletion.
     /// # Errors
     pub fn inspect_worker(&self, worker: &RunPodWorker) -> Result<Option<RunPodWorkerStatus>, RunPodError> {
+        self.require_unbound()?;
         worker.validate()?;
         self.transport
             .get(&worker.pod_id)?
-            .map(|pod| status_from_resource(&pod, worker, None))
+            .map(|pod| {
+                self.verify_attachment(&pod)
+                    .and_then(|()| status_from_resource(&pod, worker, None))
+            })
             .transpose()
     }
 
@@ -313,19 +332,25 @@ impl RunPodClient {
         if !valid_ssh_public_key(ssh_public_key) {
             return Err(RunPodError::InvalidPersistedWorker);
         }
+        self.verify_selected_volume()?;
         self.transport
             .get(&worker.pod_id)?
-            .map(|pod| status_from_resource(&pod, worker, Some(ssh_public_key)))
+            .map(|pod| {
+                self.verify_attachment(&pod)
+                    .and_then(|()| status_from_resource(&pod, worker, Some(ssh_public_key)))
+            })
             .transpose()
     }
     /// Delete only the exact resource proven to belong to the persisted workflow and job.
     /// # Errors
     pub fn delete_worker(&self, worker: &RunPodWorker) -> Result<RunPodCleanup, RunPodError> {
+        self.require_unbound()?;
         worker.validate()?;
         let Some(pod) = self.transport.get(&worker.pod_id)? else {
             return Ok(RunPodCleanup::AlreadyAbsent);
         };
         status_from_resource(&pod, worker, None)?;
+        self.verify_attachment(&pod)?;
         self.transport.delete(&worker.pod_id)
     }
 
@@ -338,10 +363,12 @@ impl RunPodClient {
         if !valid_ssh_public_key(ssh_public_key) {
             return Err(RunPodError::InvalidPersistedWorker);
         }
+        self.verify_selected_volume()?;
         let Some(pod) = self.transport.get(&worker.pod_id)? else {
             return Ok(RunPodCleanup::AlreadyAbsent);
         };
         status_from_resource(&pod, worker, Some(ssh_public_key))?;
+        self.verify_attachment(&pod)?;
         self.transport.delete(&worker.pod_id)
     }
     fn enforce_cost_limit(&self, worker: &RunPodWorker, maximum: Option<u64>) -> Result<(), RunPodError> {
@@ -389,6 +416,7 @@ impl RunPodClient {
         Self {
             transport: Box::new(transport),
             creation_fence: Box::new(creation_fence),
+            network_binding: None,
         }
     }
 }

--- a/crates/horizon-core/src/cloud_run/runpod/create_request.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/create_request.rs
@@ -27,6 +27,8 @@ pub(super) struct CreatePodRequest {
     #[serde(rename = "minUpload", skip_serializing_if = "Option::is_none")]
     pub(super) min_upload_mbps: Option<u32>,
     pub(super) name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) network_volume_id: Option<String>,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub(super) ports: String,
     pub(super) start_ssh: bool,
@@ -95,6 +97,7 @@ impl CreatePodRequest {
             min_download_mbps: profile.min_download_mbps,
             min_upload_mbps: profile.min_upload_mbps,
             name,
+            network_volume_id: None,
             ports: profile.ports.join(","),
             start_ssh: true,
             support_public_ip: true,

--- a/crates/horizon-core/src/cloud_run/runpod/host_key.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/host_key.rs
@@ -2,8 +2,11 @@
 
 use super::{
     ApiPod, CloudProvider, HOST_KEY_BOOTSTRAP_ENV, InteractiveWorkerRequest, RunPodApiKey, RunPodError,
-    RunPodHostKeySource, RunPodLifecycle, RunPodSshEndpoint, RunPodWorker, Transport, http::RunPodHttp,
-    interactive::runpod_worker, status_from_resource,
+    RunPodHostKeySource, RunPodLifecycle, RunPodSshEndpoint, RunPodWorker, Transport,
+    http::RunPodHttp,
+    interactive::runpod_worker,
+    network_attachment::{self, NetworkBinding},
+    status_from_resource,
 };
 use crate::cloud_run::{
     ArtifactDigest,
@@ -20,6 +23,7 @@ mod tests;
 pub struct RunPodHostTrust {
     expected: InteractiveWorkerRequest,
     mode: Mode,
+    network_binding: Option<NetworkBinding>,
 }
 
 enum Mode {
@@ -48,6 +52,7 @@ impl RunPodHostTrust {
         Ok(Self {
             expected: expected.clone(),
             mode: Mode::InitialTaskFree(RunPodHttp::new(api_key)),
+            network_binding: None,
         })
     }
 
@@ -73,11 +78,22 @@ impl RunPodHostTrust {
                 lifetime: retained.lifetime,
                 ssh: ssh.clone(),
             },
+            network_binding: None,
         })
     }
 
+    pub(super) fn bind_network(&mut self, binding: &NetworkBinding) -> Result<(), RunPodError> {
+        if self.expected != binding.request || self.network_binding.as_ref().is_some_and(|current| current != binding) {
+            return Err(RunPodError::InvalidTarget);
+        }
+        self.network_binding = Some(binding.clone());
+        Ok(())
+    }
+
     fn observed(&self, pod: &ApiPod, worker: &RunPodWorker, endpoint: &RunPodSshEndpoint) -> bool {
-        pod.env.get(HOST_KEY_BOOTSTRAP_ENV) == Some(&VERSION.to_string())
+        network_attachment::verify_attachment(pod, self.network_binding.as_ref().map(|binding| &binding.selection))
+            .is_ok()
+            && pod.env.get(HOST_KEY_BOOTSTRAP_ENV) == Some(&VERSION.to_string())
             && status_from_resource(pod, worker, Some(&self.expected.ssh_public_key)).is_ok_and(|status| {
                 status.lifecycle == RunPodLifecycle::Running
                     && status.ssh_username.as_ref() == Some(&endpoint.username)

--- a/crates/horizon-core/src/cloud_run/runpod/host_key/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/host_key/tests.rs
@@ -71,6 +71,7 @@ impl Fixture {
             RunPodHostTrust {
                 expected: self.request.clone(),
                 mode: Mode::InitialTaskFree(http),
+                network_binding: None,
             },
             calls,
         )
@@ -267,6 +268,58 @@ fn malformed_mismatched_and_conflicting_records_never_select_a_key() {
         );
         assert!(!error.to_string().contains(&line));
     }
+}
+
+#[test]
+fn selected_attachment_must_match_both_observations_around_first_pin_logs() {
+    use super::super::{RunPodNetworkVolumeExpectation, network_attachment::NetworkBinding};
+    let fixture = Fixture::new();
+    let selection = RunPodNetworkVolumeExpectation {
+        volume_id: "volume_exact".into(),
+        data_center_id: "EUR-NO-1".into(),
+        minimum_size_gb: 10,
+    };
+    let binding = NetworkBinding::new(&fixture.request, &selection, &profile()).expect("binding");
+    let mut pod = fixture.pod();
+    pod["mounts"] = json!({"network": [{"volumeId": "volume_exact", "path": "/workspace"}]});
+    pod["cloud"] = json!("SECURE");
+    pod["dataCenterId"] = json!("EUR-NO-1");
+    let responses = || {
+        vec![
+            (200, "application/json", pod.to_string()),
+            (200, "text/event-stream", record_event(&fixture.record())),
+            (200, "application/json", pod.to_string()),
+        ]
+    };
+    let (mut source, calls) = fixture.source(responses());
+    source.bind_network(&binding).expect("bind");
+    assert_eq!(fixture.key(&source), Some(ed25519_key(73)));
+    assert_eq!(calls.lock().expect("calls").len(), 3);
+    for index in [0, 2] {
+        for pointer in [
+            "/mounts",
+            "/mounts/network/0/volumeId",
+            "/mounts/network/0/path",
+            "/cloud",
+            "/dataCenterId",
+        ] {
+            let mut changed = pod.clone();
+            *changed.pointer_mut(pointer).expect("field") = json!("changed");
+            let mut replies = responses();
+            replies[index].2 = changed.to_string();
+            let (mut source, calls) = fixture.source(replies);
+            source.bind_network(&binding).expect("bind");
+            assert_eq!(fixture.key(&source), None, "{pointer} at read {index}");
+            assert_eq!(calls.lock().expect("calls").len(), index + 1);
+        }
+    }
+    let (source, calls) = fixture.source(responses());
+    assert_eq!(
+        fixture.key(&source),
+        None,
+        "ordinary trust must not adopt network storage"
+    );
+    assert_eq!(calls.lock().expect("calls").len(), 1);
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -8,8 +8,9 @@ use super::super::{
     interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
 };
 use super::{
-    RunPodCleanup, RunPodClient, RunPodEnsure, RunPodError, RunPodLifecycle, RunPodProfile, RunPodSshEndpoint,
-    RunPodWorker, RunPodWorkerStatus, resource_name,
+    RunPodCleanup, RunPodClient, RunPodEnsure, RunPodError, RunPodHostTrust, RunPodLifecycle,
+    RunPodNetworkVolumeExpectation, RunPodProfile, RunPodSshEndpoint, RunPodWorker, RunPodWorkerStatus,
+    network_attachment::NetworkBinding, resource_name,
 };
 
 /// Trusted source for the runtime SSH host key of one exact worker.
@@ -50,6 +51,25 @@ pub struct RunPodInteractiveWorkerProvider {
 }
 
 impl RunPodInteractiveWorkerProvider {
+    /// Bind one caller-authorized selection to the complete persistent request.
+    /// The caller must retain this selection before creation and reuse it on recovery.
+    /// This does not prove volume ownership, exclusivity, contents or durability,
+    /// and grants no volume mutation or network-volume Stop support.
+    /// # Errors
+    /// Rejects invalid or conflicting requests, profiles and prior bindings before I/O.
+    pub fn new_with_network_volume(
+        mut client: RunPodClient,
+        profile: RunPodProfile,
+        mut trust: RunPodHostTrust,
+        expected: &InteractiveWorkerRequest,
+        selection: &RunPodNetworkVolumeExpectation,
+    ) -> Result<Self, RunPodError> {
+        let binding = NetworkBinding::new(expected, selection, &profile)?;
+        client.bind_network(&binding)?;
+        trust.bind_network(&binding)?;
+        Ok(Self::new(client, profile, trust))
+    }
+
     #[must_use]
     pub fn new(client: RunPodClient, profile: RunPodProfile, host_keys: impl RunPodHostKeySource + 'static) -> Self {
         Self {
@@ -169,6 +189,7 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
     }
 
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.client.check_network_worker(worker)?;
         let target = worker.target.clone();
         let ssh_public_key = worker.ssh_public_key.clone();
         let worker = runpod_worker(worker)?;
@@ -187,6 +208,7 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
     }
 
     fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.client.check_network_worker(worker)?;
         let ssh_public_key = worker.ssh_public_key.clone();
         let worker = runpod_worker(worker)?;
         Ok(match self.client.delete_interactive_worker(&worker, &ssh_public_key)? {
@@ -198,6 +220,10 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
 
 impl InteractiveWorkerStopProvider for RunPodInteractiveWorkerProvider {
     fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error> {
+        self.client.check_network_worker(worker)?;
+        if self.client.network_binding.is_some() {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
         let retained = runpod_worker(worker)?;
         super::validate_target(&worker.target, &self.profile)?;
         self.client

--- a/crates/horizon-core/src/cloud_run/runpod/network_attachment.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_attachment.rs
@@ -1,0 +1,166 @@
+//! Request-bound attachment checks, not volume ownership or exclusivity proof.
+
+use super::{
+    ApiPod, CloudJobId, CloudProvider, CloudWorkflowId, CreatePodRequest, InteractiveWorkerRequest, RunPodClient,
+    RunPodError, RunPodNetworkVolumeExpectation, RunPodProfile, WorkerLifetime, WorkerTarget, validate_target,
+};
+use crate::cloud_run::interactive_worker::InteractiveWorker;
+use serde::Deserialize;
+
+#[derive(Clone, Eq, PartialEq)]
+pub(super) struct NetworkBinding {
+    pub(super) request: InteractiveWorkerRequest,
+    pub(super) selection: RunPodNetworkVolumeExpectation,
+}
+
+impl NetworkBinding {
+    pub(super) fn new(
+        request: &InteractiveWorkerRequest,
+        selection: &RunPodNetworkVolumeExpectation,
+        profile: &RunPodProfile,
+    ) -> Result<Self, RunPodError> {
+        validate_target(&request.target, profile)?;
+        selection.validate()?;
+        if !request.is_valid_for(CloudProvider::RunPod)
+            || request.target.lifetime != WorkerLifetime::Persistent
+            || profile
+                .data_center_id
+                .as_ref()
+                .is_some_and(|id| id != &selection.data_center_id)
+        {
+            return Err(RunPodError::InvalidTarget);
+        }
+        Ok(Self {
+            request: request.clone(),
+            selection: selection.clone(),
+        })
+    }
+}
+
+impl RunPodClient {
+    pub(super) fn bind_network(&mut self, binding: &NetworkBinding) -> Result<(), RunPodError> {
+        if self.network_binding.as_ref().is_some_and(|current| current != binding) {
+            return Err(RunPodError::InvalidTarget);
+        }
+        self.network_binding = Some(binding.clone());
+        Ok(())
+    }
+
+    pub(super) fn check_network_request(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        key: Option<&str>,
+    ) -> Result<(), RunPodError> {
+        if let Some(binding) = &self.network_binding {
+            let expected = &binding.request;
+            if expected.workflow_id != workflow_id
+                || expected.job_id != job_id
+                || &expected.target != target
+                || key != Some(expected.ssh_public_key.as_str())
+            {
+                return Err(RunPodError::InvalidTarget);
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn check_network_worker(&self, worker: &InteractiveWorker) -> Result<(), RunPodError> {
+        if self.network_binding.is_some() && !worker.is_valid_for(CloudProvider::RunPod) {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        self.check_network_request(
+            worker.identity.workflow_id,
+            worker.identity.job_id,
+            &worker.target,
+            Some(&worker.ssh_public_key),
+        )
+    }
+
+    pub(super) fn require_unbound(&self) -> Result<(), RunPodError> {
+        self.network_binding
+            .is_none()
+            .then_some(())
+            .ok_or(RunPodError::InvalidTarget)
+    }
+
+    pub(super) fn verify_selected_volume(&self) -> Result<(), RunPodError> {
+        if let Some(binding) = &self.network_binding {
+            self.inspect_high_performance_volume(&binding.selection)?
+                .ok_or(RunPodError::ResourceIdentityMismatch)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn apply_network_selection(&self, request: &mut CreatePodRequest) {
+        if let Some(binding) = &self.network_binding {
+            request.network_volume_id = Some(binding.selection.volume_id.clone());
+            request.data_center_id = Some(binding.selection.data_center_id.clone());
+            request.volume_in_gb = 0;
+        }
+    }
+
+    pub(super) fn fresh_attachment(&self, pod: ApiPod) -> Result<ApiPod, RunPodError> {
+        let current = if self.network_binding.is_some() {
+            let current = self
+                .transport
+                .get(&pod.id)?
+                .ok_or(RunPodError::ResourceIdentityMismatch)?;
+            if current.id != pod.id {
+                return Err(RunPodError::ResourceIdentityMismatch);
+            }
+            current
+        } else {
+            pod
+        };
+        self.verify_attachment(&current)?;
+        Ok(current)
+    }
+
+    pub(super) fn verify_attachment(&self, pod: &ApiPod) -> Result<(), RunPodError> {
+        verify_attachment(pod, self.network_binding.as_ref().map(|binding| &binding.selection))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkMounts {
+    network: Vec<NetworkMount>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct NetworkMount {
+    volume_id: String,
+    path: String,
+}
+
+pub(super) fn verify_attachment(
+    pod: &ApiPod,
+    selection: Option<&RunPodNetworkVolumeExpectation>,
+) -> Result<(), RunPodError> {
+    let mounts = pod.stop.mounts();
+    let Some(selection) = selection else {
+        // Unknown optional legacy metadata remains compatible; a network entry
+        // (even malformed or empty) must never select ordinary adoption.
+        return mounts
+            .get("network")
+            .is_none()
+            .then_some(())
+            .ok_or(RunPodError::ResourceIdentityMismatch);
+    };
+    let mounts: NetworkMounts =
+        serde_json::from_value(mounts.clone()).map_err(|_| RunPodError::ResourceIdentityMismatch)?;
+    if !pod.stop.is_secure_data_center(&selection.data_center_id)
+        || mounts.network.len() != 1
+        || mounts.network[0].volume_id != selection.volume_id
+        || mounts.network[0].path != "/workspace"
+    {
+        return Err(RunPodError::ResourceIdentityMismatch);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests.rs
@@ -1,0 +1,441 @@
+use super::super::{
+    RunPodApiKey, RunPodCleanup, RunPodHostTrust, RunPodInteractiveWorkerProvider, Transport,
+    interactive::runpod_worker,
+    network_volume::ApiNetworkVolume,
+    resource_name,
+    stop::StopMetadata,
+    tests::{ed25519_key, interactive_request, profile},
+};
+use super::*;
+use crate::cloud_run::interactive_worker::{
+    InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity, InteractiveWorkerLifetime,
+    InteractiveWorkerProvider, InteractiveWorkerSshEndpoint,
+};
+use crate::cloud_run::interactive_worker_stop::InteractiveWorkerStopProvider;
+use serde_json::{Value, json};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Clone)]
+struct FakeTransport(Arc<Mutex<State>>);
+
+struct State {
+    calls: Vec<&'static str>,
+    volume: Option<Value>,
+    pods: Vec<ApiPod>,
+    template: ApiPod,
+    creates: Vec<CreatePodRequest>,
+    lose_create: bool,
+    fresh: Option<ApiPod>,
+    deleted: Vec<String>,
+}
+
+impl Transport for FakeTransport {
+    fn network_volume(&self, id: &str) -> Result<Option<ApiNetworkVolume>, RunPodError> {
+        assert_eq!(id, "volume_exact");
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("volume");
+        Ok(state
+            .volume
+            .clone()
+            .map(|value| serde_json::from_value(value).expect("volume")))
+    }
+    fn list_by_name(&self, _: &str) -> Result<Vec<ApiPod>, RunPodError> {
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("list");
+        Ok(state.pods.clone())
+    }
+    fn create(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError> {
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("create");
+        state.creates.push(request.clone());
+        let pod = state.template.clone();
+        state.pods.push(pod.clone());
+        if state.lose_create {
+            Err(RunPodError::RequestFailed {
+                operation: "pod creation",
+            })
+        } else {
+            Ok(pod)
+        }
+    }
+    fn get(&self, id: &str) -> Result<Option<ApiPod>, RunPodError> {
+        assert_eq!(id, "pod_exact");
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("get");
+        Ok(state.fresh.clone().or_else(|| state.pods.first().cloned()))
+    }
+    fn stop(&self, _: &str) -> Result<(), RunPodError> {
+        panic!("network Stop is unsupported")
+    }
+    fn delete(&self, id: &str) -> Result<RunPodCleanup, RunPodError> {
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("delete");
+        state.deleted.push(id.into());
+        state.pods.clear();
+        Ok(RunPodCleanup::Deleted)
+    }
+}
+
+struct Fixture {
+    request: InteractiveWorkerRequest,
+    selection: RunPodNetworkVolumeExpectation,
+    transport: FakeTransport,
+    claims: Arc<AtomicUsize>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let mut request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+        request.target.lifetime = WorkerLifetime::Persistent;
+        let selection = RunPodNetworkVolumeExpectation {
+            volume_id: "volume_exact".into(),
+            data_center_id: "EUR-NO-1".into(),
+            minimum_size_gb: 10,
+        };
+        let template = serde_json::from_value(json!({
+            "id": "pod_exact", "name": resource_name(request.workflow_id, request.job_id),
+            "image": request.target.image, "status": "RUNNING", "cost": 0.5,
+            "env": {"HORIZON_WORKFLOW_ID": request.workflow_id, "HORIZON_JOB_ID": request.job_id,
+                "HORIZON_CLOUD_PROTOCOL_VERSION": "1", "HORIZON_WORKER_LIFETIME": "persistent",
+                "HORIZON_SSH_PUBLIC_KEY": request.ssh_public_key},
+            "ssh": {"direct": {"username": "root", "host": "worker.example", "port": 2200}},
+            "cloud": "SECURE", "dataCenterId": selection.data_center_id,
+            "mounts": {"network": [{"volumeId": selection.volume_id, "path": "/workspace"}]}
+        }))
+        .expect("pod");
+        let volume = Some(
+            json!({"id": selection.volume_id, "dataCenter": selection.data_center_id,
+            "size": 10, "type": "HIGH_PERFORMANCE"}),
+        );
+        Self {
+            request,
+            selection,
+            claims: Arc::new(AtomicUsize::new(0)),
+            transport: FakeTransport(Arc::new(Mutex::new(State {
+                calls: Vec::new(),
+                volume,
+                pods: Vec::new(),
+                template,
+                creates: Vec::new(),
+                lose_create: false,
+                fresh: None,
+                deleted: Vec::new(),
+            }))),
+        }
+    }
+    fn client(&self) -> RunPodClient {
+        let claims = self.claims.clone();
+        let transport = self.transport.clone();
+        RunPodClient::with_transport_and_fence(self.transport.clone(), move |_, _, _: &WorkerTarget, _: &str| {
+            transport.0.lock().expect("state").calls.push("claim");
+            Ok(claims.fetch_add(1, Ordering::SeqCst) == 0)
+        })
+    }
+    fn worker(&self) -> InteractiveWorker {
+        InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::RunPod,
+                workflow_id: self.request.workflow_id,
+                job_id: self.request.job_id,
+                resource_id: "pod_exact".into(),
+            },
+            target: self.request.target.clone(),
+            ssh_public_key: self.request.ssh_public_key.clone(),
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        }
+    }
+    fn trust(&self) -> RunPodHostTrust {
+        RunPodHostTrust::retained(
+            &self.worker(),
+            &InteractiveWorkerSshEndpoint {
+                username: "root".into(),
+                host: "worker.example".into(),
+                port: 2200,
+                host_key: ed25519_key(73),
+            },
+        )
+        .expect("retained trust")
+    }
+    fn provider(&self) -> RunPodInteractiveWorkerProvider {
+        RunPodInteractiveWorkerProvider::new_with_network_volume(
+            self.client(),
+            profile(),
+            self.trust(),
+            &self.request,
+            &self.selection,
+        )
+        .expect("bound provider")
+    }
+    fn existing(&self) {
+        let mut state = self.transport.0.lock().expect("state");
+        state.pods = vec![state.template.clone()];
+    }
+    fn untouched(&self) {
+        assert!(self.transport.0.lock().expect("state").calls.is_empty());
+        assert_eq!(self.claims.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn constructor_refuses_conflicts_and_never_silently_rebinds() {
+    let fixture = Fixture::new();
+    let binding = NetworkBinding::new(&fixture.request, &fixture.selection, &profile()).expect("binding");
+    for change in 0..6 {
+        let mut selection = fixture.selection.clone();
+        let mut expected = fixture.request.clone();
+        let mut selected_profile = profile();
+        match change {
+            0 => selection.volume_id = "../wrong".into(),
+            1 => selection.minimum_size_gb = 0,
+            2 => selected_profile.data_center_id = Some("other".into()),
+            3 => expected.target.lifetime = WorkerLifetime::TimeLimited { seconds: 3600 },
+            4 => expected.job_id = CloudJobId::new(),
+            _ => selection.volume_id = "another_volume".into(),
+        }
+        let mut client = fixture.client();
+        client.bind_network(&binding).expect("first bind");
+        assert!(
+            RunPodInteractiveWorkerProvider::new_with_network_volume(
+                client,
+                selected_profile,
+                fixture.trust(),
+                &expected,
+                &selection
+            )
+            .is_err()
+        );
+    }
+    let mut trust = fixture.trust();
+    trust.bind_network(&binding).expect("first trust binding");
+    let mut changed = binding.clone();
+    changed.selection.minimum_size_gb += 1;
+    assert_eq!(trust.bind_network(&changed), Err(RunPodError::InvalidTarget));
+    trust.bind_network(&binding).expect("same trust binding");
+    let api_key = RunPodApiKey::new("synthetic").expect("key");
+    let mut other = fixture.request.clone();
+    other.job_id = CloudJobId::new();
+    let trust = RunPodHostTrust::initial_task_free(&api_key, &other).expect("other trust");
+    assert!(
+        RunPodInteractiveWorkerProvider::new_with_network_volume(
+            fixture.client(),
+            profile(),
+            trust,
+            &fixture.request,
+            &fixture.selection
+        )
+        .is_err()
+    );
+    fixture.untouched();
+}
+
+#[test]
+fn complete_request_and_original_worker_guards_precede_every_io_path() {
+    let fixture = Fixture::new();
+    let provider = fixture.provider();
+    for change in 0..9 {
+        let mut request = fixture.request.clone();
+        match change {
+            0 => request.workflow_id = CloudWorkflowId::new(),
+            1 => request.job_id = CloudJobId::new(),
+            2 => request.target.profile = "other".into(),
+            3 => request.target.disk_gib += 1,
+            4 => request.target.max_hourly_cost_micros = Some(123),
+            5 => request.target.image = request.target.image.replace('d', "e"),
+            6 => request.target.lifetime = WorkerLifetime::TimeLimited { seconds: 3600 },
+            7 => request.ssh_public_key = ed25519_key(90),
+            _ => request.target.provider = CloudProvider::Azure,
+        }
+        assert!(provider.ensure_worker(&request).is_err());
+        assert!(provider.reconcile_worker(&request).is_err());
+        let mut worker = fixture.worker();
+        worker.identity.workflow_id = request.workflow_id;
+        worker.identity.job_id = request.job_id;
+        worker.target = request.target;
+        worker.ssh_public_key = request.ssh_public_key;
+        assert!(provider.inspect_worker(&worker).is_err());
+        assert!(provider.delete_worker(&worker).is_err());
+        assert!(provider.stop_worker(&worker).is_err());
+    }
+    assert_eq!(
+        provider.stop_worker(&fixture.worker()),
+        Err(RunPodError::StopRetentionUnverified)
+    );
+    let mut client = fixture.client();
+    client
+        .bind_network(&NetworkBinding::new(&fixture.request, &fixture.selection, &profile()).expect("binding"))
+        .expect("bind");
+    let worker = runpod_worker(&fixture.worker()).expect("worker");
+    assert!(client.inspect_worker(&worker).is_err());
+    assert!(client.delete_worker(&worker).is_err());
+    assert!(
+        client
+            .ensure_worker(
+                fixture.request.workflow_id,
+                fixture.request.job_id,
+                &fixture.request.target,
+                &profile()
+            )
+            .is_err()
+    );
+    fixture.untouched();
+}
+
+#[test]
+fn absent_or_mismatched_fresh_volume_never_consumes_a_creation_claim() {
+    for change in 0..5 {
+        let fixture = Fixture::new();
+        {
+            let mut state = fixture.transport.0.lock().expect("state");
+            let volume = state.volume.as_mut().expect("volume");
+            match change {
+                0 => volume["id"] = json!("other"),
+                1 => volume["dataCenter"] = json!("other"),
+                2 => volume["type"] = json!("STANDARD"),
+                3 => volume["size"] = json!(9),
+                _ => state.volume = None,
+            }
+        }
+        assert_eq!(
+            fixture.provider().ensure_worker(&fixture.request),
+            Err(RunPodError::ResourceIdentityMismatch)
+        );
+        assert_eq!(fixture.claims.load(Ordering::SeqCst), 0);
+        let state = fixture.transport.0.lock().expect("state");
+        assert!(state.creates.is_empty() && state.deleted.is_empty());
+    }
+}
+
+#[test]
+fn selected_creation_uses_exact_payload_and_checks_metadata_before_claim() {
+    let fixture = Fixture::new();
+    let mut selected_profile = profile();
+    selected_profile.data_center_id = None;
+    let provider = RunPodInteractiveWorkerProvider::new_with_network_volume(
+        fixture.client(),
+        selected_profile,
+        fixture.trust(),
+        &fixture.request,
+        &fixture.selection,
+    )
+    .expect("bind");
+    let InteractiveWorkerEnsure::Created(status) = provider.ensure_worker(&fixture.request).expect("create") else {
+        panic!("created")
+    };
+    assert!(status.is_ready_for(&fixture.request, time::OffsetDateTime::now_utc()));
+    let state = fixture.transport.0.lock().expect("state");
+    let payload = serde_json::to_value(&state.creates[0]).expect("payload");
+    assert_eq!(payload["networkVolumeId"], "volume_exact");
+    assert_eq!(payload["dataCenterId"], "EUR-NO-1");
+    assert_eq!(payload["volumeInGb"], 0);
+    assert_eq!(payload["volumeMountPath"], "/workspace");
+    assert_eq!(payload["cloudType"], "SECURE");
+    assert!(payload.get("terminateAfter").is_none());
+    assert!(
+        state
+            .calls
+            .windows(3)
+            .any(|calls| calls == ["volume", "claim", "create"])
+    );
+    assert_eq!(state.calls.last(), Some(&"get"));
+}
+
+#[test]
+fn lost_create_response_is_recovered_without_another_create_or_cleanup() {
+    let fixture = Fixture::new();
+    fixture.transport.0.lock().expect("state").lose_create = true;
+    assert!(matches!(
+        fixture.provider().ensure_worker(&fixture.request),
+        Err(RunPodError::PersistentCreationUnresolved { .. })
+    ));
+    let pod = fixture
+        .transport
+        .0
+        .lock()
+        .expect("state")
+        .pods
+        .pop()
+        .expect("created pod");
+    assert!(matches!(
+        fixture.provider().ensure_worker(&fixture.request),
+        Err(RunPodError::CreationUnresolved { .. })
+    ));
+    fixture.transport.0.lock().expect("state").pods.push(pod);
+    let recovered = fixture
+        .provider()
+        .reconcile_worker(&fixture.request)
+        .expect("recover")
+        .expect("pod");
+    assert!(recovered.is_ready_for(&fixture.request, time::OffsetDateTime::now_utc()));
+    assert!(matches!(
+        fixture.provider().ensure_worker(&fixture.request),
+        Ok(InteractiveWorkerEnsure::Reused(_))
+    ));
+    let state = fixture.transport.0.lock().expect("state");
+    assert_eq!(state.creates.len(), 1);
+    assert!(state.deleted.is_empty());
+}
+
+#[test]
+fn v2_attachment_mismatches_never_adopt_ready_or_delete_a_resource() {
+    for metadata in [
+        json!({}),
+        json!({"network": []}),
+        json!({"network": [{"volumeId":"other","path":"/workspace"}]}),
+        json!({"network": [{"volumeId":"volume_exact","path":"/elsewhere"}]}),
+        json!({"network": [{"volumeId":"volume_exact","path":"/workspace"},{"volumeId":"volume_exact","path":"/workspace"}]}),
+        json!({"network": [{"volumeId":"volume_exact","path":"/workspace"}],"persistent":{"path":"/workspace","size":10}}),
+    ] {
+        let fixture = Fixture::new();
+        fixture.existing();
+        fixture.transport.0.lock().expect("state").pods[0].stop = serde_json::from_value(json!({
+            "mounts": metadata, "cloud":"SECURE", "dataCenterId":"EUR-NO-1"}))
+        .expect("metadata");
+        let provider = fixture.provider();
+        assert!(provider.ensure_worker(&fixture.request).is_err());
+        assert!(provider.reconcile_worker(&fixture.request).is_err());
+        assert!(provider.inspect_worker(&fixture.worker()).is_err());
+        assert!(provider.delete_worker(&fixture.worker()).is_err());
+        let state = fixture.transport.0.lock().expect("state");
+        assert!(state.creates.is_empty() && state.deleted.is_empty());
+        assert_eq!(fixture.claims.load(Ordering::SeqCst), 0);
+    }
+    for field in ["cloud", "dataCenterId"] {
+        let fixture = Fixture::new();
+        let mut metadata = json!({"mounts":{"network":[{"volumeId":"volume_exact","path":"/workspace"}]},
+            "cloud":"SECURE", "dataCenterId":"EUR-NO-1"});
+        metadata[field] = json!("other");
+        let mut state = fixture.transport.0.lock().expect("state");
+        state.template.stop = serde_json::from_value(metadata).expect("metadata");
+        drop(state);
+        assert!(fixture.provider().ensure_worker(&fixture.request).is_err());
+        assert!(fixture.transport.0.lock().expect("state").deleted.is_empty());
+    }
+}
+
+#[test]
+fn fresh_exact_pod_and_ordinary_rejection_cannot_be_bypassed() {
+    let fixture = Fixture::new();
+    fixture.existing();
+    let mut drift = fixture.transport.0.lock().expect("state").template.clone();
+    drift.stop = StopMetadata::default();
+    fixture.transport.0.lock().expect("state").fresh = Some(drift);
+    assert!(fixture.provider().ensure_worker(&fixture.request).is_err());
+    fixture.transport.0.lock().expect("state").fresh = None;
+    let ordinary = RunPodInteractiveWorkerProvider::new(fixture.client(), profile(), fixture.trust());
+    assert!(ordinary.ensure_worker(&fixture.request).is_err());
+    assert!(ordinary.reconcile_worker(&fixture.request).is_err());
+    assert!(ordinary.inspect_worker(&fixture.worker()).is_err());
+    assert!(ordinary.delete_worker(&fixture.worker()).is_err());
+    let worker = runpod_worker(&fixture.worker()).expect("worker");
+    assert!(fixture.client().inspect_worker(&worker).is_err());
+    assert!(fixture.client().delete_worker(&worker).is_err());
+    assert!(fixture.transport.0.lock().expect("state").deleted.is_empty());
+    assert_eq!(
+        fixture.provider().delete_worker(&fixture.worker()),
+        Ok(InteractiveWorkerCleanup::Deleted)
+    );
+    assert_eq!(fixture.transport.0.lock().expect("state").deleted, ["pod_exact"]);
+}

--- a/crates/horizon-core/src/cloud_run/runpod/network_volume.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_volume.rs
@@ -16,6 +16,18 @@ pub struct RunPodNetworkVolumeExpectation {
     pub minimum_size_gb: u32,
 }
 
+impl RunPodNetworkVolumeExpectation {
+    pub(super) fn validate(&self) -> Result<(), RunPodError> {
+        if !valid_provider_id(&self.volume_id)
+            || !valid_provider_id(&self.data_center_id)
+            || !(MIN_VOLUME_GB..=MAX_VOLUME_GB).contains(&self.minimum_size_gb)
+        {
+            return Err(RunPodError::InvalidTarget);
+        }
+        Ok(())
+    }
+}
+
 /// Point-in-time metadata for a matching High-Performance network volume.
 ///
 /// This is not proof of ownership, exclusivity, mount permissions, filesystem
@@ -51,12 +63,7 @@ impl RunPodClient {
         &self,
         expected: &RunPodNetworkVolumeExpectation,
     ) -> Result<Option<RunPodNetworkVolume>, RunPodError> {
-        if !valid_provider_id(&expected.volume_id)
-            || !valid_provider_id(&expected.data_center_id)
-            || !(MIN_VOLUME_GB..=MAX_VOLUME_GB).contains(&expected.minimum_size_gb)
-        {
-            return Err(RunPodError::InvalidTarget);
-        }
+        expected.validate()?;
         let Some(volume) = self.transport.network_volume(&expected.volume_id)? else {
             return Ok(None);
         };

--- a/crates/horizon-core/src/cloud_run/runpod/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/stop.rs
@@ -20,6 +20,18 @@ pub(super) struct StopMetadata {
     cloud: Value,
     cluster: Value,
     runtime: Value,
+    #[serde(rename = "dataCenterId")]
+    data_center_id: Value,
+}
+
+impl StopMetadata {
+    pub(super) fn mounts(&self) -> &Value {
+        &self.mounts
+    }
+
+    pub(super) fn is_secure_data_center(&self, expected: &str) -> bool {
+        self.cloud == "SECURE" && self.data_center_id.as_str() == Some(expected)
+    }
 }
 
 #[derive(Deserialize)]
@@ -49,6 +61,9 @@ impl RunPodClient {
         ssh_public_key: &str,
         profile: &RunPodProfile,
     ) -> Result<InteractiveWorkerStop, RunPodError> {
+        if self.network_binding.is_some() {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
         worker.validate()?;
         if worker.lifetime != InteractiveWorkerLifetime::Persistent {
             return Err(RunPodError::StopUnsupportedLifetime);

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -429,6 +429,13 @@ back into large multi-purpose modules.
   creation-request construction. Public type re-exports remain stable. HTTP
   transport and common interactive-worker adaptation stay in their existing
   `http.rs` and `interactive.rs` leaves.
+- `cloud_run/runpod/network_attachment.rs` binds one complete interactive request
+  and caller-selected HPS volume to the client and host trust. Fresh volume
+  metadata precedes the creation claim; exact v2 Pod attachment checks precede
+  readiness and both first-pin observations. Ordinary clients reject network
+  adoption. This leaf grants no storage ownership, exclusivity, contents trust,
+  volume mutation or network-volume Stop, and does not wire setup admission.
+  Its colocated tests retain the ordinary lifecycle regression boundary.
 - `cloud_run/runpod/stop.rs` adds only explicit, exact-Pod Stop for persistent
   workers with a verified ordinary `/workspace` volume. It verifies retained
   inactive state after a single Stop action, including a lost response, without


### PR DESCRIPTION
## Purpose

Enforce a caller-selected network-volume attachment for one exact persistent worker request. Reuses #516 metadata verification and the saved immutable selection from #518. Part of #473; does not close it.

## Behavior

- Adds an explicit request/selection-bound provider constructor. A different workflow, job, complete target or SSH client key is rejected before provider I/O; existing bindings cannot be silently redirected.
- Fresh exact volume metadata is checked before the one-shot creation claim. Creation supplies the selected volume/data center at `/workspace`, with no ordinary Pod volume allocation.
- Fresh v2 Pod attachment checks precede readiness, inspection and exact Pod deletion, including both observations around initial host-key log sampling. Missing, changed, duplicate or conflicting mounts fail closed.
- Lost create responses preserve existing reconciliation semantics: no automatic create replay or compensating deletion of uncertain persistent resources.
- Ordinary clients reject network-volume adoption. Network-volume Stop remains explicitly unsupported in this slice.
- Shared volume-input validation and a small attachment module keep provider orchestration and metadata parsing separate.

The caller must authorize and retain the selection. This does not prove volume ownership, exclusivity, trusted contents, filesystem durability or cloud retention, and adds no volume create/update/delete operation. Saved-selection setup/recovery wiring follows separately.

## Validation

- Independent full local review and correction review: clear.
- Focused provider and first-pin HTTP regressions cover request mismatch, exact payload, metadata-before-claim, lost-response reconciliation, attachment drift, ordinary rejection and exact cleanup boundaries.
- All 69 focused provider tests passed, including the real HTTP first-pin observation regressions.
- All eight local gates passed on `205646ebf1384d95945157551f3e219cba487d97`: format, maintainability, version sync, full default/speech workspace tests and blocking/strict/advisory Clippy. The checkout remained clean throughout final validation.

Nine source/test files, 783 changed source/test lines, plus seven architecture-note lines. No UI, configuration defaults or dependencies changed. No live UI smoke applies; actual cloud attachment/retention is a later integration acceptance gate, not claimed by these synthetic tests.
