### PR TITLE
feat(cloud): verify selected volume retention during explicit stop

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -54,7 +54,7 @@ impl RunPodInteractiveWorkerProvider {
     /// Bind one caller-authorized selection to the complete persistent request.
     /// The caller must retain this selection before creation and reuse it on recovery.
     /// This does not prove volume ownership, exclusivity, contents or durability,
-    /// and grants no volume mutation or network-volume Stop support.
+    /// and grants no volume mutation. Explicit Stop verifies retained attachment separately.
     /// # Errors
     /// Rejects invalid or conflicting requests, profiles and prior bindings before I/O.
     pub fn new_with_network_volume(
@@ -221,9 +221,6 @@ impl InteractiveWorkerProvider for RunPodInteractiveWorkerProvider {
 impl InteractiveWorkerStopProvider for RunPodInteractiveWorkerProvider {
     fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error> {
         self.client.check_network_worker(worker)?;
-        if self.client.network_binding.is_some() {
-            return Err(RunPodError::StopRetentionUnverified);
-        }
         let retained = runpod_worker(worker)?;
         super::validate_target(&worker.target, &self.profile)?;
         self.client

--- a/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests.rs
@@ -13,6 +13,7 @@ use crate::cloud_run::interactive_worker::{
 };
 use crate::cloud_run::interactive_worker_stop::InteractiveWorkerStopProvider;
 use serde_json::{Value, json};
+use std::collections::VecDeque;
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
@@ -30,6 +31,10 @@ struct State {
     lose_create: bool,
     fresh: Option<ApiPod>,
     deleted: Vec<String>,
+    scripted_gets: VecDeque<Result<Option<ApiPod>, RunPodError>>,
+    scripted_volumes: VecDeque<Result<Option<Value>, RunPodError>>,
+    stop_error: Option<RunPodError>,
+    on_stop: Option<Box<dyn Fn() + Send>>,
 }
 
 impl Transport for FakeTransport {
@@ -37,10 +42,11 @@ impl Transport for FakeTransport {
         assert_eq!(id, "volume_exact");
         let mut state = self.0.lock().expect("state");
         state.calls.push("volume");
-        Ok(state
-            .volume
-            .clone()
-            .map(|value| serde_json::from_value(value).expect("volume")))
+        let volume = state
+            .scripted_volumes
+            .pop_front()
+            .unwrap_or_else(|| Ok(state.volume.clone()))?;
+        Ok(volume.map(|value| serde_json::from_value(value).expect("volume")))
     }
     fn list_by_name(&self, _: &str) -> Result<Vec<ApiPod>, RunPodError> {
         let mut state = self.0.lock().expect("state");
@@ -65,10 +71,22 @@ impl Transport for FakeTransport {
         assert_eq!(id, "pod_exact");
         let mut state = self.0.lock().expect("state");
         state.calls.push("get");
+        if let Some(scripted) = state.scripted_gets.pop_front() {
+            return scripted;
+        }
         Ok(state.fresh.clone().or_else(|| state.pods.first().cloned()))
     }
-    fn stop(&self, _: &str) -> Result<(), RunPodError> {
-        panic!("network Stop is unsupported")
+    fn stop(&self, id: &str) -> Result<(), RunPodError> {
+        assert_eq!(id, "pod_exact");
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("stop");
+        if let Some(hook) = &state.on_stop {
+            hook();
+        }
+        if let Some(pod) = state.pods.first_mut() {
+            pod.status = Some("EXITED".into());
+        }
+        state.stop_error.take().map_or(Ok(()), Err)
     }
     fn delete(&self, id: &str) -> Result<RunPodCleanup, RunPodError> {
         let mut state = self.0.lock().expect("state");
@@ -88,7 +106,9 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
-        let mut request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+        Self::from_request(interactive_request(CloudWorkflowId::new(), CloudJobId::new()))
+    }
+    fn from_request(mut request: InteractiveWorkerRequest) -> Self {
         request.target.lifetime = WorkerLifetime::Persistent;
         let selection = RunPodNetworkVolumeExpectation {
             volume_id: "volume_exact".into(),
@@ -123,6 +143,10 @@ impl Fixture {
                 lose_create: false,
                 fresh: None,
                 deleted: Vec::new(),
+                scripted_gets: VecDeque::new(),
+                scripted_volumes: VecDeque::new(),
+                stop_error: None,
+                on_stop: None,
             }))),
         }
     }
@@ -259,10 +283,6 @@ fn complete_request_and_original_worker_guards_precede_every_io_path() {
         assert!(provider.delete_worker(&worker).is_err());
         assert!(provider.stop_worker(&worker).is_err());
     }
-    assert_eq!(
-        provider.stop_worker(&fixture.worker()),
-        Err(RunPodError::StopRetentionUnverified)
-    );
     let mut client = fixture.client();
     client
         .bind_network(&NetworkBinding::new(&fixture.request, &fixture.selection, &profile()).expect("binding"))
@@ -439,3 +459,5 @@ fn fresh_exact_pod_and_ordinary_rejection_cannot_be_bypassed() {
     );
     assert_eq!(fixture.transport.0.lock().expect("state").deleted, ["pod_exact"]);
 }
+
+mod stop;

--- a/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests/stop.rs
@@ -1,0 +1,382 @@
+use super::*;
+use crate::{
+    cloud_run::{CloudWorkflowStore, interactive_worker_stop::InteractiveWorkerStop},
+    remote_workspace::stop::{RemoteWorkspaceStopError, stop_remote_workspace},
+    remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
+};
+
+fn metadata() -> Value {
+    json!({"mounts":{"network":[{"volumeId":"volume_exact","path":"/workspace"}]},
+        "cloud":"SECURE", "dataCenterId":"EUR-NO-1", "cluster":null,
+        "locked":false, "actions":["stop","terminate"], "runtime":null})
+}
+
+fn prepare(fixture: &Fixture) {
+    let mut state = fixture.transport.0.lock().expect("state");
+    state.template.stop = serde_json::from_value(metadata()).expect("metadata");
+    state.pods = vec![state.template.clone()];
+}
+
+fn fixture() -> Fixture {
+    let fixture = Fixture::new();
+    prepare(&fixture);
+    fixture
+}
+
+fn pod(fixture: &Fixture) -> ApiPod {
+    fixture.transport.0.lock().expect("state").pods[0].clone()
+}
+
+fn assert_calls(fixture: &Fixture, calls: &[&str]) {
+    let state = fixture.transport.0.lock().expect("state");
+    assert_eq!(state.calls, calls);
+    assert!(state.creates.is_empty() && state.deleted.is_empty());
+    assert_eq!(fixture.claims.load(Ordering::SeqCst), 0);
+}
+
+fn failed_stop() -> RunPodError {
+    RunPodError::RequestFailed { operation: "pod Stop" }
+}
+
+#[test]
+fn one_stop_verifies_both_sides_and_already_stopped_needs_no_mutation() {
+    for lost_reply in [false, true] {
+        let fixture = fixture();
+        let before = pod(&fixture);
+        fixture.transport.0.lock().expect("state").stop_error = lost_reply.then(failed_stop);
+        // The selected network volume replaces the ordinary profile volume.
+        let mut configuration = profile();
+        configuration.volume_gib = 0;
+        let provider = RunPodInteractiveWorkerProvider::new_with_network_volume(
+            fixture.client(),
+            configuration,
+            fixture.trust(),
+            &fixture.request,
+            &fixture.selection,
+        )
+        .expect("provider");
+        assert_eq!(
+            provider.stop_worker(&fixture.worker()),
+            Ok(InteractiveWorkerStop::Stopped)
+        );
+        assert_calls(&fixture, &["get", "volume", "stop", "get", "volume"]);
+        let after = pod(&fixture);
+        assert_eq!(after.env, before.env);
+        assert_eq!(after.id, before.id);
+        assert_eq!(after.status.as_deref(), Some("EXITED"));
+        assert_eq!(
+            provider.stop_worker(&fixture.worker()),
+            Ok(InteractiveWorkerStop::Stopped)
+        );
+        assert_calls(&fixture, &["get", "volume", "stop", "get", "volume", "get", "volume"]);
+    }
+}
+
+#[test]
+fn still_running_is_not_retained_stopped_even_after_a_successful_response() {
+    for lost_reply in [false, true] {
+        let fixture = fixture();
+        let before = pod(&fixture);
+        let mut state = fixture.transport.0.lock().expect("state");
+        state.scripted_gets = [Ok(Some(before.clone())), Ok(Some(before))].into();
+        state.stop_error = lost_reply.then(failed_stop);
+        drop(state);
+        let expected = if lost_reply {
+            failed_stop()
+        } else {
+            RunPodError::StopVerificationFailed
+        };
+        assert_eq!(fixture.provider().stop_worker(&fixture.worker()), Err(expected));
+        assert_calls(&fixture, &["get", "volume", "stop", "get", "volume"]);
+    }
+}
+
+#[test]
+fn exact_volume_metadata_must_match_before_and_after_stop() {
+    for after_stop in [false, true] {
+        for changed in 0..6 {
+            let fixture = fixture();
+            let mut state = fixture.transport.0.lock().expect("state");
+            let valid = state.volume.clone();
+            let mut changed_volume = valid.clone().expect("volume");
+            match changed {
+                0 => changed_volume["id"] = json!("foreign"),
+                1 => changed_volume["dataCenter"] = json!("foreign"),
+                2 => changed_volume["type"] = json!("STANDARD"),
+                3 => changed_volume["size"] = json!(9),
+                _ => {}
+            }
+            let invalid = match changed {
+                4 => Ok(None),
+                5 => Err(failed_stop()),
+                _ => Ok(Some(changed_volume)),
+            };
+            if after_stop {
+                state.scripted_volumes.push_back(Ok(valid));
+            }
+            state.scripted_volumes.push_back(invalid);
+            drop(state);
+            let expected = if changed == 5 {
+                failed_stop()
+            } else {
+                RunPodError::ResourceIdentityMismatch
+            };
+            assert_eq!(fixture.provider().stop_worker(&fixture.worker()), Err(expected));
+            assert_calls(
+                &fixture,
+                if after_stop {
+                    &["get", "volume", "stop", "get", "volume"]
+                } else {
+                    &["get", "volume"]
+                },
+            );
+        }
+    }
+}
+
+#[test]
+fn exact_attachment_and_worker_identity_are_verified_on_both_sides() {
+    for after_stop in [false, true] {
+        for changed in 0..11 {
+            let fixture = fixture();
+            let before = pod(&fixture);
+            let mut invalid = before.clone();
+            let mut data = metadata();
+            match changed {
+                0 => data["mounts"]["network"][0]["volumeId"] = json!("foreign"),
+                1 => data["mounts"]["network"][0]["path"] = json!("/other"),
+                2 => data["dataCenterId"] = json!("foreign"),
+                3 => data["mounts"]["network"] = json!([]),
+                4 => data["mounts"]["persistent"] = json!({"path":"/workspace","size":20}),
+                5 => invalid.id = "other_pod".into(),
+                6 => invalid.name = "foreign".into(),
+                7 => invalid.image = format!("example/other@sha256:{}", "a".repeat(64)),
+                8 => {
+                    invalid
+                        .env
+                        .insert("HORIZON_WORKFLOW_ID".into(), CloudWorkflowId::new().to_string());
+                }
+                9 => {
+                    invalid
+                        .env
+                        .insert("HORIZON_JOB_ID".into(), CloudJobId::new().to_string());
+                }
+                _ => {
+                    invalid.env.insert("HORIZON_SSH_PUBLIC_KEY".into(), ed25519_key(90));
+                }
+            }
+            invalid.stop = serde_json::from_value(data).expect("metadata");
+            let mut state = fixture.transport.0.lock().expect("state");
+            if after_stop {
+                state.scripted_gets.push_back(Ok(Some(before)));
+            }
+            state.scripted_gets.push_back(Ok(Some(invalid)));
+            drop(state);
+            assert_eq!(
+                fixture.provider().stop_worker(&fixture.worker()),
+                Err(RunPodError::ResourceIdentityMismatch)
+            );
+            let mut expected = if after_stop {
+                vec!["get", "volume", "stop", "get"]
+            } else {
+                vec!["get"]
+            };
+            if changed < 5 {
+                expected.push("volume");
+            }
+            assert_calls(&fixture, &expected);
+        }
+    }
+}
+
+#[test]
+fn selected_stop_keeps_positive_state_and_capability_requirements() {
+    for after_stop in [false, true] {
+        for changed in 0..9 {
+            let fixture = fixture();
+            let before = pod(&fixture);
+            let mut invalid = before.clone();
+            let mut data = metadata();
+            match changed {
+                0 => data["locked"] = json!(true),
+                1 => data["actions"] = json!(["terminate"]),
+                2 => data["cloud"] = json!("COMMUNITY"),
+                3 => data["cluster"] = json!({"id":"foreign"}),
+                4 => invalid.status = Some("ERROR".into()),
+                5 => invalid.status = None,
+                6 => invalid.status = Some("TERMINATED".into()),
+                7 => invalid.status = Some("unknown".into()),
+                _ => {
+                    invalid.status = Some("EXITED".into());
+                    data["runtime"] = json!({"uptime":1});
+                }
+            }
+            invalid.stop = serde_json::from_value(data).expect("metadata");
+            let mut state = fixture.transport.0.lock().expect("state");
+            if after_stop {
+                state.scripted_gets.push_back(Ok(Some(before)));
+            }
+            state.scripted_gets.push_back(Ok(Some(invalid)));
+            drop(state);
+            let retention = changed == 2 || changed == 3;
+            let error = if retention {
+                RunPodError::StopRetentionUnverified
+            } else {
+                RunPodError::StopStateUnverified
+            };
+            assert_eq!(fixture.provider().stop_worker(&fixture.worker()), Err(error));
+            let mut expected = if after_stop {
+                vec!["get", "volume", "stop", "get"]
+            } else {
+                vec!["get"]
+            };
+            if !retention {
+                expected.push("volume");
+            }
+            assert_calls(&fixture, &expected);
+        }
+    }
+}
+
+#[test]
+fn absence_and_unknown_reads_never_acknowledge_a_retained_stop() {
+    let absent = fixture();
+    absent.transport.0.lock().expect("state").pods.clear();
+    assert_eq!(
+        absent.provider().stop_worker(&absent.worker()),
+        Ok(InteractiveWorkerStop::AlreadyAbsent)
+    );
+    assert_calls(&absent, &["get"]);
+    for after_stop in [false, true] {
+        let fixture = fixture();
+        let before = pod(&fixture);
+        let mut state = fixture.transport.0.lock().expect("state");
+        if after_stop {
+            state.scripted_gets.push_back(Ok(Some(before)));
+        }
+        state.scripted_gets.push_back(Err(failed_stop()));
+        drop(state);
+        assert_eq!(fixture.provider().stop_worker(&fixture.worker()), Err(failed_stop()));
+        assert_calls(
+            &fixture,
+            if after_stop {
+                &["get", "volume", "stop", "get"]
+            } else {
+                &["get"]
+            },
+        );
+    }
+    let lost = fixture();
+    let before = pod(&lost);
+    lost.transport.0.lock().expect("state").scripted_gets = [Ok(Some(before)), Ok(None)].into();
+    assert_eq!(
+        lost.provider().stop_worker(&lost.worker()),
+        Err(RunPodError::StopResourceLost)
+    );
+    assert_calls(&lost, &["get", "volume", "stop", "get"]);
+}
+
+#[test]
+fn provisioning_stop_works_but_ordinary_provider_cannot_adopt_network_retention() {
+    for status in ["PROVISIONING", "STARTING"] {
+        let fixture = fixture();
+        fixture.transport.0.lock().expect("state").pods[0].status = Some(status.into());
+        let ordinary = RunPodInteractiveWorkerProvider::new(fixture.client(), profile(), fixture.trust());
+        assert_eq!(
+            ordinary.stop_worker(&fixture.worker()),
+            Err(RunPodError::StopRetentionUnverified)
+        );
+        assert_calls(&fixture, &["get"]);
+        assert_eq!(
+            fixture.provider().stop_worker(&fixture.worker()),
+            Ok(InteractiveWorkerStop::Stopped)
+        );
+        assert_calls(&fixture, &["get", "get", "volume", "stop", "get", "volume"]);
+    }
+}
+
+#[test]
+fn durable_intent_selection_and_identity_survive_unverified_stop() {
+    const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+    let directory = tempfile::tempdir().expect("private fixture");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let fixture = Fixture::new();
+    let workspace: RemoteWorkspaceState = serde_json::from_value(json!({
+        "version":1,"spec":{"workspace_local_id":"workspace","working_directory":".","generation":0,
+            "target":fixture.request.target,"repository":{"repository":"example/project","commit":"b".repeat(40)},"panels":[]}
+    })).expect("workspace");
+    let dormant = store.create_remote_workspace(OWNER, &workspace).expect("create");
+    let allocated = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocate");
+    store
+        .record_remote_network_volume_selection(&allocated, &fixture.selection)
+        .expect("selection");
+    let reserved = store
+        .reserve_remote_worker_request(&allocated, &fixture.request.ssh_public_key)
+        .expect("reserve");
+    let fixture = Fixture::from_request(reserved.worker_request().expect("request"));
+    prepare(&fixture);
+    let mut saved = reserved.workspace().state().clone();
+    let runtime = saved.runtime.as_mut().expect("runtime");
+    runtime.worker = Some(fixture.worker());
+    runtime.phase = RemoteRuntimePhase::Reconciling;
+    let saved = store
+        .replace_remote_workspace(reserved.workspace(), &saved)
+        .expect("worker");
+    let hook_store = store.clone();
+    let worker = fixture.worker();
+    let before = pod(&fixture);
+    {
+        let mut state = fixture.transport.0.lock().expect("state");
+        state.scripted_gets = [Ok(Some(before.clone())), Ok(Some(before))].into();
+        state.stop_error = Some(failed_stop());
+        state.on_stop = Some(Box::new(move || {
+            let pending = hook_store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("read")
+                .expect("allocation");
+            let runtime = pending.workspace().state().runtime.as_ref().expect("runtime");
+            assert!(matches!(runtime.phase, RemoteRuntimePhase::Stopping { .. }));
+            assert_eq!(runtime.worker.as_ref(), Some(&worker));
+            assert!(
+                hook_store
+                    .load_remote_network_volume_selection(&pending)
+                    .expect("selection")
+                    .is_some()
+            );
+        }));
+    }
+    assert_eq!(
+        stop_remote_workspace(&store, &fixture.provider(), &saved),
+        Err(RemoteWorkspaceStopError::ProviderUnavailable)
+    );
+    let path = store.path().to_path_buf();
+    fixture.transport.0.lock().expect("state").on_stop = None;
+    drop(store);
+    let reopened = CloudWorkflowStore::open_path(path).expect("reopen");
+    let pending = reopened
+        .load_remote_allocation(OWNER, "workspace")
+        .expect("read")
+        .expect("pending");
+    let phase = pending.workspace().state().runtime.as_ref().expect("runtime").phase;
+    assert!(matches!(phase, RemoteRuntimePhase::Stopping { .. }));
+    let mut expected = saved.state().clone();
+    expected.runtime.as_mut().expect("runtime").phase = phase;
+    assert_eq!(pending.workspace().state(), &expected);
+    assert_eq!(
+        reopened
+            .load_remote_network_volume_selection(&pending)
+            .expect("selection"),
+        Some(fixture.selection.clone())
+    );
+    let stopped = stop_remote_workspace(&reopened, &fixture.provider(), pending.workspace()).expect("observed stopped");
+    assert!(matches!(
+        stopped.workspace().state().runtime.as_ref().expect("runtime").phase,
+        RemoteRuntimePhase::Stopped { .. }
+    ));
+    assert_eq!(
+        stopped.workspace().state().runtime.as_ref().expect("runtime").worker,
+        expected.runtime.expect("runtime").worker
+    );
+    assert_eq!(stopped.workflow(), pending.workflow());
+    assert_calls(&fixture, &["get", "volume", "stop", "get", "volume", "get", "volume"]);
+}

--- a/crates/horizon-core/src/cloud_run/runpod/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/stop.rs
@@ -1,4 +1,4 @@
-//! Exact-Pod Stop with ordinary volume retention, separate from termination.
+//! Exact-Pod Stop with verified volume retention, separate from termination.
 //! Provider metadata proves only point-in-time retained/inactive state, not a backup,
 //! successful task exit, preserved process memory, or qualified filesystem durability.
 
@@ -48,8 +48,14 @@ struct PersistentMount {
 }
 
 struct RetainedState {
-    mount: PersistentMount,
+    mount: RetainedMount,
     stopped: bool,
+}
+
+#[derive(Eq, PartialEq)]
+enum RetainedMount {
+    Ordinary(PersistentMount),
+    SelectedNetwork,
 }
 
 impl RunPodClient {
@@ -61,9 +67,6 @@ impl RunPodClient {
         ssh_public_key: &str,
         profile: &RunPodProfile,
     ) -> Result<InteractiveWorkerStop, RunPodError> {
-        if self.network_binding.is_some() {
-            return Err(RunPodError::StopRetentionUnverified);
-        }
         worker.validate()?;
         if worker.lifetime != InteractiveWorkerLifetime::Persistent {
             return Err(RunPodError::StopUnsupportedLifetime);
@@ -71,13 +74,13 @@ impl RunPodClient {
         if !valid_ssh_public_key(ssh_public_key) {
             return Err(RunPodError::InvalidPersistedWorker);
         }
-        if profile.volume_gib == 0 {
+        if self.network_binding.is_none() && profile.volume_gib == 0 {
             return Err(RunPodError::StopRetentionUnverified);
         }
         let Some(before) = self.transport.get(&worker.pod_id)? else {
             return Ok(InteractiveWorkerStop::AlreadyAbsent);
         };
-        let before = retained_state(&before, worker, ssh_public_key, profile)?;
+        let before = self.retained_state(&before, worker, ssh_public_key, profile)?;
         if before.stopped {
             return Ok(InteractiveWorkerStop::Stopped);
         }
@@ -86,7 +89,7 @@ impl RunPodClient {
             .transport
             .get(&worker.pod_id)?
             .ok_or(RunPodError::StopResourceLost)?;
-        let after = retained_state(&after, worker, ssh_public_key, profile)?;
+        let after = self.retained_state(&after, worker, ssh_public_key, profile)?;
         if before.mount != after.mount {
             return Err(RunPodError::StopRetentionUnverified);
         }
@@ -96,40 +99,43 @@ impl RunPodClient {
         stopping?;
         Err(RunPodError::StopVerificationFailed)
     }
-}
-
-fn retained_state(
-    pod: &ApiPod,
-    worker: &RunPodWorker,
-    ssh_public_key: &str,
-    profile: &RunPodProfile,
-) -> Result<RetainedState, RunPodError> {
-    let status = status_from_resource(pod, worker, Some(ssh_public_key))?;
-    let metadata = &pod.stop;
-    let mounts: Mounts =
-        serde_json::from_value(metadata.mounts.clone()).map_err(|_| RunPodError::StopRetentionUnverified)?;
-    if metadata.cloud != "SECURE"
-        || !metadata.cluster.is_null()
-        || mounts.persistent.path != "/workspace"
-        || mounts.persistent.size < profile.volume_gib
-    {
-        return Err(RunPodError::StopRetentionUnverified);
-    }
-    let stopped = match status.lifecycle {
-        RunPodLifecycle::Exited if metadata.runtime.is_null() => true,
-        RunPodLifecycle::Provisioning | RunPodLifecycle::Running
-            if metadata.locked == false
-                && metadata
-                    .actions
-                    .as_array()
-                    .is_some_and(|actions| actions.iter().any(|value| value == "stop")) =>
-        {
-            false
+    fn retained_state(
+        &self,
+        pod: &ApiPod,
+        worker: &RunPodWorker,
+        ssh_public_key: &str,
+        profile: &RunPodProfile,
+    ) -> Result<RetainedState, RunPodError> {
+        let status = status_from_resource(pod, worker, Some(ssh_public_key))?;
+        let metadata = &pod.stop;
+        if metadata.cloud != "SECURE" || !metadata.cluster.is_null() {
+            return Err(RunPodError::StopRetentionUnverified);
         }
-        _ => return Err(RunPodError::StopStateUnverified),
-    };
-    Ok(RetainedState {
-        mount: mounts.persistent,
-        stopped,
-    })
+        let mount = if self.network_binding.is_some() {
+            self.verify_selected_volume()?;
+            self.verify_attachment(pod)?;
+            RetainedMount::SelectedNetwork
+        } else {
+            let mounts: Mounts =
+                serde_json::from_value(metadata.mounts.clone()).map_err(|_| RunPodError::StopRetentionUnverified)?;
+            if mounts.persistent.path != "/workspace" || mounts.persistent.size < profile.volume_gib {
+                return Err(RunPodError::StopRetentionUnverified);
+            }
+            RetainedMount::Ordinary(mounts.persistent)
+        };
+        let stopped = match status.lifecycle {
+            RunPodLifecycle::Exited if metadata.runtime.is_null() => true,
+            RunPodLifecycle::Provisioning | RunPodLifecycle::Running
+                if metadata.locked == false
+                    && metadata
+                        .actions
+                        .as_array()
+                        .is_some_and(|actions| actions.iter().any(|value| value == "stop")) =>
+            {
+                false
+            }
+            _ => return Err(RunPodError::StopStateUnverified),
+        };
+        Ok(RetainedState { mount, stopped })
+    }
 }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -434,13 +434,17 @@ back into large multi-purpose modules.
   metadata precedes the creation claim; exact v2 Pod attachment checks precede
   readiness and both first-pin observations. Ordinary clients reject network
   adoption. This leaf grants no storage ownership, exclusivity, contents trust,
-  volume mutation or network-volume Stop, and does not wire setup admission.
+  volume mutation or implicit Stop authority. Setup persists the selection before
+  identity preparation and reloads it on retry/recovery.
   Its colocated tests retain the ordinary lifecycle regression boundary.
 - `cloud_run/runpod/stop.rs` adds only explicit, exact-Pod Stop for persistent
-  workers with a verified ordinary `/workspace` volume. It verifies retained
-  inactive state after a single Stop action, including a lost response, without
-  deletion, restart, SSH, or UI admission. This is not a backup or filesystem
-  durability claim; the existing durable Stop coordinator owns saved intent.
+  workers with a verified ordinary or request-bound HPS `/workspace` volume.
+  Selected-volume Stop checks fresh volume metadata and exact Pod attachment
+  before and after one action, including a lost response, without deletion,
+  restart, SSH, or UI admission. Provider observations do not prove a backup,
+  filesystem durability or process survival; the existing durable Stop coordinator
+  owns saved intent. Colocated network attachment Stop tests cover identity drift
+  and uncertain results independently of the ordinary retention regression suite.
 - `cloud_run/runpod/host_key.rs` separates explicit task-free first-pin bootstrap
   from saved-full-pin reconnect. Its `sample.rs` leaf validates bounded authenticated
   log samples without claiming current-boot freshness or exhaustive history. The


### PR DESCRIPTION
## Purpose

Enable explicit Stop for a persistent worker with an already saved, request-bound high-performance network volume. Advances #473 under #383; it does not close cloud retention acceptance.

## Behavior

- Verify the exact worker, selected volume metadata and `/workspace` attachment before and after one Stop action.
- Require positive provider Stop capability and inactive retained state; an accepted or lost response alone cannot acknowledge success.
- Preserve saved Stop intent, worker identity and storage selection on uncertain outcomes. Never create, restart, delete, fetch host keys or mutate a volume.
- Preserve ordinary-volume Stop behavior. Provider metadata is not filesystem durability, backup or process-survival proof.

## Validation

All required local gates passed on commit `21bccc19d9de9fcdcd0ea456732c62c9d8dbe09a`: formatting, maintainability, version synchronization, workspace tests with warnings denied, speech-feature workspace tests, blocking Clippy, strict no-unwrap/no-expect Clippy, and advisory pedantic Clippy. No warnings were found in the final logs.

Independent local review completed on the full five-file patch. Focused validation passed 77 provider and 18 durable Stop-coordinator tests, including eight new selected-volume test functions with before/after identity, attachment, capability, lost-response and retained-state cases.

This change is provider/core-only and introduces no UI, desktop platform restriction, schema or dependency changes. No live cloud Stop was performed; retained-storage cloud acceptance remains in #473 and #475.
