### PR TITLE
feat(workspace): detach ordinary Git setup from its request channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Verify detached setup handoff contract
-        run: python3 -B containers/remote-worker/test_setup_launch.py -v
+        run: python3 -B -m unittest discover -s containers/remote-worker -p 'test*setup_launch.py' -v
       - name: Verify on-demand GitHub credentials
         run: python3 -B containers/remote-worker/test_github_credentials.py -v
       - name: Verify explicit worker token installation

--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -128,6 +128,14 @@ The separate `horizon-setup-launch` command can submit setup independently of it
 request channel; it does not turn submission or a claim into proof of liveness.
 See [independent setup submission](../../docs/remote-repository-command.md#independent-setup-submission)
 for its bounded handoff, observation and recording limitations.
+For ordinary remote Git, `horizon-setup-launch --git` delegates strict observation
+to `horizon-repository git-status` and hands an absent request to `git-prepare`
+in an independent process session. The 16 KiB request is passed only through
+stdin. Submission is not completion: inspect `git-status` afterward. Existing
+claims, errors and completed checkouts never authorize another Git run. A lost
+reply does not cancel the worker child, reset the checkout or grant replay.
+This mode requires an image containing the Git commands; it does not install a
+PAT, start a task, add LFS/submodule support or prove cloud durability.
 The same helper can explicitly receive a canonical overlay bundle into an existing
 private bundle store and inspect a lost acknowledgement without writing. See
 [worker overlay receipt](../../docs/remote-overlay-transfer.md) for the framed

--- a/containers/remote-worker/setup-launch.py
+++ b/containers/remote-worker/setup-launch.py
@@ -12,6 +12,8 @@ import time
 REQUEST_LIMIT = 128 * 1024
 OBSERVATION_LIMIT = 128 * 1024
 RESPONSE_LIMIT = 2 * OBSERVATION_LIMIT
+GIT_REQUEST_LIMIT = 16 * 1024
+GIT_OBSERVATION_LIMIT = 1024
 OBSERVE_SECONDS = 30
 HANDOFF_SECONDS = 15
 HELPER = '/usr/local/bin/horizon-repository'
@@ -31,20 +33,44 @@ def unique_fields(pairs):
     return result
 
 
-def observe(request):
+def git_observation(value, code):
+    if (not isinstance(value, dict) or set(value) != {'version', 'state', 'reason', 'checkout'}
+            or type(value['version']) is not int or value['version'] != 1
+            or not isinstance(value['state'], str)
+            or value['state'] not in ('absent', 'claimed_unknown', 'complete', 'error')):
+        raise LaunchError('Git setup observation is invalid')
+    reason = value['reason']
+    if reason is not None and (not isinstance(reason, str) or reason not in (
+            'invalid', 'unsupported', 'unsafe_root', 'conflict', 'storage', 'git',
+            'interrupted', 'unsupported_repository')):
+        raise LaunchError('Git setup observation reason is invalid')
+    checkout = '/workspace/horizon/repository' if value['state'] == 'complete' else None
+    if value['checkout'] != checkout or value['state'] == 'error' and reason is None:
+        raise LaunchError('Git setup observation is inconsistent')
+    expected = (0 if value['state'] in ('complete', 'absent') and reason is None
+                else 2 if reason in ('invalid', 'unsupported') else 1)
+    if code != expected or value['state'] == 'absent' and reason is not None:
+        raise LaunchError('Git setup observation exit status is inconsistent')
+    return value, code
+
+
+def observe(request, git=False):
     try:
-        result = subprocess.run([HELPER, 'setup-status'], input=request,
+        result = subprocess.run([HELPER, 'git-status' if git else 'setup-status'], input=request,
             capture_output=True, check=False, timeout=OBSERVE_SECONDS,
             cwd='/', env=ENVIRONMENT, close_fds=True)
     except (OSError, subprocess.TimeoutExpired) as error:
         raise LaunchError('setup observation did not complete') from error
     if (result.returncode not in (0, 1, 2, 4) or result.stderr
-            or len(result.stdout) > OBSERVATION_LIMIT or not result.stdout.endswith(b'\n')):
+            or len(result.stdout) > (GIT_OBSERVATION_LIMIT if git else OBSERVATION_LIMIT)
+            or not result.stdout.endswith(b'\n')):
         raise LaunchError('setup observation is unavailable')
     try:
         value = json.loads(result.stdout.decode('utf-8'), object_pairs_hook=unique_fields)
     except (ValueError, RecursionError) as error:
         raise LaunchError('setup observation is invalid') from error
+    if git:
+        return git_observation(value, result.returncode)
     if (not isinstance(value, dict) or set(value) != {'version', 'status', 'recording', 'reason', 'execution'}
             or type(value['version']) is not int or value['version'] != 1
             or value['status'] not in ('absent', 'claimed_unknown', 'completed', 'error', 'rejected')
@@ -73,9 +99,9 @@ def observe(request):
     return value, result.returncode
 
 
-def handoff(request):
+def handoff(request, git=False):
     try:
-        process = subprocess.Popen([HELPER, 'setup'], stdin=subprocess.PIPE,
+        process = subprocess.Popen([HELPER, 'git-prepare' if git else 'setup'], stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, bufsize=0,
             close_fds=True, start_new_session=True, cwd='/', env=ENVIRONMENT, umask=0o077)
     except OSError as error:
@@ -113,24 +139,26 @@ def handoff(request):
     return complete
 
 
-def execute(stream):
+def execute(stream, git=False):
     if stream is None:
         return 'rejected', None, 2
     try:
-        request = stream.read(REQUEST_LIMIT + 1)
+        limit = GIT_REQUEST_LIMIT if git else REQUEST_LIMIT
+        request = stream.read(limit + 1)
     except (OSError, ValueError):
         return 'rejected', None, 2
-    if len(request) > REQUEST_LIMIT:
+    if len(request) > limit:
         return 'rejected', None, 2
-    observation, code = observe(request)
-    if observation['status'] != 'absent':
+    observation, code = observe(request, True) if git else observe(request)
+    if observation['state' if git else 'status'] != 'absent':
         return 'observed', observation, code
-    return ('submitted', None, 0) if handoff(request) else ('handoff_unconfirmed', None, 1)
+    complete = handoff(request, True) if git else handoff(request)
+    return ('submitted', None, 0) if complete else ('handoff_unconfirmed', None, 1)
 
 
-def run(stream, output, diagnostics):
+def run(stream, output, diagnostics, git=False):
     try:
-        state, observation, code = execute(stream)
+        state, observation, code = execute(stream, True) if git else execute(stream)
     except LaunchError as error:
         state, observation, code = 'error', None, 1
         try:
@@ -150,10 +178,11 @@ def run(stream, output, diagnostics):
 
 
 def main():
-    if sys.argv[1:]:
+    arguments = sys.argv[1:]
+    if arguments not in ([], ['--git']):
         try:
             if sys.stderr is not None:
-                os.write(sys.stderr.fileno(), b'Usage: horizon-setup-launch < setup-request.json\n')
+                os.write(sys.stderr.fileno(), b'Usage: horizon-setup-launch [--git] < setup-request.json\n')
         except (OSError, ValueError):
             pass
         return 2
@@ -173,7 +202,8 @@ def main():
             except (OSError, ValueError):
                 pass
         with diagnostics:
-            return run(sys.stdin.buffer if sys.stdin is not None else None, output, diagnostics)
+            stream = sys.stdin.buffer if sys.stdin is not None else None
+            return run(stream, output, diagnostics, True) if arguments else run(stream, output, diagnostics)
 
 
 if __name__ == '__main__':

--- a/containers/remote-worker/test_git_setup_launch.py
+++ b/containers/remote-worker/test_git_setup_launch.py
@@ -1,0 +1,114 @@
+"""Ordinary Git submission shares the established detached handoff, never overlay intake."""
+
+import io
+import json
+import subprocess
+import unittest
+from unittest import mock
+
+from test_setup_launch import MODULE, result
+
+HANDOFF = MODULE.handoff
+
+
+def observation(state='absent', reason=None):
+    return {'version': 1, 'state': state, 'reason': reason,
+            'checkout': '/workspace/horizon/repository' if state == 'complete' else None}
+
+
+class GitSetupLaunchTests(unittest.TestCase):
+    def setUp(self):
+        self.runner = self.enterContext(mock.patch.object(MODULE.subprocess, 'run'))
+        self.handoff = self.enterContext(mock.patch.object(MODULE, 'handoff', return_value=True))
+        self.runner.return_value = result(observation())
+
+    def request(self, value=b'synthetic request'):
+        output, diagnostics = io.BytesIO(), io.StringIO()
+        code = MODULE.run(io.BytesIO(value), output, diagnostics, True)
+        return code, json.loads(output.getvalue()), diagnostics.getvalue()
+
+    def test_absence_submits_only_fixed_git_operation(self):
+        self.assertEqual(self.request(),
+                         (0, {'version': 1, 'state': 'submitted', 'observation': None}, ''))
+        self.handoff.assert_called_once_with(b'synthetic request', True)
+        args, kwargs = self.runner.call_args
+        self.assertEqual(args, ([MODULE.HELPER, 'git-status'],))
+        self.assertEqual(kwargs['input'], b'synthetic request')
+        self.assertEqual(kwargs['env'], MODULE.ENVIRONMENT)
+
+    def test_existing_claim_success_and_failure_never_replay(self):
+        for state, reason, code in [('claimed_unknown', None, 1), ('complete', None, 0),
+                                   ('claimed_unknown', 'git', 1), ('error', 'invalid', 2),
+                                   ('error', 'unsupported', 2), ('error', 'unsafe_root', 1),
+                                   ('complete', 'unsafe_root', 1)]:
+            with self.subTest(state=state, reason=reason):
+                value = observation(state, reason)
+                self.runner.return_value = result(value, code)
+                self.assertEqual(self.request(),
+                                 (code, {'version': 1, 'state': 'observed', 'observation': value}, ''))
+        self.handoff.assert_not_called()
+
+    def test_protocol_mismatch_never_submits_or_exposes_raw_output(self):
+        invalid = [(dict(observation(), version=True), 0),
+                   (dict(observation(), extra='private text'), 0),
+                   (dict(observation(), state=[]), 0),
+                   (dict(observation(), reason=[]), 0),
+                   (observation('absent', 'git'), 1),
+                   (observation('error'), 1),
+                   (observation('claimed_unknown'), 0),
+                   (dict(observation('complete'), checkout='/private/path'), 0),
+                   (observation('error', 'private text'), 1),
+                   (observation('complete'), 1)]
+        for value, code in invalid:
+            self.runner.return_value = result(value, code)
+            actual, response, diagnostics = self.request()
+            self.assertEqual((actual, response), (1, {'version': 1, 'state': 'error', 'observation': None}))
+            self.assertNotIn('private', diagnostics)
+        for raw in [b'private text\n', b' ' * 1024 + b'\n',
+                    b'{"version":1,"version":1,"state":"absent","reason":null,"checkout":null}\n',
+                    json.dumps(observation()).encode() + b'\n{}\n']:
+            self.runner.return_value = subprocess.CompletedProcess([], 0, raw, b'')
+            self.assertEqual(self.request()[0], 1)
+        self.handoff.assert_not_called()
+
+    def test_git_request_limit_is_narrower_than_overlay(self):
+        self.assertEqual(self.request(b' ' * (16 * 1024 + 1))[0], 2)
+        self.runner.assert_not_called()
+        self.handoff.assert_not_called()
+
+    def test_handoff_loss_stays_unknown_without_second_attempt(self):
+        self.handoff.return_value = False
+        self.assertEqual(self.request(),
+                         (1, {'version': 1, 'state': 'handoff_unconfirmed', 'observation': None}, ''))
+        self.handoff.assert_called_once_with(b'synthetic request', True)
+
+    def test_git_handoff_detaches_fixed_child_without_waiting_or_killing(self):
+        with mock.patch.object(MODULE.subprocess, 'Popen') as spawn, \
+                mock.patch.object(MODULE.os, 'set_blocking'), \
+                mock.patch.object(MODULE.os, 'write', return_value=5), \
+                mock.patch.object(MODULE.selectors, 'DefaultSelector') as select:
+            process = spawn.return_value
+            process.stdin.fileno.return_value = 29
+            select.return_value.__enter__.return_value.select.return_value = [(29, 2)]
+            self.assertTrue(HANDOFF(b'hello', True))
+            args, kwargs = spawn.call_args
+            self.assertEqual(args, ([MODULE.HELPER, 'git-prepare'],))
+            self.assertTrue(kwargs['start_new_session'] and kwargs['close_fds'])
+            self.assertEqual(kwargs['umask'], 0o077)
+            self.assertEqual((kwargs['stdout'], kwargs['stderr']),
+                             (subprocess.DEVNULL, subprocess.DEVNULL))
+            for method in ('wait', 'kill', 'terminate', 'communicate'):
+                getattr(process, method).assert_not_called()
+            process.poll.assert_called_once_with()
+            process.stdin.close.assert_called_once_with()
+
+    def test_main_rejects_other_switch_shapes(self):
+        for arguments in [['--git', 'extra'], ['--git=true'], ['--git', '--git']]:
+            with mock.patch.object(MODULE.sys, 'argv', ['launcher', *arguments]), \
+                    mock.patch.object(MODULE.os, 'write'), mock.patch.object(MODULE, 'run') as run:
+                self.assertEqual(MODULE.main(), 2)
+                run.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/containers/remote-worker/test_setup_launch.py
+++ b/containers/remote-worker/test_setup_launch.py
@@ -215,9 +215,9 @@ def unexpected(*args, **kwargs):
     raise AssertionError('response-only probe must not observe or launch a worker')
 launcher.observe = launcher.handoff = unexpected
 if mode == 'submitted':
-    launcher.execute = lambda stream: ('submitted', None, 0)
+    launcher.execute = lambda stream, git=False: ('submitted', None, 0)
 elif mode == 'error':
-    def failure(stream):
+    def failure(stream, git=False):
         raise launcher.LaunchError('static failure')
     launcher.execute = failure
 sys.exit(launcher.main())
@@ -250,6 +250,13 @@ sys.exit(launcher.main())
         diagnostics = self.probe('exec 2>/dev/full', 'error')
         self.assertEqual((diagnostics.returncode, diagnostics.stderr), (1, b''))
         self.assertEqual(json.loads(diagnostics.stdout)['state'], 'error')
+
+    def test_git_entrypoint_preserves_closed_stream_and_lost_output_behavior(self):
+        closed = self.probe('exec 0<&-', 'unchanged', '--git')
+        self.assertEqual((closed.returncode, closed.stderr), (2, b''))
+        self.assertEqual(json.loads(closed.stdout)['state'], 'rejected')
+        lost = self.probe('exec 1>/dev/full', 'submitted', '--git')
+        self.assertEqual((lost.returncode, lost.stdout, lost.stderr), (3, b'', b''))
 
 
 if __name__ == '__main__':

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -385,6 +385,11 @@ back into large multi-purpose modules.
   launcher writes no request/log files; retained Rust completion remains the
   recovery surface, not transient child output. Missing recording stays unknown.
   It does not own task supervision, transport, provider lifetime or client wiring.
+  Its explicit `--git` mode reuses that detached handoff for ordinary Git:
+  `git-status` owns strict request/root admission and `git-prepare` owns the
+  exclusive retained claim. Git responses have their own bounded validator;
+  overlay grants and storage qualification are not involved. No implicit retry
+  or clone cancellation follows from client-channel loss.
 - `containers/remote-worker/host-identity.py` owns workspace-retained server-key
   initialization, validation and runtime materialization before SSH starts.
   Its real-key regressions are separate from the retained-volume SSH smoke in


### PR DESCRIPTION
## Purpose

Extend the existing detached setup launcher with an explicit `--git` mode for #470 (parent #383), building on #526. One independently testable worker outcome: submitting ordinary Git preparation does not tie its lifetime to the request channel.

## Behavior

- The fixed `git-status` operation validates the bounded request and observes retained state. Only a positive absent result admits the fixed `git-prepare` handoff through stdin.
- The existing private, closed-descriptor, independent-session handoff is reused. Closing the launcher or losing its output does not cancel the worker child.
- Submitted means handoff, not completion or liveness. Later status observes the original receipt; claims, errors and completion do not grant automatic retries or resets.
- Git replies have a separate strict bounded validator. The existing overlay entrypoint is preserved; no overlay intake or PC-file synchronization is added.

Requires Linux worker confinement and an image containing the Git CLI. No controller/provider wiring, PAT installation, task startup, LFS/submodule support, UI change, image publication or release is included. This is not cloud/client-off acceptance.

## Validation

- All 22 Python launcher tests passed, covering both Git and existing overlay behavior, strict replies, request limits, closed streams and lost output.
- Independent local full-diff review completed. Required precommit lint, formatting, maintainability and version checks passed on the final staged tree.
- All eight exact-commit workspace validation lanes passed without retries: 2,293 default and 2,338 speech-tier tests, zero failures, six existing ignored tests per tier; formatting, maintainability, version and all three Clippy tiers passed.
- Native worker proof passed on launcher commit `f70230eed581675febbaf9d5fefb112a1a79c6ed`: two isolated cases used the actual installed launcher, CLI, Git, TLS verification and credential helper. A gated authenticated Git fetch proved that the launcher had exited while the same independent worker process remained alive, then completed after gate release.
- Both normal launcher exit and an already-closed stdout pipe passed. Later status reported completion at the selected older exact commit and explicit branch; repeated launcher/status calls preserved dirty tracked/untracked files and issued no further HTTP requests.
- The CLI was reused from its verified `a68c83a5` build, with identical Git, shared validation/reader and dependency inputs checked against this candidate. The launcher bytes match this exact commit; fixture permissions match the Dockerfile installation. This is not a newly packaged full runtime image.
- Synthetic credentials stayed out of process arguments/environment, responses and retained workspace files. Only the exact disposable containers were removed; private evidence remains available.
- An initial harness-only run failed because the source-script mount lacked executable permissions. Fresh Dockerfile-equivalent fixtures passed both cases without any product change. No failed product check is waived.

The HTTPS endpoint and PAT were synthetic and restricted to container loopback. This proves worker-side detached execution, not SSH disconnects, real GitHub authorization, cloud data retention or PC-off acceptance.
