### PR TITLE
test(azure): add the client-off mutation phases, provisioning and runbook

### DIFF
--- a/docs/testing/azure-client-off-acceptance.md
+++ b/docs/testing/azure-client-off-acceptance.md
@@ -1,0 +1,251 @@
+# Azure client-off acceptance: harness and runbook
+
+Azure lane of the approved disposable-client test in
+[#475](https://github.com/peters/horizon/issues/475), for
+[#474](https://github.com/peters/horizon/issues/474). The harness lives in
+`scripts/azure-client-off/` (`client_off.py` with deterministic tests under
+`tests/`, and `provision-client.sh`). This document is the runbook; it records no
+completed allocation and no passing result. Nothing in this lane touches the user's
+PC, existing Horizon processes or existing workspaces.
+
+## Topology
+
+| Role | What it is | Owner of its paths |
+| --- | --- | --- |
+| Client A | Disposable Ubuntu VM in its own exact resource group, running the exact Horizon Linux client (built from `client_sha`) under a virtual display, with an isolated persistent client home on its OS disk (retained across deallocation) | Azure lane |
+| Worker B | Separate persistent Azure CPU worker in its own exact group, created through the product path once the shared wiring accepts Azure; until then through the adapter's live driver | Product path: lead lane; adapter: Azure lane |
+| Observer C | This controller, outside A and B: read-only ARM reads and one pinned SSH session per sample with a key that sshd restricts (`restrict,command=`) to a forced reader of the progress and checkpoint files | Azure lane |
+
+C never renews a lease, delivers a keepalive, reconnects a terminal, checkpoints or
+replays a task. C may enforce the declared cleanup deadline.
+
+## Manifest, frozen before anything is rented
+
+```json
+{
+  "subscription_id": "<exact UUID>",
+  "location": "northeurope",
+  "run_id": "<32 hex digits drawn now: head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \\n'>",
+  "client_group": "horizon-client-<run_id>",
+  "client_vm_size": "Standard_B2s",
+  "client_sha": "<40-hex commit the client binary was built from>",
+  "client_binary_sha256": "<digest of that binary, from record-client-build.sh>",
+  "worker_group": "horizon-ws-<workflow>-<job>",
+  "worker_image": "<registry>/horizon-remote-worker@sha256:<digest>",
+  "hourly_cost_micros": 41000,
+  "budget_micros": 2000000,
+  "cleanup_deadline_utc": "<ISO-8601 with an explicit offset, within 24 h and far enough ahead for the run>",
+  "off_minutes": 12,
+  "lease_seconds": 600
+}
+```
+
+`client_off.py --manifest m.json validate` refuses to run anything until the
+manifest is complete: exact UUID, a fresh `run_id` with A's group named
+`horizon-client-<run_id>` and B's group the adapter's `horizon-ws-<workflow>-<job>`
+(every name the harness may create or delete is unique to one run, because ARM
+resource IDs are name-based and offer no conditional delete or power operation),
+two different exact groups, a full commit SHA and
+the binary digest, a digest image reference, positive price and budget (the example
+values above are a `Standard_B2s` list price and a two-currency-unit budget; replace
+them with the current price and your bound), a deadline within 24 hours carrying an
+explicit UTC offset and, for the phases that rent or keep compute alive, far enough
+ahead to outlast them (`validate`: the 30-minute provisioning bound, the 10-minute
+observer install bound, the off-phase setup at its bounds (eleven bounded ARM reads
+for the client, worker and identity-bracketed state attestations, the observer
+probe, and the deallocation with its poll, which share one 10-minute bound; about
+29 minutes), the off interval and everything that must still follow it: the return
+phase's own setup and the cleanup window (about 37 minutes); `off` and `install-observer-key`: their share of the
+same sum; `return`: its own setup at its bounds (seven bounded reads and the start
+with its poll, about 22 minutes) plus the cleanup window it must leave intact), so the
+reaper can never reach a group mid-run; the phases arm their runtime deadline from
+the same numbers,
+an off interval of at least ten minutes that exceeds the configured lease. `verdict` and `cleanup` also run after the deadline: a late cleanup is exactly
+the case that must run. The
+manifest, current price and deadline are posted on #474 before the paid run starts;
+credentials and identifiers stay private.
+
+## Procedure
+
+1. **Prepare locally** (Linux controller with GNU `timeout`). In a fully clean
+   checkout at `client_sha` run `record-client-build.sh --out client-build.json` (lands
+   in the slice after this one): it
+   refuses modified or untracked files, builds the `horizon` binary for
+   `x86_64-unknown-linux-gnu` from that tree, refuses anything that is not an ELF
+   x86-64 binary, and records HEAD together with the digest of the binary it just
+   produced, so the digest can only belong to that commit; confirm the worker image digest is pullable by the pull identity; generate
+   a fresh Ed25519 key pair for A (`key`, `key.pub`); record the pre-existing resource
+   groups in the manifest subscription as JSON
+   (`az group list --subscription <id> --query '[].name' -o json > groups.json`) for
+   the cleanup comparison.
+2. **Provision A** (the script lands in a following slice; the contract below is what
+   it must meet): `provision-client.sh --manifest m.json --ssh-private-key key
+   --horizon-binary <binary from the record> --build-record client-build.json
+   --ssh-source-cidr <controller address>/32 --out client.json`. Diagnostics go to
+   stderr and `client.json` is the exact-A descriptor the later phases take. A's Ed25519 host key is read through
+   the control plane (run command inside the exact VM) before the first connection,
+   and every SSH and SCP call uses the fresh client key explicitly with
+   `IdentitiesOnly`, `BatchMode`, strict checking against that pin and a bounded
+   controller-side timeout. It refuses a binary whose commit or digest differs from
+   the record and the manifest, a `.pub` that does not belong to the private key, and
+   a VM size the location does not offer to the subscription without restrictions
+   (checked with `az vm list-skus` before anything is created). The group and VM
+   creates are treated as ambiguous once sent: each is reconciled by reading the exact
+   resource back with this run's tags for as long as the bound allows, and the group
+   is journaled the moment it is confirmed, with every journal and descriptor write
+   checked, every local file (descriptor, its temporary, the journal and its
+   temporary, the pinned host-key file) reserved with an exclusive create before the
+   first cloud call, the group record required to carry the expected name and ARM ID,
+   and the public address polled under the bound while the network converges. After
+   the host key is read, the VM is attested again (instance identity and tags) before
+   the key is pinned. Everything it writes
+   locally is private to the caller (`umask 077`), and `--out` may not alias the
+   creation journal. It creates the
+   run-named group (journaling it in `created-groups.json` the moment it exists) and
+   the VM with the reaper tags, the manifest deadline and the run identity, admits
+   SSH only from the given range, waits for cloud-init to
+   finish with the display and window-manager services active and the client
+   directory present, copies the binary, verifies its digest on A, and runs a launch
+   gate: the client must open a Horizon window on the virtual display (runtime
+   libraries and a software Vulkan driver are installed by cloud-init). The whole
+   provisioning and readiness path, from the first cloud call to the launch gate,
+   runs under one absolute 30-minute bound. The descriptor records A's group ID, VM
+   ID, instance identity (`vmId`) and `run_id`, each read back from ARM and checked
+   for shape: ARM IDs are name-based paths that a same-name recreation keeps, so the
+   off and return phases attest the instance identity and the run identity as well
+   as the IDs and the full tag set immediately before they touch anything and on
+   every poll afterwards, and every observer sample records which A instance was
+   off. Azure offers no identity-conditioned power or run-command operation; the
+   residual window between that read and the call reaching ARM is covered by the
+   names being unique to this run, not by a compare-and-swap.
+3. **Baseline on A** (product path): start Horizon on A's display with
+   `HOME=/home/horizon/.horizon-client-home` (the descriptor's `client_home`; Horizon
+   keeps its state under `$HOME/.horizon`, reported as `client_state_root`), the same
+   `HOME` the launch gate used, create or recover B through the common setup, verify the original SSH
+   identity and pin, prepare the remote repository and start a deterministic task on
+   B that writes an increasing counter to a progress file and, where the shared
+   checkpoint capability exists, worker-owned checkpoints. Record worker, session and
+   task identities, the starting counter, dirty file hashes and the checkpoint
+   sequence. The task must advance its counter at least once per 15-second sample.
+   Write `worker.json` for the observer: `vm_name`, `port`, `host_key` (the attested
+   key), `observer_key_path` (the private half of a fresh Ed25519 key generated for
+   observer C only, never the client's worker key), `progress_path` and optionally
+   `checkpoint_path` (plain, distinct paths under `/workspace`, no `.` or `..`
+   components, so no two spellings can name one file), and the identity
+   recorded now, before A is stopped: `group_id`, `vm_id`, `instance_id` (the VM's
+   `vmId`, which a same-name recreation does not keep) and `host` as ARM reports them.
+   Then install the observer key as a restricted key (`install-observer-key`, which
+   lands in the slice after this one together with `observer-key-line` and
+   `remove-observer-key`). The worker image authorises `HORIZON_SSH_PUBLIC_KEY` as an
+   unrestricted root key, so a plain key would not be a read-only channel; the
+   harness instead appends one `authorized_keys` line of the form
+   `restrict,command="<reader>" ssh-ed25519 ...` inside the worker container through
+   the ARM run-command channel, after the same identity, image-tag and running gates
+   the off phase applies. `restrict` disables pty, port, agent and X11 forwarding and
+   user rc; the forced reader (its source and arguments travel base64-encoded, so no
+   quoting layer can alter them) opens the two paths component by component with
+   `O_NOFOLLOW` below `/workspace`, returns a capped prefix of regular files only and
+   prints one JSON object, whatever command the client asked for. The off phase
+   requires this channel to answer before A is touched. The line lives in the running
+   container only: the worker entrypoint rewrites `authorized_keys` on every container
+   start. A first-class observer account in the worker image is lead-owned and would
+   replace this step.
+   If this run created B's group, journal its exact identity: `client_off.py
+   --manifest m.json journal-group --group <B's group> --created created-groups.json`
+   (it reads the ARM ID and full tag set into the journal).
+4. **Off**: `client_off.py --manifest m.json --journal journal.ndjson off --worker
+   worker.json --client client.json` (the provisioning output; the journal path is the
+   one the verdict reads in step 6). Binds the whole phase to one absolute
+   deadline (the manifest deadline minus the return phase and the cleanup window it
+   must leave, so A is deallocated only when it can still be brought back): every ARM
+   call, probe, poll and the sampling itself is cut off there (an observation gets
+   what is left, never more than its own 30-second bound, and none starts with less
+   than 10 s left), so the reaper can never act during a live phase. Validates both descriptors, attests that A
+   is the exact VM provisioned for this run (group ID, VM ID and the full tag set,
+   which includes the client binary digest, read from ARM now) and currently
+   running, confirms B is the baseline worker carrying the manifest image's tag and
+   running, proves the observer key is the restricted one (the forced reader must
+   answer; a key whose session runs the requested command fails the gate and nothing
+   is stopped; every session requests a pty and a remote port forward, and only the
+   refusal of both, the `restrict` option's doing on a worker whose sshd already
+   disables agent and X11 forwarding, counts as a restricted channel: a `command=`
+   line without `restrict` answers but is reported as unrestricted, and every later
+   sample from such a channel is unreadable), requires the declared interval plus its
+   setup to fit before the phase deadline (re-checked with the remaining budget right
+   before the deallocation, whose call and poll share one 10-minute bound), creates
+   the journal exclusively with that baseline as its header only once every check that
+   could still refuse has passed, so a refusal leaves no header behind and the same
+   path can be retried (a dry run keeps its plan in memory and never touches that path)
+   (flushed and synced before the irreversible call, as is every sample),
+   re-attests A in the same read as its running state, then deallocates A only,
+   requires `PowerState/deallocated` from the re-attested A on every poll, then
+   samples every 15 s for `off_minutes`: A's power state together with the evidence
+   of its attestation (group and VM IDs, instance identity, the tag maps ARM showed
+   on VM and group, kept verbatim so the offline verdict re-derives it; the identity
+   is read before and after the state and the state counts only when both agree), B's
+   group and VM identity, instance identity, image-reference tag,
+   power state and public address as ARM reports them, and the counter and
+   checkpoint sequence through one restricted, pinned session to that address only
+   (any answer other than the forced reader's JSON object is an unreadable sample).
+   B's identity is read again after its state and reading; if it changed in
+   between, the sample keeps the identity it named but no state or reading. Each
+   sample's instant is taken at its start, so acquisition latency never makes it late. The journal is one JSON line per sample and its
+   path must be unused.
+5. **Return**: `client_off.py --manifest m.json return --client client.json`. Bound
+   the same way to the manifest deadline minus the cleanup window, and the start is
+   issued only while its 10-minute start-and-poll bound still fits. Attests
+   the same exact A again, requires it to be deallocated, starts it only and requires
+   `PowerState/running`. On A, start Horizon again with the same home and reconnect
+   to the same B and task sessions: same worker identity, no additional create, no
+   task replay, dirty bytes intact, no credential rotation.
+6. **Verdict**: `client_off.py --manifest m.json verdict --journal-in journal.ndjson`.
+   The journal's first line is the baseline header the off phase wrote (worker
+   identity and image); a journal without it, or for another image, never passes.
+   Pass requires the declared interval crossed, the lease exceeded, the 15-second
+   cadence met (every sample carries its scheduled and actual instant; a sample more
+   than 5 s late, a skipped slot, or consecutive observations more than 15 s apart
+   beyond one second of wake-up latency is a finding), A deallocated and attested as
+   the provisioned resource in every sample, the first sample matching the baseline identity,
+   B's identity, endpoint and running state unchanged, B carrying the manifest
+   image's reference tag throughout, and a counter that advances between every pair
+   of consecutive samples. Worker-owned checkpoint progress is reported as a
+   separate boolean and is never inferred from the counter.
+7. **Worker lifecycle** is a different assertion, already covered by the adapter's
+   live driver (Stop, explicit start, pinned reattach). Do not Stop or start B during
+   the off interval.
+8. **Remove the observer key** (lands in the slice after this one): once the return
+   and the reconnect check on A are done and before the run is reported finished, the
+   observer's `authorized_keys` line is removed from B through the run-command
+   channel and the removal is proven by B refusing the key. Until that slice lands, a
+   run must not be reported finished while the observer key is authorized on a B
+   that outlives it.
+9. **Cleanup**: `client_off.py --manifest m.json cleanup --groups-before groups.json
+   --created created-groups.json`. Deletes only the manifest groups that this run
+   journaled as created and that did not exist before the run (anything else is
+   refused and reported; the journal holds each group's ARM ID and full tag set from
+   creation), re-reads each group immediately before its delete and refuses one whose
+   ID or tag set differs from the journaled identity (absent, recreated or retagged).
+   Because ARM group IDs are name-based paths that a same-name recreation keeps, a
+   journaled record authorizes a delete only when its tags bind it to this run: A's
+   group must be `horizon-client-<run_id>` carrying the manifest's `run_id`, and B's group must carry the
+   adapter's `horizon-workflow-id` and `horizon-job-id` from which its own name is
+   derived; anything else is refused before it is even read. It then waits for
+   proven absence (an unreadable answer is unknown, never absence) and compares the
+   remaining groups with the list from step 1.
+
+## Labelling
+
+- A run whose B was created through the adapter's live driver instead of the
+  product path is an **adapter-only rehearsal**. It exercises A, C, the off interval
+  and the cleanup, and it is reported as such; it is never the #475 product pass.
+- The product pass needs the shared wiring to accept Azure in the configured
+  setup path (today it answers `UnsupportedProvider`); that dependency and its
+  owner are recorded on #474.
+- Counter progress proves the task kept running. Checkpoint proof needs
+  worker-owned checkpoints advancing during the interval.
+
+## Status
+
+No allocation has been made under this runbook yet. The harness and its
+deterministic tests are in place; the manifest will be posted on #474 before the
+first paid run.

--- a/scripts/azure-client-off/README.md
+++ b/scripts/azure-client-off/README.md
@@ -1,32 +1,43 @@
 # Azure client-off harness
 
-Tooling for the Azure client-off acceptance of #474 / #475: client VM A runs the
-exact Horizon client, a separate worker B keeps a task running, and observer C (this
-controller) proves that B keeps working while A is deallocated and that A
-reconnects afterwards without a new create or a replay.
-
-This slice ships the core; the mutation phases (off, observer install, return) and
-the provisioning scripts follow in the next slice together with the runbook.
+Harness for the Azure lane of the disposable-client test (#475) under #474. See
+`docs/testing/azure-client-off-acceptance.md` for the runbook, manifest and
+labelling rules.
 
 - `clientoff/`: the harness modules. `manifest.py` (schema, constants, the deadline
   arithmetic that keeps the reaper away from a live run), `verdict.py` (pure
-  evaluation of recorded observer samples: cadence, A deallocated throughout, B's
-  identity, image tag and endpoint constant, counter advancing, checkpoints judged
-  apart), `az.py` (bounded `az` calls without a shell; every mutation names the exact
-  resource and `--dry-run` journals instead of issuing) and `cleanup.py` (deletion
-  of exactly the groups this run journaled, re-proven owned immediately before the
-  delete, and only when their tags bind them to this run: A's group is named
-  `horizon-client-<run_id>` and carries the manifest's `run_id`, B's group is the
-  adapter's `horizon-ws-<workflow>-<job>` and carries those identities). ARM offers
-  no conditional delete for resource groups, so this rests on names no other run can
-  reuse rather than on a compare-and-delete.
-- `client_off.py`: the command line: `validate`, `journal-group`, `cleanup`,
-  `verdict`, driven by a frozen manifest that carries a `run_id` drawn when it was
-  frozen (`head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'`).
+  evaluation of recorded observer samples; the offline verdict also checks that the
+  journal's baseline names an Azure worker in the manifest's group), `az.py` (bounded
+  `az` calls without a shell; every mutation names the exact resource and `--dry-run`
+  journals instead of issuing), `observer.py` (worker descriptor gates and the pinned,
+  channel-aware read; the forced reader and its authorized_keys line join it in the
+  next slice), `phases.py`
+  (attestation of the exact A and B from ARM, off, return; the observer-key install
+  and removal join it in the next slice) and
+  `cleanup.py` (deletion of exactly the journaled groups, re-proven owned immediately
+  before the delete and only when name and tags bind them to this run: A's group is
+  `horizon-client-<run_id>` carrying the manifest's `run_id`, B's group is the
+  adapter's `horizon-ws-<workflow>-<job>` carrying those identities; ARM offers no
+  conditional delete for resource groups, so this rests on names no other run can
+  reuse rather than on a compare-and-delete).
+- `client_off.py`: the command line: `validate`, `journal-group`, `off`, `return`,
+  `cleanup`, `verdict` (the observer-key lifecycle, `observer-key-line`,
+  `install-observer-key` and `remove-observer-key`, lands in the next slice),
+  driven by a frozen manifest that carries a `run_id` drawn when it was frozen
+  (`head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'`); `--dry-run` never issues
+  a mutating call and returns the journaled plan instead of waiting for a state it
+  never caused.
 - The tests run in CI (`Azure harness tests` job) next to the workspace preflight
   suite.
+- `record-client-build.sh` (next slice): builds the client from a fully clean checkout
+  and records HEAD with the digest of the binary it produced, the provenance the
+  provisioning step verifies.
+- `provision-client.sh` (a following slice): creates client VM A in the manifest's
+  run-named group with the reaper tags and the run identity, and copies the exact
+  Horizon build after checking its provenance.
 - `tests/`: deterministic coverage of the manifest gates, the verdict logic, the
-  cleanup authorization and the `az` client, run with
-  `python3 -B -m unittest discover -s scripts/azure-client-off/tests -v`.
+  cleanup authorization, the `az` client, the observer channel and the mutation
+  phases, run with `python3 -B -m unittest discover -s scripts/azure-client-off/tests -v`
+  and in CI (`Azure harness tests` job).
 
 No `az login`, provider registration or extension install happens anywhere here.

--- a/scripts/azure-client-off/client_off.py
+++ b/scripts/azure-client-off/client_off.py
@@ -13,10 +13,6 @@ Observer C's only reach into B is a pinned SSH session with a key that sshd rest
 is installed through the ARM run-command channel and accepted only once the forced
 reader answers a session that asked for another command.
 
-This slice ships the core: the manifest gate, the pure verdict over a recorded journal,
-the creation journal and cleanup authorization. The mutation phases (off, observer
-install, return) and the provisioning scripts follow in the next slice.
-
 Nothing here logs in, registers a provider or installs an extension. Every `az` call is
 an argument list without a shell, bounded in time. The observer never renews a lease,
 reconnects a terminal, checkpoints or replays a task. Counter progress is recorded as
@@ -36,6 +32,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from clientoff.az import Az  # noqa: E402
 from clientoff.cleanup import identity_record, journal_records, phase_cleanup  # noqa: E402
 from clientoff.manifest import TOOL_VERSION, validate_manifest  # noqa: E402
+from clientoff.phases import phase_off, phase_return  # noqa: E402
 from clientoff.verdict import verdict_from_records  # noqa: E402
 
 def load_json(path: str) -> Any:
@@ -57,6 +54,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     journal = sub.add_parser("journal-group", help="append a group's ARM identity and tags to the creation journal")
     journal.add_argument("--group", required=True)
     journal.add_argument("--created", required=True, help="JSON array file to append to (created if absent)")
+    off = sub.add_parser("off", help="deallocate A only and observe B for the declared interval")
+    off.add_argument("--client", required=True, help="provision-client.sh output JSON (exact A identity)")
+    off.add_argument("--worker", required=True,
+                     help="JSON with vm_name, port, host_key, observer_key_path (the restricted key), progress_path, "
+                          "optional checkpoint_path, and the baseline identity group_id, vm_id, host")
+    ret = sub.add_parser("return", help="start A only and require running")
+    ret.add_argument("--client", required=True, help="provision-client.sh output JSON (exact A identity)")
     cleanup = sub.add_parser("cleanup", help="delete exactly the groups this run created")
     cleanup.add_argument("--groups-before", required=True, help="JSON list of group names recorded before the run")
     cleanup.add_argument("--created", required=True,
@@ -72,7 +76,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(json.dumps({"runnable": False, "problems": [f"manifest unreadable: {type(error).__name__}"]}, indent=2))
         return 2
     # Only the phases that rent or keep compute alive need a future deadline.
-    problems = validate_manifest(manifest, renting=args.command in ("validate", "off", "return"), phase=args.command)
+    # Phases that rent, keep compute alive or mutate a live VM need a deadline that
+    # outlasts them; verdict and cleanup also run after it.
+    problems = validate_manifest(manifest, renting=args.command in ("validate", "off", "install-observer-key", "return"),
+                                 phase=args.command)
     if problems:
         print(json.dumps({"runnable": False, "problems": problems}, indent=2))
         return 2
@@ -115,16 +122,24 @@ def main(argv: Optional[List[str]] = None) -> int:
         os.replace(temporary, args.created)
         print(json.dumps({"passed": True, "journaled": record}, indent=2))
         return 0
-    try:
-        with open(args.groups_before, encoding="utf-8") as handle:
-            before = json.load(handle)
-        with open(args.created, encoding="utf-8") as handle:
-            created = json.load(handle)
-    except (OSError, json.JSONDecodeError) as error:
-        result = {"passed": False, "deleted": [],
-                  "findings": [f"groups-before or created unreadable: {type(error).__name__}; nothing deleted"]}
+    if args.command in ("off", "return"):
+        client = load_json(args.client)
+    if args.command == "off":
+        worker = load_json(args.worker)
+        result = phase_off(az, manifest, worker, client, args.journal)
+    elif args.command == "return":
+        result = phase_return(az, manifest, client)
     else:
-        result = phase_cleanup(az, manifest, before, created)
+        try:
+            with open(args.groups_before, encoding="utf-8") as handle:
+                before = json.load(handle)
+            with open(args.created, encoding="utf-8") as handle:
+                created = json.load(handle)
+        except (OSError, json.JSONDecodeError) as error:
+            result = {"passed": False, "deleted": [],
+                      "findings": [f"groups-before or created unreadable: {type(error).__name__}; nothing deleted"]}
+        else:
+            result = phase_cleanup(az, manifest, before, created)
     result["az_calls"] = az.journal
     print(json.dumps(result, indent=2))
     return 0 if result.get("passed") else 1

--- a/scripts/azure-client-off/clientoff/__init__.py
+++ b/scripts/azure-client-off/clientoff/__init__.py
@@ -1,7 +1,7 @@
-"""Azure client-off harness modules: manifest and pure verdict, the bounded `az` client and
-cleanup authorization. `client_off.py` is the command-line entry point."""
-from __future__ import annotations
+"""Azure client-off harness modules: manifest and pure verdict, the bounded `az` client, the
+restricted observer channel, the mutation phases and cleanup authorization. `client_off.py`
+is the command-line entry point."""
 
-from . import az, cleanup, manifest, verdict
+from . import az, cleanup, manifest, observer, phases, verdict  # noqa: E402
 
-MODULES = (manifest, verdict, az, cleanup)
+MODULES = (manifest, verdict, az, observer, phases, cleanup)

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -1,11 +1,11 @@
 """Bounded `az` calls without a shell; every mutation names the exact resource."""
 from __future__ import annotations
 
-import base64
 import json
 import subprocess
+import time
 from typing import Any, Dict, List, Optional
-from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, RUN_COMMAND_SECONDS, TAG_IMAGE_REF, WORKER_CONTAINER, utc_now
+from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, TAG_IMAGE_REF, utc_now
 
 
 class Az:
@@ -13,12 +13,25 @@ class Az:
 
     def __init__(self, subscription: str, dry_run: bool = False) -> None:
         self.subscription, self.dry_run, self.journal = subscription, dry_run, []
+        # An absolute phase deadline (monotonic seconds) once a phase sets one: every
+        # call is cut off at it and none starts past it, so no read, probe, mutation or
+        # poll can outlive the window the manifest reserved for the phase.
+        self.deadline: Optional[float] = None
+
+    def left(self) -> Optional[float]:
+        """Seconds left until the phase deadline, or None when no deadline is set."""
+        return None if self.deadline is None else self.deadline - time.monotonic()
 
     def run(self, args: List[str], mutating: bool = False, timeout: int = CLI_STEP_SECONDS) -> Optional[Any]:
         command = ["az", *args, "--subscription", self.subscription, "-o", "json"]
         self.journal.append({"at": utc_now().isoformat(), "mutating": mutating, "args": args})
         if self.dry_run and mutating:
             return None
+        left = self.left()
+        if left is not None:
+            if left < 1:
+                return None  # past the phase deadline: nothing more is asked of ARM
+            timeout = max(1, min(timeout, int(left)))
         try:
             completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
         except (subprocess.TimeoutExpired, OSError):
@@ -31,8 +44,8 @@ class Az:
         except json.JSONDecodeError:
             return None
 
-    def power_state(self, group: str, name: str) -> Optional[str]:
-        view = self.run(["vm", "get-instance-view", "-g", group, "-n", name])
+    def power_state(self, group: str, name: str, timeout: int = CLI_STEP_SECONDS) -> Optional[str]:
+        view = self.run(["vm", "get-instance-view", "-g", group, "-n", name], timeout=timeout)
         if not isinstance(view, dict):
             return None
         instance_view = view.get("instanceView")
@@ -49,15 +62,6 @@ class Az:
             if code.startswith("PowerState/"):
                 codes.append(code)
         return codes[0] if len(codes) == 1 else None
-
-    def append_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
-        """Append one `authorized_keys` line inside the worker container through the ARM
-        run-command channel; the line travels base64-encoded so no quoting layer can alter it."""
-        encoded = base64.b64encode((line.rstrip("\n") + "\n").encode("ascii")).decode("ascii")
-        script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && mkdir -p /root/.ssh && "
-                  f"echo {encoded} | base64 -d >> /root/.ssh/authorized_keys'")
-        return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
-                         "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
 
     def vm_identity(self, group: str, name: str) -> Dict[str, Optional[str]]:
         vm = self.run(["vm", "show", "-g", group, "-n", name])

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -71,14 +71,35 @@ CLEANUP_MARGIN_MINUTES = 30
 RETURN_MARGIN_MINUTES = 15
 
 
+# Work the off phase does before its sampling interval starts, at its bounds: eleven
+# bounded ARM reads (the client attestation, the worker attestation with its identity
+# and power reads, and the identity-bracketed client state read), the observer probe,
+# and the deallocation with its poll, which share one 600-second bound; plus slack.
+OFF_SETUP_MINUTES = (11 * CLI_STEP_SECONDS + 30 + 600) // 60 + 2
+# Work the return phase does before A is verified running, at its bounds: seven
+# bounded ARM reads (the client attestation and the identity-bracketed state read) and
+# the start with its poll, which share one 600-second bound; plus slack.
+RETURN_SETUP_MINUTES = (7 * CLI_STEP_SECONDS + 600) // 60 + 2
+# What the return phase must leave untouched after itself: the cleanup window.
+RETURN_RESERVE_MINUTES = CLEANUP_MARGIN_MINUTES - RETURN_MARGIN_MINUTES
+# What must remain after the off interval: the whole return phase (its setup at its
+# bounds) and the cleanup window it leaves; the off phase may deallocate A only when
+# the return can still complete.
+AFTER_OFF_MINUTES = RETURN_SETUP_MINUTES + RETURN_RESERVE_MINUTES
+
+
 def required_minutes(manifest: Dict[str, Any], phase: str) -> int:
-    """How many minutes past `now` the deadline must lie for `phase` to start."""
+    """How many minutes past `now` the deadline must lie for `phase` to start. The
+    phases arm their runtime deadline from these same numbers, so a manifest that
+    validates can always run its phase to the end of the declared work."""
     off = manifest.get("off_minutes") if type(manifest.get("off_minutes")) is int else MIN_OFF_MINUTES  # noqa: E721
     install = RUN_COMMAND_SECONDS // 60
-    return {"validate": PROVISION_MINUTES + install + off + CLEANUP_MARGIN_MINUTES, "off": off + CLEANUP_MARGIN_MINUTES,
+    return {"validate": PROVISION_MINUTES + install + OFF_SETUP_MINUTES + off + AFTER_OFF_MINUTES,
+            "off": OFF_SETUP_MINUTES + off + AFTER_OFF_MINUTES,
             # The install may spend its whole run-command bound before the off interval starts.
-            "install-observer-key": install + off + CLEANUP_MARGIN_MINUTES,
-            "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
+            "install-observer-key": install + OFF_SETUP_MINUTES + off + AFTER_OFF_MINUTES,
+            # The return needs its own setup and keeps the cleanup window intact after it.
+            "return": RETURN_SETUP_MINUTES + RETURN_RESERVE_MINUTES}.get(phase, 0)
 
 
 def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = None, renting: bool = True,

--- a/scripts/azure-client-off/clientoff/observer.py
+++ b/scripts/azure-client-off/clientoff/observer.py
@@ -1,0 +1,171 @@
+"""Observer C's only reach into worker B: the descriptor gates, the forced reader installed behind a restricted key, and the pinned read."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import selectors
+import subprocess
+import tempfile
+import time
+from typing import Any, Dict, List, Optional
+from .manifest import HOST_KEY_RE, INSTANCE_ID_RE, PROGRESS_PATH_RE, PROGRESS_READ_LIMIT, routable
+
+
+# The adapter names the worker VM inside its group; any other VM in it is not B.
+WORKER_VM_NAME = "worker"
+WORKER_FIELDS = ("vm_name", "port", "host_key", "observer_key_path", "progress_path", "group_id", "vm_id", "instance_id",
+                 "host")
+
+
+def validate_worker(worker: Any) -> List[str]:
+    """Fail-closed schema for the observer's worker descriptor, checked before A is stopped."""
+    if not isinstance(worker, dict):
+        return ["worker descriptor is not an object"]
+    problems = [f"missing {field}" for field in WORKER_FIELDS if field not in worker]
+    if problems:
+        return problems
+    if worker["vm_name"] != WORKER_VM_NAME:
+        problems.append(f"vm_name must be {WORKER_VM_NAME!r}, the adapter's fixed worker VM name")
+    if type(worker["port"]) is not int or not 1 <= worker["port"] <= 65535:  # noqa: E721
+        problems.append("port is not a TCP port")
+    if not isinstance(worker["host_key"], str) or not HOST_KEY_RE.fullmatch(worker["host_key"]):
+        problems.append("host_key is not a single Ed25519 host key line")
+    if not isinstance(worker["observer_key_path"], str) or not os.path.isfile(worker["observer_key_path"]):
+        problems.append("observer_key_path is not a readable file")
+    if not isinstance(worker["progress_path"], str) or not PROGRESS_PATH_RE.fullmatch(worker["progress_path"]):
+        problems.append("progress_path is not a plain path under /workspace")
+    checkpoint = worker.get("checkpoint_path")
+    if checkpoint is not None and (not isinstance(checkpoint, str) or not PROGRESS_PATH_RE.fullmatch(checkpoint)):
+        problems.append("checkpoint_path is not a plain path under /workspace")
+    elif checkpoint is not None and checkpoint == worker.get("progress_path"):
+        problems.append("checkpoint_path must be a separate worker-owned file, not the progress counter")
+    for field in ("group_id", "vm_id"):
+        if not isinstance(worker[field], str) or not worker[field]:
+            problems.append(f"{field} (the identity recorded at baseline) is not a string")
+    if not isinstance(worker["instance_id"], str) or not INSTANCE_ID_RE.fullmatch(worker["instance_id"]):
+        problems.append("instance_id (the worker VM's vmId recorded at baseline) is not an instance identity")
+    if not routable(worker["host"]):
+        problems.append("host (the address recorded at baseline) is not a public IP address")
+    return problems
+
+
+def parse_counter(text: Any) -> Optional[int]:
+    """Exactly one non-negative decimal integer, or nothing."""
+    if not isinstance(text, str) or not re.fullmatch(r"\s*[0-9]{1,18}\s*", text):
+        return None
+    return int(text.strip())
+
+
+# The remote port whose forwarding every observation requests, expecting sshd to deny it.
+FORWARD_PROBE_PORT = 47331
+# One observation may take this long; a phase hands over less when less is left.
+OBSERVATION_SECONDS = 30
+# An observation given less than this cannot say anything: it is not started.
+OBSERVATION_MIN_SECONDS = 10
+
+
+def read_observations(host: str, port: int, host_key: str, key_path: str, directory: str,
+                      budget_seconds: float = OBSERVATION_SECONDS) -> Dict[str, Any]:
+    """One pinned SSH session with the observer key and no command: the server's forced
+    reader answers. Output is streamed under a cap and a deadline; anything unexpected
+    is an unreadable sample, never a crash.
+
+    `channel` tells the outcomes apart: `answered` (the forced reader replied and the
+    session was denied both a pty and a remote port forward, as `restrict` demands),
+    `unrestricted` (the forced reader replied but a denied capability was granted: a
+    `command=` line without `restrict`), `refused` (the
+    server explicitly refused the key: publickey authentication denied under the pinned
+    host key), `unavailable` (transport, pin, timeout or any other failure: nothing is
+    known either way). A pty and a remote port forward are requested on every session
+    precisely so that their refusal proves the option set, not merely the forced
+    command.
+    """
+    nothing: Dict[str, Any] = {"progress": None, "checkpoint": None, "channel": "unavailable"}
+    if not HOST_KEY_RE.fullmatch(host_key) or not routable(host) or budget_seconds < OBSERVATION_MIN_SECONDS:
+        return nothing
+    budget_seconds = min(float(OBSERVATION_SECONDS), budget_seconds)
+    # The pin lives in a private per-observation file so concurrent runs in one
+    # directory never share or overwrite it.
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=directory, prefix="observer_known_hosts.", suffix=".tmp",
+                                         delete=False, encoding="utf-8") as handle:
+            handle.write(f"[{host}]:{port} {host_key}\n")
+            known_hosts = handle.name
+    except OSError:
+        return nothing
+    try:
+        return _observe(host, port, key_path, known_hosts, budget_seconds)
+    finally:
+        try:
+            os.unlink(known_hosts)
+        except OSError:
+            pass
+
+
+def _observe(host: str, port: int, key_path: str, known_hosts: str, budget_seconds: float) -> Dict[str, Any]:
+    nothing: Dict[str, Any] = {"progress": None, "checkpoint": None, "channel": "unavailable"}
+    # A command is sent on purpose: with the restricted key the server must ignore it,
+    # which the JSON answer (and never this command's output) proves on every sample.
+    # `-tt` forces a pty request: under `restrict` sshd denies it ("PTY allocation
+    # request failed") and the forced reader still answers; a `command=` line without
+    # `restrict` grants it, which is the difference between a read-only channel and a
+    # key that may forward ports or agents.
+    command = ["ssh", "-F", "/dev/null", "-i", key_path, "-p", str(port), "-o", f"UserKnownHostsFile={known_hosts}",
+               "-o", "GlobalKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "-o", "BatchMode=yes",
+               "-o", f"ConnectTimeout={max(1, min(10, int(budget_seconds)))}", "-o", "IdentitiesOnly=yes", "-tt",
+               "-R", f"127.0.0.1:{FORWARD_PROBE_PORT}:127.0.0.1:1", f"root@{host}", "id"]
+    try:
+        process = subprocess.Popen(command, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError:
+        return nothing
+    # Both streams are read under the same byte cap and one deadline: a hostile or
+    # failing endpoint can fill neither the memory nor the disk of the controller.
+    streams = {process.stdout: b"", process.stderr: b""}
+    limit = 4 * PROGRESS_READ_LIMIT
+    try:
+        deadline = time.monotonic() + budget_seconds
+        with selectors.DefaultSelector() as selector:
+            for stream in streams:
+                selector.register(stream, selectors.EVENT_READ)
+            while selector.get_map():
+                left = deadline - time.monotonic()
+                if left <= 0:
+                    raise TimeoutError
+                for key, _ in selector.select(timeout=left):
+                    chunk = os.read(key.fileobj.fileno(), limit + 1 - len(streams[key.fileobj]))
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    streams[key.fileobj] += chunk
+                    if len(streams[key.fileobj]) > limit:
+                        raise ValueError("output over the cap")
+        returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+    except (TimeoutError, ValueError, subprocess.TimeoutExpired, OSError):
+        try:
+            process.kill()
+        except OSError:
+            pass  # already gone: nothing left to stop
+        process.wait()
+        return nothing
+    output = streams[process.stdout]
+    diagnostics = streams[process.stderr].decode("utf-8", "replace")
+    if returncode != 0:
+        # ssh exits 255 for its own failures; only an explicit publickey refusal under
+        # the pinned host key is knowledge that the key is not authorized.
+        if returncode == 255 and "Permission denied (publickey" in diagnostics and "Host key verification failed" not in diagnostics:
+            return dict(nothing, channel="refused")
+        return nothing
+    try:
+        answer = json.loads(output.decode("ascii").replace("\r", ""))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return nothing
+    if not isinstance(answer, dict) or set(answer) != {"progress", "checkpoint"}:
+        return nothing  # the forced reader did not answer: the key is not restricted as required
+    # `restrict` denies both the pty and the port forward; sshd offers no way to read
+    # an authorized_keys option set from the client, so the denied capabilities are the
+    # proof (agent and X11 forwarding are disabled server-wide in the worker image).
+    restricted = "PTY allocation request failed" in diagnostics and "remote port forwarding failed" in diagnostics
+    channel = "answered" if restricted else "unrestricted"
+    return {"progress": parse_counter(answer.get("progress")), "checkpoint": parse_counter(answer.get("checkpoint")),
+            "channel": channel}

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -1,0 +1,367 @@
+"""The mutation phases: attest the exact A and B from ARM, then off, observer install and return."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from .az import Az
+from .manifest import (AFTER_OFF_MINUTES, CLI_STEP_SECONDS, CLIENT_VM_NAME, INSTANCE_ID_RE, OFF_SETUP_MINUTES,
+                       RETURN_RESERVE_MINUTES,
+                       RUN_ID_RE, SAMPLE_SECONDS, client_tags, image_ref_digest, parse_utc, routable, same_group, same_id,
+                       utc_now)
+from .observer import OBSERVATION_MIN_SECONDS, OBSERVATION_SECONDS, read_observations, validate_worker
+from .verdict import evaluate_samples
+
+
+CLIENT_FIELDS = ("client_group", "client_vm_id", "client_group_id", "client_instance_id", "run_id", "client_sha",
+                 "client_binary_sha256")
+
+
+def validate_client(client: Any) -> List[str]:
+    """Fail-closed schema for the provisioning output that identifies the exact A."""
+    if not isinstance(client, dict):
+        return ["client descriptor is not an object"]
+    problems = [f"missing {field}" for field in CLIENT_FIELDS if field not in client]
+    if problems:
+        return problems
+    problems = [f"{field} is not a string" for field in CLIENT_FIELDS if not isinstance(client[field], str) or not client[field]]
+    if not problems and not RUN_ID_RE.fullmatch(client["run_id"]):
+        problems.append("run_id is not the 32-hex-digit per-run identity")
+    if not problems and not INSTANCE_ID_RE.fullmatch(client["client_instance_id"]):
+        problems.append("client_instance_id is not a VM instance identity (vmId)")
+    return problems
+
+
+# A power call (deallocate or start) and the poll that verifies it share this bound.
+POWER_CALL_SECONDS = 600
+
+
+def arm_phase_deadline(az: Az, manifest: Dict[str, Any], reserve_minutes: int) -> Optional[str]:
+    """Bind the phase to the manifest deadline minus the minutes reserved for what must
+    still follow it; every ARM call, probe and poll the phase makes is cut off there.
+    Returns the problem when nothing is left."""
+    try:
+        until = parse_utc(str(manifest["cleanup_deadline_utc"]))
+    except ValueError:
+        return "cleanup_deadline_utc is not an ISO-8601 instant"
+    left = (until - utc_now()).total_seconds() - reserve_minutes * 60
+    if left < 60:
+        return f"less than a minute left before the reserved margin ({reserve_minutes} min) of the manifest deadline"
+    az.deadline = time.monotonic() + left
+    return None
+
+
+def observation_budget(az: Az) -> float:
+    """What an observation may take now: its own bound, or less when the phase deadline
+    is nearer; below the observation minimum the caller must not start one."""
+    left = az.left()
+    return float(OBSERVATION_SECONDS) if left is None else min(float(OBSERVATION_SECONDS), left)
+
+
+def observe_client(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
+                   timeout: int = CLI_STEP_SECONDS) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Read A from ARM and attest it: same group ID, same VM ID, same instance identity
+    and exactly this run's tags on group and VM. Returns the evidence (what ARM showed,
+    for the journal) and the problem, if any."""
+    evidence: Dict[str, Any] = {"a_group_id": None, "a_vm_id": None, "a_instance_id": None, "a_tags": None,
+                                "a_group_tags": None}
+    if (not same_group(client["client_group"], manifest["client_group"]) or client["client_sha"] != manifest["client_sha"]
+            or client["client_binary_sha256"] != manifest["client_binary_sha256"] or client["run_id"] != manifest["run_id"]):
+        return evidence, "client descriptor does not belong to this manifest"
+    group = az.run(["group", "show", "-n", manifest["client_group"]], timeout=timeout)
+    vm = az.run(["vm", "show", "-g", manifest["client_group"], "-n", CLIENT_VM_NAME], timeout=timeout)
+    if not isinstance(group, dict) or not isinstance(vm, dict):
+        return evidence, "client group or VM could not be read"
+    evidence.update({"a_group_id": group.get("id"), "a_vm_id": vm.get("id"), "a_instance_id": vm.get("vmId"),
+                     "a_tags": vm.get("tags"), "a_group_tags": group.get("tags")})
+    if not same_id(group.get("id"), client["client_group_id"]) or not same_id(vm.get("id"), client["client_vm_id"]):
+        return evidence, "client VM or group is not the resource provisioned for this run"
+    # ARM IDs are name-based paths and survive a same-name recreation; the VM's
+    # instance identity and the run identity in the tags do not.
+    if vm.get("vmId") != client["client_instance_id"]:
+        return evidence, "client VM is not the instance provisioned for this run"
+    expected = client_tags(manifest)
+    if group.get("tags") != expected or vm.get("tags") != expected:
+        return evidence, "client group or VM does not carry exactly this run's tags"
+    return evidence, None
+
+
+def bound_client_state(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
+                       timeout: int = CLI_STEP_SECONDS) -> Tuple[Dict[str, Any], Optional[str], Optional[str]]:
+    """A's power state bound to one attested identity: the identity is attested before
+    and after the state read, and the state counts only when both attestations pass on
+    the same evidence, so a same-name replacement is a problem, never a state. Returns
+    the evidence ARM showed (for the journal), the state, and the problem."""
+    before, problem_before = observe_client(az, manifest, client, timeout)
+    if problem_before:
+        return before, None, problem_before
+    state = az.power_state(manifest["client_group"], CLIENT_VM_NAME, timeout=timeout)
+    after, problem_after = observe_client(az, manifest, client, timeout)
+    if problem_after:
+        return before, None, problem_after
+    if before != after:
+        return before, None, "client A changed identity around the state read"
+    return before, state, None
+
+
+def observe_client_state(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
+                         timeout: int = CLI_STEP_SECONDS) -> Tuple[Dict[str, Any], Optional[str]]:
+    """The evidence ARM showed for A together with its bound power state (None unless bound)."""
+    evidence, state, _ = bound_client_state(az, manifest, client, timeout)
+    return evidence, state
+
+
+def client_power(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
+                 timeout: int = CLI_STEP_SECONDS) -> Tuple[Optional[str], Optional[str]]:
+    """The exact A's bound power state and the problem, for the mutation paths."""
+    _, state, problem = bound_client_state(az, manifest, client, timeout)
+    return state, problem
+
+
+def attest_client(az: Az, manifest: Dict[str, Any], client: Dict[str, Any], timeout: int = CLI_STEP_SECONDS) -> Optional[str]:
+    """The problem with A, or None when it is the exact provisioned resource right now."""
+    return observe_client(az, manifest, client, timeout)[1]
+
+
+def await_client_state(az: Az, manifest: Dict[str, Any], client: Dict[str, Any], target: str,
+                       bound_seconds: int = 600) -> Optional[str]:
+    """Wait for the exact A to report `target` under an absolute bound: every ARM
+    request is handed what is left of it, the sleep never crosses it, and every poll
+    re-attests A's identity, so the answer is only ever about the provisioned instance.
+    Returns the problem."""
+    deadline = time.monotonic() + bound_seconds
+    if az.deadline is not None:
+        deadline = min(deadline, az.deadline)
+    while True:
+        left = deadline - time.monotonic()
+        # Five requests per poll share what is left, each cut off at the bound; a poll
+        # that cannot fit five one-second requests is not started at all.
+        if left < 5:
+            return f"client A did not reach {target} within the bound"
+        state, problem = client_power(az, manifest, client, timeout=int(left / 5))
+        if problem:
+            return f"{problem} while waiting for {target}"
+        if state == target:
+            return None
+        left = deadline - time.monotonic()
+        if left <= 0:
+            return f"client A did not reach {target} within {bound_seconds}s (last {state})"
+        time.sleep(min(5.0, left))
+
+
+def attest_worker(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any]) -> Tuple[Dict[str, Optional[str]], Optional[str]]:
+    """B must be the worker recorded at baseline (group, VM and address as ARM reports
+    them now), carry the manifest image's tag and be running, before any phase touches
+    it or A. Returns the ARM observation and the first problem, if any."""
+    expected = {"b_group_id": worker["group_id"], "b_vm_id": worker["vm_id"], "b_instance_id": worker["instance_id"], "b_host": worker["host"]}
+    baseline = az.vm_identity(manifest["worker_group"], worker["vm_name"])
+    if any(not same_id(baseline.get(field), expected[field]) for field in expected):
+        return baseline, "worker B does not match the identity recorded at baseline"
+    if baseline.get("b_image_ref") != image_ref_digest(manifest["worker_image"]):
+        return baseline, "worker B does not carry the manifest image's reference tag"
+    if az.power_state(manifest["worker_group"], worker["vm_name"]) != "PowerState/running":
+        return baseline, "worker B is not running"
+    return baseline, None
+
+
+def phase_off(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], client: Dict[str, Any], journal_path: str,
+              sample_seconds: int = SAMPLE_SECONDS, interval_seconds: Optional[float] = None,
+              reader: Optional[Callable[..., Dict[str, Optional[int]]]] = None) -> Dict[str, Any]:
+    """Deallocate A only, require deallocated, observe for the declared interval.
+
+    `interval_seconds` and `reader` exist for deterministic tests of the mutation
+    boundary; production callers leave them unset.
+    """
+    reader = reader or read_observations
+    sample_seconds = max(1, sample_seconds)
+    client_group = manifest["client_group"]
+    problems = validate_worker(worker) + [f"client: {p}" for p in validate_client(client)]
+    if problems:
+        return {"passed": False, "findings": [f"descriptor: {problem}" for problem in problems]}
+    # One absolute deadline for the whole phase: the manifest deadline minus what the
+    # return phase and the cleanup window need after the interval, so A is deallocated
+    # only when it can still be brought back. The declared interval plus the
+    # pre-sampling work must fit inside it before anything is stopped.
+    problem = arm_phase_deadline(az, manifest, AFTER_OFF_MINUTES) or attest_client(az, manifest, client)
+    if problem:
+        return {"passed": False, "findings": [f"{problem}; nothing stopped"]}
+    interval = interval_seconds if interval_seconds is not None else manifest["off_minutes"] * 60
+    if az.left() is not None and az.left() < OFF_SETUP_MINUTES * 60 + interval:
+        return {"passed": False, "findings": ["the declared off interval and its setup do not fit before the phase deadline; "
+                                              "nothing stopped"]}
+    directory = os.path.dirname(os.path.abspath(journal_path))
+    expected_identity = {"b_group_id": worker["group_id"], "b_vm_id": worker["vm_id"], "b_instance_id": worker["instance_id"],
+                         "b_host": worker["host"], "a_group_id": client["client_group_id"], "a_vm_id": client["client_vm_id"],
+                         "a_instance_id": client["client_instance_id"]}
+    # The observed image tag is what the header records.
+    baseline, problem = attest_worker(az, manifest, worker)
+    if problem:
+        return {"passed": False, "findings": [f"{problem}; nothing stopped"]}
+    # The observer channel must already be the restricted one: the forced reader must
+    # answer (and the sent command must not) before A is touched.
+    if observation_budget(az) < OBSERVATION_MIN_SECONDS:
+        return {"passed": False, "findings": ["phase deadline too near for the observer probe; nothing stopped"]}
+    probe = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                   observation_budget(az))
+    if probe.get("channel") == "unrestricted":
+        return {"passed": False, "findings": ["observer key runs the forced reader but is not `restrict`ed on B (a pty was "
+                                              "granted); nothing stopped"]}
+    if probe.get("channel") != "answered" or probe.get("progress") is None:
+        return {"passed": False, "findings": ["observer key is not a working restricted read channel on B, or the counter "
+                                              "is not readable yet; nothing stopped"]}
+    # The client must actually be on, and must still be the exact A in the same read
+    # that precedes the mutation: ARM offers no conditional power operation, so the
+    # attestation is repeated immediately before the call and on every poll after it,
+    # and A's group name is unique to this run, so nothing else can stand at the path.
+    state, problem = client_power(az, manifest, client)
+    if problem:
+        return {"passed": False, "findings": [f"{problem}; nothing stopped"]}
+    if state != "PowerState/running":
+        return {"passed": False, "findings": ["client A is not running before the off interval; nothing stopped"]}
+    # The last check before the irreversible call, with the remaining budget as it is
+    # now: the deallocation and its poll share one bound, and the declared interval must
+    # still fit after it.
+    if az.left() is not None and az.left() < POWER_CALL_SECONDS + interval:
+        return {"passed": False, "findings": ["the deallocation bound and the declared interval no longer fit before the "
+                                              "phase deadline; nothing stopped"]}
+    if az.dry_run:
+        # The plan stays in memory: a dry run must not consume the production journal
+        # path that the real run will need to create exclusively.
+        if os.path.exists(journal_path):
+            return {"passed": False, "findings": [f"journal {journal_path} already exists; the real run would refuse it"]}
+        az.run(["vm", "deallocate", "-g", client_group, "-n", CLIENT_VM_NAME], mutating=True, timeout=POWER_CALL_SECONDS)
+        return {"passed": False, "dry_run": True, "findings": ["dry run: A would be deallocated now; no sample taken"],
+                "plan": az.journal}
+    # The journal is created only now, once every check that could still refuse has
+    # passed: a refusal before this point leaves no header behind, so the same path can
+    # be retried; from here on the deallocation is attempted and the header must exist.
+    try:
+        # Exclusive creation proves the path is fresh and writable before A is touched;
+        # the first line records the baseline the offline verdict must enforce.
+        with open(journal_path, "x", encoding="utf-8") as handle:
+            handle.write(json.dumps({"baseline": expected_identity, "worker_image": manifest["worker_image"],
+                                     "observed_image_ref": baseline["b_image_ref"]}, sort_keys=True) + "\n")
+            # Durable before the irreversible call: a crash right after the deallocate
+            # must still leave the header naming what was stopped.
+            handle.flush()
+            os.fsync(handle.fileno())
+    except FileExistsError:
+        return {"passed": False, "findings": [f"journal {journal_path} already exists; each run needs a fresh path"]}
+    except OSError as error:
+        # Created by this call but not written through: remove it, so the path stays
+        # retryable; nothing has been mutated.
+        try:
+            os.unlink(journal_path)
+        except OSError:
+            pass
+        return {"passed": False, "findings": [f"journal {journal_path} cannot be written: {type(error).__name__}"]}
+    call_started = time.monotonic()
+    az.run(["vm", "deallocate", "-g", client_group, "-n", CLIENT_VM_NAME], mutating=True, timeout=POWER_CALL_SECONDS)
+    problem = await_client_state(az, manifest, client, "PowerState/deallocated",
+                                 bound_seconds=int(POWER_CALL_SECONDS - (time.monotonic() - call_started)))
+    if problem:
+        return {"passed": False, "findings": [problem]}
+    samples: List[Dict[str, Any]] = []
+    first_slot = utc_now()
+    origin = time.monotonic()
+    end = origin + interval
+    if az.deadline is not None:
+        end = min(end, az.deadline)
+    index = 0
+    while True:
+        # Fixed schedule from the first slot; the actual instant is recorded beside it.
+        slot_offset = index * sample_seconds
+        scheduled_at = (first_slot + _dt.timedelta(seconds=slot_offset)).isoformat()
+        # The observation instant is the start of the sample: acquisition latency belongs
+        # to the sample, never to the slot.
+        at = utc_now().isoformat()
+        # A first: its state, bracketed by its attestation, is what the sample's instant
+        # attributes; B's reads and the SSH observation follow, so a transition of A
+        # during them can never be back-dated to `at`.
+        a_evidence, a_power = observe_client_state(az, manifest, client)
+        identity = az.vm_identity(manifest["worker_group"], worker["vm_name"])
+        host = identity.get("b_host")
+        b_power = az.power_state(manifest["worker_group"], worker["vm_name"])
+        # Read only through the endpoint ARM reports for B right now, pinned to the
+        # attested key, with the restricted observer key whose forced reader returns
+        # the counter and, when the task exposes one, the worker-owned checkpoint.
+        # The reading gets what is left of the phase, never more than its own bound.
+        observed = (reader(host, worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                           observation_budget(az))
+                    if routable(host) else {"progress": None, "checkpoint": None})
+        # B's state and reading count only when B's identity (group, VM, instance, image
+        # tag, endpoint) is the same before and after them; a replacement or repointed
+        # endpoint in between leaves an unattested sample, never a stale identity next to
+        # a replacement's state.
+        if az.vm_identity(manifest["worker_group"], worker["vm_name"]) != identity or observed.get("channel") != "answered":
+            # A replaced B, or a channel that is not the restricted reader any more
+            # (refused, unavailable, or answering with a pty granted), leaves an
+            # unreadable sample: its state and reading are never evidence.
+            b_power, observed = None, {"progress": None, "checkpoint": None}
+        # A's evidence (group and VM IDs, instance identity, the tag maps ARM showed) is
+        # journaled verbatim so the offline verdict re-derives that the exact provisioned
+        # A was off in every sample, not merely a VM of that name.
+        sample = {"scheduled_at": scheduled_at, "at": at,
+                  "a_power": a_power,
+                  **a_evidence,
+                  "b_power": b_power,
+                  **identity,
+                  "progress": observed.get("progress"),
+                  "checkpoint": observed.get("checkpoint") if worker.get("checkpoint_path") else None}
+        samples.append(sample)
+        try:
+            with open(journal_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(sample, sort_keys=True) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as error:
+            return {"passed": False, "findings": [f"journal became unwritable during the interval: {type(error).__name__}"],
+                    "samples": len(samples)}
+        if time.monotonic() > end:
+            break
+        # Sleep to the next slot; a slow sample skips slots, which the journal shows. A
+        # slot that falls after the end, or leaves no room for one observation before
+        # the phase deadline, is not started: the sleep never crosses the end.
+        index += 1
+        while origin + index * sample_seconds < time.monotonic():
+            index += 1
+        next_slot = origin + index * sample_seconds
+        # The slot at the endpoint is still sampled: the interval is closed on its end.
+        if next_slot > end or (az.deadline is not None and az.deadline - next_slot < OBSERVATION_MIN_SECONDS):
+            break
+        time.sleep(max(0.0, next_slot - time.monotonic()))
+    return evaluate_samples(samples, manifest["off_minutes"], manifest["lease_seconds"], manifest["worker_image"],
+                            expected_identity, client_tags(manifest))
+
+
+def phase_return(az: Az, manifest: Dict[str, Any], client: Dict[str, Any]) -> Dict[str, Any]:
+    """Start A only and require running; the client reconnect step follows on A."""
+    client_group = manifest["client_group"]
+    problems = validate_client(client)
+    if problems:
+        return {"passed": False, "findings": [f"client descriptor: {problem}" for problem in problems]}
+    # The return keeps the cleanup window untouched after itself.
+    problem = arm_phase_deadline(az, manifest, RETURN_RESERVE_MINUTES) or attest_client(az, manifest, client)
+    if problem:
+        return {"passed": False, "findings": [f"{problem}; nothing started"]}
+    # Only the exact A, and only when it is actually off, can be brought back: identity
+    # and state are read together immediately before the start and on every poll after.
+    state, problem = client_power(az, manifest, client)
+    if problem:
+        return {"passed": False, "findings": [f"{problem}; nothing started"]}
+    if state != "PowerState/deallocated":
+        return {"passed": False, "findings": ["client A is not deallocated before the return; nothing started"]}
+    # The start and its poll share one bound, which must fit before the phase deadline.
+    if az.left() is not None and az.left() < POWER_CALL_SECONDS:
+        return {"passed": False, "findings": ["the start bound no longer fits before the phase deadline; nothing started"]}
+    call_started = time.monotonic()
+    az.run(["vm", "start", "-g", client_group, "-n", CLIENT_VM_NAME], mutating=True, timeout=POWER_CALL_SECONDS)
+    if az.dry_run:
+        return {"passed": False, "dry_run": True, "findings": ["dry run: A would be started now"], "plan": az.journal}
+    problem = await_client_state(az, manifest, client, "PowerState/running",
+                                 bound_seconds=int(POWER_CALL_SECONDS - (time.monotonic() - call_started)))
+    if problem:
+        return {"passed": False, "findings": [problem]}
+    return {"passed": True, "findings": []}

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -39,7 +39,17 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(client_off.required_minutes(manifest(), "validate"),
                          client_off.PROVISION_MINUTES + client_off.required_minutes(manifest(), "install-observer-key"),
                          "renting is approved only when provisioning and then the install can both run to their bounds")
-        self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="return"), [])
+        later = (NOW + dt.timedelta(minutes=client_off.required_minutes(manifest(), "return"))).isoformat()
+        self.assertTrue(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="return"),
+                        "the return needs its setup and keeps the whole cleanup window")
+        self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=later), NOW, phase="return"), [])
+        self.assertEqual(client_off.required_minutes(manifest(), "return"),
+                         client_off.RETURN_SETUP_MINUTES + client_off.CLEANUP_MARGIN_MINUTES - client_off.RETURN_MARGIN_MINUTES)
+        self.assertGreaterEqual(client_off.OFF_SETUP_MINUTES, (11 * client_off.CLI_STEP_SECONDS + 30 + 600) // 60,
+                                "eleven bounded reads, the probe and the shared deallocate bound")
+        self.assertEqual(client_off.required_minutes(manifest(), "off"),
+                         client_off.OFF_SETUP_MINUTES + manifest()["off_minutes"] + client_off.required_minutes(manifest(), "return"),
+                         "A is deallocated only when the whole return phase can still follow")
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, renting=False), [])
         enough = (NOW + dt.timedelta(minutes=client_off.required_minutes(manifest(), "validate"))).isoformat()
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=enough), NOW), [])

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -1,0 +1,630 @@
+"""Deterministic coverage of the mutation phases and the observer channel: which az calls
+happen, in which order, on which resource, and what the restricted reader accepts. No
+Azure, no network."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import pathlib
+import tempfile
+import time
+import unittest
+import unittest.mock as mock
+
+from harness_fixtures import A_INSTANCE, B_INSTANCE, IMAGE, RUN_ID, client_off, manifest, samples
+
+class WorkerDescriptorTests(unittest.TestCase):
+    def descriptor(self, **overrides):
+        base = {"vm_name": "worker", "port": 2222, "host_key": "ssh-ed25519 " + "A" * 68, "observer_key_path": __file__,
+                "progress_path": "/workspace/live/progress", "group_id": "/g/b", "vm_id": "/g/b/vm", "instance_id": B_INSTANCE,
+                "host": "52.174.10.5"}
+        base.update(overrides)
+        return base
+
+    def test_descriptor_gates_are_named_before_anything_is_stopped(self):
+        self.assertEqual(client_off.validate_worker(self.descriptor()), [])
+        self.assertEqual(client_off.validate_worker(self.descriptor(checkpoint_path="/workspace/live/checkpoint")), [])
+        self.assertTrue(client_off.validate_worker(self.descriptor(checkpoint_path="/workspace/live/progress")),
+                        "the counter file can never stand in for a checkpoint")
+        for alias in ("/workspace/live/./progress", "/workspace/./live/progress", "/workspace/live/../live/progress"):
+            with self.subTest(alias=alias):
+                self.assertTrue(client_off.validate_worker(self.descriptor(checkpoint_path=alias)),
+                                "no spelling of the counter path may pass as the checkpoint")
+                self.assertTrue(client_off.validate_worker(self.descriptor(progress_path=alias)))
+        self.assertEqual(client_off.validate_worker(self.descriptor(progress_path="/workspace/.hidden/a..b")), [])
+        for field, value in (("vm_name", "a b"), ("vm_name", "other"), ("vm_name", "Worker"), ("port", "2222"), ("port", True), ("host_key", "ssh-rsa AAAA"),
+                             ("host_key", "ssh-ed25519 " + "A" * 68 + "\n[evil]:22 ssh-ed25519 " + "B" * 68),
+                             ("host_key", "ssh-ed25519 " + "A" * 68 + " comment"),
+                             ("host_key", "ssh-ed25519 " + "A" * 68 + "\n"), ("instance_id", "not-a-vmid"),
+                             ("observer_key_path", "/nonexistent/key"), ("progress_path", "/etc/passwd"),
+                             ("checkpoint_path", "/dev/zero"), ("group_id", 5), ("host", "")):
+            with self.subTest(field=field, value=value):
+                self.assertTrue(client_off.validate_worker(self.descriptor(**{field: value})))
+        self.assertEqual(client_off.validate_worker("worker"), ["worker descriptor is not an object"])
+        self.assertTrue(all(problem.startswith("missing ") for problem in client_off.validate_worker({})))
+
+    def test_endpoints_must_be_public_addresses(self):
+        for host in ("10.0.0.5", "127.0.0.1", "169.254.169.254", "not-an-ip", "224.0.0.1", "::1"):
+            with self.subTest(host=host):
+                self.assertTrue(client_off.validate_worker(self.descriptor(host=host)))
+                self.assertFalse(client_off.evaluate_samples(samples(49, host=host), 12, 600)["passed"])
+        self.assertTrue(client_off.routable("52.174.10.7"))
+        self.assertFalse(client_off.routable("192.168.1.1"))
+
+
+def fake_ssh(payload: bytes, returncode: int = 0, diagnostics: bytes = b""):
+    """A Popen stand-in that streams `payload` on stdout, writes `diagnostics` to the
+    stderr file it is handed and exits with `returncode`."""
+    class FakeProcess:
+        def __init__(self, *args, **kwargs):
+            r, w = os.pipe()
+            os.write(w, payload)
+            os.close(w)
+            self.stdout = os.fdopen(r, "rb")
+            r, w = os.pipe()
+            os.write(w, diagnostics)
+            os.close(w)
+            self.stderr = os.fdopen(r, "rb")
+            self.returncode = returncode
+
+        def wait(self, timeout=None):
+            return returncode
+
+        def kill(self):
+            pass
+
+    return FakeProcess
+
+
+class ObserverChannelTests(unittest.TestCase):
+    """Observer C reads through a key sshd restricts to one forced reader."""
+
+    HOST_KEY = "ssh-ed25519 " + "A" * 68
+
+    PTY_DENIED = (b"Warning: remote port forwarding failed for listen port 47331\r\n"
+                  b"PTY allocation request failed on channel 0\r\n")
+
+    def observe(self, payload, returncode=0, diagnostics=PTY_DENIED):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(client_off.subprocess, "Popen", fake_ssh(payload, returncode, diagnostics)):
+            return client_off.read_observations("52.174.10.5", 2222, self.HOST_KEY, "/dev/null", directory)
+
+    def test_only_the_forced_readers_json_answer_counts(self):
+        nothing = {"progress": None, "checkpoint": None, "channel": "unavailable"}
+        self.assertEqual(self.observe(b'{"progress": "42\\n", "checkpoint": " 7 "}'),
+                         {"progress": 42, "checkpoint": 7, "channel": "answered"})
+        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}'),
+                         {"progress": 42, "checkpoint": None, "channel": "answered"})
+        self.assertEqual(self.observe(b'{"progress": null, "checkpoint": null}'),
+                         {"progress": None, "checkpoint": None, "channel": "answered"},
+                         "an authorized key whose files are missing is still an authorized key")
+        # The forced reader answered but the pty was granted: a `command=` line without
+        # `restrict`, which is not the read-only channel the acceptance needs.
+        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}', diagnostics=b""),
+                         {"progress": 42, "checkpoint": None, "channel": "unrestricted"})
+        self.assertEqual(self.observe(b'{"progress": "42",\r\n "checkpoint": null}\r\n', diagnostics=b""),
+                         {"progress": 42, "checkpoint": None, "channel": "unrestricted"}, "a pty's CRLF is not a parse failure")
+        for partial in (b"PTY allocation request failed on channel 0\r\n",
+                        b"Warning: remote port forwarding failed for listen port 47331\r\n"):
+            with self.subTest(partial=partial):
+                self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}', diagnostics=partial)["channel"],
+                                 "unrestricted", "one denied capability is not `restrict`: both must be denied")
+        refused = b"root@52.174.10.5: Permission denied (publickey).\n"
+        self.assertEqual(self.observe(b"", 255, refused), dict(nothing, channel="refused"))
+        for returncode, diagnostics in ((255, b"ssh: connect to host 52.174.10.5 port 2222: Connection refused\n"),
+                                        (255, b"Host key verification failed.\n" + refused), (255, b""), (1, refused),
+                                        (0, refused)):
+            with self.subTest(returncode=returncode, diagnostics=diagnostics[:30]):
+                self.assertEqual(self.observe(b"", returncode, diagnostics), nothing,
+                                 "only an explicit publickey refusal under the pin is a refusal")
+        # The forced reader answered, but the counter is not exactly one integer: the
+        # key is authorized and the sample is unreadable.
+        for payload in (b'{"progress": "1\\n2\\n", "checkpoint": null}', b'{"progress": "-3", "checkpoint": null}',
+                        b'{"progress": "4x", "checkpoint": null}', b'{"progress": "' + b"1" * 19 + b'", "checkpoint": null}'):
+            with self.subTest(payload=payload[:40]):
+                self.assertEqual(self.observe(payload), dict(nothing, channel="answered"))
+        # Not the forced reader's answer at all: nothing is known.
+        for payload in (b"uid=0(root) gid=0(root)\n",  # the sent command ran: the key is not restricted
+                        b'{"progress": "42"}', b'{"progress": "42", "checkpoint": null, "shell": "sh"}', b"", b"\xff",
+                        b'{"progress": "' + b"9" * 2000 + b'", "checkpoint": null}'):
+            with self.subTest(payload=payload[:40]):
+                self.assertEqual(self.observe(payload), nothing)
+        self.assertEqual(client_off.read_observations("52.174.10.5", 2222, "ssh-ed25519 AAAA\nx", "/dev/null", "/tmp"),
+                         nothing, "a pin with a newline is never written")
+        self.assertEqual(client_off.read_observations("203.0.113.5", 2222, self.HOST_KEY, "/dev/null", "/tmp"), nothing,
+                         "an unroutable endpoint is never dialled")
+
+
+class ClientIdentityTests(unittest.TestCase):
+    def test_client_descriptor_and_attestation_gate_every_mutation(self):
+        m = manifest()
+        client = {"client_group": m["client_group"], "client_vm_id": "/g/client/vm", "client_group_id": "/g/client",
+                  "client_instance_id": A_INSTANCE, "run_id": RUN_ID,
+                  "client_sha": m["client_sha"], "client_binary_sha256": m["client_binary_sha256"]}
+        self.assertEqual(client_off.validate_client(client), [])
+        self.assertTrue(client_off.validate_client({}))
+        self.assertTrue(client_off.validate_client(dict(client, client_vm_id="")))
+        answers = {}
+
+        class FakeAz:
+            def run(self, args, mutating=False, timeout=0):
+                return answers.get(args[0])
+
+        good_tags = client_off.client_tags(m)
+        good_vm = {"id": "/g/client/vm", "vmId": A_INSTANCE, "tags": dict(good_tags)}
+        answers.update(group={"id": "/G/CLIENT", "tags": dict(good_tags)}, vm=dict(good_vm))
+        self.assertIsNone(client_off.attest_client(FakeAz(), m, client))
+        answers["vm"] = dict(good_vm, id="/g/client/other")
+        self.assertIn("not the resource provisioned", client_off.attest_client(FakeAz(), m, client))
+        # A same-name recreation keeps the ARM ID and every manifest-derived tag; it
+        # cannot keep the instance identity or this run's drawn value.
+        answers["vm"] = dict(good_vm, vmId="3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f")
+        self.assertIn("not the instance provisioned", client_off.attest_client(FakeAz(), m, client))
+        answers["vm"] = dict(good_vm, tags=dict(good_tags, run_id="f" * 32))
+        self.assertIn("exactly this run's tags", client_off.attest_client(FakeAz(), m, client))
+        answers["vm"] = {"id": "/g/client/vm", "vmId": A_INSTANCE, "tags": {"lane": "azure-client-off", "client_sha": m["client_sha"]}}
+        self.assertIn("exactly this run's tags", client_off.attest_client(FakeAz(), m, client))
+        answers["vm"] = dict(good_vm)
+        answers["group"] = {"id": "/G/CLIENT", "tags": dict(good_tags, purpose="other")}
+        self.assertIn("exactly this run's tags", client_off.attest_client(FakeAz(), m, client))
+        answers["group"] = {"id": "/G/CLIENT", "tags": dict(good_tags)}
+        answers["vm"] = None
+        self.assertIn("could not be read", client_off.attest_client(FakeAz(), m, client))
+        self.assertIn("does not belong", client_off.attest_client(FakeAz(), m, dict(client, client_sha="f" * 40)))
+        self.assertIn("does not belong", client_off.attest_client(FakeAz(), m, dict(client, client_binary_sha256="f" * 64)))
+        self.assertIn("client_binary_sha256", client_off.client_tags(m))
+        self.assertTrue(client_off.validate_client(dict(client, run_id="short")))
+        self.assertTrue(client_off.validate_client(dict(client, client_instance_id="not-a-vmid")))
+
+
+class OffPhaseTests(unittest.TestCase):
+    """The irreversible boundary: which az calls happen, in which order, on which resource."""
+
+    def plane(self, *, a_power="PowerState/running", b_power="PowerState/running", b_vm_id="/g/b/vm",
+              client_vm_id="/g/client/vm", image=IMAGE, b_instance=B_INSTANCE, a_instance=A_INSTANCE,
+              retag_client_after_deallocate=False, hours_left=3, deadline_in=None):
+        # The phases bind themselves to the manifest deadline against real time.
+        m = manifest(cleanup_deadline_utc=(client_off.utc_now() + (deadline_in or dt.timedelta(hours=hours_left))).isoformat())
+        calls = []
+        tags = client_off.client_tags(m)
+
+        class FakeAz:
+            dry_run = False
+            journal = []
+            deadline = None
+
+            def left(self):
+                return None if self.deadline is None else self.deadline - time.monotonic()
+
+            def run(self, args, mutating=False, timeout=0):
+                calls.append(("mutate" if mutating else "read", tuple(args)))
+                if args[:2] == ["vm", "deallocate"] or args[:3] == ["vm", "run-command", "invoke"]:
+                    return {}
+                if args[:2] == ["group", "show"]:
+                    name = args[args.index("-n") + 1]
+                    if name == m["client_group"]:
+                        return {"id": "/g/client", "name": name, "tags": dict(tags)}
+                    return {"id": "/g/b", "name": name, "tags": {}}
+                if args[:2] == ["vm", "show"]:
+                    group = args[args.index("-g") + 1]
+                    if group == m["client_group"]:
+                        # Retag once sampling has begun: the reads of A after the mutation are
+                        # the deallocation poll, then two per sample.
+                        mutated = next((i for i, c in enumerate(calls) if c[0] == "mutate"), None)
+                        reads_after = 0 if mutated is None else sum(
+                            1 for c in calls[mutated:] if c[1][:2] == ("vm", "show") and m["client_group"] in c[1])
+                        retag = retag_client_after_deallocate and reads_after >= 4
+                        client_tags = dict(tags, run_id="f" * 32) if retag else dict(tags)
+                        return {"id": client_vm_id, "vmId": a_instance, "tags": client_tags}
+                    return {"id": b_vm_id, "vmId": b_instance,
+                            "tags": {client_off.TAG_IMAGE_REF: client_off.image_ref_digest(image)}}
+                if args[:3] == ["network", "public-ip", "show"]:
+                    return {"ipAddress": "52.174.10.5"}
+                if args[:2] == ["vm", "get-instance-view"]:
+                    group = args[args.index("-g") + 1]
+                    power = a_power if group == m["client_group"] else b_power
+                    # A follows the last power call made on it.
+                    if group == m["client_group"]:
+                        last = [c[1][1] for c in calls if c[0] == "mutate" and c[1][:2] in (("vm", "deallocate"), ("vm", "start"))]
+                        if last:
+                            power = "PowerState/deallocated" if last[-1] == "deallocate" else "PowerState/running"
+                    return {"instanceView": {"statuses": [{"code": power}]}}
+                return None
+
+            def power_state(self, group, name, timeout=0):
+                return client_off.Az.power_state(self, group, name, timeout)
+
+            def vm_identity(self, group, name):
+                return client_off.Az.vm_identity(self, group, name)
+
+        return m, FakeAz(), calls
+
+    def descriptors(self, m):
+        worker = {"vm_name": "worker", "port": 2222, "host_key": "ssh-ed25519 " + "A" * 68, "observer_key_path": __file__,
+                  "progress_path": "/workspace/live/progress", "group_id": "/g/b", "vm_id": "/g/b/vm", "instance_id": B_INSTANCE,
+                "host": "52.174.10.5"}
+        client = {"client_group": m["client_group"], "client_vm_id": "/g/client/vm", "client_group_id": "/g/client",
+                  "client_instance_id": A_INSTANCE, "run_id": RUN_ID,
+                  "client_sha": m["client_sha"], "client_binary_sha256": m["client_binary_sha256"]}
+        return worker, client
+
+    def run_off(self, m, az, worker, client, directory, seconds=0.2):
+        counter = iter(range(1, 10_000))
+        journal = pathlib.Path(directory) / "journal.ndjson"
+        return client_off.phase_off(az, m, worker, client, str(journal), sample_seconds=1, interval_seconds=seconds,
+                                    reader=lambda *args: {"progress": next(counter), "checkpoint": None, "channel": "answered"})
+
+    def mutations(self, calls):
+        return [c[1][:2] for c in calls if c[0] == "mutate"]
+
+    def test_all_gates_pass_then_only_client_a_is_deallocated(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_off(m, az, worker, client, directory)
+            journal = (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(self.mutations(calls), [("vm", "deallocate")])
+        deallocate = next(c[1] for c in calls if c[1][:2] == ("vm", "deallocate"))
+        self.assertIn(m["client_group"], deallocate)
+        self.assertIn("client", deallocate)
+        self.assertNotIn(m["worker_group"], deallocate)
+        self.assertIn("baseline", journal[0], "the header is the first record")
+        self.assertGreaterEqual(len(journal), 2)
+        # A one-second test cadence cannot satisfy the 15-second verdict; the boundary and
+        # the journal are what this test proves.
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["samples"], len(journal) - 1)
+
+    def test_no_gate_failure_reaches_the_deallocate_call(self):
+        cases = {
+            "bad descriptor": dict(worker_patch={"host_key": "ssh-rsa AAAA"}),
+            "foreign client": dict(client_patch={"client_vm_id": "/g/client/other"}),
+            "replaced worker": dict(plane={"b_vm_id": "/g/b/other"}),
+            "recreated worker": dict(plane={"b_instance": A_INSTANCE}),
+            "recreated client": dict(plane={"a_instance": B_INSTANCE}),
+            "other image": dict(plane={"image": "x.azurecr.io/horizon-remote-worker@sha256:" + "c" * 64}),
+            "worker not running": dict(plane={"b_power": "PowerState/deallocated"}),
+            "client already off": dict(plane={"a_power": "PowerState/deallocated"}),
+            "observer channel unavailable": dict(reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "unavailable"}),
+            "observer key refused": dict(reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"}),
+            "observer key not restricted": dict(reader=lambda *args: {"progress": 3, "checkpoint": None, "channel": "unrestricted"}),
+        }
+        for label, case in cases.items():
+            with self.subTest(label=label):
+                m, az, calls = self.plane(**case.get("plane", {}))
+                worker, client = self.descriptors(m)
+                worker.update(case.get("worker_patch", {}))
+                client.update(case.get("client_patch", {}))
+                with tempfile.TemporaryDirectory() as directory:
+                    if "reader" in case:
+                        result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1,
+                                                      interval_seconds=0.2, reader=case["reader"])
+                    else:
+                        result = self.run_off(m, az, worker, client, directory)
+                self.assertFalse(result["passed"], label)
+                self.assertEqual(self.mutations(calls), [], f"{label}: a gate failure must never deallocate")
+
+    def test_the_client_wait_hands_each_request_what_is_left_of_the_bound(self):
+        m, az, calls = self.plane(a_power="PowerState/running")
+        _, client = self.descriptors(m)
+        budgets = []
+        original = az.run
+
+        def budgeted(args, mutating=False, timeout=0):
+            budgets.append(timeout)
+            return original(args, mutating, timeout)
+
+        az.run = budgeted
+        # Simulated time: sleeps advance the clock instantly and are recorded, so the
+        # bound arithmetic runs exactly without a real second passing.
+        clock = {"now": 1000.0, "sleeps": []}
+
+        def fake_sleep(seconds):
+            clock["sleeps"].append(seconds)
+            clock["now"] += seconds
+
+        real_started = time.monotonic()
+        with mock.patch.object(client_off.time, "monotonic", lambda: clock["now"]), \
+                mock.patch.object(client_off.time, "sleep", fake_sleep):
+            # A that never deallocates against a 60-second bound: the wait ends at the
+            # bound, every request got a share of what was left, no sleep crossed it.
+            problem = client_off.await_client_state(az, m, client, "PowerState/deallocated", bound_seconds=60)
+            self.assertIn("did not reach PowerState/deallocated", problem)
+            self.assertTrue(budgets and all(1 <= budget <= 60 // 5 for budget in budgets), budgets)
+            self.assertEqual(budgets[0], 12, "the first poll shares the whole bound five ways")
+            self.assertLessEqual(clock["now"] - 1000.0, 60, "no sleep crossed the bound")
+            self.assertTrue(all(0 < sleep <= 5 for sleep in clock["sleeps"]), clock["sleeps"])
+            # Below five seconds no poll starts: a poll cannot be cut shorter than its five
+            # one-second requests, so it would overrun the bound.
+            budgets.clear()
+            problem = client_off.await_client_state(az, m, client, "PowerState/deallocated", bound_seconds=4)
+            self.assertEqual(budgets, [])
+            self.assertIn("did not reach", problem)
+        self.assertLess(time.monotonic() - real_started, 3, "the fake answers instantly; only the bound arithmetic runs")
+
+    def test_a_state_counts_only_when_the_identity_around_it_agrees(self):
+        m, az, calls = self.plane(a_power="PowerState/deallocated")
+        _, client = self.descriptors(m)
+        evidence, state = client_off.observe_client_state(az, m, client)
+        self.assertEqual((evidence["a_instance_id"], state), (A_INSTANCE, "PowerState/deallocated"))
+        # A replaced between the identity read and the state read: the state is unreadable.
+        shows = iter([A_INSTANCE, B_INSTANCE])
+        original = az.run
+
+        def flipping(args, mutating=False, timeout=0):
+            answer = original(args, mutating, timeout)
+            if args[:2] == ["vm", "show"] and m["client_group"] in args:
+                answer = dict(answer, vmId=next(shows, B_INSTANCE))
+            return answer
+
+        az.run = flipping
+        evidence, state = client_off.observe_client_state(az, m, client)
+        self.assertEqual(evidence["a_instance_id"], A_INSTANCE)
+        self.assertIsNone(state, "a state between two different identities belongs to neither")
+        # Two identical but failing attestations (a retagged A) yield no state either.
+        m, az, calls = self.plane(a_power="PowerState/deallocated")
+        _, client = self.descriptors(m)
+        _, state = client_off.observe_client_state(az, m, dict(client, client_instance_id=B_INSTANCE))
+        self.assertIsNone(state, "a stable identity that is not the provisioned one yields no state")
+
+    def test_off_and_return_read_a_identity_together_with_its_state_around_the_mutation(self):
+        # The fake reports A's identity from the plane; every power read of A is preceded
+        # by a fresh `vm show` and `group show` of A (the attestation), before the
+        # mutation and on every poll after it, and each sample carries A's instance.
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_off(m, az, worker, client, directory)
+            journal = (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()
+        client_group = m["client_group"]
+        mutation = next(i for i, c in enumerate(calls) if c[0] == "mutate")
+        before = [c for c in calls[:mutation] if c[1][:2] == ("vm", "show") and client_group in c[1]]
+        self.assertGreaterEqual(len(before), 2, "attested at the gate and again immediately before the call")
+        # Immediately before the call: identity, state, identity again (one bound read).
+        self.assertEqual([c[1][:2] for c in calls[mutation - 5:mutation]],
+                         [("group", "show"), ("vm", "show"), ("vm", "get-instance-view"), ("group", "show"), ("vm", "show")],
+                         f"the state read is bracketed by A's identity: {calls[mutation - 6:mutation]}")
+        self.assertTrue(all(json.loads(line).get("a_instance_id") == A_INSTANCE for line in journal[1:]), journal[:2])
+        expected_tags = client_off.client_tags(m)
+        for line in journal[1:]:
+            row = json.loads(line)
+            self.assertEqual((row["a_group_id"], row["a_vm_id"], row["a_tags"], row["a_group_tags"]),
+                             ("/g/client", "/g/client/vm", expected_tags, expected_tags), "the attestation evidence is journaled")
+        # A retagged after the deallocation is recorded as unattested in every later sample.
+        m, az, calls = self.plane(retag_client_after_deallocate=True)
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_off(m, az, worker, client, directory, seconds=1.5)
+            journal = (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()
+        tags_seen = [json.loads(line).get("a_tags", {}).get("run_id") for line in journal[1:]]
+        self.assertIn("f" * 32, tags_seen, journal[:3])
+        self.assertFalse(result["passed"])  # the verdict's own rule on the evidence is covered in test_core
+        m, az, calls = self.plane(a_power="PowerState/deallocated")
+        _, client = self.descriptors(m)
+        result = client_off.phase_return(az, m, client)
+        self.assertEqual(self.mutations(calls), [("vm", "start")])
+        mutation = next(i for i, c in enumerate(calls) if c[0] == "mutate")
+        self.assertEqual([c[1][:2] for c in calls[mutation - 5:mutation]],
+                         [("group", "show"), ("vm", "show"), ("vm", "get-instance-view"), ("group", "show"), ("vm", "show")],
+                         "return brackets A's state with its identity immediately before starting it")
+
+    def test_a_sample_is_unattested_when_b_changes_around_the_reading(self):
+        # B's instance flips between the identity read before and after the reading.
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        original = az.run
+
+        def flipping(args, mutating=False, timeout=0):
+            answer = original(args, mutating, timeout)
+            if args[:2] == ["vm", "show"] and m["worker_group"] in args:
+                # After the mutation, B's identity reads come in pairs per sample (before
+                # and after the reading): the second read of the first sample sees another
+                # instance.
+                mutated = next((i for i, c in enumerate(calls) if c[0] == "mutate"), None)
+                reads_after = 0 if mutated is None else sum(
+                    1 for c in calls[mutated:] if c[1][:2] == ("vm", "show") and m["worker_group"] in c[1])
+                answer = dict(answer, vmId=A_INSTANCE if reads_after == 2 else B_INSTANCE)
+            return answer
+
+        az.run = flipping
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_off(m, az, worker, client, directory, seconds=0.2)
+            journal = (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()
+        first = json.loads(journal[1])
+        self.assertEqual(first["b_instance_id"], B_INSTANCE, "the identity read before the reading is what the sample names")
+        self.assertIsNone(first["b_power"], "a state read between two different B identities belongs to neither")
+        self.assertIsNone(first["progress"], "so does the reading")
+        self.assertFalse(result["passed"])
+        # The observation instant is the start of the sample, before any acquisition.
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        slow = az.run
+
+        def slow_run(args, mutating=False, timeout=0):
+            if args[:3] == ["network", "public-ip", "show"]:
+                time.sleep(0.3)
+            return slow(args, mutating, timeout)
+
+        az.run = slow_run
+        with tempfile.TemporaryDirectory() as directory:
+            self.run_off(m, az, worker, client, directory, seconds=0.2)
+            journal = (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()
+        row = json.loads(journal[1])
+        lag = (client_off.parse_utc(row["at"]) - client_off.parse_utc(row["scheduled_at"])).total_seconds()
+        self.assertLess(lag, 0.25, f"acquisition latency does not make the sample late: {lag}s")
+
+    def test_phases_bind_themselves_to_the_manifest_deadline(self):
+        # A deadline that leaves nothing after the reserved margin: nothing is stopped.
+        m, az, calls = self.plane(deadline_in=dt.timedelta(minutes=client_off.AFTER_OFF_MINUTES))
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_off(m, az, worker, client, directory)
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("reserved margin" in f for f in result["findings"]), result)
+        self.assertEqual(self.mutations(calls), [])
+        # With time left, the phase deadline is armed on the az client and the return
+        # phase keeps the cleanup window: its deadline is earlier than the off phase's.
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            self.run_off(m, az, worker, client, directory)
+        off_deadline = az.deadline
+        self.assertIsNotNone(off_deadline)
+        m2, az2, _ = self.plane(a_power="PowerState/deallocated")
+        m2["cleanup_deadline_utc"] = m["cleanup_deadline_utc"]
+        client_off.phase_return(az2, m2, client)
+        self.assertGreater(az2.deadline, off_deadline, "the return may run later, keeping only the cleanup bound")
+        # Past its deadline the az client asks ARM nothing more.
+        real = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100")
+        real.deadline = time.monotonic() - 1
+        with mock.patch.object(client_off.subprocess, "run", side_effect=AssertionError("must not be called")):
+            self.assertIsNone(real.run(["group", "exists", "-n", "g"]))
+        real.deadline = time.monotonic() + 30
+        with mock.patch.object(client_off.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout="true")
+            real.run(["group", "exists", "-n", "g"], timeout=90)
+            self.assertLessEqual(run.call_args.kwargs["timeout"], 30, "a call is cut off at the phase deadline")
+
+    def test_observations_get_what_is_left_of_the_phase_and_none_starts_too_late(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        budgets = []
+
+        def reader(*args):
+            budgets.append(args[5] if len(args) > 5 else None)
+            return {"progress": len(budgets), "checkpoint": None, "channel": "answered"}
+
+        with tempfile.TemporaryDirectory() as directory:
+            client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1, interval_seconds=0.2,
+                                 reader=reader)
+        self.assertTrue(budgets and all(b is not None and 0 < b <= client_off.OBSERVATION_SECONDS for b in budgets), budgets)
+        # With the phase deadline only seconds away, the probe is not even started.
+        m, az, calls = self.plane(deadline_in=dt.timedelta(minutes=client_off.AFTER_OFF_MINUTES, seconds=70))
+        worker, client = self.descriptors(m)
+        budgets.clear()
+        with tempfile.TemporaryDirectory() as directory:
+            result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1,
+                                          interval_seconds=0.2, reader=reader)
+        self.assertEqual(self.mutations(calls), [], "an interval that cannot fit before the deadline stops nothing")
+        self.assertTrue(any("do not fit" in f for f in result["findings"]), result)
+        # read_observations itself refuses a budget below the minimum without dialling.
+        with mock.patch.object(client_off.subprocess, "Popen", side_effect=AssertionError("must not dial")):
+            self.assertEqual(client_off.read_observations("52.174.10.5", 2222, "ssh-ed25519 " + "A" * 68, "/dev/null", "/tmp", 5)["channel"],
+                             "unavailable")
+
+    def test_a_sample_from_a_channel_that_is_not_the_restricted_reader_is_unreadable(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        answers = iter([{"progress": 1, "checkpoint": None, "channel": "answered"}])  # the gate probe
+        later = {"progress": 9, "checkpoint": None, "channel": "unrestricted"}
+        with tempfile.TemporaryDirectory() as directory:
+            client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1, interval_seconds=0.2,
+                                 reader=lambda *args: next(answers, later))
+            journal = (pathlib.Path(directory) / "j.ndjson").read_text(encoding="utf-8").splitlines()
+        rows = [json.loads(line) for line in journal[1:]]
+        self.assertTrue(rows and all(row["progress"] is None and row["b_power"] is None for row in rows), rows)
+        # A dry run keeps its plan in memory and leaves the production journal path alone.
+        m, az, calls = self.plane()
+        az.dry_run = True
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson",
+                                          reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered"})
+            self.assertFalse(os.path.exists(f"{directory}/j.ndjson"), "no header is left behind")
+        self.assertTrue(result["dry_run"])
+
+    def test_a_refusal_before_the_deallocation_leaves_no_journal_behind(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1,
+                                          interval_seconds=0.2,
+                                          reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "unavailable"})
+            self.assertFalse(result["passed"])
+            self.assertFalse(os.path.exists(f"{directory}/j.ndjson"), "the same path can be retried")
+            self.assertEqual(self.mutations(calls), [])
+            # Once the deallocation is attempted, the header exists first.
+            result = self.run_off(m, az, worker, client, directory)
+            self.assertIn("baseline", (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()[0])
+
+    def test_a_sample_reads_the_client_before_the_worker_and_the_observation(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            self.run_off(m, az, worker, client, directory, seconds=0.2)
+        mutation = next(i for i, c in enumerate(calls) if c[0] == "mutate")
+        after = [c[1] for c in calls[mutation + 1:]]
+        # The first worker read after the deallocation belongs to the first sample, and
+        # the five reads right before it are A's bracketed state: A is read first.
+        worker_first = next(i for i, c in enumerate(after) if m["worker_group"] in c)
+        bracket = [c[:2] for c in after[worker_first - 5:worker_first]]
+        self.assertEqual(bracket, [("group", "show"), ("vm", "show"), ("vm", "get-instance-view"), ("group", "show"), ("vm", "show")])
+        self.assertTrue(all(m["client_group"] in c for c in after[worker_first - 5:worker_first]))
+
+    def test_a_journal_that_cannot_be_written_is_removed_again(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        real_fsync = os.fsync
+
+        def failing_fsync(fd):
+            raise OSError("disk full")
+
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(client_off.os, "fsync", failing_fsync):
+            result = self.run_off(m, az, worker, client, directory)
+            self.assertFalse(os.path.exists(f"{directory}/journal.ndjson"), "the path stays retryable")
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("cannot be written" in f for f in result["findings"]), result)
+        self.assertEqual(self.mutations(calls), [], "nothing was stopped")
+        os.fsync = real_fsync
+
+    def test_the_slot_at_the_end_of_the_interval_is_still_sampled(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_off(m, az, worker, client, directory, seconds=3)
+            journal = (pathlib.Path(directory) / "journal.ndjson").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(result["samples"], 4, "slots at 0, 1, 2 and 3 seconds: the interval is closed on its end")
+        first, last = json.loads(journal[1]), json.loads(journal[-1])
+        span = (client_off.parse_utc(last["scheduled_at"]) - client_off.parse_utc(first["scheduled_at"])).total_seconds()
+        self.assertEqual(span, 3)
+
+    def test_dry_run_off_journals_the_intended_call_and_never_waits(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        az.dry_run = True
+        started = time.monotonic()
+        with tempfile.TemporaryDirectory() as directory:
+            result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson",
+                                          reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered"})
+        self.assertLess(time.monotonic() - started, 5, "a dry run returns without polling for a state it never caused")
+        self.assertFalse(result["passed"])
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(self.mutations(calls), [("vm", "deallocate")], "the intended call is journaled, not issued")
+
+    def test_return_requires_a_deallocated_client(self):
+        m, az, calls = self.plane(a_power="PowerState/running")
+        _, client = self.descriptors(m)
+        result = client_off.phase_return(az, m, client)
+        self.assertFalse(result["passed"])
+        self.assertEqual(self.mutations(calls), [], "a running client is never re-started")
+        m, az, calls = self.plane(a_power="PowerState/deallocated")
+        az.dry_run = True
+        started = time.monotonic()
+        result = client_off.phase_return(az, m, client)
+        self.assertLess(time.monotonic() - started, 5, "a dry run never waits for a start it did not issue")
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(self.mutations(calls), [("vm", "start")], "the intended call is journaled, not issued")
+
+    def test_existing_journal_blocks_the_mutation(self):
+        m, az, calls = self.plane()
+        worker, client = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            (pathlib.Path(directory) / "journal.ndjson").write_text("old\n", encoding="utf-8")
+            result = self.run_off(m, az, worker, client, directory)
+        self.assertFalse(result["passed"])
+        self.assertEqual(self.mutations(calls), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (client-off acceptance tooling for #475, second slice; does not complete either issue). Built on the merged harness core (#557).

## Why

The harness crossed the per-PR size limits during its review rounds, so it lands in slices. This one carries everything that mutates or provisions. The observer-key lifecycle (`observer-key-line`, `install-observer-key`, `remove-observer-key`) with the forced reader, the clean-tree build-record script (`record-client-build.sh`) and the provisioning script (`provision-client.sh`) follow in their own slices, opened right after this one merges; the runbook names them and keeps their contracts. They were moved out after the review rounds pushed this slice past the 1,500-line ceiling.

## What

- `clientoff/observer.py`: worker descriptor gates (fixed VM name `worker`, plain paths) and observer C's pinned, channel-aware read: every session requests a pty and a remote port forward and reports `answered` only when both are denied and the forced reader replied; otherwise `unrestricted`, `refused` (explicit publickey refusal under the pinned host key) or `unavailable`. The forced reader itself and its authorized_keys line arrive with the observer-key lifecycle slice.
- `clientoff/phases.py`: attestation of the exact A (ARM IDs, `vmId`, full tag set including the run identity) and B (baseline IDs, `vmId`, image tag, running) from ARM; every state read of A is bracketed by two attestations and counts only when both pass on the same evidence; `off` (gates, exclusive journal with baseline header, deallocate A only, fixed-schedule sampling whose samples take their instant at the start, persist A's attestation evidence and bracket B's state and reading with two identity reads), `return` (same attestation, start A only). Waits hand each request a share of the remaining bound. Dry runs return the plan.
- `client_off.py`: adds `off` and `return`.
- `provision-client.sh`: A in the manifest's run-named group under a 30-minute bound with the kill grace inside it; descriptor and journal reserved before the first cloud call; key pair (no passphrase prompt) and SKU checked before any create; globally routable source range; control-plane host key accepted only as exactly one key line with empty stderr; identities read back with shape checks; exact build copied and digest-verified; launch gate.
- `docs/testing/azure-client-off-acceptance.md`: runbook, manifest, labelling (adapter-only rehearsal vs product pass), observer-key removal, cleanup.
- Tests: deterministic cases over a fake control plane: which `az` calls happen, in which order, on which resource; the probe's channel outcomes; the sampler's schedule, deadline and evidence.

## Validation

Full local matrix green on this head: fmt, maintainability, version sync, preflight and harness tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic.