### PR TITLE
feat(cloud): add explicit compute start for stopped Azure workers

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 mod artifact_digest;
 pub mod azure;
 pub mod interactive_worker;
+pub mod interactive_worker_start;
 pub mod interactive_worker_stop;
 pub mod local_docker;
 pub mod runpod;

--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -269,6 +269,8 @@ pub enum AzureError {
     },
     #[error("worker stop did not reach a verified retained inactive state")]
     StopUnverified,
+    #[error("worker start did not reach a verified running state for the same worker")]
+    StartUnverified,
 }
 
 /// Parsed `/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{kind}/{name}`.

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -6,21 +6,31 @@ use super::super::{
     deployment::{SSH_PORT, identity_tags},
     transport::remaining,
 };
-use super::{AzureClient, Placement, SSH_USERNAME, vm_lifecycle};
+use super::{AzureClient, Observation, Placement, SSH_USERNAME, vm_lifecycle};
 use crate::cloud_run::{
     WorkerTarget,
     interactive_worker::{InteractiveWorker, InteractiveWorkerSshEndpoint, valid_ssh_public_key},
+    interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
     interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
 };
 use std::time::{Duration, Instant};
 
-/// Polling schedule for a deallocation to be observed after Azure accepted it;
-/// D-series deallocations commonly take one to three minutes.
-const STOP_BACKOFF_MS: [u64; 14] = [
-    0, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 30_000, 30_000, 30_000, 30_000, 30_000, 30_000, 30_000,
-];
+/// Polling schedule for a power transition (deallocation or start) to be observed after
+/// Azure accepted it; D-series transitions commonly take one to three minutes. The last
+/// step repeats until the absolute bound ends the wait.
+const POWER_BACKOFF_MS: [u64; 7] = [0, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
 /// Absolute bound on that wait, sleeps and requests included.
-const STOP_BOUND: Duration = Duration::from_secs(300);
+const POWER_BOUND: Duration = Duration::from_secs(300);
+/// Budget kept back from the last sleep so one more poll fits before the deadline: the
+/// final observation happens this close to the deadline, which is as near as a bounded
+/// request allows (an ARM lookup normally answers in well under a second).
+const FINAL_POLL_RESERVE: Duration = Duration::from_secs(5);
+/// Polls a test may observe before the wait is treated as exhausted (tests skip the
+/// sleeps, so the absolute bound alone would spin for its whole length).
+#[cfg(test)]
+const TEST_POLLS: usize = 14;
+/// The non-billed state the worker must hold after a stop.
+const RETAINED: AzureLifecycle = AzureLifecycle::Deallocated;
 
 /// Trusted source for the runtime SSH host key of one exact worker; `None` keeps a
 /// running worker in `Provisioning`. Implementations must obtain the key through a
@@ -159,24 +169,51 @@ impl InteractiveWorkerStopProvider for AzureClient {
                 Err(error) => return Err(error),
             }
         }
