### PR TITLE
feat(storage): reserve immutable provider binding schema

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -11,7 +11,7 @@ use rusqlite::{Connection, OpenFlags, TransactionBehavior};
 
 use super::{CloudStoreError, remote_workspaces::creation_fences};
 
-const STORE_SCHEMA_VERSION: i64 = 6;
+const STORE_SCHEMA_VERSION: i64 = 7;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS cloud_workflows (
@@ -87,6 +87,24 @@ const NETWORK_VOLUME_SCHEMA: [&str; 3] = [
 ) STRICT, WITHOUT ROWID",
     "CREATE TRIGGER remote_network_volume_selections_no_update BEFORE UPDATE ON remote_network_volume_selections BEGIN SELECT RAISE(ABORT, 'network volume selections are immutable'); END",
     "CREATE TRIGGER remote_network_volume_selections_no_delete BEFORE DELETE ON remote_network_volume_selections BEGIN SELECT RAISE(ABORT, 'network volume selections are immutable'); END",
+];
+
+// Frozen version-one identity binding, not provider observation or creation authority.
+const PROVIDER_BINDING_SCHEMA: [&str; 4] = [
+    r"CREATE TABLE remote_provider_bindings (
+    workspace_local_id TEXT PRIMARY KEY NOT NULL REFERENCES remote_runtime_allocations(workspace_local_id),
+    session_id TEXT NOT NULL CHECK (length(session_id) = 36),
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    workflow_id TEXT NOT NULL UNIQUE CHECK (length(workflow_id) = 36),
+    job_id TEXT NOT NULL UNIQUE CHECK (length(job_id) = 36),
+    version INTEGER NOT NULL CHECK (version = 1),
+    provider TEXT NOT NULL CHECK (provider = 'azure'),
+    subscription_id TEXT NOT NULL CHECK (length(subscription_id) = 36),
+    profile_digest TEXT NOT NULL CHECK (length(CAST(profile_digest AS BLOB)) = 64 AND length(profile_digest) = 64 AND profile_digest NOT GLOB '*[^0-9a-f]*')
+) STRICT, WITHOUT ROWID",
+    "CREATE TRIGGER remote_provider_bindings_no_replace BEFORE INSERT ON remote_provider_bindings WHEN EXISTS(SELECT 1 FROM remote_provider_bindings WHERE workspace_local_id = NEW.workspace_local_id OR workflow_id = NEW.workflow_id OR job_id = NEW.job_id) BEGIN SELECT RAISE(ABORT, 'provider binding already exists'); END",
+    "CREATE TRIGGER remote_provider_bindings_no_update BEFORE UPDATE ON remote_provider_bindings BEGIN SELECT RAISE(ABORT, 'provider bindings are immutable'); END",
+    "CREATE TRIGGER remote_provider_bindings_no_delete BEFORE DELETE ON remote_provider_bindings BEGIN SELECT RAISE(ABORT, 'provider bindings are immutable'); END",
 ];
 
 pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
@@ -167,6 +185,14 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
         }
     }
     validate_network_volume_schema(&transaction)?;
+    if version < 7 {
+        // Legacy profile names never imply an approved subscription or placement.
+        validate_no_provider_binding_schema(&transaction)?;
+        for definition in PROVIDER_BINDING_SCHEMA {
+            transaction.execute_batch(definition)?;
+        }
+    }
+    validate_provider_binding_schema(&transaction)?;
     transaction.pragma_update(None, "user_version", STORE_SCHEMA_VERSION)?;
     transaction.commit()?;
     Ok(())
