### PR TITLE
feat(remote): configure task-free workspace setup

### DIFF
--- a/crates/horizon-core/src/remote_ssh_identity.rs
+++ b/crates/horizon-core/src/remote_ssh_identity.rs
@@ -50,6 +50,20 @@ impl RemoteSshIdentityStore {
         }
     }
 
+    /// Read-only path checks before another store writes beneath this home.
+    /// A missing home is allowed only below existing trusted ancestors. This does
+    /// not bind an inode or protect against same-user concurrent path replacement.
+    pub(crate) fn validate_home(&self) -> Result<(), RemoteSshIdentityError> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::validate_home(&self.home)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(RemoteSshIdentityError::UnsupportedPlatform)
+        }
+    }
+
     /// Retain a candidate for a new, unclaimed allocation before reserving its public key.
     /// Reuses an interrupted candidate for these exact IDs; never overwrites a key.
     /// This operation must not be used to recover an already reserved/claimed allocation.

--- a/crates/horizon-core/src/remote_ssh_identity/linux.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/linux.rs
@@ -54,6 +54,15 @@ pub(super) fn recover(
     Ok(identity)
 }
 
+pub(super) fn validate_home(home: &Path) -> Result<(), Error> {
+    // A trailing separator or `.` must not make symlink_metadata follow the final link.
+    let root = trusted_home(&home.components().collect::<PathBuf>())?;
+    match check_directory(&root, false, false) {
+        Ok(()) | Err(Error::Missing) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 fn directory(home: &Path, create: bool) -> Result<PathBuf, Error> {
     let root = trusted_home(home)?;
     check_directory(&root, create, false)?;

--- a/crates/horizon-core/src/remote_ssh_identity/linux.rs
+++ b/crates/horizon-core/src/remote_ssh_identity/linux.rs
@@ -58,7 +58,9 @@ pub(super) fn validate_home(home: &Path) -> Result<(), Error> {
     // A trailing separator or `.` must not make symlink_metadata follow the final link.
     let root = trusted_home(&home.components().collect::<PathBuf>())?;
     match check_directory(&root, false, false) {
-        Ok(()) | Err(Error::Missing) => Ok(()),
+        Ok(()) => Ok(()),
+        // A sticky parent protects an existing owned child, not an absent final entry.
+        Err(Error::Missing) => check_directory(root.parent().ok_or(Error::InsecurePath)?, false, false),
         Err(error) => Err(error),
     }
 }

--- a/crates/horizon-core/src/remote_workspace_setup.rs
+++ b/crates/horizon-core/src/remote_workspace_setup.rs
@@ -1,7 +1,13 @@
 //! Explicit initial setup and interrupted-setup retry, separate from client reconnect.
 //! All operations are synchronous and must run off the render thread.
 
+mod configured;
 mod runpod;
+pub use configured::{
+    ConfiguredWorkspaceSetupAttempt, ConfiguredWorkspaceSetupError, ConfiguredWorkspaceSetupObservation,
+    PreparedRemoteWorkspaceSetup, RemoteWorkspaceSetupConsent, RemoteWorkspaceSetupDraft, RemoteWorkspaceSetupLocator,
+    check_configured_remote_workspace_setup, preview_configured_remote_workspace, submit_configured_remote_workspace,
+};
 pub use runpod::{
     RunPodWorkspaceSetupError, recover_runpod_workspace, retry_runpod_workspace_setup,
     start_task_free_runpod_workspace, start_task_free_runpod_workspace_with_network_volume,

--- a/crates/horizon-core/src/remote_workspace_setup/configured.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured.rs
@@ -28,6 +28,8 @@ pub struct RemoteWorkspaceSetupDraft {
 }
 
 /// Recovery coordinates, not authority. Preserve before dispatch and after every failure.
+/// The filesystem-free preview binds a lexical home, not a directory inode. Storage
+/// access rejects symlinked/untrusted homes; same-user path replacement is not fenced.
 #[derive(Clone, Eq, PartialEq)]
 pub struct RemoteWorkspaceSetupLocator {
     home: PathBuf,
@@ -234,6 +236,7 @@ fn submit_with(
     }
     validate_selection(config, target, prepared.network_volume.as_ref())?;
     valid_expiry(prepared.retain_until_millis)?;
+    validate_home(home)?;
     let store = CloudWorkflowStore::open(home).map_err(|_| Error::StorageUnavailable)?;
     let saved = store
         .create_remote_workspace(owner, &prepared.state)
@@ -299,6 +302,7 @@ fn check_with(
 ) -> Result<ConfiguredWorkspaceSetupObservation, Error> {
     platform()?;
     locator.check(home, owner)?;
+    validate_home(home)?;
     let store = CloudWorkflowStore::open_read_only(home).map_err(|_| Error::StorageUnavailable)?;
     let Some(saved) = store
         .load_remote_workspace(owner, &locator.workspace_local_id)
@@ -355,6 +359,7 @@ fn check_saved_with(
     }
     validate_selection(config, &saved.state().spec.target, selection.as_ref())?;
     // Only an existing, validated eligible allocation reaches the writable recovery store.
+    validate_home(home)?;
     let writable = CloudWorkflowStore::open(home).map_err(|_| Error::StorageUnavailable)?;
     super::validate_allocation(&writable, &allocation).map_err(|_| Error::ContextChanged)?;
     let result = recover(&writable, &allocation)?;
@@ -430,6 +435,12 @@ fn validate_selection(
         }
         _ => Err(Error::InvalidRequest),
     }
+}
+
+fn validate_home(home: &HorizonHome) -> Result<(), Error> {
+    RemoteSshIdentityStore::new(home)
+        .validate_home()
+        .map_err(|_| Error::StorageUnavailable)
 }
 
 fn local_provider(

--- a/crates/horizon-core/src/remote_workspace_setup/configured.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured.rs
@@ -1,0 +1,494 @@
+//! Consumed, home-bound authorization for one new task-free worker, not repository or task execution.
+
+use crate::{
+    HorizonHome, PanelKind,
+    cloud_run::{
+        CloudProvider, CloudWorkflowStore, GitSource, RemoteWorkspaceStoreError, StoredRemoteAllocation,
+        StoredRemoteWorkspace, WorkerLifetime, WorkerTarget,
+        local_docker::LocalDockerInteractiveWorkerProvider,
+        runpod::{RunPodApiKey, RunPodHostTrust, RunPodNetworkVolumeExpectation, validate_target},
+    },
+    remote_provider_config::RemoteProviderConfig,
+    remote_ssh_identity::RemoteSshIdentityStore,
+    remote_workspace::{RemotePanelBinding, RemotePanelCommand, RemoteWorkspaceSpec, RemoteWorkspaceState},
+};
+use ConfiguredWorkspaceSetupError as Error;
+use std::path::PathBuf;
+
+/// Non-secret caller input. No defaults select an image, profile, branch, command or storage.
+pub struct RemoteWorkspaceSetupDraft {
+    pub target: WorkerTarget,
+    pub repository: GitSource,
+    pub working_directory: String,
+    pub command: RemotePanelCommand,
+    pub panel_directory: Option<String>,
+    /// Absolute setup authorization expiry, never a persistent worker execution deadline.
+    pub retain_until_millis: i64,
+    pub network_volume: Option<RunPodNetworkVolumeExpectation>,
+}
+
+/// Recovery coordinates, not authority. Preserve before dispatch and after every failure.
+#[derive(Clone, Eq, PartialEq)]
+pub struct RemoteWorkspaceSetupLocator {
+    home: PathBuf,
+    pub owning_session_id: String,
+    pub workspace_local_id: String,
+}
+
+impl RemoteWorkspaceSetupLocator {
+    /// Reconstruct coordinates from saved inventory in the selected home, without I/O.
+    /// # Errors
+    /// Rejects noncanonical owner IDs and malformed workspace identities.
+    pub fn new(home: &HorizonHome, owner: &str, workspace: &str) -> Result<Self, Error> {
+        if !uuid::Uuid::parse_str(owner).is_ok_and(|id| !id.is_nil() && id.to_string() == owner)
+            || !crate::remote_workspace::valid_local_id(workspace)
+        {
+            return Err(Error::InvalidRequest);
+        }
+        Ok(Self {
+            home: std::path::absolute(home.root()).map_err(|_| Error::InvalidRequest)?,
+            owning_session_id: owner.into(),
+            workspace_local_id: workspace.into(),
+        })
+    }
+
+    fn check(&self, home: &HorizonHome, owner: &str) -> Result<(), Error> {
+        if Self::new(home, owner, &self.workspace_local_id)? != *self {
+            return Err(Error::ContextChanged);
+        }
+        Ok(())
+    }
+}
+
+/// No Clone or deserialization: submission consumes the displayed, immutable confirmation.
+pub struct PreparedRemoteWorkspaceSetup {
+    locator: RemoteWorkspaceSetupLocator,
+    config: RemoteProviderConfig,
+    state: RemoteWorkspaceState,
+    retain_until_millis: i64,
+    network_volume: Option<RunPodNetworkVolumeExpectation>,
+}
+
+impl PreparedRemoteWorkspaceSetup {
+    #[must_use]
+    pub fn locator(&self) -> &RemoteWorkspaceSetupLocator {
+        &self.locator
+    }
+    #[must_use]
+    pub fn spec(&self) -> &RemoteWorkspaceSpec {
+        &self.state.spec
+    }
+    #[must_use]
+    pub fn network_volume(&self) -> Option<&RunPodNetworkVolumeExpectation> {
+        self.network_volume.as_ref()
+    }
+    #[must_use]
+    pub fn retain_until_millis(&self) -> i64 {
+        self.retain_until_millis
+    }
+}
+
+/// Positive authorization for the exact displayed image and, for `RunPod`, volume.
+/// The caller independently trusts the entrypoint-only image and supplied storage
+/// contents, authorizes their use and persistent billing, and permits no tasks before
+/// first pin. This is not ownership, exclusivity, image or filesystem attestation.
+pub enum RemoteWorkspaceSetupConsent {
+    LocalDocker {
+        image: String,
+    },
+    RunPodHps {
+        image: String,
+        volume: RunPodNetworkVolumeExpectation,
+    },
+}
+
+/// Even an error retains the original locator. Errors after saving do not prove absence.
+pub struct ConfiguredWorkspaceSetupAttempt {
+    pub locator: RemoteWorkspaceSetupLocator,
+    pub result: Result<StoredRemoteAllocation, Error>,
+}
+
+/// Point-in-time saved setup state, never repository/task readiness or permission to replay.
+pub enum ConfiguredWorkspaceSetupObservation {
+    Missing,
+    SavedOnly(StoredRemoteWorkspace),
+    Interrupted(StoredRemoteWorkspace),
+    /// Noncreating recovery completed; even this may retain an absent/unavailable worker.
+    Observed(StoredRemoteAllocation),
+}
+
+/// Validate only local values; no store, key, environment or provider access occurs.
+/// IDs are generated once for this confirmation. Caller supplies the actual persistent
+/// session, not an inventory owner or copied view. Run off the render thread.
+/// # Errors
+/// Rejects unsupported platforms/providers, invalid intent, profile, storage and expiry.
+pub fn preview_configured_remote_workspace(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    client_session_id: &str,
+    draft: RemoteWorkspaceSetupDraft,
+) -> Result<PreparedRemoteWorkspaceSetup, Error> {
+    platform()?;
+    let locator = RemoteWorkspaceSetupLocator::new(home, client_session_id, &uuid::Uuid::new_v4().to_string())?;
+    let state = RemoteWorkspaceState::new(RemoteWorkspaceSpec {
+        workspace_local_id: locator.workspace_local_id.clone(),
+        target: draft.target,
+        repository: draft.repository,
+        working_directory: draft.working_directory,
+        generation: 0,
+        panels: vec![RemotePanelBinding {
+            panel_local_id: uuid::Uuid::new_v4().to_string(),
+            kind: PanelKind::Shell,
+            command: Some(draft.command),
+            working_directory: draft.panel_directory,
+            task_handoff: None,
+            agent_session_id: None,
+        }],
+    })
+    .map_err(|_| Error::InvalidRequest)?;
+    if state.spec.repository.branch.is_none() {
+        return Err(Error::InvalidRequest);
+    }
+    validate_selection(config, &state.spec.target, draft.network_volume.as_ref())?;
+    valid_expiry(draft.retain_until_millis)?;
+    Ok(PreparedRemoteWorkspaceSetup {
+        locator,
+        config: config.clone(),
+        state,
+        retain_until_millis: draft.retain_until_millis,
+        network_volume: draft.network_volume,
+    })
+}
+
+/// Consume explicit consent, save once, and call the existing task-free setup operation.
+/// Validation precedes writable storage and credential lookup. A duplicate never adopts
+/// an existing record. No PAT, Git, task, attachment or compensating cleanup is dispatched.
+/// Closing the client cannot revoke an admitted operation. Run off the render thread.
+#[must_use]
+pub fn submit_configured_remote_workspace(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    client_session_id: &str,
+    prepared: PreparedRemoteWorkspaceSetup,
+    consent: RemoteWorkspaceSetupConsent,
+) -> ConfiguredWorkspaceSetupAttempt {
+    let result = submit_with(home, config, client_session_id, &prepared, &consent, |store, saved| {
+        let identities = RemoteSshIdentityStore::new(home);
+        match saved.state().spec.target.provider {
+            CloudProvider::LocalDocker => super::start_remote_workspace(
+                store,
+                &identities,
+                &local_provider(store, config, &saved.state().spec.target)?,
+                saved,
+                prepared.retain_until_millis,
+            )
+            .map_err(|_| Error::SetupUnconfirmed),
+            CloudProvider::RunPod => super::start_task_free_runpod_workspace_with_network_volume(
+                store,
+                &identities,
+                &credential()?,
+                config
+                    .runpod_profile(&saved.state().spec.target.profile)
+                    .map_err(|_| Error::InvalidProfile)?,
+                saved,
+                prepared.retain_until_millis,
+                prepared.network_volume.as_ref().ok_or(Error::ConsentMismatch)?,
+            )
+            .map_err(|_| Error::SetupUnconfirmed),
+            CloudProvider::Azure => Err(Error::UnsupportedProvider),
+        }
+    });
+    drop(consent);
+    ConfiguredWorkspaceSetupAttempt {
+        locator: prepared.locator,
+        result,
+    }
+}
+
+fn submit_with(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    owner: &str,
+    prepared: &PreparedRemoteWorkspaceSetup,
+    consent: &RemoteWorkspaceSetupConsent,
+    start: impl FnOnce(&CloudWorkflowStore, &StoredRemoteWorkspace) -> Result<StoredRemoteAllocation, Error>,
+) -> Result<StoredRemoteAllocation, Error> {
+    platform()?;
+    prepared.locator.check(home, owner)?;
+    if *config != prepared.config {
+        return Err(Error::ContextChanged);
+    }
+    let target = &prepared.state.spec.target;
+    let authorized = match consent {
+        RemoteWorkspaceSetupConsent::LocalDocker { image } => {
+            target.provider == CloudProvider::LocalDocker && *image == target.image && prepared.network_volume.is_none()
+        }
+        RemoteWorkspaceSetupConsent::RunPodHps { image, volume } => {
+            target.provider == CloudProvider::RunPod
+                && *image == target.image
+                && prepared.network_volume.as_ref() == Some(volume)
+        }
+    };
+    if !authorized {
+        return Err(Error::ConsentMismatch);
+    }
+    validate_selection(config, target, prepared.network_volume.as_ref())?;
+    valid_expiry(prepared.retain_until_millis)?;
+    let store = CloudWorkflowStore::open(home).map_err(|_| Error::StorageUnavailable)?;
+    let saved = store
+        .create_remote_workspace(owner, &prepared.state)
+        .map_err(|error| match error {
+            RemoteWorkspaceStoreError::AlreadyExists => Error::SaveConflict,
+            _ => Error::StorageUnavailable,
+        })?;
+    let allocation = start(&store, &saved)?;
+    let mut spec = allocation.workspace().state().spec.clone();
+    if spec.generation != 1 {
+        return Err(Error::SetupUnconfirmed);
+    }
+    spec.generation = 0;
+    if spec != prepared.state.spec || allocation.workspace().session_id() != owner {
+        return Err(Error::SetupUnconfirmed);
+    }
+    check_result(&store, &allocation, prepared.network_volume.as_ref())?;
+    Ok(allocation)
+}
+
+/// Manually recover only the original saved setup. No key/intent repair, allocation,
+/// ensure, creation, renewal or cleanup is allowed. A dormant or interrupted pre-intent
+/// setup is reported locally. Eligible recovery may persist a pin/observation.
+/// Current profile validation cannot attest historical edits under the same name.
+/// Run off-thread; caller discards results on current session/config/selection drift.
+/// # Errors
+/// Rejects foreign homes/owners, invalid bindings, missing storage and recovery failures.
+pub fn check_configured_remote_workspace_setup(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    client_session_id: &str,
+    locator: &RemoteWorkspaceSetupLocator,
+) -> Result<ConfiguredWorkspaceSetupObservation, Error> {
+    check_with(home, config, client_session_id, locator, |store, allocation| {
+        let identities = RemoteSshIdentityStore::new(home);
+        let target = &allocation.workspace().state().spec.target;
+        match target.provider {
+            CloudProvider::LocalDocker => {
+                super::recover(store, &identities, &local_provider(store, config, target)?, allocation)
+                    .map_err(|_| Error::SetupUnconfirmed)
+            }
+            CloudProvider::RunPod => super::recover_runpod_workspace(
+                store,
+                &identities,
+                &credential()?,
+                config
+                    .runpod_profile(&target.profile)
+                    .map_err(|_| Error::InvalidProfile)?,
+                allocation,
+            )
+            .map_err(|_| Error::SetupUnconfirmed),
+            CloudProvider::Azure => Err(Error::UnsupportedProvider),
+        }
+    })
+}
+
+fn check_with(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    owner: &str,
+    locator: &RemoteWorkspaceSetupLocator,
+    recover: impl FnOnce(&CloudWorkflowStore, &StoredRemoteAllocation) -> Result<StoredRemoteAllocation, Error>,
+) -> Result<ConfiguredWorkspaceSetupObservation, Error> {
+    platform()?;
+    locator.check(home, owner)?;
+    let store = CloudWorkflowStore::open_read_only(home).map_err(|_| Error::StorageUnavailable)?;
+    let Some(saved) = store
+        .load_remote_workspace(owner, &locator.workspace_local_id)
+        .map_err(storage)?
+    else {
+        return Ok(ConfiguredWorkspaceSetupObservation::Missing);
+    };
+    check_saved_with(home, config, &store, saved, recover)
+}
+
+fn check_saved_with(
+    home: &HorizonHome,
+    config: &RemoteProviderConfig,
+    store: &CloudWorkflowStore,
+    saved: StoredRemoteWorkspace,
+    recover: impl FnOnce(&CloudWorkflowStore, &StoredRemoteAllocation) -> Result<StoredRemoteAllocation, Error>,
+) -> Result<ConfiguredWorkspaceSetupObservation, Error> {
+    validate_profile(config, &saved.state().spec.target)?;
+    if saved.state().runtime.is_none() {
+        return Ok(ConfiguredWorkspaceSetupObservation::SavedOnly(saved));
+    }
+    let allocation = store
+        .load_remote_allocation(saved.session_id(), &saved.state().spec.workspace_local_id)
+        .map_err(storage)?
+        .ok_or(Error::SetupUnconfirmed)?;
+    if allocation.workspace() != &saved {
+        return Err(Error::ContextChanged);
+    }
+    let selection = store
+        .load_remote_network_volume_selection(&allocation)
+        .map_err(storage)?;
+    match allocation.recovery_request() {
+        Ok(_) => {}
+        Err(RemoteWorkspaceStoreError::RuntimeRequestRequired) => {
+            return Ok(ConfiguredWorkspaceSetupObservation::Interrupted(saved));
+        }
+        Err(_) => return Err(Error::SetupUnconfirmed),
+    }
+    if saved.state().spec.target.provider == CloudProvider::RunPod {
+        if selection.is_none() {
+            return Ok(ConfiguredWorkspaceSetupObservation::Interrupted(saved));
+        }
+        let runtime = saved.state().runtime.as_ref().ok_or(Error::SetupUnconfirmed)?;
+        if let Some(ssh) = &runtime.ssh {
+            let worker = runtime.worker.as_ref().ok_or(Error::InvalidRequest)?;
+            RunPodHostTrust::retained(worker, ssh).map_err(|_| Error::InvalidRequest)?;
+        } else if store
+            .load_remote_first_pin_request(&allocation)
+            .map_err(storage)?
+            .is_none()
+        {
+            return Ok(ConfiguredWorkspaceSetupObservation::Interrupted(saved));
+        }
+    }
+    validate_selection(config, &saved.state().spec.target, selection.as_ref())?;
+    // Only an existing, validated eligible allocation reaches the writable recovery store.
+    let writable = CloudWorkflowStore::open(home).map_err(|_| Error::StorageUnavailable)?;
+    super::validate_allocation(&writable, &allocation).map_err(|_| Error::ContextChanged)?;
+    let result = recover(&writable, &allocation)?;
+    if result.workspace().session_id() != saved.session_id() || result.workspace().state().spec != saved.state().spec {
+        return Err(Error::SetupUnconfirmed);
+    }
+    check_result(&writable, &result, selection.as_ref())?;
+    Ok(ConfiguredWorkspaceSetupObservation::Observed(result))
+}
+
+fn check_result(
+    store: &CloudWorkflowStore,
+    result: &StoredRemoteAllocation,
+    selection: Option<&RunPodNetworkVolumeExpectation>,
+) -> Result<(), Error> {
+    super::validate_allocation(store, result).map_err(|_| Error::SetupUnconfirmed)?;
+    if store
+        .load_remote_network_volume_selection(result)
+        .map_err(storage)?
+        .as_ref()
+        != selection
+    {
+        return Err(Error::SetupUnconfirmed);
+    }
+    Ok(())
+}
+
+fn validate_profile(config: &RemoteProviderConfig, target: &WorkerTarget) -> Result<(), Error> {
+    if target.lifetime != WorkerLifetime::Persistent {
+        return Err(Error::InvalidRequest);
+    }
+    match target.provider {
+        CloudProvider::LocalDocker => {
+            config
+                .local_docker_profile(&target.profile)
+                .map_err(|_| Error::InvalidProfile)?;
+        }
+        CloudProvider::RunPod => {
+            let profile = config
+                .runpod_profile(&target.profile)
+                .map_err(|_| Error::InvalidProfile)?;
+            validate_target(target, profile).map_err(|_| Error::InvalidProfile)?;
+            if target.max_hourly_cost_micros.is_none() {
+                return Err(Error::InvalidRequest);
+            }
+        }
+        CloudProvider::Azure => return Err(Error::UnsupportedProvider),
+    }
+    Ok(())
+}
+
+fn validate_selection(
+    config: &RemoteProviderConfig,
+    target: &WorkerTarget,
+    selection: Option<&RunPodNetworkVolumeExpectation>,
+) -> Result<(), Error> {
+    validate_profile(config, target)?;
+    match (target.provider, selection) {
+        (CloudProvider::LocalDocker, None) => Ok(()),
+        (CloudProvider::RunPod, Some(volume)) => {
+            volume.validate().map_err(|_| Error::InvalidRequest)?;
+            let profile = config
+                .runpod_profile(&target.profile)
+                .map_err(|_| Error::InvalidProfile)?;
+            if profile
+                .data_center_id
+                .as_ref()
+                .is_some_and(|id| *id != volume.data_center_id)
+            {
+                return Err(Error::InvalidRequest);
+            }
+            Ok(())
+        }
+        _ => Err(Error::InvalidRequest),
+    }
+}
+
+fn local_provider(
+    store: &CloudWorkflowStore,
+    config: &RemoteProviderConfig,
+    target: &WorkerTarget,
+) -> Result<LocalDockerInteractiveWorkerProvider, Error> {
+    let profile = config
+        .local_docker_profile(&target.profile)
+        .map_err(|_| Error::InvalidProfile)?;
+    LocalDockerInteractiveWorkerProvider::new(profile.clone(), store.clone()).map_err(|_| Error::InvalidProfile)
+}
+
+fn credential() -> Result<RunPodApiKey, Error> {
+    RunPodApiKey::from_env().map_err(|_| Error::CredentialUnavailable)
+}
+
+fn valid_expiry(expiry: i64) -> Result<(), Error> {
+    if i128::from(expiry) <= time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000 {
+        return Err(Error::InvalidRequest);
+    }
+    Ok(())
+}
+
+fn platform() -> Result<(), Error> {
+    if !cfg!(target_os = "linux") {
+        return Err(Error::UnsupportedPlatform);
+    }
+    Ok(())
+}
+
+fn storage(_: RemoteWorkspaceStoreError) -> Error {
+    Error::StorageUnavailable
+}
+
+/// Fixed diagnostics never echo task arguments, private paths or provider payloads.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum ConfiguredWorkspaceSetupError {
+    #[error("new remote workspace setup is supported only on Linux")]
+    UnsupportedPlatform,
+    #[error("this provider is not supported for new workspace setup")]
+    UnsupportedProvider,
+    #[error("remote workspace setup requires valid explicit intent, storage and expiry")]
+    InvalidRequest,
+    #[error("remote workspace setup requires an exact valid configured profile")]
+    InvalidProfile,
+    #[error("remote workspace home, owner, configuration or saved state changed")]
+    ContextChanged,
+    #[error("explicit consent does not match this worker image and storage selection")]
+    ConsentMismatch,
+    #[error("remote workspace identity is already saved; no existing record was adopted")]
+    SaveConflict,
+    #[error("remote control storage could not be verified; retain the original locator")]
+    StorageUnavailable,
+    #[error("RunPod credentials are unavailable; the saved workspace was retained")]
+    CredentialUnavailable,
+    #[error("worker setup is unconfirmed; retain the original locator and check without creating")]
+    SetupUnconfirmed,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
@@ -1,0 +1,499 @@
+//! Coordinator tests use local stores and fake dispatch, never provider or credential access.
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn unsupported_platform_refuses() {
+    assert_eq!(super::platform(), Err(super::Error::UnsupportedPlatform));
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::super::*;
+    use crate::cloud_run::{GitCommitSha, local_docker::LocalDockerProfile, runpod::RunPodProfile};
+    use std::{
+        cell::Cell,
+        os::unix::fs::PermissionsExt,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+    const OTHER: &str = "00000000-0000-4000-8000-000000000002";
+
+    struct Fixture {
+        directory: tempfile::TempDir,
+        home: HorizonHome,
+        config: RemoteProviderConfig,
+    }
+    impl Fixture {
+        fn new() -> Self {
+            let directory = tempfile::tempdir().expect("fixture");
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+            let home = HorizonHome::from_root(directory.path().join("home"));
+            let config = RemoteProviderConfig {
+                local_docker: vec![LocalDockerProfile {
+                    name: "local".into(),
+                    docker_host: "unix:///tmp/setup-fixture.sock".into(),
+                }],
+                runpod: vec![RunPodProfile {
+                    name: "cloud".into(),
+                    gpu_type_ids: vec!["fixture-gpu".into()],
+                    gpu_count: 1,
+                    allowed_cuda_versions: vec![],
+                    data_center_id: Some("fixture-dc".into()),
+                    ports: vec!["22/tcp".into()],
+                    volume_gib: 0,
+                    min_download_mbps: None,
+                    min_upload_mbps: None,
+                    min_disk_bandwidth_mbps: None,
+                    container_registry_auth_id: None,
+                }],
+            };
+            Self {
+                directory,
+                home,
+                config,
+            }
+        }
+        fn draft(cloud: bool) -> RemoteWorkspaceSetupDraft {
+            RemoteWorkspaceSetupDraft {
+                target: WorkerTarget {
+                    provider: if cloud {
+                        CloudProvider::RunPod
+                    } else {
+                        CloudProvider::LocalDocker
+                    },
+                    profile: if cloud { "cloud" } else { "local" }.into(),
+                    image: format!("example/worker@sha256:{}", "a".repeat(64)),
+                    disk_gib: 20,
+                    lifetime: WorkerLifetime::Persistent,
+                    max_hourly_cost_micros: cloud.then_some(1_000_000),
+                },
+                repository: GitSource {
+                    repository: "example/project".into(),
+                    commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+                    branch: Some("work/fixture".into()),
+                },
+                working_directory: ".".into(),
+                command: RemotePanelCommand {
+                    program: "/bin/sh".into(),
+                    args: vec!["-c".into(), "printf '%s' 'two words'".into()],
+                },
+                panel_directory: Some("src".into()),
+                retain_until_millis: i64::MAX,
+                network_volume: cloud.then(|| RunPodNetworkVolumeExpectation {
+                    volume_id: "fixture-volume".into(),
+                    data_center_id: "fixture-dc".into(),
+                    minimum_size_gb: 10,
+                }),
+            }
+        }
+        fn preview(&self, cloud: bool) -> PreparedRemoteWorkspaceSetup {
+            preview_configured_remote_workspace(&self.home, &self.config, OWNER, Self::draft(cloud)).expect("preview")
+        }
+        fn store(&self) -> CloudWorkflowStore {
+            CloudWorkflowStore::open(&self.home).expect("store")
+        }
+        fn submit(&self, prepared: &PreparedRemoteWorkspaceSetup) -> Result<StoredRemoteAllocation, Error> {
+            submit_with(
+                &self.home,
+                &self.config,
+                OWNER,
+                prepared,
+                &consent(prepared),
+                |store, saved| allocate(store, saved, prepared),
+            )
+        }
+        fn check(&self, locator: &RemoteWorkspaceSetupLocator) -> Result<ConfiguredWorkspaceSetupObservation, Error> {
+            check_with(&self.home, &self.config, OWNER, locator, |_, _| {
+                panic!("must not recover")
+            })
+        }
+    }
+    fn consent(prepared: &PreparedRemoteWorkspaceSetup) -> RemoteWorkspaceSetupConsent {
+        let image = prepared.spec().target.image.clone();
+        match prepared.network_volume() {
+            Some(volume) => RemoteWorkspaceSetupConsent::RunPodHps {
+                image,
+                volume: volume.clone(),
+            },
+            None => RemoteWorkspaceSetupConsent::LocalDocker { image },
+        }
+    }
+    fn allocate(
+        store: &CloudWorkflowStore,
+        saved: &StoredRemoteWorkspace,
+        prepared: &PreparedRemoteWorkspaceSetup,
+    ) -> Result<StoredRemoteAllocation, Error> {
+        let allocation = store
+            .allocate_remote_runtime(saved, prepared.retain_until_millis())
+            .map_err(storage)?;
+        if let Some(volume) = prepared.network_volume() {
+            store
+                .record_remote_network_volume_selection(&allocation, volume)
+                .map_err(storage)?;
+        }
+        Ok(allocation)
+    }
+    fn duplicate(prepared: &PreparedRemoteWorkspaceSetup) -> PreparedRemoteWorkspaceSetup {
+        // Competing confirmations with the same IDs are a store-fence fixture, not a public Clone API.
+        PreparedRemoteWorkspaceSetup {
+            locator: prepared.locator.clone(),
+            config: prepared.config.clone(),
+            state: prepared.state.clone(),
+            retain_until_millis: prepared.retain_until_millis,
+            network_volume: prepared.network_volume.clone(),
+        }
+    }
+    fn reserve(store: &CloudWorkflowStore, allocation: &StoredRemoteAllocation) -> StoredRemoteAllocation {
+        use base64::Engine as _;
+        let mut key = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+        key.extend([7; 32]);
+        let key = format!("ssh-ed25519 {}", base64::engine::general_purpose::STANDARD.encode(key));
+        // Synthetic reserved public identity isolates this coordinator; no private-key proof is claimed.
+        store.reserve_remote_worker_request(allocation, &key).expect("reserve")
+    }
+    fn expire(store: &CloudWorkflowStore, allocation: &StoredRemoteAllocation) {
+        let mut workflow = allocation.workflow().workflow().clone();
+        workflow.created_at_millis = 1000;
+        workflow.updated_at_millis = 1000;
+        workflow.retain_until_millis = 2000;
+        rusqlite::Connection::open(store.path()).expect("fixture database").execute(
+            "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000, retain_until_millis=2000, snapshot=?1 WHERE workflow_id=?2",
+            rusqlite::params![serde_json::to_vec(&workflow).expect("snapshot"), workflow.id.to_string()],
+        ).expect("expire fixture");
+    }
+
+    #[test]
+    fn preview_is_inert_and_binds_exact_fresh_intent() {
+        let f = Fixture::new();
+        for cloud in [false, true] {
+            let prepared = f.preview(cloud);
+            assert_eq!(prepared.spec().generation, 0);
+            assert_eq!(prepared.spec().panels.len(), 1);
+            assert_eq!(prepared.spec().panels[0].kind, PanelKind::Shell);
+            assert_eq!(
+                prepared.spec().panels[0].command.as_ref(),
+                Some(&Fixture::draft(cloud).command)
+            );
+            assert_eq!(prepared.spec().repository, Fixture::draft(cloud).repository);
+            assert_ne!(
+                prepared.locator().workspace_local_id,
+                f.preview(cloud).locator().workspace_local_id
+            );
+            assert!(prepared.state.runtime.is_none());
+        }
+        assert!(!f.home.root().exists());
+    }
+
+    #[test]
+    fn malformed_or_unsupported_previews_have_no_side_effects() {
+        let f = Fixture::new();
+        for mutate in [
+            |d: &mut RemoteWorkspaceSetupDraft| d.target.image = "example/worker:latest".into(),
+            |d: &mut RemoteWorkspaceSetupDraft| d.target.provider = CloudProvider::Azure,
+            |d: &mut RemoteWorkspaceSetupDraft| d.target.lifetime = WorkerLifetime::TimeLimited { seconds: 900 },
+            |d: &mut RemoteWorkspaceSetupDraft| d.repository.branch = None,
+            |d: &mut RemoteWorkspaceSetupDraft| d.working_directory = "../outside".into(),
+            |d: &mut RemoteWorkspaceSetupDraft| d.command.program.clear(),
+            |d: &mut RemoteWorkspaceSetupDraft| d.command.args.push("bad\0argument".into()),
+            |d: &mut RemoteWorkspaceSetupDraft| d.retain_until_millis = 0,
+        ] {
+            let mut draft = Fixture::draft(false);
+            mutate(&mut draft);
+            assert!(preview_configured_remote_workspace(&f.home, &f.config, OWNER, draft).is_err());
+        }
+        for owner in ["", "nil", "00000000-0000-0000-0000-000000000000"] {
+            assert!(preview_configured_remote_workspace(&f.home, &f.config, owner, Fixture::draft(false)).is_err());
+        }
+        for mutate in [
+            |d: &mut RemoteWorkspaceSetupDraft| d.network_volume = None,
+            |d: &mut RemoteWorkspaceSetupDraft| d.network_volume.as_mut().expect("volume").minimum_size_gb = 9,
+            |d: &mut RemoteWorkspaceSetupDraft| {
+                d.network_volume.as_mut().expect("volume").data_center_id = "elsewhere".into();
+            },
+            |d: &mut RemoteWorkspaceSetupDraft| d.target.max_hourly_cost_micros = None,
+        ] {
+            let mut draft = Fixture::draft(true);
+            mutate(&mut draft);
+            assert!(preview_configured_remote_workspace(&f.home, &f.config, OWNER, draft).is_err());
+        }
+        assert!(!f.home.root().exists());
+    }
+
+    #[test]
+    fn confirmation_rechecks_home_owner_full_configuration_consent_and_expiry() {
+        let f = Fixture::new();
+        for mode in 0..7 {
+            let mut p = f.preview(true);
+            let mut config = f.config.clone();
+            let mut approval = consent(&p);
+            let other_home = HorizonHome::from_root(f.directory.path().join("other"));
+            let home = if mode == 0 { &other_home } else { &f.home };
+            let owner = if mode == 1 { OTHER } else { OWNER };
+            match mode {
+                2 => config.runpod[0].gpu_count = 2,
+                3 => {
+                    approval = RemoteWorkspaceSetupConsent::LocalDocker {
+                        image: p.spec().target.image.clone(),
+                    }
+                }
+                4 | 6 => {
+                    let RemoteWorkspaceSetupConsent::RunPodHps { image, volume } = &mut approval else {
+                        panic!("RunPod consent");
+                    };
+                    if mode == 4 {
+                        volume.volume_id = "foreign".into();
+                    } else {
+                        *image = format!("example/worker@sha256:{}", "c".repeat(64));
+                    }
+                }
+                5 => p.retain_until_millis = 0,
+                _ => {}
+            }
+            if mode == 0 {
+                let locator = p.locator().clone();
+                let attempt = submit_configured_remote_workspace(home, &config, owner, p, approval);
+                assert!(attempt.locator == locator);
+                assert!(matches!(attempt.result, Err(Error::ContextChanged)));
+            } else {
+                assert!(submit_with(home, &config, owner, &p, &approval, |_, _| panic!("no dispatch")).is_err());
+            }
+            assert!(!f.home.root().exists());
+            assert!(!other_home.root().exists());
+        }
+    }
+
+    #[test]
+    fn exact_submit_preserves_one_workspace_panel_generation_and_volume() {
+        for cloud in [false, true] {
+            let f = Fixture::new();
+            let p = f.preview(cloud);
+            let allocation = f.submit(&p).expect("submitted");
+            assert_eq!(allocation.workspace().state().spec.generation, 1);
+            assert_eq!(allocation.workspace().state().spec.panels, p.spec().panels);
+            let store = f.store();
+            assert_eq!(
+                store
+                    .load_remote_allocation(OWNER, &p.locator.workspace_local_id)
+                    .expect("load")
+                    .as_ref(),
+                Some(&allocation)
+            );
+            assert_eq!(
+                store
+                    .load_remote_network_volume_selection(&allocation)
+                    .expect("selection")
+                    .as_ref(),
+                p.network_volume()
+            );
+            assert_eq!(f.submit(&p).err(), Some(Error::SaveConflict));
+            assert!(!f.home.root().join("remote-ssh-identities").exists());
+        }
+    }
+
+    #[test]
+    fn concurrent_duplicate_confirmations_dispatch_only_once() {
+        let f = Fixture::new();
+        let p = f.preview(false);
+        let other = duplicate(&p);
+        let _store = f.store();
+        let barrier = Arc::new(Barrier::new(2));
+        let calls = AtomicUsize::new(0);
+        let results = std::thread::scope(|scope| {
+            let (fixture, barrier, calls) = (&f, &barrier, &calls);
+            let handles = [&p, &other].map(|prepared| {
+                scope.spawn(move || {
+                    barrier.wait();
+                    submit_with(
+                        &fixture.home,
+                        &fixture.config,
+                        OWNER,
+                        prepared,
+                        &consent(prepared),
+                        |store, saved| {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            allocate(store, saved, prepared)
+                        },
+                    )
+                })
+            });
+            handles.map(|handle| handle.join().expect("concurrent confirmation"))
+        });
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(results.iter().any(|result| matches!(result, Err(Error::SaveConflict))));
+    }
+
+    #[test]
+    fn partial_save_and_pre_request_interruption_are_locatable_without_repair() {
+        for cloud in [false, true] {
+            for allocated in [false, true] {
+                let f = Fixture::new();
+                let p = f.preview(cloud);
+                let locator = p.locator().clone();
+                let result = submit_with(&f.home, &f.config, OWNER, &p, &consent(&p), |store, saved| {
+                    if allocated {
+                        store.allocate_remote_runtime(saved, i64::MAX).expect("allocation");
+                    }
+                    Err(Error::SetupUnconfirmed)
+                });
+                assert_eq!(result.err(), Some(Error::SetupUnconfirmed));
+                let before = f
+                    .store()
+                    .load_remote_workspace(OWNER, &locator.workspace_local_id)
+                    .expect("saved");
+                for _ in 0..2 {
+                    match f.check(&locator).expect("check") {
+                        ConfiguredWorkspaceSetupObservation::Interrupted(_) if allocated => {}
+                        ConfiguredWorkspaceSetupObservation::SavedOnly(_) if !allocated => {}
+                        _ => panic!("unexpected recovery stage"),
+                    }
+                }
+                assert_eq!(
+                    f.store()
+                        .load_remote_workspace(OWNER, &locator.workspace_local_id)
+                        .expect("unchanged"),
+                    before
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn runpod_reserved_request_without_initial_intent_is_not_bootstrapped() {
+        let f = Fixture::new();
+        let p = f.preview(true);
+        let allocation = f.submit(&p).expect("allocated");
+        let store = f.store();
+        let reserved = reserve(&store, &allocation);
+        assert!(matches!(
+            f.check(p.locator()).expect("check"),
+            ConfiguredWorkspaceSetupObservation::Interrupted(_)
+        ));
+        assert_eq!(
+            store
+                .load_remote_allocation(OWNER, &p.locator.workspace_local_id)
+                .expect("load"),
+            Some(reserved)
+        );
+    }
+
+    #[test]
+    fn lost_reply_and_expired_setup_recover_only_the_retained_generation() {
+        for cloud in [false, true] {
+            let f = Fixture::new();
+            let p = f.preview(cloud);
+            assert_eq!(
+                submit_with(&f.home, &f.config, OWNER, &p, &consent(&p), |store, saved| {
+                    let allocation = reserve(store, &allocate(store, saved, &p)?);
+                    if cloud {
+                        store
+                            .record_remote_first_pin_intent(&allocation)
+                            .expect("initial intent");
+                    }
+                    let request = allocation.worker_request().expect("request");
+                    assert!(
+                        store
+                            .claim_worker_creation(
+                                request.workflow_id,
+                                request.job_id,
+                                &request.target,
+                                "synthetic-worker"
+                            )
+                            .expect("claim")
+                    );
+                    expire(store, &allocation);
+                    Err(Error::SetupUnconfirmed)
+                })
+                .err(),
+                Some(Error::SetupUnconfirmed)
+            );
+            let store = f.store();
+            let before = store
+                .load_remote_allocation(OWNER, &p.locator.workspace_local_id)
+                .expect("load")
+                .expect("allocation");
+            let calls = Cell::new(0);
+            let observed = check_with(&f.home, &f.config, OWNER, p.locator(), |store, allocation| {
+                calls.set(calls.get() + 1);
+                store.record_remote_worker_recovery(allocation, None).map_err(storage)
+            })
+            .expect("noncreating check");
+            let ConfiguredWorkspaceSetupObservation::Observed(after) = observed else {
+                panic!("recovery");
+            };
+            assert_eq!(
+                before.worker_request().expect("before"),
+                after.worker_request().expect("after")
+            );
+            assert_eq!(
+                before.workflow().workflow().retain_until_millis,
+                after.workflow().workflow().retain_until_millis
+            );
+            assert_eq!(before.workspace().state().spec, after.workspace().state().spec);
+            assert_eq!(calls.get(), 1);
+        }
+    }
+
+    #[test]
+    fn split_snapshot_reads_refuse_before_recovery() {
+        let f = Fixture::new();
+        for cloud in [false, true] {
+            let p = f.preview(cloud);
+            let allocation = f.submit(&p).expect("allocation");
+            let store = f.store();
+            reserve(&store, &allocation);
+            let result = check_saved_with(&f.home, &f.config, &store, allocation.workspace().clone(), |_, _| {
+                panic!("recovery")
+            });
+            assert!(matches!(result, Err(Error::ContextChanged)));
+            if !cloud {
+                let identities = RemoteSshIdentityStore::new(&f.home);
+                let provider = local_provider(&store, &f.config, &p.spec().target).expect("local provider");
+                assert!(matches!(
+                    super::super::super::recover(&store, &identities, &provider, &allocation),
+                    Err(super::super::super::RemoteWorkspaceSetupError::Recovery(
+                        crate::remote_workspace_recovery::RemoteWorkspaceRecoveryError::StateChanged
+                    ))
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn callback_drift_cannot_be_published_as_success() {
+        let f = Fixture::new();
+        let p = f.preview(false);
+        let allocation = f.submit(&p).expect("allocation");
+        reserve(&f.store(), &allocation);
+        let result = check_with(&f.home, &f.config, OWNER, p.locator(), |store, current| {
+            let mut next = current.workspace().state().clone();
+            next.spec.working_directory = "changed".into();
+            store
+                .replace_remote_workspace(current.workspace(), &next)
+                .expect("fixture drift");
+            Ok(current.clone())
+        });
+        assert!(matches!(result, Err(Error::SetupUnconfirmed)));
+    }
+
+    #[test]
+    fn missing_or_foreign_check_never_creates_storage() {
+        let f = Fixture::new();
+        let p = f.preview(false);
+        assert!(matches!(f.check(p.locator()), Err(Error::StorageUnavailable)));
+        assert!(!f.home.root().exists());
+        assert!(matches!(
+            check_with(&f.home, &f.config, OTHER, p.locator(), |_, _| panic!("dispatch")),
+            Err(Error::ContextChanged)
+        ));
+        let _store = f.store();
+        assert!(matches!(
+            f.check(p.locator()).expect("existing empty store"),
+            ConfiguredWorkspaceSetupObservation::Missing
+        ));
+    }
+}

--- a/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
@@ -12,7 +12,7 @@ mod linux {
     use crate::cloud_run::{GitCommitSha, local_docker::LocalDockerProfile, runpod::RunPodProfile};
     use std::{
         cell::Cell,
-        os::unix::fs::PermissionsExt,
+        os::unix::fs::{DirBuilderExt, PermissionsExt, symlink},
         sync::{
             Arc, Barrier,
             atomic::{AtomicUsize, Ordering},
@@ -263,6 +263,132 @@ mod linux {
             }
             assert!(!f.home.root().exists());
             assert!(!other_home.root().exists());
+        }
+    }
+
+    fn retargeted_submit(relative: Option<&str>) {
+        let f = Fixture::new();
+        let destinations = [f.directory.path().join("first"), f.directory.path().join("second")];
+        for destination in &destinations {
+            std::fs::DirBuilder::new()
+                .mode(0o700)
+                .create(destination)
+                .expect("target");
+        }
+        let link = f.directory.path().join("selected");
+        symlink(&destinations[0], &link).expect("initial selection");
+        let home = HorizonHome::from_root(relative.map_or_else(|| link.clone(), |relative| link.join(relative)));
+        let prepared = preview_configured_remote_workspace(&home, &f.config, OWNER, Fixture::draft(false))
+            .expect("filesystem-free preview");
+        let locator = prepared.locator().clone();
+        let approval = consent(&prepared);
+        std::fs::remove_file(&link).expect("remove owned link");
+        symlink(&destinations[1], &link).expect("retarget owned link");
+        let attempt = submit_configured_remote_workspace(&home, &f.config, OWNER, prepared, approval);
+        assert!(attempt.locator == locator);
+        for destination in &destinations {
+            let destination = HorizonHome::from_root(destination.join(relative.unwrap_or_default()));
+            assert!(!destination.root().join("remote-ssh-identities").exists());
+            assert!(
+                !destination.cloud_workflow_store_path().exists(),
+                "no wrong-home database"
+            );
+            assert!(!destination.root().join("cloud-run").exists());
+        }
+        assert!(matches!(attempt.result, Err(Error::StorageUnavailable)));
+    }
+
+    #[test]
+    fn public_submit_refuses_retargeted_home_before_writing() {
+        for relative in [None, Some(""), Some(".")] {
+            retargeted_submit(relative);
+        }
+    }
+
+    #[test]
+    fn public_submit_refuses_retargeted_ancestor_before_writing() {
+        retargeted_submit(Some("home"));
+    }
+
+    #[test]
+    fn recovery_refuses_a_linked_home_before_adopting_a_saved_record() {
+        let f = Fixture::new();
+        let prepared = f.preview(false);
+        f.submit(&prepared).expect("saved allocation");
+        let link = f.directory.path().join("selected");
+        symlink(f.home.root(), &link).expect("linked home");
+        let home = HorizonHome::from_root(link);
+        let locator = RemoteWorkspaceSetupLocator::new(&home, OWNER, &prepared.locator.workspace_local_id)
+            .expect("lexical locator");
+        let before = std::fs::read(f.home.cloud_workflow_store_path()).expect("saved bytes");
+        assert!(matches!(
+            check_configured_remote_workspace_setup(&home, &f.config, OWNER, &locator),
+            Err(Error::StorageUnavailable)
+        ));
+        assert_eq!(
+            std::fs::read(f.home.cloud_workflow_store_path()).expect("unchanged"),
+            before
+        );
+    }
+
+    #[test]
+    fn recovery_rechecks_home_before_opening_a_writable_store() {
+        let f = Fixture::new();
+        let prepared = f.preview(false);
+        let allocation = reserve(&f.store(), &f.submit(&prepared).expect("allocation"));
+        let link = f.directory.path().join("selected");
+        symlink(f.home.root(), &link).expect("initial home");
+        let home = HorizonHome::from_root(link.clone());
+        let observed = CloudWorkflowStore::open_read_only(&home).expect("original read-only store");
+        let other = HorizonHome::from_root(f.directory.path().join("other"));
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(other.root())
+            .expect("other");
+        std::fs::remove_file(&link).expect("remove owned link");
+        symlink(other.root(), &link).expect("retarget owned link");
+        let result = check_saved_with(&home, &f.config, &observed, allocation.workspace().clone(), |_, _| {
+            panic!("no recovery")
+        });
+        assert!(
+            !other.cloud_workflow_store_path().exists(),
+            "no redirected recovery store"
+        );
+        assert!(!other.root().join("cloud-run").exists());
+        assert!(matches!(result, Err(Error::StorageUnavailable)));
+        assert_eq!(
+            observed
+                .load_remote_allocation(OWNER, &prepared.locator.workspace_local_id)
+                .expect("load"),
+            Some(allocation)
+        );
+    }
+
+    #[test]
+    fn untrusted_home_components_refuse_before_storage_or_dispatch() {
+        for mode in 0..5 {
+            let mut f = Fixture::new();
+            match mode {
+                0 => {
+                    std::fs::create_dir(f.home.root()).expect("home");
+                    std::fs::set_permissions(f.home.root(), std::fs::Permissions::from_mode(0o770)).expect("mode");
+                }
+                1 => std::fs::set_permissions(f.directory.path(), std::fs::Permissions::from_mode(0o770))
+                    .expect("untrusted parent"),
+                2 => std::fs::write(f.home.root(), b"not a directory").expect("file"),
+                3 => f.home = HorizonHome::from_root(f.directory.path().join("missing-parent/home")),
+                _ => {
+                    std::fs::create_dir(f.directory.path().join("parent")).expect("parent");
+                    f.home = HorizonHome::from_root(f.directory.path().join("parent/../home"));
+                }
+            }
+            let prepared = f.preview(false);
+            let result = submit_with(&f.home, &f.config, OWNER, &prepared, &consent(&prepared), |_, _| {
+                panic!("no dispatch")
+            });
+            assert!(matches!(result, Err(Error::StorageUnavailable)));
+            assert!(!f.home.cloud_workflow_store_path().exists());
+            assert!(!f.home.root().join("remote-ssh-identities").exists());
         }
     }
 

--- a/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
@@ -310,6 +310,45 @@ mod linux {
         retargeted_submit(Some("home"));
     }
 
+    fn shared_parent_fixture() -> Fixture {
+        let mut fixture = Fixture::new();
+        let parent = fixture.directory.path().join("shared");
+        std::fs::create_dir(&parent).expect("shared parent");
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o1777)).expect("sticky mode");
+        fixture.home = HorizonHome::from_root(parent.join("home"));
+        fixture
+    }
+
+    #[test]
+    fn missing_home_under_shared_sticky_parent_refuses_before_writes() {
+        let f = shared_parent_fixture();
+        let prepared = f.preview(false);
+        let result = submit_with(&f.home, &f.config, OWNER, &prepared, &consent(&prepared), |_, _| {
+            Err(Error::SetupUnconfirmed)
+        });
+        assert!(!f.home.root().exists(), "no control store below shared parent");
+        assert!(matches!(result, Err(Error::StorageUnavailable)));
+        let locator = prepared.locator().clone();
+        let approval = consent(&prepared);
+        let attempt = submit_configured_remote_workspace(&f.home, &f.config, OWNER, prepared, approval);
+        assert!(attempt.locator == locator);
+        assert!(matches!(attempt.result, Err(Error::StorageUnavailable)));
+        assert!(!f.home.root().exists());
+        assert!(!f.home.root().join("remote-ssh-identities").exists());
+    }
+
+    #[test]
+    fn existing_owned_home_below_shared_sticky_parent_remains_valid() {
+        let f = shared_parent_fixture();
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(f.home.root())
+            .expect("owned home");
+        let allocation = f.submit(&f.preview(false)).expect("fake dispatch");
+        assert_eq!(allocation.workspace().state().spec.generation, 1);
+        assert!(!f.home.root().join("remote-ssh-identities").exists());
+    }
+
     #[test]
     fn recovery_refuses_a_linked_home_before_adopting_a_saved_record() {
         let f = Fixture::new();

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -133,6 +133,12 @@ back into large multi-purpose modules.
   positive first-pin intent or a complete retained pin. Selection and non-creating
   recovery bind the same owned snapshot; an unmarked interrupted start is refused,
   never inferred as first-bootstrap authority or automatically cleaned up.
+  Its `configured` leaf validates a home/owner/profile-bound new-workspace preview,
+  consumes exact image/storage consent and saves one immutable identity before
+  task-free allocation. Errors retain recovery coordinates; manual checks distinguish
+  dormant and interrupted records and recover only the same allocation snapshot.
+  This leaf does not prepare Git, deliver repository credentials, start tasks or
+  attest caller-supplied image/storage trust. UI confirmation remains a separate layer.
 - `remote_environment_observation.rs` produces overview-safe, point-in-time
   provider observations with exact snapshot checks but no private-key access or
   saved-state writes. It shares allocation observation validation with recovery;


### PR DESCRIPTION
## Purpose

Add a configured core API for explicitly creating one task-free remote workspace using LocalDocker or a caller-selected RunPod HPS volume.

## Behavior

- Preview validates the exact image, provider profile, repository/branch, Shell intent, storage selection and setup expiry without opening storage or reading credentials.
- Confirmation consumes the displayed home/owner/configuration-bound preview and exact image/storage consent, saves one identity, then uses the existing task-free setup operation. Every result retains the original recovery locator; duplicate confirmation never adopts an existing workspace.
- Before control-store access, shared identity path validation rejects symlinked or untrusted homes and ancestors, including trailing-separator/current-directory spellings. A missing home additionally requires a current-user-owned parent that is not group/other-writable; an existing owned home beneath a sticky ancestor remains supported. Preview binds a lexical path, not an inode; same-user filesystem replacement is outside this boundary.
- Manual Check distinguishes missing, saved-only and interrupted setup. Eligible recovery rechecks the home before writable access, uses only the original allocation, validates split-read and callback snapshots, and cannot allocate another worker, repair identity or renew setup authority.
- RunPod consent authorizes the supplied digest-pinned entrypoint-only image and HPS storage. It does not attest image provenance, volume ownership/exclusivity or filesystem safety.

## Validation

- Exact candidate: `38814ef0f8e9f6621d1a8f72e26e58ff36f3fe16`. All eight validation gates passed: formatting, maintainability, version sync, default and speech workspace tests, blocking/strict Clippy and advisory pedantic Clippy.
- Workspace totals: 2,410 default tests and 2,455 speech-tier tests passed, with 7 ignored tests in each tier.
- All 53 focused setup-family tests and 12 identity tests passed. The 18 configured cases use local stores, injected dispatch and public refusal paths: exact consent/context, locator retention, duplicate/concurrent confirmation, partial saves, interrupted first pin, uncertain replies, expired setup, snapshot drift and home-path rejection.
- Final public-submit regressions assert rejected retargets and missing homes under shared sticky parents create no control store or identity directory. Recovery tests cover both read admission and the later writable-store boundary; positive controls retain missing homes under owned private parents and existing owned homes beneath sticky parents.

## Scope

Core API only, supported on Linux; Azure and other platforms refuse. No UI wiring, repository credential delivery, Git preparation, task execution, automatic cleanup or new provider/storage APIs. UI and positive live-cloud acceptance remain pending.

Refs #472, #383, #473.