-        let group = current.worker.resource_group.clone();
-        // An absolute deadline covers the sleeps, and each request is handed only what
-        // is left of it, so the wait cannot stretch past the bound on slow requests.
-        let deadline = Instant::now() + STOP_BOUND;
-        for delay_ms in STOP_BACKOFF_MS {
+        match self.await_power(&current, &expected, RETAINED)? {
+            Some(_) => Ok(InteractiveWorkerStop::Stopped),
+            None => Err(AzureError::StopUnverified),
+        }
+    }
+}
+
+impl AzureClient {
+    /// Wait for the exact worker's VM to reach `target`, under an absolute deadline that
+    /// covers the sleeps with each request handed only what is left of it. The wait spans
+    /// minutes, so every poll re-proves the group (identity tags, recorded ID, not
+    /// deleting) and the VM (identity tags): a recreated or retagged worker at the same
+    /// path is an identity error, never this worker's transition. `None` means the
+    /// transition was not verified within the bound (vanished, failed, deleting, or late).
+    fn await_power(
+        &self,
+        current: &Observation,
+        expected: &std::collections::BTreeMap<String, String>,
+        target: AzureLifecycle,
+    ) -> Result<Option<crate::cloud_run::azure::AzureVmView>, AzureError> {
+        let group = &current.worker.resource_group;
+        let deadline = Instant::now() + POWER_BOUND;
+        let last = POWER_BACKOFF_MS[POWER_BACKOFF_MS.len() - 1];
+        let schedule = POWER_BACKOFF_MS.into_iter().chain(std::iter::repeat(last));
+        #[cfg(test)]
+        let schedule = schedule.take(TEST_POLLS);
+        for delay_ms in schedule {
+            // Only the absolute deadline ends the wait; a transition that completes late
+            // in the bound is still observed.
             let Some(left) = remaining(deadline) else {
                 break;
             };
-            if !cfg!(test) && delay_ms > 0 {
-                std::thread::sleep(Duration::from_millis(delay_ms).min(left));
+            // Never sleep into the deadline: the sleep stops a small reserve short of
+            // it, and the poll made inside that reserve, a few seconds before the
+            // deadline, is the last one, so a transition that completes at the very end
+            // of the bound is still observed without busy-polling.
+            let sleep_for = Duration::from_millis(delay_ms).min(left.saturating_sub(FINAL_POLL_RESERVE));
+            if !cfg!(test) && !sleep_for.is_zero() {
+                std::thread::sleep(sleep_for);
             }
-            // The wait spans minutes: every poll re-proves the group and the VM through
-            // the same identity checks, so a recreated or retagged worker at the same
-            // path is never reported as this one being stopped.
             let Some(budget) = remaining(deadline) else {
                 break;
             };
-            let Some(live) = self.transport.get_resource_group_within(&group, budget)? else {
+            let final_poll = budget <= FINAL_POLL_RESERVE;
+            let Some(live) = self.transport.get_resource_group_within(group, budget)? else {
                 break;
             };
             if expected.iter().any(|(key, value)| live.tags.get(key) != Some(value))
@@ -184,25 +221,108 @@ impl InteractiveWorkerStopProvider for AzureClient {
             {
                 return Err(AzureError::ResourceIdentityMismatch);
             }
-            // Disks and address are going away with the group: not a retained stop.
+            // Disks and address are going away with the group: no state is retained.
             if live.provisioning_state == "Deleting" {
                 break;
             }
             let Some(budget) = remaining(deadline) else {
                 break;
             };
-            let Some(vm) = self.transport.get_vm_within(&group, WORKER_VM_NAME, budget)? else {
+            let Some(vm) = self.transport.get_vm_within(group, WORKER_VM_NAME, budget)? else {
                 break;
             };
             if expected.iter().any(|(key, value)| vm.tags.get(key) != Some(value)) {
                 return Err(AzureError::ResourceIdentityMismatch);
             }
             match vm_lifecycle(&vm) {
-                AzureLifecycle::Deallocated => return Ok(InteractiveWorkerStop::Stopped),
+                lifecycle if lifecycle == target => return Ok(Some(vm)),
                 AzureLifecycle::Failed | AzureLifecycle::Deleting => break,
+                _ if final_poll => break,
                 _ => {}
             }
         }
-        Err(AzureError::StopUnverified)
+        Ok(None)
+    }
+}
+
+impl InteractiveWorkerStartProvider for AzureClient {
+    /// Start the VM's compute again after an explicit stop: the retained disks and the
+    /// static address come back under the same identity. A running worker is never
+    /// re-posted; a VM already starting is only awaited. Once running, the same worker
+    /// is observed again through the readiness path, so `Started` carries `Ready` only
+    /// with a freshly attested host key and `Provisioning` otherwise.
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+        let Some((handle, group, expected)) = self.owned_handle(worker)? else {
+            return Ok(InteractiveWorkerStart::AlreadyAbsent);
+        };
+        let Some(current) = self.observe(handle.clone(), &group, &expected, None, Placement::Ignore)? else {
+            return Err(AzureError::StartUnverified);
+        };
+        let Some(vm) = current.vm.as_ref() else {
+            return Err(AzureError::StartUnverified);
+        };
+        // A worker whose group is being deleted or whose deployment failed is not a
+        // stopped worker, whatever its leftover VM reports: nothing is started.
+        if matches!(current.lifecycle, AzureLifecycle::Deleting | AzureLifecycle::Failed) {
+            return Err(AzureError::StartUnverified);
+        }
+        let starting = vm.power_state.as_deref() == Some("PowerState/starting");
+        match vm_lifecycle(vm) {
+            AzureLifecycle::Running => {
+                let status = self.status(current, &worker.target, &worker.ssh_public_key, Placement::Ignore)?;
+                return Ok(InteractiveWorkerStart::AlreadyRunning(status));
+            }
+            AzureLifecycle::Deallocated | AzureLifecycle::StoppedAllocated => {}
+            AzureLifecycle::Transitioning if starting => {}
+            AzureLifecycle::Transitioning
+            | AzureLifecycle::Failed
+            | AzureLifecycle::Deleting
+            | AzureLifecycle::Unknown => return Err(AzureError::StartUnverified),
+        }
+        if !starting {
+            match self.transport.start_vm(&current.worker.resource_group, WORKER_VM_NAME) {
+                // Compute answers 409 while a start is already in flight.
+                Ok(Some(_)) | Err(AzureError::UnexpectedStatus { status: 409, .. }) => {}
+                // Vanished between the observation and the POST: nothing to start, and
+                // never something to allocate.
+                Ok(None) => return Err(AzureError::StartUnverified),
+                Err(error) => return Err(error),
+            }
+        }
+        if self
+            .await_power(&current, &expected, AzureLifecycle::Running)?
+            .is_none()
+        {
+            return Err(AzureError::StartUnverified);
+        }
+        // Running is not ready: the same worker goes through the full observation and
+        // attestation path before anything is claimed about it.
+        let Some(live) = self.owned_group(&handle.resource_group, &expected)? else {
+            return Err(AzureError::StartUnverified);
+        };
+        if !live.id.eq_ignore_ascii_case(&handle.group_id) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
+        let Some(fresh) = self.observe(handle, &live, &expected, None, Placement::Ignore)? else {
+            return Err(AzureError::StartUnverified);
+        };
+        // Only a worker whose VM is physically running is a started worker; anything
+        // else observed after the wait (a failure, a deletion begun meanwhile, a new
+        // transition, an unreadable power state) stays unverified. A running VM without
+        // a usable address is observed as Unknown; it is started, just not reachable, and
+        // is reported as Provisioning rather than Ready.
+        let running_vm = fresh
+            .vm
+            .as_ref()
+            .is_some_and(|vm| vm_lifecycle(vm) == AzureLifecycle::Running);
+        if !running_vm || !matches!(fresh.lifecycle, AzureLifecycle::Running | AzureLifecycle::Unknown) {
+            return Err(AzureError::StartUnverified);
+        }
+        let fresh = Observation {
+            lifecycle: AzureLifecycle::Running,
+            ..fresh
+        };
+        let status = self.status(fresh, &worker.target, &worker.ssh_public_key, Placement::Ignore)?;
+        Ok(InteractiveWorkerStart::Started(status))
     }
 }

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -29,6 +29,7 @@ pub(super) enum Call {
     GetDeployment(String),
     GetVm(String),
     Deallocate(String),
+    Start(String),
     Run(String, AzureRunCommand),
 }
 
@@ -53,10 +54,14 @@ pub(super) struct Plane {
     pub(super) vanish_after_first_lookup: bool,
     pub(super) delete_status: Option<u16>,
     pub(super) deallocate: Option<Result<Option<AzureLongRunningState>, AzureError>>,
+    pub(super) start: Option<Result<Option<AzureLongRunningState>, AzureError>>,
     pub(super) run_output: Option<String>,
     /// Replaces the group once the deallocation was posted, as a concurrent retag or
     /// deletion during the wait would.
     pub(super) group_after_deallocate: Option<GroupChange>,
+    /// Replaces the group once the start was posted, as a concurrent retag or deletion
+    /// during the wait would.
+    pub(super) group_after_start: Option<GroupChange>,
     pub(super) calls: Vec<Call>,
 }
 
@@ -200,6 +205,18 @@ impl AzureManagementTransport for Fake {
         self.get_vm(group, name)
     }
 
+    fn start_vm(&self, group: &str, _name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
+        let mut plane = self.lock();
+        plane.calls.push(Call::Start(group.into()));
+        if let Some(change) = plane.group_after_start.take() {
+            plane.group = match change {
+                GroupChange::Replaced(group) => Some(group),
+                GroupChange::Deleted => None,
+            };
+        }
+        plane.start.clone().unwrap_or(Ok(Some(AzureLongRunningState::Accepted)))
+    }
+
     fn deallocate_vm(&self, group: &str, _name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
         let mut plane = self.lock();
         plane.calls.push(Call::Deallocate(group.into()));
@@ -339,3 +356,4 @@ pub(super) const MISMATCH: AzureError = AzureError::ResourceIdentityMismatch;
 mod creation;
 mod observation;
 mod running;
+mod start;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/start.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/start.rs
@@ -1,0 +1,313 @@
+use super::*;
+use crate::cloud_run::interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider};
+
+#[test]
+fn start_posts_once_awaits_running_and_reobserves_through_the_readiness_path() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    assert_eq!(client.start_worker(&worker), Ok(InteractiveWorkerStart::AlreadyAbsent));
+    assert!(s.plane.mutations().is_empty(), "absence never allocates");
+    let address = || Some(deployment("Succeeded", "203.0.113.9"));
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![
+            Some(vm("deallocated", &s.tags)),
+            Some(vm("starting", &s.tags)),
+            Some(vm("running", &s.tags)),
+        ],
+    );
+    let started = client.start_worker(&worker).expect("start");
+    let InteractiveWorkerStart::Started(status) = &started else {
+        panic!("a deallocated worker is started: {started:?}");
+    };
+    assert_eq!(
+        status.lifecycle,
+        Lifecycle::Ready,
+        "ready only through the attested key"
+    );
+    assert_eq!(
+        status.ssh.as_ref().map(|ssh| ssh.host_key.as_str()),
+        Some(host_key().as_str())
+    );
+    assert_eq!(s.plane.mutations(), [Call::Start(s.group.clone())]);
+    // Already running: observed, never re-posted.
+    s.plane
+        .script(Some(owned(&s)), address(), vec![Some(vm("running", &s.tags))]);
+    let running = client.start_worker(&worker).expect("running");
+    assert!(
+        matches!(running, InteractiveWorkerStart::AlreadyRunning(_)),
+        "{running:?}"
+    );
+    assert_eq!(running.status().map(|status| status.lifecycle), Some(Lifecycle::Ready));
+    assert!(s.plane.mutations().is_empty(), "no start against a running worker");
+    // Without an attested key the start is real but the worker is still provisioning.
+    let pending = s.client(false, None);
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![Some(vm("deallocated", &s.tags)), Some(vm("running", &s.tags))],
+    );
+    let started = pending.start_worker(&worker).expect("start");
+    assert_eq!(
+        started.status().map(|status| (status.lifecycle, status.ssh.is_some())),
+        Some((Lifecycle::Provisioning, false))
+    );
+    // A guest-halted (billed) VM, a synchronous completion and an in-flight start.
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![Some(vm("stopped", &s.tags)), Some(vm("running", &s.tags))],
+    );
+    s.plane.lock().start = Some(Ok(Some(AzureLongRunningState::Completed)));
+    assert!(matches!(
+        client.start_worker(&worker),
+        Ok(InteractiveWorkerStart::Started(_))
+    ));
+    assert_eq!(s.plane.mutations(), [Call::Start(s.group.clone())]);
+    s.plane.lock().start = None;
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![Some(vm("starting", &s.tags)), Some(vm("running", &s.tags))],
+    );
+    assert!(matches!(
+        client.start_worker(&worker),
+        Ok(InteractiveWorkerStart::Started(_))
+    ));
+    assert!(
+        s.plane.mutations().is_empty(),
+        "a start already in flight is awaited, not re-posted"
+    );
+}
+
+#[test]
+fn start_never_allocates_and_reports_unverified_states_honestly() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let conflict = |status| {
+        Some(Err(AzureError::UnexpectedStatus {
+            operation: "virtual machine start",
+            status,
+        }))
+    };
+    let address = || Some(deployment("Succeeded", "203.0.113.9"));
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![Some(vm("deallocated", &s.tags)), Some(vm("running", &s.tags))],
+    );
+    s.plane.lock().start = conflict(409);
+    assert!(
+        matches!(client.start_worker(&worker), Ok(InteractiveWorkerStart::Started(_))),
+        "409 means a start is already in flight; it is awaited"
+    );
+    s.plane.lock().start = conflict(403);
+    s.plane
+        .script(Some(owned(&s)), address(), vec![Some(vm("deallocated", &s.tags))]);
+    assert!(matches!(
+        client.start_worker(&worker),
+        Err(AzureError::UnexpectedStatus { status: 403, .. })
+    ));
+    s.plane.lock().start = Some(Ok(None));
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "a VM that vanished before the POST is unverified, never re-created"
+    );
+    s.plane.lock().start = None;
+    for (states, label) in [
+        (vec![Some(vm("deallocated", &s.tags))], "never running within the bound"),
+        (vec![None], "no VM to start"),
+        (
+            vec![Some(vm("deallocated", &s.tags)), None],
+            "VM vanished while starting",
+        ),
+        (vec![Some(vm("deallocating", &s.tags))], "still deallocating"),
+    ] {
+        s.plane.script(Some(owned(&s)), address(), states);
+        assert_eq!(
+            client.start_worker(&worker),
+            Err(AzureError::StartUnverified),
+            "{label}"
+        );
+        assert!(
+            !s.plane.calls().iter().any(|call| matches!(
+                call,
+                Call::DeleteGroup(_) | Call::CreateGroup(..) | Call::PutDeployment(..)
+            )),
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn start_never_starts_a_failed_worker_and_rejects_foreign_handles_before_any_mutation() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let address = || Some(deployment("Succeeded", "203.0.113.9"));
+    let mut failed = vm("deallocated", &s.tags);
+    failed.provisioning_state = "Failed".into();
+    s.plane.script(Some(owned(&s)), address(), vec![Some(failed)]);
+    assert_eq!(client.start_worker(&worker), Err(AzureError::StartUnverified));
+    assert!(s.plane.mutations().is_empty(), "no start on a failed VM");
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Failed", "")),
+        vec![Some(vm("deallocated", &s.tags))],
+    );
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "a failed deployment's leftover VM is not a stopped worker"
+    );
+    assert!(s.plane.mutations().is_empty(), "no start behind a failed deployment");
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![Some(vm("deallocated", &s.tags)), Some(vm("running", &s.tags))],
+    );
+    s.plane.lock().deployment_on_second_read = Some(deployment("Failed", ""));
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "a deployment that failed during the wait is never reported as started"
+    );
+    s.plane.script(
+        Some(group_info(&s.group, s.tags.clone(), "Deleting")),
+        address(),
+        vec![Some(vm("deallocated", &s.tags))],
+    );
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "group deleting"
+    );
+    assert!(s.plane.mutations().is_empty());
+    s.plane
+        .script(Some(owned(&s)), address(), vec![Some(vm("deallocated", &s.tags))]);
+    s.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "a group that vanishes right after its proof is a race, not an absence"
+    );
+    assert!(s.plane.mutations().is_empty());
+    let mut foreign = worker.clone();
+    foreign.identity.resource_id = format!("{}-other", worker.identity.resource_id);
+    assert_eq!(client.start_worker(&foreign), Err(AzureError::InvalidPersistedWorker));
+    let mut other_tags = s.tags.clone();
+    other_tags.insert("horizon-job-id".into(), "other".into());
+    s.plane.script(
+        Some(group_info(&s.group, other_tags, "Succeeded")),
+        address(),
+        vec![Some(vm("deallocated", &s.tags))],
+    );
+    assert_eq!(client.start_worker(&worker), Err(MISMATCH));
+    assert!(s.plane.mutations().is_empty());
+}
+
+#[test]
+fn start_reproves_ownership_on_every_poll_and_before_answering() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let address = || Some(deployment("Succeeded", "203.0.113.9"));
+    let mut retagged = s.tags.clone();
+    retagged.insert("horizon-job-id".into(), "other".into());
+    let mut foreign_vm = vm("running", &s.tags);
+    foreign_vm.tags = retagged.clone();
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![Some(vm("deallocated", &s.tags)), Some(foreign_vm.clone())],
+    );
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(MISMATCH),
+        "a retagged VM at the same path is not this worker starting"
+    );
+    let two_step = || vec![Some(vm("deallocated", &s.tags)), Some(vm("running", &s.tags))];
+    s.plane.script(Some(owned(&s)), address(), two_step());
+    s.plane.lock().group_after_start = Some(GroupChange::Replaced(group_info(&s.group, retagged, "Succeeded")));
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(MISMATCH),
+        "group retagged during the wait"
+    );
+    s.plane.script(Some(owned(&s)), address(), two_step());
+    s.plane.lock().group_after_start = Some(GroupChange::Deleted);
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "group deleted during the wait"
+    );
+    s.plane.script(Some(owned(&s)), address(), two_step());
+    s.plane.lock().group_after_start = Some(GroupChange::Replaced(group_info(&s.group, s.tags.clone(), "Deleting")));
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "a running VM inside a group being deleted is not a started worker"
+    );
+    // Running is reached, but the re-observation finds a replaced VM: nothing is claimed.
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![
+            Some(vm("deallocated", &s.tags)),
+            Some(vm("running", &s.tags)),
+            Some(foreign_vm),
+        ],
+    );
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(MISMATCH),
+        "VM replaced before the answer"
+    );
+    assert!(
+        !s.plane.calls().iter().any(|call| matches!(
+            call,
+            Call::DeleteGroup(_) | Call::CreateGroup(..) | Call::PutDeployment(..)
+        )),
+        "start never deletes or creates"
+    );
+}
+
+#[test]
+fn start_answers_only_for_a_vm_observed_physically_running_after_the_wait() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    // Running but behind an unusable address: started, not reachable, so Provisioning.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "10.0.0.5")),
+        vec![Some(vm("deallocated", &s.tags)), Some(vm("running", &s.tags))],
+    );
+    let started = client.start_worker(&worker).expect("start");
+    assert_eq!(
+        started.status().map(|status| (status.lifecycle, status.ssh.is_some())),
+        Some((Lifecycle::Provisioning, false)),
+        "{started:?}"
+    );
+    // The wait saw running, but the answer-time observation cannot read a power state.
+    let mut unreadable = vm("running", &s.tags);
+    unreadable.power_state = None;
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        vec![
+            Some(vm("deallocated", &s.tags)),
+            Some(vm("running", &s.tags)),
+            Some(unreadable),
+        ],
+    );
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(AzureError::StartUnverified),
+        "an unreadable VM is never reported as started"
+    );
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -545,6 +545,34 @@ fn operation_url() -> String {
 }
 
 #[test]
