### PR TITLE
feat(worker): install runtime credentials without overwrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: python3 -B containers/remote-worker/test_setup_launch.py -v
       - name: Verify on-demand GitHub credentials
         run: python3 -B containers/remote-worker/test_github_credentials.py -v
+      - name: Verify explicit worker token installation
+        run: python3 -B containers/remote-worker/test_github_token_install.py -v
       - name: Verify source allowlist and excluded-file controls
         run: python3 -B containers/remote-worker/test_repository_packaging.py --docker-host unix:///var/run/docker.sock
 

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -191,7 +191,7 @@ configuration error, not an instruction to run forever. Existing providers that
 supply deadlines retain their bounded behavior; provider API/profile support for
 persistent lifetime is a separate integration step.
 
-The optional GitHub token must be mounted as the exact read-only file
+At startup, the optional GitHub token must be mounted as the exact read-only file
 `/run/secrets/github-token`, with `HORIZON_GITHUB_TOKEN_FILE` set to that path.
 Writable mounts, other paths, symlinks, and direct `HORIZON_GITHUB_TOKEN`
 injection are rejected. The standard `GITHUB_TOKEN` and `GH_TOKEN` environment
@@ -254,10 +254,38 @@ Supply a fine-grained PAT restricted to the required repositories and permission
 creation, rotation and provider delivery of that token remain separate work.
 Retained repository setup remains offline and does not acquire credentials.
 
+For providers without a secret-file mount, the worker also exposes an explicit
+`/usr/local/bin/horizon-github-credential install` command. A controller must first
+admit the exact owned worker and authenticate its retained SSH host pin, then send
+only the PAT on that command's stdin over the pinned connection. Never put the
+token in a command argument, environment variable or provider descriptor. This
+worker-side primitive does not implement controller admission or provider/UI wiring.
+
+Input is bounded to 16 KiB, with at most one trailing newline. Installation requires
+the existing private `/run/horizon` directory; it never creates or repairs that
+directory. A successful reply is JSON with `version: 1` and `status: installed`.
+Re-supplying the exact existing token returns `status: present` without writing.
+A different or unsafe existing token, concurrent installation, invalid input or an
+interrupted private candidate fails without replacing the credential. Errors and
+receipts contain no token or token hash. A failed/missing reply is uncertain, not
+permission to remove files, rotate credentials or restart the worker.
+A delayed concurrent loser may leave its private candidate after another installer
+publishes; this does not replace the winning token. Directory changes during the
+final verification can also produce an uncertain reply despite publication.
+
+The token and exclusive `.pending` candidate remain runtime-only, outside retained
+workspace data. Startup clears both before applying any explicitly mounted token;
+after a provider restart, the controller must explicitly supply a token again.
+No periodic client renewal is required while the worker keeps running. The command
+does not start Git or tasks, contact GitHub, validate PAT permissions or stop any
+existing work. Root inside the worker can intentionally read the credential; this
+is not isolation from authorized root tasks.
+
 Run the credential regressions without network or real credentials:
 
 ```bash
 python3 -B containers/remote-worker/test_github_credentials.py -v
+python3 -B containers/remote-worker/test_github_token_install.py -v
 ```
 
 The provider or operator must supply retained storage at `/workspace`; the image

--- a/containers/remote-worker/entrypoint.sh
+++ b/containers/remote-worker/entrypoint.sh
@@ -80,7 +80,7 @@ fi
 install -m 0600 "${authorized_key_candidate}" /root/.ssh/authorized_keys
 rm -f "${authorized_key_candidate}"
 
-rm -f /run/horizon/github-token
+rm -f /run/horizon/github-token /run/horizon/github-token.pending
 github_token_file=${HORIZON_GITHUB_TOKEN_FILE:-}
 token_bytes=0
 if [ -n "${github_token_file}" ]; then

