### PR TITLE
test(cloud): add the Azure worker live acceptance driver and run record

### DIFF
--- a/crates/horizon-core/tests/azure_live_worker.rs
+++ b/crates/horizon-core/tests/azure_live_worker.rs
@@ -1,0 +1,850 @@
+//! Live acceptance run of the Azure worker adapter against a real subscription.
+//!
+//! Ignored by default and driven entirely by environment variables, so the ordinary
+//! test matrix never touches Azure. It creates exactly one task-owned resource group,
+//! proves readiness with the attested host key by opening a pinned SSH session,
+//! stops the worker, verifies the retained state, deletes the group and proves it is
+//! gone. Every step is timed and written as one JSON line per event to stdout.
+//!
+//! Required: `HORIZON_AZURE_LIVE_SUBSCRIPTION`, `HORIZON_AZURE_LIVE_IMAGE` (digest
+//! reference on the registry), `HORIZON_AZURE_LIVE_PULL_IDENTITY` (resource ID),
+//! `HORIZON_AZURE_LIVE_REGISTRY` (login server). Optional:
+//! `HORIZON_AZURE_LIVE_LOCATION` (default `northeurope`), `HORIZON_AZURE_LIVE_VM_SIZE`
+//! (default `Standard_D2s_v3`), `HORIZON_AZURE_LIVE_REAPER_HOURS` (default `2`, 1 to 24,
+//! checked before anything is created), `HORIZON_AZURE_LIVE_HOURLY_COST_MICROS`
+//! (default `120000`, the declared hourly price of the chosen size; change it together
+//! with the size), `HORIZON_AZURE_LIVE_KEEP` (skip deletion and the failure cleanup),
+//! `HORIZON_AZURE_LIVE_REAPER_GROUP` and
+//! `HORIZON_AZURE_LIVE_REAPER_ACCOUNT` (default `horizon-worker-registry` and
+//! `horizon-spike-reaper`).
+//!
+//! Compute bound without this controller: before anything is created, the run
+//! checks that the subscription-side spike reaper schedule is enabled, runs every 15
+//! minutes and is due within the next interval; once the worker VM exists (about 15 s after creation) it is tagged for that
+//! reaper. The window between deployment submission and the tag is not covered by
+//! the reaper: a controller lost in that window leaves an untagged VM that the
+//! operator must delete by hand (the adapter's own template does not carry
+//! operator tags). A phase that fails after creation requests deletion of the exact
+//! group on the way out, unless `HORIZON_AZURE_LIVE_KEEP` is set.
+//!
+//! Run with `cargo test -p horizon-core --test azure_live_worker -- --ignored --nocapture`.
+//!
+//! Unix only: the driver relies on `ssh`, process groups and `/bin/kill` to bound
+//! every external command including its descendants.
+#![cfg(unix)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use horizon_core::cloud_run::{
+    CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime, WorkerTarget,
+    azure::{
+        AzureCliCredential, AzureClient, AzureDiskSku, AzureError, AzureProfile, WORKER_VM_NAME,
+        deployment::{TAG_JOB, TAG_WORKFLOW},
+        resource_group_name,
+    },
+    interactive_worker::{
+        InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerLifecycle as Lifecycle,
+        InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerStatus,
+    },
+    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+};
+use std::{
+    path::Path,
+    process::Command,
+    sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant},
+};
+
+const READY_BOUND: Duration = Duration::from_mins(15);
+const GONE_BOUND: Duration = Duration::from_mins(20);
+const POLL: Duration = Duration::from_secs(10);
+
+struct Run {
+    started: Instant,
+}
+
+impl Run {
+    fn event(&self, name: &str, detail: &str) {
+        println!(
+            r#"{{"event":"{name}","t_seconds":{:.1},"detail":{}}}"#,
+            self.started.elapsed().as_secs_f64(),
+            serde_json::Value::String(detail.to_string())
+        );
+    }
+}
+
+/// Run `az` with the given arguments, bounded: the child is killed once `deadline`
+/// passes, so a hung CLI can never leave the run (and its billed VM) waiting.
+fn az(args: &[&str], deadline: Instant) -> Option<std::process::Output> {
+    let mut command = Command::new("az");
+    command.args(args);
+    bounded(command, deadline)
+}
+
+/// Run any command to completion within `deadline`. The command runs in its own
+/// process group (Unix), both pipes are drained on threads with a cap, and every wait
+/// (the child, then each drained stream) is bounded by the same deadline; on expiry
+/// the whole group is killed, so a descendant that inherited a pipe cannot extend the
+/// step either.
+fn bounded(mut command: Command, deadline: Instant) -> Option<std::process::Output> {
+    use std::io::Read as _;
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        command.process_group(0);
+    }
+    let mut child = command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .ok()?;
+    let kill_tree = |child: &mut std::process::Child| {
+        #[cfg(unix)]
+        let _ = Command::new("/bin/kill")
+            .args(["-KILL", "--", &format!("-{}", child.id())])
+            .status();
+        let _ = child.kill();
+        let _ = child.wait();
+    };
+    // Read each stream to end so the child never sees a closed pipe; keep only the
+    // capped prefix; report through a channel so the wait can be bounded.
+    let drain = |stream: Option<Box<dyn std::io::Read + Send>>| {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let mut retained = Vec::new();
+            let mut chunk = [0_u8; 8 * 1024];
+            if let Some(mut stream) = stream {
+                while let Ok(count) = stream.read(&mut chunk) {
+                    if count == 0 {
+                        break;
+                    }
+                    let room = OUTPUT_CAP.saturating_sub(retained.len());
+                    retained.extend_from_slice(&chunk[..count.min(room)]);
+                }
+            }
+            let _ = sender.send(retained);
+        });
+        receiver
+    };
+    let stdout = drain(
+        child
+            .stdout
+            .take()
+            .map(|s| Box::new(s) as Box<dyn std::io::Read + Send>),
+    );
+    let stderr = drain(
+        child
+            .stderr
+            .take()
+            .map(|s| Box::new(s) as Box<dyn std::io::Read + Send>),
+    );
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(200).min(deadline.saturating_duration_since(Instant::now())));
+            }
+            _ => {
+                kill_tree(&mut child);
+                return None;
+            }
+        }
+    };
+    let remaining = || deadline.saturating_duration_since(Instant::now());
+    let (Ok(stdout), Ok(stderr)) = (stdout.recv_timeout(remaining()), stderr.recv_timeout(remaining())) else {
+        // A descendant still holds a pipe past the deadline: end the whole group.
+        kill_tree(&mut child);
+        return None;
+    };
+    Some(std::process::Output { status, stdout, stderr })
+}
+
+/// Longest output kept from one external command.
+const OUTPUT_CAP: usize = 4 * 1024 * 1024;
+
+const CLI_STEP: Duration = Duration::from_secs(90);
+
+/// `HORIZON_AZURE_LIVE_KEEP`: leave the worker in place at the end and after a failure.
+fn keep() -> bool {
+    std::env::var_os("HORIZON_AZURE_LIVE_KEEP").is_some()
+}
+
+fn required(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set for the live run"))
+}
+
+fn optional(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+fn generate_client_key(directory: &Path) -> (String, std::path::PathBuf) {
+    let private = directory.join("client_ed25519");
+    let status = Command::new("ssh-keygen")
+        .args(["-q", "-t", "ed25519", "-N", "", "-C", "", "-f"])
+        .arg(&private)
+        .status()
+        .expect("ssh-keygen");
+    assert!(status.success(), "ssh-keygen failed");
+    let public = std::fs::read_to_string(private.with_extension("pub")).expect("public key");
+    let mut fields = public.split_ascii_whitespace();
+    let key = format!("{} {}", fields.next().unwrap(), fields.next().unwrap());
+    (key, private)
+}
+
+/// The spike reaper deallocates any VM carrying these tags once the deadline passed;
+/// merged in so the worker's own identity tags stay intact. Every CLI attempt is
+/// bounded; if the tag cannot be installed within the bound the run fails and the
+/// armed cleanup guard requests the ownership-checked deletion of the group.
+fn arm_reaper(subscription: &str, group: &str, deadline: &str, run: &Run) {
+    let vm_id = format!(
+        "/subscriptions/{subscription}/resourceGroups/{group}/providers/Microsoft.Compute/virtualMachines/{WORKER_VM_NAME}"
+    );
+    let until = Instant::now() + READY_BOUND;
+    while Instant::now() < until {
+        let tag = format!("deadline={deadline}");
+        let args = [
+            "tag",
+            "update",
+            "--subscription",
+            subscription,
+            "--resource-id",
+            &vm_id,
+            "--operation",
+            "merge",
+            "--tags",
+            "purpose=horizon-azure-vm-spike",
+            &tag,
+        ];
+        if az(&args, (Instant::now() + CLI_STEP).min(until)).is_some_and(|output| output.status.success()) {
+            run.event("reaper_armed", &format!("deadline {deadline}"));
+            return;
+        }
+        std::thread::sleep(POLL.min(until.saturating_duration_since(Instant::now())));
+    }
+    // The armed cleanup guard performs the ownership-checked deletion on unwind.
+    panic!("the worker VM never became taggable for the reaper");
+}
+
+fn ssh_proof(
+    endpoint: &horizon_core::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+    private: &Path,
+    directory: &Path,
+    command: &str,
+) -> String {
+    let known_hosts = directory.join("known_hosts");
+    std::fs::write(
+        &known_hosts,
+        format!("[{}]:{} {}\n", endpoint.host, endpoint.port, endpoint.host_key),
+    )
+    .expect("known_hosts");
+    let mut ssh = Command::new("ssh");
+    // No operator configuration: only the options given here decide which endpoint is
+    // contacted and which host key is trusted.
+    ssh.args(["-F", "/dev/null"])
+        .arg("-i")
+        .arg(private)
+        .args(["-p", &endpoint.port.to_string()])
+        .arg("-o")
+        .arg(format!("UserKnownHostsFile={}", known_hosts.display()))
+        .args([
+            "-o",
+            "GlobalKnownHostsFile=/dev/null",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=20",
+            "-o",
+            "IdentitiesOnly=yes",
+        ])
+        .arg(format!("{}@{}", endpoint.username, endpoint.host))
+        .arg(command);
+    // Bounded like every other external step: a stalled session is killed, so the
+    // cleanup guard always gets to run.
+    let output = bounded(ssh, Instant::now() + CLI_STEP).expect("ssh finished within its bound");
+    assert!(
+        output.status.success(),
+        "pinned ssh failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// Poll until `poll` answers, within `bound`: the deadline is checked before every
+/// poll and the sleep never crosses it. One poll may itself take up to the adapter's
+/// own operation bound (two minutes for a run command), so the wait can end at most
+/// that much after `bound`; that is the adapter's bound, not an unbounded wait.
+fn wait_for<T>(bound: Duration, mut poll: impl FnMut() -> Result<Option<T>, AzureError>) -> Result<T, String> {
+    let until = Instant::now() + bound;
+    loop {
+        let left = until.saturating_duration_since(Instant::now());
+        if left.is_zero() {
+            return Err("bound exceeded".into());
+        }
+        match poll() {
+            Ok(Some(value)) => return Ok(value),
+            Ok(None) => {}
+            Err(error) => return Err(format!("{error:?}")),
+        }
+        std::thread::sleep(POLL.min(until.saturating_duration_since(Instant::now())));
+    }
+}
+
+/// One `az` invocation: arguments in, bounded output out. Injected so the cleanup
+/// guard's decisions can be tested without Azure.
+type Runner = Box<dyn Fn(&[&str], Instant) -> Option<std::process::Output> + Send>;
+
+/// What the failure cleanup did, printed on the way out and asserted in tests.
+#[derive(Debug, PartialEq, Eq)]
+enum CleanupOutcome {
+    /// The group carried this run's identifiers and its deletion was accepted.
+    DeletionRequested,
+    /// The group is ours but no deletion request was accepted: operator action needed.
+    DeletionNotAccepted,
+    /// The group is absent, or a same-named group that is not ours: left untouched.
+    NotOurs,
+    /// Ownership could not be checked at all: operator action needed.
+    OwnershipUnknown,
+    /// Nothing to do: not armed, or the run asked to keep the worker.
+    Skipped,
+}
+
+/// Requests deletion of the exact group if the run ends before its own delete step,
+/// so a failed phase leaves nothing billing beyond the deletion itself. Disarmed by
+/// the delete step and by an explicit keep. Ownership is proven first: the group must
+/// carry this run's workflow and job identifiers in the adapter's identity tags, so a
+/// same-named group that is not ours is left untouched and reported instead.
+struct Cleanup {
+    subscription: String,
+    group: String,
+    workflow_id: String,
+    job_id: String,
+    armed: bool,
+    keep: bool,
+    run_az: Runner,
+}
+
+impl Cleanup {
+    fn live(subscription: String, group: String, workflow_id: String, job_id: String) -> Self {
+        Self {
+            subscription,
+            group,
+            workflow_id,
+            job_id,
+            armed: false,
+            keep: keep(),
+            run_az: Box::new(az),
+        }
+    }
+
+    fn owned(&self) -> Option<bool> {
+        let shown = (self.run_az)(
+            &[
+                "group",
+                "show",
+                "--subscription",
+                &self.subscription,
+                "--name",
+                &self.group,
+                "-o",
+                "json",
+            ],
+            Instant::now() + CLI_STEP,
+        )?;
+        if !shown.status.success() {
+            // `az group show` on a missing group exits non-zero: nothing to clean.
+            return String::from_utf8_lossy(&shown.stderr)
+                .contains("ResourceGroupNotFound")
+                .then_some(false);
+        }
+        let value: serde_json::Value = serde_json::from_slice(&shown.stdout).ok()?;
+        let tag = |name: &str| value["tags"][name].as_str().map(str::to_string);
+        Some(tag(TAG_WORKFLOW) == Some(self.workflow_id.clone()) && tag(TAG_JOB) == Some(self.job_id.clone()))
+    }
+
+    fn request_deletion(&self) -> bool {
+        (0..3).any(|_| {
+            (self.run_az)(
+                &[
+                    "group",
+                    "delete",
+                    "--subscription",
+                    &self.subscription,
+                    "--name",
+                    &self.group,
+                    "--yes",
+                    "--no-wait",
+                ],
+                Instant::now() + CLI_STEP,
+            )
+            .is_some_and(|output| output.status.success())
+        })
+    }
+
+    /// Decide and act once; `Drop` calls this and prints the outcome.
+    fn run(&mut self) -> CleanupOutcome {
+        if !self.armed || self.keep {
+            return CleanupOutcome::Skipped;
+        }
+        self.armed = false;
+        match self.owned() {
+            Some(true) if self.request_deletion() => CleanupOutcome::DeletionRequested,
+            Some(true) => CleanupOutcome::DeletionNotAccepted,
+            Some(false) => CleanupOutcome::NotOurs,
+            None => CleanupOutcome::OwnershipUnknown,
+        }
+    }
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        let group = self.group.clone();
+        match self.run() {
+            CleanupOutcome::Skipped => {}
+            CleanupOutcome::DeletionRequested => eprintln!("cleanup: deletion of group {group} requested"),
+            CleanupOutcome::DeletionNotAccepted => {
+                eprintln!("cleanup: group {group} is ours but its deletion could not be requested; delete it by hand");
+            }
+            CleanupOutcome::NotOurs => eprintln!("cleanup: group {group} is absent or not ours; left untouched"),
+            CleanupOutcome::OwnershipUnknown => {
+                eprintln!("cleanup: ownership of group {group} could not be checked; inspect and delete it by hand");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod cleanup_tests {
+    //! Deterministic coverage of the failure cleanup's decisions, with a scripted
+    //! runner in place of `az`; these run in the ordinary matrix.
+    use super::*;
+    use std::{
+        os::unix::process::ExitStatusExt as _,
+        sync::{Arc, Mutex},
+    };
+
+    fn output(code: i32, stdout: &str, stderr: &str) -> std::process::Output {
+        std::process::Output {
+            status: std::process::ExitStatus::from_raw(code << 8),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    /// A guard whose `az` answers `show` with `shown` and `delete` with `deleted`,
+    /// recording every call.
+    fn guard(
+        shown: Option<std::process::Output>,
+        deleted: Option<std::process::Output>,
+    ) -> (Cleanup, Arc<Mutex<Vec<String>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&calls);
+        let run_az: Runner = Box::new(move |args: &[&str], _: Instant| {
+            seen.lock().unwrap().push(args[1].to_string());
+            match args[1] {
+                "show" => shown.clone(),
+                "delete" => deleted.clone(),
+                other => panic!("unexpected az call {other}"),
+            }
+        });
+        let cleanup = Cleanup {
+            subscription: "sub".into(),
+            group: "horizon-ws-test".into(),
+            workflow_id: "wf".into(),
+            job_id: "job".into(),
+            armed: true,
+            keep: false,
+            run_az,
+        };
+        (cleanup, calls)
+    }
+
+    fn owned_group() -> std::process::Output {
+        output(0, r#"{"tags":{"horizon-workflow-id":"wf","horizon-job-id":"job"}}"#, "")
+    }
+
+    #[test]
+    fn owned_group_is_deleted_and_the_acceptance_is_checked() {
+        let (mut cleanup, calls) = guard(Some(owned_group()), Some(output(0, "", "")));
+        assert_eq!(cleanup.run(), CleanupOutcome::DeletionRequested);
+        assert_eq!(*calls.lock().unwrap(), ["show", "delete"]);
+        assert_eq!(cleanup.run(), CleanupOutcome::Skipped, "acts once");
+    }
+
+    #[test]
+    fn rejected_deletion_is_retried_then_reported_for_the_operator() {
+        let (mut cleanup, calls) = guard(Some(owned_group()), Some(output(1, "", "throttled")));
+        assert_eq!(cleanup.run(), CleanupOutcome::DeletionNotAccepted);
+        assert_eq!(*calls.lock().unwrap(), ["show", "delete", "delete", "delete"]);
+        let (mut cleanup, _) = guard(Some(owned_group()), None);
+        assert_eq!(
+            cleanup.run(),
+            CleanupOutcome::DeletionNotAccepted,
+            "a hung CLI is not an acceptance"
+        );
+    }
+
+    #[test]
+    fn foreign_and_absent_groups_are_left_untouched() {
+        let foreign = Some(output(
+            0,
+            r#"{"tags":{"horizon-workflow-id":"other","horizon-job-id":"job"}}"#,
+            "",
+        ));
+        let (mut cleanup, calls) = guard(foreign, Some(output(0, "", "")));
+        assert_eq!(cleanup.run(), CleanupOutcome::NotOurs);
+        assert_eq!(*calls.lock().unwrap(), ["show"], "no delete against a foreign group");
+        let untagged = Some(output(0, r#"{"tags":null}"#, ""));
+        let (mut cleanup, calls) = guard(untagged, Some(output(0, "", "")));
+        assert_eq!(cleanup.run(), CleanupOutcome::NotOurs);
+        assert_eq!(*calls.lock().unwrap(), ["show"]);
+        let absent = Some(output(
+            3,
+            "",
+            "(ResourceGroupNotFound) Resource group 'horizon-ws-test' could not be found.",
+        ));
+        let (mut cleanup, calls) = guard(absent, Some(output(0, "", "")));
+        assert_eq!(cleanup.run(), CleanupOutcome::NotOurs);
+        assert_eq!(*calls.lock().unwrap(), ["show"]);
+    }
+
+    #[test]
+    fn unverifiable_ownership_never_deletes() {
+        for shown in [
+            None,
+            Some(output(1, "", "AuthorizationFailed")),
+            Some(output(0, "not json", "")),
+        ] {
+            let (mut cleanup, calls) = guard(shown, Some(output(0, "", "")));
+            assert_eq!(cleanup.run(), CleanupOutcome::OwnershipUnknown);
+            assert_eq!(*calls.lock().unwrap(), ["show"], "no delete without an ownership proof");
+        }
+    }
+
+    #[test]
+    fn disarmed_or_kept_guards_do_nothing() {
+        let (mut cleanup, calls) = guard(Some(owned_group()), Some(output(0, "", "")));
+        cleanup.armed = false;
+        assert_eq!(cleanup.run(), CleanupOutcome::Skipped);
+        let (mut cleanup, kept_calls) = guard(Some(owned_group()), Some(output(0, "", "")));
+        cleanup.keep = true;
+        assert_eq!(cleanup.run(), CleanupOutcome::Skipped);
+        assert!(calls.lock().unwrap().is_empty() && kept_calls.lock().unwrap().is_empty());
+    }
+}
+
+struct Live {
+    run: Run,
+    cleanup: std::cell::RefCell<Cleanup>,
+    /// The exact deadline written on the VM for the reaper, fixed before creation.
+    reaper_deadline: String,
+    client: AzureClient,
+    request: InteractiveWorkerRequest,
+    group: String,
+    subscription: String,
+    private_key: std::path::PathBuf,
+    directory: tempfile::TempDir,
+}
+
+fn settings() -> (AzureProfile, String) {
+    let subscription = required("HORIZON_AZURE_LIVE_SUBSCRIPTION");
+    let profile = AzureProfile {
+        name: "live-acceptance".into(),
+        subscription_id: subscription.clone(),
+        location: optional("HORIZON_AZURE_LIVE_LOCATION", "northeurope"),
+        vm_size: optional("HORIZON_AZURE_LIVE_VM_SIZE", "Standard_D2s_v3"),
+        image_pull_identity_id: required("HORIZON_AZURE_LIVE_PULL_IDENTITY"),
+        declared_hourly_cost_micros: optional("HORIZON_AZURE_LIVE_HOURLY_COST_MICROS", "120000")
+            .parse()
+            .expect("HORIZON_AZURE_LIVE_HOURLY_COST_MICROS must be a whole number"),
+        registry_login_server: required("HORIZON_AZURE_LIVE_REGISTRY"),
+        disk_sku: AzureDiskSku::default(),
+    };
+    (profile, subscription)
+}
+
+/// The reaper must exist and be armed before any VM does; the run refuses otherwise.
+/// Like the spike harness, it resolves the job-schedule link of the reaper runbook for
+/// this subscription and validates that linked schedule, so an unrelated schedule in
+/// the same account cannot stand in for a working reaper.
+fn preflight_reaper(subscription: &str, reaper_deadline: time::OffsetDateTime, run: &Run) {
+    let group = optional("HORIZON_AZURE_LIVE_REAPER_GROUP", "horizon-worker-registry");
+    let account = optional("HORIZON_AZURE_LIVE_REAPER_ACCOUNT", "horizon-spike-reaper");
+    let base = format!(
+        "https://management.azure.com/subscriptions/{subscription}/resourceGroups/{group}/providers/Microsoft.Automation/automationAccounts/{account}"
+    );
+    let get = |url: String| -> serde_json::Value {
+        let output = az(
+            &["rest", "--method", "get", "--url", &url, "-o", "json"],
+            Instant::now() + CLI_STEP,
+        )
+        .expect("az rest finished within its bound");
+        assert!(output.status.success(), "reaper lookup failed");
+        serde_json::from_slice(&output.stdout).expect("reaper json")
+    };
+    let links = get(format!("{base}/jobSchedules?api-version=2023-11-01"));
+    let schedule_name = links["value"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|link| link["properties"]["runbook"]["name"].as_str() == Some("horizon-spike-deadline-reaper"))
+        .filter_map(|link| link["properties"]["jobScheduleId"].as_str().map(str::to_string))
+        // The list omits parameters; each link is read by id, and Azure re-cases the key.
+        .map(|id| get(format!("{base}/jobSchedules/{id}?api-version=2023-11-01")))
+        .find(|link| {
+            link["properties"]["parameters"]
+                .as_object()
+                .into_iter()
+                .flatten()
+                .any(|(key, value)| {
+                    key.eq_ignore_ascii_case("subscriptionid")
+                        && value
+                            .as_str()
+                            .is_some_and(|value| value.eq_ignore_ascii_case(subscription))
+                })
+        })
+        .and_then(|link| link["properties"]["schedule"]["name"].as_str().map(str::to_string))
+        .expect("the reaper runbook is linked to a schedule for this subscription; refusing to create");
+    let schedule = get(format!("{base}/schedules/{schedule_name}?api-version=2023-11-01"));
+    // The same facts the spike harness requires: enabled, a 15-minute cadence, and a
+    // next run inside that cadence, so the tagged VM is reaped within one interval of
+    // its deadline whatever happens to this controller.
+    let now = time::OffsetDateTime::now_utc();
+    let properties = &schedule["properties"];
+    let instant = |field: &str| {
+        properties[field]
+            .as_str()
+            .and_then(|value| time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok())
+    };
+    // Automation schedules can expire: it must still be running one interval after
+    // the exact deadline that will be written on the VM. Azure reports "never" as a
+    // far-future expiry.
+    let must_run_until = reaper_deadline + time::Duration::minutes(15);
+    let armed = properties["isEnabled"].as_bool() == Some(true)
+        && properties["frequency"].as_str() == Some("Minute")
+        && properties["interval"].as_u64() == Some(15)
+        && instant("nextRun").is_some_and(|next| next > now && next <= now + time::Duration::minutes(16))
+        && match &properties["expiryTime"] {
+            serde_json::Value::Null => true,
+            serde_json::Value::String(_) => instant("expiryTime").is_some_and(|expiry| expiry > must_run_until),
+            // Any other shape is unreadable and counts as expired: fail closed.
+            _ => false,
+        };
+    assert!(
+        armed,
+        "the reaper's linked schedule is not an enabled 15-minute schedule with a run due within the next interval and no expiry before the worker deadline; refusing to create"
+    );
+    run.event(
+        "reaper_preflight",
+        &format!(
+            "runbook linked to schedule {schedule_name}: enabled, every 15 minutes, next run within the interval, no expiry before the worker deadline"
+        ),
+    );
+}
+
+fn setup() -> Live {
+    let run = Run {
+        started: Instant::now(),
+    };
+    let (profile, subscription) = settings();
+    // Everything that could fail is read and range-checked before anything is billed.
+    let reaper_hours: i64 = optional("HORIZON_AZURE_LIVE_REAPER_HOURS", "2")
+        .parse()
+        .expect("HORIZON_AZURE_LIVE_REAPER_HOURS must be a whole number of hours");
+    assert!(
+        (1..=24).contains(&reaper_hours),
+        "HORIZON_AZURE_LIVE_REAPER_HOURS must be between 1 and 24"
+    );
+    // One deadline instant serves both the preflight and the tag on the VM.
+    let reaper_deadline_at = time::OffsetDateTime::now_utc() + time::Duration::hours(reaper_hours);
+    let reaper_deadline = reaper_deadline_at
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("deadline");
+    preflight_reaper(&subscription, reaper_deadline_at, &run);
+    let image = required("HORIZON_AZURE_LIVE_IMAGE");
+    let directory = tempfile::tempdir().expect("temp dir");
+    let (client_key, private_key) = generate_client_key(directory.path());
+    let claimed = AtomicBool::new(false);
+    let fence =
+        move |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| Ok(!claimed.swap(true, Ordering::SeqCst));
+    let credential = AzureCliCredential::new(subscription.clone()).expect("credential");
+    let client = AzureClient::new(profile, credential, fence).expect("client");
+    let request = InteractiveWorkerRequest {
+        workflow_id: CloudWorkflowId::new(),
+        job_id: CloudJobId::new(),
+        target: WorkerTarget {
+            provider: CloudProvider::Azure,
+            profile: "live-acceptance".into(),
+            image,
+            disk_gib: 32,
+            lifetime: WorkerLifetime::Persistent,
+            max_hourly_cost_micros: None,
+        },
+        ssh_public_key: client_key,
+    };
+    let group = resource_group_name(request.workflow_id, request.job_id);
+    run.event("start", &format!("group {group}"));
+    let cleanup = std::cell::RefCell::new(Cleanup::live(
+        subscription.clone(),
+        group.clone(),
+        request.workflow_id.to_string(),
+        request.job_id.to_string(),
+    ));
+    Live {
+        run,
+        cleanup,
+        reaper_deadline,
+        client,
+        request,
+        group,
+        subscription,
+        private_key,
+        directory,
+    }
+}
+
+impl Live {
+    /// Create once, bound the VM's compute, and show a second ensure only reuses.
+    fn create(&self) -> InteractiveWorker {
+        // The exact group name is known before anything exists, and ensure mutates
+        // (group, then deployment) before it answers: arm the cleanup first.
+        self.cleanup.borrow_mut().armed = true;
+        let created = self.client.ensure_worker(&self.request).expect("ensure");
+        let InteractiveWorkerEnsure::Created(status) = &created else {
+            panic!("first ensure must create: {created:?}");
+        };
+        self.run.event("created", &format!("{:?}", status.lifecycle));
+        arm_reaper(&self.subscription, &self.group, &self.reaper_deadline, &self.run);
+        let reused = self.client.ensure_worker(&self.request).expect("ensure again");
+        assert!(matches!(reused, InteractiveWorkerEnsure::Reused(_)), "{reused:?}");
+        self.run.event("reused", &format!("{:?}", reused.status().lifecycle));
+        status.worker.clone()
+    }
+
+    /// Ready only with an attested host key, then that key on the wire.
+    fn ready_and_prove_ssh(&self, persisted: &InteractiveWorker) {
+        let ready: InteractiveWorkerStatus = wait_for(READY_BOUND, || {
+            let status = self.client.reconcile_worker(&self.request)?.expect("worker present");
+            Ok(match status.lifecycle {
+                Lifecycle::Ready => Some(status),
+                Lifecycle::Provisioning => None,
+                other => panic!("unexpected lifecycle while waiting for ready: {other:?}"),
+            })
+        })
+        .expect("ready");
+        let endpoint = ready.ssh.as_ref().expect("endpoint");
+        self.run.event(
+            "ready",
+            &format!("host key {} ... port {}", &endpoint.host_key[..24], endpoint.port),
+        );
+        assert!(ready.is_ready_for(&self.request, time::OffsetDateTime::now_utc()));
+        let seen = ssh_proof(
+            endpoint,
+            &self.private_key,
+            self.directory.path(),
+            "echo live-marker > /workspace/.horizon-live-marker && cat /workspace/.horizon-live-marker && id -un",
+        );
+        assert_eq!(seen, "live-marker\nroot");
+        self.run
+            .event("ssh_proved", "pinned host key accepted, marker written to /workspace");
+        let inspected = self
+            .client
+            .inspect_worker(persisted)
+            .expect("inspect")
+            .expect("present");
+        assert_eq!(inspected.lifecycle, Lifecycle::Ready);
+        self.run.event("inspected", "ready from the persisted handle");
+    }
+
+    /// Explicit stop: retained and verified; nothing afterwards creates.
+    fn stop(&self, persisted: &InteractiveWorker) {
+        let started = Instant::now();
+        assert_eq!(
+            self.client.stop_worker(persisted).expect("stop"),
+            InteractiveWorkerStop::Stopped
+        );
+        self.run.event(
+            "stopped",
+            &format!("verified deallocated in {:.0}s", started.elapsed().as_secs_f64()),
+        );
+        let after = self
+            .client
+            .inspect_worker(persisted)
+            .expect("inspect")
+            .expect("present");
+        assert_eq!(after.lifecycle, Lifecycle::Stopped);
+        assert_eq!(
+            self.client.stop_worker(persisted).expect("stop again"),
+            InteractiveWorkerStop::Stopped
+        );
+        let ensured = self.client.ensure_worker(&self.request).expect("ensure stopped");
+        assert!(matches!(ensured, InteractiveWorkerEnsure::Reused(_)));
+        assert_eq!(ensured.status().lifecycle, Lifecycle::Stopped);
+        self.run.event(
+            "stopped_observed",
+            "inspect, repeated stop and ensure all report the retained stop without creating",
+        );
+    }
+
+    /// Delete exactly the owned group and prove it is gone.
+    fn delete(&self, persisted: &InteractiveWorker) {
+        let started = Instant::now();
+        let deleted = self.client.delete_worker(persisted).expect("delete");
+        assert!(matches!(deleted, InteractiveWorkerCleanup::Deleted), "{deleted:?}");
+        // Deletion is accepted and in flight: from here on it is the cleanup.
+        self.cleanup.borrow_mut().armed = false;
+        wait_for(GONE_BOUND, || {
+            Ok(match self.client.inspect_worker(persisted)? {
+                None => Some(()),
+                Some(status) => {
+                    assert_eq!(status.lifecycle, Lifecycle::Deleting, "{status:?}");
+                    None
+                }
+            })
+        })
+        .expect("gone");
+        let exists = az(
+            &[
+                "group",
+                "exists",
+                "--subscription",
+                &self.subscription,
+                "--name",
+                &self.group,
+                "-o",
+                "tsv",
+            ],
+            Instant::now() + CLI_STEP,
+        )
+        .expect("az group exists finished within its bound");
+        assert!(exists.status.success(), "az group exists failed");
+        assert_eq!(String::from_utf8_lossy(&exists.stdout).trim(), "false");
+        self.run.event(
+            "deleted",
+            &format!("group gone in {:.0}s", started.elapsed().as_secs_f64()),
+        );
+        assert_eq!(
+            self.client.delete_worker(persisted).expect("delete again"),
+            InteractiveWorkerCleanup::AlreadyAbsent
+        );
+    }
+}
+
+#[test]
+#[ignore = "live Azure run; set HORIZON_AZURE_LIVE_* and pass --ignored"]
+fn live_worker_create_ready_stop_delete() {
+    let live = setup();
+    let persisted = live.create();
+    live.ready_and_prove_ssh(&persisted);
+    live.stop(&persisted);
+    if keep() {
+        live.cleanup.borrow_mut().armed = false;
+        live.run
+            .event("kept", &format!("group {} left in place on request", live.group));
+        return;
+    }
+    live.delete(&persisted);
+    live.run
+        .event("done", "create, ready, pinned ssh, stop, delete all proven");
+}

--- a/docs/testing/azure-workspace-live-acceptance.md
+++ b/docs/testing/azure-workspace-live-acceptance.md
@@ -1,0 +1,189 @@
+# Azure workspace live acceptance: adapter run record
+
+Permanent record of the first end-to-end run of the merged Azure worker adapter
+(`crates/horizon-core/src/cloud_run/azure`) against a real subscription, for
+[#474](https://github.com/peters/horizon/issues/474). The driver is the ignored
+integration test `crates/horizon-core/tests/azure_live_worker.rs` (Unix only); the
+live test is never part of the ordinary test matrix and runs only with the
+`HORIZON_AZURE_LIVE_*` variables set, while the failure cleanup's decision tests in
+the same file run in every matrix without Azure.
+
+## What one run proves
+
+1. **Create once.** `ensure_worker` creates the task-owned resource group and
+   submits the deployment behind the creation fence; a second `ensure_worker`
+   reuses it and never creates.
+2. **Compute bounded without the controller, from shortly after creation.**
+   Before anything is created, the driver resolves the job-schedule link of the spike
+   reaper runbook for this subscription and checks that the linked schedule is
+   enabled, runs every 15 minutes, is due within the next interval and does not
+   expire before the worker's reaper deadline plus one interval (the same facts the
+   spike harness requires, plus the expiry); it refuses to create otherwise. Once the
+   worker VM exists (about 15 s after creation on the recorded runs) the driver merges
+   the reaper's `purpose` and `deadline` tags onto it, keeping the adapter's identity
+   tags intact. This is a driver safeguard, not an adapter property: the adapter's
+   template carries no operator tags, so a controller lost between deployment
+   submission and the tag leaves an untagged VM for the operator to delete by hand,
+   and the driver does not verify the reaper's identity or runbook content the way
+   the spike harness does.
+3. **Ready only with an attested host key.** `reconcile_worker` reports `Ready`
+   only when the run-command channel returns the host key the container's SSH
+   server serves and the group, VM and address re-prove unchanged.
+4. **The key is the one on the wire.** A pinned SSH session (no operator
+   configuration read, `StrictHostKeyChecking=yes`, the global known-hosts file
+   disabled, a `known_hosts` holding only the attested key, the generated client key)
+   runs a command as `root` and leaves a marker on the retained data disk.
+5. **Inspect from the persisted handle only** reports `Ready` without creating.
+6. **Explicit Stop** deallocates and verifies `PowerState/deallocated` within its
+   deadline; inspect, a repeated Stop and `ensure_worker` all report the retained
+   stop without creating.
+7. **Delete exactly the owned group**, then prove absence through the adapter
+   (`inspect_worker` returns nothing) and through `az group exists` in the exercised
+   subscription; a repeated delete is `AlreadyAbsent`. A failure anywhere between the
+   first ensure and the adapter's acceptance of the deletion makes the driver request
+   deletion of the group on the way out, after proving through the group's identity
+   tags that it carries this run's workflow and job identifiers (a same-named group
+   that is not ours is left untouched and reported); the outcome of that request is
+   reported. Deletion is confirmed only on that successful path; when ownership
+   cannot be checked or every deletion request fails, the driver prints a warning that
+   names the group and the operator must inspect and delete it by hand, because the
+   VM may still be billing until then (bounded by the reaper tag once it is on).
+
+## Run record
+
+Fifteen runs on 2026-09-11/12 in the spike subscription, region `northeurope`, size
+`Standard_D2s_v3`, 32 GiB data disk, the worker image published for the #508 spike
+(digest `sha256:20cc03ef…`, built from commit 22674061), the persistent pull identity
+from `docs/testing/azure-workspace-readiness.md`. Timestamps are seconds after the
+driver started, which is about 0.6 s before the first `ensure_worker` call (the
+reaper preflight, the client key generation and the client construction come
+first). Subscription, group and address values are not recorded.
+
+**Run 1 (adapter as merged through #530): failed at the readiness gate.** The
+worker was created in 5 s, cloud-init finished at about 120 s, the container was up
+and its host key readable on the VM, yet `reconcile_worker` reported `Provisioning`
+for the whole 15-minute bound. Cause: ARM answers a run command with an
+`Azure-AsyncOperation` URL that carries a signing certificate in its query string
+(3,249 bytes on this run); the transport's 2 KB operation-URL cap refused it, and the
+host-key source swallowed the error. Fixed in #533 with a regression test of the live
+shape and length. The leftover group was deleted by hand.
+
+**Run 2 (with #533): passed end to end.**
+
+| Step | Seconds after the driver started | Note |
+| --- | --- | --- |
+| `ensure_worker` returned `Created` | 4.8 | group created, deployment submitted |
+| reaper tag merged onto the VM | 16.6 | VM resource existed by then |
+| second `ensure_worker` returned `Reused` | 16.8 | no second creation |
+| `reconcile_worker` reported `Ready` | 258.2 | attested Ed25519 host key, port 2222, user `root` |
+| pinned SSH command succeeded | 258.8 | marker written to `/workspace`, ran as `root` |
+| `inspect_worker` from the persisted handle | 275.9 | `Ready` |
+| `stop_worker` returned `Stopped` | 308.2 | deallocation verified in 32 s |
+| inspect, repeated stop, ensure after stop | 309.5 | all `Stopped`, nothing created |
+| `delete_worker` then absence proven | 494.8 | group gone in 185 s, adapter and `az group exists` agree |
+
+**Run 3 (restructured driver, accidentally built from main without #533): failed
+at the readiness gate** in the same way as run 1, which confirms the cause: the fix
+is the only difference between a run that never becomes ready and one that does.
+The leftover group was deleted by hand.
+
+**Run 4 (restructured driver on main with #533, reaper preflight included):
+passed end to end.**
+
+| Step | Seconds after the driver started | Note |
+| --- | --- | --- |
+| reaper preflight | 0.6 | enabled schedule with a future run |
+| `ensure_worker` returned `Created` | 6.3 | |
+| reaper tag merged onto the VM | 19.5 | |
+| second `ensure_worker` returned `Reused` | 19.9 | |
+| `reconcile_worker` reported `Ready` | 185.5 | |
+| pinned SSH command succeeded | 186.1 | |
+| `inspect_worker` from the persisted handle | 203.7 | `Ready` |
+| `stop_worker` returned `Stopped` | 220.2 | deallocation verified in 17 s |
+| inspect, repeated stop, ensure after stop | 221.1 | all `Stopped`, nothing created |
+| `delete_worker` then absence proven | 467.8 | group gone in 247 s |
+
+**Run 5 (bounded CLI calls, settings validated before creation,
+subscription-scoped absence check): passed end to end** with readiness at 246.4 s,
+pinned SSH at 247.1 s, Stop verified in 32 s (296.3 s) and the group gone in 245 s
+(542.7 s).
+
+**Run 6 (additionally the global known-hosts file disabled for the pinned session,
+the declared hourly cost configurable next to the size, and a failure cleanup that
+requests deletion of the exact group): passed end to end** with readiness at
+261.8 s, pinned SSH at 262.4 s, Stop verified in 31 s (311.2 s) and the group gone in
+246 s (558.3 s).
+
+**Run 7 (additionally the SSH step bounded like every other external step, and
+every fallback deletion gated on the keep flag): passed end to end** with readiness
+at 214.1 s, pinned SSH at 214.9 s, Stop verified in 17 s (248.8 s) and the group gone
+in 185 s (435.0 s).
+
+**Run 8 (additionally both output pipes of every external command drained
+concurrently under a cap): passed end to end** with readiness at 257.0 s, pinned SSH
+at 257.6 s, Stop verified in 16 s (291.6 s) and the group gone in 184 s (476.6 s).
+
+**Run 9 (additionally the pipes drained to end of stream keeping a capped prefix,
+and the failure cleanup armed before the first ensure and kept armed until the
+adapter accepted the deletion): passed end to end**
+with readiness at 289.7 s, pinned SSH at 290.5 s, Stop verified in 32 s (340.3 s) and
+the group gone in 125 s (466.3 s).
+
+The readiness poll runs every 10 s and the host-key read itself takes about 10 s
+through the run-command channel, so each readiness figure carries up to about 20 s
+of driver latency on top of the worker's own boot. **Run 10 (additionally the reaper preflight requires the 15-minute cadence with a
+run due within the interval, and the tag-failure path leaves deletion to the
+cleanup guard): passed end to end** with readiness at 251.2 s, pinned SSH at
+252.0 s, Stop verified in 16 s (285.2 s) and the group gone in 245 s (531.2 s).
+
+**Run 11 (additionally the preflight resolves the reaper runbook's job-schedule
+link for this subscription and validates that linked schedule): passed end to end**
+with readiness at 228.2 s, pinned SSH at 228.8 s, Stop verified in 16 s (262.6 s) and
+the group gone in 245 s (509.2 s).
+
+**Run 12 (additionally the preflight requires the linked schedule not to expire
+before the worker deadline plus one interval): passed end to end** with readiness at
+270.6 s, pinned SSH at 271.4 s, Stop verified in 32 s (321.2 s) and the group gone in
+248 s (570.1 s).
+
+**Run 13 (additionally one reaper deadline instant shared by the preflight and the
+VM tag, waits that check their deadline before every poll and never sleep past it,
+and a format-independent absence check): passed end to end** with readiness at
+229.9 s, pinned SSH at 230.7 s, Stop verified in 16 s (264.3 s) and the group gone in
+246 s (511.5 s).
+
+**Run 14 (additionally external commands run in their own process group with the
+drained streams received under the same deadline and the whole group killed on
+expiry, the tag loop capped by its own budget, the SSH session ignoring all operator
+configuration, and a non-string expiry counted as expired): passed end to end** with
+readiness at 234.0 s, pinned SSH at 234.6 s, Stop verified in 32 s (283.2 s) and the
+group gone in 247 s (531.0 s).
+
+**Run 15 (the driver as committed here: additionally the failure cleanup takes an
+injectable command runner and its decisions are covered by five deterministic tests
+in the ordinary matrix, and the driver is gated to Unix): passed end to end** with
+readiness at 264.8 s, pinned SSH at 265.6 s, Stop verified in 32 s (316.1 s) and the
+group gone in 246 s (563.0 s). A passing run never exercises the failure cleanup's
+decisions; those are proven by the deterministic tests (owned group deleted once
+and the acceptance checked; rejected or hung deletion retried then reported;
+foreign, untagged and absent groups left untouched; unverifiable ownership never
+deletes; disarmed or kept guards do nothing).
+
+The thirteen passing runs give
+258 s, 186 s, 246 s, 262 s, 214 s, 257 s, 290 s, 251 s, 228 s, 271 s, 230 s, 234 s
+and 265 s: the spread is Azure's (image pull and VM start), and all sit above the
+180-second boundary that is still awaiting a decision on #474. Deletion of the group
+took 185 s, 247 s, 245 s, 246 s, 185 s, 184 s, 125 s, 245 s, 245 s, 248 s, 246 s,
+247 s and 246 s; Stop 32 s, 17 s, 32 s, 31 s, 17 s, 16 s, 32 s, 16 s, 16 s, 32 s,
+16 s, 32 s and 32 s.
+
+## What this run does not prove
+
+- Resuming a stopped worker. The shared interactive-worker contract has no start
+  operation yet, so PC-off resume is not exercised; the adapter reports the
+  retained `Stopped` state and would need a start operation to bring it back.
+- Repository handoff on the worker (depends on the PAT setup owned in #470).
+- Three panels on one worker and multi-day retention.
+- Bounded compute in the first seconds after creation (see item 2 above) and an
+  independent verification of the reaper's identity and runbook; both belong to the
+  spike harness today.


### PR DESCRIPTION
## Summary

Live acceptance driver and run record for the Azure worker adapter. Part of #474 (the issue stays open; the acceptance list there is still tracked against live runs).

- `crates/horizon-core/tests/azure_live_worker.rs` (Unix only): an ignored integration test, driven only by `HORIZON_AZURE_LIVE_*` variables, that runs the merged adapter against a real subscription: create once, reuse without creating, readiness with the attested host key, a pinned SSH session through that key (`StrictHostKeyChecking=yes`, a `known_hosts` holding only the attested key) that leaves a marker on the retained disk, inspect from the persisted handle, Stop with verified retained state, delete and absence proof through the adapter and `az group exists`. The worker VM is tagged for the spike reaper right after it appears, so compute stays bounded if the controller dies. The ordinary test matrix never touches Azure.
- Five deterministic tests in the same file, run by the ordinary matrix without Azure, cover the failure cleanup's decisions through an injectable command runner: an owned group is deleted once and the acceptance checked; a rejected or hung deletion is retried and then reported for the operator; foreign, untagged and absent groups are left untouched; unverifiable ownership never deletes; disarmed or kept guards do nothing.
- `docs/testing/azure-workspace-live-acceptance.md`: what one run proves, the run record, and what is not proven yet.

## Run record

Run 1 (adapter as merged through #530) failed at the readiness gate and exposed the operation-URL cap fixed in #533. Run 3 (the restructured driver, accidentally built without #533) failed the same way and confirms the cause. Runs 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 and 15 (with #533; run 15 is the driver as committed here) passed end to end:

| Step | Run 2, seconds after the driver started | Run 4 | Run 5 | Run 6 | Run 7 | Run 8 | Run 9 | Run 10 | Run 11 | Run 12 | Run 13 | Run 14 | Run 15 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| created | 4.8 | 6.3 | 5.7 | 5.9 | 6.3 | 5.6 | 5.1 | 5.8 | 7.1 | 7.0 | 7.7 | 6.8 | 6.0 |
| ready with attested host key | 258.2 | 185.5 | 246.4 | 261.8 | 214.1 | 257.0 | 289.7 | 251.2 | 228.2 | 270.6 | 229.9 | 234.0 | 264.8 |
| pinned SSH proven | 258.8 | 186.1 | 247.1 | 262.4 | 214.9 | 257.6 | 290.5 | 252.0 | 228.8 | 271.4 | 230.7 | 234.6 | 265.6 |
| stop verified | 308.2 (32 s) | 220.2 (17 s) | 296.3 (32 s) | 311.2 (31 s) | 248.8 (17 s) | 291.6 (16 s) | 340.3 (32 s) | 285.2 (16 s) | 262.6 (16 s) | 321.2 (32 s) | 264.3 (16 s) | 283.2 (32 s) | 316.1 (32 s) |
| deleted and gone | 494.8 (185 s) | 467.8 (247 s) | 542.7 (245 s) | 558.3 (246 s) | 435.0 (185 s) | 476.6 (184 s) | 466.3 (125 s) | 531.2 (245 s) | 509.2 (245 s) | 570.1 (248 s) | 511.5 (246 s) | 531.0 (247 s) | 563.0 (246 s) |

Timestamps count from the driver start, about 0.6 to 1.6 s before the first ensure (the reaper preflight comes first). Each readiness figure carries up to about 20 s of driver latency (10 s poll, 10 s host-key read). All sit above the 180-second boundary awaiting a decision on #474.

## Compute bound without the controller

The driver validates its settings before anything is billed, preflights the spike reaper (resolves the reaper runbook's job-schedule link for this subscription and requires that linked schedule to be enabled, every 15 minutes, due within the next interval and not expiring before the worker deadline plus one interval, the same facts the spike harness requires; refusing to create otherwise), tags the VM for it about 15 s after creation, bounds every CLI call and kills a hung one, fails the run if the tag cannot be installed (the cleanup guard then performs the verified deletion), and, armed before the first ensure and kept armed until the adapter has accepted the deletion, requests deletion of the exact group if anything fails in between, after proving through the identity tags that the group carries this run's workflow and job identifiers (a same-named foreign group is left untouched and reported), and reports whether the deletion request was accepted (unless the run was asked to keep the worker). The pinned SSH session reads no operator configuration and disables the global known-hosts file so only the stated endpoint and the attested key can satisfy it. Every external command runs in its own process group, has both output pipes drained under a cap, and has the child and the drained streams all waited for under one deadline, with the whole group killed on expiry. Every fallback deletion, including the tag-failure path, respects the keep flag. That is a driver safeguard, not an adapter property: the adapter's template carries no operator tags, so a controller lost between deployment submission and the tag leaves an untagged VM for the operator to delete by hand, and the driver does not verify the reaper's identity or runbook content the way the spike harness does. The document says so.

## Not proven

Resuming a stopped worker (the shared contract has no start operation yet), repository handoff on the worker (#470), three panels on one worker, multi-day retention.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic. The live test itself is ignored in the matrix; its two runs are recorded above.
