### PR TITLE
feat(remote): expose saved Shell start eligibility

### DIFF
--- a/crates/horizon-core/src/board/remote_views.rs
+++ b/crates/horizon-core/src/board/remote_views.rs
@@ -6,16 +6,18 @@ use super::Board;
 use crate::{
     Panel, PanelId, PanelKind, PanelOptions, RemoteWorkspaceReference, SshConnectionStatus,
     cloud_run::{CloudWorkflowStore, StoredRemoteWorkspace},
-    remote_workspace::RemoteEnvironmentSummary,
+    remote_workspace::{RemoteEnvironmentSummary, RemotePanelBinding},
 };
 use std::time::Duration;
 use target::ViewTarget;
 
-/// Bounded saved panel identities without commands, task context or credentials.
-/// Loading this catalog does not observe a provider or certify that tasks exist.
+/// Bounded saved panel identities and static eligibility hints, without commands,
+/// task context or credentials. Loading neither observes a provider nor certifies
+/// task existence, live readiness or execution authority.
 pub struct RemoteViewCatalog {
     expected: RemoteEnvironmentSummary,
     panels: Vec<String>,
+    shell_start_eligible: Vec<bool>,
 }
 
 impl RemoteViewCatalog {
@@ -30,21 +32,35 @@ impl RemoteViewCatalog {
         expected: &RemoteEnvironmentSummary,
     ) -> Result<Self, RemoteViewReopenError> {
         let record = load_current(store, client_session_id, expected)?;
+        let (panels, shell_start_eligible) = record
+            .state()
+            .spec
+            .panels
+            .iter()
+            .map(|panel| (panel.panel_local_id.clone(), saved_shell_start_eligible(panel)))
+            .unzip();
         Ok(Self {
             expected: expected.clone(),
-            panels: record
-                .state()
-                .spec
-                .panels
-                .iter()
-                .map(|panel| panel.panel_local_id.clone())
-                .collect(),
+            panels,
+            shell_start_eligible,
         })
     }
 
     #[must_use]
     pub fn panel_ids(&self) -> &[String] {
         &self.panels
+    }
+
+    /// Static saved binding shape only: Shell with a command and no task handoff
+    /// or agent session. Unknown identities are ineligible. This cached hint does
+    /// not validate command contents, Git readiness, ownership at execution time
+    /// or worker availability; starting still requires fresh explicit admission.
+    #[must_use]
+    pub fn saved_shell_start_eligible(&self, panel_local_id: &str) -> bool {
+        self.panels
+            .iter()
+            .zip(&self.shell_start_eligible)
+            .any(|(id, eligible)| id == panel_local_id && *eligible)
     }
 
     /// Whether this saved identity has a local view of the same remote environment.
@@ -61,6 +77,13 @@ impl RemoteViewCatalog {
                     })
             })
     }
+}
+
+fn saved_shell_start_eligible(panel: &RemotePanelBinding) -> bool {
+    panel.kind == PanelKind::Shell
+        && panel.command.is_some()
+        && panel.task_handoff.is_none()
+        && panel.agent_session_id.is_none()
 }
 
 /// An unreserved local insertion proposal. Board changes may invalidate it.

--- a/crates/horizon-core/src/board/remote_views/tests.rs
+++ b/crates/horizon-core/src/board/remote_views/tests.rs
@@ -90,6 +90,78 @@ fn matching_workspace(board: &mut Board) -> WorkspaceId {
 }
 
 #[test]
+fn catalog_caches_only_static_shell_start_eligibility() {
+    let mut fixture = Fixture::new();
+    let mut state = fixture.record.state().clone();
+    let mut shell = state.spec.panels[0].clone();
+    shell.kind = PanelKind::Shell;
+    shell.task_handoff = None;
+    shell.agent_session_id = Some("private-agent-marker".into());
+    assert!(!saved_shell_start_eligible(&shell));
+    shell.agent_session_id = None;
+    state.spec.panels = [
+        "shell",
+        "command",
+        "agent",
+        "missing-command",
+        "handoff",
+        "agent-session",
+    ]
+    .into_iter()
+    .map(|id| {
+        let mut panel = shell.clone();
+        panel.panel_local_id = id.into();
+        match id {
+            "command" => panel.kind = PanelKind::Command,
+            "agent" => panel.kind = PanelKind::Claude,
+            "missing-command" => panel.command = None,
+            "handoff" => panel.task_handoff = Some("private-task-marker".into()),
+            "agent-session" => {
+                panel.kind = PanelKind::Claude;
+                panel.agent_session_id = Some("private-agent-marker".into());
+            }
+            _ => {}
+        }
+        panel
+    })
+    .collect();
+    fixture.record = fixture
+        .store
+        .replace_remote_workspace(&fixture.record, &state)
+        .expect("bindings");
+    let catalog = fixture.catalog();
+    assert_eq!(catalog.panel_ids().len(), 6);
+    assert_eq!(catalog.shell_start_eligible, [true, false, false, false, false, false]);
+    for id in catalog.panel_ids() {
+        assert_eq!(catalog.saved_shell_start_eligible(id), id == "shell");
+        assert!(!id.contains("private-"));
+    }
+    assert!(!catalog.saved_shell_start_eligible("unknown"));
+    fixture.assert_unchanged();
+
+    let summary = fixture.record.environment_summary();
+    state.spec.panels[0].command = None;
+    fixture.record = fixture
+        .store
+        .replace_remote_workspace(&fixture.record, &state)
+        .expect("change");
+    assert!(
+        catalog.saved_shell_start_eligible("shell"),
+        "cached hint is not live authority"
+    );
+    assert!(!fixture.catalog().saved_shell_start_eligible("shell"));
+    assert!(matches!(
+        RemoteViewCatalog::load(&fixture.store, OWNER, &summary),
+        Err(RemoteViewReopenError::StateChanged)
+    ));
+    assert!(matches!(
+        RemoteViewCatalog::load(&fixture.store, FOREIGN, &fixture.record.environment_summary()),
+        Err(RemoteViewReopenError::ClientSessionMismatch)
+    ));
+    fixture.assert_unchanged();
+}
+
+#[test]
 fn catalog_presence_requires_both_saved_identity_and_execution_reference() {
     let fixture = Fixture::new();
     let catalog = fixture.catalog();


### PR DESCRIPTION
## Purpose

Expose static saved-Shell eligibility from the existing remote view catalog, so the UI can avoid offering unsupported start operations. Focused prerequisite for #472 and #539.

## Behavior

- Cache only a boolean beside each saved panel identity: eligible means Shell with a command and without a task handoff or agent session.
- Return false for unknown panel IDs. Keep command arguments, task context and agent-session data out of the catalog.
- Preserve the existing owner and current-summary checks. The cached hint is not live readiness or execution authority; actual start still requires fresh admission.
- No UI, provider, transport, task execution or schema changes.

## Validation

- Independent local full-diff review passed.
- Focused catalog suite: 10 passed, including all unsupported shapes, unknown identity, unchanged storage and stale cached-vs-fresh behavior.
- Exact commit `0ecb0ee0`: full validation matrix passed (formatting, maintainability, version synchronization, default and speech workspace tests, blocking/strict/advisory Clippy).
- Native UI/provider smoke is not applicable: this change exposes a read-only core projection and has no consuming UI or runtime change.

An initial synthetic fixture incorrectly persisted a Shell agent-session combination that domain validation rejects. The fixture now uses a valid agent binding, while a direct predicate test retains coverage of the rejected Shell shape. Production behavior was unchanged by that correction.
