### PR TITLE
fix(cloud): follow ARM's signed async-operation URLs for Azure run commands

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -664,6 +664,32 @@ fn run_command_polls_only_owned_operations_and_extracts_stdout() {
 }
 
 #[test]
+fn run_command_follows_arm_signed_operation_urls() {
+    // Live ARM answers with a signed status URL: a `c=` certificate parameter of about
+    // 3 KB plus `p`, `t`, `s` and `h` tokens, all base64url. The adapter's earlier 2 KB
+    // cap refused it, which kept a healthy worker in Provisioning forever.
+    let certificate: String = std::iter::repeat_n("MIIHlTCCBn2gAwIBAgIRAKGW41M2RjI0CVOmoqSB-m4_", 72).collect();
+    let operation = format!(
+        "https://management.azure.com/subscriptions/{SUB}/providers/Microsoft.Compute/locations/northeurope/operations/7bfb09fc-d6d3-4e6a-893f-a5d7501ed7e0?p=628ba44e-30c2-4d77-8ae4-98243359e7d1&api-version=2024-03-01&t=639247605279933261&c={certificate}&s=bddvIFxYRvg_1lwZBp8TNWzEd77WEAYqY8alVRoFCieUG17fuQCEe-Tut&h=X-yOGgLsaSE9H9QW_nVQonYY3eX6gk3VysBsfVEleZA"
+    );
+    assert!(operation.len() > 3_000, "realistic length: {}", operation.len());
+    let done = r#"{"status":"Succeeded","properties":{"output":{"value":[{"code":"ProvisioningState/succeeded","message":"Enable succeeded: \n[stdout]\nssh-ed25519 AAAAC3 host\n\n[stderr]\n"}]}}}"#;
+    let (transport, calls) = http(vec![
+        with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "azure-asyncoperation",
+            operation.clone(),
+        ),
+        expect("GET", operation.clone(), 200, done, None),
+    ]);
+    assert_eq!(
+        transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+        Ok(Some("ssh-ed25519 AAAAC3 host".into()))
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
 fn run_command_refuses_operation_urls_that_could_escape_the_subscription() {
     let escapes = [
         format!("https://management.azure.com/subscriptions/{SUB}/../../subscriptions/{FOREIGN_SUB}/operations/op"),

--- a/crates/horizon-core/src/cloud_run/azure/transport/run_command.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport/run_command.rs
@@ -11,6 +11,10 @@ const RUN_COMMAND_BACKOFF_MS: [u64; 9] = [500, 1_000, 2_000, 4_000, 8_000, 15_00
 const RUN_COMMAND_BOUND: Duration = Duration::from_secs(120);
 /// Longest single wait a `Retry-After` header may ask for.
 const RETRY_AFTER_CAP: Duration = Duration::from_secs(60);
+/// Longest operation URL followed. ARM signs its async-operation URLs with a
+/// certificate carried in the query string (`c=`), which alone runs to about 3 KB, so
+/// the live URL is well over 3 KB; 8 KB leaves room without accepting arbitrary sizes.
+const OPERATION_URL_LIMIT: usize = 8_192;
 
 /// The only scripts the adapter ever executes inside a worker; there is no way to pass
 /// arbitrary text to the run-command channel.
@@ -83,7 +87,8 @@ impl AzureArmHttp {
     /// Only an operation URL under this subscription on the management endpoint is
     /// polled, and only one whose path cannot be normalised out of it: every segment
     /// after the subscription is a plain token (no dot segments, no percent-encoding, no
-    /// backslashes or other separators) and the query carries only the API version shape.
+    /// backslashes or other separators) and the query carries only the shape ARM uses
+    /// (the API version plus its signature parameters, all base64url or plain tokens).
     fn owns_operation_url(&self, url: &str) -> bool {
         let prefix = format!("{MANAGEMENT_ENDPOINT}/subscriptions/{}/", self.subscription_id);
         let Some(rest) = url.strip_prefix(&prefix) else {
@@ -98,7 +103,7 @@ impl AzureArmHttp {
                     .bytes()
                     .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
         };
-        url.len() <= 2_048
+        url.len() <= OPERATION_URL_LIMIT
             && path.split('/').all(plain_segment)
             && query
                 .bytes()


### PR DESCRIPTION
## Summary

Fix found by the first live acceptance run of the merged Azure worker adapter (part of #474; the issue stays open).

The worker was created and booted correctly (cloud-init finished, the container was up, the host key was readable on the VM), but the adapter never reported it `Ready`. Azure Resource Manager answers a run command with an `Azure-AsyncOperation` URL whose query string carries a signing certificate (`c=`) plus `p`, `t`, `s` and `h` tokens; the live URL is over 3 KB. The transport's operation-URL cap was 2 KB, so the URL was refused as an invalid response, the host-key source swallowed the error, and the worker stayed in `Provisioning` for the whole 15-minute bound.

- Raise the cap to 8 KB. The exact origin and subscription prefix, the plain-segment path check and the query charset check are unchanged; the live URL satisfies all of them.

## Behaviour impact

Readiness now works against real ARM. No other path changes.

## Tests

- `run_command_follows_arm_signed_operation_urls`: a URL of the live shape and length (about 3.3 KB) is followed and the command output is returned; the test fails at the old cap and passes at the new one.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic. The live acceptance rerun with this fix is recorded in a follow-up PR.
