### PR TITLE
feat(cloud): bound Azure token acquisition by the caller's budget

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/credential.rs
+++ b/crates/horizon-core/src/cloud_run/azure/credential.rs
@@ -72,6 +72,18 @@ pub trait AzureCredentialSource: Send + Sync {
     /// # Errors
     /// Returns a redacted error when no usable token can be obtained.
     fn token(&self) -> Result<AzureAccessToken, AzureError>;
+
+    /// A token obtained within `budget`, for callers polling under an absolute
+    /// deadline. The default serves sources that answer at once (a cached or synthetic
+    /// token); a source that may block, as the CLI does on a refresh, must bound its
+    /// own waiting by the budget and answer [`AzureError::CredentialUnavailable`] once
+    /// it is spent.
+    /// # Errors
+    /// Returns a redacted error when no usable token can be obtained in time.
+    fn token_within(&self, budget: Duration) -> Result<AzureAccessToken, AzureError> {
+        let _ = budget;
+        self.token()
+    }
 }
 
 impl<F> AzureCredentialSource for F
@@ -124,9 +136,10 @@ impl AzureCliCredential {
         self
     }
 
-    fn fetch(&self) -> Result<AzureAccessToken, AzureError> {
+    /// Run the CLI once, ending the whole tree if it is not done by `deadline`.
+    fn fetch(&self, deadline: Instant) -> Result<AzureAccessToken, AzureError> {
         let unavailable = |reason| AzureError::CredentialUnavailable { reason };
-        let started = Instant::now();
+        let left = || deadline.saturating_duration_since(Instant::now());
         let mut command = Command::new(&self.executable);
         command
             .args([
@@ -150,42 +163,106 @@ impl AzureCliCredential {
             command.process_group(0);
         }
         let mut child = OwnedChild(spawn_tree(command).map_err(|_| unavailable("Azure CLI could not be started"))?);
-        let stdout = child.take_stdout().ok_or(unavailable("Azure CLI produced no output"))?;
+        // From here on every exit hands the tree to the detached reaper: no path after
+        // the spawn waits on process teardown from the caller's thread.
+        let Some(stdout) = child.take_stdout() else {
+            reap(child, None);
+            return Err(unavailable("Azure CLI produced no output"));
+        };
         let (sender, receiver) = mpsc::sync_channel(1);
         let limit = self.output_limit as u64 + 1;
-        std::thread::Builder::new()
+        let reader = std::thread::Builder::new()
             .name("azure-cli-output".into())
             .spawn(move || {
                 let mut output = Vec::new();
                 let result = stdout.take(limit).read_to_end(&mut output).map(|_| output);
                 let _ = sender.send(result);
-            })
-            .map_err(|_| unavailable("Azure CLI output could not be read"))?;
+            });
+        if reader.is_err() {
+            reap(child, Some(receiver));
+            return Err(unavailable("Azure CLI output could not be read"));
+        }
         let status = loop {
-            if let Some(status) = child
-                .0
-                .try_wait()
-                .map_err(|_| unavailable("Azure CLI could not be waited on"))?
-            {
-                break status;
+            // Deadline first: a process that finished while the last sleep crossed it
+            // is still late, and the sleep itself never overshoots the bound.
+            let left = left();
+            if left.is_zero() {
+                return Err(abandon(child, receiver));
             }
-            if started.elapsed() >= self.timeout {
-                return Err(abandon(child, &receiver));
+            match child.0.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) => std::thread::sleep(Duration::from_millis(20).min(left)),
+                Err(_) => {
+                    reap(child, Some(receiver));
+                    return Err(unavailable("Azure CLI could not be waited on"));
+                }
             }
-            std::thread::sleep(Duration::from_millis(20));
         };
         // A descendant that inherited stdout can outlive the leader; the same bound applies.
-        let output = match receiver.recv_timeout(self.timeout.saturating_sub(started.elapsed())) {
+        let output = match receiver.recv_timeout(left()) {
             Ok(Ok(output)) => output,
             Ok(Err(_)) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                reap(child, None);
                 return Err(unavailable("Azure CLI output could not be read"));
             }
-            Err(mpsc::RecvTimeoutError::Timeout) => return Err(abandon(child, &receiver)),
+            Err(mpsc::RecvTimeoutError::Timeout) => return Err(abandon(child, receiver)),
         };
+        // The leader has exited and its output is in hand; ending the rest of the
+        // tree is bookkeeping that must not sit on the caller's deadline either.
+        reap(child, None);
         if !status.success() || output.len() > self.output_limit {
             return Err(unavailable("Azure CLI did not return a token"));
         }
-        parse_cli_token(&output)
+        let token = parse_cli_token(&output)?;
+        // Output that arrived right at the bound is still late for the caller.
+        if Instant::now() > deadline {
+            return Err(unavailable("Azure CLI timed out"));
+        }
+        Ok(token)
+    }
+}
+
+impl AzureCliCredential {
+    /// Serve from the cache or refresh, with the cache lock wait and the CLI run both
+    /// bounded by `budget` (a refresh in another thread holds the lock for its whole run).
+    fn token_bounded(&self, budget: Duration) -> Result<AzureAccessToken, AzureError> {
+        let exceeded = || AzureError::CredentialUnavailable {
+            reason: "Azure CLI refresh in progress exceeded the caller's budget",
+        };
+        // The public budget is clamped to the credential's own timeout before it gets
+        // here, so this cannot overflow; a redacted error, never a panic, if it ever did.
+        let Some(deadline) = Instant::now().checked_add(budget) else {
+            return Err(AzureError::CredentialUnavailable {
+                reason: "token budget is out of range",
+            });
+        };
+        let mut cached = loop {
+            match self.cached.try_lock() {
+                Ok(guard) => break guard,
+                Err(std::sync::TryLockError::Poisoned(poisoned)) => break poisoned.into_inner(),
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    let left = deadline.saturating_duration_since(Instant::now());
+                    if left.is_zero() {
+                        return Err(exceeded());
+                    }
+                    std::thread::sleep(Duration::from_millis(10).min(left));
+                }
+            }
+        };
+        // The lock may have been won only after the budget ran out (a refresh that
+        // finished late): a late answer is not an answer, cached or not, and no refresh
+        // starts past the deadline. Abandoning a run is detached, so an in-budget run
+        // may use everything that is left.
+        if Instant::now() >= deadline {
+            return Err(exceeded());
+        }
+        if let Some(token) = cached.as_ref().filter(|token| !token.needs_refresh()) {
+            return Ok(token.clone());
+        }
+        // The same absolute deadline governs the run, so nothing is re-measured.
+        let token = self.fetch(deadline)?;
+        *cached = Some(token.clone());
+        Ok(token)
     }
 }
 
