### PR TITLE
feat(remote): configure explicit CPU provider profiles

### DIFF
--- a/crates/horizon-core/src/remote_provider_config.rs
+++ b/crates/horizon-core/src/remote_provider_config.rs
@@ -1,7 +1,8 @@
 //! Explicit non-secret provider configuration, independent of provider I/O and UI.
 
 use crate::cloud_run::{
-    interactive_worker::valid_worker_profile_name, local_docker::LocalDockerProfile, runpod::RunPodProfile,
+    azure::AzureProfile, interactive_worker::valid_worker_profile_name, local_docker::LocalDockerProfile,
+    runpod::RunPodProfile,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -14,6 +15,9 @@ pub struct RemoteProviderConfig {
     /// Non-secret placement only. The controller reads `RUNPOD_API_KEY` only on an explicit connection.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runpod: Vec<RunPodProfile>,
+    /// Non-secret placement only. Loading profiles never invokes the subscription-pinned CLI credential.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub azure: Vec<AzureProfile>,
 }
 
 impl<'de> Deserialize<'de> for RemoteProviderConfig {
@@ -25,6 +29,8 @@ impl<'de> Deserialize<'de> for RemoteProviderConfig {
             local_docker: Vec<LocalDockerProfile>,
             #[serde(default)]
             runpod: Vec<RunPodProfile>,
+            #[serde(default)]
+            azure: Vec<AzureProfile>,
         }
 
         // Parser errors can contain malformed values, even in a non-secret configuration block.
@@ -32,6 +38,7 @@ impl<'de> Deserialize<'de> for RemoteProviderConfig {
             .map(|fields| Self {
                 local_docker: fields.local_docker,
                 runpod: fields.runpod,
+                azure: fields.azure,
             })
             .map_err(|_| serde::de::Error::custom("invalid remote provider configuration"))
     }
@@ -40,7 +47,7 @@ impl<'de> Deserialize<'de> for RemoteProviderConfig {
 impl RemoteProviderConfig {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.local_docker.is_empty() && self.runpod.is_empty()
+        self.local_docker.is_empty() && self.runpod.is_empty() && self.azure.is_empty()
     }
 
     /// Validate explicit names and local endpoints without provider or credential access.
@@ -64,6 +71,15 @@ impl RemoteProviderConfig {
             }
             if !names.insert(profile.name.as_str()) {
                 return Err(RemoteProviderConfigError::DuplicateRunPodProfile { index });
+            }
+        }
+        names.clear();
+        for (index, profile) in self.azure.iter().enumerate() {
+            profile
+                .validate()
+                .map_err(|_| RemoteProviderConfigError::InvalidAzureProfile { index })?;
+            if !names.insert(profile.name.as_str()) {
+                return Err(RemoteProviderConfigError::DuplicateAzureProfile { index });
             }
         }
         Ok(())
@@ -91,6 +107,18 @@ impl RemoteProviderConfig {
             .find(|profile| profile.name == name)
             .ok_or(RemoteProviderConfigError::UnconfiguredRunPodProfile)
     }
+
+    /// Resolve an exact explicit CPU profile without reading credentials or calling the provider.
+    /// Target, image and cost authorization remain the adapter's separate responsibility.
+    /// # Errors
+    /// Rejects invalid configuration, duplicate names and absent profiles without echoing values.
+    pub fn azure_profile(&self, name: &str) -> Result<&AzureProfile, RemoteProviderConfigError> {
+        self.validate()?;
+        self.azure
+            .iter()
+            .find(|profile| profile.name == name)
+            .ok_or(RemoteProviderConfigError::UnconfiguredAzureProfile)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
@@ -107,6 +135,12 @@ pub enum RemoteProviderConfigError {
     DuplicateRunPodProfile { index: usize },
     #[error("no RunPod profile exactly matches this saved environment")]
     UnconfiguredRunPodProfile,
+    #[error("remote.azure[{index}] requires valid explicit placement, identity, registry and declared cost")]
+    InvalidAzureProfile { index: usize },
+    #[error("remote.azure[{index}] repeats an earlier profile name")]
+    DuplicateAzureProfile { index: usize },
+    #[error("no CPU provider profile exactly matches this saved environment")]
+    UnconfiguredAzureProfile,
 }
 
 #[cfg(test)]

--- a/crates/horizon-core/src/remote_provider_config/tests.rs
+++ b/crates/horizon-core/src/remote_provider_config/tests.rs
@@ -5,6 +5,7 @@ use crate::cloud_run::{
     local_docker::{LocalDockerError, LocalDockerInteractiveWorkerProvider},
 };
 
+mod azure;
 mod config;
 
 fn runpod_profile(name: &str) -> RunPodProfile {

--- a/crates/horizon-core/src/remote_provider_config/tests/azure.rs
+++ b/crates/horizon-core/src/remote_provider_config/tests/azure.rs
@@ -1,0 +1,168 @@
+use super::*;
+use crate::{Config, cloud_run::azure::AzureDiskSku};
+
+const SUBSCRIPTION: &str = "0f0e0d0c-0b0a-4908-8706-050403020100";
+const MARKER: &str = "synthetic-private-marker";
+
+fn cpu_profile(name: &str) -> AzureProfile {
+    AzureProfile {
+        name: name.into(),
+        subscription_id: SUBSCRIPTION.into(),
+        location: "northeurope".into(),
+        vm_size: "Standard_D2s_v3".into(),
+        image_pull_identity_id: format!(
+            "/subscriptions/{SUBSCRIPTION}/resourceGroups/synthetic-registry/providers/Microsoft.ManagedIdentity/userAssignedIdentities/puller"
+        ),
+        declared_hourly_cost_micros: 100_000,
+        registry_login_server: "example.azurecr.io".into(),
+        disk_sku: AzureDiskSku::default(),
+    }
+}
+
+fn configured() -> RemoteProviderConfig {
+    RemoteProviderConfig {
+        azure: vec![cpu_profile("saved")],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn cpu_profiles_are_explicit_case_sensitive_and_provider_scoped() {
+    let mut remote = configured();
+    remote.local_docker.push(profile("saved", "unix:///unused.sock"));
+    remote.runpod.push(runpod_profile("saved"));
+    assert_eq!(remote.validate(), Ok(()));
+    assert_eq!(remote.azure_profile("saved"), Ok(&remote.azure[0]));
+    for name in ["", "Saved", " saved", "saved ", "default", "AZURE_SUBSCRIPTION_ID"] {
+        assert_eq!(
+            remote.azure_profile(name),
+            Err(RemoteProviderConfigError::UnconfiguredAzureProfile)
+        );
+    }
+    remote.azure.push(cpu_profile("Saved"));
+    assert_eq!(remote.azure_profile("Saved"), Ok(&remote.azure[1]));
+    remote.azure.push(cpu_profile("saved"));
+    assert_eq!(
+        remote.validate(),
+        Err(RemoteProviderConfigError::DuplicateAzureProfile { index: 2 })
+    );
+    assert_eq!(
+        remote.azure_profile("saved"),
+        Err(RemoteProviderConfigError::DuplicateAzureProfile { index: 2 })
+    );
+}
+
+#[test]
+fn empty_and_legacy_configuration_never_selects_a_cpu_profile() {
+    for yaml in ["{}", "remote: {}", "remote: {azure: []}"] {
+        let config = Config::from_yaml(yaml).expect("legacy or empty configuration");
+        assert!(config.remote.azure.is_empty() && config.remote.is_empty());
+        assert_eq!(
+            config.remote.azure_profile("saved"),
+            Err(RemoteProviderConfigError::UnconfiguredAzureProfile)
+        );
+        assert!(!config.to_yaml().expect("serialize").contains("\nremote:"));
+    }
+    for yaml in [
+        "local_docker: [{name: local, docker_host: 'unix:///unused.sock'}]",
+        "runpod: []",
+    ] {
+        let remote: RemoteProviderConfig = serde_yaml::from_str(yaml).expect("existing profile schema");
+        assert!(remote.azure.is_empty());
+        assert!(!serde_yaml::to_string(&remote).expect("serialize").contains("azure:"));
+    }
+}
+
+#[test]
+fn cpu_profile_round_trips_through_full_config_without_credential_fields() {
+    for disk_sku in [AzureDiskSku::StandardSsdLrs, AzureDiskSku::PremiumLrs] {
+        let mut config = Config {
+            remote: configured(),
+            ..Default::default()
+        };
+        config.remote.azure[0].disk_sku = disk_sku;
+        let yaml = config.to_yaml().expect("serialize");
+        let restored = Config::from_yaml(&yaml).expect("full configuration");
+        assert_eq!(restored.remote, config.remote);
+        assert!(!restored.remote.is_empty());
+        for credential in ["access_token:", "client_secret:", "api_key:", "password:"] {
+            assert!(!yaml.contains(credential));
+        }
+    }
+    let mut value = serde_json::to_value(configured()).expect("serialize");
+    value["azure"][0].as_object_mut().expect("profile").remove("disk_sku");
+    assert_eq!(
+        serde_json::from_value::<RemoteProviderConfig>(value).expect("default disk SKU"),
+        configured()
+    );
+}
+
+#[test]
+fn invalid_cpu_placement_fails_before_lookup_without_value_leakage() {
+    let mutations: [fn(&mut AzureProfile); 7] = [
+        |p| p.name = format!(" {MARKER}"),
+        |p| p.subscription_id = MARKER.into(),
+        |p| p.location = MARKER.into(),
+        |p| p.vm_size = MARKER.into(),
+        |p| p.image_pull_identity_id = MARKER.into(),
+        |p| p.registry_login_server = MARKER.into(),
+        |p| p.declared_hourly_cost_micros = 0,
+    ];
+    for mutate in mutations {
+        let mut remote = configured();
+        remote.azure.push(cpu_profile("other"));
+        mutate(&mut remote.azure[1]);
+        let expected = Err(RemoteProviderConfigError::InvalidAzureProfile { index: 1 });
+        assert_eq!(remote.validate(), expected);
+        let error = remote.azure_profile("saved").expect_err("invalid unrelated profile");
+        assert_eq!(error, RemoteProviderConfigError::InvalidAzureProfile { index: 1 });
+        assert!(!format!("{error:?}: {error}").contains(MARKER));
+        let config = Config {
+            remote,
+            ..Default::default()
+        };
+        let error =
+            Config::from_yaml(&config.to_yaml().expect("serialize malformed values")).expect_err("semantic validation");
+        assert!(!format!("{error:?}: {error}").contains(MARKER));
+    }
+}
+
+#[test]
+fn malformed_cpu_profiles_and_secret_fields_are_redacted() {
+    for field in ["access_token", "client_secret", "api_key", "password", "unknown"] {
+        let mut value = serde_json::to_value(configured()).expect("serialize");
+        value["azure"][0][field] = serde_json::json!(MARKER);
+        let yaml = serde_yaml::to_string(&serde_json::json!({"remote": value})).expect("serialize");
+        let error = Config::from_yaml(&yaml).expect_err("unknown credential field");
+        assert!(!format!("{error:?}: {error}").contains(MARKER));
+    }
+    for value in [
+        serde_json::json!(MARKER),
+        serde_json::json!([MARKER]),
+        serde_json::json!([{"name": MARKER}]),
+        serde_json::json!([{"name": [MARKER]}]),
+    ] {
+        let yaml = serde_yaml::to_string(&serde_json::json!({"remote": {"azure": value}})).expect("serialize");
+        let error = Config::from_yaml(&yaml).expect_err("malformed profile");
+        assert!(!format!("{error:?}: {error}").contains(MARKER));
+    }
+    let mut value = serde_json::to_value(configured()).expect("serialize");
+    value["azure"][0]["disk_sku"] = serde_json::json!(MARKER);
+    let error = serde_json::from_value::<RemoteProviderConfig>(value).expect_err("invalid disk SKU");
+    assert!(!format!("{error:?}: {error}").contains(MARKER));
+}
+
+#[test]
+fn cpu_configuration_load_preserves_file_without_creating_runtime_state() {
+    let directory = tempfile::tempdir().expect("temporary config home");
+    let path = directory.path().join("config.yaml");
+    let config = Config {
+        remote: configured(),
+        ..Default::default()
+    };
+    let original = config.to_yaml().expect("serialize");
+    std::fs::write(&path, &original).expect("write fixture");
+    assert_eq!(Config::load(Some(&path)).expect("load").remote, config.remote);
+    assert_eq!(std::fs::read_to_string(&path).expect("retained config"), original);
+    assert_eq!(std::fs::read_dir(directory.path()).expect("directory").count(), 1);
+}

--- a/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
@@ -50,6 +50,7 @@ mod linux {
                     min_disk_bandwidth_mbps: None,
                     container_registry_auth_id: None,
                 }],
+                ..Default::default()
             };
             Self {
                 directory,

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -115,6 +115,9 @@ back into large multi-purpose modules.
   defaults, exact lookup and redacted validation. The main configuration delegates
   to it; local profile construction shares target-name and local-endpoint rules.
   Configuration loading never selects an ambient daemon or performs provider I/O.
+  CPU profile configuration reuses the Azure adapter's pure placement validation;
+  serialization and exact lookup never acquire credentials or construct a client.
+  A saved profile is not UI/dispatcher support or authorization to allocate a worker.
 - `remote_ssh_identity.rs` exposes retained local client-key preparation and strict
   recovery, separately from the pure remote aggregate. Linux filesystem privacy
   and durable publication live in `remote_ssh_identity/linux.rs`; bounded key-utility


### PR DESCRIPTION
## Purpose

Add explicit, non-secret CPU provider profiles to the existing remote configuration.
Refs #474 and #383. This is configuration support, not completed provider/UI integration.

## Behavior

- Accept `remote.azure` profiles using the adapter's existing placement, managed-identity, registry, disk-SKU and declared-cost validation.
- Resolve only exact, explicitly configured names; names are scoped per provider. Empty and older configurations remain empty without selecting credentials or compute.
- Reject malformed values, unknown credential fields and duplicate names with static, redacted diagnostics. Loading a configuration neither invokes the credential CLI nor creates runtime state or rewrites the file.
- Reuse the existing schema and adapter validation. No new dependency, network call, credential storage, allocation, task dispatch, UI change or local configuration default change.

## Validation

- All 24 remote-provider configuration tests passed, including six new CPU-profile cases covering full-config round-trip/load, legacy defaults, exact lookup, duplicate names, invalid placement and error redaction.
- Independent local code review passed. The refresh onto `3f784027` preserves every source/test byte and the complete stable patch; no behavior changed during the rebase.
- All eight final validation gates passed on `30ce5363`: formatting, maintainability, version sync, 2,445 default and 2,490 speech workspace tests (seven ignored in each suite), blocking/strict Clippy and the advisory pedantic tier.

Scope: four source/test files, 208 changed source/test lines, plus three architecture-note lines.
