### PR TITLE
test(cloud): retry the exec race in the budgeted Azure CLI credential test

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/tests.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests.rs
@@ -455,15 +455,28 @@ fn cli_credential_bounds_a_budgeted_token_by_the_caller_not_by_its_own_timeout()
     // and the timeout teardown is detached, so the call returns at the budget.
     let (credential, _) = slow("fake-az-slow-budget");
     let budget = Duration::from_millis(300);
-    let started = std::time::Instant::now();
-    assert_eq!(
-        credential.token_within(budget).expect_err("budget"),
-        unavailable("Azure CLI timed out")
-    );
+    // Another test thread may fork while the script is still open for writing, which
+    // makes the exec fail with "text file busy"; such an attempt ends at once and is
+    // simply retried, like the first call in the sibling CLI test.
+    let (error, elapsed) = (0..5)
+        .map(|_| {
+            let started = std::time::Instant::now();
+            let error = credential.token_within(budget).expect_err("budget");
+            (error, started.elapsed())
+        })
+        .find(|(error, _)| {
+            let retryable = *error == unavailable("Azure CLI could not be started");
+            if retryable {
+                // The window closes within milliseconds once the other fork execs.
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            !retryable
+        })
+        .expect("an attempt that started the CLI");
+    assert_eq!(error, unavailable("Azure CLI timed out"));
     assert!(
-        started.elapsed() < budget + Duration::from_millis(250),
-        "the call returns at the budget without waiting for the tree: {:?}",
-        started.elapsed()
+        elapsed < budget + Duration::from_millis(250),
+        "the call returns at the budget without waiting for the tree: {elapsed:?}"
     );
     // A refresh already running in another thread holds the cache lock; a budgeted
     // caller waits at most its budget for it instead of the refresh's whole run.


### PR DESCRIPTION
## Summary

Test-only follow-up to #532 (part of #474; the issue stays open). The budget phase of `cli_credential_bounds_a_budgeted_token_by_the_caller_not_by_its_own_timeout` failed once in a local matrix run with "Azure CLI could not be started" instead of the expected timeout: another test thread forked while the fake CLI script was still open for writing, so the exec hit "text file busy". The contention phase of the same test and the sibling CLI test already retry that window; the budget phase now does too (up to five attempts, keeping the first attempt that actually started the CLI).

## Behaviour impact

None; test only.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.
