### PR TITLE
feat(cloud): bind storage selection during workspace setup

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod/network_volume.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_volume.rs
@@ -17,7 +17,7 @@ pub struct RunPodNetworkVolumeExpectation {
 }
 
 impl RunPodNetworkVolumeExpectation {
-    pub(super) fn validate(&self) -> Result<(), RunPodError> {
+    pub(crate) fn validate(&self) -> Result<(), RunPodError> {
         if !valid_provider_id(&self.volume_id)
             || !valid_provider_id(&self.data_center_id)
             || !(MIN_VOLUME_GB..=MAX_VOLUME_GB).contains(&self.minimum_size_gb)

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/network_volume.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/network_volume.rs
@@ -13,7 +13,7 @@ impl CloudWorkflowStore {
     /// This is inert, non-secret intent: it neither verifies provider storage nor
     /// establishes ownership, exclusivity, attachment or provisioning authority.
     /// It does not bump the allocation revision or consume/renew a creation grant.
-    /// Existing setup/provider APIs do not yet consume this selection.
+    /// Explicit task-free setup and its retry/recovery bind the provider to this selection.
     /// No retirement or next-generation rebinding is exposed for this workspace,
     /// matching the existing allocation and first-pin boundaries.
     ///

--- a/crates/horizon-core/src/remote_workspace_setup.rs
+++ b/crates/horizon-core/src/remote_workspace_setup.rs
@@ -3,7 +3,8 @@
 
 mod runpod;
 pub use runpod::{
-    RunPodWorkspaceSetupError, recover_runpod_workspace, retry_runpod_workspace_setup, start_task_free_runpod_workspace,
+    RunPodWorkspaceSetupError, recover_runpod_workspace, retry_runpod_workspace_setup,
+    start_task_free_runpod_workspace, start_task_free_runpod_workspace_with_network_volume,
 };
 
 use crate::{

--- a/crates/horizon-core/src/remote_workspace_setup/runpod.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod.rs
@@ -6,9 +6,11 @@ use super::{
     StoredRemoteWorkspace, prepare_identity, recover, retry_remote_workspace_setup, validate_allocation,
 };
 use crate::cloud_run::{
-    WorkerTarget,
+    WorkerLifetime, WorkerTarget,
+    interactive_worker::InteractiveWorkerRequest,
     runpod::{
-        RunPodApiKey, RunPodClient, RunPodHostTrust, RunPodInteractiveWorkerProvider, RunPodProfile, validate_target,
+        RunPodApiKey, RunPodClient, RunPodHostTrust, RunPodInteractiveWorkerProvider, RunPodNetworkVolumeExpectation,
+        RunPodProfile, validate_target,
     },
 };
 
@@ -36,7 +38,48 @@ pub fn start_task_free_runpod_workspace(
         profile,
         expected,
         retain_until_millis,
-        |trust| provider(store, api_key, profile, trust),
+        |trust, request, selection| provider(store, api_key, profile, trust, request, selection),
+    )
+}
+
+/// Start one task-free persistent generation with a caller-authorized HPS selection.
+/// Selection is saved before any client identity, first-pin intent or creation claim.
+/// It proves neither volume ownership nor exclusivity, contents trust or durability.
+/// Failures retain the allocation and any saved intent; retry/recovery never replace
+/// a selection or repair an interrupted pre-intent start. No volume mutation occurs.
+/// Run synchronously off the render thread.
+/// # Errors
+/// Rejects invalid profiles/selections, stale ownership and identity/intent/provider
+/// failures. A selection-recording failure may leave an unmarked allocation.
+pub fn start_task_free_runpod_workspace_with_network_volume(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+    selection: &RunPodNetworkVolumeExpectation,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    validate_profile(&expected.state().spec.target, profile)?;
+    selection
+        .validate()
+        .map_err(|_| RunPodWorkspaceSetupError::InvalidNetworkVolumeSelection)?;
+    if expected.state().spec.target.lifetime != WorkerLifetime::Persistent
+        || profile
+            .data_center_id
+            .as_ref()
+            .is_some_and(|id| id != &selection.data_center_id)
+    {
+        return Err(RunPodWorkspaceSetupError::NetworkVolumeBindingRejected);
+    }
+    let allocation = allocate_start(store, expected, retain_until_millis, Some(selection))?;
+    finish_start(
+        store,
+        identities,
+        api_key,
+        profile,
+        &allocation,
+        |trust, request, selection| provider(store, api_key, profile, trust, request, selection),
     )
 }
 
@@ -44,6 +87,7 @@ pub fn start_task_free_runpod_workspace(
 /// Never prepares a replacement key or records new intent. Claimed, observed or
 /// expired setup uses non-creating recovery. Success remains Reconciling, not ready.
 /// Supplied profile validation does not detect historical edits under the same name.
+/// Any saved volume selection is loaded unchanged; absence preserves ordinary setup.
 /// Run synchronously off the render thread; the supplied store owns explicit writes.
 /// # Errors
 /// Rejects invalid profiles, missing trust/keys, management intent and snapshot drift.
@@ -61,7 +105,7 @@ pub fn retry_runpod_workspace_setup(
         profile,
         expected,
         Operation::Retry,
-        |trust| provider(store, api_key, profile, trust),
+        |trust, request, selection| provider(store, api_key, profile, trust, request, selection),
     )
 }
 
@@ -86,7 +130,7 @@ pub fn recover_runpod_workspace(
         profile,
         expected,
         Operation::Recover,
-        |trust| provider(store, api_key, profile, trust),
+        |trust, request, selection| provider(store, api_key, profile, trust, request, selection),
     )
 }
 
@@ -106,9 +150,18 @@ fn provider(
     api_key: &RunPodApiKey,
     profile: &RunPodProfile,
     trust: TrustSelection,
-) -> RunPodInteractiveWorkerProvider {
+    request: &InteractiveWorkerRequest,
+    selection: Option<&RunPodNetworkVolumeExpectation>,
+) -> Result<RunPodInteractiveWorkerProvider, RunPodWorkspaceSetupError> {
     let (TrustSelection::Initial(trust) | TrustSelection::Retained(trust)) = trust;
-    RunPodInteractiveWorkerProvider::new(RunPodClient::new(api_key, store.clone()), profile.clone(), trust)
+    let client = RunPodClient::new(api_key, store.clone());
+    match selection {
+        Some(selection) => {
+            RunPodInteractiveWorkerProvider::new_with_network_volume(client, profile.clone(), trust, request, selection)
+                .map_err(|_| RunPodWorkspaceSetupError::NetworkVolumeBindingRejected)
+        }
+        None => Ok(RunPodInteractiveWorkerProvider::new(client, profile.clone(), trust)),
+    }
 }
 
 fn validate_profile(target: &WorkerTarget, profile: &RunPodProfile) -> Result<(), RunPodWorkspaceSetupError> {
@@ -125,11 +178,43 @@ fn start_with<P: InteractiveWorkerProvider>(
     profile: &RunPodProfile,
     expected: &StoredRemoteWorkspace,
     retain_until_millis: i64,
-    factory: impl FnOnce(TrustSelection) -> P,
+    factory: impl FnOnce(
+        TrustSelection,
+        &InteractiveWorkerRequest,
+        Option<&RunPodNetworkVolumeExpectation>,
+    ) -> Result<P, RunPodWorkspaceSetupError>,
 ) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
     validate_profile(&expected.state().spec.target, profile)?;
+    let allocation = allocate_start(store, expected, retain_until_millis, None)?;
+    finish_start(store, identities, api_key, profile, &allocation, factory)
+}
+
+fn allocate_start(
+    store: &CloudWorkflowStore,
+    expected: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+    selection: Option<&RunPodNetworkVolumeExpectation>,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
     let allocation = store.allocate_remote_runtime(expected, retain_until_millis)?;
-    let allocation = prepare_identity(store, identities, &allocation)?;
+    if let Some(selection) = selection {
+        store.record_remote_network_volume_selection(&allocation, selection)?;
+    }
+    Ok(allocation)
+}
+
+fn finish_start<P: InteractiveWorkerProvider>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    api_key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteAllocation,
+    factory: impl FnOnce(
+        TrustSelection,
+        &InteractiveWorkerRequest,
+        Option<&RunPodNetworkVolumeExpectation>,
+    ) -> Result<P, RunPodWorkspaceSetupError>,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    let allocation = prepare_identity(store, identities, expected)?;
     store.record_remote_first_pin_intent(&allocation)?;
     dispatch(
         store,
@@ -149,11 +234,16 @@ fn dispatch<P: InteractiveWorkerProvider>(
     profile: &RunPodProfile,
     expected: &StoredRemoteAllocation,
     operation: Operation,
-    factory: impl FnOnce(TrustSelection) -> P,
+    factory: impl FnOnce(
+        TrustSelection,
+        &InteractiveWorkerRequest,
+        Option<&RunPodNetworkVolumeExpectation>,
+    ) -> Result<P, RunPodWorkspaceSetupError>,
 ) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
     validate_profile(&expected.workspace().state().spec.target, profile)?;
     validate_allocation(store, expected)?;
     let request = expected.recovery_request()?;
+    let selection = store.load_remote_network_volume_selection(expected)?;
     let runtime = expected
         .workspace()
         .state()
@@ -178,7 +268,7 @@ fn dispatch<P: InteractiveWorkerProvider>(
         )
     };
     identities.recover(request.workflow_id, request.job_id, &request.ssh_public_key)?;
-    let provider = factory(trust);
+    let provider = factory(trust, &request, selection.as_ref())?;
     match operation {
         Operation::Retry => retry_remote_workspace_setup(store, identities, &provider, expected),
         Operation::Recover => recover(store, identities, &provider, expected),
@@ -193,6 +283,10 @@ pub enum RunPodWorkspaceSetupError {
     InvalidProfile,
     #[error("explicit first-pin setup intent is unavailable; missing trust cannot authorize bootstrap")]
     FirstPinIntentUnavailable,
+    #[error("supplied network volume selection is invalid")]
+    InvalidNetworkVolumeSelection,
+    #[error("saved network volume selection cannot bind the supplied worker request and profile")]
+    NetworkVolumeBindingRejected,
     #[error(transparent)]
     Setup(#[from] RemoteWorkspaceSetupError),
 }
@@ -200,6 +294,7 @@ pub enum RunPodWorkspaceSetupError {
 impl From<RemoteWorkspaceStoreError> for RunPodWorkspaceSetupError {
     fn from(error: RemoteWorkspaceStoreError) -> Self {
         match error {
+            RemoteWorkspaceStoreError::InvalidNetworkVolumeSelection => Self::InvalidNetworkVolumeSelection,
             RemoteWorkspaceStoreError::RuntimeSetupUnavailable => Self::FirstPinIntentUnavailable,
             _ => Self::Setup(error.into()),
         }

--- a/crates/horizon-core/src/remote_workspace_setup/runpod/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod/tests.rs
@@ -16,6 +16,8 @@ mod admission;
 #[cfg(target_os = "linux")]
 mod lifecycle;
 #[cfg(target_os = "linux")]
+mod network_volume;
+#[cfg(target_os = "linux")]
 mod races;
 
 const OWNER: &str = "00000000-0000-4000-8000-000000000001";
@@ -88,6 +90,23 @@ fn public_apis_refuse_unsupported_platform_before_identity_or_provider_work() {
     assert_eq!(
         start_task_free_runpod_workspace(&f.store, &f.identities, &f.key, &f.profile, &f.dormant, i64::MAX),
         Err(error)
+    );
+    assert_eq!(f.counts(), [0; 4]);
+    assert_eq!(
+        start_task_free_runpod_workspace_with_network_volume(
+            &f.store,
+            &f.identities,
+            &f.key,
+            &f.profile,
+            &f.dormant,
+            i64::MAX,
+            &RunPodNetworkVolumeExpectation {
+                volume_id: "volume".into(),
+                data_center_id: "DC".into(),
+                minimum_size_gb: 10
+            }
+        ),
+        Err(RemoteSshIdentityError::UnsupportedPlatform.into())
     );
     assert_eq!(f.counts(), [0; 4]);
     let allocation = f
@@ -184,7 +203,18 @@ impl Fixture {
             dormant,
             ..
         } = self;
-        start_with(store, identities, key, profile, dormant, retention, factory)
+        start_with(
+            store,
+            identities,
+            key,
+            profile,
+            dormant,
+            retention,
+            |trust, _, selection| {
+                assert!(selection.is_none(), "ordinary fixture has no saved selection");
+                Ok(factory(trust))
+            },
+        )
     }
 
     fn run(&self, operation: Operation) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
@@ -236,6 +266,32 @@ impl Fixture {
     fn status(&self) -> InteractiveWorkerStatus {
         status(&self.allocation().worker_request().expect("request"), false)
     }
+}
+
+// Keep ordinary lifecycle fixtures focused on trust mode; network tests exercise
+// the request/selection-aware fallible factory directly.
+#[cfg(target_os = "linux")]
+fn dispatch(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    key: &RunPodApiKey,
+    profile: &RunPodProfile,
+    expected: &StoredRemoteAllocation,
+    operation: Operation,
+    factory: impl FnOnce(TrustSelection) -> Provider,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    super::dispatch(
+        store,
+        identities,
+        key,
+        profile,
+        expected,
+        operation,
+        |trust, _, selection| {
+            assert!(selection.is_none(), "ordinary fixture has no saved selection");
+            Ok(factory(trust))
+        },
+    )
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/horizon-core/src/remote_workspace_setup/runpod/tests/network_volume.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/runpod/tests/network_volume.rs
@@ -1,0 +1,309 @@
+use super::*;
+
+fn selection() -> RunPodNetworkVolumeExpectation {
+    RunPodNetworkVolumeExpectation {
+        volume_id: "volume_synthetic".into(),
+        data_center_id: "DC-synthetic".into(),
+        minimum_size_gb: 10,
+    }
+}
+
+fn allocate(f: &Fixture) -> StoredRemoteAllocation {
+    allocate_start(&f.store, &f.dormant, i64::MAX, Some(&selection())).expect("selected allocation")
+}
+
+fn finish(
+    f: &Fixture,
+    allocation: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    finish_start(
+        &f.store,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        allocation,
+        |trust, request, selected| {
+            assert_eq!(selected, Some(&selection()));
+            assert_eq!(*request, f.allocation().worker_request().expect("request"));
+            Ok(f.factory(&trust))
+        },
+    )
+}
+
+fn resume(f: &Fixture, operation: Operation) -> Result<StoredRemoteAllocation, RunPodWorkspaceSetupError> {
+    super::super::dispatch(
+        &f.store,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        &f.allocation(),
+        operation,
+        |trust, request, selected| {
+            assert_eq!(selected, Some(&selection()));
+            assert_eq!(*request, f.allocation().recovery_request().expect("request"));
+            Ok(f.factory(&trust))
+        },
+    )
+}
+
+#[test]
+fn selection_precedes_identity_intent_and_claim_and_survives_retained_recovery() {
+    let f = Fixture::new();
+    let allocation = allocate(&f);
+    assert_eq!(f.counts(), [1, 1, 0, 0]);
+    assert!(f.keys().is_empty());
+    assert_eq!(
+        f.store
+            .load_remote_network_volume_selection(&allocation)
+            .expect("selection"),
+        Some(selection())
+    );
+    assert_eq!(f.allocation(), allocation, "selection does not revise allocation");
+    let saved = finish(&f, &allocation).expect("start");
+    let before = f.snapshot();
+    let mut replacement = selection();
+    replacement.volume_id = "replacement".into();
+    assert!(matches!(
+        f.store.record_remote_network_volume_selection(&saved, &replacement),
+        Err(RemoteWorkspaceStoreError::ReplacementIdentityMismatch)
+    ));
+    for operation in [Operation::Retry, Operation::Recover] {
+        assert_eq!(resume(&f, operation).expect("retained"), saved);
+    }
+    assert_eq!(f.snapshot(), before);
+    assert_eq!(f.counts(), [1, 1, 1, 0]);
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [1, 1, 0, 2, 0]);
+    assert_eq!(
+        f.store.load_remote_network_volume_selection(&saved).expect("selection"),
+        Some(selection())
+    );
+}
+
+#[test]
+fn public_invalid_selection_does_not_allocate_and_a_valid_start_remains_available() {
+    let f = Fixture::new();
+    let mut invalid = selection();
+    invalid.volume_id = "private-selection-sentinel/invalid".into();
+    let error = start_task_free_runpod_workspace_with_network_volume(
+        &f.store,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        &f.dormant,
+        i64::MAX,
+        &invalid,
+    )
+    .expect_err("invalid selection");
+    assert_eq!(error, RunPodWorkspaceSetupError::InvalidNetworkVolumeSelection);
+    assert!(!format!("{error:?} {error}").contains("private-selection-sentinel"));
+    assert_eq!(f.counts(), [0; 4]);
+    assert!(f.keys().is_empty());
+    assert!(
+        f.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("lookup")
+            .is_none()
+    );
+    let allocation = allocate(&f);
+    finish(&f, &allocation).expect("valid selected start");
+    assert_eq!(f.counts(), [1, 1, 1, 0]);
+}
+
+#[test]
+fn invalid_network_profile_refuses_before_allocation_and_binding_errors_are_redacted() {
+    let mut f = Fixture::new();
+    f.profile.data_center_id = Some("private-profile-sentinel".into());
+    let error = start_task_free_runpod_workspace_with_network_volume(
+        &f.store,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        &f.dormant,
+        i64::MAX,
+        &selection(),
+    )
+    .expect_err("conflict");
+    assert_eq!(error, RunPodWorkspaceSetupError::NetworkVolumeBindingRejected);
+    assert!(!format!("{error:?} {error}").contains("private-profile-sentinel"));
+    assert_eq!(f.counts(), [0; 4]);
+    assert!(f.keys().is_empty());
+    let allocation = allocate(&f);
+    let saved = prepare_identity(&f.store, &f.identities, &allocation).expect("identity");
+    let request = saved.worker_request().expect("request");
+    let trust = RunPodHostTrust::initial_task_free(&f.key, &request).expect("trust");
+    assert!(matches!(
+        provider(
+            &f.store,
+            &f.key,
+            &f.profile,
+            TrustSelection::Initial(trust),
+            &request,
+            Some(&selection())
+        ),
+        Err(RunPodWorkspaceSetupError::NetworkVolumeBindingRejected)
+    ));
+    assert_eq!(f.counts(), [1, 1, 0, 0]);
+}
+
+#[test]
+fn pre_intent_interruptions_never_backfill_selection_or_prepare_a_replacement_key() {
+    for stage in 0..3 {
+        let f = Fixture::new();
+        let allocation =
+            allocate_start(&f.store, &f.dormant, i64::MAX, (stage != 0).then_some(&selection())).expect("allocate");
+        if stage == 2 {
+            prepare_identity(&f.store, &f.identities, &allocation).expect("identity");
+        }
+        let before = f.snapshot();
+        for operation in [Operation::Retry, Operation::Recover] {
+            assert_eq!(
+                resume(&f, operation),
+                Err(if stage == 2 {
+                    RunPodWorkspaceSetupError::FirstPinIntentUnavailable
+                } else {
+                    RemoteWorkspaceRecoveryError::MissingRequest.into()
+                })
+            );
+        }
+        assert_eq!(f.snapshot(), before);
+        assert_eq!(
+            f.store
+                .load_remote_network_volume_selection(&f.allocation())
+                .expect("selection"),
+            (stage != 0).then_some(selection())
+        );
+        assert_eq!(*f.remote.calls.lock().expect("calls"), [0; 5]);
+    }
+}
+
+#[test]
+fn lost_response_reopens_with_saved_selection_and_never_ensures_twice() {
+    let f = Fixture::new();
+    let allocation = allocate(&f);
+    f.remote.lose_response.store(true, Ordering::SeqCst);
+    assert_eq!(
+        finish(&f, &allocation),
+        Err(RemoteWorkspaceSetupError::ProviderUnavailable.into())
+    );
+    let before = f.snapshot();
+    let reopened = CloudWorkflowStore::open_path(f.store.path()).expect("reopen");
+    super::super::dispatch(
+        &reopened,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        &before.allocation,
+        Operation::Retry,
+        |trust, request, selected| {
+            assert_eq!(selected, Some(&selection()));
+            assert_eq!(*request, before.allocation.recovery_request().expect("original"));
+            Ok(f.factory(&trust))
+        },
+    )
+    .expect("noncreating recovery");
+    resume(&f, Operation::Retry).expect("retained retry");
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [1, 1, 1, 1, 0]);
+    assert_eq!(f.keys(), before.keys);
+    assert_eq!(f.counts(), [1, 1, 1, 0]);
+}
+
+#[test]
+fn corrupt_selection_is_not_absence_or_an_ordinary_provider_fallback() {
+    let f = Fixture::new();
+    let allocation = allocate(&f);
+    let allocation = prepare_identity(&f.store, &f.identities, &allocation).expect("identity");
+    f.store.record_remote_first_pin_intent(&allocation).expect("intent");
+    let raw = rusqlite::Connection::open(f.store.path()).expect("database");
+    let trigger: String = raw
+        .query_row(
+            "SELECT sql FROM sqlite_schema WHERE name='remote_network_volume_selections_no_update'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("trigger");
+    raw.execute_batch(
+        "DROP TRIGGER remote_network_volume_selections_no_update;
+        UPDATE remote_network_volume_selections SET volume_id='volume_synthetic'||char(0)||'private-sentinel';",
+    )
+    .expect("corrupt fixture");
+    raw.execute_batch(&trigger).expect("restore schema guard");
+    let before = f.snapshot();
+    for operation in [Operation::Retry, Operation::Recover] {
+        let error = resume(&f, operation).expect_err("corrupt selection");
+        assert_eq!(error, RemoteWorkspaceRecoveryError::StorageUnavailable.into());
+        assert!(!format!("{error:?} {error}").contains("private-sentinel"));
+    }
+    assert_eq!(f.snapshot(), before);
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [0; 5]);
+    assert_eq!(*f.remote.selections.lock().expect("selections"), [0; 2]);
+}
+
+#[test]
+fn management_race_after_selected_factory_prevents_ensure_and_keeps_selection() {
+    let f = Fixture::new();
+    let allocation = allocate(&f);
+    let allocation = prepare_identity(&f.store, &f.identities, &allocation).expect("identity");
+    f.store.record_remote_first_pin_intent(&allocation).expect("intent");
+    let keys = f.keys();
+    let result = super::super::dispatch(
+        &f.store,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        &allocation,
+        Operation::Retry,
+        |trust, _, selected| {
+            assert_eq!(selected, Some(&selection()));
+            record_management(&f.store, &allocation);
+            Ok(f.factory(&trust))
+        },
+    );
+    assert_eq!(result, Err(RemoteWorkspaceRecoveryError::StateChanged.into()));
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [0; 5]);
+    assert_eq!(f.keys(), keys);
+    assert_eq!(
+        f.store
+            .load_remote_network_volume_selection(&f.allocation())
+            .expect("selection"),
+        Some(selection())
+    );
+}
+
+#[test]
+fn expired_selected_setup_and_factory_failure_never_renew_creation_authority() {
+    let f = Fixture::new();
+    let allocation = allocate(&f);
+    let allocation = prepare_identity(&f.store, &f.identities, &allocation).expect("identity");
+    f.store.record_remote_first_pin_intent(&allocation).expect("intent");
+    let before = f.snapshot();
+    let failed = super::super::dispatch(
+        &f.store,
+        &f.identities,
+        &f.key,
+        &f.profile,
+        &allocation,
+        Operation::Retry,
+        |_, _, _| -> Result<Provider, _> { Err(RunPodWorkspaceSetupError::NetworkVolumeBindingRejected) },
+    );
+    assert_eq!(failed, Err(RunPodWorkspaceSetupError::NetworkVolumeBindingRejected));
+    assert_eq!(f.snapshot(), before);
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [0; 5]);
+    let mut workflow = allocation.workflow().workflow().clone();
+    workflow.created_at_millis = 1000;
+    workflow.updated_at_millis = 1000;
+    workflow.retain_until_millis = 2000;
+    rusqlite::Connection::open(f.store.path()).expect("database").execute(
+        "UPDATE cloud_workflows SET created_at_millis=1000,updated_at_millis=1000,retain_until_millis=2000,snapshot=?1 WHERE workflow_id=?2",
+        rusqlite::params![serde_json::to_vec(&workflow).expect("snapshot"), workflow.id.to_string()],
+    ).expect("expire fixture");
+    resume(&f, Operation::Retry).expect("noncreating expired recovery");
+    assert_eq!(f.keys(), before.keys);
+    assert_eq!(*f.remote.calls.lock().expect("calls"), [0, 0, 1, 0, 0]);
+    assert_eq!(f.counts(), [1, 1, 0, 1]);
+    assert_eq!(
+        f.store
+            .load_remote_network_volume_selection(&f.allocation())
+            .expect("selection"),
+        Some(selection())
+    );
+}


### PR DESCRIPTION
## Purpose

Continue #473 and #383 by connecting the saved, immutable network-volume selection to explicit task-free workspace setup and non-creating recovery.

## Behavior

- Validate explicit profile/selection input before allocating. Save the selection before creating a client identity or recording first-pin/creation intent.
- Bind the provider to the exact saved request and selection. Retry/recovery load that selection; neither accepts a replacement nor falls back to ordinary storage on read/binding errors.
- Preserve existing creation fences, lost-response reconciliation and ordinary-storage behavior. An interrupted pre-intent start is not automatically repaired.

Six source/test files, 491 changed lines. No schema, UI, configuration, dependency, task-start or volume-management changes. This slice does not implement network-volume Stop or prove cloud retention, ownership or exclusive access.

## Validation

Exact head: `fa56d3b3d891145bb528a2be8ee7b195f59d4de7`.

- All eight local gates passed: formatting, maintainability, version sync, default workspace tests, speech workspace tests, blocking Clippy, strict Clippy and advisory pedantic Clippy.
- 35 setup tests and 69 provider tests passed. Coverage includes selection ordering, rejected input without allocation, interrupted setup, immutable replacement refusal, lost-response restart, corruption, management races, expired setup and factory failures.
- Independent local review completed; its input-validation correction is included and revalidated.
- Unsupported client platforms reject before identity/provider work. No rendering changes; UI smoke is not applicable. Provider interaction tests use synthetic fixtures, not live cloud acceptance.

The parent and child issues remain open for the remaining integration and acceptance work.
