### PR TITLE
feat(cloud): start saved Shell tasks in prepared Git checkouts

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -6,8 +6,8 @@
 `1`, `workspace_local_id`, non-nil UUID `runtime_id`, `source` (GitHub `owner/repo`,
 exact 40-character `commit`, optional `branch`), and explicit `work_branch`.
 It fetches the exact commit over HTTPS, not the moving source branch, into the
-fresh fixed `/workspace/horizon/repository` checkout. Existing panel tasks can
-select relative directory `repository`; preparation does not start a task.
+fresh fixed `/workspace/horizon/repository` checkout. Preparation does not start
+a task; use the Git-bound start operation below for ordinary Git task admission.
 Authentication uses only the protected runtime token through the installed Git
 credential helper. No credentials belong in the request, URL or Git config.
 
@@ -371,6 +371,30 @@ Status never creates a session; repeating start retains the existing one-shot
 intent rules. Interactive attachment still uses the separate `attach` command
 and PTY. Malformed request errors never echo stdin or task content. This protocol
 does not itself provide authenticated transport or authorize a new task.
+
+For ordinary Git, use `operation: "start-git"` with the same fields plus
+`repository`, containing the exact `GitPreparation` request used at preparation.
+Here `directory` is relative to `/workspace/horizon/repository`, not its parent.
+The worker calls bounded, read-only `git-binding` and `git-checkout` projections:
+the first canonicalizes the request without requiring current files; the second
+requires its matching completion record and returns the fixed checkout's device
+and inode. A new task holds and checks that identity, private mode and confined
+cwd before claiming the existing one-shot task marker. No Git operation runs.
+
+An existing matching Git-bound task is only observed, including after completion
+or checkout removal; dirty files and new commits are not reset. Conflicting,
+partial or uncertain identities never authorize replacement or replay. A plain
+task cannot be adopted by Git start. These checks require stable trusted worker
+ownership; they are not a sandbox against another task with the same worker UID.
+
+The Linux `remote_worker_status::start_remote_git_shell` controller API derives
+the repository, runtime, saved work branch, Shell command and cwd from the exact
+saved allocation. It requires an existing owned worker, retained SSH identity/pin,
+noncreating provider inspection and current lease. The request travels only over
+fixed pinned SSH with a 15-second stdin budget capped by the remaining lease.
+Only a strict matching response confirms status; output loss or post-send state
+drift is unknown and must not trigger automatic retry. No provider creation, PAT
+delivery, push/PR, Stop/Delete or UI behavior is included.
 
 A `verify` request uses the same fields as `start`, but only compares the supplied
 directory and literal argv with the retained task's launch digest before returning

--- a/containers/remote-worker/panel-session.py
+++ b/containers/remote-worker/panel-session.py
@@ -48,9 +48,9 @@ def execute_request(service, stream):
         raise SessionError("structured session request is invalid")
     if request.get("operation") == "status" and set(request) == common:
         return service.status(request["runtime"], request["panel"])
-    prepared = request.get("operation") == "start-prepared"
+    prepared = request.get("operation") in ("start-prepared", "start-git")
     expected = common | {"directory", "argv"} | ({"repository"} if prepared else set())
-    if request.get("operation") not in ("start", "verify", "start-prepared") or set(request) != expected:
+    if request.get("operation") not in ("start", "verify", "start-prepared", "start-git") or set(request) != expected:
         raise SessionError("unsupported structured session request")
     if (
         not isinstance(request["directory"], str)
@@ -60,14 +60,14 @@ def execute_request(service, stream):
         raise SessionError("structured task intent is invalid")
     if prepared:
         return service.start_prepared(request["runtime"], request["panel"], request["directory"],
-                                      request["argv"], request["repository"])
+                                      request["argv"], request["repository"], git=request["operation"] == "start-git")
     operation = service.verify if request["operation"] == "verify" else service.start
     return operation(request["runtime"], request["panel"], request["directory"], request["argv"])
 
 
 def repository_selection(operation, selection):
     """Only the fixed trusted core helper canonicalizes and inspects this selection."""
-    if operation not in ("setup-binding", "setup-checkout"):
+    if operation not in ("setup-binding", "setup-checkout", "git-binding", "git-checkout"):
         raise SessionError("unsupported repository inspection")
     encoded = json.dumps(selection, ensure_ascii=False).encode()
     if len(encoded) > 34 * 1024:
@@ -82,7 +82,7 @@ def repository_selection(operation, selection):
             or type(value["version"]) is not int or value["version"] != 1 or value["reason"] is not None
             or not isinstance(value["runtime"], str) or not isinstance(value["binding_sha256"], str)
             or not re.fullmatch(r"[0-9a-f]{64}", value["binding_sha256"])
-            or operation == "setup-binding" and value["root"] is not None):
+            or operation.endswith("-binding") and value["root"] is not None):
         raise SessionError("prepared repository inspection is invalid")
     return value
 
@@ -241,10 +241,11 @@ class PanelSessions:
         working_directory, intent = self.launch_intent(directory, arguments)
         return self._start_at(runtime, panel, working_directory, arguments, intent)
 
-    def start_prepared(self, runtime, panel, directory, arguments, selection):
+    def start_prepared(self, runtime, panel, directory, arguments, selection, *, git=False):
         self.identities(runtime, panel)
         intent = self.intent_digest(directory, arguments)
-        binding = repository_selection("setup-binding", selection)
+        prefix = "git" if git else "setup"
+        binding = repository_selection(f"{prefix}-binding", selection)
         if binding["runtime"] != runtime:
             raise SessionError("prepared repository runtime does not match the task")
         try:
@@ -254,7 +255,7 @@ class PanelSessions:
         if marker is not None:
             self.match_intent(marker, intent, binding["binding_sha256"])
             return self.status(runtime, panel)
-        inspected = repository_selection("setup-checkout", selection)
+        inspected = repository_selection(f"{prefix}-checkout", selection)
         root = inspected["root"]
         if (inspected["runtime"] != runtime or inspected["binding_sha256"] != binding["binding_sha256"]
                 or not isinstance(root, dict) or set(root) != {"path", "device", "inode"}
@@ -262,6 +263,8 @@ class PanelSessions:
                 or any(type(root[key]) is not int or root[key] < 0 for key in ("device", "inode"))):
             raise SessionError("prepared repository root is invalid")
         repository = Path(root["path"])
