### PR TITLE
feat(cloud): assemble the production Azure worker client

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider.rs
@@ -2,8 +2,8 @@
 //! behind a durable fence, recover and inspect without creating, delete exactly the
 //! owned resource group; readiness attestation and Stop live in `running`.
 use super::{
-    AzureDeploymentPlan, AzureError, AzureGroupInfo, AzureLifecycle, AzureManagementTransport, AzureProfile,
-    AzureVmView, AzureWorker, WORKER_VM_NAME,
+    AzureArmHttp, AzureCredentialSource, AzureDeploymentPlan, AzureError, AzureGroupInfo, AzureLifecycle,
+    AzureManagementTransport, AzureProfile, AzureVmView, AzureWorker, WORKER_VM_NAME,
     deployment::{DEPLOYMENT_NAME, identity_tags, worker_tags},
     resource_group_name,
 };
@@ -15,7 +15,7 @@ use crate::cloud_run::{
         InteractiveWorkerStatus,
     },
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 mod running;
 pub use running::{AzureHostKeySource, AzureRunCommandHostKeys};
@@ -50,6 +50,21 @@ where
         resource_group: &str,
     ) -> Result<bool, AzureError> {
         self(workflow_id, job_id, target, resource_group)
+    }
+}
+
+/// The workflow store is the production fence: one durable claim per job, shared by
+/// every controller that opens the same store.
+impl AzureCreationFence for crate::cloud_run::CloudWorkflowStore {
+    fn claim_once(
+        &self,
+        workflow_id: CloudWorkflowId,
+        job_id: CloudJobId,
+        target: &WorkerTarget,
+        resource_group: &str,
+    ) -> Result<bool, AzureError> {
+        self.claim_worker_creation(workflow_id, job_id, target, resource_group)
+            .map_err(|_| AzureError::CreationFenceFailed)
     }
 }
 
@@ -92,8 +107,23 @@ struct Observation {
 }
 
 impl AzureClient {
-    /// Client over any management transport; the HTTPS production constructor arrives
-    /// with the configuration wiring that first needs it.
+    /// Production client: HTTPS-only requests to Azure Resource Manager under the
+    /// profile's subscription, one authenticated transport shared by the management
+    /// calls and the run-command host-key source, and the given durable fence.
+    /// # Errors
+    /// Rejects an invalid profile.
+    pub fn new(
+        profile: AzureProfile,
+        credential: impl AzureCredentialSource + 'static,
+        fence: impl AzureCreationFence + 'static,
+    ) -> Result<Self, AzureError> {
+        profile.validate()?;
+        let transport = Arc::new(AzureArmHttp::new(profile.subscription_id.clone(), credential)?);
+        let host_keys = AzureRunCommandHostKeys::new(transport.clone());
+        Self::with_transport(profile, transport, fence, host_keys)
+    }
+
+    /// Client over any management transport and host-key source.
     /// # Errors
     /// Rejects an invalid profile.
     pub fn with_transport(

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/creation.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/creation.rs
@@ -287,3 +287,25 @@ fn ensure_never_deploys_into_a_group_changed_right_after_creation() {
     assert_eq!(deleting.status().lifecycle, Lifecycle::Deleting);
     assert!(t.plane.mutations().is_empty());
 }
+
+#[test]
+fn production_client_is_bound_to_the_profile_before_any_request() {
+    use crate::cloud_run::azure::AzureAccessToken;
+    let credential = || AzureAccessToken::new("synthetic-token-value", std::time::Duration::from_secs(600));
+    let never = |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| Ok(false);
+    let client = AzureClient::new(profile(), credential, never).expect("client");
+    let s = Scenario::new();
+    let mut foreign = s.persisted();
+    foreign.identity.provider = CloudProvider::RunPod;
+    assert_eq!(
+        client.inspect_worker(&foreign),
+        Err(AzureError::InvalidPersistedWorker),
+        "shape checks run before the network is touched"
+    );
+    let mut invalid = profile();
+    invalid.subscription_id = "not-a-subscription".into();
+    assert!(matches!(
+        AzureClient::new(invalid, credential, never),
+        Err(AzureError::InvalidProfile)
+    ));
+}

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -549,6 +549,35 @@ fn runpod_fence_uses_the_durable_workflow_claim() {
 }
 
 #[test]
+fn azure_fence_uses_the_durable_workflow_claim() {
+    use super::super::azure::{AzureCreationFence, AzureError};
+    let temp = TempDir::new().expect("temp dir");
+    let store = store(&temp);
+    let workflow = retained_workflow(CloudProvider::Azure, 30_000);
+    let job_id = workflow.nodes[0].id;
+    let target = worker_target(&workflow);
+    store.create(&workflow).expect("create workflow");
+    let group = super::super::azure::resource_group_name(workflow.id, job_id);
+    assert!(AzureCreationFence::claim_once(&store, workflow.id, job_id, target, &group).expect("first claim"));
+    assert!(!AzureCreationFence::claim_once(&store, workflow.id, job_id, target, &group).expect("repeated claim"));
+    let other_job = CloudJobId::new();
+    assert_eq!(
+        AzureCreationFence::claim_once(&store, workflow.id, other_job, target, &group),
+        Err(AzureError::CreationFenceFailed),
+        "a job outside the workflow never claims"
+    );
+    let connection = Connection::open(store.path()).expect("open raw store");
+    connection
+        .pragma_update(None, "user_version", 7)
+        .expect("set unsupported schema");
+    drop(connection);
+    assert_eq!(
+        AzureCreationFence::claim_once(&store, workflow.id, job_id, target, &group),
+        Err(AzureError::CreationFenceFailed)
+    );
+}
+
+#[test]
 fn invalid_snapshots_and_future_schema_fail_closed() {
     let temp = TempDir::new().expect("temp dir");
     let store = store(&temp);


### PR DESCRIPTION
## Summary

Sixth isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open; configuration, dispatcher and UI wiring follow separately, coordinated with the lead). No wiring in this slice.

- **Production constructor** (`AzureClient::new(profile, credential, fence)`): HTTPS-only Azure Resource Manager requests under the profile's subscription through one authenticated transport, shared by the management calls and the run-command host-key source, with the caller's durable creation fence. The profile is validated first; the transport is bound to the profile's subscription like every other client.
- **Store-backed fence** (`impl AzureCreationFence for CloudWorkflowStore`): the workflow store's per-job creation claim is the production fence, so every controller opening the same store shares exactly one claim per worker (the resource-group name is the claimed resource). Store failures surface as the static `CreationFenceFailed` without echoing their cause.

## Behaviour impact

None for existing code paths; this adds the way a production client is assembled. Nothing constructs it yet.

## Tests

- `tests::provider::creation::production_client_is_bound_to_the_profile_before_any_request`: the production client rejects an invalid profile and shape-checks persisted handles before any request is issued.
- `store::tests::azure_fence_uses_the_durable_workflow_claim`: one claim per job, a repeated claim is refused, a job outside the workflow never claims, and an unsupported store schema fails closed as `CreationFenceFailed`.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.

## Follow-ups

1. Wiring into configuration, dispatchers and UI once the common provider boundary settles (coordinated on #474).
2. Deadline-aware token acquisition in the CLI credential.
3. Live acceptance runs: three panels on one worker, PC-off development, Stop and delete proofs.
