### PR TITLE
feat(cloud): deliver repository credentials over pinned SSH

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -20,6 +20,7 @@ mod managed_install;
 mod opencode_paths;
 mod panel;
 pub mod remote_environment_observation;
+pub mod remote_github_credential;
 mod remote_hosts;
 pub mod remote_panel_attachment;
 pub mod remote_provider_config;

--- a/crates/horizon-core/src/remote_github_credential.rs
+++ b/crates/horizon-core/src/remote_github_credential.rs
@@ -51,7 +51,8 @@ pub enum RemoteCredentialInstallation {
 /// delivery. No keys, allocations, tasks, descriptors or saved state are created.
 /// Existing credentials are never replaced; reconnect never calls this implicitly.
 ///
-/// Run off the render thread. The 15-second pipe deadline excludes spawn/reap.
+/// Run off the render thread. Stdin admission is capped to 15 seconds or the
+/// remaining worker lease, including spawn elapsed time. Spawn/reap may still block.
 /// Admission is point-in-time, not an atomic Stop fence or continuous revocation.
 /// Failure after transport starts can leave the token installed or a private pending
 /// file; do not automatically retry, rotate, repair, restart or terminate anything.
@@ -130,13 +131,7 @@ fn validate_delivery<'a>(
     recovered: &'a crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
 ) -> Result<&'a crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, RemoteCredentialDeliveryError> {
     let endpoint = crate::remote_worker_inspection::validate_current(store, recovered, None)?;
-    if let Some(lease) = recovered
-        .observation()
-        .and_then(|status| status.worker.lifetime.as_time_limited())
-    {
-        let deadline =
-            time::OffsetDateTime::parse(&lease.terminate_after, &time::format_description::well_known::Rfc3339)
-                .map_err(|_| RemoteCredentialDeliveryError::ExpiredWorker)?;
+    if let Some(deadline) = lease_deadline(recovered)? {
         // Observation tolerates provider clock skew; secret release must not use
         // that tolerance to extend the worker's explicitly recorded deadline.
         if deadline <= time::OffsetDateTime::now_utc() {
@@ -144,6 +139,20 @@ fn validate_delivery<'a>(
         }
     }
     Ok(endpoint)
+}
+
+#[cfg(target_os = "linux")]
+fn lease_deadline(
+    recovered: &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+) -> Result<Option<time::OffsetDateTime>, RemoteCredentialDeliveryError> {
+    recovered
+        .observation()
+        .and_then(|status| status.worker.lifetime.as_time_limited())
+        .map(|lease| {
+            time::OffsetDateTime::parse(&lease.terminate_after, &time::format_description::well_known::Rfc3339)
+                .map_err(|_| RemoteCredentialDeliveryError::ExpiredWorker)
+        })
+        .transpose()
 }
 
 /// Diagnostics never contain the token, remote output, command or private paths.

