### PR TITLE
feat(repository): hydrate bounded initial Git submodules

### DIFF
--- a/crates/horizon-core/src/repository_git/git.rs
+++ b/crates/horizon-core/src/repository_git/git.rs
@@ -254,6 +254,21 @@ pub(super) fn prepare(
     cancelled: &dyn Fn() -> bool,
     verify: &dyn Fn() -> Result<(), Error>,
 ) -> Result<(), Error> {
+    let mut budget = super::submodules::Budget::default();
+    prepare_repository(git, directory, request, cancelled, verify, &mut budget, 0)?;
+    budget.verify()?;
+    verify()
+}
+
+pub(super) fn prepare_repository(
+    git: &mut impl Commands,
+    directory: &Path,
+    request: &GitPreparation,
+    cancelled: &dyn Fn() -> bool,
+    verify: &dyn Fn() -> Result<(), Error>,
+    budget: &mut super::submodules::Budget,
+    depth: usize,
+) -> Result<(), Error> {
     let mut run = |args: &[&str], input: &[u8], missing| {
         verify()?;
         let output = git.run(directory, args, input, missing, cancelled)?;
@@ -284,12 +299,20 @@ pub(super) fn prepare(
         return Err(Error::Git);
     }
     let modes = run(&["ls-tree", "-r", "--format=%(objectmode)", commit], &[], false)?;
-    if modes.split(|byte| *byte == b'\n').any(|mode| mode == b"160000")
-        || !run(&["ls-tree", "--name-only", commit, "--", ".lfsconfig"], &[], false)?.is_empty()
-    {
+    budget.charge(modes.len())?;
+    if !run(&["ls-tree", "--name-only", commit, "--", ".lfsconfig"], &[], false)?.is_empty() {
         return Err(Error::UnsupportedRepository);
     }
-    run(&["checkout", "-b", &request.work_branch, commit], &[], false)?;
+    let has_children = modes.split(|byte| *byte == b'\n').any(|mode| mode == b"160000");
+    let mut plan = super::submodules::read_plan(&mut run, request, has_children, depth, budget)?;
+    // Git inherits caller umask. Admit and create only planned empty directories
+    // privately before checkout, rather than chmod/adopt paths after materialization.
+    plan.prepare_paths(directory, verify)?;
+    if depth == 0 {
+        run(&["checkout", "-b", &request.work_branch, commit], &[], false)?;
+    } else {
+        run(&["checkout", "--detach", commit], &[], false)?;
+    }
     let paths = run(&["ls-files", "-z"], &[], false)?;
     let attributes = run(&["check-attr", "--cached", "-z", "--stdin", "filter"], &paths, false)?;
     let pointers = run(
@@ -306,7 +329,58 @@ pub(super) fn prepare(
         &[],
         true,
     )?;
-    super::lfs::hydrate(git, directory, request, &attributes, &pointers, cancelled, verify)?;
+    super::lfs::hydrate(
+        git,
+        directory,
+        request,
+        super::lfs::Selection {
+            attributes: &attributes,
+            matches: &pointers,
+        },
+        &mut budget.lfs,
+        cancelled,
+        verify,
+    )?;
+    super::submodules::hydrate(git, directory, request, plan, cancelled, verify, budget)?;
+    if depth > 0 || has_children {
+        verify_checkout(git, directory, commit, cancelled, verify)?;
+    }
+    Ok(())
+}
+
+fn verify_checkout(
+    git: &mut impl Commands,
+    directory: &Path,
+    commit: &str,
+    cancelled: &dyn Fn() -> bool,
+    verify: &dyn Fn() -> Result<(), Error>,
+) -> Result<(), Error> {
+    let mut run = |args: &[&str]| {
+        verify()?;
+        let output = git.run(directory, args, &[], false, cancelled)?;
+        verify()?;
+        Ok::<_, Error>(output)
+    };
+    if run(&["rev-parse", "--verify", "HEAD^{commit}"])? != format!("{commit}\n").as_bytes() {
+        return Err(Error::Git);
+    }
+    run(&["diff-index", "--cached", "--quiet", commit, "--"])?;
+    // Match admitted LFS clean semantics, including Git's child status processes.
+    // Setup otherwise disables process filters while checking out pointers.
+    let status = run(&[
+        "-c",
+        "filter.lfs.process=/usr/bin/git-lfs filter-process",
+        "-c",
+        "filter.lfs.required=true",
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignore-submodules=none",
+    ])?;
+    if !status.is_empty() {
+        return Err(Error::Git);
+    }
     Ok(())
 }
 

--- a/crates/horizon-core/src/repository_git/lfs.rs
+++ b/crates/horizon-core/src/repository_git/lfs.rs
@@ -17,6 +17,37 @@ const MAX_TOTAL: usize = 512 * 1024 * 1024;
 const MAX_PATHS: usize = 1024;
 const PREFIX: &str = "version https://git-lfs.github.com/spec/v1\n";
 
+/// One admission budget for the superproject and every nested checkout.
+#[derive(Default)]
+pub(super) struct Budget {
+    paths: usize,
+    bytes: usize,
+}
+
+impl Budget {
+    fn reserve(&mut self, pointers: &[Pointer]) -> Result<(), Error> {
+        let paths = self
+            .paths
+            .checked_add(pointers.len())
+            .ok_or(Error::UnsupportedRepository)?;
+        let bytes = pointers.iter().try_fold(self.bytes, |sum, pointer| {
+            sum.checked_add(pointer.size).ok_or(Error::UnsupportedRepository)
+        })?;
+        if paths > MAX_PATHS || bytes > MAX_TOTAL {
+            return Err(Error::UnsupportedRepository);
+        }
+        self.paths = paths;
+        self.bytes = bytes;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct Selection<'a> {
+    pub attributes: &'a [u8],
+    pub matches: &'a [u8],
+}
+
 pub(super) struct Pointer {
     pub path: String,
     pub encoded: Vec<u8>,
@@ -165,14 +196,20 @@ pub(super) fn hydrate(
     git: &mut impl Commands,
     directory: &Path,
     request: &GitPreparation,
-    attributes: &[u8],
-    matches: &[u8],
+    selection: Selection<'_>,
+    budget: &mut Budget,
     cancelled: &dyn Fn() -> bool,
     verify: &dyn Fn() -> Result<(), Error>,
 ) -> Result<(), Error> {
     verify()?;
-    let pointers = plan(directory, attributes, matches, request.source.commit.as_str())?;
+    let pointers = plan(
+        directory,
+        selection.attributes,
+        selection.matches,
+        request.source.commit.as_str(),
+    )?;
     verify()?;
+    budget.reserve(&pointers)?;
     if pointers.is_empty() {
         return Ok(());
     }

--- a/crates/horizon-core/src/repository_git/lfs/tests.rs
+++ b/crates/horizon-core/src/repository_git/lfs/tests.rs
@@ -304,8 +304,11 @@ fn hydration_verifies_before_and_after_planning_and_version_probe() {
                 &mut probe,
                 root.path(),
                 &request,
-                b"asset.bin\0filter\0lfs\0",
-                b"",
+                Selection {
+                    attributes: b"asset.bin\0filter\0lfs\0",
+                    matches: b""
+                },
+                &mut Budget::default(),
                 &|| false,
                 &|| {
                     checks.set(checks.get() + 1);
@@ -328,12 +331,34 @@ fn hydration_verifies_before_and_after_planning_and_version_probe() {
             &mut probe,
             Path::new("/nonexistent-lfs-proof"),
             &request,
-            b"",
-            b"",
+            Selection {
+                attributes: b"",
+                matches: b""
+            },
+            &mut Budget::default(),
             &|| false,
             &|| Err(Error::UnsafeRoot)
         ),
         Err(Error::UnsafeRoot)
     );
     assert_eq!(probe.0, 0);
+}
+
+#[test]
+fn root_and_children_share_one_lfs_byte_and_path_budget() {
+    let mut budget = Budget::default();
+    let mut large = pointer(b"x");
+    large.size = MAX_OBJECT;
+    for _ in 0..MAX_TOTAL / MAX_OBJECT {
+        budget.reserve(std::slice::from_ref(&large)).unwrap();
+    }
+    assert_eq!(budget.reserve(&[pointer(b"x")]), Err(Error::UnsupportedRepository));
+    assert_eq!((budget.paths, budget.bytes), (MAX_TOTAL / MAX_OBJECT, MAX_TOTAL));
+    let mut budget = Budget::default();
+    let zero = pointer(b"");
+    for _ in 0..MAX_PATHS {
+        budget.reserve(std::slice::from_ref(&zero)).unwrap();
+    }
+    assert_eq!(budget.reserve(&[zero]), Err(Error::UnsupportedRepository));
+    assert_eq!((budget.paths, budget.bytes), (MAX_PATHS, 0));
 }

--- a/crates/horizon-core/src/repository_git/linux.rs
+++ b/crates/horizon-core/src/repository_git/linux.rs
@@ -49,6 +49,64 @@ pub(super) struct Directory {
 }
 
 impl Directory {
+    pub(super) fn submodule(parent: &Path, path: &str) -> Result<Vec<Self>, Error> {
+        if !super::submodules::valid_path(path) {
+            return Err(Error::UnsafeRoot);
+        }
+        let mut held = vec![Self::open_mode(parent, false)?];
+        for part in path.split('/') {
+            let parent = held.last().ok_or(Error::UnsafeRoot)?;
+            parent.verify()?;
+            let handle = match openat2(
+                &parent.handle,
+                part,
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            ) {
+                Ok(handle) => handle,
+                Err(rustix::io::Errno::NOENT) => {
+                    mkdirat(&parent.handle, part, PRIVATE).map_err(|_| Error::Conflict)?;
+                    parent.handle.sync_all().map_err(|_| Error::Storage)?;
+                    openat2(
+                        &parent.handle,
+                        part,
+                        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                        Mode::empty(),
+                        CONFINED,
+                    )
+                    .map_err(|_| Error::UnsafeRoot)?
+                }
+                Err(_) => return Err(Error::UnsafeRoot),
+            };
+            let child = Self {
+                handle: File::from(handle),
+                path: parent.path.join(part),
+                private: false,
+            };
+            child.verify()?;
+            child.handle.sync_all().map_err(|_| Error::Storage)?;
+            parent.verify()?;
+            held.push(child);
+        }
+        let child = held.last().ok_or(Error::UnsafeRoot)?;
+        if std::fs::read_dir(&child.path)
+            .map_err(|_| Error::UnsafeRoot)?
+            .next()
+            .is_some()
+        {
+            return Err(Error::Conflict);
+        }
+        for handle in &held {
+            handle.verify()?;
+        }
+        Ok(held)
+    }
+
+    pub(super) fn fresh_git_directory(&self) -> Result<Self, Error> {
+        self.child(".git", true)?.ok_or(Error::UnsafeRoot)
+    }
+
     fn open_mode(path: &Path, private: bool) -> Result<Self, Error> {
         let handle = open_directory(path)?;
         let directory = Self {

--- a/crates/horizon-core/src/repository_git/mod.rs
+++ b/crates/horizon-core/src/repository_git/mod.rs
@@ -7,6 +7,8 @@ mod git;
 mod lfs;
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "linux")]
+mod submodules;
 
 use crate::{cloud_run::GitSource, remote_workspace::valid_local_id};
 use serde::{Deserialize, Serialize};

--- a/crates/horizon-core/src/repository_git/submodules.rs
+++ b/crates/horizon-core/src/repository_git/submodules.rs
@@ -1,0 +1,314 @@
+//! Initial recorded-commit hydration; never delegate recursion to repository configuration.
+use super::{GitPreparation, GitPreparationError as Error, git, lfs, linux::Directory};
+use crate::cloud_run::GitCommitSha;
+use std::{collections::BTreeMap, path::Path};
+
+const MAX_DEPTH: usize = 4;
+const MAX_REPOSITORIES: usize = 32;
+const MAX_METADATA: usize = 1024 * 1024;
+const MAX_RESPONSE: usize = 128 * 1024;
+
+#[derive(Default)]
+pub(super) struct Budget {
+    repositories: usize,
+    metadata: usize,
+    directories: Vec<Directory>,
+    pub lfs: lfs::Budget,
+}
+
+impl Budget {
+    pub(super) fn verify(&self) -> Result<(), Error> {
+        for directory in &self.directories {
+            directory.verify()?;
+        }
+        Ok(())
+    }
+    pub(super) fn charge(&mut self, bytes: usize) -> Result<(), Error> {
+        self.metadata = self.metadata.checked_add(bytes).ok_or(Error::UnsupportedRepository)?;
+        if bytes > MAX_RESPONSE || self.metadata > MAX_METADATA {
+            return Err(Error::UnsupportedRepository);
+        }
+        Ok(())
+    }
+}
+
+struct Entry {
+    name: String,
+    path: String,
+    repository: String,
+    commit: GitCommitSha,
+}
+
+pub(super) struct Plan {
+    entries: Vec<Entry>,
+    depth: usize,
+    directories: Vec<Vec<Directory>>,
+}
+
+impl Plan {
+    pub(super) fn prepare_paths(
+        &mut self,
+        directory: &Path,
+        verify: &dyn Fn() -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        for entry in &self.entries {
+            verify()?;
+            self.directories.push(Directory::submodule(directory, &entry.path)?);
+            verify()?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn valid_path(path: &str) -> bool {
+    !path.is_empty()
+        && path.len() <= 1024
+        && path.split('/').count() <= 16
+        && !path.chars().any(|c| c.is_control() || c == '\\')
+        && path.split('/').all(|p| {
+            !p.is_empty()
+                && p.len() <= 255
+                && !matches!(p, "." | "..")
+                && !p.trim_end_matches(['.', ' ']).eq_ignore_ascii_case(".git")
+        })
+}
+
+fn repository(value: &str, parent: &str) -> Result<String, Error> {
+    let absolute;
+    let path = if let Some(path) = value.strip_prefix("https://github.com/") {
+        path
+    } else if value.starts_with("./") || value.starts_with("../") {
+        let base = format!("{parent}.git");
+        let mut parts: Vec<_> = base.split('/').collect();
+        for part in value.split('/') {
+            match part {
+                "." => {}
+                ".." => {
+                    parts.pop().ok_or(Error::UnsupportedRepository)?;
+                }
+                "" => return Err(Error::UnsupportedRepository),
+                _ => parts.push(part),
+            }
+        }
+        absolute = parts.join("/");
+        &absolute
+    } else {
+        return Err(Error::UnsupportedRepository);
+    };
+    let slug = path.strip_suffix(".git").ok_or(Error::UnsupportedRepository)?;
+    let parts: Vec<_> = slug.split('/').collect();
+    if parts.len() != 2
+        || slug.len() > 512
+        || parts.iter().any(|p| {
+            p.is_empty()
+                || matches!(*p, "." | "..")
+                || !p.bytes().all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+        })
+    {
+        return Err(Error::UnsupportedRepository);
+    }
+    Ok(slug.into())
+}
+
+fn records(bytes: &[u8]) -> Result<impl Iterator<Item = &str>, Error> {
+    let text = std::str::from_utf8(bytes).map_err(|_| Error::UnsupportedRepository)?;
+    let text = text.strip_suffix('\0').ok_or(Error::UnsupportedRepository)?;
+    Ok(text.split('\0'))
+}
+
+fn decode(tree: &[u8], config: &[u8], parent: &str) -> Result<Vec<Entry>, Error> {
+    let mut links = BTreeMap::new();
+    let mut modules = false;
+    for record in records(tree)? {
+        let (object, path) = record.split_once('\t').ok_or(Error::UnsupportedRepository)?;
+        let fields: Vec<_> = object.split(' ').collect();
+        if fields.len() != 3 {
+            return Err(Error::UnsupportedRepository);
+        }
+        if path == ".gitmodules" {
+            if modules || !matches!(fields[0], "100644" | "100755") || fields[1] != "blob" {
+                return Err(Error::UnsupportedRepository);
+            }
+            modules = true;
+        }
+        if fields[0] == "160000" {
+            let commit = GitCommitSha::parse(fields[2]).map_err(|_| Error::UnsupportedRepository)?;
+            if fields[1] != "commit"
+                || !valid_path(path)
+                || fields[2].bytes().all(|b| b == b'0')
+                || links.insert(path.to_owned(), commit).is_some()
+            {
+                return Err(Error::UnsupportedRepository);
+            }
+        }
+    }
+    if !modules || links.is_empty() || links.len() > MAX_REPOSITORIES {
+        return Err(Error::UnsupportedRepository);
+    }
+    let mut sections: BTreeMap<&str, BTreeMap<&str, &str>> = BTreeMap::new();
+    for record in records(config)? {
+        let (key, value) = record.split_once('\n').ok_or(Error::UnsupportedRepository)?;
+        let (name, key) = key
+            .strip_prefix("submodule.")
+            .and_then(|s| s.rsplit_once('.'))
+            .ok_or(Error::UnsupportedRepository)?;
+        if name.is_empty()
+            || name.len() > 128
+            || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b"._-/".contains(&b))
+            || value.chars().any(char::is_control)
+            || sections.entry(name).or_default().insert(key, value).is_some()
+        {
+            return Err(Error::UnsupportedRepository);
+        }
+        match key {
+            "path" | "url" | "branch" => {}
+            "update" if value == "checkout" => {}
+            "ignore" if value == "none" => {}
+            "shallow" if matches!(value, "true" | "false") => {}
+            "fetchrecursesubmodules" if matches!(value, "true" | "false" | "on-demand") => {}
+            _ => return Err(Error::UnsupportedRepository),
+        }
+    }
+    let mut entries = Vec::new();
+    for (name, fields) in sections {
+        let path = *fields.get("path").ok_or(Error::UnsupportedRepository)?;
+        let commit = links.remove(path).ok_or(Error::UnsupportedRepository)?;
+        let repository = repository(fields.get("url").ok_or(Error::UnsupportedRepository)?, parent)?;
+        entries.push(Entry {
+            name: name.into(),
+            path: path.into(),
+            repository,
+            commit,
+        });
+    }
+    if !links.is_empty()
+        || entries.iter().enumerate().any(|(i, a)| {
+            entries[..i]
+                .iter()
+                .any(|b| a.path.starts_with(&format!("{}/", b.path)) || b.path.starts_with(&format!("{}/", a.path)))
+        })
+    {
+        return Err(Error::UnsupportedRepository);
+    }
+    Ok(entries)
+}
+
+pub(super) fn read_plan(
+    run: &mut impl FnMut(&[&str], &[u8], bool) -> Result<Vec<u8>, Error>,
+    request: &GitPreparation,
+    has_children: bool,
+    depth: usize,
+    budget: &mut Budget,
+) -> Result<Plan, Error> {
+    if !has_children {
+        return Ok(Plan {
+            entries: Vec::new(),
+            depth,
+            directories: Vec::new(),
+        });
+    }
+    if depth >= MAX_DEPTH {
+        return Err(Error::UnsupportedRepository);
+    }
+    let commit = request.source.commit.as_str();
+    let tree = run(&["ls-tree", "-rz", commit], &[], false)?;
+    budget.charge(tree.len())?;
+    let blob = format!("{commit}:.gitmodules");
+    let size = run(&["cat-file", "-s", &blob], &[], false)?;
+    let size: usize = std::str::from_utf8(&size)
+        .ok()
+        .and_then(|s| s.trim_end().parse().ok())
+        .filter(|size| *size <= MAX_RESPONSE)
+        .ok_or(Error::UnsupportedRepository)?;
+    budget.charge(size)?;
+    let config = run(
+        &["config", "--no-includes", &format!("--blob={blob}"), "--null", "--list"],
+        &[],
+        false,
+    )?;
+    budget.charge(config.len())?;
+    let entries = decode(&tree, &config, &request.source.repository)?;
+    budget.repositories = budget
+        .repositories
+        .checked_add(entries.len())
+        .ok_or(Error::UnsupportedRepository)?;
+    if budget.repositories > MAX_REPOSITORIES {
+        return Err(Error::UnsupportedRepository);
+    }
+    Ok(Plan {
+        entries,
+        depth,
+        directories: Vec::new(),
+    })
+}
+
+pub(super) fn hydrate(
+    git: &mut impl git::Commands,
+    directory: &Path,
+    request: &GitPreparation,
+    plan: Plan,
+    cancelled: &dyn Fn() -> bool,
+    verify: &dyn Fn() -> Result<(), Error>,
+    budget: &mut Budget,
+) -> Result<(), Error> {
+    if plan.entries.is_empty() {
+        return verify();
+    }
+    if plan.entries.len() != plan.directories.len() {
+        return Err(Error::UnsafeRoot);
+    }
+    for (entry, handles) in plan.entries.iter().zip(plan.directories) {
+        verify()?;
+        for handle in &handles {
+            handle.verify()?;
+        }
+        let child = handles.last().ok_or(Error::UnsafeRoot)?;
+        let git_directory = child.fresh_git_directory()?;
+        let verify_child = || {
+            verify()?;
+            for handle in &handles {
+                handle.verify()?;
+            }
+            git_directory.verify()
+        };
+        let mut child_request = request.clone();
+        child_request.source.repository.clone_from(&entry.repository);
+        child_request.source.commit = entry.commit.clone();
+        child_request.source.branch = None;
+        git::prepare_repository(
+            git,
+            &child.path,
+            &child_request,
+            cancelled,
+            &verify_child,
+            budget,
+            plan.depth + 1,
+        )?;
+        verify_child()?;
+        // Only admitted metadata is registered; no update strategy or URL is copied blindly.
+        for (key, value) in [
+            ("url", format!("https://github.com/{}.git", entry.repository)),
+            ("active", "true".into()),
+        ] {
+            verify_child()?;
+            git.run(
+                directory,
+                &["config", "--local", &format!("submodule.{}.{key}", entry.name), &value],
+                &[],
+                false,
+                cancelled,
+            )?;
+            verify_child()?;
+        }
+        budget.directories.extend(handles);
+        budget.directories.push(git_directory);
+    }
+    budget.verify()?;
+    verify()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod native_tests;
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_git/submodules/native_tests.rs
+++ b/crates/horizon-core/src/repository_git/submodules/native_tests.rs
@@ -1,0 +1,290 @@
+use super::*;
+use crate::repository_git::{
+    GitPreparationState as State,
+    git::{Commands, Git},
+    linux,
+    tests::{local_git, request, roots},
+};
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+const PAYLOAD: &[u8] = b"synthetic nested LFS bytes";
+
+fn source(child: Option<(&str, &str)>, lfs: bool) -> tempfile::TempDir {
+    let root = tempfile::tempdir().unwrap();
+    local_git(root.path(), &["init", "--template=", "--initial-branch=main"]);
+    if lfs {
+        fs::write(root.path().join(".gitattributes"), "tracked filter=lfs\n").unwrap();
+        fs::write(
+            root.path().join("tracked"),
+            format!(
+                "version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n",
+                crate::cloud_run::ArtifactDigest::sha256(PAYLOAD).as_str(),
+                PAYLOAD.len()
+            ),
+        )
+        .unwrap();
+    } else {
+        fs::write(root.path().join("tracked"), "retained synthetic bytes").unwrap();
+    }
+    if let Some((url, sha)) = child {
+        fs::write(
+            root.path().join(".gitmodules"),
+            format!("[submodule \"child\"]\npath = nested/child\nurl = {url}\nbranch = wrong-tip\n"),
+        )
+        .unwrap();
+        local_git(
+            root.path(),
+            &[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                &format!("160000,{sha},nested/child"),
+            ],
+        );
+    }
+    local_git(root.path(), &["add", "tracked"]);
+    if lfs {
+        local_git(root.path(), &["add", ".gitattributes"]);
+    }
+    if child.is_some() {
+        local_git(root.path(), &["add", ".gitmodules"]);
+    }
+    local_git(root.path(), &["commit", "-m", "Synthetic recorded source"]);
+    root
+}
+
+struct Sources {
+    git: Git,
+    by_commit: BTreeMap<String, PathBuf>,
+    fetches: usize,
+    fail_at: Option<usize>,
+    fail_lfs: bool,
+    delay_at: Option<usize>,
+    calls: usize,
+    lfs_repositories: Vec<String>,
+    last_command: Vec<String>,
+    last_output: Vec<u8>,
+}
+
+impl Sources {
+    fn new(sources: &[&tempfile::TempDir]) -> Self {
+        Self {
+            git: Git::new(),
+            by_commit: sources
+                .iter()
+                .map(|source| {
+                    (
+                        local_git(source.path(), &["rev-parse", "HEAD"]),
+                        source.path().to_owned(),
+                    )
+                })
+                .collect(),
+            fetches: 0,
+            fail_at: None,
+            fail_lfs: false,
+            delay_at: None,
+            calls: 0,
+            lfs_repositories: Vec::new(),
+            last_command: Vec::new(),
+            last_output: Vec::new(),
+        }
+    }
+}
+
+impl Commands for Sources {
+    fn run(
+        &mut self,
+        directory: &Path,
+        args: &[&str],
+        input: &[u8],
+        missing: bool,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        self.calls += 1;
+        self.last_command = args.iter().map(|s| (*s).to_owned()).collect();
+        if args[0] == "fetch" {
+            self.fetches += 1;
+            assert_eq!(
+                &args[1..5],
+                &["--no-tags", "--no-recurse-submodules", "--depth=1", "origin"]
+            );
+            if self.fail_at == Some(self.fetches) {
+                return Err(Error::Git);
+            }
+            if self.delay_at == Some(self.fetches) {
+                std::thread::sleep(Duration::from_millis(600));
+            }
+            let source = self.by_commit.get(args[5]).ok_or(Error::Git)?;
+            // Local fixture transport only, matching the existing ordinary-Git tests.
+            // No production protocol allowlist or HTTPS endpoint is changed.
+            self.git.run(
+                directory,
+                &[
+                    "-c",
+                    "protocol.file.allow=always",
+                    "fetch",
+                    source.to_str().unwrap(),
+                    args[5],
+                ],
+                input,
+                missing,
+                cancelled,
+            )
+        } else {
+            let result = self.git.run(directory, args, input, missing, cancelled)?;
+            self.last_output.clone_from(&result);
+            if args[0] == "checkout" {
+                // Fixed synthetic tracked file only: model entrypoint umask077,
+                // as the existing LFS integration fixture does, without global umask changes.
+                let path = directory.join("tracked");
+                assert!(fs::symlink_metadata(&path).unwrap().is_file());
+                fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+            }
+            Ok(result)
+        }
+    }
+
+    fn smudge(
+        &mut self,
+        _: &Path,
+        request: &GitPreparation,
+        _: &lfs::Pointer,
+        _: &dyn Fn() -> bool,
+    ) -> Result<Vec<u8>, Error> {
+        self.lfs_repositories.push(request.source.repository.clone());
+        if self.fail_lfs {
+            return Err(Error::Git);
+        }
+        Ok(PAYLOAD.to_vec())
+    }
+}
+
+#[test]
+fn actual_git_nested_recorded_commits_lfs_and_existing_dirty_receipt() {
+    let leaf = source(None, true);
+    let leaf_sha = local_git(leaf.path(), &["rev-parse", "HEAD"]);
+    let child = source(Some(("../leaf.git", &leaf_sha)), false);
+    let child_sha = local_git(child.path(), &["rev-parse", "HEAD"]);
+    let parent = source(Some(("https://github.com/fixture/child.git", &child_sha)), false);
+    let mut transport = Sources::new(&[&parent, &child, &leaf]);
+    let mut request = request();
+    request.source.commit = GitCommitSha::parse(local_git(parent.path(), &["rev-parse", "HEAD"])).unwrap();
+    // Branch tips move independently; the gitlinks remain authoritative.
+    for source in [&parent, &child] {
+        fs::write(source.path().join("later"), b"not selected").unwrap();
+        local_git(source.path(), &["add", "later"]);
+        local_git(source.path(), &["commit", "-m", "Synthetic later tip"]);
+    }
+    let root = roots();
+    let result = linux::execute(root.path(), &request, false, &|| false, &mut transport);
+    assert_eq!(
+        (result.state, result.reason),
+        (State::Complete, None),
+        "last synthetic command {:?}, output {:?}",
+        transport.last_command,
+        String::from_utf8_lossy(&transport.last_output)
+    );
+    assert_eq!(transport.fetches, 3);
+    assert_eq!(transport.lfs_repositories, ["fixture/leaf"]);
+    let checkout = root.path().join("horizon/repository");
+    for (path, sha) in [
+        (&checkout, request.source.commit.as_str()),
+        (&checkout.join("nested/child"), &child_sha),
+        (&checkout.join("nested/child/nested/child"), &leaf_sha),
+    ] {
+        assert_eq!(local_git(path, &["rev-parse", "HEAD"]), sha);
+        assert!(local_git(path, &["status", "--porcelain", "--ignore-submodules=none"]).is_empty());
+        assert!(!path.join("later").exists());
+    }
+    assert!(local_git(&checkout.join("nested/child"), &["branch", "--show-current"]).is_empty());
+    assert_eq!(
+        fs::read(checkout.join("nested/child/nested/child/tracked")).unwrap(),
+        PAYLOAD
+    );
+    assert!(local_git(&checkout, &["submodule", "status", "--recursive"]).contains(&leaf_sha));
+    fs::write(checkout.join("nested/child/tracked"), b"dirty child").unwrap();
+    fs::write(checkout.join("nested/child/untracked"), b"untracked child").unwrap();
+    let calls = transport.calls;
+    for observe in [true, false] {
+        assert_eq!(
+            linux::execute(root.path(), &request, observe, &|| false, &mut transport).state,
+            State::Complete
+        );
+        assert_eq!(transport.calls, calls);
+    }
+    assert_eq!(fs::read(checkout.join("nested/child/tracked")).unwrap(), b"dirty child");
+    assert_eq!(
+        fs::read(checkout.join("nested/child/untracked")).unwrap(),
+        b"untracked child"
+    );
+}
+
+#[test]
+fn missing_private_child_and_shared_deadline_never_complete_or_replay() {
+    for fault in ["git-denied", "lfs-denied", "deadline"] {
+        let child = source(None, fault == "lfs-denied");
+        let parent = source(
+            Some(("../child.git", &local_git(child.path(), &["rev-parse", "HEAD"]))),
+            false,
+        );
+        let mut transport = Sources::new(&[&parent, &child]);
+        if fault == "deadline" {
+            transport.git = Git::with_timeout(Duration::from_millis(500));
+            transport.delay_at = Some(2);
+        } else if fault == "git-denied" {
+            transport.fail_at = Some(2);
+        } else {
+            transport.fail_lfs = true;
+        }
+        let mut request = request();
+        request.source.commit = GitCommitSha::parse(local_git(parent.path(), &["rev-parse", "HEAD"])).unwrap();
+        let root = roots();
+        let start = Instant::now();
+        let result = linux::execute(root.path(), &request, false, &|| false, &mut transport);
+        if fault == "deadline" {
+            assert_eq!(result.reason, Some(Error::Interrupted));
+        }
+        if fault == "lfs-denied" {
+            assert_eq!(transport.lfs_repositories, ["fixture/child"]);
+        }
+        assert_eq!(result.state, State::ClaimedUnknown);
+        assert!(result.reason.is_some());
+        assert!(start.elapsed() < Duration::from_secs(3));
+        assert!(!root.path().join(".horizon-worker/git-workspace/complete.json").exists());
+        assert!(linux::inspect_checkout(root.path(), &request).is_err());
+        let calls = transport.calls;
+        assert_eq!(
+            linux::execute(root.path(), &request, false, &|| false, &mut transport).state,
+            State::ClaimedUnknown
+        );
+        assert_eq!(transport.calls, calls);
+    }
+}
+
+#[test]
+fn gitmodules_include_is_parsed_as_data_and_never_followed() {
+    let child = source(None, false);
+    let parent = source(
+        Some(("../child.git", &local_git(child.path(), &["rev-parse", "HEAD"]))),
+        false,
+    );
+    let modules = parent.path().join(".gitmodules");
+    let mut bytes = fs::read(&modules).unwrap();
+    bytes.extend_from_slice(b"[include]\npath = /nonexistent-private-submodule-config\n");
+    fs::write(modules, bytes).unwrap();
+    local_git(parent.path(), &["add", ".gitmodules"]);
+    local_git(parent.path(), &["commit", "-m", "Synthetic rejected include"]);
+    let mut transport = Sources::new(&[&parent, &child]);
+    let mut request = request();
+    request.source.commit = GitCommitSha::parse(local_git(parent.path(), &["rev-parse", "HEAD"])).unwrap();
+    let root = roots();
+    let result = linux::execute(root.path(), &request, false, &|| false, &mut transport);
+    assert_eq!(result.reason, Some(Error::UnsupportedRepository));
+    assert_eq!(transport.fetches, 1);
+    assert!(!root.path().join("horizon/repository/.gitmodules").exists());
+}

--- a/crates/horizon-core/src/repository_git/submodules/tests.rs
+++ b/crates/horizon-core/src/repository_git/submodules/tests.rs
@@ -1,0 +1,186 @@
+use super::*;
+use crate::repository_git::tests::{request, roots};
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+};
+
+fn tree(path: &str) -> Vec<u8> {
+    format!(
+        "100644 blob {}\t.gitmodules\0\
+             160000 commit {}\t{path}\0",
+        "a".repeat(40),
+        "b".repeat(40)
+    )
+    .into_bytes()
+}
+
+fn config(path: &str, url: &str) -> Vec<u8> {
+    format!("submodule.child.path\n{path}\0submodule.child.url\n{url}\0").into_bytes()
+}
+
+#[test]
+fn exact_mapping_and_git_relative_url_resolution() {
+    for url in [
+        "https://github.com/owner/child.git",
+        "../child.git",
+        "../../owner/child.git",
+    ] {
+        let entries = decode(&tree("nested/child"), &config("nested/child", url), "owner/parent").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].repository, "owner/child");
+        assert_eq!(entries[0].commit.as_str(), "b".repeat(40));
+    }
+    let mut input = config("nested/child", "../child.git");
+    input.extend_from_slice(b"submodule.child.branch\nmoving-tip\0submodule.child.shallow\ntrue\0");
+    assert_eq!(
+        decode(&tree("nested/child"), &input, "owner/parent").unwrap()[0]
+            .commit
+            .as_str(),
+        "b".repeat(40)
+    );
+}
+
+#[test]
+fn foreign_credentials_encoded_paths_and_remote_helpers_refused() {
+    for url in [
+        "http://github.com/o/r.git",
+        "ssh://github.com/o/r.git",
+        "git@github.com:o/r.git",
+        "file:///tmp/repo",
+        "ext::sh evil",
+        "https://other.invalid/o/r.git",
+        "https://github.com.evil/o/r.git",
+        "https://github.com:443/o/r.git",
+        "https://token@github.com/o/r.git",
+        "https://github.com/o/r.git?x",
+        "https://github.com/o/r.git#x",
+        "https://github.com/o/%2er.git",
+        "https://github.com/o/r.git/",
+        "https://github.com/o//r.git",
+        "../../../o/r.git",
+        "../r.git\n",
+        "../r.git\\x",
+        "../r.git?x",
+    ] {
+        assert!(repository(url, "owner/parent").is_err(), "{url}");
+    }
+}
+
+#[test]
+fn metadata_requires_one_to_one_mapping_and_no_custom_behavior() {
+    let base = config("child", "../child.git");
+    for extra in [
+        "include.path\n/secret\0",
+        "includeif.onbranch:main.path\n/secret\0",
+        "submodule.child.update\n!touch sentinel\0",
+        "submodule.child.update\nmerge\0",
+        "submodule.child.ignore\nall\0",
+        "submodule.child.path\nchild\0",
+        "submodule.child.fetchrecursesubmodules\ncustom\0",
+        "submodule.child.unknown\nx\0",
+        "submodule.other.path\nchild\0submodule.other.url\n../child.git\0",
+    ] {
+        let mut bytes = base.clone();
+        bytes.extend_from_slice(extra.as_bytes());
+        assert!(decode(&tree("child"), &bytes, "o/parent").is_err(), "{extra}");
+    }
+    assert!(decode(&tree("other"), &base, "o/parent").is_err());
+    assert!(decode(&tree("child"), &base[..base.len() - 1], "o/parent").is_err());
+    for mode in ["120000", "160000"] {
+        let bad = String::from_utf8(tree("child")).unwrap().replacen("100644", mode, 1);
+        assert!(decode(bad.as_bytes(), &base, "o/parent").is_err());
+    }
+    let zero = String::from_utf8(tree("child"))
+        .unwrap()
+        .replace(&"b".repeat(40), &"0".repeat(40));
+    assert!(decode(zero.as_bytes(), &base, "o/parent").is_err());
+}
+
+#[test]
+fn path_validation_rejects_redirection_and_overlapping_siblings() {
+    for path in [
+        "",
+        "/absolute",
+        "../escape",
+        "a/../b",
+        "a//b",
+        "a/",
+        "a\\b",
+        "a\nb",
+        ".git",
+        "a/.GiT/b",
+        "a/.git./b",
+        "a/.git /b",
+    ] {
+        assert!(!valid_path(path), "{path}");
+    }
+    assert!(!valid_path(&"a/".repeat(17)));
+    let mut both = tree("child");
+    both.extend_from_slice(format!("160000 commit {}\tchild/nested\0", "c".repeat(40)).as_bytes());
+    let mut cfg = config("child", "../child.git");
+    cfg.extend_from_slice(b"submodule.nested.path\nchild/nested\0submodule.nested.url\n../nested.git\0");
+    assert!(decode(&both, &cfg, "owner/parent").is_err());
+}
+
+#[test]
+fn aggregate_metadata_repository_count_and_depth_are_not_reset() {
+    let request = request();
+    let mut calls = 0;
+    let mut run = |args: &[&str], _: &[u8], _: bool| {
+        calls += 1;
+        Ok(match args[0] {
+            "ls-tree" => tree("child"),
+            "cat-file" => b"100\n".to_vec(),
+            "config" => config("child", "../child.git"),
+            _ => panic!("unexpected planning command"),
+        })
+    };
+    let mut budget = Budget::default();
+    for _ in 0..MAX_REPOSITORIES {
+        read_plan(&mut run, &request, true, 0, &mut budget).unwrap();
+    }
+    assert!(read_plan(&mut run, &request, true, 0, &mut budget).is_err());
+    assert!(read_plan(&mut run, &request, true, MAX_DEPTH, &mut Budget::default()).is_err());
+    assert_eq!(calls, 3 * (MAX_REPOSITORIES + 1));
+    let mut budget = Budget::default();
+    for _ in 0..MAX_METADATA / MAX_RESPONSE {
+        budget.charge(MAX_RESPONSE).unwrap();
+    }
+    assert_eq!(budget.charge(1), Err(Error::UnsupportedRepository));
+    assert_eq!(
+        Budget::default().charge(MAX_RESPONSE + 1),
+        Err(Error::UnsupportedRepository)
+    );
+}
+
+#[test]
+fn child_directory_admission_refuses_nonempty_links_and_path_replacement() {
+    for fault in ["nonempty", "symlink", "ancestor", "permissions", "gitfile"] {
+        let root = roots();
+        let outside = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("child")).unwrap();
+        fs::set_permissions(root.path().join("child"), fs::Permissions::from_mode(0o700)).unwrap();
+        match fault {
+            "nonempty" => fs::write(root.path().join("child/retained"), b"keep").unwrap(),
+            "gitfile" => fs::write(root.path().join("child/.git"), b"gitdir: /outside").unwrap(),
+            "symlink" | "ancestor" => {
+                fs::remove_dir(root.path().join("child")).unwrap();
+                symlink(outside.path(), root.path().join("child")).unwrap();
+            }
+            _ => fs::set_permissions(root.path().join("child"), fs::Permissions::from_mode(0o777)).unwrap(),
+        }
+        assert!(Directory::submodule(root.path(), if fault == "ancestor" { "child/nested" } else { "child" }).is_err());
+        assert_eq!(fs::read_dir(outside.path()).unwrap().count(), 0);
+    }
+    let root = roots();
+    let held = Directory::submodule(root.path(), "nested/child").unwrap();
+    let child = held.last().unwrap();
+    let git = child.fresh_git_directory().unwrap();
+    assert!(child.fresh_git_directory().is_err());
+    fs::rename(&child.path, root.path().join("retained")).unwrap();
+    fs::create_dir(&child.path).unwrap();
+    assert!(child.verify().is_err());
+    assert!(git.verify().is_err());
+    assert!(root.path().join("retained/.git").is_dir());
+}

--- a/crates/horizon-core/src/repository_git/tests.rs
+++ b/crates/horizon-core/src/repository_git/tests.rs
@@ -11,7 +11,7 @@ use std::{
     process::Command,
 };
 
-fn request() -> Request {
+pub(super) fn request() -> Request {
     Request {
         version: 1,
         workspace_local_id: "synthetic-workspace".into(),
@@ -25,7 +25,7 @@ fn request() -> Request {
     }
 }
 
-fn roots() -> tempfile::TempDir {
+pub(super) fn roots() -> tempfile::TempDir {
     let root = tempfile::tempdir().unwrap();
     for suffix in ["", ".horizon-worker", "horizon"] {
         let path = root.path().join(suffix);
@@ -319,16 +319,24 @@ fn unsafe_roots_preexisting_checkout_and_replacement_are_not_adopted() {
 }
 
 #[test]
-fn submodules_fail_explicitly_before_checkout() {
+fn submodules_without_matching_metadata_fail_without_a_completion_or_replay() {
     let root = roots();
     let mut git = Fake::new();
     git.mode = "100644\n160000\n";
-    let result = execute(root.path(), &request(), false, &mut git);
+    let request = request();
+    let result = execute(root.path(), &request, false, &mut git);
     assert_eq!(result.reason, Some(Error::UnsupportedRepository));
-    assert_eq!(git.calls, 5);
+    assert_eq!(result.state, State::ClaimedUnknown);
+    let calls = git.calls;
+    assert_eq!(
+        execute(root.path(), &request, false, &mut git).state,
+        State::ClaimedUnknown
+    );
+    assert_eq!(git.calls, calls);
+    assert!(!root.path().join(".horizon-worker/git-workspace/complete.json").exists());
 }
 
-fn local_git(root: &Path, args: &[&str]) -> String {
+pub(super) fn local_git(root: &Path, args: &[&str]) -> String {
     let output = Command::new("/usr/bin/git")
         .env_clear()
         .env("PATH", "/usr/bin:/bin")

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -594,10 +594,17 @@ observation API. Its `linux` leaf confines the separate one-shot claim and fixed
 task-accessible checkout, while `git` owns sanitized bounded Git subprocesses.
 The `lfs` leaf admits standard bounded pointers, hydrates them through the packaged
 client with per-child file limits, and verifies the fresh checkout/index before completion.
-The repository CLI only frames bounded requests and responses. This prerequisite
-does not use the retained overlay setup qualifier or
-support submodules/custom LFS configuration; unsupported repositories retain state without a
-completion receipt. Observation never mutates user commits or worktree changes.
+The `submodules` leaf admits committed metadata and GitHub-only URLs, then hydrates
+exact gitlink commits in confined, initially empty directories with detached child HEADs.
+It does not delegate recursion, update strategies or configuration to `.gitmodules`.
+Root and children share one 300-second Git command deadline and cumulative LFS budget
+(1,024 paths, 64 MiB per object, 512 MiB payload); recursion is capped at depth four
+and 32 children with 1 MiB aggregate planning metadata. These are not an aggregate
+quota on Git packfiles or filesystem usage. Custom LFS configuration/filters and
+unsupported submodule metadata fail without a completion receipt. The CLI only
+frames existing requests/responses; this does not use the retained overlay qualifier.
+Observation never mutates user commits or worktree changes, and old failed claims
+are never upgraded or replayed by newly supported preparation behavior.
 
 Ordinary Git task admission uses `repository_git` canonical binding and read-only
 checkout identity projections, framed in the existing CLI Git leaf. The worker's


### PR DESCRIPTION
## Purpose

Support bounded initial submodule hydration in ordinary remote Git preparation.
Continues #470; does not close its remaining workflow acceptance.

## Behavior

- Resolve admitted GitHub-only submodule URLs and fetch each recorded gitlink
  commit into a fresh confined directory, with detached child HEADs.
- Reject custom update strategies, unsafe metadata/paths, foreign URLs and custom
  LFS configuration. Parent completion requires clean exact root and child trees.
- Share the existing 300-second deadline and LFS limits across the complete tree:
  1,024 LFS paths, 64 MiB per object, 512 MiB payload; at most 32 children, depth four
  and 1 MiB planning metadata. These are not an aggregate Git-pack/disk quota.
- Preserve existing completed/failed claims and dirty child bytes without replay,
  overwrite or automatic retry. No controller/UI/provider/schema changes.

## Validation

- Independent local full-diff review completed; introduced lint corrections reviewed.
- 31 focused tests and blocking/strict precommit checks passed.
- Packaged CLI with Git 2.39.5/LFS 3.3.0 passed all 11 isolated synthetic HTTPS cases:
  exact nested commits/LFS, child authentication failure, denied/missing/corrupt LFS,
  unsafe metadata/configuration, depth bound, dirty preservation and no replay.
  All 11 owned fixture containers were removed; existing containers were retained.
- The first smoke attempt stopped during adversarial fixture construction, before
  a preparation claim. Six passing cases and cleanup evidence were preserved; the
  corrected fixture passed all 11 cases without a product change.
- Native evidence is bound to pre-rebase `12a2b253`; the mechanical rebase retains
  identical repository implementation, CLI, dependency-lock and image inputs.
  It is not a complete rebuilt-image, cloud, real-credential or new-binary claim.
- Final exact-commit full matrix passed on `e2a6eb06`: formatting, maintainability,
  version sync, default and speech workspace tests, blocking/strict Clippy and the
  advisory pedantic lane. Hosted checks and independent hosted review follow publication.

Scope: 9 source/test paths, 1,030 changed source/test lines, plus the architecture note.
