### PR TITLE
feat(cloud): submit and inspect pinned remote Git setup

### DIFF
--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -20,6 +20,7 @@ mod managed_install;
 mod opencode_paths;
 mod panel;
 pub mod remote_environment_observation;
+pub mod remote_git_setup;
 pub mod remote_github_credential;
 mod remote_hosts;
 pub mod remote_panel_attachment;

--- a/crates/horizon-core/src/remote_git_setup.rs
+++ b/crates/horizon-core/src/remote_git_setup.rs
@@ -1,0 +1,224 @@
+//! Explicit ordinary Git setup on an existing pinned worker; never reconnect automation.
+
+#[cfg(target_os = "linux")]
+mod protocol;
+#[cfg(target_os = "linux")]
+mod transport;
+
+use crate::{
+    cloud_run::{CloudWorkflowStore, StoredRemoteAllocation, interactive_worker::InteractiveWorkerProvider},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_worker_status::RemotePanelStatusError,
+    remote_workspace_recovery::RemoteWorkspaceRecoveryError,
+};
+
+/// Original preparation state, not current HEAD, cleanliness or task readiness.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteGitState {
+    Absent,
+    ClaimedUnknown,
+    Complete,
+    Error,
+}
+
+/// Allowlisted worker diagnostics; remote text and repository paths are discarded.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteGitReason {
+    Invalid,
+    Unsupported,
+    UnsafeRoot,
+    Conflict,
+    Storage,
+    Git,
+    Interrupted,
+    UnsupportedRepository,
+}
+
+/// A degraded completion (non-null reason) does not establish a usable checkout.
+/// Absence is an observation, never permission to replay an uncertain submission.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemoteGitObservation {
+    pub state: RemoteGitState,
+    pub reason: Option<RemoteGitReason>,
+}
+
+/// Submission acknowledges only the detached handoff, not preparation completion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoteGitSubmission {
+    Submitted,
+    Observed(RemoteGitObservation),
+    Unknown,
+}
+
+/// Explicitly admit one Git setup submission, using the exact saved repository and
+/// runtime. `work_branch` must equal the saved, nonempty repository branch; callers
+/// choose a dedicated branch at workspace setup, never invent one on reconnect.
+/// This API cannot persist separate source/work branches or select a PR base.
+///
+/// Requires an existing worker and retained pin before noncreating inspection.
+/// No provider creation, PAT installation, task start or local store writes occur.
+/// The caller owns actual-session and cost authorization. Run off the render thread.
+/// Stdin admission is capped to 60 seconds and the remaining worker lease, including
+/// spawn elapsed time; spawn/reap may block. This is not atomic Stop revocation of
+/// bytes already sent. Unknown outcomes must not cause automatic resubmission.
+/// # Errors
+/// Rejects invalid saved binding, missing trust, stale state, pending management,
+/// expired workers and unavailable/unconfirmed SSH exchanges.
+pub fn submit_remote_git_setup<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    work_branch: &str,
+) -> Result<RemoteGitSubmission, RemoteGitSetupError> {
+    #[cfg(target_os = "linux")]
+    {
+        operate_with(
+            store,
+            identities,
+            provider,
+            allocation,
+            work_branch,
+            |store, recovered, input| transport::execute(store, recovered, input, false),
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, identities, provider, allocation, work_branch);
+        Err(RemoteGitSetupError::UnsupportedPlatform)
+    }
+}
+
+/// Read the original Git receipt without launching preparation or granting replay.
+/// Uses the same saved branch, ownership and pin admission as explicit submission.
+/// Bounded to 40 seconds of stdin admission or the remaining lease; run off-thread.
+/// # Errors
+/// Refuses invalid or changed ownership/trust and unconfirmed observations.
+pub fn inspect_remote_git_setup<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    work_branch: &str,
+) -> Result<RemoteGitObservation, RemoteGitSetupError> {
+    #[cfg(target_os = "linux")]
+    {
+        match operate_with(
+            store,
+            identities,
+            provider,
+            allocation,
+            work_branch,
+            |store, recovered, input| transport::execute(store, recovered, input, true),
+        )? {
+            RemoteGitSubmission::Observed(observation) => Ok(observation),
+            _ => Err(RemoteGitSetupError::OutcomeUnknown),
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, identities, provider, allocation, work_branch);
+        Err(RemoteGitSetupError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn operate_with<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    work_branch: &str,
+    execute: impl FnOnce(
+        &CloudWorkflowStore,
+        &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+        &[u8],
+    ) -> Result<RemoteGitSubmission, RemoteGitSetupError>,
+) -> Result<RemoteGitSubmission, RemoteGitSetupError> {
+    let input = protocol::request(allocation, work_branch)?;
+    let current = store
+        .load_remote_allocation(
+            allocation.workspace().session_id(),
+            &allocation.workspace().state().spec.workspace_local_id,
+        )
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    if current.as_ref() != Some(allocation) {
+        return Err(RemoteWorkspaceRecoveryError::StateChanged.into());
+    }
+    allocation
+        .recovery_request()
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteGitSetupError::MissingRetainedWorker)?;
+    if runtime.worker.is_none()
+        || !runtime
+            .ssh
+            .as_ref()
+            .is_some_and(crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint::is_complete)
+    {
+        return Err(RemoteGitSetupError::MissingRetainedWorker);
+    }
+    let recovered = crate::remote_workspace_recovery::inspect_remote_allocation(identities, provider, allocation)?;
+    validate_current(store, &recovered)?;
+    let result = execute(store, &recovered, &input)?;
+    validate_current(store, &recovered).map_err(|_| RemoteGitSetupError::OutcomeUnknown)?;
+    Ok(result)
+}
+
+#[cfg(target_os = "linux")]
+fn validate_current<'a>(
+    store: &CloudWorkflowStore,
+    recovered: &'a crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+) -> Result<&'a crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, RemoteGitSetupError> {
+    let endpoint = crate::remote_worker_inspection::validate_current(store, recovered, None)?;
+    if lease_deadline(recovered)?.is_some_and(|end| end <= time::OffsetDateTime::now_utc()) {
+        return Err(RemoteGitSetupError::ExpiredWorker);
+    }
+    Ok(endpoint)
+}
+
+#[cfg(target_os = "linux")]
+fn lease_deadline(
+    recovered: &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+) -> Result<Option<time::OffsetDateTime>, RemoteGitSetupError> {
+    recovered
+        .observation()
+        .and_then(|status| status.worker.lifetime.as_time_limited())
+        .map(|lease| {
+            time::OffsetDateTime::parse(&lease.terminate_after, &time::format_description::well_known::Rfc3339)
+                .map_err(|_| RemoteGitSetupError::ExpiredWorker)
+        })
+        .transpose()
+}
+
+/// Static diagnostics never include SSH output, paths or request bytes.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteGitSetupError {
+    #[error("Git setup requires the exact saved repository, runtime and explicit saved work branch")]
+    InvalidBinding,
+    #[error("Git setup requires an existing worker and retained SSH pin")]
+    MissingRetainedWorker,
+    #[error("Git setup requires an unexpired worker lifetime")]
+    ExpiredWorker,
+    #[error("Git setup outcome is unknown; do not automatically resubmit")]
+    OutcomeUnknown,
+    #[error("worker rejected the Git setup request")]
+    Rejected,
+    #[error("worker Git setup launcher is unavailable; no retry is implied")]
+    Unavailable,
+    #[error("remote Git setup is not yet supported on this client platform")]
+    UnsupportedPlatform,
+    #[error(transparent)]
+    Recovery(#[from] RemoteWorkspaceRecoveryError),
+    #[error(transparent)]
+    Admission(#[from] RemotePanelStatusError),
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_git_setup/protocol.rs
+++ b/crates/horizon-core/src/remote_git_setup/protocol.rs
@@ -105,7 +105,9 @@ pub(super) fn response(bytes: &[u8], code: Option<i32>, observe: bool) -> Result
         (LaunchState::HandoffUnconfirmed, None, 1) => Ok(Submission::Unknown),
         (LaunchState::Rejected, None, 2) => Err(Error::Rejected),
         (LaunchState::Error, None, 1) => Err(Error::Unavailable),
-        (LaunchState::Observed, Some(observation), code) => observation.checked(code).map(Submission::Observed),
+        (LaunchState::Observed, Some(observation), code) if observation.state != State::Absent => {
+            observation.checked(code).map(Submission::Observed)
+        }
         _ => Err(Error::OutcomeUnknown),
     }
 }

--- a/crates/horizon-core/src/remote_git_setup/protocol.rs
+++ b/crates/horizon-core/src/remote_git_setup/protocol.rs
@@ -1,0 +1,111 @@
+use super::{
+    RemoteGitObservation, RemoteGitReason as Reason, RemoteGitSetupError as Error, RemoteGitState as State,
+    RemoteGitSubmission as Submission,
+};
+use crate::{
+    cloud_run::StoredRemoteAllocation,
+    repository_git::{CHECKOUT, GitPreparation, RESPONSE_LIMIT},
+};
+use serde::{Deserialize, Deserializer};
+
+pub(super) const STATUS_LIMIT: usize = RESPONSE_LIMIT;
+pub(super) const LAUNCH_LIMIT: usize = 2 * RESPONSE_LIMIT;
+
+pub(super) fn request(allocation: &StoredRemoteAllocation, branch: &str) -> Result<Vec<u8>, Error> {
+    let state = allocation.workspace().state();
+    if branch.is_empty() || state.spec.repository.branch.as_deref() != Some(branch) {
+        return Err(Error::InvalidBinding);
+    }
+    let runtime = state.runtime.as_ref().ok_or(Error::InvalidBinding)?;
+    let request = GitPreparation {
+        version: 1,
+        workspace_local_id: state.spec.workspace_local_id.clone(),
+        runtime_id: runtime.job_id.to_string().parse().map_err(|_| Error::InvalidBinding)?,
+        source: state.spec.repository.clone(),
+        work_branch: branch.into(),
+    };
+    let bytes = serde_json::to_vec(&request).map_err(|_| Error::InvalidBinding)?;
+    GitPreparation::decode(&bytes).map_err(|_| Error::InvalidBinding)?;
+    Ok(bytes)
+}
+
+// A nullable field must still be present; serde's default Option behavior accepts omission.
+fn nullable<'de, D: Deserializer<'de>, T: Deserialize<'de>>(deserializer: D) -> Result<Option<T>, D::Error> {
+    Option::deserialize(deserializer)
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Observation {
+    version: u8,
+    state: State,
+    #[serde(deserialize_with = "nullable")]
+    reason: Option<Reason>,
+    #[serde(deserialize_with = "nullable")]
+    checkout: Option<String>,
+}
+
+impl Observation {
+    fn checked(self, code: i32) -> Result<RemoteGitObservation, Error> {
+        let expected = match (self.state, self.reason) {
+            (State::Absent | State::Complete, None) => 0,
+            (_, Some(Reason::Invalid | Reason::Unsupported)) => 2,
+            _ => 1,
+        };
+        if self.version != 1
+            || code != expected
+            || self.checkout.as_deref() != (self.state == State::Complete).then_some(CHECKOUT)
+            || self.state == State::Absent && self.reason.is_some()
+            || self.state == State::Error && self.reason.is_none()
+        {
+            return Err(Error::OutcomeUnknown);
+        }
+        Ok(RemoteGitObservation {
+            state: self.state,
+            reason: self.reason,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LaunchState {
+    Submitted,
+    Observed,
+    HandoffUnconfirmed,
+    Rejected,
+    Error,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Launch {
+    version: u8,
+    state: LaunchState,
+    #[serde(deserialize_with = "nullable")]
+    observation: Option<Observation>,
+}
+
+pub(super) fn response(bytes: &[u8], code: Option<i32>, observe: bool) -> Result<Submission, Error> {
+    let limit = if observe { STATUS_LIMIT } else { LAUNCH_LIMIT };
+    if bytes.len() > limit {
+        return Err(Error::OutcomeUnknown);
+    }
+    let code = code.ok_or(Error::OutcomeUnknown)?;
+    if observe {
+        let observation: Observation = serde_json::from_slice(bytes).map_err(|_| Error::OutcomeUnknown)?;
+        return observation.checked(code).map(Submission::Observed);
+    }
+    let reply: Launch = serde_json::from_slice(bytes).map_err(|_| Error::OutcomeUnknown)?;
+    if reply.version != 1 {
+        return Err(Error::OutcomeUnknown);
+    }
+    match (reply.state, reply.observation, code) {
+        (LaunchState::Submitted, None, 0) => Ok(Submission::Submitted),
+        (LaunchState::HandoffUnconfirmed, None, 1) => Ok(Submission::Unknown),
+        (LaunchState::Rejected, None, 2) => Err(Error::Rejected),
+        (LaunchState::Error, None, 1) => Err(Error::Unavailable),
+        (LaunchState::Observed, Some(observation), code) => observation.checked(code).map(Submission::Observed),
+        _ => Err(Error::OutcomeUnknown),
+    }
+}

--- a/crates/horizon-core/src/remote_git_setup/tests.rs
+++ b/crates/horizon-core/src/remote_git_setup/tests.rs
@@ -1,0 +1,281 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{CloudProvider, WorkerLifetime, interactive_worker::*},
+    remote_repository_pack::tests::Fixture,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[path = "tests/transport.rs"]
+mod io;
+#[path = "tests/protocol.rs"]
+mod wire;
+
+const BRANCH: &str = "work/explicit";
+
+fn fixture() -> Fixture {
+    Fixture::with_repository(
+        Some(InteractiveWorkerLifecycle::Ready),
+        WorkerLifetime::Persistent,
+        true,
+        Some(BRANCH),
+    )
+}
+
+struct Provider {
+    status: Option<InteractiveWorkerStatus>,
+    calls: AtomicUsize,
+    during: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl Provider {
+    fn new(fixture: &Fixture) -> Self {
+        Self {
+            status: fixture.recovered.observation().cloned(),
+            calls: AtomicUsize::new(0),
+            during: None,
+        }
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::LocalDocker
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("Git setup cannot create workers")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("Git setup cannot reconcile missing workers")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(action) = &self.during {
+            action();
+        }
+        Ok(self.status.clone())
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("Git setup cannot delete workers")
+    }
+}
+
+fn identities(fixture: &Fixture) -> RemoteSshIdentityStore {
+    RemoteSshIdentityStore::new(&HorizonHome::from_root(fixture.directory.path().join("home")))
+}
+
+fn operate(
+    fixture: &Fixture,
+    provider: &Provider,
+    allocation: &StoredRemoteAllocation,
+    branch: &str,
+    execute: impl FnOnce(
+        &CloudWorkflowStore,
+        &crate::remote_workspace_recovery::RecoveredRemoteWorkspace,
+        &[u8],
+    ) -> Result<RemoteGitSubmission, RemoteGitSetupError>,
+) -> Result<RemoteGitSubmission, RemoteGitSetupError> {
+    operate_with(
+        &fixture.store,
+        &identities(fixture),
+        provider,
+        allocation,
+        branch,
+        execute,
+    )
+}
+
+#[test]
+fn exact_saved_binding_is_sent_once_without_state_or_identity_writes() {
+    let fixture = fixture();
+    let provider = Provider::new(&fixture);
+    let before = fixture.current();
+    let key = std::fs::read(fixture.recovered.identity().private_key_path()).unwrap();
+    let mut calls = 0;
+    assert_eq!(
+        operate(&fixture, &provider, &before, BRANCH, |_, recovered, bytes| {
+            calls += 1;
+            let request = crate::repository_git::GitPreparation::decode(bytes).unwrap();
+            let state = before.workspace().state();
+            assert_eq!(request.source, state.spec.repository);
+            assert_eq!(request.work_branch, BRANCH);
+            assert_eq!(request.workspace_local_id, state.spec.workspace_local_id);
+            assert_eq!(
+                request.runtime_id.to_string(),
+                state.runtime.as_ref().unwrap().job_id.to_string()
+            );
+            assert_eq!(recovered.allocation(), &before);
+            Ok(RemoteGitSubmission::Submitted)
+        }),
+        Ok(RemoteGitSubmission::Submitted)
+    );
+    assert_eq!(calls, 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.current(), before);
+    assert_eq!(
+        std::fs::read(fixture.recovered.identity().private_key_path()).unwrap(),
+        key
+    );
+    assert!(before.workspace().state().spec.panels.is_empty());
+}
+
+#[test]
+fn missing_mismatched_and_invalid_saved_branches_reject_before_provider() {
+    for saved in [None, Some(BRANCH), Some("HEAD")] {
+        let fixture = Fixture::with_repository(
+            Some(InteractiveWorkerLifecycle::Ready),
+            WorkerLifetime::Persistent,
+            true,
+            saved,
+        );
+        let provider = Provider::new(&fixture);
+        for branch in ["", "different", "HEAD"] {
+            assert_eq!(
+                operate(&fixture, &provider, &fixture.current(), branch, |_, _, _| panic!(
+                    "no SSH"
+                )),
+                Err(RemoteGitSetupError::InvalidBinding)
+            );
+        }
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn stale_foreign_and_pending_stop_requests_never_reach_provider() {
+    for stop in [false, true] {
+        let fixture = fixture();
+        let before = fixture.current();
+        let provider = Provider::new(&fixture);
+        fixture.edit(stop);
+        assert!(operate(&fixture, &provider, &before, BRANCH, |_, _, _| panic!("no SSH")).is_err());
+        if stop {
+            assert!(
+                operate(&fixture, &provider, &fixture.current(), BRANCH, |_, _, _| panic!(
+                    "pending Stop"
+                ))
+                .is_err()
+            );
+        }
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+    let first = fixture();
+    let other = fixture();
+    let provider = Provider::new(&first);
+    assert!(operate(&other, &provider, &first.current(), BRANCH, |_, _, _| panic!("foreign")).is_err());
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn missing_worker_or_pin_never_creates_or_establishes_first_trust() {
+    for (state, pin) in [(None, true), (Some(InteractiveWorkerLifecycle::Provisioning), false)] {
+        let fixture = Fixture::with_repository(state, WorkerLifetime::Persistent, pin, Some(BRANCH));
+        let provider = Provider::new(&fixture);
+        assert_eq!(
+            operate(&fixture, &provider, &fixture.current(), BRANCH, |_, _, _| panic!(
+                "no SSH"
+            )),
+            Err(RemoteGitSetupError::MissingRetainedWorker)
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn provider_drift_and_changed_valid_pin_never_cross_ssh() {
+    let other = fixture();
+    for change in 0..5 {
+        let fixture = fixture();
+        let mut provider = Provider::new(&fixture);
+        let status = provider.status.as_mut().unwrap();
+        match change {
+            0 => status.lifecycle = InteractiveWorkerLifecycle::Stopped,
+            1 => status.ssh.as_mut().unwrap().host_key = other.recovered.identity().public_key().into(),
+            2 => status.worker.identity.resource_id = "different".into(),
+            3 => status.worker.ssh_public_key = other.recovered.identity().public_key().into(),
+            _ => provider.status = None,
+        }
+        assert!(
+            operate(&fixture, &provider, &fixture.current(), BRANCH, |_, _, _| panic!(
+                "no SSH"
+            ))
+            .is_err()
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn state_loss_during_inspection_rejects_without_recreation() {
+    let fixture = fixture();
+    let mut provider = Provider::new(&fixture);
+    let path = fixture.store.path().to_path_buf();
+    let retained = path.with_extension("retained");
+    provider.during = Some(Box::new(move || std::fs::rename(&path, &retained).unwrap()));
+    assert!(
+        operate(&fixture, &provider, &fixture.current(), BRANCH, |_, _, _| panic!(
+            "no SSH"
+        ))
+        .is_err()
+    );
+    assert!(!fixture.store.path().exists());
+}
+
+#[test]
+fn post_exchange_drift_is_unknown_and_never_replayed() {
+    for loss in [false, true] {
+        let fixture = fixture();
+        let provider = Provider::new(&fixture);
+        let mut calls = 0;
+        assert_eq!(
+            operate(&fixture, &provider, &fixture.current(), BRANCH, |_, _, _| {
+                calls += 1;
+                if loss {
+                    std::fs::rename(fixture.store.path(), fixture.store.path().with_extension("retained")).unwrap();
+                } else {
+                    fixture.edit(true);
+                }
+                Ok(RemoteGitSubmission::Submitted)
+            }),
+            Err(RemoteGitSetupError::OutcomeUnknown)
+        );
+        assert_eq!(calls, 1);
+    }
+}
+
+#[test]
+fn expired_before_exchange_rejects_and_expiry_during_exchange_is_unknown() {
+    for during in [false, true] {
+        let fixture = Fixture::with_repository(
+            Some(InteractiveWorkerLifecycle::Ready),
+            WorkerLifetime::TimeLimited { seconds: 2 },
+            true,
+            Some(BRANCH),
+        );
+        let provider = Provider::new(&fixture);
+        let deadline = lease_deadline(&fixture.recovered).unwrap().unwrap();
+        let expire = || {
+            let delay = deadline - time::OffsetDateTime::now_utc();
+            if delay.is_positive() {
+                std::thread::sleep(delay.unsigned_abs());
+            }
+        };
+        if !during {
+            expire();
+        }
+        let mut calls = 0;
+        let result = operate(&fixture, &provider, &fixture.current(), BRANCH, |_, _, _| {
+            calls += 1;
+            assert!(during);
+            expire();
+            Ok(RemoteGitSubmission::Submitted)
+        });
+        if during {
+            assert_eq!(result, Err(RemoteGitSetupError::OutcomeUnknown));
+        } else {
+            assert!(result.is_err());
+        }
+        assert_eq!(calls, usize::from(during));
+    }
+}

--- a/crates/horizon-core/src/remote_git_setup/tests/protocol.rs
+++ b/crates/horizon-core/src/remote_git_setup/tests/protocol.rs
@@ -40,7 +40,11 @@ fn all_observation_exit_pairs_and_degraded_completion_are_strict() {
                     "{state} {reason:?} {code}"
                 );
                 let wrapped = json!({"version": 1, "state": "observed", "observation": value});
-                assert_eq!(decode(&wrapped, code, false).is_ok(), valid && code == expected);
+                assert_eq!(
+                    decode(&wrapped, code, false).is_ok(),
+                    state != "absent" && valid && code == expected,
+                    "wrapped {state} {reason:?} {code}"
+                );
             }
         }
     }

--- a/crates/horizon-core/src/remote_git_setup/tests/protocol.rs
+++ b/crates/horizon-core/src/remote_git_setup/tests/protocol.rs
@@ -1,0 +1,129 @@
+use super::super::{protocol::*, *};
+use serde_json::{Value, json};
+
+fn observation(state: &str, reason: Option<&str>) -> Value {
+    json!({"version": 1, "state": state, "reason": reason,
+        "checkout": if state == "complete" { Some("/workspace/horizon/repository") } else { None }})
+}
+
+fn decode(value: &Value, code: i32, observe: bool) -> Result<RemoteGitSubmission, RemoteGitSetupError> {
+    response(&serde_json::to_vec(value).unwrap(), Some(code), observe)
+}
+
+#[test]
+fn all_observation_exit_pairs_and_degraded_completion_are_strict() {
+    for state in ["absent", "claimed_unknown", "complete", "error"] {
+        for reason in [
+            None,
+            Some("invalid"),
+            Some("unsupported"),
+            Some("unsafe_root"),
+            Some("conflict"),
+            Some("storage"),
+            Some("git"),
+            Some("interrupted"),
+            Some("unsupported_repository"),
+        ] {
+            let valid = !(state == "absent" && reason.is_some() || state == "error" && reason.is_none());
+            let expected = if matches!(state, "absent" | "complete") && reason.is_none() {
+                0
+            } else if matches!(reason, Some("invalid" | "unsupported")) {
+                2
+            } else {
+                1
+            };
+            let value = observation(state, reason);
+            for code in [0, 1, 2, 3, 255] {
+                assert_eq!(
+                    decode(&value, code, true).is_ok(),
+                    valid && code == expected,
+                    "{state} {reason:?} {code}"
+                );
+                let wrapped = json!({"version": 1, "state": "observed", "observation": value});
+                assert_eq!(decode(&wrapped, code, false).is_ok(), valid && code == expected);
+            }
+        }
+    }
+    assert_eq!(
+        decode(&observation("complete", Some("unsafe_root")), 1, true),
+        Ok(RemoteGitSubmission::Observed(RemoteGitObservation {
+            state: RemoteGitState::Complete,
+            reason: Some(RemoteGitReason::UnsafeRoot),
+        }))
+    );
+}
+
+#[test]
+fn launch_acknowledgement_never_claims_completion_or_grants_retry() {
+    for (state, code, expected) in [
+        ("submitted", 0, Ok(RemoteGitSubmission::Submitted)),
+        ("handoff_unconfirmed", 1, Ok(RemoteGitSubmission::Unknown)),
+        ("rejected", 2, Err(RemoteGitSetupError::Rejected)),
+        ("error", 1, Err(RemoteGitSetupError::Unavailable)),
+    ] {
+        let value = json!({"version": 1, "state": state, "observation": null});
+        assert_eq!(decode(&value, code, false), expected);
+        for wrong in [0, 1, 2, 3, 255].into_iter().filter(|wrong| *wrong != code) {
+            assert_eq!(decode(&value, wrong, false), Err(RemoteGitSetupError::OutcomeUnknown));
+        }
+        let extra = json!({"version": 1, "state": state, "observation": observation("complete", None)});
+        assert_eq!(decode(&extra, code, false), Err(RemoteGitSetupError::OutcomeUnknown));
+    }
+}
+
+#[test]
+fn missing_duplicate_extra_fields_and_untrusted_values_are_rejected() {
+    for (value, observe) in [
+        (observation("complete", None), true),
+        (json!({"version": 1, "state": "submitted", "observation": null}), false),
+    ] {
+        for key in value.as_object().unwrap().keys() {
+            let mut missing = value.clone();
+            missing.as_object_mut().unwrap().remove(key);
+            assert_eq!(
+                decode(&missing, 0, observe),
+                Err(RemoteGitSetupError::OutcomeUnknown),
+                "{key}"
+            );
+        }
+        let bytes = serde_json::to_vec(&value).unwrap();
+        let duplicate = String::from_utf8(bytes.clone())
+            .unwrap()
+            .replacen('{', "{\"version\":1,", 1);
+        for invalid in [duplicate.as_bytes().to_vec(), [bytes, b"{}".to_vec()].concat()] {
+            assert_eq!(
+                response(&invalid, Some(0), observe),
+                Err(RemoteGitSetupError::OutcomeUnknown)
+            );
+        }
+        for (key, replacement) in [
+            ("version", json!(true)),
+            ("version", json!(2)),
+            ("state", json!("private-output")),
+            ("extra", json!(null)),
+        ] {
+            let mut changed = value.clone();
+            changed[key] = replacement;
+            assert_eq!(decode(&changed, 0, observe), Err(RemoteGitSetupError::OutcomeUnknown));
+        }
+        let oversized = vec![b' '; if observe { STATUS_LIMIT + 1 } else { LAUNCH_LIMIT + 1 }];
+        assert_eq!(
+            response(&oversized, Some(0), observe),
+            Err(RemoteGitSetupError::OutcomeUnknown)
+        );
+        assert_eq!(response(b"{}", None, observe), Err(RemoteGitSetupError::OutcomeUnknown));
+    }
+    for (key, replacement) in [
+        ("checkout", json!("/private/untrusted")),
+        ("reason", json!("private diagnostic")),
+    ] {
+        let mut changed = observation("complete", None);
+        changed[key] = replacement;
+        assert_eq!(decode(&changed, 0, true), Err(RemoteGitSetupError::OutcomeUnknown));
+    }
+    let duplicate_nested = br#"{"version":1,"state":"observed","observation":{"version":1,"state":"complete","reason":null,"reason":null,"checkout":"/workspace/horizon/repository"}}"#;
+    assert_eq!(
+        response(duplicate_nested, Some(0), false),
+        Err(RemoteGitSetupError::OutcomeUnknown)
+    );
+}

--- a/crates/horizon-core/src/remote_git_setup/tests/transport.rs
+++ b/crates/horizon-core/src/remote_git_setup/tests/transport.rs
@@ -1,0 +1,169 @@
+use super::super::{transport::*, *};
+use crate::remote_worker_ssh::{
+    prepared_command, prepared_git_setup,
+    query::{Exchange, InputProgress},
+};
+use std::{
+    cell::Cell,
+    os::unix::process::ExitStatusExt,
+    path::Path,
+    process::{Command, ExitStatus},
+    time::Duration,
+};
+
+const SUBMITTED: &[u8] = br#"{"version":1,"state":"submitted","observation":null}"#;
+
+#[test]
+fn full_input_is_required_even_for_early_complete_or_nonzero_responses() {
+    for complete in [false, true] {
+        for written in [0, 3, 4, 5] {
+            let input = if complete {
+                InputProgress::Complete(written)
+            } else {
+                InputProgress::Incomplete(written)
+            };
+            let exchange = Exchange {
+                status: ExitStatus::from_raw(0),
+                input,
+                output: SUBMITTED.into(),
+            };
+            assert_eq!(known_response(&exchange, 4, false).is_ok(), written == 4);
+        }
+    }
+    let exchange = Exchange {
+        status: ExitStatus::from_raw(256),
+        input: InputProgress::Complete(4),
+        output: br#"{"version":1,"state":"handoff_unconfirmed","observation":null}"#.into(),
+    };
+    assert_eq!(known_response(&exchange, 4, false), Ok(RemoteGitSubmission::Unknown));
+}
+
+#[test]
+fn persistent_and_remaining_lease_budgets_are_explicit() {
+    let now = time::OffsetDateTime::UNIX_EPOCH;
+    for observe in [true, false] {
+        assert_eq!(
+            lease_timeout(observe, None, now),
+            Ok(Duration::from_secs(if observe { 40 } else { 60 }))
+        );
+        assert_eq!(
+            lease_timeout(observe, Some(now + time::Duration::seconds(2)), now),
+            Ok(Duration::from_secs(2))
+        );
+        assert_eq!(
+            lease_timeout(observe, Some(now), now),
+            Err(RemoteGitSetupError::ExpiredWorker)
+        );
+    }
+}
+
+#[test]
+fn expired_before_spawn_or_first_write_never_delivers_input() {
+    let now = time::OffsetDateTime::now_utc();
+    assert_eq!(
+        exchange_before(Command::new("/nonexistent"), b"bound request", false, Some(now), || now),
+        Err(RemoteGitSetupError::ExpiredWorker)
+    );
+    // Clock calls: budget, pre-spawn, post-spawn admission. Move the absolute
+    // deadline forward deterministically, rather than racing a sleeping child.
+    let calls = Cell::new(0);
+    let mut child = Command::new("/bin/cat");
+    child.env_clear();
+    let result = exchange_before(
+        child,
+        b"bound request",
+        false,
+        Some(now + time::Duration::seconds(1)),
+        || {
+            let count = calls.get();
+            calls.set(count + 1);
+            now + time::Duration::seconds(if count >= 2 { 2 } else { 0 })
+        },
+    );
+    assert_eq!(result, Err(RemoteGitSetupError::OutcomeUnknown));
+    assert_eq!(calls.get(), 3);
+}
+
+#[test]
+fn forward_clock_jump_after_initial_write_revokes_further_input() {
+    let now = time::OffsetDateTime::now_utc();
+    let calls = Cell::new(0);
+    let mut child = Command::new("/bin/cat");
+    child.env_clear();
+    // Exercise multiple stream chunks inside this private transport test. Public
+    // requests remain limited to one 16 KiB frame by the worker request decoder.
+    let input = vec![b'x'; 48 * 1024];
+    let result = exchange_before(child, &input, false, Some(now + time::Duration::seconds(1)), || {
+        let count = calls.get();
+        calls.set(count + 1);
+        now + time::Duration::seconds(if count >= 5 { 2 } else { 0 })
+    });
+    assert_eq!(result, Err(RemoteGitSetupError::OutcomeUnknown));
+    assert_eq!(calls.get(), 6);
+}
+
+#[test]
+fn actual_child_nonzero_frame_is_retained_and_status_never_submits() {
+    for (observe, reply, code, expected) in [
+        (
+            false,
+            "{\"version\":1,\"state\":\"handoff_unconfirmed\",\"observation\":null}",
+            "1",
+            RemoteGitSubmission::Unknown,
+        ),
+        (
+            true,
+            "{\"version\":1,\"state\":\"claimed_unknown\",\"reason\":null,\"checkout\":null}",
+            "1",
+            RemoteGitSubmission::Observed(RemoteGitObservation {
+                state: RemoteGitState::ClaimedUnknown,
+                reason: None,
+            }),
+        ),
+    ] {
+        let mut child = Command::new("/bin/sh");
+        child.env_clear().args([
+            "-c",
+            "cat >/dev/null; printf '%s' \"$1\"; exit \"$2\"",
+            "fixture",
+            reply,
+            code,
+        ]);
+        assert_eq!(
+            exchange_before(
+                child,
+                b"synthetic request",
+                observe,
+                None,
+                time::OffsetDateTime::now_utc
+            ),
+            Ok(expected)
+        );
+    }
+}
+
+#[test]
+fn fixed_git_commands_preserve_all_key_only_ssh_options() {
+    let fixture = super::fixture();
+    let endpoint = fixture.recovered.observation().unwrap().ssh.as_ref().unwrap();
+    let baseline = prepared_command(Path::new("/private/key"), Path::new("/private/trust"), endpoint).unwrap();
+    for (observe, operation) in [
+        (false, "/usr/local/bin/horizon-setup-launch --git"),
+        (true, "/usr/local/bin/horizon-repository git-status"),
+    ] {
+        let command = prepared_git_setup(
+            Path::new("/private/key"),
+            Path::new("/private/trust"),
+            endpoint,
+            observe,
+        )
+        .unwrap();
+        let mut expected: Vec<_> = baseline.get_args().map(std::ffi::OsStr::to_os_string).collect();
+        *expected.last_mut().unwrap() = operation.into();
+        assert_eq!(command.get_args().collect::<Vec<_>>(), expected);
+        assert_eq!(
+            command.get_envs().collect::<Vec<_>>(),
+            baseline.get_envs().collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/horizon-core/src/remote_git_setup/transport.rs
+++ b/crates/horizon-core/src/remote_git_setup/transport.rs
@@ -1,0 +1,78 @@
+use super::{
+    RemoteGitSetupError as Error, RemoteGitSubmission as Submission, lease_deadline, protocol, validate_current,
+};
+use crate::{
+    cloud_run::CloudWorkflowStore,
+    remote_worker_ssh::{known_hosts, prepared_git_setup, query},
+    remote_workspace_recovery::RecoveredRemoteWorkspace,
+};
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+pub(super) fn execute(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    input: &[u8],
+    observe: bool,
+) -> Result<Submission, Error> {
+    let endpoint = validate_current(store, recovered)?;
+    let identity = recovered.identity();
+    let trust = known_hosts(identity, endpoint)?;
+    let command = prepared_git_setup(identity.private_key_path(), trust.path(), endpoint, observe)?;
+    validate_current(store, recovered)?;
+    exchange_before(
+        command,
+        input,
+        observe,
+        lease_deadline(recovered)?,
+        time::OffsetDateTime::now_utc,
+    )
+}
+
+pub(super) fn exchange_before(
+    command: Command,
+    mut input: &[u8],
+    observe: bool,
+    deadline: Option<time::OffsetDateTime>,
+    utc_now: impl Fn() -> time::OffsetDateTime,
+) -> Result<Submission, Error> {
+    let started = Instant::now();
+    let timeout = lease_timeout(observe, deadline, utc_now())?;
+    let expired = || started.elapsed() >= timeout || deadline.is_some_and(|end| utc_now() >= end);
+    let limit = if observe {
+        protocol::STATUS_LIMIT
+    } else {
+        protocol::LAUNCH_LIMIT
+    };
+    let expected = input.len() as u64;
+    // Keep nonzero framed responses, but independently require every immutable
+    // request byte written. The callback includes spawn time and guards each write.
+    let result =
+        query::exchange(command, &mut input, timeout, limit, expired, None).map_err(|_| Error::OutcomeUnknown)?;
+    known_response(&result, expected, observe)
+}
+
+pub(super) fn known_response(result: &query::Exchange, expected: u64, observe: bool) -> Result<Submission, Error> {
+    let (query::InputProgress::Complete(written) | query::InputProgress::Incomplete(written)) = result.input;
+    if written != expected {
+        return Err(Error::OutcomeUnknown);
+    }
+    protocol::response(&result.output, result.status.code(), observe)
+}
+
+pub(super) fn lease_timeout(
+    observe: bool,
+    deadline: Option<time::OffsetDateTime>,
+    now: time::OffsetDateTime,
+) -> Result<Duration, Error> {
+    let timeout = Duration::from_secs(if observe { 40 } else { 60 });
+    match deadline {
+        Some(end) if end <= now => Err(Error::ExpiredWorker),
+        Some(end) => Duration::try_from(end - now)
+            .map(|remaining| remaining.min(timeout))
+            .map_err(|_| Error::ExpiredWorker),
+        None => Ok(timeout),
+    }
+}

--- a/crates/horizon-core/src/remote_repository_pack/tests.rs
+++ b/crates/horizon-core/src/remote_repository_pack/tests.rs
@@ -68,6 +68,15 @@ impl Fixture {
         lifetime: crate::cloud_run::WorkerLifetime,
         pinned: bool,
     ) -> Self {
+        Self::with_repository(lifecycle, lifetime, pinned, None)
+    }
+
+    pub(crate) fn with_repository(
+        lifecycle: Option<InteractiveWorkerLifecycle>,
+        lifetime: crate::cloud_run::WorkerLifetime,
+        pinned: bool,
+        branch: Option<&str>,
+    ) -> Self {
         use std::os::unix::fs::PermissionsExt;
         let directory = tempfile::tempdir().expect("fixture");
         std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
@@ -86,6 +95,7 @@ impl Fixture {
         }))
         .expect("state");
         state.spec.target.lifetime = lifetime;
+        state.spec.repository.branch = branch.map(str::to_owned);
         let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
         let allocation = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
         let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -73,6 +73,7 @@ enum Operation<'a> {
     IntakeStatus,
     StorageStatus,
     GithubInstall,
+    GitSetup { observe: bool },
     Attach { runtime: CloudJobId, panel: &'a str },
 }
 
@@ -92,7 +93,8 @@ fn command_for(
         | Operation::Intake
         | Operation::IntakeStatus
         | Operation::StorageStatus
-        | Operation::GithubInstall => "-T",
+        | Operation::GithubInstall
+        | Operation::GitSetup { .. } => "-T",
         Operation::Attach { panel, .. } if valid_local_id(panel) => "-tt",
         Operation::Attach { .. } => return Err(Error::UnknownPanel),
     };
@@ -146,12 +148,23 @@ fn command_for(
         Operation::IntakeStatus => "/usr/local/bin/horizon-repository intake-status".into(),
         Operation::StorageStatus => "/usr/local/bin/horizon-repository storage-status".into(),
         Operation::GithubInstall => "/usr/local/bin/horizon-github-credential install".into(),
+        Operation::GitSetup { observe: true } => "/usr/local/bin/horizon-repository git-status".into(),
+        Operation::GitSetup { observe: false } => "/usr/local/bin/horizon-setup-launch --git".into(),
         Operation::Attach { runtime, panel } => {
             format!("/usr/local/bin/horizon-panel-session attach -- {runtime} {panel}")
         }
     });
     command.env("SSH_ASKPASS_REQUIRE", "never");
     Ok(command)
+}
+
+pub(crate) fn prepared_git_setup(
+    identity: &Path,
+    known_hosts: &Path,
+    endpoint: &InteractiveWorkerSshEndpoint,
+    observe: bool,
+) -> Result<Command, Error> {
+    command_for(identity, known_hosts, endpoint, Operation::GitSetup { observe })
 }
 
 /// Private preparation must be consumed by the fresh admission boundary, never persisted.

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -157,6 +157,15 @@ back into large multi-purpose modules.
   only exact installer success replies. Post-send drift is unknown, never a
   reason for automatic retry, credential replacement or worker/task mutation.
   The borrowed secret is redacted and is not persisted or discovered implicitly.
+- `remote_git_setup.rs` admits explicit ordinary Git submission and read-only
+  receipt inspection on an existing owned, pinned worker. The saved repository,
+  exact runtime and explicitly matching saved branch bind its fixed stdin frame;
+  a separate source/work-branch model and PR base selection remain future work.
+  Its protocol leaf distinguishes detached handoff, observed original preparation
+  and unknown outcomes, not current checkout cleanliness or task readiness.
+  Its transport leaf caps each write by the remaining lease and retains valid
+  negative replies without granting replay. No allocation, PAT installation,
+  task start, storage writes or implicit recovery occur. Linux clients first.
 - `remote_worker_status.rs` gates non-creating panel inspection on exact owned
   recovery and current lifetime. Its `protocol.rs` leaf owns bounded status-only
   wire types; `ssh.rs` owns the query's private host-pin lifetime and retains the


### PR DESCRIPTION
## Purpose

Add explicit Linux controller APIs to submit ordinary Git preparation to an existing pinned worker and inspect its original preparation receipt. Follow-up for #470; this does not close the workstream.

## Behavior

- Bind requests to the saved repository, exact commit, runtime and explicitly matching saved branch. No branch defaults or separate source/work-branch persistence.
- Require current ownership, an existing worker and retained host pin before noncreating provider inspection. Reject stale state, pending management and expired leases.
- Use only the fixed detached Git launcher or read-only status command over pinned SSH. Require complete request delivery and strict bounded response/exit pairs.
- Cap stdin admission to the remaining worker lease, including spawn elapsed time and checks before each write. A submitted reply acknowledges handoff, not completion; uncertain replies or later state drift never authorize automatic replay.
- Preserve allocations, credentials, remote files and tasks. No provider creation, PAT installation, task start, checkpointing, cleanup or local-file synchronization is added.

Completion observations describe original preparation, not current HEAD, cleanliness or task readiness. LFS/submodule support and remote push/PR workflows remain separate outstanding work. Other native client platforms remain deferred; existing cross-platform CI is unchanged.

## Validation

On `73833bcb47288b21ee114d64068864810315b816`, integrated with Azure production-client work at `2cbfc4ac` and the reviewed strict launcher-observation correction:

- All eight exact-commit local validation lanes passed, including default and speech tests and all three Clippy tiers.
- Three focused wire-protocol tests passed, including exhaustive observation/exit pairs. The full matrix covers controller admission, deadlines, shared-fixture consumers, credentials and fixed SSH command isolation.
- Independent local full-diff and correction reviews passed. Nine source/test paths, 1,024 changed source/test lines, plus the architecture note.
- The launcher decoder rejects impossible `observed + absent` replies as an unknown outcome; read-only inspection still accepts valid absence. No retry is implied.

Fresh real pinned-SSH controller/runtime smoke passed on this exact head in two isolated Linux worker fixtures:

- Wrong saved branch and wrong retained host pin were rejected without checkout creation or Git traffic.
- Normal submission used the shipped fixed SSH command. A separately gated HTTPS fetch showed the detached Git worker and independent panel task continuing after the launcher exited; fresh inspection then reported completion at the requested older commit and explicit work branch.
- A fault-only reply hold allowed the exact local SSH child to be disconnected after handoff. The controller reported an unknown outcome, while the same remote Git process and independent task continued. A new inspection observed successful completion without resubmission.
- Repeated submission preserved tracked/untracked dirty files without another fetch; saved allocation, identity and task identity/progress were preserved. Both exact-owned fixtures were removed, with pre-existing containers untouched.

The test used synthetic infrastructure and credentials, the exact controller build, a byte-identical installed-mode launcher and a previously built repository CLI with verified transitive source parity. It does not establish live GitHub authentication, provider durability, PC-off recovery or newly packaged whole-image readiness. No UI behavior is changed.