--- a/crates/horizon-core/src/remote_github_credential.rs
+++ b/crates/horizon-core/src/remote_github_credential.rs
@@ -1,0 +1,172 @@
+//! Explicit first-token delivery to an existing worker, never reconnect automation.
+
+#[cfg(target_os = "linux")]
+mod transport;
+
+use crate::{
+    cloud_run::{CloudWorkflowStore, StoredRemoteAllocation, interactive_worker::InteractiveWorkerProvider},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_worker_status::RemotePanelStatusError,
+    remote_workspace_recovery::RemoteWorkspaceRecoveryError,
+};
+
+/// Borrowed runtime-only secret. Syntax validation does not prove repository scope,
+/// permission or expiry; those remain the user's authorization and GitHub's policy.
+/// No serialization, persistence or implicit environment lookup is provided.
+pub struct RepositoryPat<'a>(&'a str);
+
+impl<'a> RepositoryPat<'a> {
+    /// Accept the worker's bounded ASCII token alphabet, without a trailing newline.
+    /// # Errors
+    /// Empty, oversized or non-token input is rejected without exposing its value.
+    pub fn new(value: &'a str) -> Result<Self, RemoteCredentialDeliveryError> {
+        if value.is_empty()
+            || value.len() > 16_384
+            || !value.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        {
+            return Err(RemoteCredentialDeliveryError::InvalidToken);
+        }
+        Ok(Self(value))
+    }
+}
+
+impl std::fmt::Debug for RepositoryPat<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RepositoryPat([redacted])")
+    }
+}
+
+/// Point-in-time installer result, not GitHub authorization or repository readiness.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteCredentialInstallation {
+    Installed,
+    Present,
+}
+
+/// Explicitly authorize first-token installation on one currently owned worker.
+/// The caller must admit the actual session, provider/cost policy and disclosure of
+/// this repository-scoped PAT. Inventory access alone is not such authorization.
+/// Fresh non-creating provider inspection and retained SSH trust precede stdin-only
+/// delivery. No keys, allocations, tasks, descriptors or saved state are created.
+/// Existing credentials are never replaced; reconnect never calls this implicitly.
+///
+/// Run off the render thread. The 15-second pipe deadline excludes spawn/reap.
+/// Admission is point-in-time, not an atomic Stop fence or continuous revocation.
+/// Failure after transport starts can leave the token installed or a private pending
+/// file; do not automatically retry, rotate, repair, restart or terminate anything.
+/// # Errors
+/// Refuses unsupported clients, stale ownership, pending management, missing retained
+/// identity, changed pins, non-ready workers and unavailable or uncertain transport.
+pub fn install_remote_github_credential<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    token: &RepositoryPat<'_>,
+) -> Result<RemoteCredentialInstallation, RemoteCredentialDeliveryError> {
+    #[cfg(target_os = "linux")]
+    {
+        install_with(store, identities, provider, allocation, token, transport::install)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, identities, provider, allocation, token.0);
+        Err(RemoteCredentialDeliveryError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn install_with<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    token: &RepositoryPat<'_>,
+    execute: impl FnOnce(
+        &CloudWorkflowStore,
+        &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+        &RepositoryPat<'_>,
+    ) -> Result<RemoteCredentialInstallation, RemoteCredentialDeliveryError>,
+) -> Result<RemoteCredentialInstallation, RemoteCredentialDeliveryError> {
+    use crate::remote_workspace_recovery::inspect_remote_allocation;
+    let current = store
+        .load_remote_allocation(
+            allocation.workspace().session_id(),
+            &allocation.workspace().state().spec.workspace_local_id,
+        )
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    if current.as_ref() != Some(allocation) {
+        return Err(RemoteWorkspaceRecoveryError::StateChanged.into());
+    }
+    allocation
+        .recovery_request()
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteCredentialDeliveryError::MissingRetainedWorker)?;
+    if runtime.worker.is_none()
+        || !runtime
+            .ssh
+            .as_ref()
+            .is_some_and(crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint::is_complete)
+    {
+        return Err(RemoteCredentialDeliveryError::MissingRetainedWorker);
+    }
+    let recovered = inspect_remote_allocation(identities, provider, allocation)?;
+    validate_delivery(store, &recovered)?;
+    let result = execute(store, &recovered, token)?;
+    // Once delivery starts, stale state cannot establish that nothing was installed.
+    validate_delivery(store, &recovered).map_err(|_| RemoteCredentialDeliveryError::DeliveryUnknown)?;
+    Ok(result)
+}
+
+#[cfg(target_os = "linux")]
+fn validate_delivery<'a>(
+    store: &CloudWorkflowStore,
+    recovered: &'a crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+) -> Result<&'a crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, RemoteCredentialDeliveryError> {
+    let endpoint = crate::remote_worker_inspection::validate_current(store, recovered, None)?;
+    if let Some(lease) = recovered
+        .observation()
+        .and_then(|status| status.worker.lifetime.as_time_limited())
+    {
+        let deadline =
+            time::OffsetDateTime::parse(&lease.terminate_after, &time::format_description::well_known::Rfc3339)
+                .map_err(|_| RemoteCredentialDeliveryError::ExpiredWorker)?;
+        // Observation tolerates provider clock skew; secret release must not use
+        // that tolerance to extend the worker's explicitly recorded deadline.
+        if deadline <= time::OffsetDateTime::now_utc() {
+            return Err(RemoteCredentialDeliveryError::ExpiredWorker);
+        }
+    }
+    Ok(endpoint)
+}
+
+/// Diagnostics never contain the token, remote output, command or private paths.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteCredentialDeliveryError {
+    #[error("repository token is empty, oversized or contains unsupported characters")]
+    InvalidToken,
+    #[error("credential delivery requires an existing worker and retained SSH host key")]
+    MissingRetainedWorker,
+    #[error("credential delivery requires an unexpired worker lifetime")]
+    ExpiredWorker,
+    #[error("credential delivery is unconfirmed; do not automatically retry or replace remote credentials")]
+    DeliveryUnknown,
+    #[error("protected credential delivery is not yet supported on this client platform")]
+    UnsupportedPlatform,
+    #[error(transparent)]
+    Recovery(#[from] RemoteWorkspaceRecoveryError),
+    #[error(transparent)]
+    Admission(#[from] RemotePanelStatusError),
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;
+
+#[cfg(all(test, not(target_os = "linux")))]
+mod platform_tests;

--- a/crates/horizon-core/src/remote_github_credential/platform_tests.rs
+++ b/crates/horizon-core/src/remote_github_credential/platform_tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{CloudProvider, interactive_worker::*},
+    remote_workspace::RemoteWorkspaceState,
+};
+
+struct NeverProvider;
+
+impl InteractiveWorkerProvider for NeverProvider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        panic!("no provider access")
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no reconcile")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no inspect")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no delete")
+    }
+}
+
+#[test]
+fn unsupported_clients_return_before_store_provider_identity_or_transport_io() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(directory.path().join("home"));
+    let store = CloudWorkflowStore::open(&home).expect("store");
+    let identities = RemoteSshIdentityStore::new(&home);
+    let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+        "version":1,"spec":{
+            "workspace_local_id":"workspace","working_directory":".","generation":0,"panels":[],
+            "target":{"provider":"local_docker","profile":"development","disk_gib":20,
+                "image":format!("example/worker@sha256:{}", "a".repeat(64)),"lifetime":"persistent"},
+            "repository":{"repository":"example/project","commit":"b".repeat(40)}
+        }
+    }))
+    .expect("state");
+    let dormant = store
+        .create_remote_workspace("00000000-0000-4000-8000-000000000001", &state)
+        .expect("workspace");
+    let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+    let retained = store.path().with_extension("retained");
+    std::fs::rename(store.path(), &retained).expect("retain fixture database");
+    assert_eq!(
+        install_remote_github_credential(
+            &store,
+            &identities,
+            &NeverProvider,
+            &allocation,
+            &RepositoryPat::new("synthetic_PAT").expect("token")
+        ),
+        Err(RemoteCredentialDeliveryError::UnsupportedPlatform)
+    );
+    assert!(!store.path().exists());
+    assert!(!directory.path().join("home/remote-ssh-identities").exists());
+}