@@ -174,13 +200,18 @@ pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), Cloud
 
 pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), CloudStoreError> {
     let version = connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
-    let legacy_read = matches!(version, 4 | 5) && connection.is_readonly(rusqlite::MAIN_DB)?;
+    let legacy_read = matches!(version, 4..=6) && connection.is_readonly(rusqlite::MAIN_DB)?;
     if version != STORE_SCHEMA_VERSION && !legacy_read {
         return Err(CloudStoreError::UnsupportedSchema(version));
     }
     validate_allocation_schema(connection)?;
     creation_fences::validate_schema(connection)?;
-    if legacy_read {
+    if version < 7 {
+        validate_no_provider_binding_schema(connection)?;
+    } else {
+        validate_provider_binding_schema(connection)?;
+    }
+    if version < 6 {
         let partial: bool = connection.query_row(
             "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema
              WHERE tbl_name = 'remote_network_volume_selections' COLLATE NOCASE
@@ -209,8 +240,36 @@ pub(super) fn ensure_current_schema(connection: &Connection) -> Result<(), Cloud
         };
     }
     validate_first_pin_schema(connection)?;
-    if version == STORE_SCHEMA_VERSION {
+    if version >= 6 {
         validate_network_volume_schema(connection)?;
+    }
+    Ok(())
+}
+
+fn validate_no_provider_binding_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    let partial: bool = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema
+         WHERE tbl_name = 'remote_provider_bindings' COLLATE NOCASE
+            OR name LIKE 'remote_provider_bindings%')",
+        [],
+        |row| row.get(0),
+    )?;
+    if partial {
+        return Err(CloudStoreError::InvalidAllocationSchema);
+    }
+    Ok(())
+}
+
+fn validate_provider_binding_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    let matches: bool = connection.query_row(
+        "SELECT COUNT(*) = 4 AND COUNT(CASE WHEN sql IN (?1, ?2, ?3, ?4) THEN 1 END) = 4
+         FROM main.sqlite_schema WHERE (tbl_name = 'remote_provider_bindings' COLLATE NOCASE
+             OR name LIKE 'remote_provider_bindings%') AND sql IS NOT NULL",
+        PROVIDER_BINDING_SCHEMA,
+        |row| row.get(0),
+    )?;
+    if !matches {
+        return Err(CloudStoreError::InvalidAllocationSchema);
     }
     Ok(())
 }

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -250,7 +250,7 @@ fn validate_no_provider_binding_schema(connection: &Connection) -> Result<(), Cl
     let partial: bool = connection.query_row(
         "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema
          WHERE tbl_name = 'remote_provider_bindings' COLLATE NOCASE
-            OR name LIKE 'remote_provider_bindings%')",
+            OR name LIKE 'remote!_provider!_bindings%' ESCAPE '!')",
         [],
         |row| row.get(0),
     )?;
@@ -264,7 +264,7 @@ fn validate_provider_binding_schema(connection: &Connection) -> Result<(), Cloud
     let matches: bool = connection.query_row(
         "SELECT COUNT(*) = 4 AND COUNT(CASE WHEN sql IN (?1, ?2, ?3, ?4) THEN 1 END) = 4
          FROM main.sqlite_schema WHERE (tbl_name = 'remote_provider_bindings' COLLATE NOCASE
-             OR name LIKE 'remote_provider_bindings%') AND sql IS NOT NULL",
+             OR name LIKE 'remote!_provider!_bindings%' ESCAPE '!') AND sql IS NOT NULL",
         PROVIDER_BINDING_SCHEMA,
         |row| row.get(0),
     )?;

--- a/crates/horizon-core/src/cloud_run/store/database/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests.rs
@@ -4,6 +4,7 @@ use crate::cloud_run::{CloudProvider, GitCommitSha, GitSource};
 use crate::remote_workspace::{RemoteWorkspaceSpec, RemoteWorkspaceState};
 use rusqlite::params;
 
+mod provider_bindings;
 mod reads;
 
 const OWNER: &str = "11111111-1111-4111-8111-111111111111";
@@ -110,7 +111,7 @@ fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations
     let connection = open_connection(fixture.store.path()).expect("raw store");
     connection
         .execute_batch(
-            "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences;
+            "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences;
              DROP TABLE remote_runtime_allocations; PRAGMA user_version=2;",
         )
         .expect("schema two fixture");
@@ -121,7 +122,7 @@ fn schema_two_upgrade_preserves_records_and_claims_without_inventing_allocations
         connection
             .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
             .expect("version"),
-        6
+        7
     );
     assert_eq!(allocation_count(&connection), 0);
     let workflow = fixture.workflow.workflow();

