### PR TITLE
feat(cloud): add Azure worker readiness, stop and run-command host keys

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -19,9 +19,10 @@ mod transport;
 
 pub use credential::{AzureAccessToken, AzureCliCredential, AzureCredentialSource};
 pub use deployment::AzureDeploymentPlan;
-pub use provider::{AzureClient, AzureCreationFence};
+pub use provider::{AzureClient, AzureCreationFence, AzureHostKeySource, AzureRunCommandHostKeys, SSH_USERNAME};
 pub use transport::{
-    AzureArmHttp, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport, AzureVmView,
+    AzureArmHttp, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
+    AzureRunCommand, AzureVmView,
 };
 
 /// Public Azure Resource Manager endpoint; tokens are requested for this audience only.
@@ -251,6 +252,8 @@ pub enum AzureError {
     InvalidResponse { operation: &'static str },
     #[error("Azure returned an invalid or mismatched resource identity")]
     ResourceIdentityMismatch,
+    #[error("Azure operation {operation} did not reach a terminal state within the bound")]
+    OperationTimedOut { operation: &'static str },
     #[error("durable creation claim could not be read or recorded")]
     CreationFenceFailed,
     #[error("the worker's VM size or location no longer matches the profile")]

--- a/crates/horizon-core/src/cloud_run/azure/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider.rs
@@ -1,7 +1,6 @@
 //! The Azure provider behind the common interactive-worker contract: create once
-//! behind a durable fence, recover and inspect without creating, and delete exactly
-//! the owned resource group. SSH readiness (host-key attestation) and explicit Stop
-//! are the next slice.
+//! behind a durable fence, recover and inspect without creating, delete exactly the
+//! owned resource group; readiness attestation and Stop live in `running`.
 use super::{
     AzureDeploymentPlan, AzureError, AzureGroupInfo, AzureLifecycle, AzureManagementTransport, AzureProfile,
     AzureVmView, AzureWorker, WORKER_VM_NAME,
@@ -18,6 +17,11 @@ use crate::cloud_run::{
 };
 use std::collections::BTreeMap;
 
+mod running;
+pub use running::{AzureHostKeySource, AzureRunCommandHostKeys};
+
+/// The worker image accepts the client key for `root` only.
+pub const SSH_USERNAME: &str = "root";
 /// Durable, cross-controller compare-and-set whose claim survives process exit. A
 /// resource group name may return `true` at most once. The workflow store implements
 /// it where the production client is assembled.
@@ -54,6 +58,7 @@ pub struct AzureClient {
     profile: AzureProfile,
     transport: Box<dyn AzureManagementTransport>,
     fence: Box<dyn AzureCreationFence>,
+    host_keys: Box<dyn AzureHostKeySource>,
 }
 
 /// Whether an observation must also match the current profile's VM size and location.
@@ -82,6 +87,8 @@ struct Observation {
     lifecycle: AzureLifecycle,
     /// Neither a deployment nor a VM exists yet: the only state repair may act on.
     bare: bool,
+    host: Option<String>,
+    vm: Option<AzureVmView>,
 }
 
 impl AzureClient {
@@ -93,6 +100,7 @@ impl AzureClient {
         profile: AzureProfile,
         transport: impl AzureManagementTransport + 'static,
         fence: impl AzureCreationFence + 'static,
+        host_keys: impl AzureHostKeySource + 'static,
     ) -> Result<Self, AzureError> {
         profile.validate()?;
         // A transport for another subscription would create in the wrong place and then
@@ -104,6 +112,7 @@ impl AzureClient {
             profile,
             transport: Box::new(transport),
             fence: Box::new(fence),
+            host_keys: Box::new(host_keys),
         })
     }
 
@@ -179,6 +188,8 @@ impl AzureClient {
                     worker,
                     lifecycle: AzureLifecycle::Deleting,
                     bare: false,
+                    host: None,
+                    vm: None,
                 }));
         }
         // The group's region is immutable; a profile moved to another region under the
@@ -254,6 +265,8 @@ impl AzureClient {
             worker,
             lifecycle,
             bare,
+            host,
+            vm,
         }))
     }
 
@@ -271,14 +284,25 @@ impl AzureClient {
         })
     }
 