--- a/containers/remote-worker/github-credentials.py
+++ b/containers/remote-worker/github-credentials.py
@@ -2,6 +2,7 @@
 """Consume the worker's protected runtime token without persisting credentials."""
 
 import os
+import json
 from pathlib import Path
 import re
 import stat
@@ -60,9 +61,59 @@ def read_token():
         os.close(directory)
     # Fine-grained and classic PATs use this alphabet. Permit one file-ending LF,
     # never whitespace/control characters that could inject credential fields.
+    return decode_token(raw)
+
+
+def decode_token(raw):
+    require(1 <= len(raw) <= MAX_TOKEN)
     value = raw.removesuffix(b'\n')
     require(re.fullmatch(rb'[A-Za-z0-9_]+', value) is not None)
     return value.decode('ascii')
+
+
+def install_token(stream):
+    """Explicit first installation after pinned SSH admission; never rotation."""
+    raw = stream.read(MAX_TOKEN + 1)
+    token = decode_token(raw)
+    retained = read_token()
+    if retained is not None:
+        require(retained == token)
+        return 'present'
+    directory = os.open(RUNTIME, DIRECTORY_FLAGS)
+    try:
+        parent = os.fstat(directory)
+        require(parent.st_uid == os.geteuid() and stat.S_IMODE(parent.st_mode) == 0o700)
+        require(identity(os.stat(RUNTIME, follow_symlinks=False)) == identity(parent))
+        # This fixed candidate is also the exclusive install claim. Interrupted
+        # writes remain private and block replay; boot clears only runtime secrets.
+        descriptor = os.open('github-token.pending', os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                             | os.O_NOFOLLOW | os.O_NONBLOCK, 0o600, dir_fd=directory)
+        try:
+            candidate = os.fstat(descriptor)
+            require(stat.S_ISREG(candidate.st_mode) and candidate.st_uid == os.geteuid()
+                    and stat.S_IMODE(candidate.st_mode) == 0o600 and candidate.st_nlink == 1)
+            remaining = memoryview(token.encode('ascii'))
+            while remaining:
+                written = os.write(descriptor, remaining)
+                require(written > 0)
+                remaining = remaining[written:]
+            os.fsync(descriptor)
+            require(identity(os.stat('github-token.pending', dir_fd=directory, follow_symlinks=False))
+                    == identity(os.fstat(descriptor)))
+            require(identity(os.stat(RUNTIME, follow_symlinks=False)) == identity(os.fstat(directory)))
+            # link is an atomic, no-overwrite publication. Until the private
+            # candidate is unlinked, readers reject the transient second link.
+            os.link('github-token.pending', 'github-token', src_dir_fd=directory,
+                    dst_dir_fd=directory, follow_symlinks=False)
+            os.unlink('github-token.pending', dir_fd=directory)
+            os.fsync(directory)
+        finally:
+            os.close(descriptor)
+        require(identity(os.stat(RUNTIME, follow_symlinks=False)) == identity(os.fstat(directory)))
+        require(read_token() == token)
+        return 'installed'
+    finally:
+        os.close(directory)
 
 
 def credential_request(stream):
@@ -152,6 +203,10 @@ def main(arguments):
     try:
         if Path(sys.argv[0]).name == 'gh':
             run_gh(arguments)
+            return 0
+        if arguments == ['install']:
+            status = install_token(sys.stdin.buffer)
+            print(json.dumps({'version': 1, 'status': status}))
             return 0
         if len(arguments) == 1:
             return git_credential(arguments[0], sys.stdin.buffer, sys.stdout)