--- a/crates/horizon-core/src/cloud_run/store/database/tests/provider_bindings.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests/provider_bindings.rs
@@ -1,0 +1,245 @@
+use super::*;
+use crate::cloud_run::StoredRemoteAllocation;
+
+const SUBSCRIPTION: &str = "00000000-0000-4000-8000-000000000001";
+
+fn allocated() -> (Fixture, StoredRemoteAllocation) {
+    let mut fixture = fixture();
+    let mut state = fixture.workspace.state().clone();
+    state.spec.target.provider = CloudProvider::Azure;
+    fixture.workspace = fixture
+        .store
+        .replace_remote_workspace(&fixture.workspace, &state)
+        .expect("synthetic CPU workspace");
+    let allocation = fixture
+        .store
+        .allocate_remote_runtime(&fixture.workspace, i64::MAX)
+        .expect("allocation");
+    (fixture, allocation)
+}
+
+fn insert(connection: &Connection, allocation: &StoredRemoteAllocation) {
+    let runtime = allocation.workspace().state().runtime.as_ref().expect("runtime");
+    connection
+        .execute(
+            "INSERT INTO remote_provider_bindings VALUES (?1, ?2, ?3, ?4, ?5, 1, 'azure', ?6, ?7)",
+            params![
+                allocation.workspace().state().spec.workspace_local_id,
+                allocation.workspace().session_id(),
+                i64::try_from(runtime.generation).expect("synthetic generation"),
+                runtime.workflow_id.to_string(),
+                runtime.job_id.to_string(),
+                SUBSCRIPTION,
+                "a".repeat(64)
+            ],
+        )
+        .expect("synthetic schema row, not runtime dispatch");
+}
+
+fn binding_count(connection: &Connection) -> i64 {
+    connection
+        .query_row("SELECT COUNT(*) FROM remote_provider_bindings", [], |row| row.get(0))
+        .expect("count")
+}
+
+#[test]
+fn schema_six_reads_and_upgrade_preserve_allocations_without_backfilling_profiles() {
+    let (fixture, allocation) = allocated();
+    let connection = open_connection(fixture.store.path()).expect("raw store");
+    connection
+        .execute_batch("DROP TABLE remote_provider_bindings; PRAGMA user_version=6")
+        .expect("legacy fixture");
+    let before = saved_bytes(&connection);
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("legacy reader");
+    assert_eq!(
+        reader.load_remote_allocation(OWNER, "workspace").expect("allocation"),
+        Some(allocation.clone())
+    );
+    assert_eq!(saved_bytes(&connection), before);
+    assert_eq!(
+        connection
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .expect("version"),
+        6
+    );
+    assert!(matches!(
+        fixture.store.validate_unclaimed_remote_setup(&allocation),
+        Err(crate::cloud_run::RemoteWorkspaceStoreError::Storage(
+            CloudStoreError::UnsupportedSchema(6)
+        ))
+    ));
+    let upgraded = CloudWorkflowStore::open_path(fixture.store.path()).expect("upgrade");
+    assert_eq!(saved_bytes(&connection), before);
+    assert_eq!(binding_count(&connection), 0);
+    assert_eq!(
+        upgraded.load_remote_allocation(OWNER, "workspace").expect("allocation"),
+        Some(allocation)
+    );
+    CloudWorkflowStore::open_path(fixture.store.path()).expect("idempotent upgrade");
+    assert_eq!(binding_count(&connection), 0);
+    assert_eq!(saved_bytes(&connection), before);
+}
+
+#[test]
+fn provider_rows_reject_update_delete_and_insert_or_replace() {
+    let (fixture, allocation) = allocated();
+    let connection = open_connection(fixture.store.path()).expect("raw store");
+    insert(&connection, &allocation);
+    let before = saved_bytes(&connection);
+    for sql in [
+        "UPDATE remote_provider_bindings SET subscription_id = '00000000-0000-4000-8000-000000000002'",
+        "UPDATE remote_provider_bindings SET profile_digest = lower(hex(randomblob(32)))",
+        "DELETE FROM remote_provider_bindings",
+        "INSERT OR REPLACE INTO remote_provider_bindings SELECT * FROM remote_provider_bindings",
+        "INSERT INTO remote_provider_bindings SELECT * FROM remote_provider_bindings WHERE true ON CONFLICT DO NOTHING",
+    ] {
+        assert_eq!(
+            connection
+                .execute_batch(sql)
+                .expect_err("immutable binding")
+                .sqlite_error_code(),
+            Some(rusqlite::ErrorCode::ConstraintViolation),
+            "{sql}"
+        );
+        assert_eq!(binding_count(&connection), 1);
+        assert_eq!(saved_bytes(&connection), before);
+        let subscription: String = connection
+            .query_row("SELECT subscription_id FROM remote_provider_bindings", [], |row| {
+                row.get(0)
+            })
+            .expect("original subscription");
+        assert_eq!(subscription, SUBSCRIPTION);
+    }
+    CloudWorkflowStore::open_path(fixture.store.path()).expect("reopen with retained metadata");
+}
+
+#[test]
+fn malformed_provider_schema_fails_without_repair_or_snapshot_changes() {
+    for sql in [
+        "DROP TABLE remote_provider_bindings",
+        "DROP TRIGGER remote_provider_bindings_no_replace",
+        "DROP TRIGGER remote_provider_bindings_no_update",
+        "DROP TRIGGER remote_provider_bindings_no_delete",
+        "CREATE INDEX unexpected_provider_index ON remote_provider_bindings(subscription_id)",
+        "CREATE INDEX remote_provider_bindings_orphan ON cloud_workflows(created_at_millis)",
+        "ALTER TABLE remote_provider_bindings ADD COLUMN unexpected TEXT",
+    ] {
+        let (fixture, allocation) = allocated();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        let before = saved_bytes(&connection);
+        connection.execute_batch(sql).expect("corrupt schema fixture");
+        assert!(matches!(
+            CloudWorkflowStore::open_path(fixture.store.path()),
+            Err(CloudStoreError::InvalidAllocationSchema)
+        ));
+        assert!(CloudWorkflowStore::open_read_only_path(fixture.store.path()).is_err());
+        assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
+        assert_eq!(saved_bytes(&connection), before);
+        assert_eq!(allocation_count(&connection), 1);
+        assert_eq!(allocation.workspace().state().spec.generation, 1);
+    }
+}
+
+#[test]
+fn legacy_partial_provider_objects_do_not_gain_a_binding_or_schema_upgrade() {
+    for (version, orphan) in [(4, false), (5, false), (6, false), (4, true), (5, true), (6, true)] {
+        let (fixture, _) = allocated();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        if orphan {
+            connection
+                .execute_batch("DROP TABLE remote_provider_bindings; CREATE INDEX remote_provider_bindings_orphan ON cloud_workflows(created_at_millis)")
+                .expect("isolated partial namespace");
+        }
+        if version < 6 {
+            connection
+                .execute_batch("DROP TABLE remote_network_volume_selections")
+                .expect("v5");
+        }
+        if version == 4 {
+            connection
+                .execute_batch("DROP TABLE remote_first_pin_intents")
+                .expect("v4");
+        }
+        connection
+            .pragma_update(None, "user_version", version)
+            .expect("legacy version");
+        let before = saved_bytes(&connection);
+        assert!(CloudWorkflowStore::open_read_only_path(fixture.store.path()).is_err());
+        assert!(CloudWorkflowStore::open_path(fixture.store.path()).is_err());
+        assert_eq!(saved_bytes(&connection), before);
+        if orphan {
+            let table_exists: bool = connection
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name='remote_provider_bindings')",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("no table repair");
+            assert!(!table_exists);
+        } else {
+            assert_eq!(binding_count(&connection), 0);
+        }
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("unchanged"),
+            version
+        );
+    }
+}
+
+#[test]
+fn provider_binding_constraints_and_exact_sql_are_enforced() {
+    for (column, value) in [
+        ("session_id", "'short'"),
+        ("generation", "0"),
+        ("version", "2"),
+        ("provider", "'run_pod'"),
+        ("subscription_id", "'short'"),
+        ("profile_digest", "'short'"),
+        ("profile_digest", "printf('%064d', 0) || char(0)"),
+    ] {
+        let (fixture, allocation) = allocated();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        insert(&connection, &allocation);
+        let columns = [
+            "workspace_local_id",
+            "session_id",
+            "generation",
+            "workflow_id",
+            "job_id",
+            "version",
+            "provider",
+            "subscription_id",
+            "profile_digest",
+        ];
+        let projection = columns.map(|name| if name == column { value } else { name }).join(", ");
+        connection
+            .execute_batch("DROP TRIGGER remote_provider_bindings_no_replace")
+            .expect("constraint isolation");
+        let sql = format!(
+            "INSERT OR REPLACE INTO remote_provider_bindings SELECT {projection} FROM remote_provider_bindings"
+        );
+        assert_eq!(
+            connection
+                .execute_batch(&sql)
+                .expect_err("binding constraint")
+                .sqlite_error_code(),
+            Some(rusqlite::ErrorCode::ConstraintViolation),
+            "{column}"
+        );
+        assert_eq!(binding_count(&connection), 1);
+    }
+    let fixture = fixture();
+    let connection = open_connection(fixture.store.path()).expect("raw store");
+    for definition in PROVIDER_BINDING_SCHEMA {
+        let exists: bool = connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE sql = ?1)",
+                [definition],
+                |row| row.get(0),
+            )
+            .expect("frozen SQL");
+        assert!(exists);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/database/tests/provider_bindings.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests/provider_bindings.rs
@@ -122,6 +122,7 @@ fn malformed_provider_schema_fails_without_repair_or_snapshot_changes() {
         "DROP TRIGGER remote_provider_bindings_no_delete",
         "CREATE INDEX unexpected_provider_index ON remote_provider_bindings(subscription_id)",
         "CREATE INDEX remote_provider_bindings_orphan ON cloud_workflows(created_at_millis)",
+        "CREATE INDEX REMOTE_PROVIDER_BINDINGS_orphan ON cloud_workflows(created_at_millis)",
         "ALTER TABLE remote_provider_bindings ADD COLUMN unexpected TEXT",
     ] {
         let (fixture, allocation) = allocated();
@@ -185,6 +186,59 @@ fn legacy_partial_provider_objects_do_not_gain_a_binding_or_schema_upgrade() {
                 .expect("unchanged"),
             version
         );
+    }
+}
+
+#[test]
+fn unrelated_similarly_named_objects_remain_readable_and_upgradeable() {
+    for version in 4..=7 {
+        let (fixture, allocation) = allocated();
+        let connection = open_connection(fixture.store.path()).expect("raw store");
+        if version < 7 {
+            connection
+                .execute_batch("DROP TABLE remote_provider_bindings")
+                .expect("v6");
+        }
+        if version < 6 {
+            connection
+                .execute_batch("DROP TABLE remote_network_volume_selections")
+                .expect("v5");
+        }
+        if version == 4 {
+            connection
+                .execute_batch("DROP TABLE remote_first_pin_intents")
+                .expect("v4");
+        }
+        connection
+            .pragma_update(None, "user_version", version)
+            .expect("fixture version");
+        connection
+            .execute_batch(
+                "CREATE INDEX remoteXprovider_bindings_extra ON cloud_workflows(created_at_millis);
+             CREATE INDEX remote_providerYbindings_extra ON cloud_workflows(created_at_millis)",
+            )
+            .expect("unrelated indexes");
+        let before = saved_bytes(&connection);
+        let reader =
+            CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("unrelated namespace is readable");
+        assert_eq!(
+            reader.load_remote_allocation(OWNER, "workspace").expect("allocation"),
+            Some(allocation.clone())
+        );
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("version"),
+            version
+        );
+        let upgraded =
+            CloudWorkflowStore::open_path(fixture.store.path()).expect("unrelated namespace permits upgrade");
+        assert_eq!(
+            upgraded.load_remote_allocation(OWNER, "workspace").expect("allocation"),
+            Some(allocation)
+        );
+        assert_eq!(saved_bytes(&connection), before);
+        assert_eq!(binding_count(&connection), 0);
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests.rs
@@ -127,7 +127,7 @@ fn allocation_reopens_one_exact_identity_without_consuming_creation_or_reallocat
     Connection::open(store.path())
         .expect("schema-three allocation fixture")
         .execute_batch(
-            "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
+            "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
         )
         .expect("downgrade fixture before recovery");
     let reopened = CloudWorkflowStore::open_path(store.path()).expect("reopen");
@@ -901,7 +901,7 @@ mod first_pin {
         let before = snapshots();
         Connection::open(fixture.store.path())
             .expect("fixture connection")
-            .execute_batch("DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; PRAGMA user_version=4")
+            .execute_batch("DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; PRAGMA user_version=4")
             .expect("schema-four fixture");
         CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("compatible read-only open");
         assert_eq!(

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/tests/hardening.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/tests/hardening.rs
@@ -11,7 +11,7 @@ fn first_pin_schema_four_inventory_and_clones_remain_noncreating() {
     let connection = Connection::open(fixture.store.path()).expect("fixture connection");
     connection
         .execute_batch(
-            "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; PRAGMA user_version=4",
+            "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; PRAGMA user_version=4",
         )
         .expect("legacy schema");
     let before: (Vec<u8>, Vec<u8>, i64) = connection
@@ -91,9 +91,9 @@ fn first_pin_schema_four_inventory_and_clones_remain_noncreating() {
 #[test]
 fn first_pin_schema_four_refuses_partial_objects_and_query_only_writers() {
     for corruption in [
-        "DROP TABLE remote_network_volume_selections",
-        "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP INDEX remote_runtime_allocations_workflow",
-        "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences",
+        "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections",
+        "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP INDEX remote_runtime_allocations_workflow",
+        "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences",
     ] {
         let (fixture, saved) = reserved();
         let connection = Connection::open(fixture.store.path()).expect("fixture connection");
@@ -113,7 +113,7 @@ fn first_pin_schema_four_refuses_partial_objects_and_query_only_writers() {
     let (fixture, _) = reserved();
     let connection = Connection::open(fixture.store.path()).expect("fixture connection");
     connection
-        .execute_batch("DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; PRAGMA user_version=4; PRAGMA query_only=ON")
+        .execute_batch("DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; PRAGMA user_version=4; PRAGMA query_only=ON")
         .expect("query-only writer");
     assert!(
         !connection
@@ -364,7 +364,7 @@ fn active_legacy_unbound_records_stay_recoverable_without_allocation() {
     let connection = Connection::open(store.path()).expect("raw legacy fixture");
     connection
         .execute_batch(
-            "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
+            "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
         )
         .expect("schema-three fixture before migration");
     connection
@@ -420,7 +420,7 @@ fn migrated_bound_allocations_still_require_their_positive_binding() {
         let connection = Connection::open(fixture.store.path()).expect("raw migration fixture");
         connection
             .execute_batch(
-                "DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
+                "DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; PRAGMA user_version=3",
             )
             .expect("schema-three bound allocation");
         let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("migrate bound allocation");

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/creation_fences/tests.rs
@@ -54,7 +54,7 @@ fn fixture(version: i64) -> Fixture {
         )
         .expect("legacy record");
     connection
-        .execute_batch("DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences;")
+        .execute_batch("DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences;")
         .expect("legacy fence schema");
     if version == 2 {
         connection

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/migration.rs
@@ -11,7 +11,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
         .expect("legacy creation fence");
     let connection = Connection::open(store.path()).expect("raw store");
     connection
-        .execute_batch("DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
+        .execute_batch("DROP TABLE remote_provider_bindings; DROP TABLE remote_network_volume_selections; DROP TABLE remote_first_pin_intents; DROP TABLE remote_runtime_creation_fences; DROP TABLE remote_runtime_allocations; DROP TABLE remote_workspaces; PRAGMA user_version = 1;")
         .expect("restore schema-one fixture");
     let workflow_bytes: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
@@ -42,7 +42,7 @@ fn schema_one_migration_preserves_workflow_bytes_revisions_and_creation_claims()
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .expect("schema version");
-    assert_eq!(version, 6);
+    assert_eq!(version, 7);
     let after: Vec<u8> = connection
         .query_row("SELECT snapshot FROM cloud_workflows", [], |row| row.get(0))
         .expect("unchanged legacy bytes");
@@ -103,7 +103,7 @@ fn current_schema_with_missing_remote_table_or_index_fails_at_open() {
         let version: i64 = connection
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .expect("schema unchanged");
-        assert_eq!(version, 6);
+        assert_eq!(version, 7);
     }
 }
 
@@ -262,15 +262,26 @@ fn invalid_selection_and_mutation_or_corrupt_rows_fail_without_repair() {
 
 #[test]
 fn legacy_inventory_is_read_only_and_migration_never_backfills_a_selection() {
-    for version in [4, 5] {
+    for version in [4, 5, 6] {
         let fixture = SelectionFixture::new();
         let saved = fixture.reserve();
-        if version == 5 {
+        let expected_selection = (version == 6).then(selection);
+        if let Some(selection) = &expected_selection {
+            fixture
+                .store
+                .record_remote_network_volume_selection(&saved, selection)
+                .expect("existing HPS selection");
+        }
+        if version >= 5 {
             fixture.store.record_remote_first_pin_intent(&saved).expect("first pin");
         }
         let raw = fixture.raw();
-        raw.execute_batch("DROP TABLE remote_network_volume_selections")
+        raw.execute_batch("DROP TABLE remote_provider_bindings")
             .expect("legacy schema");
+        if version < 6 {
+            raw.execute_batch("DROP TABLE remote_network_volume_selections")
+                .expect("v5");
+        }
         if version == 4 {
             raw.execute_batch("DROP TABLE remote_first_pin_intents").expect("v4");
         }
@@ -281,7 +292,7 @@ fn legacy_inventory_is_read_only_and_migration_never_backfills_a_selection() {
             reader
                 .load_remote_network_volume_selection(&saved)
                 .expect("legacy selection"),
-            None
+            expected_selection
         );
         assert_eq!(
             reader.list_remote_environment_page(None).expect("inventory").records,
@@ -292,7 +303,7 @@ fn legacy_inventory_is_read_only_and_migration_never_backfills_a_selection() {
                 .load_remote_first_pin_request(&saved)
                 .expect("first pin")
                 .is_some(),
-            version == 5
+            version >= 5
         );
         assert_eq!(
             raw.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
@@ -305,24 +316,39 @@ fn legacy_inventory_is_read_only_and_migration_never_backfills_a_selection() {
             upgraded
                 .load_remote_network_volume_selection(&saved)
                 .expect("unselected"),
-            None
+            expected_selection
         );
-        assert_eq!(fixture.count(), 0);
+        assert_eq!(fixture.count(), i64::from(version == 6));
+        assert_eq!(
+            upgraded
+                .load_remote_first_pin_request(&saved)
+                .expect("preserved pin intent")
+                .is_some(),
+            version >= 5
+        );
+        let provider_bindings: i64 = raw
+            .query_row("SELECT COUNT(*) FROM remote_provider_bindings", [], |row| row.get(0))
+            .expect("no provider backfill");
+        assert_eq!(provider_bindings, 0);
         assert_eq!(fixture.snapshots(), before);
         assert_eq!(
             raw.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
                 .expect("version"),
-            6
+            7
         );
     }
 }
 
 #[test]
 fn partial_or_missing_schema_and_missing_database_never_trigger_repair_on_reads() {
-    for version in [4, 5, 6] {
+    for version in [4, 5, 6, 7] {
         let fixture = SelectionFixture::new();
         let raw = fixture.raw();
-        if version == 6 {
+        if version < 7 {
+            raw.execute_batch("DROP TABLE remote_provider_bindings")
+                .expect("legacy schema");
+        }
+        if version >= 6 {
             raw.execute_batch("DROP TRIGGER remote_network_volume_selections_no_delete")
                 .expect("partial");
         }

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/tests/recovery.rs
@@ -125,7 +125,7 @@ fn invalid_keys_snapshots_and_future_schema_never_replace_saved_records() {
         .query_row("SELECT snapshot FROM remote_workspaces", [], |row| row.get(0))
         .expect("before");
     connection
-        .pragma_update(None, "user_version", 7)
+        .pragma_update(None, "user_version", 8)
         .expect("future schema");
     assert!(
         store

--- a/crates/horizon-core/src/cloud_run/store/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/tests.rs
@@ -59,7 +59,7 @@ fn worker_target(workflow: &CloudWorkflow) -> &WorkerTarget {
 }
 
 fn assert_unsupported_schema<T>(result: &Result<T, CloudStoreError>) {
-    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(7))));
+    assert!(matches!(result, Err(CloudStoreError::UnsupportedSchema(8))));
 }
 
 fn store(temp: &TempDir) -> CloudWorkflowStore {
@@ -532,7 +532,7 @@ fn runpod_fence_uses_the_durable_workflow_claim() {
     );
     let connection = Connection::open(store.path()).expect("open raw store");
     connection
-        .pragma_update(None, "user_version", 7)
+        .pragma_update(None, "user_version", 8)
         .expect("set unsupported schema");
     drop(connection);
     let failed_claim = super::super::runpod::RunPodCreationFence::claim_once(
@@ -568,7 +568,7 @@ fn azure_fence_uses_the_durable_workflow_claim() {
     );
     let connection = Connection::open(store.path()).expect("open raw store");
     connection
-        .pragma_update(None, "user_version", 7)
+        .pragma_update(None, "user_version", 8)
         .expect("set unsupported schema");
     drop(connection);
     assert_eq!(
@@ -599,7 +599,7 @@ fn invalid_snapshots_and_future_schema_fail_closed() {
     replacement.updated_at_millis += 1;
     let connection = Connection::open(&future_path).expect("future store");
     connection
-        .pragma_update(None, "user_version", 7)
+        .pragma_update(None, "user_version", 8)
         .expect("future version");
     drop(connection);
     assert_unsupported_schema(&stale_store.load(workflow.id));

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -492,6 +492,9 @@ back into large multi-purpose modules.
   Its `cloud_run/store/database.rs` leaf owns private-path preparation, connection policy,
   schema initialization, and compatibility checks. Keep database opening separate
   from domain-specific record operations.
+  Schema seven reserves immutable provider-binding metadata without backfilling
+  legacy allocations; valid schema-four/five/six inventory stays read-only.
+  See [retained provider selection](remote-provider-bindings.md) for the staged API boundary.
   Existing-store observers use clone-preserved read-only handles, without private-path
   creation or migration. Single workspace/allocation getters always use read-only
   connections; live WAL updates remain visible without granting schema repair.

--- a/docs/architecture/remote-provider-bindings.md
+++ b/docs/architecture/remote-provider-bindings.md
@@ -1,0 +1,50 @@
+# Retained provider selection
+
+Status: Proposed for #474. Date: 2026-09-12.
+
+## Context
+
+A saved worker target identifies a named profile. Before an Azure resource ID is
+retained, recovery cannot determine the original subscription from that name if
+the configuration has changed. Reconciliation must not inspect a different
+subscription or infer permission to create a replacement.
+
+## Decision
+
+Store a versioned, immutable provider binding beside the exact runtime allocation
+in the same private SQLite database. Bind workspace, owner, generation, workflow
+and job identities to the explicit subscription and a digest of the complete
+approved non-secret profile. Missing metadata is missing provenance, never a
+default subscription or an instruction to repair it from current configuration.
+
+Schema seven introduces only the table, collision/update/delete protections and
+schema validation. It creates no binding rows, rewrites no runtime snapshots and
+does not enable Azure setup. Valid schema-four/five/six stores remain readable
+without migration; partial or malformed metadata fails closed. Existing schema
+six network-volume metadata remains validated on legacy reads.
+
+## Alternatives and trade-offs
+
+- Re-reading the current profile by name is smaller but loses original placement
+  provenance after an ambiguous create, so it is rejected.
+- Separate sidecar files avoid a database migration but cannot share the existing
+  allocation transaction and corruption checks, so they are rejected.
+- A database binding adds a migration and explicitly refuses recovery when the
+  original profile is unavailable. It reuses the existing ownership boundary and
+  avoids duplicating orchestration or introducing a new provider framework.
+
+## Follow-up implementation
+
+- Add bounded, exact-allocation record/load operations and a frozen version-one
+  profile digest representation. First recording must precede key preparation
+  and provider dispatch; no late backfill or replacement is permitted.
+- Wire configured preview/consent/setup/check to this binding and the shared
+  complete Azure deployment-target validator. Reject current-profile mismatch
+  before credential acquisition or provider requests.
+- Prove no-handle lost-response recovery, profile/subscription drift, competing
+  controllers, missing metadata, retained SSH pins and unchanged dirty data.
+
+The digest is a consistency binding, not a signature or provider attestation.
+Direct malicious rewriting of the private database is not prevented by SQLite
+triggers; readers must validate complete metadata and runtime identity. No token,
+credential, registry password, allocation or cloud acceptance is implied here.


### PR DESCRIPTION
## Purpose

Prerequisite for #474 and #383: retain the original provider selection before
ambiguous setup can outlive the current configuration. This PR introduces the
storage format only; record/load operations and configured setup follow separately.

## Behavior

- Schema seven adds an immutable, versioned provider-binding table beside the
  runtime allocation. It creates no binding rows and rewrites no saved snapshots.
- Valid schema-four/five/six stores remain readable without migration. Writable
  upgrade preserves existing allocation, creation-claim, first-pin and volume data.
- Missing or malformed schema objects, including reserved-name partial objects,
  fail closed. Triggers prevent replacement, update and deletion of binding rows.
- No UI/default configuration, credentials, provider requests, worker lifecycle,
  public image or release changes. Existing workspaces are not backfilled from
  whichever profile happens to be configured now.

## Validation

- 131 focused local SQLite store tests passed, including populated legacy v6
  preservation, noncreating reads, idempotent upgrade, corruption refusal and
  constraint/immutability checks.
- Independent local review completed; namespace and populated-legacy coverage
  findings were fixed. Formatting, maintainability, version and blocking/strict
  Clippy passed on the local prerequisite.
- The hosted schema-name finding is fixed: both provider-binding predicates
  escape literal underscores. Unrelated lookalike names remain readable and
  upgradeable on schemas 4/5/6/7; genuine mixed-case reserved names still fail
  closed. The new regression failed before the fix and passed afterward.
- All eight final local validation lanes passed on `9a4b5948a9738581352345d6b081672de86c9e81`:
  formatting, maintainability, version synchronization, default workspace tests
  (2,470 passed), speech workspace tests (2,515 passed), blocking Clippy, strict
  Clippy and advisory pedantic Clippy. Each test tier had seven ignored tests.
- An earlier pre-review matrix attempt failed an unchanged browser CLI timing test. The same
  test binary passed five focused reruns, then a fresh complete matrix passed
  without source changes. The timing failure remains recorded; its cause is not
  established. Hosted checks and review are still required.

Both independently reviewed commits were refreshed unchanged onto #544's verified
squash `317077b4`; the full matrix above ran in that final checkout. Fresh hosted
review/current-head checks remain required. This does not close #474 or #383.

Scope: nine source/test files, 456 changed source/test lines, plus two architecture
documents. No live cloud or PC-off acceptance is claimed by these storage tests.