+        if git and repository != self.repository / "repository":
+            raise SessionError("Git checkout path does not match the worker repository")
         descriptor = os.open(repository, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
         try:
             held = os.fstat(descriptor)

--- a/containers/remote-worker/test_panel_sessions.py
+++ b/containers/remote-worker/test_panel_sessions.py
@@ -673,6 +673,128 @@ class PanelSessionTests(unittest.TestCase):
                 MODULE.repository_selection("setup", selected)
             run.assert_not_called()
 
+    def git_request(self, panel="git", directory="nested", argv=None):
+        checkout = self.repository / "repository"
+        if not checkout.exists():
+            checkout.mkdir(mode=0o700)
+            (checkout / "nested").mkdir()
+        selection = {"version": 1, "workspace_local_id": "fixture", "runtime_id": self.runtimes[0],
+                     "source": {"repository": "fixture/repository", "commit": "a" * 40, "branch": "work/one"},
+                     "work_branch": "work/one"}
+        return self.request("start-git", panel, directory=directory, argv=argv or self.tick_command(), repository=selection)
+
+    def git_helper(self, operation, selection):
+        self.assertIn(operation, ("git-binding", "git-checkout"))
+        digest = MODULE.hashlib.sha256(json.dumps(selection, sort_keys=True).encode()).hexdigest()
+        root = None
+        if operation == "git-checkout":
+            checkout = self.repository / "repository"
+            info = checkout.stat()
+            root = {"path": str(checkout), "device": info.st_dev, "inode": info.st_ino}
+        return {"version": 1, "binding_sha256": digest, "runtime": selection["runtime_id"], "root": root, "reason": None}
+
+    def test_git_task_retains_progress_dirty_cwd_and_identity_after_disconnect(self):
+        request = self.git_request()
+        checkout = self.repository / "repository"
+        dirty = checkout / "uncommitted"
+        dirty.write_text("keep these bytes")
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.git_helper) as helper:
+            first = self.execute(request)
+            ticks = checkout / "nested" / "ticks"
+            self.wait_for(ticks.exists)
+            self.attach_and_disconnect(self.runtimes[0], "git")
+            before = ticks.stat().st_size
+            self.wait_for(lambda: ticks.stat().st_size > before)
+            marker = self.service.marker_path(self.runtimes[0], "git")
+            recorded = marker.read_bytes(), marker.stat().st_mtime_ns
+            helper.reset_mock()
+            self.assertEqual(self.execute(request)["pid"], first["pid"])
+            self.assertEqual([call.args[0] for call in helper.call_args_list], ["git-binding"])
+            self.assertEqual((marker.read_bytes(), marker.stat().st_mtime_ns), recorded)
+            self.assertEqual(dirty.read_text(), "keep these bytes")
+
+    def test_git_concurrent_start_and_lost_reply_never_duplicate_tasks(self):
+        request = self.git_request(argv=self.command("from pathlib import Path; import time; Path('runs').open('a').write('once\\n'); time.sleep(30)"))
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.git_helper):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(lambda _: self.execute(request), range(2)))
+            runs = self.repository / "repository/nested/runs"
+            self.wait_for(lambda: runs.exists() and runs.read_text() == "once\n")
+            self.assertTrue(all(result["state"] in ("running", "unavailable") for result in results))
+            self.assertEqual(len(self.service.tmux(self.runtimes[0], "list-sessions").stdout.splitlines()), 1)
+            lost = self.git_request("lost")
+            with mock.patch.object(self.service, "status", side_effect=MODULE.SessionError("lost response")), self.assertRaises(MODULE.SessionError):
+                self.execute(lost)
+            current = self.service.status(self.runtimes[0], "lost")
+            self.assertEqual(self.execute(lost)["pid"], current["pid"])
+
+    def test_git_exited_or_uncertain_task_does_not_need_current_checkout(self):
+        request = self.git_request(argv=self.command("raise SystemExit(42)"))
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.git_helper) as helper:
+            first = self.execute(request)
+            self.wait_for(lambda: self.service.status(self.runtimes[0], "git")["state"] == "exited")
+            (self.repository / "repository/nested").rmdir()
+            (self.repository / "repository").rmdir()
+            helper.reset_mock()
+            self.assertEqual(self.execute(request), {"state":"exited", "panel":"git", "pid":first["pid"], "exit_status":42})
+            self.assertEqual([call.args[0] for call in helper.call_args_list], ["git-binding"])
+            self.assertFalse((self.repository / "repository").exists())
+            self.service.tmux(self.runtimes[0], "kill-server")
+            self.assertEqual(self.execute(request)["state"], "unavailable")
+            self.assertFalse((self.repository / "repository").exists())
+
+    def test_git_selection_or_launch_intent_cannot_reuse_existing_marker(self):
+        request = self.git_request()
+        with mock.patch.object(MODULE, "repository_selection", side_effect=self.git_helper):
+            first = self.execute(request)
+            for field in ("repository", "commit", "branch", "work_branch", "workspace_local_id", "directory", "argv"):
+                changed = json.loads(json.dumps(request))
+                if field in ("repository", "commit", "branch"):
+                    changed["repository"]["source"][field] += "different"
+                elif field in ("work_branch", "workspace_local_id"):
+                    changed["repository"][field] += "different"
+                elif field == "argv":
+                    changed[field] += ["different"]
+                else:
+                    changed[field] = "."
+                with self.subTest(field=field), self.assertRaises(MODULE.SessionError):
+                    self.execute(changed)
+            with self.assertRaises(MODULE.SessionError):
+                self.service.start(self.runtimes[0], "git", "repository/nested", request["argv"])
+            self.assertEqual(self.service.status(self.runtimes[0], "git")["pid"], first["pid"])
+
+    def test_git_unconfirmed_replaced_unsafe_and_escaping_checkout_refuses_before_claim(self):
+        request = self.git_request()
+        checkout = self.repository / "repository"
+        outside = self.root / "outside"
+        outside.mkdir()
+        (checkout / "escape").symlink_to(outside)
+        for fault in ("partial", "runtime", "binding", "inode", "mode", "path", "escape"):
+            selected = json.loads(json.dumps(request))
+            if fault == "escape":
+                selected["directory"] = "escape"
+            def helper(operation, selection):
+                response = self.git_helper(operation, selection)
+                if operation == "git-checkout":
+                    if fault == "partial":
+                        raise MODULE.SessionError("unconfirmed Git")
+                    if fault in ("runtime", "binding"):
+                        response["runtime" if fault == "runtime" else "binding_sha256"] = "different"
+                    if fault == "inode":
+                        response["root"]["inode"] += 1
+                    if fault == "mode":
+                        checkout.chmod(0o755)
+                    if fault == "path":
+                        response["root"]["path"] = str(outside)
+                return response
+            try:
+                with mock.patch.object(MODULE, "repository_selection", side_effect=helper), self.assertRaises(MODULE.SessionError):
+                    self.execute(selected)
+                self.assertFalse(self.service.state.exists())
+                self.assertFalse(self.service.sockets.exists())
+            finally:
+                checkout.chmod(0o700)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/horizon-core/src/remote_worker_status.rs
+++ b/crates/horizon-core/src/remote_worker_status.rs
@@ -1,7 +1,10 @@
-//! Bounded, non-creating panel inspection through the retained worker's pinned SSH identity.
+//! Pinned panel inspection and an explicitly separate Git-bound Shell start API.
 //! Calls are synchronous and must run off the render thread.
 
 mod configured;