--- a/containers/remote-worker/test_github_token_install.py
+++ b/containers/remote-worker/test_github_token_install.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Synthetic-only, offline checks for explicit worker credential installation."""
+
+import concurrent.futures
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location('credentials', HERE / 'github-credentials.py')
+C = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(C)
+TOKEN = b'github_pat_SYNTHETIC_INSTALL_TEST'
+
+
+class InstallTests(unittest.TestCase):
+    def setUp(self):
+        self.fixture = tempfile.TemporaryDirectory(prefix='horizon-token-install-')
+        self.root = Path(self.fixture.name)
+        self.runtime = self.root / 'runtime'
+        self.runtime.mkdir(mode=0o700)
+        self.token = self.runtime / 'github-token'
+        self.pending = self.runtime / 'github-token.pending'
+        self.runtime_patch = patch.object(C, 'RUNTIME', self.runtime)
+        self.runtime_patch.start()
+
+    def tearDown(self):
+        self.runtime_patch.stop()
+        self.fixture.cleanup()
+
+    def install(self, token=TOKEN):
+        return C.install_token(io.BytesIO(token))
+
+    def wrapper(self):
+        wrapper = self.root / 'credential'
+        source = (HERE / 'github-credentials.py').read_text()
+        wrapper.write_text(source.replace("RUNTIME = Path('/run/horizon')",
+                                          'RUNTIME = Path(' + repr(str(self.runtime)) + ')'))
+        return wrapper
+
+    def test_install_is_private_and_exact_repetition_does_not_write(self):
+        self.assertEqual('installed', self.install(TOKEN + b'\n'))
+        self.assertEqual(TOKEN.decode(), C.read_token())
+        self.assertEqual(0o600, self.token.stat().st_mode & 0o777)
+        self.assertEqual(1, self.token.stat().st_nlink)
+        self.assertFalse(self.pending.exists())
+        before = (C.identity(self.token.stat()), C.identity(self.runtime.stat()))
+        self.assertEqual('present', self.install())
+        self.assertEqual(before, (C.identity(self.token.stat()), C.identity(self.runtime.stat())))
+
+    def test_different_existing_token_is_never_rotated(self):
+        self.install()
+        before = self.token.read_bytes(), C.identity(self.token.stat())
+        with self.assertRaises(C.CredentialError):
+            self.install(b'different_SYNTHETIC_token')
+        self.assertEqual(before, (self.token.read_bytes(), C.identity(self.token.stat())))
+        self.assertFalse(self.pending.exists())
+
+    def test_malformed_and_oversized_requests_do_not_create_files(self):
+        for token in (b'', b'\n', TOKEN + b'\n\n', TOKEN + b'\r\n', b'x\0y', b'private secret',
+                      b'\xff', b'x' * (C.MAX_TOKEN + 1)):
+            with self.subTest(token_length=len(token)), self.assertRaises(C.CredentialError):
+                self.install(token)
+            self.assertEqual([], list(self.runtime.iterdir()))
+
+    def test_missing_or_unsafe_runtime_is_never_created_or_repaired(self):
+        self.runtime.rmdir()
+        with self.assertRaises(OSError):
+            self.install()
+        self.assertFalse(self.runtime.exists())
+        self.runtime.mkdir(mode=0o755)
+        with self.assertRaises(C.CredentialError):
+            self.install()
+        self.assertEqual(0o755, self.runtime.stat().st_mode & 0o777)
+        self.runtime.chmod(0o700)
+        with patch.object(C.os, 'geteuid', return_value=os.geteuid() + 1):
+            with self.assertRaises(C.CredentialError):
+                self.install()
+        self.assertEqual([], list(self.runtime.iterdir()))
+
+    def test_symlink_runtime_and_final_file_are_rejected(self):
+        alias = self.root / 'alias'
+        alias.symlink_to(self.runtime, target_is_directory=True)
+        with patch.object(C, 'RUNTIME', alias), self.assertRaises(OSError):
+            self.install()
+        target = self.root / 'outside'
+        target.write_bytes(TOKEN)
+        target.chmod(0o600)
+        self.token.symlink_to(target)
+        with self.assertRaises(OSError):
+            self.install()
+        self.assertEqual(TOKEN, target.read_bytes())
+        self.assertFalse(self.pending.exists())
+
+    def test_interrupted_claim_is_not_replayed_or_removed(self):
+        self.pending.write_bytes(b'partial_SYNTHETIC')
+        self.pending.chmod(0o600)
+        before = self.pending.read_bytes(), C.identity(self.pending.stat())
+        with self.assertRaises(FileExistsError):
+            self.install()
+        self.assertEqual(before, (self.pending.read_bytes(), C.identity(self.pending.stat())))
+        self.assertFalse(self.token.exists())
+
+    def test_write_failure_retains_private_claim_without_publication(self):
+        with patch.object(C.os, 'write', side_effect=OSError('private sentinel')):
+            with self.assertRaises(OSError):
+                self.install()
+        self.assertEqual(0o600, self.pending.stat().st_mode & 0o777)
+        self.assertFalse(self.token.exists())
+        with self.assertRaises(FileExistsError):
+            self.install()
+
+    def test_short_writes_complete_before_publication(self):
+        write = os.write
+        with patch.object(C.os, 'write', side_effect=lambda fd, data: write(fd, data[:3])):
+            self.assertEqual('installed', self.install())
+        self.assertEqual(TOKEN, self.token.read_bytes())
+
+    def test_publication_never_overwrites_a_concurrent_final_file(self):
+        link = os.link
+        other = b'other_SYNTHETIC_token'
+        def insert(*args, **kwargs):
+            self.token.write_bytes(other)
+            self.token.chmod(0o600)
+            return link(*args, **kwargs)
+        with patch.object(C.os, 'link', side_effect=insert), self.assertRaises(FileExistsError):
+            self.install()
+        self.assertEqual(other, self.token.read_bytes())
+        self.assertEqual(TOKEN, self.pending.read_bytes())
+
+    def test_failed_unlink_is_unknown_not_a_readable_credential(self):
+        with patch.object(C.os, 'unlink', side_effect=OSError('synthetic unlink failure')):
+            with self.assertRaises(OSError):
+                self.install()
+        self.assertEqual(2, self.token.stat().st_nlink)
+        with self.assertRaises(C.CredentialError):
+            C.read_token()
+        with self.assertRaises(C.CredentialError):
+            self.install()
+
+    def test_cli_receipts_and_errors_never_contain_credentials(self):
+        wrapper = self.wrapper()
+        for token, expected, status in ((TOKEN, 0, 'installed'), (TOKEN, 0, 'present'),
+                                        (b'different_SYNTHETIC', 1, None), (b'bad secret', 1, None)):
+            result = subprocess.run(['/usr/bin/python3', '-I', str(wrapper), 'install'], input=token,
+                                    capture_output=True, timeout=5, check=False)
+            self.assertEqual(expected, result.returncode)
+            self.assertNotIn(token, result.stdout + result.stderr)
+            if status:
+                self.assertEqual({'version': 1, 'status': status}, json.loads(result.stdout))
+                self.assertEqual(b'', result.stderr)
+            else:
+                self.assertEqual(b'', result.stdout)
+                self.assertEqual(b'horizon-worker: GitHub credential unavailable or request rejected\n', result.stderr)
+
+    def test_concurrent_processes_publish_only_one_token(self):
+        wrapper = self.wrapper()
+        tokens = [TOKEN + str(index).encode() for index in range(4)]
+        def install(token):
+            return subprocess.run(['/usr/bin/python3', '-I', str(wrapper), 'install'], input=token,
+                                  capture_output=True, timeout=5, check=False)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(install, tokens))
+        self.assertLessEqual(sum(result.returncode == 0 for result in results), 1)
+        winner = self.token.read_bytes()
+        self.assertIn(winner, tokens)
+        self.assertEqual('present', self.install(winner))
+        if self.pending.exists():
+            self.assertIn(self.pending.read_bytes(), tokens)
+            self.assertNotEqual(winner, self.pending.read_bytes())
+            self.assertEqual(0o600, self.pending.stat().st_mode & 0o777)
+            self.assertEqual(1, self.pending.stat().st_nlink)
+        for token in tokens:
+            self.assertTrue(all(token not in result.stdout + result.stderr for result in results))
+
+    def test_delayed_loser_retains_private_candidate_without_replacing_winner(self):
+        open_file = os.open
+        other = b'other_SYNTHETIC_winner'
+        raced = False
+        def delayed_open(name, *args, **kwargs):
+            nonlocal raced
+            if name == 'github-token.pending' and not raced:
+                raced = True
+                self.assertEqual('installed', self.install(other))
+            return open_file(name, *args, **kwargs)
+        with patch.object(C.os, 'open', side_effect=delayed_open), self.assertRaises(FileExistsError):
+            self.install()
+        self.assertEqual(other, self.token.read_bytes())
+        self.assertEqual(TOKEN, self.pending.read_bytes())
+        before = C.identity(self.pending.stat())
+        self.assertEqual('present', self.install(other))
+        self.assertEqual(before, C.identity(self.pending.stat()))
+
+    def test_boot_clears_runtime_claim_but_does_not_install_implicitly(self):
+        entrypoint = (HERE / 'entrypoint.sh').read_text()
+        self.assertIn('rm -f /run/horizon/github-token /run/horizon/github-token.pending', entrypoint)
+        self.assertNotIn('horizon-github-credential install', entrypoint)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add the worker-side primitive needed to supply a repository PAT after an already-pinned SSH connection, for providers that cannot mount a startup secret file. Part of #470; this does not close it.

## Behavior

- Explicit `/usr/local/bin/horizon-github-credential install` reads at most 16 KiB from stdin. No token arguments, environment injection, GitHub calls or automatic tasks.
- Requires the existing private runtime directory. A private exclusive candidate and atomic no-overwrite publication protect first installation.
- The same existing token returns a read-only `present` receipt; another token, unsafe state or interrupted candidate is refused. No rotation or implicit repair.
- Replies contain only protocol version/status; failures never echo input. An absent/failed reply remains uncertain. A delayed concurrent loser can retain its private candidate without changing the winning token.
- Startup clears runtime credentials and the candidate before optional mounted-token activation. Explicit delivery is needed again after restart; a running worker needs no periodic client renewal.

This is not controller admission, provider/UI wiring, a credential renewal service or isolation from authorized root tasks. Remote Git clone/task/push/PR and cloud acceptance remain separate work. Existing Git credential `get`/`store`/`erase` behavior is preserved.

## Validation

- Independent local review completed; a deterministic delayed-installer regression fixed the test's overly strong cleanup/receipt assumptions.
- All 36 synthetic credential tests passed, including real Git credential-helper invocation, concurrent processes, malformed input, permission/link checks and interrupted writes.
- Packaging static checks, shell syntax, formatting, maintainability, version sync and both required precommit Clippy tiers passed.
- All eight exact-commit local gates passed on `95d463926bd524773f4d095420e45c0f8c22c4bd`, including full default/speech workspace tests and all three Clippy tiers; checkout remained clean.
- Exact Shell image `sha256:938323e26379965ff139fa1a959871b048f70c3305817065b49624a32d1cccb7` passed installed SSH/token lifecycle, all four bootstrap cases and full packaging/context audit.
- Real local SSH proof: wrong host pin blocks installation; stdin-only first install, identical repetition, different-token refusal and real Git credential fill pass without token output. The same ongoing task/session survives credential operations and disconnection. Explicit Stop/start clears runtime token/candidate, retains the host key and permits explicit reinstallation.
- Packaging verified the exact helper binary and notices, Shell flavor omissions, source allowlist and 36 final layers. All disposable test containers were removed; preexisting containers were preserved. These are local synthetic checks, not real PAT or cloud acceptance.

Five files, 296 changed lines. No UI, dependency or configuration-default changes; no live UI smoke applies. No image publication, cloud allocation, release or tag is included.