-    /// Common status for an observation. `Ready` requires a pinned host key, which the
-    /// readiness slice supplies; until then a running worker is reported `Provisioning`.
-    fn status(observation: Observation, target: &WorkerTarget, ssh_public_key: &str) -> InteractiveWorkerStatus {
+    fn status(
+        &self,
+        observation: Observation,
+        target: &WorkerTarget,
+        ssh_public_key: &str,
+        placement: Placement,
+    ) -> Result<InteractiveWorkerStatus, AzureError> {
         let worker = AzureWorker {
             image: target.image.clone(),
             ..observation.worker
         };
+        let ssh = match (observation.lifecycle, observation.host.as_deref()) {
+            (AzureLifecycle::Running, Some(host)) => {
+                self.attested_endpoint(&worker, host, target, ssh_public_key, placement)?
+            }
+            _ => None,
+        };
         let lifecycle = match observation.lifecycle {
+            AzureLifecycle::Running if ssh.is_some() => InteractiveWorkerLifecycle::Ready,
             AzureLifecycle::Running | AzureLifecycle::Transitioning => InteractiveWorkerLifecycle::Provisioning,
             AzureLifecycle::Deallocated => InteractiveWorkerLifecycle::Stopped,
             AzureLifecycle::Failed => InteractiveWorkerLifecycle::Failed,
@@ -286,7 +310,7 @@ impl AzureClient {
             // Guest halted but compute still billed: not a retained stop, not ready.
             AzureLifecycle::StoppedAllocated | AzureLifecycle::Unknown => InteractiveWorkerLifecycle::Unknown,
         };
-        InteractiveWorkerStatus {
+        Ok(InteractiveWorkerStatus {
             worker: InteractiveWorker {
                 identity: InteractiveWorkerIdentity {
                     provider: CloudProvider::Azure,
@@ -299,8 +323,8 @@ impl AzureClient {
                 lifetime: InteractiveWorkerLifetime::Persistent,
             },
             lifecycle,
-            ssh: None,
-        }
+            ssh,
+        })
     }
 
     /// Create the group behind the durable fence. ARM is consulted again right before
@@ -389,7 +413,12 @@ impl InteractiveWorkerProvider for AzureClient {
         let observation = self
             .observe(worker, &group, &expected, repair, Placement::Enforce)?
             .ok_or(AzureError::CreationUnresolved)?;
-        let status = Self::status(observation, &request.target, &request.ssh_public_key);
+        let status = self.status(
+            observation,
+            &request.target,
+            &request.ssh_public_key,
+            Placement::Enforce,
+        )?;
         Ok(if origin == Origin::Created {
             InteractiveWorkerEnsure::Created(status)
         } else {
@@ -408,7 +437,16 @@ impl InteractiveWorkerProvider for AzureClient {
         };
         let worker = self.worker_for(request.workflow_id, request.job_id, &group, &request.target.image);
         let observation = self.observe(worker, &group, &expected, None, Placement::Enforce)?;
-        Ok(observation.map(|observation| Self::status(observation, &request.target, &request.ssh_public_key)))
+        observation
+            .map(|observation| {
+                self.status(
+                    observation,
+                    &request.target,
+                    &request.ssh_public_key,
+                    Placement::Enforce,
+                )
+            })
+            .transpose()
     }
 
     fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
@@ -416,7 +454,9 @@ impl InteractiveWorkerProvider for AzureClient {
             return Ok(None);
         };
         let observation = self.observe(handle, &group, &expected, None, Placement::Ignore)?;
-        Ok(observation.map(|observation| Self::status(observation, &worker.target, &worker.ssh_public_key)))
+        observation
+            .map(|observation| self.status(observation, &worker.target, &worker.ssh_public_key, Placement::Ignore))
+            .transpose()
     }
 
     /// `Deleted` means ARM accepted (202) or completed the deletion of exactly the owned

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -1,0 +1,208 @@
+//! What the provider does with a running worker: attest its SSH host key through the
+//! control plane rather than trusting whatever answers on the network address, and stop
+//! it by deallocating the VM with retained disks.
+use super::super::{
+    AzureError, AzureLifecycle, AzureManagementTransport, AzureRunCommand, AzureWorker, WORKER_VM_NAME,
+    deployment::{SSH_PORT, identity_tags},
+    transport::remaining,
+};
+use super::{AzureClient, Placement, SSH_USERNAME, vm_lifecycle};
+use crate::cloud_run::{
+    WorkerTarget,
+    interactive_worker::{InteractiveWorker, InteractiveWorkerSshEndpoint, valid_ssh_public_key},
+    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+};
+use std::time::{Duration, Instant};
+
+/// Polling schedule for a deallocation to be observed after Azure accepted it;
+/// D-series deallocations commonly take one to three minutes.
+const STOP_BACKOFF_MS: [u64; 14] = [
+    0, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 30_000, 30_000, 30_000, 30_000, 30_000, 30_000, 30_000,
+];
+/// Absolute bound on that wait, sleeps and requests included.
+const STOP_BOUND: Duration = Duration::from_secs(300);
+
+/// Trusted source for the runtime SSH host key of one exact worker; `None` keeps a
+/// running worker in `Provisioning`. Implementations must obtain the key through a
+/// channel authenticated to the named VM resource (an unauthenticated network scan is
+/// not attestation). The client re-proves the group, VM, client-key tags and address
+/// once the key is back, so a source need not repeat those checks; `host` and the
+/// client key are passed for sources that can bind more tightly.
+pub trait AzureHostKeySource: Send + Sync {
+    /// The worker's OpenSSH Ed25519 host public key, or `None` when it is not yet
+    /// available for this exact worker.
+    #[must_use]
+    fn host_key(&self, worker: &AzureWorker, host: &str, expected_client_key: &str) -> Option<String>;
+}
+
+impl<F> AzureHostKeySource for F
+where
+    F: Fn(&AzureWorker, &str, &str) -> Option<String> + Send + Sync,
+{
+    fn host_key(&self, worker: &AzureWorker, host: &str, expected_client_key: &str) -> Option<String> {
+        self(worker, host, expected_client_key)
+    }
+}
+
+/// Host keys read through the ARM run-command channel: the control plane executes a
+/// fixed script inside the exact VM, so the returned key is bound to the authenticated
+/// resource rather than to whatever answers on the network address.
+pub struct AzureRunCommandHostKeys {
+    transport: std::sync::Arc<dyn AzureManagementTransport>,
+}
+
+impl AzureRunCommandHostKeys {
+    #[must_use]
+    pub fn new(transport: std::sync::Arc<dyn AzureManagementTransport>) -> Self {
+        Self { transport }
+    }
+}
+
+impl AzureHostKeySource for AzureRunCommandHostKeys {
+    fn host_key(&self, worker: &AzureWorker, _host: &str, _expected_client_key: &str) -> Option<String> {
+        // The command must run in the worker's own subscription; a transport bound
+        // elsewhere would read a same-named VM that is not this resource.
+        if self.transport.subscription_id() != worker.subscription_id {
+            return None;
+        }
+        let output = self
+            .transport
+            .run_command(&worker.resource_group, WORKER_VM_NAME, AzureRunCommand::HostKey)
+            .ok()
+            .flatten()?;
+        let mut lines = output.lines().filter(|line| !line.trim().is_empty());
+        let (line, extra) = (lines.next()?, lines.next());
+        let mut fields = line.split_ascii_whitespace();
+        let key = format!("{} {}", fields.next()?, fields.next()?);
+        (extra.is_none() && valid_ssh_public_key(&key)).then_some(key)
+    }
+}
+
+impl AzureClient {
+    /// The SSH endpoint, only with a host key attested for this exact worker. Reading
+    /// the key can take a while, so the key is paired with the address only if the
+    /// same owned group, VM and address are observed again once it is back; a group or
+    /// VM replaced under the same name is an identity error, anything else is simply
+    /// not attested yet.
+    pub(super) fn attested_endpoint(
+        &self,
+        worker: &AzureWorker,
+        host: &str,
+        target: &WorkerTarget,
+        ssh_public_key: &str,
+        placement: Placement,
+    ) -> Result<Option<InteractiveWorkerSshEndpoint>, AzureError> {
+        let Some(host_key) = self.host_keys.host_key(worker, host, ssh_public_key) else {
+            return Ok(None);
+        };
+        let expected = identity_tags(worker.workflow_id, worker.job_id, target, ssh_public_key);
+        let Some(group) = self.owned_group(&worker.resource_group, &expected)? else {
+            return Ok(None);
+        };
+        if !group.id.eq_ignore_ascii_case(&worker.group_id) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
+        let fresh = self.observe(worker.clone(), &group, &expected, None, placement)?;
+        let unchanged = fresh
+            .is_some_and(|fresh| fresh.lifecycle == AzureLifecycle::Running && fresh.host.as_deref() == Some(host));
+        Ok(unchanged
+            .then(|| InteractiveWorkerSshEndpoint {
+                host: host.to_string(),
+                port: SSH_PORT,
+                username: SSH_USERNAME.to_string(),
+                host_key,
+            })
+            .filter(InteractiveWorkerSshEndpoint::is_complete))
+    }
+}
+
+impl InteractiveWorkerStopProvider for AzureClient {
+    /// Deallocate the VM: compute is released and no longer billed, both disks and the
+    /// static address are retained. Verified by observing `PowerState/deallocated`
+    /// within the bound; a VM already deallocating is only awaited, never re-posted.
+    fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error> {
+        let Some((handle, group, expected)) = self.owned_handle(worker)? else {
+            return Ok(InteractiveWorkerStop::AlreadyAbsent);
+        };
+        // The group was just proven present; losing it mid-observation is a race in
+        // which no retained state was verified, not an absent worker.
+        let Some(current) = self.observe(handle, &group, &expected, None, Placement::Ignore)? else {
+            return Err(AzureError::StopUnverified);
+        };
+        let Some(vm) = current.vm.as_ref() else {
+            return Err(AzureError::StopUnverified);
+        };
+        if current.lifecycle == AzureLifecycle::Deleting {
+            return Err(AzureError::StopUnverified);
+        }
+        // Stoppability follows the VM itself: a running VM is billed whether or not its
+        // deployment or address is usable, and Stop is the cost-control action.
+        let deallocating = vm.power_state.as_deref() == Some("PowerState/deallocating");
+        match vm_lifecycle(vm) {
+            AzureLifecycle::Deallocated => return Ok(InteractiveWorkerStop::Stopped),
+            AzureLifecycle::Running | AzureLifecycle::StoppedAllocated => {}
+            AzureLifecycle::Transitioning if deallocating => {}
+            AzureLifecycle::Transitioning
+            | AzureLifecycle::Failed
+            | AzureLifecycle::Deleting
+            | AzureLifecycle::Unknown => return Err(AzureError::StopUnverified),
+        }
+        if !deallocating {
+            match self
+                .transport
+                .deallocate_vm(&current.worker.resource_group, WORKER_VM_NAME)
+            {
+                // Compute answers 409 while a deallocation is already in flight.
+                Ok(Some(_)) | Err(AzureError::UnexpectedStatus { status: 409, .. }) => {}
+                // Vanished between the observation and the POST: nothing was verified.
+                Ok(None) => return Err(AzureError::StopUnverified),
+                Err(error) => return Err(error),
+            }
+        }
+        let group = current.worker.resource_group.clone();
+        // An absolute deadline covers the sleeps, and each request is handed only what
+        // is left of it, so the wait cannot stretch past the bound on slow requests.
+        let deadline = Instant::now() + STOP_BOUND;
+        for delay_ms in STOP_BACKOFF_MS {
+            let Some(left) = remaining(deadline) else {
+                break;
+            };
+            if !cfg!(test) && delay_ms > 0 {
+                std::thread::sleep(Duration::from_millis(delay_ms).min(left));
+            }
+            // The wait spans minutes: every poll re-proves the group and the VM through
+            // the same identity checks, so a recreated or retagged worker at the same
+            // path is never reported as this one being stopped.
+            let Some(budget) = remaining(deadline) else {
+                break;
+            };
+            let Some(live) = self.transport.get_resource_group_within(&group, budget)? else {
+                break;
+            };
+            if expected.iter().any(|(key, value)| live.tags.get(key) != Some(value))
+                || !live.id.eq_ignore_ascii_case(&current.worker.group_id)
+            {
+                return Err(AzureError::ResourceIdentityMismatch);
+            }
+            // Disks and address are going away with the group: not a retained stop.
+            if live.provisioning_state == "Deleting" {
+                break;
+            }
+            let Some(budget) = remaining(deadline) else {
+                break;
+            };
+            let Some(vm) = self.transport.get_vm_within(&group, WORKER_VM_NAME, budget)? else {
+                break;
+            };
+            if expected.iter().any(|(key, value)| vm.tags.get(key) != Some(value)) {
+                return Err(AzureError::ResourceIdentityMismatch);
+            }
+            match vm_lifecycle(&vm) {
+                AzureLifecycle::Deallocated => return Ok(InteractiveWorkerStop::Stopped),
+                AzureLifecycle::Failed | AzureLifecycle::Deleting => break,
+                _ => {}
+            }
+        }
+        Err(AzureError::StopUnverified)
+    }
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -1,7 +1,7 @@
 pub(super) use super::super::{
     AzureClient, AzureDeploymentState, AzureError, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
-    AzureVmView,
-    deployment::{DEPLOYMENT_NAME, TAG_CLIENT_KEY_DIGEST, TAG_JOB, worker_tags},
+    AzureRunCommand, AzureVmView, AzureWorker, SSH_USERNAME,
+    deployment::{DEPLOYMENT_NAME, SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_JOB, worker_tags},
     resource_group_name,
 };
 pub(super) use super::{OTHER_SUB, SUB, ed25519_key, profile, target};
@@ -16,6 +16,7 @@ pub(super) use crate::cloud_run::{
 pub(super) use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 /// Every management call the provider makes, in order, with its arguments.
@@ -27,6 +28,14 @@ pub(super) enum Call {
     PutDeployment(String, String, serde_json::Value),
     GetDeployment(String),
     GetVm(String),
+    Deallocate(String),
+    Run(String, AzureRunCommand),
+}
+
+/// What a concurrent actor did to the group while the provider was waiting.
+pub(super) enum GroupChange {
+    Replaced(AzureGroupInfo),
+    Deleted,
 }
 
 #[derive(Default)]
@@ -43,6 +52,11 @@ pub(super) struct Plane {
     pub(super) deployment_on_second_read: Option<AzureDeploymentState>,
     pub(super) vanish_after_first_lookup: bool,
     pub(super) delete_status: Option<u16>,
+    pub(super) deallocate: Option<Result<Option<AzureLongRunningState>, AzureError>>,
+    pub(super) run_output: Option<String>,
+    /// Replaces the group once the deallocation was posted, as a concurrent retag or
+    /// deletion during the wait would.
+    pub(super) group_after_deallocate: Option<GroupChange>,
     pub(super) calls: Vec<Call>,
 }
 
@@ -169,6 +183,43 @@ impl AzureManagementTransport for Fake {
             plane.vm_states.first().cloned().flatten()
         })
     }
+
+    fn get_resource_group_within(&self, name: &str, budget: Duration) -> Result<Option<AzureGroupInfo>, AzureError> {
+        assert!(
+            !budget.is_zero() && budget <= Duration::from_secs(300),
+            "a poll carries what is left of the stop bound: {budget:?}"
+        );
+        self.get_resource_group(name)
+    }
+
+    fn get_vm_within(&self, group: &str, name: &str, budget: Duration) -> Result<Option<AzureVmView>, AzureError> {
+        assert!(
+            !budget.is_zero() && budget <= Duration::from_secs(300),
+            "a poll carries what is left of the stop bound: {budget:?}"
+        );
+        self.get_vm(group, name)
+    }
+
+    fn deallocate_vm(&self, group: &str, _name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::Deallocate(group.into()));
+        if let Some(change) = plane.group_after_deallocate.take() {
+            plane.group = match change {
+                GroupChange::Replaced(group) => Some(group),
+                GroupChange::Deleted => None,
+            };
+        }
+        plane
+            .deallocate
+            .clone()
+            .unwrap_or(Ok(Some(AzureLongRunningState::Accepted)))
+    }
+
+    fn run_command(&self, group: &str, _name: &str, command: AzureRunCommand) -> Result<Option<String>, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::Run(group.into(), command));
+        Ok(plane.run_output.clone())
+    }
 }
 
 pub(super) fn group_info(name: &str, tags: BTreeMap<String, String>, state: &str) -> AzureGroupInfo {
@@ -226,8 +277,9 @@ impl Scenario {
         }
     }
 
-    /// A client whose fence answers `claim` for exactly this request.
-    pub(super) fn client(&self, claim: bool) -> AzureClient {
+    /// A client whose fence answers `claim` and whose host-key source answers `host_key`
+    /// only when asked about this exact worker and client key.
+    pub(super) fn client(&self, claim: bool, host_key: Option<String>) -> AzureClient {
         let (expected, group) = (self.persisted(), self.group.clone());
         let fence = move |w: CloudWorkflowId, j: CloudJobId, t: &WorkerTarget, g: &str| {
             assert_eq!(
@@ -241,7 +293,15 @@ impl Scenario {
             );
             Ok(claim)
         };
-        AzureClient::with_transport(profile(), self.plane.clone(), fence).expect("client")
+        let (expected, group) = (self.persisted(), self.group.clone());
+        let keys = move |worker: &AzureWorker, _: &str, key: &str| {
+            assert_eq!(
+                (worker.resource_group.as_str(), key),
+                (group.as_str(), expected.ssh_public_key.as_str())
+            );
+            host_key.clone()
+        };
+        AzureClient::with_transport(profile(), self.plane.clone(), fence, keys).expect("client")
     }
 
     pub(super) fn persisted(&self) -> InteractiveWorker {
@@ -258,12 +318,16 @@ impl Scenario {
         }
     }
 
-    pub(super) fn reconcile(&self) -> InteractiveWorkerStatus {
-        self.client(false)
+    pub(super) fn reconcile(&self, host_key: Option<String>) -> InteractiveWorkerStatus {
+        self.client(false, host_key)
             .reconcile_worker(&self.request)
             .expect("reconcile")
             .expect("present")
     }
+}
+
+pub(super) fn host_key() -> String {
+    ed25519_key(9, "")
 }
 
 pub(super) fn owned(s: &Scenario) -> AzureGroupInfo {
@@ -274,3 +338,4 @@ pub(super) const MISMATCH: AzureError = AzureError::ResourceIdentityMismatch;
 
 mod creation;
 mod observation;
+mod running;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/creation.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/creation.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn ensure_creates_once_behind_the_fence_and_then_reuses() {
     let s = Scenario::new();
-    let created = s.client(true).ensure_worker(&s.request).expect("created");
+    let created = s.client(true, None).ensure_worker(&s.request).expect("created");
     let InteractiveWorkerEnsure::Created(status) = &created else {
         panic!("first ensure creates: {created:?}");
     };
@@ -44,7 +44,7 @@ fn ensure_creates_once_behind_the_fence_and_then_reuses() {
     assert_eq!(&calls[put + 1..], [lookup], "a final re-read follows the submission");
     assert_eq!(s.plane.mutations().len(), 2, "one creation, one submission");
     s.plane.lock().calls.clear();
-    let reused = s.client(false).ensure_worker(&s.request).expect("reused");
+    let reused = s.client(false, None).ensure_worker(&s.request).expect("reused");
     assert!(matches!(reused, InteractiveWorkerEnsure::Reused(_)));
     assert_eq!(
         reused.status().lifecycle,
@@ -59,7 +59,7 @@ fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
     // A claim lost to a crash before the group appeared: a second look at ARM, then unresolved.
     let s = Scenario::new();
     assert_eq!(
-        s.client(false).ensure_worker(&s.request),
+        s.client(false, None).ensure_worker(&s.request),
         Err(AzureError::CreationUnresolved)
     );
     assert_eq!(
@@ -68,7 +68,7 @@ fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
     );
     // A claim lost after the group appeared is adopted through the same tag proof.
     s.plane.script(Some(owned(&s)), None, vec![None]);
-    let adopted = s.client(true).ensure_worker(&s.request).expect("adopted");
+    let adopted = s.client(true, None).ensure_worker(&s.request).expect("adopted");
     assert!(matches!(adopted, InteractiveWorkerEnsure::Reused(_)));
     assert!(
         matches!(s.plane.mutations().as_slice(), [Call::PutDeployment(..)]),
@@ -79,7 +79,10 @@ fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
     raced.plane.lock().deployment = Some(deployment("Succeeded", "203.0.113.9"));
     raced.plane.lock().vm_states = vec![Some(vm("running", &raced.tags))];
     raced.plane.lock().appear_on_second_lookup = Some(owned(&raced));
-    let observed = raced.client(false).ensure_worker(&raced.request).expect("observed");
+    let observed = raced
+        .client(false, None)
+        .ensure_worker(&raced.request)
+        .expect("observed");
     assert!(matches!(observed, InteractiveWorkerEnsure::Reused(_)), "{observed:?}");
     assert_eq!(observed.status().lifecycle, Lifecycle::Provisioning);
     assert!(
@@ -91,7 +94,10 @@ fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
     granted.plane.lock().deployment = Some(deployment("Succeeded", "203.0.113.9"));
     granted.plane.lock().vm_states = vec![Some(vm("running", &granted.tags))];
     granted.plane.lock().appear_on_second_lookup = Some(owned(&granted));
-    let adopted = granted.client(true).ensure_worker(&granted.request).expect("adopted");
+    let adopted = granted
+        .client(true, None)
+        .ensure_worker(&granted.request)
+        .expect("adopted");
     assert!(matches!(adopted, InteractiveWorkerEnsure::Reused(_)), "{adopted:?}");
     assert!(
         granted.plane.mutations().is_empty(),
@@ -106,12 +112,15 @@ fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
         tags: other_tags,
         ..owned(&foreign)
     });
-    assert_eq!(foreign.client(true).ensure_worker(&foreign.request), Err(MISMATCH));
+    assert_eq!(
+        foreign.client(true, None).ensure_worker(&foreign.request),
+        Err(MISMATCH)
+    );
     assert!(foreign.plane.mutations().is_empty());
     // A throttled submission keeps the owned group; the next ensure repairs it.
     let t = Scenario::new();
     t.plane.lock().fail_deployment = true;
-    let error = t.client(true).ensure_worker(&t.request).expect_err("submission");
+    let error = t.client(true, None).ensure_worker(&t.request).expect_err("submission");
     assert!(
         matches!(&error, AzureError::CreationIncomplete { cause } if matches!(**cause, AzureError::UnexpectedStatus { status: 429, .. }))
     );
@@ -121,7 +130,7 @@ fn ensure_repairs_only_a_group_it_owns_and_never_one_being_deleted() {
     );
     t.plane.lock().fail_deployment = false;
     t.plane.lock().calls.clear();
-    let repaired = t.client(false).ensure_worker(&t.request).expect("repaired");
+    let repaired = t.client(false, None).ensure_worker(&t.request).expect("repaired");
     assert!(matches!(repaired, InteractiveWorkerEnsure::Reused(_)));
     assert!(matches!(t.plane.mutations().as_slice(), [Call::PutDeployment(..)]));
 }
@@ -135,7 +144,10 @@ fn ensure_never_deploys_into_a_group_that_changed_under_it() {
         provisioning_state: "Deleting".into(),
         ..owned(&racing)
     });
-    let observed = racing.client(false).ensure_worker(&racing.request).expect("observed");
+    let observed = racing
+        .client(false, None)
+        .ensure_worker(&racing.request)
+        .expect("observed");
     assert_eq!(observed.status().lifecycle, Lifecycle::Deleting);
     assert!(
         racing.plane.mutations().is_empty(),
@@ -148,7 +160,7 @@ fn ensure_never_deploys_into_a_group_that_changed_under_it() {
         tags: foreign_tags,
         ..owned(&racing)
     });
-    assert_eq!(racing.client(false).ensure_worker(&racing.request), Err(MISMATCH));
+    assert_eq!(racing.client(false, None).ensure_worker(&racing.request), Err(MISMATCH));
     assert!(
         racing.plane.mutations().is_empty(),
         "no submission into a retagged group"
@@ -158,7 +170,7 @@ fn ensure_never_deploys_into_a_group_that_changed_under_it() {
     appeared.plane.lock().group = Some(owned(&appeared));
     appeared.plane.lock().deployment_on_second_read = Some(deployment("Running", ""));
     let observed = appeared
-        .client(false)
+        .client(false, None)
         .ensure_worker(&appeared.request)
         .expect("observed");
     assert_eq!(observed.status().lifecycle, Lifecycle::Provisioning);
@@ -171,14 +183,20 @@ fn ensure_never_deploys_into_a_group_that_changed_under_it() {
         vec![Some(vm("running", &vanished.tags))],
     );
     vanished.plane.lock().vanish_after_first_lookup = true;
-    assert_eq!(vanished.client(false).reconcile_worker(&vanished.request), Ok(None));
-    vanished.plane.script(Some(owned(&vanished)), None, vec![None]);
-    vanished.plane.lock().vanish_after_first_lookup = true;
-    assert_eq!(vanished.client(false).inspect_worker(&vanished.persisted()), Ok(None));
+    assert_eq!(
+        vanished.client(false, None).reconcile_worker(&vanished.request),
+        Ok(None)
+    );
     vanished.plane.script(Some(owned(&vanished)), None, vec![None]);
     vanished.plane.lock().vanish_after_first_lookup = true;
     assert_eq!(
-        vanished.client(false).ensure_worker(&vanished.request),
+        vanished.client(false, None).inspect_worker(&vanished.persisted()),
+        Ok(None)
+    );
+    vanished.plane.script(Some(owned(&vanished)), None, vec![None]);
+    vanished.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(
+        vanished.client(false, None).ensure_worker(&vanished.request),
         Err(AzureError::CreationUnresolved),
         "a lost worker during ensure is not an absence"
     );
@@ -190,7 +208,7 @@ fn ensure_never_deploys_into_a_group_that_changed_under_it() {
     foreign_vm.tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
     vm_appeared.plane.lock().vm_states = vec![None, Some(foreign_vm)];
     assert_eq!(
-        vm_appeared.client(false).ensure_worker(&vm_appeared.request),
+        vm_appeared.client(false, None).ensure_worker(&vm_appeared.request),
         Err(MISMATCH)
     );
     assert!(
@@ -208,7 +226,7 @@ fn ensure_never_deploys_into_a_group_that_changed_under_it() {
         provisioning_state: "Deleting".into(),
         ..owned(&failed_then_deleting)
     });
-    assert_eq!(failed_then_deleting.reconcile().lifecycle, Lifecycle::Deleting);
+    assert_eq!(failed_then_deleting.reconcile(None).lifecycle, Lifecycle::Deleting);
 }
 
 #[test]
@@ -222,7 +240,7 @@ fn ensure_never_deploys_into_a_group_changed_right_after_creation() {
     retagged.plane.script(Some(deleting), None, vec![None]);
     retagged.plane.lock().group_after_first_lookup = Some(foreign);
     assert_eq!(
-        retagged.client(false).reconcile_worker(&retagged.request),
+        retagged.client(false, None).reconcile_worker(&retagged.request),
         Err(MISMATCH)
     );
     // A group retagged or deleting right after creation is never deployed into either.
@@ -233,7 +251,7 @@ fn ensure_never_deploys_into_a_group_changed_right_after_creation() {
         tags: other_tags,
         ..owned(&stolen)
     });
-    assert_eq!(stolen.client(true).ensure_worker(&stolen.request), Err(MISMATCH));
+    assert_eq!(stolen.client(true, None).ensure_worker(&stolen.request), Err(MISMATCH));
     assert!(
         !stolen
             .plane
@@ -245,14 +263,17 @@ fn ensure_never_deploys_into_a_group_changed_right_after_creation() {
     let sync_failed = Scenario::new();
     sync_failed.plane.lock().submitted_state = Some("Failed");
     let failed = sync_failed
-        .client(true)
+        .client(true, None)
         .ensure_worker(&sync_failed.request)
         .expect("created");
     assert!(matches!(failed, InteractiveWorkerEnsure::Created(_)));
     assert_eq!(failed.status().lifecycle, Lifecycle::Failed);
     let sync_ok = Scenario::new();
     sync_ok.plane.lock().submitted_state = Some("Succeeded");
-    let created = sync_ok.client(true).ensure_worker(&sync_ok.request).expect("created");
+    let created = sync_ok
+        .client(true, None)
+        .ensure_worker(&sync_ok.request)
+        .expect("created");
     assert_eq!(
         created.status().lifecycle,
         Lifecycle::Provisioning,
@@ -262,7 +283,7 @@ fn ensure_never_deploys_into_a_group_changed_right_after_creation() {
     let t = sync_failed;
     t.plane
         .script(Some(group_info(&t.group, t.tags.clone(), "Deleting")), None, vec![None]);
-    let deleting = t.client(false).ensure_worker(&t.request).expect("observed");
+    let deleting = t.client(false, None).ensure_worker(&t.request).expect("observed");
     assert_eq!(deleting.status().lifecycle, Lifecycle::Deleting);
     assert!(t.plane.mutations().is_empty());
 }

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/observation.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/observation.rs
@@ -44,11 +44,11 @@ fn recovery_maps_every_observed_state_without_creating() {
     ];
     for (deployment, vm_state, lifecycle, label) in cases {
         s.plane.script(Some(owned(&s)), deployment, vec![vm_state]);
-        assert_eq!(s.reconcile().lifecycle, lifecycle, "{label}");
+        assert_eq!(s.reconcile(Some(host_key())).lifecycle, lifecycle, "{label}");
         assert!(s.plane.mutations().is_empty(), "{label}");
     }
     s.plane.script(None, None, vec![None]);
-    assert_eq!(s.client(false).reconcile_worker(&s.request), Ok(None));
+    assert_eq!(s.client(false, None).reconcile_worker(&s.request), Ok(None));
 }
 #[test]
 fn recovery_treats_unusable_addresses_as_unknown() {
@@ -69,7 +69,7 @@ fn recovery_treats_unusable_addresses_as_unknown() {
             Some(deployment("Succeeded", address)),
             vec![Some(vm("running", &s.tags))],
         );
-        assert_eq!(s.reconcile().lifecycle, Lifecycle::Unknown, "{address}");
+        assert_eq!(s.reconcile(None).lifecycle, Lifecycle::Unknown, "{address}");
         assert!(s.plane.mutations().is_empty(), "{address}");
     }
 }
@@ -81,7 +81,7 @@ fn foreign_or_tampered_resources_are_rejected_before_any_mutation() {
     other_client.insert(TAG_CLIENT_KEY_DIGEST.into(), "0".repeat(64));
     s.plane
         .script(Some(group_info(&s.group, other_client, "Succeeded")), None, vec![None]);
-    let client = s.client(true);
+    let client = s.client(true, None);
     let worker = s.persisted();
     assert_eq!(client.ensure_worker(&s.request), Err(MISMATCH));
     assert_eq!(client.reconcile_worker(&s.request), Err(MISMATCH));
@@ -126,14 +126,20 @@ fn foreign_or_tampered_resources_are_rejected_before_any_mutation() {
 #[test]
 fn placement_and_subscription_policy_apply_to_request_paths_only() {
     let s = Scenario::new();
-    let client = s.client(false);
+    let client = s.client(false, None);
     let worker = s.persisted();
     let mut other_subscription = profile();
     other_subscription.subscription_id = OTHER_SUB.into();
     other_subscription.image_pull_identity_id = profile().image_pull_identity_id.replace(SUB, OTHER_SUB);
     let never = |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| Ok(false);
     assert!(
-        AzureClient::with_transport(other_subscription, s.plane.clone(), never).is_err(),
+        AzureClient::with_transport(
+            other_subscription,
+            s.plane.clone(),
+            never,
+            |_: &AzureWorker, _: &str, _: &str| None
+        )
+        .is_err(),
         "transport bound to the profile's subscription"
     );
     let mut relocated = owned(&s);
@@ -188,8 +194,9 @@ fn placement_and_subscription_policy_apply_to_request_paths_only() {
     renamed.target.profile = "cpu-north-b".into();
     let mut other_profile = profile();
     other_profile.name = "cpu-north-b".into();
+    let no_keys = |_: &AzureWorker, _: &str, _: &str| None;
     let never = |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| Ok(false);
-    let other = AzureClient::with_transport(other_profile, s.plane.clone(), never).expect("client");
+    let other = AzureClient::with_transport(other_profile, s.plane.clone(), never, no_keys).expect("client");
     assert_eq!(
         other.inspect_worker(&renamed),
         Err(MISMATCH),
@@ -202,7 +209,7 @@ fn placement_and_subscription_policy_apply_to_request_paths_only() {
 fn inspect_and_delete_act_only_on_the_exact_owned_group() {
     let s = Scenario::new();
     let worker = s.persisted();
-    let client = s.client(false);
+    let client = s.client(false, None);
     assert_eq!(client.inspect_worker(&worker), Ok(None));
     assert_eq!(
         client.delete_worker(&worker),

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/running.rs
@@ -1,0 +1,347 @@
+use super::*;
+use crate::cloud_run::interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider};
+
+#[test]
+fn ready_requires_a_running_vm_a_usable_address_and_a_pinned_host_key() {
+    let s = Scenario::new();
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![Some(vm("running", &s.tags))],
+    );
+    let pending = s.reconcile(None);
+    assert_eq!(
+        (pending.lifecycle, pending.ssh.is_some()),
+        (Lifecycle::Provisioning, false)
+    );
+    let ready = s.reconcile(Some(host_key()));
+    assert_eq!(ready.lifecycle, Lifecycle::Ready);
+    let ssh = ready.ssh.as_ref().expect("endpoint");
+    assert_eq!(
+        (ssh.host.as_str(), ssh.port, ssh.username.as_str()),
+        ("203.0.113.9", SSH_PORT, SSH_USERNAME)
+    );
+    assert_eq!(ssh.host_key, host_key());
+    let now = time::OffsetDateTime::now_utc();
+    assert!(ready.is_ready_for(&s.request, now));
+    let mut other = s.request.clone();
+    other.ssh_public_key = ed25519_key(8, "");
+    assert!(
+        !ready.is_ready_for(&other, now),
+        "another client key is never attachable"
+    );
+    assert_eq!(
+        s.reconcile(Some("ssh-rsa AAAA".into())).lifecycle,
+        Lifecycle::Provisioning,
+        "non-Ed25519 host key"
+    );
+    let ensured = s
+        .client(false, Some(host_key()))
+        .ensure_worker(&s.request)
+        .expect("ensure");
+    assert!(matches!(ensured, InteractiveWorkerEnsure::Reused(_)));
+    assert_eq!(ensured.status().lifecycle, Lifecycle::Ready);
+    assert!(
+        s.plane.mutations().is_empty(),
+        "recovery and reuse never create: {:?}",
+        s.plane.calls()
+    );
+    // The key is paired with the address only if the same worker is still there once
+    // the (slow) key read returns.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![Some(vm("running", &s.tags))],
+    );
+    s.plane.lock().deployment_on_second_read = Some(deployment("Succeeded", "203.0.113.10"));
+    let moved = s.reconcile(Some(host_key()));
+    assert_eq!(
+        (moved.lifecycle, moved.ssh.is_some()),
+        (Lifecycle::Provisioning, false),
+        "address changed while the key was read"
+    );
+    let mut foreign = vm("running", &s.tags);
+    foreign.tags.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![Some(vm("running", &s.tags)), Some(foreign)],
+    );
+    assert_eq!(
+        s.client(false, Some(host_key())).reconcile_worker(&s.request),
+        Err(MISMATCH),
+        "VM replaced while the key was read"
+    );
+}
+
+#[test]
+fn stop_deallocates_once_and_verifies_the_retained_inactive_state() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, None);
+    assert_eq!(client.stop_worker(&worker), Ok(InteractiveWorkerStop::AlreadyAbsent));
+    let running = || Some(vm("running", &s.tags));
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![
+            running(),
+            Some(vm("deallocating", &s.tags)),
+            Some(vm("deallocated", &s.tags)),
+        ],
+    );
+    assert_eq!(client.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    assert_eq!(s.plane.mutations(), [Call::Deallocate(s.group.clone())]);
+    assert_eq!(
+        s.plane
+            .calls()
+            .iter()
+            .filter(|call| matches!(call, Call::GetVm(_)))
+            .count(),
+        3
+    );
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("deallocated", &s.tags))]);
+    assert_eq!(
+        client.stop_worker(&worker),
+        Ok(InteractiveWorkerStop::Stopped),
+        "idempotent on a deallocated VM"
+    );
+    assert!(s.plane.mutations().is_empty());
+    s.plane.script(
+        Some(owned(&s)),
+        None,
+        vec![Some(vm("deallocating", &s.tags)), Some(vm("deallocated", &s.tags))],
+    );
+    assert_eq!(
+        client.stop_worker(&worker),
+        Ok(InteractiveWorkerStop::Stopped),
+        "a retry only awaits an in-flight deallocation"
+    );
+    assert!(s.plane.mutations().is_empty(), "no second deallocate");
+    s.plane.script(
+        Some(owned(&s)),
+        None,
+        vec![Some(vm("stopped", &s.tags)), Some(vm("deallocated", &s.tags))],
+    );
+    assert_eq!(
+        client.stop_worker(&worker),
+        Ok(InteractiveWorkerStop::Stopped),
+        "a billed guest halt is deallocated"
+    );
+    assert_eq!(s.plane.mutations(), [Call::Deallocate(s.group.clone())]);
+    s.plane
+        .script(Some(owned(&s)), None, vec![running(), Some(vm("deallocated", &s.tags))]);
+    s.plane.lock().deallocate = Some(Ok(Some(AzureLongRunningState::Completed)));
+    assert_eq!(
+        client.stop_worker(&worker),
+        Ok(InteractiveWorkerStop::Stopped),
+        "synchronous completion"
+    );
+    // Stoppability follows the VM, not the endpoint: a running VM behind an unusable
+    // address or a failed deployment is still billed.
+    for (deployment, label) in [
+        (deployment("Succeeded", "10.0.0.5"), "unusable address"),
+        (deployment("Failed", ""), "failed deployment"),
+    ] {
+        s.plane.script(
+            Some(owned(&s)),
+            Some(deployment),
+            vec![running(), Some(vm("deallocated", &s.tags))],
+        );
+        s.plane.lock().deallocate = None;
+        assert_eq!(
+            client.stop_worker(&worker),
+            Ok(InteractiveWorkerStop::Stopped),
+            "{label}"
+        );
+        assert_eq!(s.plane.mutations(), [Call::Deallocate(s.group.clone())], "{label}");
+    }
+}
+
+#[test]
+fn stop_never_deletes_and_reports_unverified_states_honestly() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, None);
+    let conflict = |status| {
+        Some(Err(AzureError::UnexpectedStatus {
+            operation: "virtual machine deallocation",
+            status,
+        }))
+    };
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("running", &s.tags))]);
+    s.plane.lock().deallocate = conflict(409);
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(AzureError::StopUnverified),
+        "409 is awaited, then unverified within the bound"
+    );
+    s.plane.lock().deallocate = conflict(403);
+    assert!(matches!(
+        client.stop_worker(&worker),
+        Err(AzureError::UnexpectedStatus { status: 403, .. })
+    ));
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("running", &s.tags))]);
+    s.plane.lock().deallocate = Some(Ok(None));
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(AzureError::StopUnverified),
+        "a VM that vanished before the POST was never verified"
+    );
+    s.plane.lock().deallocate = None;
+    for (states, label) in [
+        (vec![Some(vm("running", &s.tags))], "never deallocated within the bound"),
+        (vec![None], "no VM to stop"),
+        (vec![Some(vm("running", &s.tags)), None], "VM vanished while stopping"),
+        (vec![Some(vm("starting", &s.tags))], "starting is not stoppable"),
+    ] {
+        s.plane.script(Some(owned(&s)), None, states);
+        assert_eq!(client.stop_worker(&worker), Err(AzureError::StopUnverified), "{label}");
+        assert!(
+            !s.plane.calls().iter().any(|call| matches!(call, Call::DeleteGroup(_))),
+            "{label}"
+        );
+    }
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(vm("running", &s.tags))]);
+    s.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(AzureError::StopUnverified),
+        "a group that vanishes right after its proof is a race, not an absence"
+    );
+    assert!(s.plane.mutations().is_empty());
+    let mut failed = vm("running", &s.tags);
+    failed.provisioning_state = "Failed".into();
+    s.plane.script(Some(owned(&s)), None, vec![Some(failed)]);
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(AzureError::StopUnverified),
+        "failed VM"
+    );
+    assert!(s.plane.mutations().is_empty(), "no deallocate on a failed VM");
+    let mut foreign = worker.clone();
+    foreign.identity.resource_id = format!("{}-other", worker.identity.resource_id);
+    assert_eq!(client.stop_worker(&foreign), Err(AzureError::InvalidPersistedWorker));
+    let mut other_tags = s.tags.clone();
+    other_tags.insert("horizon-job-id".into(), "other".into());
+    s.plane
+        .script(Some(group_info(&s.group, other_tags, "Succeeded")), None, vec![None]);
+    assert_eq!(client.stop_worker(&worker), Err(MISMATCH));
+    assert!(s.plane.mutations().is_empty());
+}
+
+#[test]
+fn stop_reproves_ownership_on_every_poll_of_the_wait() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, None);
+    let mut retagged = s.tags.clone();
+    retagged.insert("horizon-job-id".into(), "other".into());
+    let mut foreign_vm = vm("deallocated", &s.tags);
+    foreign_vm.tags = retagged.clone();
+    s.plane.script(
+        Some(owned(&s)),
+        None,
+        vec![Some(vm("running", &s.tags)), Some(foreign_vm)],
+    );
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(MISMATCH),
+        "a retagged VM at the same path is not this worker stopping"
+    );
+    s.plane.script(
+        Some(owned(&s)),
+        None,
+        vec![Some(vm("running", &s.tags)), Some(vm("deallocated", &s.tags))],
+    );
+    s.plane.lock().group_after_deallocate = Some(GroupChange::Replaced(group_info(&s.group, retagged, "Succeeded")));
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(MISMATCH),
+        "group retagged during the wait"
+    );
+    s.plane.script(
+        Some(owned(&s)),
+        None,
+        vec![Some(vm("running", &s.tags)), Some(vm("deallocated", &s.tags))],
+    );
+    s.plane.lock().group_after_deallocate = Some(GroupChange::Deleted);
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(AzureError::StopUnverified),
+        "group deleted during the wait"
+    );
+    s.plane.script(
+        Some(owned(&s)),
+        None,
+        vec![Some(vm("running", &s.tags)), Some(vm("deallocated", &s.tags))],
+    );
+    s.plane.lock().group_after_deallocate =
+        Some(GroupChange::Replaced(group_info(&s.group, s.tags.clone(), "Deleting")));
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(AzureError::StopUnverified),
+        "a deallocated VM inside a group being deleted is not retained"
+    );
+}
+
+#[test]
+fn run_command_host_keys_accept_only_one_ed25519_key_read_from_the_exact_vm() {
+    use crate::cloud_run::azure::tests::IMAGE;
+    use crate::cloud_run::azure::{AzureHostKeySource, AzureRunCommandHostKeys};
+    let s = Scenario::new();
+    let source = AzureRunCommandHostKeys::new(std::sync::Arc::new(s.plane.clone()));
+    let worker = AzureWorker {
+        workflow_id: CloudWorkflowId::new(),
+        job_id: CloudJobId::new(),
+        subscription_id: SUB.into(),
+        resource_group: s.group.clone(),
+        group_id: s.group_id.clone(),
+        image: IMAGE.into(),
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    };
+    let key = ed25519_key(3, "");
+    let client_key = s.request.ssh_public_key.clone();
+    let read = |output: Option<&str>| {
+        s.plane.lock().run_output = output.map(str::to_string);
+        s.plane.lock().calls.clear();
+        source.host_key(&worker, "203.0.113.9", &client_key)
+    };
+    assert_eq!(read(Some(&key)), Some(key.clone()));
+    assert_eq!(
+        read(Some(&format!("{key} root@worker\n"))),
+        Some(key.clone()),
+        "the comment is dropped"
+    );
+    assert_eq!(
+        s.plane.calls(),
+        [Call::Run(s.group.clone(), AzureRunCommand::HostKey)],
+        "a fixed script against the exact group"
+    );
+    assert_eq!(read(None), None, "absent VM");
+    assert_eq!(read(Some("")), None, "no key yet");
+    assert_eq!(
+        read(Some(&format!("{key}\n{}", ed25519_key(4, "")))),
+        None,
+        "two keys are ambiguous"
+    );
+    assert_eq!(read(Some("ssh-rsa AAAAB3 host")), None, "wrong algorithm");
+    assert_eq!(read(Some("cat: no such file")), None, "an error message is not a key");
+    assert_eq!(read(Some("ssh-ed25519 not-base64")), None);
+    let elsewhere = AzureWorker {
+        subscription_id: OTHER_SUB.into(),
+        ..worker.clone()
+    };
+    s.plane.lock().run_output = Some(key.clone());
+    s.plane.lock().calls.clear();
+    assert_eq!(
+        source.host_key(&elsewhere, "203.0.113.9", &client_key),
+        None,
+        "never run in another subscription"
+    );
+    assert!(s.plane.calls().is_empty());
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -1,7 +1,8 @@
 use super::super::{
     AzureAccessToken, AzureArmHttp, AzureCliCredential, AzureDeploymentState, AzureError, AzureLongRunningState,
-    AzureManagementTransport, REQUEST_TIMEOUT, valid_vm_resource_id,
+    AzureManagementTransport, AzureRunCommand, REQUEST_TIMEOUT, valid_vm_resource_id,
 };
+use super::OTHER_SUB as FOREIGN_SUB;
 use super::{GROUP, OTHER_SUB, SUB};
 use std::{
     collections::BTreeMap,
@@ -24,6 +25,7 @@ struct Expectation {
     status: u16,
     body: String,
     request_body: Option<serde_json::Value>,
+    header: Option<(&'static str, String)>,
 }
 
 fn expect(
@@ -39,7 +41,13 @@ fn expect(
         status,
         body: body.to_string(),
         request_body,
+        header: None,
     }
+}
+
+fn with_header(mut expectation: Expectation, name: &'static str, value: String) -> Expectation {
+    expectation.header = Some((name, value));
+    expectation
 }
 
 fn http(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<AtomicUsize>) {
@@ -66,10 +74,11 @@ fn http(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<AtomicUsize>) {
                 ),
                 None => assert!(payload.is_empty(), "unexpected body on call {index}"),
             }
-            Ok(Response::builder()
-                .status(expectation.status)
-                .body(Body::builder().data(expectation.body))
-                .expect("response"))
+            let mut response = Response::builder().status(expectation.status);
+            if let Some((name, value)) = expectation.header {
+                response = response.header(name, value);
+            }
+            Ok(response.body(Body::builder().data(expectation.body)).expect("response"))
         })
         .build()
         .new_agent();
@@ -523,4 +532,296 @@ fn credential_failures_stop_before_any_request_and_production_agent_is_pinned() 
     assert_eq!(production.config().max_redirects(), 0);
     assert_eq!(production.config().timeouts().global, Some(REQUEST_TIMEOUT));
     assert!(!production.config().http_status_as_error());
+}
+
+fn run_command_body() -> serde_json::Value {
+    serde_json::json!({"commandId": "RunShellScript", "script": [AzureRunCommand::HostKey.script()]})
+}
+
+fn operation_url() -> String {
+    format!(
+        "https://management.azure.com/subscriptions/{SUB}/providers/Microsoft.Compute/locations/northeurope/operations/op-1?api-version=2024-03-01"
+    )
+}
+
+#[test]
+fn deallocate_uses_the_exact_path_and_maps_long_running_states() {
+    let (transport, _) = http(vec![
+        expect("POST", vm_url("/deallocate"), 202, "", None),
+        expect("POST", vm_url("/deallocate"), 200, "", None),
+        expect("POST", vm_url("/deallocate"), 409, "private-conflict", None),
+        expect("POST", vm_url("/deallocate"), 404, "", None),
+    ]);
+    assert_eq!(
+        transport.deallocate_vm(GROUP, "worker"),
+        Ok(Some(AzureLongRunningState::Accepted))
+    );
+    assert_eq!(
+        transport.deallocate_vm(GROUP, "worker"),
+        Ok(Some(AzureLongRunningState::Completed))
+    );
+    let conflict = transport.deallocate_vm(GROUP, "worker");
+    assert_eq!(
+        conflict,
+        Err(AzureError::UnexpectedStatus {
+            operation: "virtual machine deallocation",
+            status: 409
+        })
+    );
+    assert!(!format!("{conflict:?}").contains("private-"));
+    assert_eq!(transport.deallocate_vm(GROUP, "worker"), Ok(None), "absent VM");
+    for (group, name) in [("bad/group", "worker"), (GROUP, ""), (GROUP, "name with space")] {
+        assert_eq!(
+            transport.deallocate_vm(group, name),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            transport.run_command(group, name, AzureRunCommand::HostKey),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+    }
+}
+
+#[test]
+fn run_command_polls_only_owned_operations_and_extracts_stdout() {
+    let operation = operation_url();
+    let done = r#"{"status":"Succeeded","properties":{"output":{"value":[{"code":"ProvisioningState/succeeded","message":"Enable succeeded: \n[stdout]\nssh-ed25519 AAAAC3 host\n\n[stderr]\n"}]}}}"#;
+    let (transport, _) = http(vec![
+        with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "azure-asyncoperation",
+            operation.clone(),
+        ),
+        expect("GET", operation.clone(), 200, r#"{"status":"InProgress"}"#, None),
+        with_header(
+            expect("GET", operation.clone(), 429, "throttled", None),
+            "retry-after",
+            "2".into(),
+        ),
+        expect("GET", operation.clone(), 200, done, None),
+        expect(
+            "POST",
+            vm_url("/runCommand"),
+            200,
+            r#"{"value":[{"code":"ProvisioningState/succeeded","message":"[stdout]\nsync output\n[stderr]\n"}]}"#,
+            Some(run_command_body()),
+        ),
+        expect("POST", vm_url("/runCommand"), 404, "", Some(run_command_body())),
+        with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "azure-asyncoperation",
+            format!("https://management.azure.com/subscriptions/{FOREIGN_SUB}/operations/op-2"),
+        ),
+        with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "location",
+            operation.clone(),
+        ),
+        with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "azure-asyncoperation",
+            operation.clone(),
+        ),
+        expect(
+            "GET",
+            operation,
+            200,
+            r#"{"status":"Failed","error":{"message":"private-detail"}}"#,
+            None,
+        ),
+    ]);
+    let run = || transport.run_command(GROUP, "worker", AzureRunCommand::HostKey);
+    assert_eq!(
+        run(),
+        Ok(Some("ssh-ed25519 AAAAC3 host".into())),
+        "a throttled poll with Retry-After is waited out, not failed"
+    );
+    assert_eq!(run(), Ok(Some("sync output".into())));
+    assert_eq!(run(), Ok(None), "absent VM");
+    let foreign = run();
+    assert_eq!(
+        foreign,
+        Err(AzureError::InvalidResponse {
+            operation: "virtual machine run command"
+        }),
+        "a poll URL outside this subscription is never followed"
+    );
+    assert_eq!(
+        run(),
+        Err(AzureError::InvalidResponse {
+            operation: "virtual machine run command"
+        }),
+        "a Location-only answer uses a different protocol and is refused"
+    );
+    let failed = run();
+    assert_eq!(
+        failed,
+        Err(AzureError::RequestFailed {
+            operation: "virtual machine run command"
+        })
+    );
+    assert!(!format!("{failed:?}").contains("private-"));
+}
+
+#[test]
+fn run_command_refuses_operation_urls_that_could_escape_the_subscription() {
+    let escapes = [
+        format!("https://management.azure.com/subscriptions/{SUB}/../../subscriptions/{FOREIGN_SUB}/operations/op"),
+        format!("https://management.azure.com/subscriptions/{SUB}/%2e%2e/{FOREIGN_SUB}/operations/op"),
+        format!("https://management.azure.com/subscriptions/{SUB}/operations\\..\\{FOREIGN_SUB}/op"),
+        format!("https://management.azure.com/subscriptions/{SUB}//operations/op"),
+        format!(
+            "https://management.azure.com/subscriptions/{SUB}/operations/op?api-version=2024-03-01&x=/../{FOREIGN_SUB}"
+        ),
+        format!("https://management.azure.com/subscriptions/{SUB}/operations/op#frag"),
+        format!("https://management.azure.com/subscriptions/{SUB}/operations/op@evil.example/x"),
+        format!("HTTPS://management.azure.com/subscriptions/{SUB}/operations/op"),
+    ];
+    let (transport, calls) = http(
+        escapes
+            .iter()
+            .map(|poll| {
+                with_header(
+                    expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+                    "azure-asyncoperation",
+                    poll.clone(),
+                )
+            })
+            .collect(),
+    );
+    for poll in &escapes {
+        assert_eq!(
+            transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+            Err(AzureError::InvalidResponse {
+                operation: "virtual machine run command"
+            }),
+            "{poll}"
+        );
+    }
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        escapes.len(),
+        "no escape candidate was ever polled"
+    );
+}
+
+#[test]
+fn run_command_output_is_taken_only_from_a_clean_success() {
+    let cases: [(&str, Result<Option<String>, AzureError>); 8] = [
+        (
+            r#"{"value":[{"code":"ProvisioningState/succeeded","message":"Enable succeeded: \n[stdout]\nssh-ed25519 AAAAC3 host"}]}"#,
+            Err(AzureError::InvalidResponse {
+                operation: "virtual machine run command",
+            }),
+        ),
+        (
+            r#"{"value":[{"code":"ComponentStatus/StdOut/succeeded","message":"ssh-ed25519 AAAAC3 host\n"},{"code":"ComponentStatus/StdErr/succeeded","message":""}]}"#,
+            Ok(Some("ssh-ed25519 AAAAC3 host".into())),
+        ),
+        (
+            r#"{"value":[{"code":"ProvisioningState/succeeded","message":"[stdout]\nok\n[stderr]\ncat: no such file"}]}"#,
+            Err(AzureError::RequestFailed {
+                operation: "virtual machine run command",
+            }),
+        ),
+        (
+            r#"{"value":[{"code":"ComponentStatus/StdOut/succeeded","message":"ok"},{"code":"ComponentStatus/StdErr/succeeded","message":"warning"}]}"#,
+            Err(AzureError::RequestFailed {
+                operation: "virtual machine run command",
+            }),
+        ),
+        (
+            r#"{"value":[{"code":"ComponentStatus/StdOut/succeeded","message":"ok"},{"code":"ProvisioningState/failed","message":"boom"}]}"#,
+            Err(AzureError::RequestFailed {
+                operation: "virtual machine run command",
+            }),
+        ),
+        (
+            r#"{"value":[{"code":"ProvisioningState/succeeded","message":"[stdout]\none\n[stderr]\n"},{"code":"ComponentStatus/StdOut/succeeded","message":"two"}]}"#,
+            Err(AzureError::InvalidResponse {
+                operation: "virtual machine run command",
+            }),
+        ),
+        (
+            r#"{"value":[{"code":"ComponentStatus/StdErr/succeeded","message":""}]}"#,
+            Err(AzureError::InvalidResponse {
+                operation: "virtual machine run command",
+            }),
+        ),
+        (
+            r#"{"value":[{"code":"Something/Else/succeeded","message":"ok"}]}"#,
+            Err(AzureError::InvalidResponse {
+                operation: "virtual machine run command",
+            }),
+        ),
+    ];
+    let (transport, _) = http(
+        cases
+            .iter()
+            .map(|(body, _)| expect("POST", vm_url("/runCommand"), 200, body, Some(run_command_body())))
+            .collect(),
+    );
+    for (body, expected) in &cases {
+        assert_eq!(
+            &transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+            expected,
+            "{body}"
+        );
+    }
+}
+
+#[test]
+fn a_slow_credential_refresh_consumes_the_poll_budget_before_any_request() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&calls);
+    let agent = ureq::Agent::config_builder()
+        .middleware(move |_: Request<SendBody>, _: MiddlewareNext| {
+            count.fetch_add(1, Ordering::SeqCst);
+            panic!("no request may be issued once the budget is spent");
+        })
+        .build()
+        .new_agent();
+    let slow = || {
+        std::thread::sleep(Duration::from_millis(30));
+        AzureAccessToken::new("synthetic-token-value", Duration::from_secs(3_600))
+    };
+    let transport = AzureArmHttp::with_agent(agent, SUB, slow).expect("transport");
+    assert_eq!(
+        transport.get_vm_within(GROUP, "worker", Duration::from_millis(10)),
+        Err(AzureError::OperationTimedOut {
+            operation: "virtual machine lookup"
+        })
+    );
+    assert_eq!(
+        transport.get_resource_group_within(GROUP, Duration::from_millis(10)),
+        Err(AzureError::OperationTimedOut {
+            operation: "resource group lookup"
+        })
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn run_command_polling_is_bounded() {
+    let operation = operation_url();
+    let (transport, calls) = http(
+        std::iter::once(with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "azure-asyncoperation",
+            operation.clone(),
+        ))
+        .chain((0..9).map(|_| expect("GET", operation.clone(), 200, r#"{"status":"InProgress"}"#, None)))
+        .collect(),
+    );
+    assert_eq!(
+        transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+        Err(AzureError::OperationTimedOut {
+            operation: "virtual machine run command"
+        })
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        10,
+        "one submission plus nine bounded polls"
+    );
 }

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -6,7 +6,11 @@ use super::{
     REQUEST_TIMEOUT, RESOURCE_GROUP_API_VERSION, RESPONSE_LIMIT_BYTES, valid_resource_group_name,
     valid_subscription_id,
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
+
+mod run_command;
+
+pub use run_command::AzureRunCommand;
 
 /// Resource group as observed from ARM.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -59,6 +63,10 @@ pub trait AzureManagementTransport: Send + Sync {
     fn subscription_id(&self) -> &str;
     /// # Errors
     fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError>;
+    /// [`Self::get_resource_group`] for a poll under an absolute deadline: the whole
+    /// request must finish within `budget`, which is never zero.
+    /// # Errors
+    fn get_resource_group_within(&self, name: &str, budget: Duration) -> Result<Option<AzureGroupInfo>, AzureError>;
     /// # Errors
     fn create_resource_group(
         &self,
@@ -80,6 +88,75 @@ pub trait AzureManagementTransport: Send + Sync {
     fn get_deployment(&self, group: &str, name: &str) -> Result<Option<AzureDeploymentState>, AzureError>;
     /// # Errors
     fn get_vm(&self, group: &str, name: &str) -> Result<Option<AzureVmView>, AzureError>;
+    /// [`Self::get_vm`] for a poll under an absolute deadline: the whole request must
+    /// finish within `budget`, which is never zero.
+    /// # Errors
+    fn get_vm_within(&self, group: &str, name: &str, budget: Duration) -> Result<Option<AzureVmView>, AzureError>;
+    /// Release the VM's compute while retaining its disks (`PowerState/deallocated`);
+    /// `None` when the VM is absent.
+    /// # Errors
+    fn deallocate_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError>;
+    /// Run one of the closed set of commands inside the VM through the ARM run-command
+    /// channel and return its standard output, or `None` when the VM is absent.
+    /// # Errors
+    fn run_command(&self, group: &str, name: &str, command: AzureRunCommand) -> Result<Option<String>, AzureError>;
+}
+
+impl<T: AzureManagementTransport + ?Sized> AzureManagementTransport for std::sync::Arc<T> {
+    fn subscription_id(&self) -> &str {
+        (**self).subscription_id()
+    }
+
+    fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError> {
+        (**self).get_resource_group(name)
+    }
+
+    fn get_resource_group_within(&self, name: &str, budget: Duration) -> Result<Option<AzureGroupInfo>, AzureError> {
+        (**self).get_resource_group_within(name, budget)
+    }
+
+    fn create_resource_group(
+        &self,
+        name: &str,
+        location: &str,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<AzureGroupInfo, AzureError> {
+        (**self).create_resource_group(name, location, tags)
+    }
+
+    fn delete_resource_group(&self, name: &str) -> Result<AzureLongRunningState, AzureError> {
+        (**self).delete_resource_group(name)
+    }
+
+    fn put_deployment(
+        &self,
+        group: &str,
+        name: &str,
+        template: &serde_json::Value,
+        parameters: &serde_json::Value,
+    ) -> Result<AzureDeploymentState, AzureError> {
+        (**self).put_deployment(group, name, template, parameters)
+    }
+
+    fn get_deployment(&self, group: &str, name: &str) -> Result<Option<AzureDeploymentState>, AzureError> {
+        (**self).get_deployment(group, name)
+    }
+
+    fn get_vm(&self, group: &str, name: &str) -> Result<Option<AzureVmView>, AzureError> {
+        (**self).get_vm(group, name)
+    }
+
+    fn get_vm_within(&self, group: &str, name: &str, budget: Duration) -> Result<Option<AzureVmView>, AzureError> {
+        (**self).get_vm_within(group, name, budget)
+    }
+
+    fn deallocate_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
+        (**self).deallocate_vm(group, name)
+    }
+
+    fn run_command(&self, group: &str, name: &str, command: AzureRunCommand) -> Result<Option<String>, AzureError> {
+        (**self).run_command(group, name, command)
+    }
 }
 
 /// HTTPS transport pinned to the public Azure Resource Manager endpoint.
@@ -161,17 +238,48 @@ impl AzureArmHttp {
     }
 
     fn get_json(&self, url: &str, operation: &'static str) -> Result<Option<serde_json::Value>, AzureError> {
-        let authorization = self.authorization()?;
-        let response = self
-            .agent
-            .get(url)
-            .header("Authorization", &authorization)
-            .call()
-            .map_err(|_| AzureError::RequestFailed { operation })?;
+        self.get_json_within(url, operation, REQUEST_TIMEOUT)
+    }
+
+    /// A GET whose whole exchange is capped at `budget` (never above the request
+    /// timeout), so a poll loop can hand each request only what is left of its bound.
+    pub(super) fn get_json_within(
+        &self,
+        url: &str,
+        operation: &'static str,
+        budget: Duration,
+    ) -> Result<Option<serde_json::Value>, AzureError> {
+        let response = self.get_within(url, operation, budget)?;
         if response.status().as_u16() == 404 {
             return Ok(None);
         }
         decode_json(response, &[200], operation).map(Some)
+    }
+
+    /// The raw GET behind [`Self::get_json_within`], for callers that read headers.
+    /// Obtaining the token (which may refresh through the Azure CLI) counts against the
+    /// budget too: the HTTP exchange gets only what that step left, and none at all once
+    /// the budget is spent.
+    pub(super) fn get_within(
+        &self,
+        url: &str,
+        operation: &'static str,
+        budget: Duration,
+    ) -> Result<ureq::http::Response<ureq::Body>, AzureError> {
+        let started = std::time::Instant::now();
+        let authorization = self.authorization()?;
+        let budget = budget.saturating_sub(started.elapsed());
+        if budget.is_zero() {
+            return Err(AzureError::OperationTimedOut { operation });
+        }
+        self.agent
+            .get(url)
+            .config()
+            .timeout_global(Some(budget.min(REQUEST_TIMEOUT)))
+            .build()
+            .header("Authorization", &authorization)
+            .call()
+            .map_err(|_| AzureError::RequestFailed { operation })
     }
 
     /// Send a mutating request. Long-running operations answer with a status and an
@@ -269,6 +377,12 @@ fn decode_json(
         .map_err(|_| AzureError::InvalidResponse { operation })
 }
 
+/// Time left before an absolute deadline, or `None` once it has passed.
+pub(super) fn remaining(deadline: std::time::Instant) -> Option<Duration> {
+    let left = deadline.saturating_duration_since(std::time::Instant::now());
+    (!left.is_zero()).then_some(left)
+}
+
 fn long_running(status: u16) -> AzureLongRunningState {
     if status == 202 {
         AzureLongRunningState::Accepted
@@ -342,8 +456,12 @@ impl AzureManagementTransport for AzureArmHttp {
     }
 
     fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError> {
+        self.get_resource_group_within(name, REQUEST_TIMEOUT)
+    }
+
+    fn get_resource_group_within(&self, name: &str, budget: Duration) -> Result<Option<AzureGroupInfo>, AzureError> {
         let operation = "resource group lookup";
-        self.get_json(&self.group_url(name, RESOURCE_GROUP_API_VERSION)?, operation)?
+        self.get_json_within(&self.group_url(name, RESOURCE_GROUP_API_VERSION)?, operation, budget)?
             .map(|value| group_info(&value, &self.subscription_id, name, operation))
             .transpose()
     }
@@ -426,6 +544,10 @@ impl AzureManagementTransport for AzureArmHttp {
     }
 
     fn get_vm(&self, group: &str, name: &str) -> Result<Option<AzureVmView>, AzureError> {
+        self.get_vm_within(group, name, REQUEST_TIMEOUT)
+    }
+
+    fn get_vm_within(&self, group: &str, name: &str, budget: Duration) -> Result<Option<AzureVmView>, AzureError> {
         let operation = "virtual machine lookup";
         let url = self.resource_url(
             group,
@@ -434,7 +556,7 @@ impl AzureManagementTransport for AzureArmHttp {
             COMPUTE_API_VERSION,
             "",
         )?;
-        let Some(value) = self.get_json(&format!("{url}&$expand=instanceView"), operation)? else {
+        let Some(value) = self.get_json_within(&format!("{url}&$expand=instanceView"), operation, budget)? else {
             return Ok(None);
         };
         let id = text(&value, "/id").ok_or(AzureError::InvalidResponse { operation })?;
@@ -460,5 +582,25 @@ impl AzureManagementTransport for AzureArmHttp {
             power_state,
             tags: tags(&value),
         }))
+    }
+
+    fn deallocate_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
+        let operation = "virtual machine deallocation";
+        let url = self.resource_url(
+            group,
+            "Microsoft.Compute/virtualMachines",
+            name,
+            COMPUTE_API_VERSION,
+            "/deallocate",
+        )?;
+        match self.send_json("POST", &url, None, &[200, 202], false, operation) {
+            Ok((status, _)) => Ok(Some(long_running(status))),
+            Err(AzureError::UnexpectedStatus { status: 404, .. }) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn run_command(&self, group: &str, name: &str, command: AzureRunCommand) -> Result<Option<String>, AzureError> {
+        self.submit_run_command(group, name, command)
     }
 }

--- a/crates/horizon-core/src/cloud_run/azure/transport/run_command.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport/run_command.rs
@@ -1,0 +1,201 @@
+//! The ARM run-command channel: submit one of the closed set of commands, follow the
+//! `Azure-AsyncOperation` status resource only under the owning subscription, and
+//! unwrap the command's stdout.
+use super::{AzureArmHttp, AzureError, COMPUTE_API_VERSION, MANAGEMENT_ENDPOINT, decode_json, text};
+use std::time::{Duration, Instant};
+
+/// Polling schedule for the run-command async operation once it was accepted; ARM's
+/// `Retry-After` guidance lengthens a step, never shortens it.
+const RUN_COMMAND_BACKOFF_MS: [u64; 9] = [500, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 30_000, 30_000];
+/// Absolute bound on that polling, sleeps and requests included.
+const RUN_COMMAND_BOUND: Duration = Duration::from_secs(120);
+/// Longest single wait a `Retry-After` header may ask for.
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(60);
+
+/// The only scripts the adapter ever executes inside a worker; there is no way to pass
+/// arbitrary text to the run-command channel.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AzureRunCommand {
+    /// Print the host public key the worker container's SSH server is serving, from
+    /// `/etc/ssh` inside the fixed `horizon-worker` container: the retained candidate
+    /// on the data disk exists before the server does, so only the materialised key
+    /// proves the endpoint is up with this identity.
+    HostKey,
+}
+
+impl AzureRunCommand {
+    #[must_use]
+    pub const fn script(self) -> &'static str {
+        match self {
+            Self::HostKey => "docker exec horizon-worker cat /etc/ssh/ssh_host_ed25519_key.pub",
+        }
+    }
+}
+
+impl AzureArmHttp {
+    /// Execute one closed command inside the VM through ARM and return its stdout, or
+    /// `None` when the VM does not exist.
+    pub(super) fn submit_run_command(
+        &self,
+        group: &str,
+        name: &str,
+        command: AzureRunCommand,
+    ) -> Result<Option<String>, AzureError> {
+        let operation = "virtual machine run command";
+        let url = self.resource_url(
+            group,
+            "Microsoft.Compute/virtualMachines",
+            name,
+            COMPUTE_API_VERSION,
+            "/runCommand",
+        )?;
+        let authorization = self.authorization()?;
+        let body = serde_json::json!({ "commandId": "RunShellScript", "script": [command.script()] });
+        let response = self
+            .agent
+            .post(&url)
+            .header("Authorization", &authorization)
+            .send_json(&body)
+            .map_err(|_| AzureError::RequestFailed { operation })?;
+        let status = response.status().as_u16();
+        let value = match status {
+            404 => return Ok(None),
+            200 => decode_json(response, &[200], operation)?,
+            // Only the Azure-AsyncOperation status resource is followed: it reports a
+            // JSON status with the command output. A Location-only answer would need
+            // the final-resource protocol (202 while running), which Compute does not
+            // use for run commands, so it is refused rather than half-implemented.
+            202 => {
+                let poll = response
+                    .headers()
+                    .get("azure-asyncoperation")
+                    .and_then(|header| header.to_str().ok())
+                    .filter(|poll| self.owns_operation_url(poll))
+                    .ok_or(AzureError::InvalidResponse { operation })?
+                    .to_string();
+                self.await_operation(&poll, operation, retry_after_header(response.headers()))?
+            }
+            status => return Err(AzureError::UnexpectedStatus { operation, status }),
+        };
+        run_command_stdout(&value, operation).map(Some)
+    }
+
+    /// Only an operation URL under this subscription on the management endpoint is
+    /// polled, and only one whose path cannot be normalised out of it: every segment
+    /// after the subscription is a plain token (no dot segments, no percent-encoding, no
+    /// backslashes or other separators) and the query carries only the API version shape.
+    fn owns_operation_url(&self, url: &str) -> bool {
+        let prefix = format!("{MANAGEMENT_ENDPOINT}/subscriptions/{}/", self.subscription_id);
+        let Some(rest) = url.strip_prefix(&prefix) else {
+            return false;
+        };
+        let (path, query) = rest.split_once('?').unwrap_or((rest, ""));
+        let plain_segment = |segment: &str| {
+            !segment.is_empty()
+                && segment != "."
+                && segment != ".."
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        };
+        url.len() <= 2_048
+            && path.split('/').all(plain_segment)
+            && query
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'=' | b'&'))
+    }
+
+    /// Poll an async operation until it is terminal, within the run-command bound:
+    /// an absolute deadline covers the sleeps, every request is capped at what is left
+    /// of it, and ARM's `Retry-After` (from the acceptance and from every poll) is
+    /// honoured, so a throttled poll waits instead of failing the command.
+    fn await_operation(
+        &self,
+        url: &str,
+        operation: &'static str,
+        mut retry_after: Option<Duration>,
+    ) -> Result<serde_json::Value, AzureError> {
+        let deadline = Instant::now() + RUN_COMMAND_BOUND;
+        for delay_ms in RUN_COMMAND_BACKOFF_MS {
+            let Some(left) = super::remaining(deadline) else {
+                break;
+            };
+            let delay = Duration::from_millis(delay_ms).max(retry_after.unwrap_or_default());
+            if !cfg!(test) {
+                std::thread::sleep(delay.min(left));
+            }
+            let Some(budget) = super::remaining(deadline) else {
+                break;
+            };
+            let response = self.get_within(url, operation, budget)?;
+            retry_after = retry_after_header(response.headers());
+            let value = match response.status().as_u16() {
+                429 => continue,
+                404 => return Err(AzureError::InvalidResponse { operation }),
+                _ => decode_json(response, &[200], operation)?,
+            };
+            match text(&value, "/status").as_deref() {
+                Some("Succeeded") => return Ok(value),
+                Some("Failed" | "Canceled") => return Err(AzureError::RequestFailed { operation }),
+                _ => {}
+            }
+        }
+        Err(AzureError::OperationTimedOut { operation })
+    }
+}
+
+/// `Retry-After` in whole seconds, capped; the HTTP-date form is not used by ARM's
+/// async-operation resources and is ignored.
+fn retry_after_header(headers: &ureq::http::HeaderMap) -> Option<Duration> {
+    headers
+        .get("retry-after")
+        .and_then(|header| header.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(|seconds| Duration::from_secs(seconds).min(RETRY_AFTER_CAP))
+}
+
+/// Standard output of a finished run command, taken from every status record it
+/// returned. Fails closed: a record that is not a success, an unknown record kind, any
+/// standard error, and a missing or ambiguous standard output are all errors, so a
+/// half-failed command can never be promoted to a trusted result.
+fn run_command_stdout(value: &serde_json::Value, operation: &'static str) -> Result<String, AzureError> {
+    let invalid = AzureError::InvalidResponse { operation };
+    let records = value
+        .pointer("/properties/output/value")
+        .or_else(|| value.pointer("/value"))
+        .and_then(serde_json::Value::as_array)
+        .filter(|records| !records.is_empty())
+        .ok_or(invalid.clone())?;
+    let (mut stdout, mut stderr) = (None, String::new());
+    for record in records {
+        let code = text(record, "/code").ok_or(invalid.clone())?;
+        let (kind, state) = code.rsplit_once('/').ok_or(invalid.clone())?;
+        if !state.eq_ignore_ascii_case("succeeded") {
+            return Err(AzureError::RequestFailed { operation });
+        }
+        let message = text(record, "/message").unwrap_or_default();
+        let output = match kind {
+            // The classic action wraps both streams in one message; both delimiters
+            // must be present, or nothing proves standard error was empty.
+            "ProvisioningState" => {
+                let (_, streams) = message.split_once("[stdout]").ok_or(invalid.clone())?;
+                let (out, err) = streams.split_once("[stderr]").ok_or(invalid.clone())?;
+                stderr.push_str(err);
+                out.to_string()
+            }
+            "ComponentStatus/StdOut" => message,
+            "ComponentStatus/StdErr" => {
+                stderr.push_str(&message);
+                continue;
+            }
+            _ => return Err(invalid),
+        };
+        if stdout.replace(output).is_some() {
+            return Err(invalid);
+        }
+    }
+    if !stderr.trim().is_empty() {
+        return Err(AzureError::RequestFailed { operation });
+    }
+    stdout.map(|out| out.trim().to_string()).ok_or(invalid)
+}


### PR DESCRIPTION
## Summary

Fifth isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open; the production constructor and the wiring follow). Stacked on the provider slice; no configuration, dispatcher or UI wiring.

- **Readiness** (`AzureHostKeySource`): a running worker is `Ready` only when the finished deployment carries a parseable address and the injected source attests an Ed25519 host key for this exact worker and client key; the endpoint is port 2222 and user `root`. Running without a key stays `Provisioning`, so `is_ready_for` can never pass without a pinned key. Reading the key takes time, so it is paired with the address only if the same owned group, VM (all identity tags, which include the client-key digest) and address are observed again once it is back; a group or VM replaced under the same name is an identity error, any other change leaves the worker `Provisioning`.

- **Explicit Stop** (`InteractiveWorkerStopProvider` for `AzureClient`): after the same ownership proof as every mutation (persisted handle shape, every identity tag on the live group, group ID equality), the VM is deallocated: compute released and no longer billed, both disks and the static address retained. The retained inactive state is verified by observing `PowerState/deallocated` within an absolute five-minute deadline that covers sleeps and requests alike (each poll request, token acquisition included, is capped at what is left of it); otherwise `StopUnverified`. Stoppability follows the VM itself, so a running VM behind an unusable address or a failed deployment is still deallocated: it is billed either way and Stop is the cost-control action. Every poll during that wait re-proves the group (all identity tags, the recorded group ID, and not `Deleting`) and the VM (all identity tags), so a worker recreated or retagged at the same path is never reported as this one stopping. A VM already deallocating is awaited, never re-posted; a group or VM that vanishes after the initial proof is unverified, never absent; a `409` from Compute during an in-flight deallocation is treated as accepted; a billed guest halt (`PowerState/stopped`) is deallocated; failed (VM provisioning), deleting, starting, absent or vanished VMs are reported as unverified. Stop never creates, restarts or deletes. Idempotent on a deallocated VM.
- **Transport**: `deallocate_vm` (POST `/deallocate`, 200 or 202; a missing VM is `None`) and `run_command` (POST `/runCommand` with `RunShellScript` and one variant of the closed `AzureRunCommand` enum, so no caller can pass shell text; a `202` is followed only through an `Azure-AsyncOperation` status URL under this subscription on the management endpoint whose path is made of plain segments (no dot segments, percent-encoding, backslashes or other separators, so no normalisation can route it elsewhere), polled under an absolute two-minute deadline with each poll request capped at the remaining budget, honouring `Retry-After` from the acceptance and from every poll (capped at 60 s) and waiting out a `429` instead of failing; a `Location`-only answer uses a different protocol and is refused; standard output is taken from the status records fail-closed: every record must be a success of a known kind, any standard error or a missing or ambiguous standard output is an error; a missing VM is `None`). Plus a blanket `Arc<T>` implementation so one transport can be shared between the client and the host-key source.
- **Trusted host keys** (`AzureRunCommandHostKeys`): reads `/etc/ssh/ssh_host_ed25519_key.pub` inside the fixed `horizon-worker` container (through `docker exec` on the exact VM via the control plane), so the key is bound to the authenticated resource rather than to whatever answers on the network address, and it is the key the SSH server is actually serving rather than the retained candidate on the data disk, which exists before the server does. Exactly one Ed25519 key is accepted (comment dropped); empty, multi-line, wrong-algorithm or error output yields no key and the worker stays `Provisioning`.

## Layout

Everything the provider does with a running worker (host-key attestation and Stop) lives in `provider/running.rs`, and the run-command channel in `transport/run_command.rs`, keeping both parents under the split threshold.

## Tests

`tests::provider::running` (5, shares the provider fixture): readiness requires a running VM, a usable address and a pinned Ed25519 host key, and `ensure` reuse reports the same; running → deallocating → deallocated with one deallocate call and three observations; idempotent stop; retry that only awaits an in-flight deallocation; billed halt deallocated; synchronous completion; 409 awaited then unverified; 403 surfaced; unverified for a running VM that never deallocates, an absent VM, a VM that vanishes, a starting VM and a failed VM (no deallocate); no deletion on any path; foreign handle and tag mismatch rejected before I/O; host-key source called with the constant script against the exact group, accepting one key and refusing every malformed output. `tests::transport` (3 new): deallocate long-running mapping and redaction; run command with async polling, synchronous 200, absent VM, poll URL outside the subscription refused, failed operation redacted; polling bound (one submission plus nine polls). Invalid segments never reach the network.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.

## Follow-ups

1. HTTPS production constructor and wiring into configuration, dispatchers and UI once the common provider boundary settles (coordinated on #474).
2. Deadline-aware token acquisition in the CLI credential (lock wait and child timeout bounded by the caller's remaining budget); today the token step is measured and only the HTTP exchange is capped at what it left.
3. Live acceptance runs: three panels on one worker, PC-off development, Stop and delete proofs.