+fn start_uses_the_exact_path_and_maps_long_running_states() {
+    let (transport, _) = http(vec![
+        expect("POST", vm_url("/start"), 202, "", None),
+        expect("POST", vm_url("/start"), 200, "", None),
+        expect("POST", vm_url("/start"), 409, "private-conflict", None),
+        expect("POST", vm_url("/start"), 404, "", None),
+    ]);
+    assert_eq!(
+        transport.start_vm(GROUP, "worker"),
+        Ok(Some(AzureLongRunningState::Accepted))
+    );
+    assert_eq!(
+        transport.start_vm(GROUP, "worker"),
+        Ok(Some(AzureLongRunningState::Completed))
+    );
+    let conflict = transport.start_vm(GROUP, "worker");
+    assert_eq!(
+        conflict,
+        Err(AzureError::UnexpectedStatus {
+            operation: "virtual machine start",
+            status: 409
+        })
+    );
+    assert!(!format!("{conflict:?}").contains("private-"));
+    assert_eq!(transport.start_vm(GROUP, "worker"), Ok(None), "absent VM");
+}
+
+#[test]
 fn deallocate_uses_the_exact_path_and_maps_long_running_states() {
     let (transport, _) = http(vec![
         expect("POST", vm_url("/deallocate"), 202, "", None),
@@ -573,6 +601,10 @@ fn deallocate_uses_the_exact_path_and_maps_long_running_states() {
     for (group, name) in [("bad/group", "worker"), (GROUP, ""), (GROUP, "name with space")] {
         assert_eq!(
             transport.deallocate_vm(group, name),
+            Err(AzureError::ResourceIdentityMismatch)
+        );
+        assert_eq!(
+            transport.start_vm(group, name),
             Err(AzureError::ResourceIdentityMismatch)
         );
         assert_eq!(

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use std::{collections::BTreeMap, time::Duration};
 
+mod power;
 mod run_command;
 
 pub use run_command::AzureRunCommand;
@@ -96,6 +97,10 @@ pub trait AzureManagementTransport: Send + Sync {
     /// `None` when the VM is absent.
     /// # Errors
     fn deallocate_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError>;
+    /// Start a deallocated or guest-stopped VM's compute (`PowerState/running`); `None`
+    /// when the VM is absent.
+    /// # Errors
+    fn start_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError>;
     /// Run one of the closed set of commands inside the VM through the ARM run-command
     /// channel and return its standard output, or `None` when the VM is absent.
     /// # Errors
@@ -152,6 +157,10 @@ impl<T: AzureManagementTransport + ?Sized> AzureManagementTransport for std::syn
 
     fn deallocate_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
         (**self).deallocate_vm(group, name)
+    }
+
+    fn start_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
+        (**self).start_vm(group, name)
     }
 
     fn run_command(&self, group: &str, name: &str, command: AzureRunCommand) -> Result<Option<String>, AzureError> {
@@ -591,19 +600,11 @@ impl AzureManagementTransport for AzureArmHttp {
     }
 
     fn deallocate_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
-        let operation = "virtual machine deallocation";
-        let url = self.resource_url(
-            group,
-            "Microsoft.Compute/virtualMachines",
-            name,
-            COMPUTE_API_VERSION,
-            "/deallocate",
-        )?;
-        match self.send_json("POST", &url, None, &[200, 202], false, operation) {
-            Ok((status, _)) => Ok(Some(long_running(status))),
-            Err(AzureError::UnexpectedStatus { status: 404, .. }) => Ok(None),
-            Err(error) => Err(error),
-        }
+        self.power_operation(group, name, "/deallocate", "virtual machine deallocation")
+    }
+
+    fn start_vm(&self, group: &str, name: &str) -> Result<Option<AzureLongRunningState>, AzureError> {
+        self.power_operation(group, name, "/start", "virtual machine start")
     }
 
     fn run_command(&self, group: &str, name: &str, command: AzureRunCommand) -> Result<Option<String>, AzureError> {

--- a/crates/horizon-core/src/cloud_run/azure/transport/power.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport/power.rs
@@ -1,0 +1,27 @@
+//! VM power actions (deallocate, start): one POST to the exact VM resource, the
+//! long-running acceptance mapped, an absent VM reported as `None`.
+use super::{AzureArmHttp, AzureError, AzureLongRunningState, COMPUTE_API_VERSION, long_running};
+
+impl AzureArmHttp {
+    /// POST `action` (a fixed path suffix such as `/start`) on the named VM.
+    pub(super) fn power_operation(
+        &self,
+        group: &str,
+        name: &str,
+        action: &'static str,
+        operation: &'static str,
+    ) -> Result<Option<AzureLongRunningState>, AzureError> {
+        let url = self.resource_url(
+            group,
+            "Microsoft.Compute/virtualMachines",
+            name,
+            COMPUTE_API_VERSION,
+            action,
+        )?;
+        match self.send_json("POST", &url, None, &[200, 202], false, operation) {
+            Ok((status, _)) => Ok(Some(long_running(status))),
+            Err(AzureError::UnexpectedStatus { status: 404, .. }) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+}

--- a/crates/horizon-core/src/cloud_run/interactive_worker_start.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker_start.rs
@@ -1,0 +1,47 @@
+//! Opt-in compute start capability for a worker that was explicitly stopped, separate
+//! from creation, attachment and the saved-task Start.
+
+use super::interactive_worker::{InteractiveWorker, InteractiveWorkerProvider, InteractiveWorkerStatus};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InteractiveWorkerStart {
+    /// Compute was started and the same exact worker was observed again through the
+    /// provider's established readiness path. The status is `Ready` only once the
+    /// endpoint is attested; until then it is `Provisioning`. This certifies nothing
+    /// about in-memory work, which did not survive the stop.
+    Started(InteractiveWorkerStatus),
+    /// The exact worker was already running; nothing was restarted or re-posted.
+    AlreadyRunning(InteractiveWorkerStatus),
+    /// The exact resource was absent before any start command was attempted; nothing
+    /// was allocated or replaced.
+    AlreadyAbsent,
+}
+
+impl InteractiveWorkerStart {
+    /// The observed status, when the worker exists.
+    #[must_use]
+    pub fn status(&self) -> Option<&InteractiveWorkerStatus> {
+        match self {
+            Self::Started(status) | Self::AlreadyRunning(status) => Some(status),
+            Self::AlreadyAbsent => None,
+        }
+    }
+}
+
+/// An explicit, optional capability, the counterpart of the Stop capability. Callers
+/// own durable authorization/intent fencing and must invoke this off the render thread.
+/// Reconnecting, reopening a view or restarting the application never grants start
+/// authority on its own.
+pub trait InteractiveWorkerStartProvider: InteractiveWorkerProvider {
+    /// Start compute for only the exact persisted worker, keeping its resource, storage
+    /// and SSH identity. Implementations validate the handle before I/O, verify current
+    /// ownership before mutation and again while waiting, never allocate or replace an
+    /// absent resource, never restart a worker that is already running, and observe the
+    /// same worker through their readiness path before answering. They must not delete,
+    /// deliver credentials, prepare repositories or replay tasks.
+    /// # Errors
+    /// Rejects malformed/foreign handles and uncertain ownership, and reports an
+    /// operation that did not reach a verified running state within its bound as
+    /// unverified rather than guessing. Diagnostics must redact provider output.
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error>;
+}

--- a/crates/horizon-core/tests/azure_live_worker.rs
+++ b/crates/horizon-core/tests/azure_live_worker.rs
@@ -3,8 +3,9 @@
 //! Ignored by default and driven entirely by environment variables, so the ordinary
 //! test matrix never touches Azure. It creates exactly one task-owned resource group,
 //! proves readiness with the attested host key by opening a pinned SSH session,
-//! stops the worker, verifies the retained state, deletes the group and proves it is
-//! gone. Every step is timed and written as one JSON line per event to stdout.
+//! stops the worker, verifies the retained state, starts its compute again and
+//! reattaches through the same pinned key to the retained data, stops it again,
+//! deletes the group and proves it is gone. Every step is timed and written as one JSON line per event to stdout.
 //!
 //! Required: `HORIZON_AZURE_LIVE_SUBSCRIPTION`, `HORIZON_AZURE_LIVE_IMAGE` (digest
 //! reference on the registry), `HORIZON_AZURE_LIVE_PULL_IDENTITY` (resource ID),
@@ -43,8 +44,9 @@ use horizon_core::cloud_run::{
     },
     interactive_worker::{
         InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerLifecycle as Lifecycle,
-        InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerStatus,
+        InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus,
     },
+    interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
     interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
 };
 use std::{
@@ -723,7 +725,7 @@ impl Live {
     }
 
     /// Ready only with an attested host key, then that key on the wire.
-    fn ready_and_prove_ssh(&self, persisted: &InteractiveWorker) {
+    fn ready_and_prove_ssh(&self, persisted: &InteractiveWorker) -> InteractiveWorkerSshEndpoint {
         let ready: InteractiveWorkerStatus = wait_for(READY_BOUND, || {
             let status = self.client.reconcile_worker(&self.request)?.expect("worker present");
             Ok(match status.lifecycle {
@@ -755,6 +757,66 @@ impl Live {
             .expect("present");
         assert_eq!(inspected.lifecycle, Lifecycle::Ready);
         self.run.event("inspected", "ready from the persisted handle");
+        endpoint.clone()
+    }
+
+    /// Explicit compute start after the stop: the same worker comes back under the same
+    /// address and host key, with the marker still on the retained disk; a second start
+    /// finds it running and posts nothing.
+    fn start_and_reattach(&self, persisted: &InteractiveWorker, before: &InteractiveWorkerSshEndpoint) {
+        let started_at = Instant::now();
+        let started = self.client.start_worker(persisted).expect("start");
+        let InteractiveWorkerStart::Started(status) = &started else {
+            panic!("a stopped worker is started: {started:?}");
+        };
+        self.run.event(
+            "started",
+            &format!(
+                "running again in {:.0}s, observed {:?}",
+                started_at.elapsed().as_secs_f64(),
+                status.lifecycle
+            ),
+        );
+        let ready: InteractiveWorkerStatus = wait_for(READY_BOUND, || {
+            let status = self.client.inspect_worker(persisted)?.expect("worker present");
+            Ok(match status.lifecycle {
+                Lifecycle::Ready => Some(status),
+                Lifecycle::Provisioning => None,
+                other => panic!("unexpected lifecycle while waiting for ready after start: {other:?}"),
+            })
+        })
+        .expect("ready after start");
+        let endpoint = ready.ssh.as_ref().expect("endpoint");
+        assert_eq!(
+            (endpoint.host.as_str(), endpoint.port, endpoint.host_key.as_str()),
+            (before.host.as_str(), before.port, before.host_key.as_str()),
+            "same address and the same attested host key as before the stop"
+        );
+        self.run.event(
+            "ready_after_start",
+            &format!(
+                "same endpoint and host key, {:.0}s after the start call",
+                started_at.elapsed().as_secs_f64()
+            ),
+        );
+        let seen = ssh_proof(
+            endpoint,
+            &self.private_key,
+            self.directory.path(),
+            "cat /workspace/.horizon-live-marker && id -un",
+        );
+        assert_eq!(
+            seen, "live-marker\nroot",
+            "the marker written before the stop is still there"
+        );
+        self.run
+            .event("reattached", "pinned reattach with the retained marker on /workspace");
+        let again = self.client.start_worker(persisted).expect("start again");
+        assert!(matches!(again, InteractiveWorkerStart::AlreadyRunning(_)), "{again:?}");
+        self.run.event(
+            "start_idempotent",
+            "a second start finds the worker running and posts nothing",
+        );
     }
 
     /// Explicit stop: retained and verified; nothing afterwards creates.
@@ -836,7 +898,9 @@ impl Live {
 fn live_worker_create_ready_stop_delete() {
     let live = setup();
     let persisted = live.create();
-    live.ready_and_prove_ssh(&persisted);
+    let endpoint = live.ready_and_prove_ssh(&persisted);
+    live.stop(&persisted);
+    live.start_and_reattach(&persisted, &endpoint);
     live.stop(&persisted);
     if keep() {
         live.cleanup.borrow_mut().armed = false;
@@ -845,6 +909,8 @@ fn live_worker_create_ready_stop_delete() {
         return;
     }
     live.delete(&persisted);
-    live.run
-        .event("done", "create, ready, pinned ssh, stop, delete all proven");
+    live.run.event(
+        "done",
+        "create, ready, pinned ssh, stop, start, pinned reattach with retained data, stop, delete all proven",
+    );
 }

--- a/docs/testing/azure-workspace-live-acceptance.md
+++ b/docs/testing/azure-workspace-live-acceptance.md
@@ -171,17 +171,52 @@ deletes; disarmed or kept guards do nothing).
 
 The thirteen passing runs give
 258 s, 186 s, 246 s, 262 s, 214 s, 257 s, 290 s, 251 s, 228 s, 271 s, 230 s, 234 s
-and 265 s: the spread is Azure's (image pull and VM start), and all sit above the
-180-second boundary that is still awaiting a decision on #474. Deletion of the group
+and 265 s: the spread is Azure's (image pull and VM start). All sat above the
+180-second target that applied when they were recorded, and all fit the 300-second
+Azure startup target approved on 2026-09-12 (see `azure-workspace-readiness.md`);
+they are evidence, not a guarantee for future runs. Deletion of the group
 took 185 s, 247 s, 245 s, 246 s, 185 s, 184 s, 125 s, 245 s, 245 s, 248 s, 246 s,
 247 s and 246 s; Stop 32 s, 17 s, 32 s, 31 s, 17 s, 16 s, 32 s, 16 s, 16 s, 32 s,
 16 s, 32 s and 32 s.
 
+## Stop, explicit compute start, pinned reattach (run 16, 2026-09-12)
+
+With the optional compute-start capability (`InteractiveWorkerStartProvider`,
+implemented by the Azure client) the driver adds a phase between the first stop and
+the delete: `start_worker`, wait for `Ready` through the persisted handle, a pinned
+SSH session with the same host key reading the marker written before the stop, a
+second `start_worker` that must find the worker running, then a second stop. Run 16
+passed end to end, same fixture and settings as above:
+
+| Step | Seconds after the driver started | Note |
+| --- | --- | --- |
+| ready with attested host key | 260.4 | |
+| pinned SSH, marker written | 261.0 | |
+| stop verified | 309.7 | 32 s |
+| `start_worker` returned `Started` | 390.9 | running again 80 s after the call, already observed `Ready` |
+| `Ready` through the persisted handle after start | 409.0 | same address, port and attested host key as before the stop |
+| pinned reattach read the marker | 409.8 | data on the retained disk survived the stop |
+| second `start_worker` returned `AlreadyRunning` | 427.8 | nothing posted |
+| second stop verified | 459.4 | 32 s |
+| deleted and gone | 705.3 | 245 s |
+
+Run 17, with the wait polling until its absolute deadline instead of a finite
+schedule, repeated the sequence: ready at 291.4 s, stop 32 s, `Started` 80 s after
+the call, `Ready` with the same endpoint 97 s after it, marker read, second start
+`AlreadyRunning`, second stop 32 s, gone in 247 s.
+
+What this proves: an explicit, authorized start of the exact worker brings back the
+same identity (address and host key) and the retained data, is idempotent on a
+running worker, and never allocates. What it does not prove: anything about
+processes that were running before the stop, which do not survive a deallocation;
+and nothing here is the saved Shell task Start, which is a separate operation.
+
 ## What this run does not prove
 
-- Resuming a stopped worker. The shared interactive-worker contract has no start
-  operation yet, so PC-off resume is not exercised; the adapter reports the
-  retained `Stopped` state and would need a start operation to bring it back.
+- Resuming in-memory work after a stop: compute start brings back the disk and the
+  SSH identity (proven in run 16), not the processes that ran before the stop.
+- Closing Horizon or powering off its controller while a worker runs: that must leave
+  the worker running and is a separate live step that involves neither Stop nor start.
 - Repository handoff on the worker (depends on the PAT setup owned in #470).
 - Three panels on one worker and multi-day retention.
 - Bounded compute in the first seconds after creation (see item 2 above) and an

--- a/docs/testing/azure-workspace-readiness.md
+++ b/docs/testing/azure-workspace-readiness.md
@@ -22,9 +22,20 @@ From #383 and #474: remote execution and durable data are independent of the
 client PC; closing panels, exiting Horizon or losing connectivity only detaches;
 reconnect is non-creating; Stop preserves promised durable data; Delete is a
 separate explicit action; the measured create, pull, endpoint and SSH-ready path
-must fit the 180-second boundary; image access uses a managed identity without
+must fit the readiness target; image access uses a managed identity without
 registry passwords; and the worker's repository storage must pass the existing
 on-worker qualifier before any repository publication.
+
+**Current Azure startup target: 300 seconds** (five minutes), approved by the
+maintainer on 2026-09-12 and recorded on #474, replacing the 180-second target the
+spike below was measured against. The measurement is unchanged: one clock from the
+first create call through provisioning, image pull and verified SSH readiness, never
+reset between stages. The spike verdict below is kept as written against its original
+180-second target; the live adapter record in
+`azure-workspace-live-acceptance.md` compares its runs with both. Exceeding the
+target must surface an honest delayed or unknown state and explicit choices, never an
+implicit deletion, replacement or duplicate creation; the 90-second progress warning
+stays.
 
 The qualifier in `crates/horizon-core/src/repository_overlay/storage.rs` accepts
 only an ext4 filesystem whose kernel-reported options, read from
@@ -287,9 +298,11 @@ Functional results, identical in every sample unless stated:
 Cost actually incurred: eighteen VMs for 8 to 30 minutes each plus 32 GiB disks, well
 under the $10 bound; the persistent registry costs about $0.67 per day at Standard.
 
-### Verdict against the 180-second boundary
+### Verdict against the 180-second boundary (the target at the time of the spike)
 
-**Not met with this configuration.** Across the seventeen samples that reached an
+**Not met with this configuration.** (Against the 300-second target approved on
+2026-09-12, every one of the seventeen samples that reached an endpoint would have
+fit: slowest 278.0 s. The original verdict is kept as measured.) Across the seventeen samples that reached an
 endpoint, the slowest verified key-only SSH session came 278.0 s after `T0` (246.0 s
 excluding the out-of-band host-key read); even the fastest sample needed 203.4 s.
 Fifteen of seventeen also missed the boundary for endpoint-open alone (sample 6 by


### PR DESCRIPTION
## Summary

The focused compute-start slice assigned on #474 (part of #474; the issue stays open). Signature and file list were posted there before implementation.

- **Contract** (`crates/horizon-core/src/cloud_run/interactive_worker_start.rs`, new): `InteractiveWorkerStartProvider::start_worker(&InteractiveWorker) -> Result<InteractiveWorkerStart, _>` with `Started(status)`, `AlreadyRunning(status)` and `AlreadyAbsent`, an optional extension trait beside the Stop capability. The base `InteractiveWorkerProvider` and the ensure, reconcile, inspect and delete semantics are unchanged; Local Docker and RunPod are untouched; no configuration, dispatcher or UI edit.
- **Azure implementation** (`provider/running.rs`): shape check, then a fresh ownership proof (identity tags on the group and VM, recorded group ID) before the POST; an absent group is `AlreadyAbsent`; a group or VM that vanishes after the proof is the new static `StartUnverified`, never an allocation; a running worker is `AlreadyRunning` with no POST; deallocated or guest-stopped is started (`POST .../start`, a start already in flight is awaited, a 409 tolerated, a 404 unverified); the wait is the same absolute five-minute deadline as Stop, polled until that deadline (not a finite schedule) with ownership re-proved on every poll and each request capped at the remaining budget (a shared `await_power` now serves both); a worker whose group is deleting or whose deployment failed is rejected before the POST, and only a worker observed running after the wait is answered as started; once running, the same worker goes through the full observation and host-key attestation again, so `Started` carries `Ready` only with a freshly attested key and `Provisioning` otherwise. No deletion, credential delivery, repository preparation or task replay.
- **Transport**: `start_vm`, with the two power actions factored into `transport/power.rs`.
- **Runbooks**: the maintainer-approved 300-second Azure startup target is recorded in `docs/testing/azure-workspace-readiness.md` and referenced from the live-acceptance record; the spike's 180-second verdict and every historical measurement are kept as written.

## Live proof (run 16)

The live driver gained the sequence Stop, explicit start, pinned reattach, idempotent start, Stop. On the same exact task-owned fixture as the earlier runs:

| Step | Seconds after the driver started |
| --- | --- |
| ready with attested host key | 260.4 |
| stop verified | 309.7 (32 s) |
| `start_worker` returned `Started` (already `Ready`) | 390.9 (running again 80 s after the call) |
| `Ready` through the persisted handle, same address and host key | 409.0 |
| pinned reattach read the marker written before the stop | 409.8 |
| second `start_worker` returned `AlreadyRunning`, nothing posted | 427.8 |
| second stop verified | 459.4 (32 s) |
| deleted and gone | 705.3 (245 s) |

Run 17, with the deadline-driven wait, repeated the sequence (ready 291 s, start 80 s, same endpoint 97 s after the call, marker read, second start `AlreadyRunning`). Nothing was left in the subscription. This proves identity and data retention across an explicit stop and start; it says nothing about processes that ran before the stop, and it is not the saved Shell task Start.

## Tests

- `tests::provider::start` (3): start posts once, awaits running and re-observes through the readiness path (Ready only with the key, Provisioning without; already running never re-posted; guest-halt, synchronous completion and an in-flight start); every unverified state without a mutation (409 awaited, 403 surfaced, vanished before the POST, never running within the bound, no VM, vanished while starting, still deallocating, failed VM, deleting group, group vanished after its proof, foreign handle, retagged group); ownership re-proved on every poll and before the answer (retagged VM, group retagged or deleted or deleting during the wait, VM replaced before the answer), and start never deletes or creates.
- Transport: `start_vm` path, long-running mapping, redaction, 404, invalid segments.

## Scope

Ten source or test files plus two runbooks, 658 changed lines. `transport.rs` sits at 613 lines after the power split; a further split would exceed the ten-file limit for this PR and is left for a follow-up.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic. The live test is ignored in the matrix; run 16 is recorded above and in the runbook.