--- a/crates/horizon-core/src/remote_github_credential/tests.rs
+++ b/crates/horizon-core/src/remote_github_credential/tests.rs
@@ -1,0 +1,373 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{CloudProvider, interactive_worker::*},
+    remote_repository_pack::tests::Fixture,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct Provider {
+    status: Option<InteractiveWorkerStatus>,
+    calls: AtomicUsize,
+    during: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl Provider {
+    fn new(fixture: &Fixture) -> Self {
+        Self {
+            status: fixture.recovered.observation().cloned(),
+            calls: AtomicUsize::new(0),
+            during: None,
+        }
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::LocalDocker
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("credential delivery cannot create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("credential delivery requires a saved worker")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(action) = &self.during {
+            action();
+        }
+        Ok(self.status.clone())
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("credential delivery cannot delete")
+    }
+}
+
+fn identities(fixture: &Fixture) -> RemoteSshIdentityStore {
+    RemoteSshIdentityStore::new(&HorizonHome::from_root(fixture.directory.path().join("home")))
+}
+
+fn token() -> RepositoryPat<'static> {
+    RepositoryPat::new("synthetic_PAT_123").expect("synthetic")
+}
+
+#[test]
+fn tokens_are_bounded_ascii_and_debug_redacted() {
+    for value in [
+        "",
+        "synthetic token",
+        "synthetic\n",
+        "synthetic\r",
+        "synthetic\0",
+        "é",
+        "a=b",
+        "a-b",
+    ] {
+        let error = RepositoryPat::new(value).expect_err("invalid syntax");
+        assert_eq!(error, RemoteCredentialDeliveryError::InvalidToken);
+    }
+    assert!(RepositoryPat::new(&"a".repeat(16_384)).is_ok());
+    assert!(RepositoryPat::new(&"a".repeat(16_385)).is_err());
+    assert_eq!(format!("{:?}", token()), "RepositoryPat([redacted])");
+}
+
+#[test]
+fn explicit_installation_inspects_once_and_preserves_zero_panel_allocation_and_identity() {
+    for expected in [
+        RemoteCredentialInstallation::Installed,
+        RemoteCredentialInstallation::Present,
+    ] {
+        let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let before = fixture.current();
+        let key = std::fs::read(fixture.recovered.identity().private_key_path()).expect("key");
+        let provider = Provider::new(&fixture);
+        assert!(before.workspace().state().spec.panels.is_empty());
+        assert_eq!(
+            install_with(
+                &fixture.store,
+                &identities(&fixture),
+                &provider,
+                &before,
+                &token(),
+                |_, recovered, supplied| {
+                    assert_eq!(recovered.allocation(), &before);
+                    assert_eq!(recovered.observation(), provider.status.as_ref());
+                    assert_eq!(supplied.0, "synthetic_PAT_123");
+                    Ok(expected)
+                }
+            ),
+            Ok(expected)
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.current(), before);
+        assert_eq!(
+            std::fs::read(fixture.recovered.identity().private_key_path()).expect("key"),
+            key
+        );
+    }
+}
+
+#[test]
+fn stale_foreign_or_pending_management_rejects_before_provider_or_delivery() {
+    for stop in [false, true] {
+        let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let before = fixture.current();
+        let provider = Provider::new(&fixture);
+        fixture.edit(stop);
+        assert!(
+            install_with(
+                &fixture.store,
+                &identities(&fixture),
+                &provider,
+                &before,
+                &token(),
+                |_, _, _| panic!("no delivery")
+            )
+            .is_err()
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        if stop {
+            assert!(
+                install_with(
+                    &fixture.store,
+                    &identities(&fixture),
+                    &provider,
+                    &fixture.current(),
+                    &token(),
+                    |_, _, _| panic!("no delivery")
+                )
+                .is_err()
+            );
+            assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        }
+    }
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let foreign = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let provider = Provider::new(&fixture);
+    assert!(
+        install_with(
+            &foreign.store,
+            &identities(&fixture),
+            &provider,
+            &fixture.current(),
+            &token(),
+            |_, _, _| panic!("no foreign delivery")
+        )
+        .is_err()
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn changed_or_unavailable_observations_never_receive_token() {
+    let foreign = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    for change in 0..6 {
+        let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let mut provider = Provider::new(&fixture);
+        let status = provider.status.as_mut().expect("ready");
+        match change {
+            0 => status.lifecycle = InteractiveWorkerLifecycle::Stopped,
+            1 => status.ssh.as_mut().expect("ssh").host_key = "invalid pin".into(),
+            2 => status.worker.identity.resource_id = "other-worker".into(),
+            3 => status.worker.ssh_public_key = "other-client-key".into(),
+            4 => status.ssh.as_mut().expect("ssh").host_key = foreign.recovered.identity().public_key().into(),
+            _ => provider.status = None,
+        }
+        assert!(
+            install_with(
+                &fixture.store,
+                &identities(&fixture),
+                &provider,
+                &fixture.current(),
+                &token(),
+                |_, _, _| panic!("no delivery")
+            )
+            .is_err()
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn missing_retained_worker_rejects_before_reconciliation() {
+    let fixture = Fixture::new(None);
+    let provider = Provider::new(&fixture);
+    assert_eq!(
+        install_with(
+            &fixture.store,
+            &identities(&fixture),
+            &provider,
+            &fixture.current(),
+            &token(),
+            |_, _, _| panic!("no delivery")
+        ),
+        Err(RemoteCredentialDeliveryError::MissingRetainedWorker)
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn saved_worker_without_a_pin_cannot_receive_credentials_or_establish_first_trust() {
+    let fixture = Fixture::with_worker(
+        Some(InteractiveWorkerLifecycle::Provisioning),
+        crate::cloud_run::WorkerLifetime::Persistent,
+        false,
+    );
+    let provider = Provider::new(&fixture);
+    assert!(
+        fixture
+            .current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_some()
+    );
+    assert_eq!(
+        install_with(
+            &fixture.store,
+            &identities(&fixture),
+            &provider,
+            &fixture.current(),
+            &token(),
+            |_, _, _| panic!("no first trust")
+        ),
+        Err(RemoteCredentialDeliveryError::MissingRetainedWorker)
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn expired_workers_reject_delivery_and_expiry_during_delivery_is_unknown() {
+    for during in [false, true] {
+        let fixture = Fixture::with_worker(
+            Some(InteractiveWorkerLifecycle::Ready),
+            crate::cloud_run::WorkerLifetime::TimeLimited { seconds: 2 },
+            true,
+        );
+        let provider = Provider::new(&fixture);
+        let lifetime = &provider.status.as_ref().expect("status").worker.lifetime;
+        let InteractiveWorkerLifetime::TimeLimited(lease) = lifetime else {
+            panic!("timed fixture")
+        };
+        let deadline =
+            time::OffsetDateTime::parse(&lease.terminate_after, &time::format_description::well_known::Rfc3339)
+                .expect("deadline");
+        let expire = || {
+            let delay = deadline - time::OffsetDateTime::now_utc();
+            if delay.is_positive() {
+                std::thread::sleep(delay.unsigned_abs());
+            }
+        };
+        if !during {
+            expire();
+        }
+        let mut calls = 0;
+        let result = install_with(
+            &fixture.store,
+            &identities(&fixture),
+            &provider,
+            &fixture.current(),
+            &token(),
+            |_, _, _| {
+                calls += 1;
+                assert!(during, "expired worker cannot receive token");
+                expire();
+                Ok(RemoteCredentialInstallation::Installed)
+            },
+        );
+        if during {
+            assert_eq!(result, Err(RemoteCredentialDeliveryError::DeliveryUnknown));
+        } else {
+            assert!(result.is_err());
+        }
+        assert_eq!(calls, usize::from(during));
+    }
+}
+
+#[test]
+fn snapshot_drift_during_provider_inspection_rejects_before_delivery() {
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let mut provider = Provider::new(&fixture);
+    let path = fixture.store.path().to_path_buf();
+    let retained = path.with_extension("retained");
+    provider.during = Some(Box::new(move || {
+        std::fs::rename(&path, &retained).expect("retain database");
+    }));
+    assert!(
+        install_with(
+            &fixture.store,
+            &identities(&fixture),
+            &provider,
+            &fixture.current(),
+            &token(),
+            |_, _, _| panic!("no delivery")
+        )
+        .is_err()
+    );
+    assert!(!fixture.store.path().exists());
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn drift_or_store_loss_after_delivery_is_unknown_and_never_replayed() {
+    for missing in [false, true] {
+        let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+        let provider = Provider::new(&fixture);
+        let mut calls = 0;
+        assert_eq!(
+            install_with(
+                &fixture.store,
+                &identities(&fixture),
+                &provider,
+                &fixture.current(),
+                &token(),
+                |_, _, _| {
+                    calls += 1;
+                    if missing {
+                        std::fs::rename(fixture.store.path(), fixture.store.path().with_extension("retained"))
+                            .expect("retain database");
+                    } else {
+                        fixture.edit(true);
+                    }
+                    Ok(RemoteCredentialInstallation::Installed)
+                }
+            ),
+            Err(RemoteCredentialDeliveryError::DeliveryUnknown)
+        );
+        assert_eq!(calls, 1);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        if missing {
+            assert!(!fixture.store.path().exists());
+        }
+    }
+}
+
+#[test]
+fn lost_reply_or_refusal_is_unknown_and_never_replayed() {
+    let fixture = Fixture::new(Some(InteractiveWorkerLifecycle::Ready));
+    let provider = Provider::new(&fixture);
+    let before = fixture.current();
+    let mut calls = 0;
+    assert_eq!(
+        install_with(
+            &fixture.store,
+            &identities(&fixture),
+            &provider,
+            &before,
+            &token(),
+            |_, _, _| {
+                calls += 1;
+                Err(RemoteCredentialDeliveryError::DeliveryUnknown)
+            }
+        ),
+        Err(RemoteCredentialDeliveryError::DeliveryUnknown)
+    );
+    assert_eq!(calls, 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.current(), before);
+}

--- a/crates/horizon-core/src/remote_github_credential/transport.rs
+++ b/crates/horizon-core/src/remote_github_credential/transport.rs
@@ -1,0 +1,53 @@
+use super::{RemoteCredentialDeliveryError as Error, RemoteCredentialInstallation, RepositoryPat, validate_delivery};
+use crate::{
+    cloud_run::CloudWorkflowStore,
+    remote_worker_ssh::{known_hosts, prepared_github_install, query},
+    remote_workspace_recovery::RecoveredRemoteWorkspace,
+};
+use std::{process::Command, time::Duration};
+
+const RESPONSE_LIMIT: usize = 1024;
+
+pub(super) fn install(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    token: &RepositoryPat<'_>,
+) -> Result<RemoteCredentialInstallation, Error> {
+    let endpoint = validate_delivery(store, recovered)?;
+    let identity = recovered.identity();
+    let trust = known_hosts(identity, endpoint)?;
+    let command = prepared_github_install(identity.private_key_path(), trust.path(), endpoint)?;
+    validate_delivery(store, recovered)?;
+    exchange(command, token, Duration::from_secs(15))
+}
+
+pub(super) fn exchange(
+    command: Command,
+    token: &RepositoryPat<'_>,
+    timeout: Duration,
+) -> Result<RemoteCredentialInstallation, Error> {
+    // run requires successful delivery of the entire known input and a zero exit.
+    // stderr is discarded; neither raw response nor transport diagnostics escape.
+    let bytes = query::run(command, token.0.as_bytes(), timeout, RESPONSE_LIMIT).map_err(|_| Error::DeliveryUnknown)?;
+    response(&bytes)
+}
+
+fn response(bytes: &[u8]) -> Result<RemoteCredentialInstallation, Error> {
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct Response {
+        version: u8,
+        status: RemoteCredentialInstallation,
+    }
+    if bytes.len() > RESPONSE_LIMIT {
+        return Err(Error::DeliveryUnknown);
+    }
+    let reply: Response = serde_json::from_slice(bytes).map_err(|_| Error::DeliveryUnknown)?;
+    if reply.version != 1 {
+        return Err(Error::DeliveryUnknown);
+    }
+    Ok(reply.status)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_github_credential/transport.rs
+++ b/crates/horizon-core/src/remote_github_credential/transport.rs
@@ -1,10 +1,16 @@
-use super::{RemoteCredentialDeliveryError as Error, RemoteCredentialInstallation, RepositoryPat, validate_delivery};
+use super::{
+    RemoteCredentialDeliveryError as Error, RemoteCredentialInstallation, RepositoryPat, lease_deadline,
+    validate_delivery,
+};
 use crate::{
     cloud_run::CloudWorkflowStore,
     remote_worker_ssh::{known_hosts, prepared_github_install, query},
     remote_workspace_recovery::RecoveredRemoteWorkspace,
 };
-use std::{process::Command, time::Duration};
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
 
 const RESPONSE_LIMIT: usize = 1024;
 
@@ -18,18 +24,66 @@ pub(super) fn install(
     let trust = known_hosts(identity, endpoint)?;
     let command = prepared_github_install(identity.private_key_path(), trust.path(), endpoint)?;
     validate_delivery(store, recovered)?;
-    exchange(command, token, Duration::from_secs(15))
+    exchange_before(
+        command,
+        token,
+        Duration::from_secs(15),
+        lease_deadline(recovered)?,
+        time::OffsetDateTime::now_utc,
+    )
 }
 
+#[cfg(test)]
 pub(super) fn exchange(
     command: Command,
     token: &RepositoryPat<'_>,
     timeout: Duration,
 ) -> Result<RemoteCredentialInstallation, Error> {
-    // run requires successful delivery of the entire known input and a zero exit.
+    exchange_before(command, token, timeout, None, time::OffsetDateTime::now_utc)
+}
+
+fn exchange_before(
+    command: Command,
+    token: &RepositoryPat<'_>,
+    timeout: Duration,
+    deadline: Option<time::OffsetDateTime>,
+    utc_now: impl Fn() -> time::OffsetDateTime,
+) -> Result<RemoteCredentialInstallation, Error> {
+    let started = Instant::now();
+    let timeout = lease_timeout(timeout, deadline, utc_now())?;
+    // Absolute admission includes spawn overhead and is checked by exchange
+    // before spawn, after spawn, after input reads and immediately before EACH
+    // write. A forward wall-clock jump also revokes further token release.
+    let expired = || started.elapsed() >= timeout || deadline.is_some_and(|end| utc_now() >= end);
+    // Known input requires successful delivery of every byte and a zero exit.
     // stderr is discarded; neither raw response nor transport diagnostics escape.
-    let bytes = query::run(command, token.0.as_bytes(), timeout, RESPONSE_LIMIT).map_err(|_| Error::DeliveryUnknown)?;
-    response(&bytes)
+    let mut input = token.0.as_bytes();
+    let expected = input.len() as u64;
+    let result = query::exchange(command, &mut input, timeout, RESPONSE_LIMIT, expired, Some(expected))
+        .map_err(|_| Error::DeliveryUnknown)?;
+    known_response(&result, expected)
+}
+
+fn known_response(result: &query::Exchange, expected: u64) -> Result<RemoteCredentialInstallation, Error> {
+    let (query::InputProgress::Complete(written) | query::InputProgress::Incomplete(written)) = result.input;
+    if !result.status.success() || written != expected {
+        return Err(Error::DeliveryUnknown);
+    }
+    response(&result.output)
+}
+
+fn lease_timeout(
+    timeout: Duration,
+    deadline: Option<time::OffsetDateTime>,
+    now: time::OffsetDateTime,
+) -> Result<Duration, Error> {
+    match deadline {
+        Some(end) if end <= now => Err(Error::ExpiredWorker),
+        Some(end) => Duration::try_from(end - now)
+            .map(|remaining| remaining.min(timeout))
+            .map_err(|_| Error::ExpiredWorker),
+        None => Ok(timeout),
+    }
 }
 
 fn response(bytes: &[u8]) -> Result<RemoteCredentialInstallation, Error> {

--- a/crates/horizon-core/src/remote_github_credential/transport/tests.rs
+++ b/crates/horizon-core/src/remote_github_credential/transport/tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+use crate::remote_worker_ssh::prepared_command;
+
+fn shell(script: &str) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", script]);
+    command
+}
+
+#[test]
+fn strict_reply_rejects_unknown_fields_versions_statuses_duplicates_and_trailing_data() {
+    for bytes in [
+        "",
+        "{}",
+        "null",
+        "{\"version\":2,\"status\":\"installed\"}",
+        "{\"version\":1,\"status\":\"rejected\"}",
+        "{\"version\":1,\"status\":\"installed\",\"secret\":\"synthetic\"}",
+        "{\"version\":1,\"version\":1,\"status\":\"installed\"}",
+        "{\"version\":1,\"status\":\"present\"}{}",
+    ] {
+        assert_eq!(response(bytes.as_bytes()), Err(Error::DeliveryUnknown));
+    }
+    assert_eq!(response(&vec![b' '; RESPONSE_LIMIT + 1]), Err(Error::DeliveryUnknown));
+}
+
+#[test]
+fn real_child_consumes_token_only_on_stdin_and_reports_both_success_states() {
+    for (status, expected) in [
+        ("installed", RemoteCredentialInstallation::Installed),
+        ("present", RemoteCredentialInstallation::Present),
+    ] {
+        let script = format!(
+            "value=$(cat); [ \"$value\" = synthetic_PAT_123 ] || exit 9; printf '%s\\n' '{{\"version\":1,\"status\":\"{status}\"}}'"
+        );
+        let command = shell(&script);
+        let token = RepositoryPat::new("synthetic_PAT_123").expect("synthetic");
+        assert_eq!(exchange(command, &token, Duration::from_secs(2)), Ok(expected));
+    }
+}
+
+#[test]
+fn real_child_failures_and_unbounded_output_are_unknown_without_secret_diagnostics() {
+    for (script, timeout) in [
+        ("cat >/dev/null; exit 1", Duration::from_secs(2)),
+        ("cat >/dev/null; exit 255", Duration::from_secs(2)),
+        ("cat >/dev/null; exec sleep 5", Duration::from_millis(30)),
+        ("cat >/dev/null; head -c 1025 /dev/zero", Duration::from_secs(2)),
+        ("cat; printf synthetic_PAT_123 >&2", Duration::from_secs(2)),
+        (
+            "cat >/dev/null; printf '%s' '{\"version\":1,\"status\":\"installed\"}'; exit 1",
+            Duration::from_secs(2),
+        ),
+    ] {
+        let error = exchange(
+            shell(script),
+            &RepositoryPat::new("synthetic_PAT_123").expect("synthetic"),
+            timeout,
+        )
+        .expect_err("unknown");
+        assert_eq!(error, Error::DeliveryUnknown);
+        assert!(!format!("{error:?} {error}").contains("synthetic_PAT_123"));
+    }
+}
+
+#[test]
+fn fixed_command_preserves_pinned_ssh_isolation_and_carries_no_token_metadata() {
+    let fixture = crate::remote_repository_pack::tests::Fixture::new(Some(
+        crate::cloud_run::interactive_worker::InteractiveWorkerLifecycle::Ready,
+    ));
+    let identity = fixture.recovered.identity();
+    let endpoint = fixture
+        .recovered
+        .observation()
+        .and_then(|value| value.ssh.as_ref())
+        .expect("ssh");
+    let trust = known_hosts(identity, endpoint).expect("trust");
+    let baseline = prepared_command(identity.private_key_path(), trust.path(), endpoint).expect("baseline");
+    let command = prepared_github_install(identity.private_key_path(), trust.path(), endpoint).expect("install");
+    let mut expected: Vec<_> = baseline.get_args().map(std::ffi::OsStr::to_os_string).collect();
+    *expected.last_mut().expect("command") = "/usr/local/bin/horizon-github-credential install".into();
+    assert_eq!(command.get_args().collect::<Vec<_>>(), expected);
+    assert_eq!(
+        command.get_envs().collect::<Vec<_>>(),
+        baseline.get_envs().collect::<Vec<_>>()
+    );
+    assert!(!format!("{command:?}").contains("synthetic_PAT_123"));
+}

--- a/crates/horizon-core/src/remote_github_credential/transport/tests.rs
+++ b/crates/horizon-core/src/remote_github_credential/transport/tests.rs
@@ -86,3 +86,92 @@ fn fixed_command_preserves_pinned_ssh_isolation_and_carries_no_token_metadata() 
     );
     assert!(!format!("{command:?}").contains("synthetic_PAT_123"));
 }
+
+#[test]
+fn lease_caps_the_transport_but_persistent_workers_keep_fifteen_seconds() {
+    let now = time::OffsetDateTime::UNIX_EPOCH;
+    let normal = Duration::from_secs(15);
+    assert_eq!(lease_timeout(normal, None, now), Ok(normal));
+    assert_eq!(
+        lease_timeout(normal, Some(now + time::Duration::seconds(60)), now),
+        Ok(normal)
+    );
+    assert_eq!(
+        lease_timeout(normal, Some(now + time::Duration::milliseconds(250)), now),
+        Ok(Duration::from_millis(250))
+    );
+    for expired in [now, now - time::Duration::seconds(1)] {
+        assert_eq!(lease_timeout(normal, Some(expired), now), Err(Error::ExpiredWorker));
+    }
+}
+
+#[test]
+fn known_input_requires_every_byte_and_success_even_with_a_valid_reply() {
+    use std::os::unix::process::ExitStatusExt;
+    for complete in [false, true] {
+        for written in [0, 12, 13, 14] {
+            for status in [0, 1] {
+                let result = query::Exchange {
+                    input: if complete {
+                        query::InputProgress::Complete(written)
+                    } else {
+                        query::InputProgress::Incomplete(written)
+                    },
+                    status: std::process::ExitStatus::from_raw(status << 8),
+                    output: br#"{"version":1,"status":"installed"}"#.to_vec(),
+                };
+                assert_eq!(known_response(&result, 13).is_ok(), written == 13 && status == 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn expiry_after_spawn_prevents_the_first_stdin_write() {
+    use std::cell::Cell;
+    let now = time::OffsetDateTime::UNIX_EPOCH;
+    let deadline = now + time::Duration::seconds(1);
+    let samples = Cell::new(0);
+    let result = exchange_before(
+        shell("cat >/dev/null; printf '%s' '{\"version\":1,\"status\":\"installed\"}'"),
+        &RepositoryPat::new("synthetic_PAT_123").expect("synthetic"),
+        Duration::from_secs(15),
+        Some(deadline),
+        || {
+            let sample = samples.get() + 1;
+            samples.set(sample);
+            // Construction and pre-spawn admission see a valid lease; the
+            // first post-spawn admission sees expiry, without scheduling sleeps.
+            if sample < 3 { now } else { deadline }
+        },
+    );
+    assert_eq!(samples.get(), 3);
+    assert_eq!(result, Err(Error::DeliveryUnknown));
+}
+
+#[test]
+fn admission_is_rechecked_immediately_before_first_write_and_on_later_writes() {
+    use std::cell::Cell;
+    let now = time::OffsetDateTime::UNIX_EPOCH;
+    let deadline = now + time::Duration::seconds(1);
+    // Sample 5 is immediately before the first write: initial clock, pre-spawn,
+    // loop admission, after token read, pre-write. A later sample exercises the
+    // next admission while a child that never reads keeps the pipe backpressured.
+    for expiry_sample in [5, 7] {
+        let samples = Cell::new(0);
+        let token = "s".repeat(16_384);
+        let result = exchange_before(
+            shell("exec sleep 5"),
+            &RepositoryPat::new(&token).expect("synthetic"),
+            Duration::from_secs(15),
+            Some(deadline),
+            || {
+                let sample = samples.get() + 1;
+                samples.set(sample);
+                if sample < expiry_sample { now } else { deadline }
+            },
+        );
+        assert_eq!(samples.get(), expiry_sample);
+        assert_eq!(result, Err(Error::DeliveryUnknown));
+    }
+}

--- a/crates/horizon-core/src/remote_repository_pack/tests.rs
+++ b/crates/horizon-core/src/remote_repository_pack/tests.rs
@@ -60,13 +60,21 @@ pub(crate) struct Fixture {
 
 impl Fixture {
     pub(crate) fn new(lifecycle: Option<InteractiveWorkerLifecycle>) -> Self {
+        Self::with_worker(lifecycle, crate::cloud_run::WorkerLifetime::Persistent, true)
+    }
+
+    pub(crate) fn with_worker(
+        lifecycle: Option<InteractiveWorkerLifecycle>,
+        lifetime: crate::cloud_run::WorkerLifetime,
+        pinned: bool,
+    ) -> Self {
         use std::os::unix::fs::PermissionsExt;
         let directory = tempfile::tempdir().expect("fixture");
         std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
         let home = HorizonHome::from_root(directory.path().join("home"));
         let store = CloudWorkflowStore::open(&home).expect("store");
         let identities = RemoteSshIdentityStore::new(&home);
-        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
             "version": 1,
             "spec": {
                 "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
@@ -77,6 +85,7 @@ impl Fixture {
             }
         }))
         .expect("state");
+        state.spec.target.lifetime = lifetime;
         let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
         let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
         let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");
@@ -97,10 +106,20 @@ impl Fixture {
                 },
                 target: request.target,
                 ssh_public_key: request.ssh_public_key,
-                lifetime: InteractiveWorkerLifetime::Persistent,
+                lifetime: match lifetime {
+                    crate::cloud_run::WorkerLifetime::Persistent => InteractiveWorkerLifetime::Persistent,
+                    crate::cloud_run::WorkerLifetime::TimeLimited { seconds } => {
+                        InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                            terminate_after: (time::OffsetDateTime::now_utc()
+                                + time::Duration::seconds(i64::from(seconds)))
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .expect("expiry"),
+                        })
+                    }
+                },
             },
             lifecycle,
-            ssh: Some(InteractiveWorkerSshEndpoint {
+            ssh: pinned.then(|| InteractiveWorkerSshEndpoint {
                 host: "127.0.0.1".into(),
                 port: 2222,
                 username: "horizon".into(),

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -57,6 +57,14 @@ pub(crate) fn prepared_storage_status(
     command_for(identity, known_hosts, endpoint, Operation::StorageStatus)
 }
 
+pub(crate) fn prepared_github_install(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<Command, Error> {
+    command_for(identity, known_hosts, endpoint, Operation::GithubInstall)
+}
+
 #[derive(Clone, Copy)]
 enum Operation<'a> {
     Request,
@@ -64,6 +72,7 @@ enum Operation<'a> {
     Intake,
     IntakeStatus,
     StorageStatus,
+    GithubInstall,
     Attach { runtime: CloudJobId, panel: &'a str },
 }
 
@@ -82,7 +91,8 @@ fn command_for(
         | Operation::PackStatus
         | Operation::Intake
         | Operation::IntakeStatus
-        | Operation::StorageStatus => "-T",
+        | Operation::StorageStatus
+        | Operation::GithubInstall => "-T",
         Operation::Attach { panel, .. } if valid_local_id(panel) => "-tt",
         Operation::Attach { .. } => return Err(Error::UnknownPanel),
     };
@@ -135,6 +145,7 @@ fn command_for(
         Operation::Intake => "/usr/local/bin/horizon-repository intake".into(),
         Operation::IntakeStatus => "/usr/local/bin/horizon-repository intake-status".into(),
         Operation::StorageStatus => "/usr/local/bin/horizon-repository storage-status".into(),
+        Operation::GithubInstall => "/usr/local/bin/horizon-github-credential install".into(),
         Operation::Attach { runtime, panel } => {
             format!("/usr/local/bin/horizon-panel-session attach -- {runtime} {panel}")
         }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -151,6 +151,12 @@ back into large multi-purpose modules.
   valid negative observations are distinct from transport or protocol errors.
   It reuses the worker's storage status type without initialization, provider
   selection, persistence or task authority.
+- `remote_github_credential.rs` owns explicit first-PAT delivery admission after
+  non-creating provider inspection and retained host-pin checks. Its transport
+  leaf reuses the fixed SSH command and bounded stdin-only exchange, accepting
+  only exact installer success replies. Post-send drift is unknown, never a
+  reason for automatic retry, credential replacement or worker/task mutation.
+  The borrowed secret is redacted and is not persisted or discovered implicitly.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
   wire types; `ssh.rs` owns the query's private host-pin lifetime and retains the


### PR DESCRIPTION
## Purpose

Continue #470 and #383 by explicitly delivering a user-supplied repository PAT to the existing worker installer from #522.

## Behavior

- Require an owned current allocation, existing client identity, saved worker/host pin and fresh non-creating provider inspection before releasing the token.
- Send the borrowed, syntax-validated secret only on stdin to the fixed pinned-SSH installer. Never discover credentials implicitly or persist them in descriptors, command arguments, environment or diagnostics.
- Accept only a bounded, exact `installed`/`present` success reply. Refusal, lost response, timeout or post-send state/expiry drift never triggers retry, replacement, repair or worker/task cleanup.
- Cap token-write admission to the lesser of 15 seconds and the remaining recorded worker lifetime. Recheck absolute expiry before spawn and every stdin write, including time consumed by SSH startup; the ordinary observation clock-skew allowance cannot extend disclosure.

This prerequisite currently has Linux client transport only; other platforms return before provider/key/store I/O. The user approved Linux-only first delivery for #383/#475; macOS, Windows and iOS/iPadOS client work is deferred, with existing platform CI preserved. The caller still explicitly authorizes the active session, provider policy and disclosure of this credential. This is not continuous revocation, an atomic Stop fence, PAT permission validation, credential rotation or implicit reconnect behavior.

Eight source/test paths plus architecture notes; 945 changed lines total. No UI, configuration, dependency, worker-image or schema changes. Remote Git preparation and cloud acceptance remain separate work.

## Validation

Exact controller head: `e4b6ef3f46ff40136f88ef70a4ae1c97b0b5922a`.

- All eight exact-commit local gates passed: formatting, maintainability, version sync, default and speech workspace tests, blocking Clippy, strict Clippy and advisory pedantic Clippy.
- 18 focused credential tests and 11 shared-query regressions passed, including deterministic expiry after spawn and immediately before a write, persistent-worker timeout preservation, full-byte/zero-exit requirements, current/foreign/stale ownership, missing and different valid pins, management races, missing storage, bounded protocol and real-child failures. The full workspace suites cover the existing shared-fixture and pinned-SSH regressions.
- Independent local review completed and its additional negative-test coverage is included. Both the original expiry-admission regression and the review-found in-flight expiry window are fixed without changing the shared observation or query implementations.
- Fresh exact-head real SSH/public-controller API smoke passed against the already tested #522 worker image: wrong valid pin prevented installation; first install, unchanged identical-token delivery and different-token refusal behaved correctly. Store/key bytes remained unchanged. The same independent task advanced across all four calls. The worker image was unchanged; this smoke uses a persistent synthetic observation, while deterministic transport regressions cover lease-bound writes.
- Synthetic PAT and deliberately synthetic provider observation only; no cloud/GitHub authorization claim. The exact task container was removed and all pre-existing container IDs were preserved. No UI changes; rendering smoke is not applicable.

The linked issues remain open for ordinary remote Git, provider/UI integration and complete acceptance.