+mod git_start;
+
+pub use git_start::{RemoteGitTaskStartError, start_remote_git_shell};
 
 pub use configured::{
     ConfiguredRemotePanelStatusError, ConfiguredRemotePanelStatusRequest, RemotePanelObservation,

--- a/crates/horizon-core/src/remote_worker_status/git_start.rs
+++ b/crates/horizon-core/src/remote_worker_status/git_start.rs
@@ -1,0 +1,261 @@
+//! Explicit one-shot startup; existing inspection never calls this mutation path.
+
+use super::RemotePanelStatus;
+use crate::{
+    cloud_run::{CloudWorkflowStore, StoredRemoteAllocation, interactive_worker::InteractiveWorkerProvider},
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace_recovery::RemoteWorkspaceRecoveryError,
+};
+
+/// Start only the saved explicit Shell intent on its completed ordinary Git checkout.
+/// The saved cwd is relative to that checkout; the saved nonempty source branch is
+/// the work branch. No caller-supplied command, environment or repository is accepted.
+/// Requires actual-session/provider/cost authorization by the caller and runs off-thread.
+/// Existing matching or exited tasks are observed, never restarted. A missing or
+/// invalid reply is unknown: inspect before any further explicitly authorized action.
+/// No worker allocation, credential installation, Stop/Delete or automatic retry occurs.
+/// Fifteen-second stdin admission is capped by the lease, including spawn elapsed
+/// time. Spawn/reap can block; bytes already sent are not atomically revoked by Stop.
+/// # Errors
+/// Rejects unsupported intent, stale ownership, missing pins and expired lifetimes.
+pub fn start_remote_git_shell<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    panel_id: &str,
+) -> Result<RemotePanelStatus, RemoteGitTaskStartError> {
+    #[cfg(target_os = "linux")]
+    {
+        start_with(store, identities, provider, allocation, panel_id, execute)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (store, identities, provider, allocation, panel_id);
+        Err(RemoteGitTaskStartError::UnsupportedPlatform)
+    }
+}
+
+/// Static diagnostics omit task content, SSH output and private paths.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteGitTaskStartError {
+    #[error("Git task start requires a fully supported saved Shell and repository intent")]
+    InvalidIntent,
+    #[error("Git task start requires an existing worker and retained SSH pin")]
+    MissingRetainedWorker,
+    #[error("Git task start requires an unexpired worker")]
+    ExpiredWorker,
+    #[error("task start outcome is unknown; inspect without automatic retry")]
+    OutcomeUnknown,
+    #[error("Git task start is unsupported on this client platform")]
+    UnsupportedPlatform,
+    #[error(transparent)]
+    Recovery(#[from] RemoteWorkspaceRecoveryError),
+    #[error(transparent)]
+    Admission(#[from] super::RemotePanelStatusError),
+}
+
+#[cfg(target_os = "linux")]
+use {
+    crate::{
+        cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+        remote_worker_ssh::{known_hosts, prepared_command, query},
+        remote_workspace_recovery::{RecoveredRemoteWorkspace, inspect_remote_allocation},
+    },
+    std::{
+        process::Command,
+        time::{Duration, Instant},
+    },
+    time::OffsetDateTime,
+};
+
+#[cfg(target_os = "linux")]
+fn request(allocation: &StoredRemoteAllocation, panel: &str) -> Result<Vec<u8>, RemoteGitTaskStartError> {
+    use crate::{PanelKind, repository_git::GitPreparation};
+    use RemoteGitTaskStartError::InvalidIntent;
+    let state = allocation.workspace().state();
+    let spec = &state.spec;
+    let runtime = allocation
+        .worker_request()
+        .map_err(RemoteWorkspaceRecoveryError::from)?
+        .job_id;
+    let task = spec
+        .panels
+        .iter()
+        .find(|task| task.panel_local_id == panel)
+        .ok_or(InvalidIntent)?;
+    if task.kind != PanelKind::Shell || task.task_handoff.is_some() || task.agent_session_id.is_some() {
+        return Err(InvalidIntent);
+    }
+    let command = task.command.as_ref().ok_or(InvalidIntent)?;
+    let directory = task.working_directory.as_deref().unwrap_or(&spec.working_directory);
+    let path = std::path::Path::new(directory);
+    let argv: Vec<&str> = std::iter::once(command.program.as_str())
+        .chain(command.args.iter().map(String::as_str))
+        .collect();
+    if path.is_absolute()
+        || path.components().any(|part| part == std::path::Component::ParentDir)
+        || directory.contains('\0')
+        || argv[0].is_empty()
+        || argv[0].starts_with('-')
+        || argv.len() > 257
+        || argv.iter().any(|arg| arg.contains('\0'))
+        || argv.iter().map(|arg| arg.len()).sum::<usize>() > 65536
+    {
+        return Err(InvalidIntent);
+    }
+    let repository = GitPreparation {
+        version: 1,
+        workspace_local_id: spec.workspace_local_id.clone(),
+        runtime_id: runtime.to_string().parse().map_err(|_| InvalidIntent)?,
+        source: spec.repository.clone(),
+        work_branch: spec.repository.branch.clone().ok_or(InvalidIntent)?,
+    };
+    repository.binding().map_err(|_| InvalidIntent)?;
+    let bytes = serde_json::to_vec(&serde_json::json!({
+        "version":1, "operation":"start-git", "runtime":runtime, "panel":panel,
+        "directory":directory, "argv":argv, "repository":repository,
+    }))
+    .map_err(|_| InvalidIntent)?;
+    if bytes.len() > 512 * 1024 {
+        return Err(InvalidIntent);
+    }
+    Ok(bytes)
+}
+
+#[cfg(target_os = "linux")]
+fn start_with<P: InteractiveWorkerProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    allocation: &StoredRemoteAllocation,
+    panel: &str,
+    execute: impl FnOnce(
+        &CloudWorkflowStore,
+        &RecoveredRemoteWorkspace,
+        &str,
+        &[u8],
+    ) -> Result<RemotePanelStatus, RemoteGitTaskStartError>,
+) -> Result<RemotePanelStatus, RemoteGitTaskStartError> {
+    let input = request(allocation, panel)?;
+    let current = store
+        .load_remote_allocation(
+            allocation.workspace().session_id(),
+            &allocation.workspace().state().spec.workspace_local_id,
+        )
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    if current.as_ref() != Some(allocation) {
+        return Err(RemoteWorkspaceRecoveryError::StateChanged.into());
+    }
+    allocation
+        .recovery_request()
+        .map_err(RemoteWorkspaceRecoveryError::from)?;
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(RemoteGitTaskStartError::MissingRetainedWorker)?;
+    if runtime.worker.is_none()
+        || !runtime
+            .ssh
+            .as_ref()
+            .is_some_and(InteractiveWorkerSshEndpoint::is_complete)
+    {
+        return Err(RemoteGitTaskStartError::MissingRetainedWorker);
+    }
+    let recovered = inspect_remote_allocation(identities, provider, allocation)?;
+    validate(store, &recovered, panel)?;
+    let result = execute(store, &recovered, panel, &input)?;
+    validate(store, &recovered, panel).map_err(|_| RemoteGitTaskStartError::OutcomeUnknown)?;
+    Ok(result)
+}
+
+#[cfg(target_os = "linux")]
+fn lease_deadline(recovered: &RecoveredRemoteWorkspace) -> Result<Option<OffsetDateTime>, RemoteGitTaskStartError> {
+    recovered
+        .observation()
+        .and_then(|status| status.worker.lifetime.as_time_limited())
+        .map(|lease| {
+            OffsetDateTime::parse(&lease.terminate_after, &time::format_description::well_known::Rfc3339)
+                .map_err(|_| RemoteGitTaskStartError::ExpiredWorker)
+        })
+        .transpose()
+}
+
+#[cfg(target_os = "linux")]
+fn validate<'a>(
+    store: &CloudWorkflowStore,
+    recovered: &'a RecoveredRemoteWorkspace,
+    panel: &str,
+) -> Result<&'a crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint, RemoteGitTaskStartError> {
+    let endpoint = crate::remote_worker_inspection::validate_current(store, recovered, Some(panel))?;
+    if lease_deadline(recovered)?.is_some_and(|end| end <= OffsetDateTime::now_utc()) {
+        return Err(RemoteGitTaskStartError::ExpiredWorker);
+    }
+    Ok(endpoint)
+}
+
+#[cfg(target_os = "linux")]
+fn execute(
+    store: &CloudWorkflowStore,
+    recovered: &RecoveredRemoteWorkspace,
+    panel: &str,
+    input: &[u8],
+) -> Result<RemotePanelStatus, RemoteGitTaskStartError> {
+    let endpoint = validate(store, recovered, panel)?;
+    let identity = recovered.identity();
+    let trust = known_hosts(identity, endpoint)?;
+    let command = prepared_command(identity.private_key_path(), trust.path(), endpoint)?;
+    validate(store, recovered, panel)?;
+    exchange(
+        command,
+        input,
+        panel,
+        lease_deadline(recovered)?,
+        OffsetDateTime::now_utc,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn exchange(
+    command: Command,
+    mut input: &[u8],
+    panel: &str,
+    deadline: Option<OffsetDateTime>,
+    now: impl Fn() -> OffsetDateTime,
+) -> Result<RemotePanelStatus, RemoteGitTaskStartError> {
+    let started = Instant::now();
+    let timeout = timeout(deadline, now())?;
+    let expired = || started.elapsed() >= timeout || deadline.is_some_and(|end| now() >= end);
+    let expected = input.len() as u64;
+    let result = query::exchange(
+        command,
+        &mut input,
+        timeout,
+        super::protocol::RESPONSE_LIMIT,
+        expired,
+        Some(expected),
+    )
+    .map_err(|_| RemoteGitTaskStartError::OutcomeUnknown)?;
+    let (query::InputProgress::Complete(written) | query::InputProgress::Incomplete(written)) = result.input;
+    if written != expected || !result.status.success() {
+        return Err(RemoteGitTaskStartError::OutcomeUnknown);
+    }
+    super::protocol::response(&result.output, panel).map_err(|_| RemoteGitTaskStartError::OutcomeUnknown)
+}
+
+#[cfg(target_os = "linux")]
+fn timeout(deadline: Option<OffsetDateTime>, now: OffsetDateTime) -> Result<Duration, RemoteGitTaskStartError> {
+    let maximum = Duration::from_secs(15);
+    match deadline {
+        None => Ok(maximum),
+        Some(end) if end <= now => Err(RemoteGitTaskStartError::ExpiredWorker),
+        Some(end) => Duration::try_from(end - now)
+            .map(|remaining| remaining.min(maximum))
+            .map_err(|_| RemoteGitTaskStartError::ExpiredWorker),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_worker_status/git_start/tests.rs
+++ b/crates/horizon-core/src/remote_worker_status/git_start/tests.rs
@@ -1,0 +1,387 @@
+use super::*;
+use crate::{
+    HorizonHome, PanelKind,
+    cloud_run::{CloudProvider, WorkerLifetime, interactive_worker::*},
+    remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
+    remote_workspace_recovery::recover_remote_workspace,
+};
+use std::{
+    cell::Cell,
+    os::unix::fs::PermissionsExt,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+const RUNNING: &str = r#"{"state":"running","panel":"shell","pid":12,"exit_status":null}"#;
+
+struct Provider {
+    status: InteractiveWorkerStatus,
+    calls: AtomicUsize,
+}
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::LocalDocker
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        Ok(Some(self.status.clone()))
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(self.status.clone()))
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no delete")
+    }
+}
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    identities: RemoteSshIdentityStore,
+    allocation: StoredRemoteAllocation,
+    provider: Provider,
+}
+impl Fixture {
+    fn new(branch: Option<&str>, lifetime: WorkerLifetime) -> Self {
+        Self::with_pin(branch, lifetime, true)
+    }
+
+    fn with_pin(branch: Option<&str>, lifetime: WorkerLifetime, pinned: bool) -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let home = HorizonHome::from_root(directory.path().join("home"));
+        let store = CloudWorkflowStore::open(&home).unwrap();
+        let identities = RemoteSshIdentityStore::new(&home);
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1,"spec":{"workspace_local_id":"workspace","working_directory":"nested","generation":0,
+              "panels":[{"panel_local_id":"shell","kind":"shell","command":{"program":"/bin/sh","args":["-c","printf synthetic"]}}],
+              "repository":{"repository":"fixture/repository","commit":"a".repeat(40),"branch":branch},
+              "target":{"provider":"local_docker","profile":"development","image":format!("fixture/worker@sha256:{}","b".repeat(64)),
+                "disk_gib":20,"lifetime":"persistent"}}})).unwrap();
+        state.spec.target.lifetime = lifetime;
+        let workspace = store.create_remote_workspace(OWNER, &state).unwrap();
+        let allocation = store.allocate_remote_runtime(&workspace, i64::MAX).unwrap();
+        let runtime = allocation.workspace().state().runtime.as_ref().unwrap();
+        let identity = identities.prepare_new(runtime.workflow_id, runtime.job_id).unwrap();
+        let allocation = store
+            .reserve_remote_worker_request(&allocation, identity.public_key())
+            .unwrap();
+        let request = allocation.worker_request().unwrap();
+        let status = InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: request.target.provider,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: "synthetic-worker".into(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: match lifetime {
+                    WorkerLifetime::Persistent => InteractiveWorkerLifetime::Persistent,
+                    WorkerLifetime::TimeLimited { seconds } => {
+                        InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+                            terminate_after: (OffsetDateTime::now_utc() + time::Duration::seconds(i64::from(seconds)))
+                                .format(&time::format_description::well_known::Rfc3339)
+                                .unwrap(),
+                        })
+                    }
+                },
+            },
+            lifecycle: if pinned {
+                InteractiveWorkerLifecycle::Ready
+            } else {
+                InteractiveWorkerLifecycle::Provisioning
+            },
+            ssh: pinned.then(|| InteractiveWorkerSshEndpoint {
+                host: "127.0.0.1".into(),
+                port: 2222,
+                username: "horizon".into(),
+                host_key: identity.public_key().into(),
+            }),
+        };
+        let provider = Provider {
+            status,
+            calls: AtomicUsize::new(0),
+        };
+        let recovered = recover_remote_workspace(&store, &identities, &provider, OWNER, "workspace").unwrap();
+        Self {
+            _directory: directory,
+            store,
+            identities,
+            allocation: recovered.allocation().clone(),
+            provider,
+        }
+    }
+    fn ready() -> Self {
+        Self::new(Some("work/one"), WorkerLifetime::Persistent)
+    }
+    fn edit(&mut self, change: impl FnOnce(&mut RemoteWorkspaceState)) {
+        let mut state = self.allocation.workspace().state().clone();
+        change(&mut state);
+        self.store
+            .replace_remote_workspace(self.allocation.workspace(), &state)
+            .unwrap();
+        self.allocation = self.store.load_remote_allocation(OWNER, "workspace").unwrap().unwrap();
+    }
+    fn start(
+        &self,
+        execute: impl FnOnce(
+            &CloudWorkflowStore,
+            &RecoveredRemoteWorkspace,
+            &str,
+            &[u8],
+        ) -> Result<RemotePanelStatus, RemoteGitTaskStartError>,
+    ) -> Result<RemotePanelStatus, RemoteGitTaskStartError> {
+        start_with(
+            &self.store,
+            &self.identities,
+            &self.provider,
+            &self.allocation,
+            "shell",
+            execute,
+        )
+    }
+}
+
+#[test]
+fn exact_saved_shell_and_git_binding_are_sent_without_persisting_new_state() {
+    let fixture = Fixture::ready();
+    let expected = fixture.allocation.clone();
+    let result = fixture
+        .start(|_, recovered, panel, bytes| {
+            assert_eq!(recovered.allocation(), &expected);
+            assert_eq!(panel, "shell");
+            let value: serde_json::Value = serde_json::from_slice(bytes).unwrap();
+            assert_eq!(value["operation"], "start-git");
+            assert_eq!(value["directory"], "nested");
+            assert_eq!(value["argv"], serde_json::json!(["/bin/sh", "-c", "printf synthetic"]));
+            let git: crate::repository_git::GitPreparation =
+                serde_json::from_value(value["repository"].clone()).unwrap();
+            assert_eq!(git.source, expected.workspace().state().spec.repository);
+            assert_eq!(git.work_branch, "work/one");
+            assert_eq!(
+                git.runtime_id.to_string(),
+                expected.worker_request().unwrap().job_id.to_string()
+            );
+            Ok(RemotePanelStatus::Running { pid: 12 })
+        })
+        .unwrap();
+    assert_eq!(result, RemotePanelStatus::Running { pid: 12 });
+    assert_eq!(fixture.provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        fixture
+            .store
+            .load_remote_allocation(OWNER, "workspace")
+            .unwrap()
+            .unwrap(),
+        expected
+    );
+}
+
+#[test]
+fn unsupported_saved_intents_are_rejected_before_provider_or_ssh() {
+    for fault in ["kind", "command", "handoff", "args"] {
+        let mut fixture = Fixture::ready();
+        fixture.edit(|state| {
+            let task = &mut state.spec.panels[0];
+            match fault {
+                "kind" => task.kind = PanelKind::Command,
+                "command" => task.command = None,
+                "handoff" => task.task_handoff = Some("synthetic context".into()),
+                // Persisted argv permits 64KiB of arguments; the worker also
+                // counts the executable, so this valid saved intent is too large.
+                _ => task.command.as_mut().unwrap().args = vec!["a".repeat(65536)],
+            }
+        });
+        assert_eq!(
+            fixture.start(|_, _, _, _| panic!("no SSH")),
+            Err(RemoteGitTaskStartError::InvalidIntent),
+            "{fault}"
+        );
+        assert_eq!(fixture.provider.calls.load(Ordering::SeqCst), 0);
+    }
+    for branch in [None, Some("HEAD")] {
+        let fixture = Fixture::new(branch, WorkerLifetime::Persistent);
+        assert_eq!(
+            fixture.start(|_, _, _, _| panic!("no SSH")),
+            Err(RemoteGitTaskStartError::InvalidIntent)
+        );
+        assert_eq!(fixture.provider.calls.load(Ordering::SeqCst), 0);
+    }
+    let fixture = Fixture::ready();
+    assert_eq!(
+        start_with(
+            &fixture.store,
+            &fixture.identities,
+            &fixture.provider,
+            &fixture.allocation,
+            "unknown-panel",
+            |_, _, _, _| panic!("no SSH")
+        ),
+        Err(RemoteGitTaskStartError::InvalidIntent)
+    );
+    assert_eq!(fixture.provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn changed_snapshot_and_pending_management_refuse_before_provider() {
+    for stop in [false, true] {
+        let mut fixture = Fixture::ready();
+        let stale = fixture.allocation.clone();
+        if stop {
+            fixture
+                .store
+                .record_remote_stop_phase(
+                    &fixture.allocation,
+                    RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+                )
+                .unwrap();
+        } else {
+            fixture.edit(|state| state.spec.working_directory = ".".into());
+        }
+        assert!(
+            start_with(
+                &fixture.store,
+                &fixture.identities,
+                &fixture.provider,
+                &stale,
+                "shell",
+                |_, _, _, _| panic!("no SSH")
+            )
+            .is_err()
+        );
+        assert_eq!(fixture.provider.calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn changed_valid_host_key_or_missing_worker_never_sends_start() {
+    let mut fixture = Fixture::ready();
+    let another = Fixture::ready();
+    fixture.provider.status.ssh.as_mut().unwrap().host_key =
+        another.provider.status.ssh.as_ref().unwrap().host_key.clone();
+    assert!(fixture.start(|_, _, _, _| panic!("no SSH")).is_err());
+    let fixture = Fixture::with_pin(Some("work/one"), WorkerLifetime::Persistent, false);
+    assert_eq!(
+        fixture.start(|_, _, _, _| panic!("no SSH")),
+        Err(RemoteGitTaskStartError::MissingRetainedWorker)
+    );
+    assert_eq!(fixture.provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn post_send_intent_drift_is_unknown_even_with_a_valid_task_response() {
+    let fixture = Fixture::ready();
+    assert_eq!(
+        fixture.start(|store, recovered, _, _| {
+            store
+                .record_remote_stop_phase(
+                    recovered.allocation(),
+                    RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+                )
+                .unwrap();
+            Ok(RemotePanelStatus::Running { pid: 12 })
+        }),
+        Err(RemoteGitTaskStartError::OutcomeUnknown)
+    );
+}
+
+#[test]
+fn short_lease_is_enforced_without_shared_clock_skew_grace() {
+    let fixture = Fixture::new(Some("work/one"), WorkerLifetime::TimeLimited { seconds: 1 });
+    let result = fixture.start(|_, _, _, _| {
+        std::thread::sleep(Duration::from_millis(1100));
+        Ok(RemotePanelStatus::Running { pid: 12 })
+    });
+    assert_eq!(result, Err(RemoteGitTaskStartError::OutcomeUnknown));
+    assert!(
+        fixture
+            .start(|_, _, _, _| panic!("expired request must not send"))
+            .is_err()
+    );
+}
+
+fn child(script: &str) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.env_clear().arg("-c").arg(script);
+    command
+}
+
+#[test]
+fn transport_accepts_only_exact_complete_successful_matching_status() {
+    for response in [
+        RUNNING,
+        r#"{"state":"exited","panel":"shell","pid":12,"exit_status":42}"#,
+        r#"{"state":"unavailable","panel":"shell"}"#,
+    ] {
+        let script = format!("/bin/cat >/dev/null; printf '%s' '{response}'");
+        assert!(exchange(child(&script), b"request", "shell", None, OffsetDateTime::now_utc).is_ok());
+    }
+    for response in [
+        "{}",
+        r#"{"state":"running","panel":"other","pid":12,"exit_status":null}"#,
+        r#"{"state":"running","panel":"shell","pid":12}"#,
+        r#"{"state":"running","panel":"shell","pid":12,"exit_status":null,"private":"sentinel"}"#,
+    ] {
+        let script = format!("/bin/cat >/dev/null; printf '%s' '{response}'");
+        assert_eq!(
+            exchange(child(&script), b"request", "shell", None, OffsetDateTime::now_utc),
+            Err(RemoteGitTaskStartError::OutcomeUnknown)
+        );
+    }
+    for script in [
+        format!("/bin/cat >/dev/null; printf '%s' '{RUNNING}'; exit 1"),
+        format!("exec 0<&-; printf '%s' '{RUNNING}'"),
+        "/bin/cat >/dev/null".into(),
+    ] {
+        assert_eq!(
+            exchange(
+                child(&script),
+                &vec![b'x'; 256 * 1024],
+                "shell",
+                None,
+                OffsetDateTime::now_utc
+            ),
+            Err(RemoteGitTaskStartError::OutcomeUnknown)
+        );
+    }
+}
+
+#[test]
+fn absolute_deadline_covers_spawn_and_checks_before_first_stdin_write() {
+    let now = OffsetDateTime::now_utc();
+    assert_eq!(timeout(None, now), Ok(Duration::from_secs(15)));
+    assert_eq!(
+        timeout(Some(now + time::Duration::seconds(2)), now),
+        Ok(Duration::from_secs(2))
+    );
+    assert_eq!(timeout(Some(now), now), Err(RemoteGitTaskStartError::ExpiredWorker));
+    let temp = tempfile::tempdir().unwrap();
+    let received = temp.path().join("received");
+    let mut command = child("/bin/cat > \"$1\"");
+    command.arg("fixture").arg(&received);
+    let calls = Cell::new(0);
+    assert_eq!(
+        exchange(
+            command,
+            b"request must not arrive",
+            "shell",
+            Some(now + time::Duration::seconds(1)),
+            || {
+                calls.set(calls.get() + 1);
+                if calls.get() == 1 {
+                    now
+                } else {
+                    now + time::Duration::seconds(2)
+                }
+            }
+        ),
+        Err(RemoteGitTaskStartError::OutcomeUnknown)
+    );
+    assert!(!received.exists() || std::fs::read(received).unwrap().is_empty());
+}

--- a/crates/horizon-core/src/repository_git/linux.rs
+++ b/crates/horizon-core/src/repository_git/linux.rs
@@ -185,6 +185,32 @@ struct Completion {
     inode: u64,
 }
 
+pub(super) fn inspect_checkout(parent: &Path, request: &GitPreparation) -> Result<super::GitCheckoutLocation, Error> {
+    let bytes = request.encode()?;
+    let parent = Directory::open_mode(parent, false)?;
+    let worker = Directory::open_mode(&parent.path.join(".horizon-worker"), true)?;
+    let tasks = Directory::open_mode(&parent.path.join("horizon"), true)?;
+    let slot = worker.child("git-workspace", false)?.ok_or(Error::Conflict)?;
+    if slot.read("claim.json")?.as_deref() != Some(&bytes) {
+        return Err(Error::Conflict);
+    }
+    let completion: Completion =
+        serde_json::from_slice(&slot.read("complete.json")?.ok_or(Error::Conflict)?).map_err(|_| Error::Conflict)?;
+    let checkout = tasks.child("repository", false)?.ok_or(Error::Conflict)?;
+    let meta = checkout.handle.metadata().map_err(|_| Error::UnsafeRoot)?;
+    if completion.request != *request || (completion.device, completion.inode) != (meta.dev(), meta.ino()) {
+        return Err(Error::Conflict);
+    }
+    for directory in [&parent, &worker, &tasks, &slot, &checkout] {
+        directory.verify()?;
+    }
+    Ok(super::GitCheckoutLocation {
+        path: CHECKOUT,
+        device: meta.dev(),
+        inode: meta.ino(),
+    })
+}
+
 pub(super) fn execute(
     parent: &Path,
     request: &GitPreparation,

--- a/crates/horizon-core/src/repository_git/mod.rs
+++ b/crates/horizon-core/src/repository_git/mod.rs
@@ -25,6 +25,32 @@ pub struct GitPreparation {
 }
 
 impl GitPreparation {
+    /// Canonical task binding, independent of current checkout contents or existence.
+    /// # Errors
+    /// Rejects invalid preparation identities before any filesystem access.
+    pub fn binding(&self) -> Result<crate::cloud_run::ArtifactDigest, GitPreparationError> {
+        let mut bytes = b"horizon-ordinary-git-task-v1\0".to_vec();
+        bytes.extend(self.encode()?);
+        Ok(crate::cloud_run::ArtifactDigest::sha256(&bytes))
+    }
+
+    /// Inspect the completed checkout identity without Git, writes or task startup.
+    /// Requires stable trusted worker ownership; callers must hold and recheck the
+    /// returned directory identity before use. Dirty files are deliberately retained.
+    /// # Errors
+    /// Rejects incomplete/conflicting preparation, unsafe ancestry and replaced roots.
+    pub fn inspect_checkout(&self) -> Result<GitCheckoutLocation, GitPreparationError> {
+        self.encode()?;
+        #[cfg(target_os = "linux")]
+        {
+            linux::inspect_checkout(std::path::Path::new("/workspace"), self)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(GitPreparationError::Unsupported)
+        }
+    }
+
     /// Decode bounded strict JSON before touching the worker.
     /// # Errors
     /// Rejects malformed identities, source, branches, unknown fields and trailing data.
@@ -58,6 +84,14 @@ impl GitPreparation {
             .filter(|bytes| bytes.len() <= REQUEST_LIMIT)
             .ok_or(GitPreparationError::Invalid)
     }
+}
+
+/// Fixed worker checkout plus inode identity, not a caller-supplied path.
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct GitCheckoutLocation {
+    pub path: &'static str,
+    pub device: u64,
+    pub inode: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]

--- a/crates/horizon-core/src/repository_git/tests.rs
+++ b/crates/horizon-core/src/repository_git/tests.rs
@@ -35,6 +35,94 @@ fn roots() -> tempfile::TempDir {
     root
 }
 
+#[test]
+fn task_binding_is_canonical_and_includes_every_preparation_field() {
+    let original = request();
+    let binding = original.binding().unwrap();
+    assert_eq!(
+        Request::decode(&original.encode().unwrap()).unwrap().binding().unwrap(),
+        binding
+    );
+    for field in [
+        "workspace",
+        "runtime",
+        "repository",
+        "commit",
+        "source_branch",
+        "work_branch",
+    ] {
+        let mut changed = original.clone();
+        match field {
+            "workspace" => changed.workspace_local_id = "another-workspace".into(),
+            "runtime" => changed.runtime_id = uuid::Uuid::new_v4(),
+            "repository" => changed.source.repository = "fixture/another".into(),
+            "commit" => changed.source.commit = crate::cloud_run::GitCommitSha::parse("b".repeat(40)).unwrap(),
+            "source_branch" => changed.source.branch = Some("another".into()),
+            _ => changed.work_branch = "work/another".into(),
+        }
+        assert_ne!(changed.binding().unwrap(), binding, "{field}");
+    }
+    let mut invalid = original;
+    invalid.work_branch = "HEAD".into();
+    assert_eq!(invalid.binding(), Err(Error::Invalid));
+    assert_eq!(invalid.inspect_checkout(), Err(Error::Invalid));
+}
+
+#[test]
+fn task_checkout_requires_exact_completion_without_git_or_dirty_file_changes() {
+    let root = roots();
+    let request = request();
+    assert_eq!(linux::inspect_checkout(root.path(), &request), Err(Error::Conflict));
+    assert!(!root.path().join(".horizon-worker/git-workspace").exists());
+    let mut git = Fake::new();
+    assert_eq!(execute(root.path(), &request, false, &mut git).state, State::Complete);
+    let checkout = root.path().join("horizon/repository");
+    fs::write(checkout.join("dirty"), b"uncommitted task bytes").unwrap();
+    let before = git.calls;
+    let location = linux::inspect_checkout(root.path(), &request).unwrap();
+    let meta = checkout.metadata().unwrap();
+    assert_eq!(
+        (location.path, location.device, location.inode),
+        (super::CHECKOUT, meta.dev(), meta.ino())
+    );
+    assert_eq!(git.calls, before);
+    assert_eq!(fs::read(checkout.join("dirty")).unwrap(), b"uncommitted task bytes");
+    let mut other = request.clone();
+    other.work_branch = "different".into();
+    assert_eq!(linux::inspect_checkout(root.path(), &other), Err(Error::Conflict));
+    fs::rename(&checkout, root.path().join("horizon/retained")).unwrap();
+    fs::create_dir(&checkout).unwrap();
+    fs::set_permissions(&checkout, fs::Permissions::from_mode(0o700)).unwrap();
+    assert_eq!(linux::inspect_checkout(root.path(), &request), Err(Error::Conflict));
+    fs::remove_dir(&checkout).unwrap();
+    symlink(root.path().join("horizon/retained"), &checkout).unwrap();
+    assert_eq!(linux::inspect_checkout(root.path(), &request), Err(Error::UnsafeRoot));
+}
+
+#[test]
+fn task_checkout_rejects_partial_corrupt_and_insecure_records() {
+    for fault in ["partial", "completion", "claim", "mode", "ancestry"] {
+        let root = roots();
+        let request = request();
+        let mut git = Fake::new();
+        assert_eq!(execute(root.path(), &request, false, &mut git).state, State::Complete);
+        let slot = root.path().join(".horizon-worker/git-workspace");
+        match fault {
+            "partial" => fs::remove_file(slot.join("complete.json")).unwrap(),
+            "completion" => fs::write(slot.join("complete.json"), b"{}").unwrap(),
+            "claim" => fs::write(slot.join("claim.json"), b"{}").unwrap(),
+            "mode" => fs::set_permissions(
+                root.path().join("horizon/repository"),
+                fs::Permissions::from_mode(0o755),
+            )
+            .unwrap(),
+            _ => fs::set_permissions(root.path(), fs::Permissions::from_mode(0o777)).unwrap(),
+        }
+        assert!(linux::inspect_checkout(root.path(), &request).is_err(), "{fault}");
+        assert!(slot.exists());
+    }
+}
+
 struct Fake {
     calls: usize,
     fail: Option<usize>,

--- a/crates/horizon-repository/src/git.rs
+++ b/crates/horizon-repository/src/git.rs
@@ -4,6 +4,50 @@ use std::{
     process::ExitCode,
 };
 
+pub(super) fn inspect(
+    checkout: bool,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    #[derive(serde::Serialize)]
+    struct Response {
+        version: u8,
+        binding_sha256: Option<horizon_core::cloud_run::ArtifactDigest>,
+        runtime: Option<String>,
+        root: Option<repository_git::GitCheckoutLocation>,
+        reason: Option<GitPreparationError>,
+    }
+    let mut response = Response {
+        version: 1,
+        binding_sha256: None,
+        runtime: None,
+        root: None,
+        reason: None,
+    };
+    response.reason = (|| {
+        let mut bytes = Vec::new();
+        input
+            .take(REQUEST_LIMIT as u64 + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| GitPreparationError::Invalid)?;
+        let request = GitPreparation::decode(&bytes)?;
+        response.binding_sha256 = Some(request.binding()?);
+        response.runtime = Some(request.runtime_id.to_string());
+        if checkout {
+            response.root = Some(request.inspect_checkout()?);
+        }
+        Ok(())
+    })()
+    .err();
+    let code = match response.reason {
+        None => 0,
+        Some(GitPreparationError::Invalid | GitPreparationError::Unsupported) => 2,
+        Some(_) => 1,
+    };
+    super::write_response(&response, code, repository_git::RESPONSE_LIMIT, output, diagnostics)
+}
+
 pub(super) fn run(
     observe: bool,
     input: &mut impl Read,
@@ -33,6 +77,50 @@ pub(super) fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn task_binding_is_framed_and_read_only_before_checkout_inspection() {
+        let request = serde_json::json!({"version":1,"workspace_local_id":"fixture",
+            "runtime_id":"00000000-0000-4000-8000-000000000001",
+            "source":{"repository":"fixture/repository","commit":"a".repeat(40),"branch":"work/one"},
+            "work_branch":"work/one"});
+        let bytes = serde_json::to_vec(&request).unwrap();
+        let mut output = vec![];
+        assert_eq!(
+            inspect(false, &mut bytes.as_slice(), &mut output, &mut std::io::sink()),
+            ExitCode::SUCCESS
+        );
+        let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(response["runtime"], request["runtime_id"]);
+        assert!(response["root"].is_null() && response["reason"].is_null());
+        assert_eq!(response["binding_sha256"].as_str().unwrap().len(), 64);
+        assert_eq!(
+            inspect(
+                false,
+                &mut bytes.as_slice(),
+                &mut [0; 0].as_mut_slice(),
+                &mut std::io::sink()
+            ),
+            ExitCode::from(3)
+        );
+        for checkout in [false, true] {
+            for invalid in [
+                b"private-invalid".to_vec(),
+                vec![b' '; REQUEST_LIMIT + 1],
+                [bytes.clone(), b"{}".to_vec()].concat(),
+            ] {
+                output.clear();
+                assert_eq!(
+                    inspect(checkout, &mut invalid.as_slice(), &mut output, &mut std::io::sink()),
+                    ExitCode::from(2)
+                );
+                let response: serde_json::Value = serde_json::from_slice(&output).unwrap();
+                assert_eq!(response["reason"], "invalid");
+                assert!(
+                    response["root"].is_null() && response["runtime"].is_null() && response["binding_sha256"].is_null()
+                );
+            }
+        }
+    }
     #[test]
     fn malformed_input_is_redacted_and_output_loss_is_distinct() {
         for input in [

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -35,12 +35,14 @@ fn main() -> ExitCode {
                     | "storage-status"
                     | "git-prepare"
                     | "git-status"
+                    | "git-binding"
+                    | "git-checkout"
             )
         )
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status < request"
+            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
         );
         return ExitCode::from(2);
     }
@@ -48,6 +50,8 @@ fn main() -> ExitCode {
     let mut output = io::stdout().lock();
     let mut diagnostics = io::stderr().lock();
     match command {
+        Some("git-binding") => git::inspect(false, &mut input, &mut output, &mut diagnostics),
+        Some("git-checkout") => git::inspect(true, &mut input, &mut output, &mut diagnostics),
         Some("git-prepare") => git::run(false, &mut input, &mut output, &mut diagnostics),
         Some("git-status") => git::run(true, &mut input, &mut output, &mut diagnostics),
         Some("setup") => setup::run(setup::Command::Execute, &mut input, &mut output, &mut diagnostics),

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -583,9 +583,17 @@ modules.
 observation API. Its `linux` leaf confines the separate one-shot claim and fixed
 task-accessible checkout, while `git` owns sanitized bounded Git subprocesses.
 The repository CLI only frames bounded requests and responses. This prerequisite
-does not use the retained overlay setup qualifier, change task admission, or
+does not use the retained overlay setup qualifier or
 support LFS/submodules yet; unsupported repositories retain state without a
 completion receipt. Observation never mutates user commits or worktree changes.
+
+Ordinary Git task admission uses `repository_git` canonical binding and read-only
+checkout identity projections, framed in the existing CLI Git leaf. The worker's
+`start-git` shares prepared-task marker and held-directory checks without invoking
+overlay setup or Git. `remote_worker_status::git_start` owns the separate explicit
+saved-Shell mutation, provider/pin admission and lease-bounded transport; existing
+inspection functions never call it. A matching retained marker is observed before
+current checkout inspection, preserving completed/dirty tasks without replay.
 
 Use these checks during implementation and review:
 


### PR DESCRIPTION
## Purpose

Advance #470 with explicit startup of a saved Shell task in its completed ordinary Git checkout. This is a Linux controller/worker prerequisite, not complete GitHub or cloud workflow acceptance.

## Behavior

- Bind task admission to the saved repository, exact preparation commit, work branch and runtime. The worker verifies the completed checkout's retained filesystem identity before a new start; nested working directories remain confined to that checkout.
- Reuse the existing task claim, held-directory and session machinery. A matching running or exited task is observed without relaunching, resetting the repository or overwriting dirty files.
- Expose `start_remote_git_shell` for the saved explicit Shell command only. Require current owned allocation, provider observation, retained SSH pin and an unexpired lease; cap stdin admission by the lease and transport deadline.
- Treat lost or invalid replies as unknown. Follow-up inspection is noncreating; there is no automatic retry or task replay.

The focused scope is 10 source/test paths and 1,036 changed lines, plus two documentation updates. No provider allocation, credential installation, Stop/Delete, arbitrary caller command, UI wiring, local file transfer, LFS/submodule support or remote publishing API is added. Existing non-Linux CI remains required; functional controller support in this change is Linux only.

## Validation

Final candidate: `c019b61a5f46200ec64b575d17be1414782e51a6`, based on the actual #528 squash. The final tree is identical to the independently reviewed and precommit-validated integration.

- 74 focused Rust tests passed: repository binding/checkout projection, controller admission/transport and CLI framing.
- The exact-commit full matrix passed: formatting, maintainability, version synchronization, default workspace tests (2,345 passed), speech-enabled workspace tests (2,390 passed), blocking Clippy, strict Clippy and advisory pedantic Clippy. Each test suite retained six ignored tests.
- 46 installed-worker Python tests passed using pinned tmux. The tested Python source and tests are unchanged in the final candidate.
- Fresh final-head native proof passed using the actual controller, candidate CLI and worker scripts over pinned loopback SSH. Concurrent starts produced exactly one execution; the lost-reply lane recovered through noncreating observation. Both lanes preserved dirty nested checkouts, observed exit 7 without replay, verified independent task progress and token-free task environments, then removed only their two owned fixtures.
- Independent local review passed, including the subsequent method-reference lint correction. The original lint failure is preserved in private evidence.

The native fixture used a synthetic provider and synthetic HTTPS repository; it does not establish real provider or GitHub acceptance or a rebuilt whole-image packaging result.

Mandatory independent hosted review and all applicable exact-head checks remain pending after publication; no hosted readiness is claimed here.

Real GitHub commit/push/PR, provider-backed end-to-end acceptance and remaining issue checkboxes stay open. This PR does not close #470 or #383.
