### PR TITLE
Hydrate bounded Git LFS objects during remote setup

### DIFF
--- a/containers/remote-worker/README.md
+++ b/containers/remote-worker/README.md
@@ -11,13 +11,29 @@ a task; use the Git-bound start operation below for ordinary Git task admission.
 Authentication uses only the protected runtime token through the installed Git
 credential helper. No credentials belong in the request, URL or Git config.
 
-This prerequisite explicitly rejects submodules, LFS configuration/pointers and
-active Git filters as `unsupported_repository`; recursive Git/LFS support remains
-pending. It neither uploads a local overlay nor requires overlay/ext4 qualification.
+Standard GitHub LFS pointers are hydrated before completion using the packaged
+Git LFS 3.3+ client and an endpoint derived only from the validated repository:
+`https://github.com/<owner>/<repo>.git/info/lfs`. Submodules, `.lfsconfig`, pointer
+extensions and other active Git filters remain `unsupported_repository`.
+It neither uploads a local overlay nor requires overlay/ext4 qualification.
 The worker's existing private roots and trusted stable ancestry are prerequisites.
 Preparation has a 300-second child-I/O budget and bounded metadata output; slow
 or large repositories can fail conservatively. Filesystem/spawn/reap latency is
 not a hard wall-clock bound, and this is not an allocation or disk-quota manager.
+
+LFS admission allows at most 1,024 paths, 64 MiB per object and 512 MiB of total
+hydrated worktree bytes (repeated objects count per path). Downloads are serial
+and share the preparation deadline. Each child has a kernel file-size ceiling
+of its admitted object size, with a 4 KiB floor for Git metadata; stdout is bounded
+to the exact object size. The cache and hydrated checkout can together use about
+twice the admitted payload, plus bounded partial-object and Git metadata overhead.
+Object size/hash, pointer replacement, unchanged index tree and clean Git status
+are checked before completion. Missing, denied, corrupt, oversized or interrupted
+downloads leave the original claim unconfirmed; no fallback pointer completion.
+Only fixed packaged LFS filters are saved for subsequent ordinary Git operations.
+An empty regular file at `.git/lfs/logs` intentionally prevents LFS error-log
+creation; stderr is discarded so signed download URLs are not retained as logs.
+This is download preparation, not proof of LFS upload/locking support.
 
 An exclusive `.horizon-worker/git-workspace` slot prevents concurrent/replayed
 preparation. Interrupted/failed attempts retain all claims and partial data.

--- a/crates/horizon-core/src/repository_git/git.rs
+++ b/crates/horizon-core/src/repository_git/git.rs
@@ -18,6 +18,17 @@ pub(super) trait Commands {
         allow_missing: bool,
         cancelled: &dyn Fn() -> bool,
     ) -> Result<Vec<u8>, Error>;
