### PR TITLE
feat(workspace): prepare an exact remote Git checkout

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -1,5 +1,32 @@
 # Horizon remote worker image
 
+## Ordinary Git preparation (worker-only prerequisite)
+
+`horizon-repository git-prepare` reads one strict JSON request on stdin: version
+`1`, `workspace_local_id`, non-nil UUID `runtime_id`, `source` (GitHub `owner/repo`,
+exact 40-character `commit`, optional `branch`), and explicit `work_branch`.
+It fetches the exact commit over HTTPS, not the moving source branch, into the
+fresh fixed `/workspace/horizon/repository` checkout. Existing panel tasks can
+select relative directory `repository`; preparation does not start a task.
+Authentication uses only the protected runtime token through the installed Git
+credential helper. No credentials belong in the request, URL or Git config.
+
+This prerequisite explicitly rejects submodules, LFS configuration/pointers and
+active Git filters as `unsupported_repository`; recursive Git/LFS support remains
+pending. It neither uploads a local overlay nor requires overlay/ext4 qualification.
+The worker's existing private roots and trusted stable ancestry are prerequisites.
+Preparation has a 300-second child-I/O budget and bounded metadata output; slow
+or large repositories can fail conservatively. Filesystem/spawn/reap latency is
+not a hard wall-clock bound, and this is not an allocation or disk-quota manager.
+
+An exclusive `.horizon-worker/git-workspace` slot prevents concurrent/replayed
+preparation. Interrupted/failed attempts retain all claims and partial data.
+`git-status` and repeated `git-prepare` only inspect the exact original claim and
+inode-bound completion receipt; they never fetch, reset, clean or overwrite.
+`complete` attests the original preparation, **not** current HEAD/cleanliness,
+storage durability, task authorization or provider ownership. A lost reply or
+`claimed_unknown` result is not permission to rerun or delete anything.
+
 This directory defines the provider-neutral image contract for one interactive
 Horizon coding worker. The image is intentionally separate from provider
 lifecycle code: a provider prepares compute and starts this image with runtime

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod remote_worker_storage;
 pub mod remote_workspace;
 pub mod remote_workspace_recovery;
 pub mod remote_workspace_setup;
+pub mod repository_git;
 pub mod repository_overlay;
 mod runtime_state;
 pub mod search;