@@ -195,9 +272,13 @@ impl AzureCredentialSource for AzureCliCredential {
         if let Some(token) = cached.as_ref().filter(|token| !token.needs_refresh()) {
             return Ok(token.clone());
         }
-        let token = self.fetch()?;
+        let token = self.fetch(Instant::now() + self.timeout)?;
         *cached = Some(token.clone());
         Ok(token)
+    }
+
+    fn token_within(&self, budget: Duration) -> Result<AzureAccessToken, AzureError> {
+        self.token_bounded(budget.min(self.timeout))
     }
 }
 
@@ -211,11 +292,26 @@ impl fmt::Debug for AzureCliCredential {
     }
 }
 
-/// End the tree, then let the reader thread finish: killing every member closes the
-/// pipe writers, so the reader returns on its own within the grace period.
-fn abandon(child: OwnedChild, receiver: &mpsc::Receiver<std::io::Result<Vec<u8>>>) -> AzureError {
-    drop(child);
-    let _ = receiver.recv_timeout(READER_GRACE);
+/// End a CLI tree off the caller's thread: the kill, the wait and (when a reader is
+/// still attached) the reader grace run on a detached thread, so the caller's deadline
+/// never waits on process teardown. Killing every member closes the pipe writers, so
+/// the reader returns on its own within the grace period. If no thread can be
+/// spawned, the closure is dropped here together with the child, whose drop ends the
+/// tree synchronously: slower, never leaked.
+fn reap(child: OwnedChild, receiver: Option<mpsc::Receiver<std::io::Result<Vec<u8>>>>) {
+    let reaper = std::thread::Builder::new().name("azure-cli-reaper".into());
+    let spawned = reaper.spawn(move || {
+        drop(child);
+        if let Some(receiver) = receiver {
+            let _ = receiver.recv_timeout(READER_GRACE);
+        }
+    });
+    drop(spawned);
+}
+
+/// Give up on a tree that exceeded its bound without waiting for it to die.
+fn abandon(child: OwnedChild, receiver: mpsc::Receiver<std::io::Result<Vec<u8>>>) -> AzureError {
+    reap(child, Some(receiver));
     AzureError::CredentialUnavailable {
         reason: "Azure CLI timed out",
     }

--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -431,3 +431,76 @@ fn cli_credential_invokes_the_executable_without_a_shell_and_enforces_its_bounds
         unavailable("Azure CLI could not be started")
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn cli_credential_bounds_a_budgeted_token_by_the_caller_not_by_its_own_timeout() {
+    use super::AzureCredentialSource as _;
+    use std::os::unix::fs::PermissionsExt as _;
+    let directory = tempfile::tempdir().expect("temp dir");
+    // One slow fake CLI per phase, each with its own start marker, so a phase can
+    // only ever be satisfied by its own child.
+    let slow = |name: &str| {
+        let script = directory.path().join(name);
+        let marker = directory.path().join(format!("{name}.started"));
+        std::fs::write(&script, format!("#!/bin/sh\n: > '{}'\nsleep 30\n", marker.display())).expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        let credential = AzureCliCredential::with_executable(script, SUB)
+            .expect("credential")
+            .with_bounds(Duration::from_secs(5), 64 * 1024);
+        (std::sync::Arc::new(credential), marker)
+    };
+    let unavailable = |reason| AzureError::CredentialUnavailable { reason };
+    // The caller's budget ends the CLI run long before the credential's own timeout,
+    // and the timeout teardown is detached, so the call returns at the budget.
+    let (credential, _) = slow("fake-az-slow-budget");
+    let budget = Duration::from_millis(300);
+    let started = std::time::Instant::now();
+    assert_eq!(
+        credential.token_within(budget).expect_err("budget"),
+        unavailable("Azure CLI timed out")
+    );
+    assert!(
+        started.elapsed() < budget + Duration::from_millis(250),
+        "the call returns at the budget without waiting for the tree: {:?}",
+        started.elapsed()
+    );
+    // A refresh already running in another thread holds the cache lock; a budgeted
+    // caller waits at most its budget for it instead of the refresh's whole run.
+    let (credential, marker) = slow("fake-az-slow-contended");
+    // The fake CLI touches the marker once it runs, which happens under the lock.
+    // Another test thread may fork while the script is still open for writing, which
+    // makes an exec fail with "text file busy"; such an attempt ends at once without
+    // a marker and is simply retried.
+    let refresh = (0..5)
+        .find_map(|_| {
+            let refreshing = std::sync::Arc::clone(&credential);
+            let refresh = std::thread::spawn(move || refreshing.token_within(Duration::from_secs(4)));
+            let until = std::time::Instant::now() + Duration::from_secs(3);
+            while !marker.exists() {
+                if refresh.is_finished() {
+                    assert_eq!(
+                        refresh.join().expect("refresh thread").expect_err("early exit"),
+                        unavailable("Azure CLI could not be started")
+                    );
+                    return None;
+                }
+                assert!(std::time::Instant::now() < until, "the refresh never started");
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Some(refresh)
+        })
+        .expect("a refresh that started");
+    let started = std::time::Instant::now();
+    assert_eq!(
+        credential
+            .token_within(Duration::from_millis(200))
+            .expect_err("lock wait"),
+        unavailable("Azure CLI refresh in progress exceeded the caller's budget")
+    );
+    assert!(started.elapsed() < Duration::from_millis(450));
+    assert_eq!(
+        refresh.join().expect("refresh thread").expect_err("refresh"),
+        unavailable("Azure CLI timed out")
+    );
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -771,6 +771,50 @@ fn run_command_output_is_taken_only_from_a_clean_success() {
 }
 
 #[test]
+fn budgeted_lookups_ask_the_credential_for_a_token_within_the_same_budget() {
+    struct Recording(Arc<Mutex<Vec<Option<Duration>>>>);
+    impl super::super::AzureCredentialSource for Recording {
+        fn token(&self) -> Result<AzureAccessToken, AzureError> {
+            self.0.lock().expect("budgets").push(None);
+            AzureAccessToken::new("synthetic-token-value", Duration::from_secs(3_600))
+        }
+        fn token_within(&self, budget: Duration) -> Result<AzureAccessToken, AzureError> {
+            self.0.lock().expect("budgets").push(Some(budget));
+            AzureAccessToken::new("synthetic-token-value", Duration::from_secs(3_600))
+        }
+    }
+    let budgets = Arc::new(Mutex::new(Vec::new()));
+    let agent = ureq::Agent::config_builder()
+        .middleware(|_: Request<SendBody>, _: MiddlewareNext| {
+            Ok(Response::builder()
+                .status(404)
+                .body(Body::builder().data(String::new()))
+                .expect("response"))
+        })
+        .build()
+        .new_agent();
+    let transport = AzureArmHttp::with_agent(agent, SUB, Recording(Arc::clone(&budgets))).expect("transport");
+    assert_eq!(
+        transport.get_vm_within(GROUP, "worker", Duration::from_secs(7)),
+        Ok(None)
+    );
+    assert_eq!(
+        transport.get_resource_group_within(GROUP, Duration::from_secs(9)),
+        Ok(None)
+    );
+    assert_eq!(transport.get_vm(GROUP, "worker"), Ok(None));
+    assert_eq!(
+        *budgets.lock().expect("budgets"),
+        [
+            Some(Duration::from_secs(7)),
+            Some(Duration::from_secs(9)),
+            Some(REQUEST_TIMEOUT)
+        ],
+        "every lookup, budgeted or not, bounds the token step"
+    );
+}
+
+#[test]
 fn a_slow_credential_refresh_consumes_the_poll_budget_before_any_request() {
     let calls = Arc::new(AtomicUsize::new(0));
     let count = Arc::clone(&calls);

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -237,6 +237,12 @@ impl AzureArmHttp {
         self.credential.token().map(|token| token.authorization_header())
     }
 
+    fn authorization_within(&self, budget: Duration) -> Result<String, AzureError> {
+        self.credential
+            .token_within(budget)
+            .map(|token| token.authorization_header())
+    }
+
     fn get_json(&self, url: &str, operation: &'static str) -> Result<Option<serde_json::Value>, AzureError> {
         self.get_json_within(url, operation, REQUEST_TIMEOUT)
     }
@@ -257,9 +263,9 @@ impl AzureArmHttp {
     }
 
     /// The raw GET behind [`Self::get_json_within`], for callers that read headers.
-    /// Obtaining the token (which may refresh through the Azure CLI) counts against the
-    /// budget too: the HTTP exchange gets only what that step left, and none at all once
-    /// the budget is spent.
+    /// Obtaining the token counts against the budget: the credential itself is asked to
+    /// answer within it (a CLI refresh is bounded by it), the HTTP exchange gets only
+    /// what that step left, and none at all once the budget is spent.
     pub(super) fn get_within(
         &self,
         url: &str,
@@ -267,7 +273,7 @@ impl AzureArmHttp {
         budget: Duration,
     ) -> Result<ureq::http::Response<ureq::Body>, AzureError> {
         let started = std::time::Instant::now();
-        let authorization = self.authorization()?;
+        let authorization = self.authorization_within(budget)?;
         let budget = budget.saturating_sub(started.elapsed());
         if budget.is_zero() {
             return Err(AzureError::OperationTimedOut { operation });


### PR DESCRIPTION
## Summary

Seventh isolated slice of the Azure Linux VM worker adapter. Part of #474 (the issue stays open). Closes the follow-up recorded in #529 and #530: token acquisition now counts against a poll's budget instead of only the HTTP exchange.

- `AzureCredentialSource::token_within(budget)`: a budgeted token operation with a default for sources that answer at once (cached or synthetic tokens). The CLI credential implements it by waiting for its cache lock at most the budget (a refresh in another thread holds that lock for its whole run) and running `az account get-access-token` for at most the remaining part. Abandoning a timed-out run is detached: the kill, the wait and the reader grace run on a reaper thread, so the call returns at the budget even when the process is slow to exit (if no thread can be spawned, the tree is ended synchronously instead of leaked).
- Budgeted lookups (`get_vm_within`, `get_resource_group_within`, run-command polling) obtain their token through `token_within`, so the stop wait (five minutes) and the run-command wait (two minutes) hold their absolute deadlines across a token refresh. Plain lookups bound the token step by the standard request timeout.

## Behaviour impact

Only for polling paths: a token refresh that would overrun the caller's remaining budget now fails that poll with the redacted `CredentialUnavailable` instead of stretching the wait. Ordinary calls are unchanged.

## Tests

- `cli_credential_bounds_a_budgeted_token_by_the_caller_not_by_its_own_timeout` (Unix): a 300 ms budget ends a slow CLI run and returns within the budget plus a 250 ms scheduling tolerance; a caller waiting behind a running refresh (a separate fake CLI whose start marker proves the refresh holds the lock) gives up within its budget while the refresh itself still ends at its bound.
- `budgeted_lookups_ask_the_credential_for_a_token_within_the_same_budget`: budgeted lookups pass their budget to the credential and plain lookups pass the request timeout.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.