+
+    fn smudge(
+        &mut self,
+        directory: &Path,
+        request: &GitPreparation,
+        pointer: &super::lfs::Pointer,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        let _ = (directory, request, pointer, cancelled);
+        Err(Error::Git)
+    }
 }
 
 pub(super) struct Git {
@@ -27,6 +38,13 @@ impl Git {
     pub fn new() -> Self {
         Self {
             deadline: Instant::now() + Duration::from_secs(300),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_timeout(timeout: Duration) -> Self {
+        Self {
+            deadline: Instant::now() + timeout,
         }
     }
 }
@@ -84,14 +102,89 @@ impl Commands for Git {
         &mut self,
         directory: &Path,
         args: &[&str],
+        input: &[u8],
+        allow_missing: bool,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        self.exchange(command(directory, args), input, LIMIT, allow_missing, cancelled)
+    }
+
+    fn smudge(
+        &mut self,
+        directory: &Path,
+        request: &GitPreparation,
+        pointer: &super::lfs::Pointer,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        self.smudge_endpoint(
+            directory,
+            pointer,
+            cancelled,
+            &format!("https://github.com/{}.git/info/lfs", request.source.repository),
+        )
+    }
+}
+
+impl Git {
+    pub(super) fn smudge_endpoint(
+        &mut self,
+        directory: &Path,
+        pointer: &super::lfs::Pointer,
+        cancelled: &dyn Fn() -> bool,
+        endpoint: &str,
+    ) -> Result<Vec<u8>, Error> {
+        let mut child = command(directory, &[]);
+        child.env_remove("GIT_LFS_SKIP_SMUDGE");
+        for option in [
+            format!("lfs.url={endpoint}"),
+            "lfs.basictransfersonly=true".into(),
+            "lfs.concurrenttransfers=1".into(),
+            "lfs.transfer.maxretries=1".into(),
+            "lfs.fetchinclude=".into(),
+            "lfs.fetchexclude=".into(),
+            "lfs.skipdownloaderrors=false".into(),
+            "lfs.remote.autodetect=false".into(),
+            "lfs.remote.searchall=false".into(),
+            "lfs.dialtimeout=10".into(),
+            "lfs.tlstimeout=10".into(),
+            "lfs.activitytimeout=10".into(),
+        ] {
+            child.args(["-c", &option]);
+        }
+        child.args(["lfs", "smudge", "--", &pointer.path]);
+        // A downloader may write before verifying the advertised object size.
+        // Apply a kernel ceiling to every child file, including incomplete cache files.
+        // Small fixed Git metadata writes need at most the additional 4 KiB floor.
+        let mut bounded = Command::new("/usr/bin/prlimit");
+        bounded
+            .arg(format!("--fsize={0}:{0}", pointer.size.max(4096)))
+            .args(["--core=0:0", "--", "/usr/bin/git"])
+            .args(child.get_args())
+            .env_clear()
+            .envs(
+                child
+                    .get_envs()
+                    .filter_map(|(key, value)| value.map(|value| (key, value))),
+            )
+            .current_dir(directory)
+            .process_group(0)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        self.exchange(bounded, &pointer.encoded, pointer.size, false, cancelled)
+    }
+    fn exchange(
+        &mut self,
+        mut command: Command,
         mut input: &[u8],
+        limit: usize,
         allow_missing: bool,
         cancelled: &dyn Fn() -> bool,
     ) -> Result<Vec<u8>, Error> {
         if cancelled() || Instant::now() >= self.deadline {
             return Err(Error::Interrupted);
         }
-        let mut child = Owned(command(directory, args).spawn().map_err(|_| Error::Git)?);
+        let mut child = Owned(command.spawn().map_err(|_| Error::Git)?);
         let mut stdin = child.0.stdin.take();
         let mut stdout = child.0.stdout.take().ok_or(Error::Git)?;
         let input_fd = stdin.as_ref().ok_or(Error::Git)?;
@@ -125,7 +218,7 @@ impl Commands for Git {
             let mut buffer = [0; 8192];
             match stdout.read(&mut buffer) {
                 Ok(0) => eof = true,
-                Ok(count) if output.len() + count <= LIMIT => output.extend_from_slice(&buffer[..count]),
+                Ok(count) if output.len() + count <= limit => output.extend_from_slice(&buffer[..count]),
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
                 Ok(_) | Err(_) => return Err(Error::Git),
             }
@@ -199,29 +292,21 @@ pub(super) fn prepare(
     run(&["checkout", "-b", &request.work_branch, commit], &[], false)?;
     let paths = run(&["ls-files", "-z"], &[], false)?;
     let attributes = run(&["check-attr", "--cached", "-z", "--stdin", "filter"], &paths, false)?;
-    if attributes
-        .split(|byte| *byte == 0)
-        .skip(2)
-        .step_by(3)
-        .any(|value| value != b"unspecified" && value != b"unset")
-        || !run(
-            &[
-                "grep",
-                "-I",
-                "-l",
-                "-z",
-                "-e",
-                "^version https://git-lfs.github.com/spec/v1$",
-                commit,
-                "--",
-            ],
-            &[],
-            true,
-        )?
-        .is_empty()
-    {
-        return Err(Error::UnsupportedRepository);
-    }
+    let pointers = run(
+        &[
+            "grep",
+            "-I",
+            "-l",
+            "-z",
+            "-e",
+            "^version https://git-lfs.github.com/spec/v1$",
+            commit,
+            "--",
+        ],
+        &[],
+        true,
+    )?;
+    super::lfs::hydrate(git, directory, request, &attributes, &pointers, cancelled, verify)?;
     Ok(())
 }
 

--- a/crates/horizon-core/src/repository_git/lfs.rs
+++ b/crates/horizon-core/src/repository_git/lfs.rs
@@ -156,6 +156,7 @@ fn replace_pointer(directory: &Path, pointer: &Pointer, bytes: &[u8]) -> Result<
     std::io::Seek::rewind(&mut file).map_err(|_| Error::Storage)?;
     file.set_len(0)
         .and_then(|()| file.write_all(bytes))
+        .and_then(|()| file.sync_all())
         .map_err(|_| Error::Storage)?;
     Ok(())
 }
@@ -169,11 +170,14 @@ pub(super) fn hydrate(
     cancelled: &dyn Fn() -> bool,
     verify: &dyn Fn() -> Result<(), Error>,
 ) -> Result<(), Error> {
+    verify()?;
     let pointers = plan(directory, attributes, matches, request.source.commit.as_str())?;
+    verify()?;
     if pointers.is_empty() {
         return Ok(());
     }
     let version = git.run(directory, &["lfs", "version"], &[], false, cancelled)?;
+    verify()?;
     let version = std::str::from_utf8(&version).map_err(|_| Error::Git)?;
     let minor = version
         .strip_prefix("git-lfs/3.")
@@ -182,7 +186,6 @@ pub(super) fn hydrate(
     if minor.is_none_or(|minor| minor < 3) {
         return Err(Error::UnsupportedRepository);
     }
-    verify()?;
     block_logs(directory)?;
     for pointer in &pointers {
         verify()?;

--- a/crates/horizon-core/src/repository_git/lfs.rs
+++ b/crates/horizon-core/src/repository_git/lfs.rs
@@ -1,0 +1,257 @@
+//! Standard GitHub LFS hydration, only inside a newly claimed private checkout.
+use super::{GitPreparation, GitPreparationError as Error, git::Commands};
+use crate::{
+    cloud_run::ArtifactDigest,
+    repository_overlay::reader::{SelectedRepositoryNode, SelectedRepositoryReader},
+};
+use rustix::fs::{Mode, OFlags, ResolveFlags, openat2};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt},
+    path::Path,
+};
+
+pub(super) const MAX_OBJECT: usize = 64 * 1024 * 1024;
+const MAX_TOTAL: usize = 512 * 1024 * 1024;
+const MAX_PATHS: usize = 1024;
+const PREFIX: &str = "version https://git-lfs.github.com/spec/v1\n";
+
+pub(super) struct Pointer {
+    pub path: String,
+    pub encoded: Vec<u8>,
+    pub size: usize,
+    digest: ArtifactDigest,
+}
+
+impl Pointer {
+    fn parse(path: String, encoded: Vec<u8>) -> Result<Self, Error> {
+        let raw = std::str::from_utf8(&encoded).map_err(|_| Error::UnsupportedRepository)?;
+        let (oid, size) = raw
+            .strip_prefix(PREFIX)
+            .and_then(|value| value.strip_prefix("oid sha256:"))
+            .and_then(|value| value.split_once("\nsize "))
+            .ok_or(Error::UnsupportedRepository)?;
+        let size = size.strip_suffix('\n').ok_or(Error::UnsupportedRepository)?;
+        let parsed: usize = size.parse().map_err(|_| Error::UnsupportedRepository)?;
+        if parsed > MAX_OBJECT
+            || size != parsed.to_string()
+            || oid.len() != 64
+            || !oid.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(Error::UnsupportedRepository);
+        }
+        let digest = ArtifactDigest::parse_sha256(oid).map_err(|_| Error::UnsupportedRepository)?;
+        Ok(Self {
+            path,
+            encoded,
+            size: parsed,
+            digest,
+        })
+    }
+
+    fn verify_bytes(&self, bytes: &[u8]) -> Result<(), Error> {
+        if bytes.len() != self.size || ArtifactDigest::sha256(bytes) != self.digest {
+            return Err(Error::Git);
+        }
+        Ok(())
+    }
+}
+
+fn plan(directory: &Path, attributes: &[u8], matches: &[u8], commit: &str) -> Result<Vec<Pointer>, Error> {
+    if !attributes.is_empty() && !attributes.ends_with(&[0]) {
+        return Err(Error::UnsupportedRepository);
+    }
+    let fields: Vec<_> = attributes.split(|b| *b == 0).collect();
+    let fields = &fields[..fields.len() - 1];
+    if fields.len() % 3 != 0 {
+        return Err(Error::UnsupportedRepository);
+    }
+    let reader = SelectedRepositoryReader::open(directory).map_err(|_| Error::UnsafeRoot)?;
+    let mut pointers = Vec::new();
+    let mut total = 0usize;
+    let mut names = std::collections::BTreeSet::new();
+    for fields in fields.as_chunks::<3>().0 {
+        if fields[1] != b"filter" || !names.insert(fields[0]) {
+            return Err(Error::UnsupportedRepository);
+        }
+        match fields[2] {
+            b"unspecified" | b"unset" => continue,
+            b"lfs" => {}
+            _ => return Err(Error::UnsupportedRepository),
+        }
+        if pointers.len() == MAX_PATHS {
+            return Err(Error::UnsupportedRepository);
+        }
+        let path = std::str::from_utf8(fields[0])
+            .map_err(|_| Error::UnsupportedRepository)?
+            .to_owned();
+        let SelectedRepositoryNode::File { bytes, .. } =
+            reader.read(&path, 1024).map_err(|_| Error::UnsupportedRepository)?
+        else {
+            return Err(Error::UnsupportedRepository);
+        };
+        let pointer = Pointer::parse(path, bytes)?;
+        total = total
+            .checked_add(pointer.size)
+            .filter(|total| *total <= MAX_TOTAL)
+            .ok_or(Error::UnsupportedRepository)?;
+        pointers.push(pointer);
+    }
+    // Pointer-looking tracked data without the LFS attribute is not silently left unhydrated.
+    for matched in matches.split(|b| *b == 0).filter(|value| !value.is_empty()) {
+        let path = matched
+            .strip_prefix(format!("{commit}:").as_bytes())
+            .ok_or(Error::UnsupportedRepository)?;
+        if !pointers.iter().any(|p| p.path.as_bytes() == path) {
+            return Err(Error::UnsupportedRepository);
+        }
+    }
+    Ok(pointers)
+}
+
+fn block_logs(directory: &Path) -> Result<(), Error> {
+    let root = directory.join(".git/lfs");
+    fs::DirBuilder::new()
+        .mode(0o700)
+        .create(&root)
+        .map_err(|_| Error::Storage)?;
+    // git-lfs v3 writes panic/download logs under LocalLogDir. A regular file
+    // makes mkdir/log creation fail; stderr is discarded by the command runner.
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(root.join("logs"))
+        .map_err(|_| Error::Storage)?;
+    Ok(())
+}
+
+fn replace_pointer(directory: &Path, pointer: &Pointer, bytes: &[u8]) -> Result<(), Error> {
+    pointer.verify_bytes(bytes)?;
+    let parent = File::open(directory).map_err(|_| Error::UnsafeRoot)?;
+    let mut file = File::from(
+        openat2(
+            &parent,
+            pointer.path.as_str(),
+            OFlags::RDWR | OFlags::CLOEXEC,
+            Mode::empty(),
+            ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS | ResolveFlags::NO_XDEV,
+        )
+        .map_err(|_| Error::UnsafeRoot)?,
+    );
+    let metadata = file.metadata().map_err(|_| Error::Storage)?;
+    if !metadata.is_file()
+        || metadata.nlink() != 1
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.mode() & 0o7022 != 0
+    {
+        return Err(Error::UnsafeRoot);
+    }
+    let mut current = Vec::new();
+    std::io::Read::read_to_end(&mut std::io::Read::take(&mut file, 1025), &mut current).map_err(|_| Error::Storage)?;
+    if current != pointer.encoded {
+        return Err(Error::Conflict);
+    }
+    std::io::Seek::rewind(&mut file).map_err(|_| Error::Storage)?;
+    file.set_len(0)
+        .and_then(|()| file.write_all(bytes))
+        .map_err(|_| Error::Storage)?;
+    Ok(())
+}
+
+pub(super) fn hydrate(
+    git: &mut impl Commands,
+    directory: &Path,
+    request: &GitPreparation,
+    attributes: &[u8],
+    matches: &[u8],
+    cancelled: &dyn Fn() -> bool,
+    verify: &dyn Fn() -> Result<(), Error>,
+) -> Result<(), Error> {
+    let pointers = plan(directory, attributes, matches, request.source.commit.as_str())?;
+    if pointers.is_empty() {
+        return Ok(());
+    }
+    let version = git.run(directory, &["lfs", "version"], &[], false, cancelled)?;
+    let version = std::str::from_utf8(&version).map_err(|_| Error::Git)?;
+    let minor = version
+        .strip_prefix("git-lfs/3.")
+        .and_then(|v| v.split('.').next())
+        .and_then(|v| v.parse::<u32>().ok());
+    if minor.is_none_or(|minor| minor < 3) {
+        return Err(Error::UnsupportedRepository);
+    }
+    verify()?;
+    block_logs(directory)?;
+    for pointer in &pointers {
+        verify()?;
+        let bytes = git.smudge(directory, request, pointer, cancelled)?;
+        verify()?;
+        replace_pointer(directory, pointer, &bytes)?;
+    }
+    finish_index(git, directory, request, &pointers, cancelled, verify)
+}
+
+fn finish_index(
+    git: &mut impl Commands,
+    directory: &Path,
+    request: &GitPreparation,
+    pointers: &[Pointer],
+    cancelled: &dyn Fn() -> bool,
+    verify: &dyn Fn() -> Result<(), Error>,
+) -> Result<(), Error> {
+    // Ordinary task-side Git must clean hydrated bytes back to their index pointers.
+    // Only fixed packaged commands are installed, never a repository-supplied filter.
+    for (key, value) in [
+        ("filter.lfs.clean", "/usr/bin/git-lfs clean -- %f"),
+        ("filter.lfs.smudge", "/usr/bin/git-lfs smudge -- %f"),
+        ("filter.lfs.process", "/usr/bin/git-lfs filter-process"),
+        ("filter.lfs.required", "true"),
+    ] {
+        verify()?;
+        git.run(directory, &["config", "--local", key, value], &[], false, cancelled)?;
+        verify()?;
+    }
+    let mut run = |args: &[&str], input: &[u8]| {
+        let mut configured = vec![
+            "--literal-pathspecs",
+            "-c",
+            "filter.lfs.process=/usr/bin/git-lfs filter-process",
+            "-c",
+            "filter.lfs.smudge=/usr/bin/git-lfs smudge -- %f",
+            "-c",
+            "filter.lfs.required=true",
+        ];
+        configured.extend_from_slice(args);
+        verify()?;
+        let output = git.run(directory, &configured, input, false, cancelled)?;
+        verify()?;
+        Ok::<_, Error>(output)
+    };
+    let mut paths = Vec::new();
+    for pointer in pointers {
+        paths.extend_from_slice(pointer.path.as_bytes());
+        paths.push(0);
+    }
+    // Refresh the fresh index's filtered-file stat entries, then prove the entire
+    // index still represents the exact fetched tree. This never runs on old claims.
+    run(&["add", "--pathspec-from-file=-", "--pathspec-file-nul"], &paths)?;
+    run(
+        &[
+            "diff-index",
+            "--cached",
+            "--quiet",
+            request.source.commit.as_str(),
+            "--",
+        ],
+        &[],
+    )?;
+    if !run(&["status", "--porcelain=v1", "-z", "--untracked-files=all"], &[])?.is_empty() {
+        return Err(Error::Git);
+    }
+    verify()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_git/lfs/tests.rs
+++ b/crates/horizon-core/src/repository_git/lfs/tests.rs
@@ -1,0 +1,270 @@
+use super::*;
+use crate::repository_git::git::Git;
+use std::{
+    io::Read,
+    net::TcpListener,
+    process::Command,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+fn pointer(bytes: &[u8]) -> Pointer {
+    Pointer::parse(
+        "asset.bin".into(),
+        format!(
+            "{PREFIX}oid sha256:{}\nsize {}\n",
+            ArtifactDigest::sha256(bytes).as_str(),
+            bytes.len()
+        )
+        .into_bytes(),
+    )
+    .unwrap()
+}
+
+fn repository() -> tempfile::TempDir {
+    let root = tempfile::tempdir().unwrap();
+    assert!(
+        Command::new("/usr/bin/git")
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .env("HOME", "/nonexistent")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .args(["init", "--template=", "--initial-branch=main"])
+            .current_dir(root.path())
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    root
+}
+
+#[test]
+fn canonical_pointer_only_and_actual_content_hash_size() {
+    let valid = pointer(b"synthetic payload");
+    assert!(valid.verify_bytes(b"synthetic payload").is_ok());
+    assert!(valid.verify_bytes(b"different payload").is_err());
+    let text = String::from_utf8(valid.encoded.clone()).unwrap();
+    for bad in [
+        text.replace("size 17", "size 017"),
+        text.replace("sha256:", "sha1:"),
+        text.replace("\nsize", "\next-0-custom value\nsize"),
+        text.replace('\n', "\r\n"),
+        text.trim_end().into(),
+        text.replace("size 17", &format!("size {}", MAX_OBJECT + 1)),
+    ] {
+        assert!(Pointer::parse("asset.bin".into(), bad.into_bytes()).is_err());
+    }
+    assert_eq!(pointer(b"").size, 0);
+}
+
+#[test]
+fn selection_requires_complete_attributes_and_rejects_custom_and_symlink() {
+    let root = repository();
+    let p = pointer(b"safe");
+    fs::write(root.path().join(&p.path), &p.encoded).unwrap();
+    let attrs = b"asset.bin\0filter\0lfs\0";
+    assert_eq!(plan(root.path(), attrs, b"abc:asset.bin\0", "abc").unwrap().len(), 1);
+    for invalid in [
+        b"asset.bin\0filter\0custom\0".as_slice(),
+        b"asset.bin\0filter\0lfs",
+        b"asset.bin\0other\0lfs\0",
+    ] {
+        assert!(plan(root.path(), invalid, b"", "abc").is_err());
+    }
+    assert!(plan(root.path(), b"asset.bin\0filter\0unset\0", b"abc:asset.bin\0", "abc").is_err());
+    assert!(plan(root.path(), attrs, b"abc:other\0", "abc").is_err());
+    fs::remove_file(root.path().join(&p.path)).unwrap();
+    std::os::unix::fs::symlink("other", root.path().join(&p.path)).unwrap();
+    assert!(plan(root.path(), attrs, b"", "abc").is_err());
+}
+
+#[test]
+fn count_and_total_admission_precede_any_download() {
+    let root = repository();
+    let mut attrs = Vec::new();
+    let p = pointer(b"x");
+    for n in 0..=MAX_PATHS {
+        let name = format!("asset{n}");
+        fs::write(root.path().join(&name), &p.encoded).unwrap();
+        attrs.extend_from_slice(format!("{name}\0filter\0lfs\0").as_bytes());
+    }
+    assert!(plan(root.path(), &attrs, b"", "abc").is_err());
+    let large = String::from_utf8(p.encoded)
+        .unwrap()
+        .replace("size 1", &format!("size {MAX_OBJECT}"));
+    attrs.clear();
+    for n in 0..=MAX_TOTAL / MAX_OBJECT {
+        let name = format!("asset{n}");
+        fs::write(root.path().join(&name), &large).unwrap();
+        attrs.extend_from_slice(format!("{name}\0filter\0lfs\0").as_bytes());
+    }
+    assert!(plan(root.path(), &attrs, b"", "abc").is_err());
+}
+
+struct Server {
+    endpoint: String,
+    stop: Arc<AtomicBool>,
+    task: Option<thread::JoinHandle<()>>,
+}
+impl Server {
+    fn new(pointer: &Pointer, body: Vec<u8>, status: u16) -> Self {
+        let socket = TcpListener::bind("127.0.0.1:0").unwrap();
+        socket.set_nonblocking(true).unwrap();
+        let address = socket.local_addr().unwrap();
+        let stop = Arc::new(AtomicBool::new(false));
+        let done = stop.clone();
+        let oid = pointer.digest.as_str().to_owned();
+        let size = pointer.size;
+        let task = thread::spawn(move || {
+            while !done.load(Ordering::Relaxed) {
+                let Ok((mut client, _)) = socket.accept() else {
+                    thread::sleep(Duration::from_millis(5));
+                    continue;
+                };
+                client.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+                client.set_write_timeout(Some(Duration::from_secs(1))).unwrap();
+                let mut request = Vec::new();
+                let mut byte = [0];
+                while request.len() < 8192 && !request.ends_with(b"\r\n\r\n") {
+                    if client.read_exact(&mut byte).is_err() {
+                        break;
+                    }
+                    request.push(byte[0]);
+                }
+                let head = String::from_utf8_lossy(&request);
+                let length = head
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length: ")
+                            .and_then(|v| v.parse::<usize>().ok())
+                    })
+                    .unwrap_or(0);
+                if length > 8192 {
+                    continue;
+                }
+                let mut payload = vec![0; length];
+                let _ = client.read_exact(&mut payload);
+                let response = if request.starts_with(b"POST ") {
+                    serde_json::to_vec(&serde_json::json!({"objects":[{"oid":oid,"size":size,
+                        "actions":{"download":{"href":format!("http://{address}/object?signed=synthetic_private_value")}}}]})).unwrap()
+                } else {
+                    body.clone()
+                };
+                let code = if request.starts_with(b"POST ") { 200 } else { status };
+                if code == 504 {
+                    thread::sleep(Duration::from_millis(500));
+                }
+                let header = format!(
+                    "HTTP/1.1 {code} Result\r\nContent-Type: application/vnd.git-lfs+json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    response.len()
+                );
+                let _ = client.write_all(header.as_bytes());
+                let _ = client.write_all(&response);
+            }
+        });
+        Self {
+            endpoint: format!("http://{address}/info/lfs"),
+            stop,
+            task: Some(task),
+        }
+    }
+}
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.task.take().unwrap().join().unwrap();
+    }
+}
+
+#[test]
+fn installed_smudge_verifies_download_and_blocks_secret_error_logs() {
+    for (body, status, success) in [
+        (b"synthetic bytes".to_vec(), 200, true),
+        (b"wrong bytes".to_vec(), 200, false),
+        (b"denied".to_vec(), 403, false),
+        (vec![0; 128 * 1024], 200, false),
+    ] {
+        let root = repository();
+        let pointer = pointer(b"synthetic bytes");
+        block_logs(root.path()).unwrap();
+        let server = Server::new(&pointer, body, status);
+        let output = Git::new().smudge_endpoint(root.path(), &pointer, &|| false, &server.endpoint);
+        if success {
+            assert_eq!(output.unwrap(), b"synthetic bytes");
+        } else {
+            assert!(output.is_err());
+        }
+        let logs = root.path().join(".git/lfs/logs");
+        assert!(logs.is_file());
+        assert_eq!(fs::read(logs).unwrap(), b"");
+        for entry in fs::read_dir(root.path().join(".git/lfs/incomplete")).unwrap() {
+            assert!(entry.unwrap().metadata().unwrap().len() <= 4096);
+        }
+        let config = fs::read_to_string(root.path().join(".git/config")).unwrap();
+        assert!(!config.contains("signed=") && !config.contains("synthetic_private_value"));
+    }
+}
+
+#[test]
+fn replacement_preserves_mode_and_refuses_dirty_changed_or_wrong_content() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = repository();
+    let pointer = pointer(b"new bytes");
+    let path = root.path().join(&pointer.path);
+    fs::write(&path, &pointer.encoded).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(replace_pointer(root.path(), &pointer, b"wrong").is_err());
+    fs::write(&path, b"user edit").unwrap();
+    assert!(replace_pointer(root.path(), &pointer, b"new bytes").is_err());
+    assert_eq!(fs::read(&path).unwrap(), b"user edit");
+    fs::write(&path, &pointer.encoded).unwrap();
+    let mode = fs::metadata(&path).unwrap().mode();
+    replace_pointer(root.path(), &pointer, b"new bytes").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"new bytes");
+    assert_eq!(fs::metadata(path).unwrap().mode(), mode);
+}
+
+#[test]
+fn expired_or_cancelled_smudge_never_spawns_or_creates_cache() {
+    let root = repository();
+    let pointer = pointer(b"synthetic");
+    let endpoint = "https://must-not-contact.invalid/info/lfs";
+    assert_eq!(
+        Git::with_timeout(Duration::ZERO).smudge_endpoint(root.path(), &pointer, &|| false, endpoint),
+        Err(Error::Interrupted)
+    );
+    assert_eq!(
+        Git::new().smudge_endpoint(root.path(), &pointer, &|| true, endpoint),
+        Err(Error::Interrupted)
+    );
+    assert!(!root.path().join(".git/lfs").exists());
+}
+
+#[test]
+fn live_child_deadline_preserves_pointer_and_never_creates_completion() {
+    let root = repository();
+    let pointer = pointer(b"synthetic bytes");
+    block_logs(root.path()).unwrap();
+    fs::write(root.path().join(&pointer.path), &pointer.encoded).unwrap();
+    let server = Server::new(&pointer, b"late error".to_vec(), 504);
+    let start = std::time::Instant::now();
+    assert_eq!(
+        Git::with_timeout(Duration::from_millis(150)).smudge_endpoint(
+            root.path(),
+            &pointer,
+            &|| false,
+            &server.endpoint
+        ),
+        Err(Error::Interrupted)
+    );
+    assert!(start.elapsed() < Duration::from_secs(2));
+    assert_eq!(fs::read(root.path().join(&pointer.path)).unwrap(), pointer.encoded);
+    assert!(!root.path().join("complete.json").exists());
+}

--- a/crates/horizon-core/src/repository_git/lfs/tests.rs
+++ b/crates/horizon-core/src/repository_git/lfs/tests.rs
@@ -268,3 +268,72 @@ fn live_child_deadline_preserves_pointer_and_never_creates_completion() {
     assert_eq!(fs::read(root.path().join(&pointer.path)).unwrap(), pointer.encoded);
     assert!(!root.path().join("complete.json").exists());
 }
+
+#[test]
+fn hydration_verifies_before_and_after_planning_and_version_probe() {
+    struct Probe(usize);
+    impl Commands for Probe {
+        fn run(
+            &mut self,
+            _directory: &Path,
+            args: &[&str],
+            _input: &[u8],
+            _allow_missing: bool,
+            _cancelled: &dyn Fn() -> bool,
+        ) -> Result<Vec<u8>, Error> {
+            assert_eq!(args, ["lfs", "version"]);
+            self.0 += 1;
+            Ok(b"git-lfs/3.3.0".to_vec())
+        }
+    }
+    let request = GitPreparation::decode(
+        &serde_json::to_vec(&serde_json::json!({"version":1,"workspace_local_id":"lfs-verification",
+            "runtime_id":uuid::Uuid::new_v4(),"source":{"repository":"fixture/repository",
+            "commit":"a".repeat(40),"branch":"main"},"work_branch":"work/proof"}))
+        .unwrap(),
+    )
+    .unwrap();
+    for reject_at in 1..=3 {
+        let root = repository();
+        let pointer = pointer(b"synthetic");
+        fs::write(root.path().join(&pointer.path), &pointer.encoded).unwrap();
+        let checks = std::cell::Cell::new(0);
+        let mut probe = Probe(0);
+        assert_eq!(
+            hydrate(
+                &mut probe,
+                root.path(),
+                &request,
+                b"asset.bin\0filter\0lfs\0",
+                b"",
+                &|| false,
+                &|| {
+                    checks.set(checks.get() + 1);
+                    if checks.get() == reject_at {
+                        Err(Error::UnsafeRoot)
+                    } else {
+                        Ok(())
+                    }
+                }
+            ),
+            Err(Error::UnsafeRoot)
+        );
+        assert_eq!(probe.0, usize::from(reject_at == 3));
+        assert!(!root.path().join(".git/lfs").exists());
+        assert_eq!(fs::read(root.path().join(&pointer.path)).unwrap(), pointer.encoded);
+    }
+    let mut probe = Probe(0);
+    assert_eq!(
+        hydrate(
+            &mut probe,
+            Path::new("/nonexistent-lfs-proof"),
+            &request,
+            b"",
+            b"",
+            &|| false,
+            &|| Err(Error::UnsafeRoot)
+        ),
+        Err(Error::UnsafeRoot)
+    );
+    assert_eq!(probe.0, 0);
+}

--- a/crates/horizon-core/src/repository_git/mod.rs
+++ b/crates/horizon-core/src/repository_git/mod.rs
@@ -4,6 +4,8 @@
 #[cfg(target_os = "linux")]
 mod git;
 #[cfg(target_os = "linux")]
+mod lfs;
+#[cfg(target_os = "linux")]
 mod linux;
 
 use crate::{cloud_run::GitSource, remote_workspace::valid_local_id};

--- a/crates/horizon-core/src/repository_git/tests.rs
+++ b/crates/horizon-core/src/repository_git/tests.rs
@@ -456,3 +456,102 @@ fn command_has_no_inherited_configuration_or_token_and_deadline_prevents_spawn()
         Err(Error::Interrupted)
     );
 }