--- a/crates/horizon-core/src/repository_git/git.rs
+++ b/crates/horizon-core/src/repository_git/git.rs
@@ -1,0 +1,231 @@
+use super::{GitPreparation, GitPreparationError as Error};
+use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+use std::{
+    io::{Read, Write},
+    os::unix::process::CommandExt,
+    path::Path,
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+const LIMIT: usize = 128 * 1024;
+pub(super) trait Commands {
+    fn run(
+        &mut self,
+        directory: &Path,
+        args: &[&str],
+        input: &[u8],
+        allow_missing: bool,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error>;
+}
+
+pub(super) struct Git {
+    deadline: Instant,
+}
+impl Git {
+    pub fn new() -> Self {
+        Self {
+            deadline: Instant::now() + Duration::from_secs(300),
+        }
+    }
+}
+
+fn command(directory: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new("/usr/bin/git");
+    command
+        .env_clear()
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("LC_ALL", "C")
+        .env("HOME", "/nonexistent")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_LFS_SKIP_SMUDGE", "1")
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .current_dir(directory)
+        .process_group(0);
+    for option in [
+        "credential.helper=",
+        "credential.helper=/usr/local/bin/horizon-github-credential",
+        "credential.interactive=false",
+        "core.askPass=/bin/false",
+        "core.hooksPath=/dev/null",
+        "protocol.allow=never",
+        "protocol.https.allow=always",
+        "http.followRedirects=false",
+        "filter.lfs.process=",
+        "filter.lfs.smudge=",
+        "filter.lfs.required=false",
+    ] {
+        command.args(["-c", option]);
+    }
+    command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    command
+}
+
+struct Owned(Child);
+impl Drop for Owned {
+    fn drop(&mut self) {
+        if let Some(pid) = i32::try_from(self.0.id()).ok().and_then(rustix::process::Pid::from_raw) {
+            let _ = rustix::process::kill_process_group(pid, rustix::process::Signal::KILL);
+        }
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+impl Commands for Git {
+    fn run(
+        &mut self,
+        directory: &Path,
+        args: &[&str],
+        mut input: &[u8],
+        allow_missing: bool,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        if cancelled() || Instant::now() >= self.deadline {
+            return Err(Error::Interrupted);
+        }
+        let mut child = Owned(command(directory, args).spawn().map_err(|_| Error::Git)?);
+        let mut stdin = child.0.stdin.take();
+        let mut stdout = child.0.stdout.take().ok_or(Error::Git)?;
+        let input_fd = stdin.as_ref().ok_or(Error::Git)?;
+        fcntl_setfl(
+            input_fd,
+            fcntl_getfl(input_fd).map_err(|_| Error::Git)? | OFlags::NONBLOCK,
+        )
+        .map_err(|_| Error::Git)?;
+        fcntl_setfl(
+            &stdout,
+            fcntl_getfl(&stdout).map_err(|_| Error::Git)? | OFlags::NONBLOCK,
+        )
+        .map_err(|_| Error::Git)?;
+        let mut output = Vec::new();
+        let mut eof = false;
+        loop {
+            if cancelled() || Instant::now() >= self.deadline {
+                return Err(Error::Interrupted);
+            }
+            if !input.is_empty() {
+                match stdin.as_mut().ok_or(Error::Git)?.write(input) {
+                    Ok(0) => return Err(Error::Git),
+                    Ok(count) => input = &input[count..],
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(_) => return Err(Error::Git),
+                }
+            }
+            if input.is_empty() {
+                stdin.take();
+            }
+            let mut buffer = [0; 8192];
+            match stdout.read(&mut buffer) {
+                Ok(0) => eof = true,
+                Ok(count) if output.len() + count <= LIMIT => output.extend_from_slice(&buffer[..count]),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Ok(_) | Err(_) => return Err(Error::Git),
+            }
+            let pid = i32::try_from(child.0.id())
+                .ok()
+                .and_then(rustix::process::Pid::from_raw)
+                .ok_or(Error::Git)?;
+            // Keep the leader unreaped until Drop kills the owned group. This
+            // prevents PID reuse from ever turning cleanup into an unrelated signal.
+            if eof
+                && let Some(status) = rustix::process::waitid(
+                    rustix::process::WaitId::Pid(pid),
+                    rustix::process::WaitIdOptions::EXITED
+                        | rustix::process::WaitIdOptions::NOHANG
+                        | rustix::process::WaitIdOptions::NOWAIT,
+                )
+                .map_err(|_| Error::Git)?
+            {
+                if status.exit_status() == Some(0) || allow_missing && status.exit_status() == Some(1) {
+                    return Ok(output);
+                }
+                return Err(Error::Git);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+pub(super) fn prepare(
+    git: &mut impl Commands,
+    directory: &Path,
+    request: &GitPreparation,
+    cancelled: &dyn Fn() -> bool,
+    verify: &dyn Fn() -> Result<(), Error>,
+) -> Result<(), Error> {
+    let mut run = |args: &[&str], input: &[u8], missing| {
+        verify()?;
+        let output = git.run(directory, args, input, missing, cancelled)?;
+        verify()?;
+        Ok::<_, Error>(output)
+    };
+    let commit = request.source.commit.as_str();
+    let origin = format!("https://github.com/{}.git", request.source.repository);
+    run(
+        &["init", "--template=", "--initial-branch=horizon-unprepared", "."],
+        &[],
+        false,
+    )?;
+    run(&["remote", "add", "origin", &origin], &[], false)?;
+    run(
+        &[
+            "fetch",
+            "--no-tags",
+            "--no-recurse-submodules",
+            "--depth=1",
+            "origin",
+            commit,
+        ],
+        &[],
+        false,
+    )?;
+    if run(&["rev-parse", "--verify", "FETCH_HEAD^{commit}"], &[], false)? != format!("{commit}\n").as_bytes() {
+        return Err(Error::Git);
+    }
+    let modes = run(&["ls-tree", "-r", "--format=%(objectmode)", commit], &[], false)?;
+    if modes.split(|byte| *byte == b'\n').any(|mode| mode == b"160000")
+        || !run(&["ls-tree", "--name-only", commit, "--", ".lfsconfig"], &[], false)?.is_empty()
+    {
+        return Err(Error::UnsupportedRepository);
+    }
+    run(&["checkout", "-b", &request.work_branch, commit], &[], false)?;
+    let paths = run(&["ls-files", "-z"], &[], false)?;
+    let attributes = run(&["check-attr", "--cached", "-z", "--stdin", "filter"], &paths, false)?;
+    if attributes
+        .split(|byte| *byte == 0)
+        .skip(2)
+        .step_by(3)
+        .any(|value| value != b"unspecified" && value != b"unset")
+        || !run(
+            &[
+                "grep",
+                "-I",
+                "-l",
+                "-z",
+                "-e",
+                "^version https://git-lfs.github.com/spec/v1$",
+                commit,
+                "--",
+            ],
+            &[],
+            true,
+        )?
+        .is_empty()
+    {
+        return Err(Error::UnsupportedRepository);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn environment(directory: &Path) -> Command {
+    command(directory, &["status"])
+}

--- a/crates/horizon-core/src/repository_git/linux.rs
+++ b/crates/horizon-core/src/repository_git/linux.rs
@@ -1,0 +1,267 @@
+use super::{
+    CHECKOUT, GitPreparation, GitPreparationError as Error, GitPreparationResponse, GitPreparationState as State,
+    REQUEST_LIMIT, git::Commands,
+};
+use crate::repository_overlay::reader::{SelectedRepositoryNode, SelectedRepositoryReader};
+use rustix::fs::{CWD, Mode, OFlags, ResolveFlags, mkdirat, openat2};
+use std::{
+    fs::File,
+    io::Write,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const PRIVATE: Mode = Mode::RUSR.union(Mode::WUSR).union(Mode::XUSR);
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+fn open_directory(path: &Path) -> Result<File, Error> {
+    openat2(
+        CWD,
+        path,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+        ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS,
+    )
+    .map(File::from)
+    .map_err(|_| Error::UnsafeRoot)
+}
+
+fn record_identity(meta: &std::fs::Metadata) -> (u64, u64, u32, u64, i64, i64) {
+    (
+        meta.dev(),
+        meta.ino(),
+        meta.mode(),
+        meta.len(),
+        meta.ctime(),
+        meta.ctime_nsec(),
+    )
+}
+
+/// A held inode plus a rechecked pathname. Git remains path-based: stable trusted
+/// ownership/ancestry is a precondition, not protection from a malicious worker owner.
+pub(super) struct Directory {
+    handle: File,
+    pub path: PathBuf,
+    private: bool,
+}
+
+impl Directory {
+    fn open_mode(path: &Path, private: bool) -> Result<Self, Error> {
+        let handle = open_directory(path)?;
+        let directory = Self {
+            handle,
+            path: path.to_owned(),
+            private,
+        };
+        directory.verify()?;
+        Ok(directory)
+    }
+
+    pub fn verify(&self) -> Result<(), Error> {
+        let held = self.handle.metadata().map_err(|_| Error::UnsafeRoot)?;
+        let actual = open_directory(&self.path)?.metadata().map_err(|_| Error::UnsafeRoot)?;
+        if held.uid() != rustix::process::geteuid().as_raw()
+            || held.mode() & 0o7022 != 0
+            || self.private && held.mode() & 0o7777 != 0o700
+            || held.nlink() == 0
+            || (held.dev(), held.ino()) != (actual.dev(), actual.ino())
+        {
+            return Err(Error::UnsafeRoot);
+        }
+        Ok(())
+    }
+
+    fn child(&self, name: &str, create: bool) -> Result<Option<Self>, Error> {
+        self.verify()?;
+        if create {
+            mkdirat(&self.handle, name, PRIVATE).map_err(|_| Error::Conflict)?;
+        }
+        let handle = match openat2(
+            &self.handle,
+            name,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        ) {
+            Ok(handle) => File::from(handle),
+            Err(rustix::io::Errno::NOENT) if !create => return Ok(None),
+            Err(_) => return Err(Error::UnsafeRoot),
+        };
+        let child = Self {
+            handle,
+            path: self.path.join(name),
+            private: true,
+        };
+        child.verify()?;
+        if create {
+            child
+                .handle
+                .sync_all()
+                .and_then(|()| self.handle.sync_all())
+                .map_err(|_| Error::Storage)?;
+        }
+        self.verify()?;
+        Ok(Some(child))
+    }
+
+    fn write(&self, name: &str, bytes: &[u8]) -> Result<(), Error> {
+        self.verify()?;
+        let mut file = File::from(
+            openat2(
+                &self.handle,
+                name,
+                OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC,
+                Mode::RUSR | Mode::WUSR,
+                CONFINED,
+            )
+            .map_err(|_| Error::Conflict)?,
+        );
+        file.write_all(bytes)
+            .and_then(|()| file.sync_all())
+            .and_then(|()| self.handle.sync_all())
+            .map_err(|_| Error::Storage)?;
+        self.verify()?;
+        if self.read(name)?.as_deref() != Some(bytes) {
+            return Err(Error::Conflict);
+        }
+        Ok(())
+    }
+
+    fn read(&self, name: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.verify()?;
+        let file = match openat2(
+            &self.handle,
+            name,
+            OFlags::PATH | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        ) {
+            Ok(file) => File::from(file),
+            Err(rustix::io::Errno::NOENT) => return Ok(None),
+            Err(_) => return Err(Error::Conflict),
+        };
+        let meta = file.metadata().map_err(|_| Error::Conflict)?;
+        if !meta.is_file()
+            || meta.uid() != rustix::process::geteuid().as_raw()
+            || meta.mode() & 0o7777 != 0o600
+            || meta.nlink() != 1
+        {
+            return Err(Error::Conflict);
+        }
+        let value = SelectedRepositoryReader::open(&self.path)
+            .and_then(|reader| reader.read(name, REQUEST_LIMIT))
+            .map_err(|_| Error::Conflict)?;
+        let current = File::from(
+            openat2(
+                &self.handle,
+                name,
+                OFlags::PATH | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            )
+            .map_err(|_| Error::Conflict)?,
+        )
+        .metadata()
+        .map_err(|_| Error::Conflict)?;
+        if record_identity(&meta) != record_identity(&current) {
+            return Err(Error::Conflict);
+        }
+        self.verify()?;
+        match value {
+            SelectedRepositoryNode::File { bytes, .. } => Ok(Some(bytes)),
+            SelectedRepositoryNode::Symlink { .. } => Err(Error::Conflict),
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Completion {
+    request: GitPreparation,
+    device: u64,
+    inode: u64,
+}
+
+pub(super) fn execute(
+    parent: &Path,
+    request: &GitPreparation,
+    observe: bool,
+    cancelled: &dyn Fn() -> bool,
+    git: &mut impl Commands,
+) -> GitPreparationResponse {
+    let mut response = GitPreparationResponse::failure(Error::Storage);
+    let result = (|| {
+        let bytes = request.encode()?;
+        let parent = Directory::open_mode(parent, false)?;
+        let worker = Directory::open_mode(&parent.path.join(".horizon-worker"), true)?;
+        let tasks = Directory::open_mode(&parent.path.join("horizon"), true)?;
+        let existing = worker.child("git-workspace", false)?;
+        if let Some(slot) = existing {
+            response.state = State::ClaimedUnknown;
+            if slot.read("claim.json")?.as_deref() != Some(&bytes) {
+                return Err(Error::Conflict);
+            }
+            if let Some(completion) = slot.read("complete.json")? {
+                let completion: Completion = serde_json::from_slice(&completion).map_err(|_| Error::Conflict)?;
+                let checkout = tasks.child("repository", false)?.ok_or(Error::Conflict)?;
+                let meta = checkout.handle.metadata().map_err(|_| Error::Conflict)?;
+                if completion.request != *request || (completion.device, completion.inode) != (meta.dev(), meta.ino()) {
+                    return Err(Error::Conflict);
+                }
+                response.state = State::Complete;
+                response.checkout = Some(CHECKOUT);
+            }
+            parent.verify()?;
+            worker.verify()?;
+            tasks.verify()?;
+            return Ok(());
+        }
+        if observe {
+            response.state = State::Absent;
+            return Ok(());
+        }
+        if cancelled() {
+            return Err(Error::Interrupted);
+        }
+        // Exclusive mkdir is the irreversible replay barrier even if claim writing fails.
+        response.state = State::ClaimedUnknown;
+        let slot = worker.child("git-workspace", true)?.ok_or(Error::Storage)?;
+        slot.write("claim.json", &bytes)?;
+        let checkout = tasks.child("repository", true)?.ok_or(Error::Storage)?;
+        super::git::prepare(git, &checkout.path, request, cancelled, &|| {
+            if cancelled() {
+                return Err(Error::Interrupted);
+            }
+            parent.verify()?;
+            worker.verify()?;
+            tasks.verify()?;
+            slot.verify()?;
+            checkout.verify()
+        })?;
+        if cancelled() {
+            return Err(Error::Interrupted);
+        }
+        let meta = checkout.handle.metadata().map_err(|_| Error::Storage)?;
+        let completion = Completion {
+            request: request.clone(),
+            device: meta.dev(),
+            inode: meta.ino(),
+        };
+        slot.write(
+            "complete.json",
+            &serde_json::to_vec(&completion).map_err(|_| Error::Storage)?,
+        )?;
+        parent.verify()?;
+        worker.verify()?;
+        tasks.verify()?;
+        checkout.verify()?;
+        response.state = State::Complete;
+        response.checkout = Some(CHECKOUT);
+        Ok(())
+    })();
+    response.reason = result.err();
+    response
+}

--- a/crates/horizon-core/src/repository_git/mod.rs
+++ b/crates/horizon-core/src/repository_git/mod.rs
@@ -1,0 +1,158 @@
+//! One-shot ordinary Git preparation on an already trusted worker, not overlay setup.
+//! Receipts attest initial preparation only; observation never resets user changes.
+
+#[cfg(target_os = "linux")]
+mod git;
+#[cfg(target_os = "linux")]
+mod linux;
+
+use crate::{cloud_run::GitSource, remote_workspace::valid_local_id};
+use serde::{Deserialize, Serialize};
+
+pub const REQUEST_LIMIT: usize = 16 * 1024;
+pub const RESPONSE_LIMIT: usize = 1024;
+pub const CHECKOUT: &str = "/workspace/horizon/repository";
+
+/// Explicit, credential-free preparation identity, not provider ownership evidence.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GitPreparation {
+    pub version: u8,
+    pub workspace_local_id: String,
+    pub runtime_id: uuid::Uuid,
+    pub source: GitSource,
+    pub work_branch: String,
+}
+
+impl GitPreparation {
+    /// Decode bounded strict JSON before touching the worker.
+    /// # Errors
+    /// Rejects malformed identities, source, branches, unknown fields and trailing data.
+    pub fn decode(bytes: &[u8]) -> Result<Self, GitPreparationError> {
+        if bytes.len() > REQUEST_LIMIT {
+            return Err(GitPreparationError::Invalid);
+        }
+        let request: Self = serde_json::from_slice(bytes).map_err(|_| GitPreparationError::Invalid)?;
+        request.encode()?;
+        Ok(request)
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, GitPreparationError> {
+        let mut work = self.source.clone();
+        work.branch = Some(self.work_branch.clone());
+        if self.source.repository.len() > 512
+            || self.source.branch.as_ref().is_some_and(|branch| branch.len() > 1024)
+            || self.work_branch.len() > 1024
+            || self.version != 1
+            || !valid_local_id(&self.workspace_local_id)
+            || self.runtime_id.is_nil()
+            || self.source.validate().is_err()
+            || work.validate().is_err()
+            || self.source.commit.as_str().bytes().all(|byte| byte == b'0')
+        {
+            return Err(GitPreparationError::Invalid);
+        }
+        serde_json::to_vec(self)
+            .ok()
+            .filter(|bytes| bytes.len() <= REQUEST_LIMIT)
+            .ok_or(GitPreparationError::Invalid)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitPreparationState {
+    Absent,
+    ClaimedUnknown,
+    Complete,
+    Error,
+}
+
+/// No raw Git output, credentials or caller-supplied paths enter this response.
+#[derive(Debug, Serialize)]
+pub struct GitPreparationResponse {
+    pub version: u8,
+    pub state: GitPreparationState,
+    pub reason: Option<GitPreparationError>,
+    pub checkout: Option<&'static str>,
+}
+
+impl GitPreparationResponse {
+    #[must_use]
+    pub fn failure(reason: GitPreparationError) -> Self {
+        Self {
+            version: 1,
+            state: GitPreparationState::Error,
+            reason: Some(reason),
+            checkout: None,
+        }
+    }
+
+    #[must_use]
+    pub fn exit_code(&self) -> u8 {
+        match (self.state, self.reason) {
+            (GitPreparationState::Complete | GitPreparationState::Absent, None) => 0,
+            (_, Some(GitPreparationError::Invalid | GitPreparationError::Unsupported)) => 2,
+            _ => 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+pub enum GitPreparationError {
+    #[error("invalid Git preparation request")]
+    Invalid,
+    #[error("Git preparation requires Linux confinement")]
+    Unsupported,
+    #[error("worker directory is unsafe or changed")]
+    UnsafeRoot,
+    #[error("Git preparation state conflicts or cannot be read safely")]
+    Conflict,
+    #[error("storage operation failed; retain all state")]
+    Storage,
+    #[error("Git operation failed; retain all state")]
+    Git,
+    #[error("Git preparation cancelled or exceeded its deadline; retain all state")]
+    Interrupted,
+    #[error("repository requires unsupported LFS, submodule or custom filter preparation")]
+    UnsupportedRepository,
+}
+
+/// Prepare once, or observe the existing claim without invoking Git again.
+/// Requires trusted stable worker ancestry and exclusive ownership throughout I/O.
+/// No overlay filesystem qualification, task start, cleanup or retry is implied.
+/// Cancellation/deadlines bound child I/O, not blocked filesystem operations/spawn/reap.
+pub fn prepare(request: &GitPreparation, cancelled: impl Fn() -> bool) -> GitPreparationResponse {
+    execute(request, false, cancelled)
+}
+
+/// Read the original completion receipt only, not current HEAD, cleanliness or readiness.
+#[must_use]
+pub fn observe(request: &GitPreparation) -> GitPreparationResponse {
+    execute(request, true, || false)
+}
+
+fn execute(request: &GitPreparation, observe: bool, cancelled: impl Fn() -> bool) -> GitPreparationResponse {
+    if let Err(reason) = request.encode() {
+        return GitPreparationResponse::failure(reason);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::execute(
+            std::path::Path::new("/workspace"),
+            request,
+            observe,
+            &cancelled,
+            &mut git::Git::new(),
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (observe, cancelled);
+        GitPreparationResponse::failure(GitPreparationError::Unsupported)
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/repository_git/mod.rs
+++ b/crates/horizon-core/src/repository_git/mod.rs
@@ -43,6 +43,7 @@ impl GitPreparation {
         if self.source.repository.len() > 512
             || self.source.branch.as_ref().is_some_and(|branch| branch.len() > 1024)
             || self.work_branch.len() > 1024
+            || self.work_branch == "HEAD"
             || self.version != 1
             || !valid_local_id(&self.workspace_local_id)
             || self.runtime_id.is_nil()

--- a/crates/horizon-core/src/repository_git/tests.rs
+++ b/crates/horizon-core/src/repository_git/tests.rs
@@ -88,7 +88,7 @@ fn strict_request_framing_identity_and_branch() {
         value.as_object_mut().unwrap().remove(field);
         assert!(Request::decode(&serde_json::to_vec(&value).unwrap()).is_err());
     }
-    for branch in ["-bad", "a..b", "a.lock", "x\ny", "", "refs/../bad"] {
+    for branch in ["-bad", "a..b", "a.lock", "x\ny", "", "refs/../bad", "HEAD"] {
         let mut changed = original.clone();
         changed.work_branch = branch.into();
         assert!(changed.encode().is_err());
@@ -96,6 +96,32 @@ fn strict_request_framing_identity_and_branch() {
     let mut changed = original;
     changed.source.repository = "https://private@elsewhere/repo".into();
     assert!(changed.encode().is_err());
+}
+
+#[test]
+fn reserved_head_is_rejected_before_worker_state_or_git() {
+    let root = roots();
+    let mut request = request();
+    request.work_branch = "HEAD".into();
+    assert_eq!(
+        Request::decode(&serde_json::to_vec(&request).unwrap()),
+        Err(Error::Invalid)
+    );
+    let response = super::prepare(&request, || panic!("invalid request must not enter preparation"));
+    assert_eq!(
+        (response.state, response.reason, response.exit_code()),
+        (State::Error, Some(Error::Invalid), 2)
+    );
+    let mut git = Fake::new();
+    let response = execute(root.path(), &request, false, &mut git);
+    assert_eq!((response.state, response.reason), (State::Error, Some(Error::Invalid)));
+    assert_eq!(git.calls, 0);
+    for directory in [".horizon-worker", "horizon"] {
+        assert!(fs::read_dir(root.path().join(directory)).unwrap().next().is_none());
+    }
+    request.work_branch = "work/explicit".into();
+    request.source.branch = Some("HEAD".into());
+    assert!(request.encode().is_ok());
 }
 
 #[test]

--- a/crates/horizon-core/src/repository_git/tests.rs
+++ b/crates/horizon-core/src/repository_git/tests.rs
@@ -1,0 +1,344 @@
+use super::git::{Commands, Git};
+use super::{
+    GitPreparation as Request, GitPreparationError as Error, GitPreparationResponse as Response,
+    GitPreparationState as State, GitSource, REQUEST_LIMIT, git, linux,
+};
+
+use std::{
+    fs,
+    os::unix::fs::{MetadataExt, PermissionsExt, symlink},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn request() -> Request {
+    Request {
+        version: 1,
+        workspace_local_id: "synthetic-workspace".into(),
+        runtime_id: uuid::Uuid::new_v4(),
+        source: GitSource {
+            repository: "fixture/repository".into(),
+            commit: crate::cloud_run::GitCommitSha::parse("a".repeat(40)).unwrap(),
+            branch: Some("main".into()),
+        },
+        work_branch: "work/explicit".into(),
+    }
+}
+
+fn roots() -> tempfile::TempDir {
+    let root = tempfile::tempdir().unwrap();
+    for suffix in ["", ".horizon-worker", "horizon"] {
+        let path = root.path().join(suffix);
+        fs::create_dir_all(&path).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    root
+}
+
+struct Fake {
+    calls: usize,
+    fail: Option<usize>,
+    mode: &'static str,
+}
+impl Fake {
+    fn new() -> Self {
+        Self {
+            calls: 0,
+            fail: None,
+            mode: "100644\n",
+        }
+    }
+}
+impl Commands for Fake {
+    fn run(&mut self, _: &Path, args: &[&str], _: &[u8], _: bool, _: &dyn Fn() -> bool) -> Result<Vec<u8>, Error> {
+        self.calls += 1;
+        if self.fail == Some(self.calls) {
+            return Err(Error::Git);
+        }
+        Ok(match args[0] {
+            "rev-parse" => format!("{}\n", "a".repeat(40)).into_bytes(),
+            "ls-tree" if args[1] == "-r" => self.mode.as_bytes().to_vec(),
+            _ => vec![],
+        })
+    }
+}
+
+fn execute(root: &Path, request: &Request, observe: bool, git: &mut impl Commands) -> Response {
+    linux::execute(root, request, observe, &|| false, git)
+}
+
+#[test]
+fn strict_request_framing_identity_and_branch() {
+    let original = request();
+    let encoded = original.encode().unwrap();
+    assert_eq!(Request::decode(&encoded).unwrap(), original);
+    for bytes in [
+        b"{}".to_vec(),
+        vec![b' '; REQUEST_LIMIT + 1],
+        [encoded.clone(), b"{}".to_vec()].concat(),
+        String::from_utf8(encoded.clone())
+            .unwrap()
+            .replacen('{', "{\"version\":1,", 1)
+            .into_bytes(),
+    ] {
+        assert_eq!(Request::decode(&bytes), Err(Error::Invalid));
+    }
+    for field in ["version", "workspace_local_id", "runtime_id", "source", "work_branch"] {
+        let mut value: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        value.as_object_mut().unwrap().remove(field);
+        assert!(Request::decode(&serde_json::to_vec(&value).unwrap()).is_err());
+    }
+    for branch in ["-bad", "a..b", "a.lock", "x\ny", "", "refs/../bad"] {
+        let mut changed = original.clone();
+        changed.work_branch = branch.into();
+        assert!(changed.encode().is_err());
+    }
+    let mut changed = original;
+    changed.source.repository = "https://private@elsewhere/repo".into();
+    assert!(changed.encode().is_err());
+}
+
+#[test]
+fn observation_absent_is_read_only_and_repeat_preserves_dirty_checkout() {
+    let root = roots();
+    let request = request();
+    let mut git = Fake::new();
+    assert_eq!(execute(root.path(), &request, true, &mut git).state, State::Absent);
+    assert!(!root.path().join(".horizon-worker/git-workspace").exists());
+    assert_eq!(execute(root.path(), &request, false, &mut git).state, State::Complete);
+    let calls = git.calls;
+    let user = root.path().join("horizon/repository/user-change");
+    fs::write(&user, "retained user bytes").unwrap();
+    for observe in [true, false] {
+        assert_eq!(execute(root.path(), &request, observe, &mut git).state, State::Complete);
+    }
+    assert_eq!(git.calls, calls);
+    assert_eq!(fs::read_to_string(user).unwrap(), "retained user bytes");
+    let mut conflicting = request;
+    conflicting.runtime_id = uuid::Uuid::new_v4();
+    assert_eq!(
+        execute(root.path(), &conflicting, false, &mut git).reason,
+        Some(Error::Conflict)
+    );
+    assert_eq!(git.calls, calls);
+}
+
+#[test]
+fn every_failed_command_is_a_permanent_replay_barrier() {
+    for failure in 1..=10 {
+        let root = roots();
+        let request = request();
+        let mut git = Fake::new();
+        git.fail = Some(failure);
+        let result = execute(root.path(), &request, false, &mut git);
+        assert_eq!(result.state, State::ClaimedUnknown);
+        assert_eq!(result.reason, Some(Error::Git));
+        let calls = git.calls;
+        git.fail = None;
+        assert_eq!(
+            execute(root.path(), &request, false, &mut git).state,
+            State::ClaimedUnknown
+        );
+        assert_eq!(git.calls, calls);
+    }
+}
+
+#[test]
+fn missing_or_corrupt_claim_never_grants_replay() {
+    for claim in [None, Some("{}"), Some("private-invalid-claim")] {
+        let root = roots();
+        let mut git = Fake::new();
+        let slot = root.path().join(".horizon-worker/git-workspace");
+        fs::create_dir(&slot).unwrap();
+        fs::set_permissions(&slot, fs::Permissions::from_mode(0o700)).unwrap();
+        if let Some(claim) = claim {
+            fs::write(slot.join("claim.json"), claim).unwrap();
+        }
+        assert_eq!(
+            execute(root.path(), &request(), false, &mut git).reason,
+            Some(Error::Conflict)
+        );
+        assert_eq!(git.calls, 0);
+    }
+}
+
+#[test]
+fn unsafe_roots_preexisting_checkout_and_replacement_are_not_adopted() {
+    for relative in [".horizon-worker", "horizon"] {
+        let root = roots();
+        let mut git = Fake::new();
+        fs::set_permissions(root.path().join(relative), fs::Permissions::from_mode(0o777)).unwrap();
+        assert_eq!(
+            execute(root.path(), &request(), false, &mut git).reason,
+            Some(Error::UnsafeRoot)
+        );
+        assert_eq!(git.calls, 0);
+    }
+    for link in [false, true] {
+        let root = roots();
+        let mut git = Fake::new();
+        let checkout = root.path().join("horizon/repository");
+        if link {
+            symlink(root.path(), &checkout).unwrap();
+        } else {
+            fs::create_dir(&checkout).unwrap();
+        }
+        assert_eq!(
+            execute(root.path(), &request(), false, &mut git).reason,
+            Some(Error::Conflict)
+        );
+        assert_eq!(git.calls, 0);
+        assert!(fs::symlink_metadata(checkout).is_ok());
+    }
+    let root = roots();
+    let mut git = Fake::new();
+    let request = request();
+    assert_eq!(execute(root.path(), &request, false, &mut git).state, State::Complete);
+    let checkout = root.path().join("horizon/repository");
+    fs::rename(&checkout, root.path().join("retained-original")).unwrap();
+    fs::create_dir(&checkout).unwrap();
+    fs::set_permissions(&checkout, fs::Permissions::from_mode(0o700)).unwrap();
+    assert_eq!(
+        execute(root.path(), &request, true, &mut git).reason,
+        Some(Error::Conflict)
+    );
+}
+
+#[test]
+fn submodules_fail_explicitly_before_checkout() {
+    let root = roots();
+    let mut git = Fake::new();
+    git.mode = "100644\n160000\n";
+    let result = execute(root.path(), &request(), false, &mut git);
+    assert_eq!(result.reason, Some(Error::UnsupportedRepository));
+    assert_eq!(git.calls, 5);
+}
+
+fn local_git(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("/usr/bin/git")
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .env("HOME", "/nonexistent")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .args([
+            "-c",
+            "user.name=Synthetic",
+            "-c",
+            "user.email=synthetic@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+        ])
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "synthetic Git fixture failed");
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
+}
+
+struct Local {
+    git: Git,
+    source: PathBuf,
+}
+impl Commands for Local {
+    fn run(
+        &mut self,
+        directory: &Path,
+        args: &[&str],
+        input: &[u8],
+        missing: bool,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        if args[0] == "fetch" {
+            // Test-only transport substitution. All other commands use the actual runner.
+            self.git.run(
+                directory,
+                &[
+                    "-c",
+                    "protocol.file.allow=always",
+                    "fetch",
+                    self.source.to_str().unwrap(),
+                    args[5],
+                ],
+                input,
+                missing,
+                cancelled,
+            )
+        } else {
+            self.git.run(directory, args, input, missing, cancelled)
+        }
+    }
+}
+
+#[test]
+fn actual_git_exact_commit_explicit_branch_and_lfs_rejection() {
+    for kind in ["plain", "filter", "pointer", "lfsconfig"] {
+        let source = tempfile::tempdir().unwrap();
+        local_git(source.path(), &["init", "--template=", "--initial-branch=main"]);
+        fs::write(source.path().join("tracked"), "first bytes").unwrap();
+        match kind {
+            "filter" => fs::write(source.path().join(".gitattributes"), "tracked filter=lfs\n").unwrap(),
+            "pointer" => fs::write(
+                source.path().join("tracked"),
+                "version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 1\n",
+            )
+            .unwrap(),
+            "lfsconfig" => fs::write(
+                source.path().join(".lfsconfig"),
+                "[lfs]\nurl = https://untrusted.invalid\n",
+            )
+            .unwrap(),
+            _ => {}
+        }
+        local_git(source.path(), &["add", "."]);
+        local_git(source.path(), &["commit", "-m", "Synthetic initial"]);
+        let mut request = request();
+        request.source.commit =
+            crate::cloud_run::GitCommitSha::parse(local_git(source.path(), &["rev-parse", "HEAD"])).unwrap();
+        fs::write(source.path().join("later"), "moving branch must not select these bytes").unwrap();
+        local_git(source.path(), &["add", "."]);
+        local_git(source.path(), &["commit", "-m", "Synthetic later"]);
+        let root = roots();
+        let mut git = Local {
+            git: Git::new(),
+            source: source.path().to_owned(),
+        };
+        let result = execute(root.path(), &request, false, &mut git);
+        if kind == "plain" {
+            assert_eq!(result.reason, None);
+            assert_eq!(result.state, State::Complete);
+            let checkout = root.path().join("horizon/repository");
+            assert_eq!(
+                local_git(&checkout, &["rev-parse", "HEAD"]),
+                request.source.commit.as_str()
+            );
+            assert_eq!(local_git(&checkout, &["branch", "--show-current"]), request.work_branch);
+            assert!(!checkout.join("later").exists());
+            assert_eq!(fs::metadata(checkout).unwrap().mode() & 0o777, 0o700);
+        } else {
+            assert_eq!(result.reason, Some(Error::UnsupportedRepository), "{kind}");
+        }
+    }
+}
+
+#[test]
+fn command_has_no_inherited_configuration_or_token_and_deadline_prevents_spawn() {
+    let command = git::environment(Path::new("/synthetic"));
+    let env: Vec<_> = command.get_envs().collect();
+    assert!(!env.iter().any(|(key, _)| key.to_str().unwrap().contains("TOKEN")));
+    assert!(
+        env.iter()
+            .any(|(key, value)| *key == "GIT_CONFIG_GLOBAL" && *value == Some(std::ffi::OsStr::new("/dev/null")))
+    );
+    let args: Vec<_> = command.get_args().map(|arg| arg.to_str().unwrap()).collect();
+    assert!(args.contains(&"http.followRedirects=false"));
+    assert!(args.contains(&"protocol.allow=never"));
+    assert!(args.contains(&"credential.helper=/usr/local/bin/horizon-github-credential"));
+    let root = roots();
+    let mut git = Git::new();
+    assert_eq!(
+        git.run(root.path(), &["version"], &[], false, &|| true),
+        Err(Error::Interrupted)
+    );
+}

--- a/crates/horizon-repository/src/git.rs
+++ b/crates/horizon-repository/src/git.rs
@@ -1,0 +1,66 @@
+use horizon_core::repository_git::{self, GitPreparation, GitPreparationError, GitPreparationResponse, REQUEST_LIMIT};
+use std::{
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+pub(super) fn run(
+    observe: bool,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    let mut bytes = Vec::new();
+    let request = input
+        .take(REQUEST_LIMIT as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| GitPreparationError::Invalid)
+        .and_then(|_| GitPreparation::decode(&bytes));
+    let response = match request {
+        Ok(request) if observe => repository_git::observe(&request),
+        Ok(request) => repository_git::prepare(&request, || false),
+        Err(reason) => GitPreparationResponse::failure(reason),
+    };
+    super::write_response(
+        &response,
+        response.exit_code(),
+        repository_git::RESPONSE_LIMIT,
+        output,
+        diagnostics,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn malformed_input_is_redacted_and_output_loss_is_distinct() {
+        for input in [
+            b"private-invalid".to_vec(),
+            vec![b' '; REQUEST_LIMIT + 1],
+            b"{}{}".to_vec(),
+        ] {
+            for observe in [false, true] {
+                let mut output = Vec::new();
+                assert_eq!(
+                    run(observe, &mut input.as_slice(), &mut output, &mut std::io::sink()),
+                    ExitCode::from(2)
+                );
+                assert_eq!(
+                    serde_json::from_slice::<serde_json::Value>(&output).unwrap()["reason"],
+                    "invalid"
+                );
+                assert!(!String::from_utf8(output).unwrap().contains("private-invalid"));
+            }
+        }
+        assert_eq!(
+            run(
+                false,
+                &mut b"{}".as_slice(),
+                &mut [0; 0].as_mut_slice(),
+                &mut std::io::sink()
+            ),
+            ExitCode::from(3)
+        );
+    }
+}

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod git;
 mod intake;
 mod pack;
 mod protocol;
@@ -32,12 +33,14 @@ fn main() -> ExitCode {
                     | "intake"
                     | "intake-status"
                     | "storage-status"
+                    | "git-prepare"
+                    | "git-status"
             )
         )
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status < request"
+            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status < request"
         );
         return ExitCode::from(2);
     }
@@ -45,6 +48,8 @@ fn main() -> ExitCode {
     let mut output = io::stdout().lock();
     let mut diagnostics = io::stderr().lock();
     match command {
+        Some("git-prepare") => git::run(false, &mut input, &mut output, &mut diagnostics),
+        Some("git-status") => git::run(true, &mut input, &mut output, &mut diagnostics),
         Some("setup") => setup::run(setup::Command::Execute, &mut input, &mut output, &mut diagnostics),
         Some("setup-status") => setup::run(setup::Command::Observe, &mut input, &mut output, &mut diagnostics),
         Some("setup-binding") => setup_checkout::run(

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -555,6 +555,14 @@ modules.
 
 ## Review Heuristics
 
+`repository_git` owns the worker-only ordinary Git preparation identity and
+observation API. Its `linux` leaf confines the separate one-shot claim and fixed
+task-accessible checkout, while `git` owns sanitized bounded Git subprocesses.
+The repository CLI only frames bounded requests and responses. This prerequisite
+does not use the retained overlay setup qualifier, change task admission, or
+support LFS/submodules yet; unsupported repositories retain state without a
+completion receipt. Observation never mutates user commits or worktree changes.
+
 Use these checks during implementation and review:
 
 - Does this file have one reason to change?


### PR DESCRIPTION
## Purpose

Add one-shot, worker-owned Git preparation and `horizon-repository git-prepare` / `git-status` for #470 (parent #383). This is a Linux-only prerequisite, not completion of the remote Git or cloud workflow.

## Behavior

- Strict, bounded, credential-free input selects a GitHub repository, exact commit and explicit work branch. Standard Git fetches over HTTPS into the fixed worker checkout.
- Retained private claims prevent automatic retries, overwrite or repair after an uncertain result. Status and repeated preparation read the original completion receipt without resetting later user changes.
- Git runs with a restricted environment, the installed credential helper, no interactive prompts/hooks/redirects, bounded output and a five-minute child-I/O budget. Diagnostics do not return raw Git output or secrets.
- Requires trusted, stable Linux worker ancestry and existing private worker directories. Path/inode checks do not defend against a malicious worker owner or prove cloud durability.
- LFS, submodules and custom filters are explicitly rejected in this prerequisite, with partial state retained. Their required support, controller wiring, task startup and commit/push/PR remain follow-up acceptance work.

No PC-file transfer, provider allocation, image publication, UI change or release is included. Existing desktop-platform CI remains intact.

## Validation

- All eight repository-mandated local lanes passed on `a68c83a53d6477780a6b7c9811a5823af56965fb` without retries, including 2,259 default and 2,304 speech-tier tests (six existing ignored in each).
- Focused regressions cover exact commit versus moving branch, explicit work branch, claim/replay barriers, dirty-data preservation, unsafe/replaced roots, Git failures/cancellation, request framing and environment restrictions.
- Independent local full-diff review completed.
- Installed-worker HTTPS CLI smoke passed on the exact candidate. The binary was built with the original pinned container build stage and mounted into the retained worker runtime. Unchanged production Git commands, TLS verification and the installed credential helper fetched an older exact SHA while the source branch pointed elsewhere.
- Four isolated cases passed: ordinary work-branch checkout, checkout onto the initial unborn branch name `horizon-unprepared`, unsupported-repository rejection, and missing-token failure. Both successful checkouts preserved dirty data. Repeated status/preparation performed no further HTTP request and preserved retained state. Synthetic token privacy checks passed; only the four exact disposable containers were removed.
- Fresh exact-head smoke also rejects the reserved `HEAD` work branch before any claim, workspace mutation or HTTP request. The shared source-ref validator is unchanged.
- The endpoint and token were synthetic, with container-loopback-only networking. This proves installed CLI/Git/TLS/helper integration, not real GitHub authorization, a newly packaged full runtime image, cloud storage or client-off acceptance.
- All 14 applicable hosted CI lanes passed on the corrected head, including macOS x64. The previous head's browser-CLI timing-test failure remains historical; no failed current check is waived.
- The refreshed review's alleged unborn-branch collision was disproved with actual host Git and the installed-worker HTTPS case above, without changing production code. The original reserved-`HEAD` finding is fixed and covered; both review threads are resolved with evidence.
