### PR TITLE
feat(cloud): expose the Azure deployment target validation as one helper

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/deployment.rs
@@ -60,14 +60,9 @@ impl AzureDeploymentPlan {
     /// time-limited Azure worker needs a provider-side power bound that this adapter
     /// does not provide yet, so it is refused rather than silently made persistent.
     pub fn new(profile: &AzureProfile, request: &InteractiveWorkerRequest) -> Result<Self, AzureError> {
-        profile.validate_target(&request.target)?;
-        if !request.is_valid_for(crate::cloud_run::CloudProvider::Azure) || !shell_safe(&request.target.image) {
-            return Err(AzureError::InvalidTarget);
-        }
-        if request.target.lifetime != WorkerLifetime::Persistent {
-            return Err(AzureError::UnsupportedLifetime);
-        }
-        if request.target.disk_gib > MAX_DATA_DISK_GIB {
+        Self::validate_target(profile, &request.target)?;
+        // Beyond the target: the request's own shape and the client key.
+        if !request.is_valid_for(crate::cloud_run::CloudProvider::Azure) {
             return Err(AzureError::InvalidTarget);
         }
         let tags = worker_tags(request);
@@ -89,6 +84,29 @@ impl AzureDeploymentPlan {
             template: template(),
             parameters,
         })
+    }
+}
+
+impl AzureDeploymentPlan {
+    /// The complete target-only contract a deployment applies, for a caller that must
+    /// refuse a target before saving intent, reading credentials or allocating and has
+    /// no request or client key yet: the profile fit (provider, profile name, image on
+    /// the declared registry, cost limit, provider-neutral target shape), a persistent
+    /// lifetime, a data disk within the single-sourced maximum, and an image reference
+    /// made only of bytes that can never reach a shell line. [`Self::new`] applies
+    /// exactly this and then the request and key checks; there is no second copy.
+    /// # Errors
+    /// [`AzureError::InvalidProfile`], [`AzureError::InvalidTarget`],
+    /// [`AzureError::DeclaredCostExceedsLimit`] or [`AzureError::UnsupportedLifetime`].
+    pub fn validate_target(profile: &AzureProfile, target: &WorkerTarget) -> Result<(), AzureError> {
+        profile.validate_target(target)?;
+        if target.lifetime != WorkerLifetime::Persistent {
+            return Err(AzureError::UnsupportedLifetime);
+        }
+        if target.disk_gib > MAX_DATA_DISK_GIB || !shell_safe(&target.image) {
+            return Err(AzureError::InvalidTarget);
+        }
+        Ok(())
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
@@ -308,3 +308,88 @@ fn plan_rejects_unsupported_lifetimes_and_targets_before_any_io() {
         Err(AzureError::InvalidProfile)
     );
 }
+
+type Mutation = Box<dyn Fn(&mut InteractiveWorkerRequest)>;
+
+#[test]
+fn target_validation_is_complete_single_sourced_and_shared_with_the_constructor() {
+    let ok = request("");
+    assert_eq!(AzureDeploymentPlan::validate_target(&profile(), &ok.target), Ok(()));
+    // Boundaries: the disk maximum and the accepted image bytes.
+    let mut edge = request("");
+    edge.target.disk_gib = 4_095;
+    assert_eq!(AzureDeploymentPlan::validate_target(&profile(), &edge.target), Ok(()));
+    assert!(AzureDeploymentPlan::new(&profile(), &edge).is_ok());
+    let mut over = request("");
+    over.target.disk_gib = 4_096;
+    assert_eq!(
+        AzureDeploymentPlan::validate_target(&profile(), &over.target),
+        Err(AzureError::InvalidTarget)
+    );
+    let mut zero = request("");
+    zero.target.disk_gib = 0;
+    assert_eq!(
+        AzureDeploymentPlan::validate_target(&profile(), &zero.target),
+        Err(AzureError::InvalidTarget)
+    );
+    // Every target-only refusal the constructor makes is made by the helper first, with
+    // the same error, and every helper acceptance is accepted by the constructor: one
+    // contract, no second copy.
+    let cases: Vec<(&str, Mutation)> = vec![
+        (
+            "time-limited lifetime",
+            Box::new(|r| r.target.lifetime = WorkerLifetime::TimeLimited { seconds: 600 }),
+        ),
+        (
+            "other registry",
+            Box::new(|r| r.target.image = IMAGE.replace("example.azurecr.io", "other.azurecr.io")),
+        ),
+        (
+            "mutable tag",
+            Box::new(|r| r.target.image = "example.azurecr.io/horizon-remote-worker:latest".into()),
+        ),
+        (
+            "shell text in image",
+            Box::new(|r| r.target.image = format!("{IMAGE};id")),
+        ),
+        ("space in image", Box::new(|r| r.target.image = format!("{IMAGE} x"))),
+        (
+            "other profile name",
+            Box::new(|r| r.target.profile = "cpu-south".into()),
+        ),
+        (
+            "cost limit below declared",
+            Box::new(|r| r.target.max_hourly_cost_micros = Some(1)),
+        ),
+        (
+            "zero cost limit",
+            Box::new(|r| r.target.max_hourly_cost_micros = Some(0)),
+        ),
+        ("disk over maximum", Box::new(|r| r.target.disk_gib = 4_096)),
+    ];
+    for (label, mutate) in cases {
+        let mut request = request("");
+        mutate(&mut request);
+        let helper = AzureDeploymentPlan::validate_target(&profile(), &request.target);
+        let constructor = AzureDeploymentPlan::new(&profile(), &request).map(|_| ());
+        assert!(helper.is_err(), "{label}: helper accepts");
+        assert_eq!(helper, constructor, "{label}: helper and constructor disagree");
+    }
+    // What the helper cannot see is still refused by the constructor: the client key.
+    let mut bad_key = request("");
+    bad_key.ssh_public_key = "ssh-rsa AAAA".into();
+    assert_eq!(
+        AzureDeploymentPlan::validate_target(&profile(), &bad_key.target),
+        Ok(())
+    );
+    assert_eq!(
+        AzureDeploymentPlan::new(&profile(), &bad_key),
+        Err(AzureError::InvalidTarget)
+    );
+    let mut bad_profile = profile();
+    bad_profile.location = "North Europe".into();
+    assert_eq!(
+        AzureDeploymentPlan::validate_target(&bad_profile, &request("").target),
+        Err(AzureError::InvalidProfile)
+    );
+}


### PR DESCRIPTION
## Summary

Azure-owned prerequisite requested on #474 for the lead's configured preview (part of #474; the issue stays open). Two files: `crates/horizon-core/src/cloud_run/azure/deployment.rs` and its test module.

- `AzureDeploymentPlan::validate_target(&AzureProfile, &WorkerTarget) -> Result<(), AzureError>`: the complete target-only contract in one place: profile fit through `AzureProfile::validate_target` (provider, profile name, image on the declared registry, cost limit, provider-neutral shape), persistent lifetime (`UnsupportedLifetime`), data disk within the single-sourced maximum, and an image reference made only of shell-safe bytes (`InvalidTarget`).
- `AzureDeploymentPlan::new` calls the helper first and then applies only what the helper cannot see: the request shape and the Ed25519 client key. Error semantics are unchanged; the disk bound and the accepted image bytes have no second copy.

No I/O, no new dependency, no shared configuration, dispatcher, UI or schema change.

## Tests

`target_validation_is_complete_single_sourced_and_shared_with_the_constructor`: disk maximum edge accepted by both, over and zero refused; for nine target-only refusals (time-limited lifetime, other registry, mutable tag, shell text or a space in the image, other profile name, cost limit below declared or zero, disk over maximum) the helper refuses and returns the same error as the constructor; a bad client key passes the helper and is refused by the constructor; an invalid profile is `InvalidProfile`. The existing deployment tests are unchanged and still pass.

## Validation

Full matrix on the pushed head in a task-owned worktree: fmt, maintainability, version sync, preflight unit tests, `cargo test --workspace` (default and `speech`), clippy blocking, clippy strict, clippy pedantic.