+
+#[test]
+fn lfs_initial_hydration_is_clean_and_completed_or_failed_claims_never_replay() {
+    struct Hydrating {
+        local: Local,
+        object: Vec<u8>,
+        fail: bool,
+        smudges: usize,
+    }
+    impl Commands for Hydrating {
+        fn run(
+            &mut self,
+            directory: &Path,
+            args: &[&str],
+            input: &[u8],
+            missing: bool,
+            cancelled: &dyn Fn() -> bool,
+        ) -> Result<Vec<u8>, Error> {
+            let output = self.local.run(directory, args, input, missing, cancelled)?;
+            if args[0] == "checkout" {
+                // Match the worker's private umask, independent of the host test runner.
+                fs::set_permissions(directory.join("asset.bin"), fs::Permissions::from_mode(0o600)).unwrap();
+            }
+            Ok(output)
+        }
+        fn smudge(
+            &mut self,
+            directory: &Path,
+            request: &Request,
+            pointer: &super::lfs::Pointer,
+            cancelled: &dyn Fn() -> bool,
+        ) -> Result<Vec<u8>, Error> {
+            self.smudges += 1;
+            if self.fail {
+                return Err(Error::Git);
+            }
+            // Seed only synthetic cached content; the real packaged smudge and all
+            // Git commands still run. HTTP/body limits have their own real-child test.
+            let digest = crate::cloud_run::ArtifactDigest::sha256(&self.object);
+            let oid = digest.as_str();
+            let cache = directory.join(".git/lfs/objects").join(&oid[..2]).join(&oid[2..4]);
+            fs::create_dir_all(&cache).unwrap();
+            fs::write(cache.join(oid), &self.object).unwrap();
+            self.local.git.smudge(directory, request, pointer, cancelled)
+        }
+    }
+    for fail in [false, true] {
+        let source = tempfile::tempdir().unwrap();
+        local_git(source.path(), &["init", "--template=", "--initial-branch=main"]);
+        let object = b"synthetic LFS bytes\0with binary tail".to_vec();
+        let digest = crate::cloud_run::ArtifactDigest::sha256(&object);
+        fs::write(
+            source.path().join(".gitattributes"),
+            "asset.bin filter=lfs diff=lfs merge=lfs -text\n",
+        )
+        .unwrap();
+        let pointer = format!(
+            "version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n",
+            digest.as_str(),
+            object.len()
+        );
+        fs::write(source.path().join("asset.bin"), &pointer).unwrap();
+        local_git(source.path(), &["add", "."]);
+        local_git(source.path(), &["commit", "-m", "Synthetic LFS object"]);
+        let mut request = request();
+        request.source.commit =
+            crate::cloud_run::GitCommitSha::parse(local_git(source.path(), &["rev-parse", "HEAD"])).unwrap();
+        let root = roots();
+        let mut git = Hydrating {
+            local: Local {
+                git: Git::new(),
+                source: source.path().to_owned(),
+            },
+            object: object.clone(),
+            fail,
+            smudges: 0,
+        };
+        let first = execute(root.path(), &request, false, &mut git);
+        assert_eq!(git.smudges, 1);
+        let checkout = root.path().join("horizon/repository");
+        if fail {
+            assert_eq!(first.state, State::ClaimedUnknown);
+            assert_eq!(first.reason, Some(Error::Git));
+            assert_eq!(fs::read(checkout.join("asset.bin")).unwrap(), pointer.as_bytes());
+        } else {
+            assert_eq!(first.state, State::Complete, "{first:?}");
+            assert_eq!(first.reason, None);
+            assert_eq!(fs::read(checkout.join("asset.bin")).unwrap(), object);
+            assert_eq!(local_git(&checkout, &["status", "--porcelain=v1"]), "");
+            fs::write(checkout.join("asset.bin"), b"dirty user edit").unwrap();
+        }
+        let repeated = execute(root.path(), &request, false, &mut git);
+        assert_eq!(repeated.state, first.state);
+        assert_eq!(git.smudges, 1);
+        if !fail {
+            assert_eq!(fs::read(checkout.join("asset.bin")).unwrap(), b"dirty user edit");
+        }
+    }
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -582,9 +582,11 @@ modules.
 `repository_git` owns the worker-only ordinary Git preparation identity and
 observation API. Its `linux` leaf confines the separate one-shot claim and fixed
 task-accessible checkout, while `git` owns sanitized bounded Git subprocesses.
+The `lfs` leaf admits standard bounded pointers, hydrates them through the packaged
+client with per-child file limits, and verifies the fresh checkout/index before completion.
 The repository CLI only frames bounded requests and responses. This prerequisite
 does not use the retained overlay setup qualifier or
-support LFS/submodules yet; unsupported repositories retain state without a
+support submodules/custom LFS configuration; unsupported repositories retain state without a
 completion receipt. Observation never mutates user commits or worktree changes.
 
 Ordinary Git task admission uses `repository_git` canonical binding and read-only


### PR DESCRIPTION
## Purpose

Hydrate standard Git LFS files during first-time ordinary Git workspace preparation, so an admitted checkout contains verified object bytes rather than pointers.

## Behavior

- Fetch only the saved exact Git commit and derive the LFS endpoint from its validated GitHub repository. Existing completed or failed claims remain observe-only; repeated setup never overwrites dirty work or restarts an interrupted download.
- Admit canonical SHA-256 pointers and the standard LFS filter only. Reject `.lfsconfig`, custom filters, submodules, malformed pointers and unsafe filesystem paths.
- Bound hydration to 64 MiB per object, 512 MiB per checkout and 1,024 LFS paths. The supervised child deadline, actual output bound and OS file-size limit constrain downloads; hashes and sizes must match before pointer replacement.
- Disable LFS error-log creation, discard raw child diagnostics and retain the protected runtime credential helper. Recheck checkout identity around planning and the version probe, sync hydrated file bytes before completion, enable only the packaged standard filters for subsequent ordinary Git operations, verify the index still equals the requested commit, and require a clean checkout before writing completion.

This is a Linux worker preparation slice. It does not add submodule support, provider allocation, backup, local workspace transfer, token provisioning or a publishing API.

Non-round-tripping nested pointers are unsupported: an LFS object's hydrated bytes must not themselves be a canonical LFS pointer. The exact-tree/clean-status gate rejects that case without a completion receipt or Git-bound task admission; it does not hide dirty state by rewriting index semantics.

## Validation

- Independent local review completed; five source/test files plus two docs.
- Twenty-one focused repository Git tests passed, including a genuine failing-before/fixed-after regression for verification ordering. The suite exercises real installed LFS downloads, wrong/missing/oversized responses, filesystem safety, actual child expiry, clean status and dirty/failed claim no-replay.
- Exact-tree fmt, maintainability, version, blocking Clippy and strict Clippy passed before commit.
- All eight validation gates passed on the exact review-fix commit: fmt, maintainability, version consistency, full default and speech-enabled workspace suites, blocking/strict/advisory Clippy. All 21 repository Git tests passed in both suites.
- Fresh review-fix Dockerfile-packaged CLI on the unchanged complete Shell worker image: all seven synthetic HTTPS cases passed using packaged Git LFS 3.3.0. Coverage includes clean hydration/dirty no-replay, denied, missing, wrong-hash and oversized objects, `.lfsconfig` and custom-filter rejection. No GitHub credential reached the separate synthetic object host; process/output/workspace leak checks passed. All eight new build/runtime containers were removed and preexisting containers preserved. Earlier-head receipts remain separate historical evidence.
- All 14 applicable hosted CI jobs passed on the current head; the two skipped jobs are explicitly non-applicable. Independent hosted review completed. Its nested-pointer observation is an unsupported-boundary follow-up, not an index-rewriting change: a synthetic offline Git LFS 3.4.1 reproduction showed that standard clean cannot round-trip this payload and preserving the original index still leaves ordinary Git status dirty. This additional diagnostic used host 3.4.1, not the separately validated packaged 3.3.0 runtime.

The first precommit Clippy failure and intermediate focused-test diagnostics are preserved in private evidence; no failing run is represented as a pass.

Candidate: `1ddf2126a51d7e4d1d9300871bb9ced7d68cf2b1`. The packaged smoke uses a fresh candidate CLI on an existing immutable worker runtime; it does not claim a rebuilt/published complete candidate image or provider acceptance.
