### PR TITLE
feat(storage): bind immutable CPU provider profiles

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -14,8 +14,8 @@ mod store;
 mod validation;
 mod worker_lifetime;
 pub use store::{
-    CloudStoreError, CloudWorkflowStore, RemoteEnvironmentPage, RemoteWorkspaceStoreError, StoredRemoteAllocation,
-    StoredRemoteWorkspace, StoredWorkflow,
+    CloudStoreError, CloudWorkflowStore, RemoteCpuProfileBinding, RemoteEnvironmentPage, RemoteWorkspaceStoreError,
+    StoredRemoteAllocation, StoredRemoteWorkspace, StoredWorkflow,
 };
 pub use worker_lifetime::WorkerLifetime;
 pub const CLOUD_RUN_PROTOCOL_VERSION: u32 = 1;

--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -5,7 +5,7 @@ mod remote_allocations;
 mod remote_workspaces;
 mod workflow_writes;
 
-pub use remote_allocations::StoredRemoteAllocation;
+pub use remote_allocations::{RemoteCpuProfileBinding, StoredRemoteAllocation};
 pub use remote_workspaces::{RemoteEnvironmentPage, RemoteWorkspaceStoreError, StoredRemoteWorkspace};
 use workflow_writes::PreparedWorkflowInsert;
 

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -9,6 +9,8 @@ mod request;
 mod setup;
 mod stop;
 
+pub use setup::RemoteCpuProfileBinding;
+
 pub(super) use guards::{
     ensure_unbound_workflow, validate_creation_claim, validate_workflow_replacement, validate_workspace_write,
 };

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup.rs
@@ -1,6 +1,9 @@
 //! Setup admission is a point-in-time check, never a provider creation grant.
 
 mod network_volume;
+mod provider_binding;
+
+pub use provider_binding::RemoteCpuProfileBinding;
 
 use super::super::{
     CloudStoreError, current_unix_millis,

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/provider_binding.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/provider_binding.rs
@@ -1,0 +1,229 @@
+//! Immutable CPU placement provenance, not provider attestation or creation authority.
+
+use super::{
+    CloudStoreError, CloudWorkflowStore, Error, StoredRemoteAllocation, current_unix_millis, ensure_current_schema,
+    exact_allocation, open_read_connection, validate_unclaimed,
+};
+use crate::cloud_run::{
+    ArtifactDigest, CloudProvider, WorkerLifetime,
+    azure::{AzureDeploymentPlan, AzureDiskSku, AzureError, AzureProfile, valid_subscription_id},
+};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+
+/// Non-secret version-one profile consistency binding. Not a signature, provider
+/// observation, permission to create, or proof that any private key is absent.
+/// No deserialization bypasses the validating profile constructor or storage reader.
+#[derive(Clone, Eq, PartialEq)]
+pub struct RemoteCpuProfileBinding {
+    subscription_id: String,
+    profile_digest: ArtifactDigest,
+}
+
+impl std::fmt::Debug for RemoteCpuProfileBinding {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RemoteCpuProfileBinding { .. }")
+    }
+}
+
+impl RemoteCpuProfileBinding {
+    /// Bind all approved profile fields without I/O or implicit defaults.
+    /// # Errors
+    /// Rejects an invalid profile before computing its digest.
+    pub fn from_profile(profile: &AzureProfile) -> Result<Self, AzureError> {
+        profile.validate()?;
+        // Exhaustive destructuring deliberately forces a version decision when a
+        // profile field is added. Never hash the live struct's serde representation.
+        let AzureProfile {
+            name,
+            subscription_id,
+            location,
+            vm_size,
+            image_pull_identity_id,
+            declared_hourly_cost_micros,
+            registry_login_server,
+            disk_sku,
+        } = profile;
+        let price = declared_hourly_cost_micros.to_be_bytes();
+        let disk: &[u8] = match disk_sku {
+            AzureDiskSku::StandardSsdLrs => b"StandardSSD_LRS",
+            AzureDiskSku::PremiumLrs => b"Premium_LRS",
+        };
+        // Frozen v1: domain/version bytes, then eight u64-BE byte lengths and
+        // exact UTF-8 fields in the declared order (price is eight BE bytes).
+        let mut bytes = b"horizon.remote.cpu-profile.azure.v1\0".to_vec();
+        for field in [
+            name.as_bytes(),
+            subscription_id.as_bytes(),
+            location.as_bytes(),
+            vm_size.as_bytes(),
+            image_pull_identity_id.as_bytes(),
+            price.as_slice(),
+            registry_login_server.as_bytes(),
+            disk,
+        ] {
+            bytes.extend_from_slice(&(field.len() as u64).to_be_bytes());
+            bytes.extend_from_slice(field);
+        }
+        Ok(Self {
+            subscription_id: subscription_id.clone(),
+            profile_digest: ArtifactDigest::sha256(&bytes),
+        })
+    }
+
+    #[must_use]
+    pub fn subscription_id(&self) -> &str {
+        &self.subscription_id
+    }
+
+    #[must_use]
+    pub fn profile_digest(&self) -> &ArtifactDigest {
+        &self.profile_digest
+    }
+
+    /// Compare explicit subscription and all profile bytes, without I/O.
+    /// # Errors
+    /// Rejects an invalid supplied profile rather than treating it as a match.
+    pub fn matches_profile(&self, profile: &AzureProfile) -> Result<bool, AzureError> {
+        Self::from_profile(profile).map(|candidate| self == &candidate)
+    }
+}
+
+impl CloudWorkflowStore {
+    /// Record one immutable CPU profile binding for this exact allocation.
+    /// First recording must precede client-key preparation/reservation and provider
+    /// dispatch. The caller must enforce private-key-file ordering; this database
+    /// cannot prove absence of a file. No credentials, provider I/O, snapshot writes,
+    /// revision bumps or creation-grant consumption/renewal occur here.
+    /// An exact existing binding is idempotent even after setup expires or closes.
+    /// Run synchronously off the render thread.
+    /// # Errors
+    /// Refuses stale/foreign allocations, unsupported complete deployment targets,
+    /// late first recording, replacement, corrupt rows and storage errors.
+    pub fn record_remote_cpu_profile_binding(
+        &self,
+        expected: &StoredRemoteAllocation,
+        profile: &AzureProfile,
+    ) -> Result<(), Error> {
+        let proposed = RemoteCpuProfileBinding::from_profile(profile).map_err(|_| Error::RuntimeSetupUnavailable)?;
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        ensure_current_schema(&transaction)?;
+        let current = exact_allocation(&transaction, expected)?;
+        let state = current.workspace().state();
+        AzureDeploymentPlan::validate_target(profile, &state.spec.target)
+            .map_err(|_| Error::RuntimeSetupUnavailable)?;
+        if let Some(existing) = load_binding(&transaction, &current)? {
+            return if existing == proposed {
+                Ok(())
+            } else {
+                Err(Error::ReplacementIdentityMismatch)
+            };
+        }
+        validate_unclaimed(&transaction, &current)?;
+        let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+        let first_pin: bool = transaction.query_row(
+            "SELECT EXISTS(SELECT 1 FROM remote_first_pin_intents WHERE workspace_local_id = ?1)",
+            [&state.spec.workspace_local_id],
+            |row| row.get(0),
+        )?;
+        if runtime.ssh_public_key.is_some()
+            || first_pin
+            || current.workflow().workflow().retain_until_millis <= current_unix_millis()?
+        {
+            return Err(Error::RuntimeSetupUnavailable);
+        }
+        transaction.execute(
+            "INSERT INTO remote_provider_bindings
+             (workspace_local_id, session_id, generation, workflow_id, job_id, version,
+              provider, subscription_id, profile_digest)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1, 'azure', ?6, ?7)",
+            params![
+                state.spec.workspace_local_id,
+                current.workspace().session_id(),
+                i64::try_from(runtime.generation).map_err(|_| Error::GenerationExhausted)?,
+                runtime.workflow_id.to_string(),
+                runtime.job_id.to_string(),
+                proposed.subscription_id,
+                proposed.profile_digest.as_str()
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Read immutable provenance from one exact consistent allocation snapshot.
+    /// No creation, schema migration/backfill, expiry renewal or provider I/O.
+    /// Valid schema-four/five/six stores and genuinely absent metadata return `None`.
+    /// Bound records remain inspectable after setup expiry or management intent.
+    /// Missing provenance never authorizes adoption from current configuration.
+    /// # Errors
+    /// Rejects stale/foreign allocations, malformed/colliding rows and storage errors.
+    pub fn load_remote_cpu_profile_binding(
+        &self,
+        expected: &StoredRemoteAllocation,
+    ) -> Result<Option<RemoteCpuProfileBinding>, Error> {
+        let mut connection = open_read_connection(self.path())?;
+        let transaction = connection.transaction()?;
+        ensure_current_schema(&transaction)?;
+        let current = exact_allocation(&transaction, expected)?;
+        let version = transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
+        if matches!(version, 4..=6) {
+            return Ok(None);
+        }
+        load_binding(&transaction, &current)
+    }
+}
+
+fn load_binding(
+    connection: &Connection,
+    allocation: &StoredRemoteAllocation,
+) -> Result<Option<RemoteCpuProfileBinding>, Error> {
+    let state = allocation.workspace().state();
+    let runtime = state.runtime.as_ref().ok_or(Error::UnboundRuntime)?;
+    let row = connection
+        .query_row(
+            "SELECT workspace_local_id = ?1 AND session_id = ?2 AND generation = ?3
+                AND workflow_id = ?4 AND job_id = ?5 AND version = 1 AND provider = 'azure'
+                AND (SELECT COUNT(*) FROM remote_provider_bindings
+                     WHERE workspace_local_id = ?1 OR workflow_id = ?4 OR job_id = ?5) = 1,
+                CAST(substr(CAST(subscription_id AS BLOB), 1, 37) AS TEXT),
+                CAST(substr(CAST(profile_digest AS BLOB), 1, 65) AS TEXT)
+         FROM remote_provider_bindings WHERE workspace_local_id = ?1 OR workflow_id = ?4 OR job_id = ?5",
+            params![
+                state.spec.workspace_local_id,
+                allocation.workspace().session_id(),
+                i64::try_from(runtime.generation).map_err(|_| Error::GenerationExhausted)?,
+                runtime.workflow_id.to_string(),
+                runtime.job_id.to_string()
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, bool>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((matches, subscription_id, digest)) = row else {
+        return Ok(None);
+    };
+    if !matches
+        || !valid_subscription_id(&subscription_id)
+        || state.spec.target.provider != CloudProvider::Azure
+        || state.spec.target.lifetime != WorkerLifetime::Persistent
+    {
+        return Err(CloudStoreError::InvalidRemoteAllocation.into());
+    }
+    let profile_digest = ArtifactDigest::parse_sha256(&digest).map_err(|_| CloudStoreError::InvalidRemoteAllocation)?;
+    if profile_digest.as_str() != digest {
+        return Err(CloudStoreError::InvalidRemoteAllocation.into());
+    }
+    Ok(Some(RemoteCpuProfileBinding {
+        subscription_id,
+        profile_digest,
+    }))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/provider_binding/tests.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/provider_binding/tests.rs
@@ -1,0 +1,391 @@
+use super::*;
+use crate::cloud_run::interactive_worker::{
+    InteractiveWorker, InteractiveWorkerIdentity, InteractiveWorkerLifecycle, InteractiveWorkerLifetime,
+    InteractiveWorkerStatus,
+};
+use crate::cloud_run::store::encode_workflow;
+use crate::remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::{Arc, Barrier};
+
+mod corruption;
+
+const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+const SUBSCRIPTION: &str = "00000000-0000-4000-8000-000000000001";
+
+fn profile() -> AzureProfile {
+    AzureProfile {
+        name: "development".into(),
+        subscription_id: SUBSCRIPTION.into(),
+        location: "northeurope".into(),
+        vm_size: "Standard_D4s_v3".into(),
+        image_pull_identity_id: format!(
+            "/subscriptions/{SUBSCRIPTION}/resourceGroups/synthetic/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"
+        ),
+        declared_hourly_cost_micros: 100_000,
+        registry_login_server: "synthetic.azurecr.io".into(),
+        disk_sku: AzureDiskSku::StandardSsdLrs,
+    }
+}
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    saved: StoredRemoteAllocation,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_target(|_| {})
+    }
+    fn with_target(change: impl FnOnce(&mut crate::cloud_run::WorkerTarget)) -> Self {
+        let directory = tempfile::tempdir().expect("directory");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+        let mut state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version": 1, "spec": {
+                "workspace_local_id": "workspace", "working_directory": ".", "generation": 0, "panels": [],
+                "target": { "provider": "azure", "profile": "development",
+                    "image": format!("synthetic.azurecr.io/worker@sha256:{}", "a".repeat(64)),
+                    "disk_gib": 20, "lifetime": "persistent" },
+                "repository": { "repository": "example/project", "commit": "b".repeat(40) }
+            }
+        }))
+        .expect("state");
+        change(&mut state.spec.target);
+        let dormant = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let saved = store.allocate_remote_runtime(&dormant, i64::MAX).expect("allocation");
+        Self {
+            _directory: directory,
+            store,
+            saved,
+        }
+    }
+    fn raw(&self) -> Connection {
+        Connection::open(self.store.path()).expect("raw fixture")
+    }
+    fn reload(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+    fn count(&self) -> i64 {
+        self.raw()
+            .query_row("SELECT COUNT(*) FROM remote_provider_bindings", [], |row| row.get(0))
+            .expect("count")
+    }
+    fn snapshots(&self) -> Vec<(i64, Vec<u8>)> {
+        self.raw().prepare("SELECT revision, snapshot FROM remote_workspaces UNION ALL SELECT revision, snapshot FROM cloud_workflows")
+            .expect("query").query_map([], |row| Ok((row.get(0)?, row.get(1)?))).expect("rows")
+            .collect::<Result<_, _>>().expect("snapshots")
+    }
+    fn record(&self) {
+        self.store
+            .record_remote_cpu_profile_binding(&self.saved, &profile())
+            .expect("record");
+    }
+    fn claim(&self) -> bool {
+        let runtime = self.saved.workspace().state().runtime.as_ref().expect("runtime");
+        self.store
+            .claim_worker_creation(
+                runtime.workflow_id,
+                runtime.job_id,
+                &self.saved.workspace().state().spec.target,
+                "synthetic-worker",
+            )
+            .expect("claim")
+    }
+    fn reserve(&self) -> StoredRemoteAllocation {
+        let mut key = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+        key.extend([7; 32]);
+        self.store
+            .reserve_remote_worker_request(&self.reload(), &format!("ssh-ed25519 {}", STANDARD.encode(key)))
+            .expect("key")
+    }
+    fn expire(&self) -> StoredRemoteAllocation {
+        let mut workflow = self.reload().workflow().workflow().clone();
+        workflow.created_at_millis = 1000;
+        workflow.updated_at_millis = 1000;
+        workflow.retain_until_millis = 2000;
+        self.raw()
+            .execute(
+                "UPDATE cloud_workflows SET created_at_millis=1000, updated_at_millis=1000,
+            retain_until_millis=2000, snapshot=?1",
+                [encode_workflow(&workflow).expect("snapshot")],
+            )
+            .expect("expire");
+        self.reload()
+    }
+    fn observe(&self) -> StoredRemoteAllocation {
+        let saved = self.reserve();
+        let request = saved.worker_request().expect("request");
+        let status = InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::Azure,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: format!("/subscriptions/{SUBSCRIPTION}/resourceGroups/synthetic"),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            lifecycle: InteractiveWorkerLifecycle::Provisioning,
+            ssh: None,
+        };
+        self.store
+            .record_remote_worker_recovery(&saved, Some(&status))
+            .expect("observation")
+    }
+}
+
+#[test]
+fn frozen_digest_covers_every_profile_field_and_rejects_invalid_profiles() {
+    let original = profile();
+    let binding = RemoteCpuProfileBinding::from_profile(&original).expect("binding");
+    assert_eq!(binding.subscription_id(), SUBSCRIPTION);
+    assert_eq!(
+        binding.profile_digest().as_str(),
+        "c35a8253e80b9965b2e38b95f928cbabeffbeda306a12a2c2d3b128ca305f615"
+    );
+    assert!(binding.matches_profile(&original).expect("match"));
+    for mode in 0..8 {
+        let mut next = original.clone();
+        match mode {
+            0 => next.name = "another".into(),
+            1 => {
+                next.subscription_id = "00000000-0000-4000-8000-000000000002".into();
+                next.image_pull_identity_id = next.image_pull_identity_id.replace(SUBSCRIPTION, &next.subscription_id);
+            }
+            2 => next.location = "westeurope".into(),
+            3 => next.vm_size = "Standard_D8s_v3".into(),
+            4 => next.image_pull_identity_id.push('2'),
+            5 => next.declared_hourly_cost_micros += 1,
+            6 => next.registry_login_server = "other.azurecr.io".into(),
+            _ => next.disk_sku = AzureDiskSku::PremiumLrs,
+        }
+        assert!(!binding.matches_profile(&next).expect("valid different profile"));
+    }
+    let mut invalid = original;
+    invalid.subscription_id = "invalid-sensitive-value".into();
+    assert!(binding.matches_profile(&invalid).is_err());
+    assert!(!format!("{binding:?}").contains(SUBSCRIPTION));
+}
+
+#[test]
+fn record_reopen_and_late_exact_repeats_preserve_snapshots_and_creation_grant() {
+    let fixture = Fixture::new();
+    let before = fixture.snapshots();
+    assert_eq!(
+        fixture
+            .store
+            .load_remote_cpu_profile_binding(&fixture.saved)
+            .expect("absent"),
+        None
+    );
+    fixture.record();
+    fixture.record();
+    assert_eq!(fixture.count(), 1);
+    assert_eq!(fixture.snapshots(), before);
+    assert_eq!(fixture.reload(), fixture.saved);
+    let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("reader");
+    assert_eq!(
+        reader.load_remote_cpu_profile_binding(&fixture.saved).expect("read"),
+        Some(RemoteCpuProfileBinding::from_profile(&profile()).expect("profile"))
+    );
+    assert!(fixture.claim());
+    assert!(!fixture.claim());
+    fixture.record();
+    let expired = fixture.expire();
+    let before = fixture.snapshots();
+    fixture
+        .store
+        .record_remote_cpu_profile_binding(&expired, &profile())
+        .expect("expired same binding");
+    assert!(
+        reader
+            .load_remote_cpu_profile_binding(&expired)
+            .expect("expired read")
+            .is_some()
+    );
+    assert_eq!(fixture.snapshots(), before);
+}
+
+#[test]
+fn different_stale_and_foreign_bindings_cannot_replace_the_original() {
+    let fixture = Fixture::new();
+    fixture.record();
+    let mut next = profile();
+    next.location = "westeurope".into();
+    assert!(matches!(
+        fixture.store.record_remote_cpu_profile_binding(&fixture.saved, &next),
+        Err(Error::ReplacementIdentityMismatch)
+    ));
+    let other = Fixture::new();
+    assert!(
+        fixture
+            .store
+            .record_remote_cpu_profile_binding(&other.saved, &profile())
+            .is_err()
+    );
+    assert!(fixture.store.load_remote_cpu_profile_binding(&other.saved).is_err());
+    let current = fixture.reserve();
+    assert!(matches!(
+        fixture.store.load_remote_cpu_profile_binding(&fixture.saved),
+        Err(Error::SnapshotConflict)
+    ));
+    assert!(matches!(
+        fixture
+            .store
+            .record_remote_cpu_profile_binding(&fixture.saved, &profile()),
+        Err(Error::SnapshotConflict)
+    ));
+    assert!(
+        fixture
+            .store
+            .load_remote_cpu_profile_binding(&current)
+            .expect("current")
+            .is_some()
+    );
+    assert_eq!(fixture.count(), 1);
+}
+
+#[test]
+fn first_record_rejects_claim_key_expiry_first_pin_worker_and_management() {
+    for mode in 0..6 {
+        let fixture = Fixture::new();
+        let mut saved = fixture.saved.clone();
+        match mode {
+            0 => {
+                assert!(fixture.claim());
+            }
+            1 => saved = fixture.reserve(),
+            2 => saved = fixture.expire(),
+            3 => {
+                let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+                fixture
+                    .raw()
+                    .execute(
+                        "INSERT INTO remote_first_pin_intents VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6)",
+                        params![
+                            "workspace",
+                            OWNER,
+                            i64::try_from(runtime.generation).expect("generation"),
+                            runtime.workflow_id.to_string(),
+                            runtime.job_id.to_string(),
+                            "a".repeat(64)
+                        ],
+                    )
+                    .expect("first-pin fixture");
+            }
+            4 => saved = fixture.observe(),
+            _ => {
+                saved = fixture
+                    .store
+                    .record_remote_stop_phase(
+                        &fixture.observe(),
+                        RemoteRuntimePhase::Stopping {
+                            requested_at_millis: 1000,
+                        },
+                    )
+                    .expect("Stop intent");
+            }
+        }
+        let before = fixture.snapshots();
+        assert!(matches!(
+            fixture.store.record_remote_cpu_profile_binding(&saved, &profile()),
+            Err(Error::RuntimeSetupUnavailable)
+        ));
+        assert_eq!(fixture.count(), 0);
+        assert_eq!(fixture.snapshots(), before);
+    }
+}
+
+#[test]
+fn existing_binding_remains_readable_in_management_without_state_changes() {
+    let fixture = Fixture::new();
+    fixture.record();
+    let stopped = fixture
+        .store
+        .record_remote_stop_phase(
+            &fixture.observe(),
+            RemoteRuntimePhase::Stopping {
+                requested_at_millis: 1000,
+            },
+        )
+        .expect("Stop intent");
+    let before = fixture.snapshots();
+    fixture
+        .store
+        .record_remote_cpu_profile_binding(&stopped, &profile())
+        .expect("same binding");
+    assert!(
+        fixture
+            .store
+            .load_remote_cpu_profile_binding(&stopped)
+            .expect("read")
+            .is_some()
+    );
+    assert_eq!(fixture.reload(), stopped);
+    assert_eq!(fixture.snapshots(), before);
+}
+
+#[test]
+fn competing_identical_or_different_profiles_have_no_replacement_or_snapshot_writes() {
+    for identical in [true, false] {
+        let fixture = Fixture::new();
+        let before = fixture.snapshots();
+        let barrier = Arc::new(Barrier::new(2));
+        let handles: Vec<_> = (0..2)
+            .map(|index| {
+                let store = fixture.store.clone();
+                let saved = fixture.saved.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let mut candidate = profile();
+                    if index == 1 && !identical {
+                        candidate.location = "westeurope".into();
+                    }
+                    barrier.wait();
+                    store.record_remote_cpu_profile_binding(&saved, &candidate)
+                })
+            })
+            .collect();
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().expect("thread")).collect();
+        assert_eq!(
+            results.iter().filter(|r| r.is_ok()).count(),
+            if identical { 2 } else { 1 }
+        );
+        assert!(
+            results
+                .iter()
+                .all(|r| r.is_ok() || matches!(r, Err(Error::ReplacementIdentityMismatch)))
+        );
+        assert_eq!(fixture.count(), 1);
+        assert_eq!(fixture.snapshots(), before);
+    }
+}
+
+#[test]
+fn complete_deployment_target_is_required_before_any_binding_write() {
+    for mode in 0..6 {
+        let fixture = Fixture::with_target(|target| match mode {
+            0 => target.provider = CloudProvider::LocalDocker,
+            1 => target.profile = "other".into(),
+            2 => target.disk_gib = 4096,
+            3 => target.max_hourly_cost_micros = Some(1),
+            4 => target.image = format!("foreign.azurecr.io/worker@sha256:{}", "a".repeat(64)),
+            _ => target.lifetime = WorkerLifetime::TimeLimited { seconds: 60 },
+        });
+        let before = fixture.snapshots();
+        assert!(matches!(
+            fixture
+                .store
+                .record_remote_cpu_profile_binding(&fixture.saved, &profile()),
+            Err(Error::RuntimeSetupUnavailable)
+        ));
+        assert_eq!(fixture.count(), 0);
+        assert_eq!(fixture.snapshots(), before);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/provider_binding/tests/corruption.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/setup/provider_binding/tests/corruption.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+fn corrupt(fixture: &Fixture, sql: &str) {
+    let connection = fixture.raw();
+    let definitions: Vec<String> = connection.prepare(
+        "SELECT sql FROM sqlite_schema WHERE name IN ('remote_provider_bindings_no_update', 'remote_provider_bindings_no_replace') ORDER BY name"
+    ).expect("query").query_map([], |row| row.get(0)).expect("definitions")
+        .collect::<Result<_, _>>().expect("triggers");
+    connection
+        .execute_batch(
+            "PRAGMA foreign_keys=OFF; PRAGMA ignore_check_constraints=ON;
+        DROP TRIGGER remote_provider_bindings_no_update; DROP TRIGGER remote_provider_bindings_no_replace;",
+        )
+        .expect("synthetic corruption admission");
+    connection.execute_batch(sql).expect("corrupt row");
+    for definition in definitions {
+        connection.execute_batch(&definition).expect("restore exact schema");
+    }
+    connection
+        .execute_batch("PRAGMA foreign_keys=ON; PRAGMA ignore_check_constraints=OFF")
+        .expect("restore connection guards");
+}
+
+#[test]
+fn malformed_rows_are_errors_not_absence_or_backfill_and_never_echo_payloads() {
+    let cases = [
+        "workspace_local_id = 'foreign'",
+        "session_id = '22222222-2222-4222-8222-222222222222'",
+        "generation = generation + 1",
+        "workflow_id = '33333333-3333-4333-8333-333333333333'",
+        "job_id = '44444444-4444-4444-8444-444444444444'",
+        "version = 2",
+        "provider = 'run_pod'",
+        "subscription_id = 'invalid-sensitive-value'",
+        "subscription_id = subscription_id || char(0)",
+        "subscription_id = 'AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA'",
+        "subscription_id = replace(hex(zeroblob(65536)), '0', 's')",
+        "profile_digest = ''",
+        "profile_digest = upper(profile_digest)",
+        "profile_digest = profile_digest || char(0)",
+        "profile_digest = replace(hex(zeroblob(65536)), '0', 'a')",
+    ];
+    for assignment in cases {
+        let fixture = Fixture::new();
+        fixture.record();
+        corrupt(&fixture, &format!("UPDATE remote_provider_bindings SET {assignment}"));
+        let before = fixture.snapshots();
+        let error = fixture
+            .store
+            .load_remote_cpu_profile_binding(&fixture.saved)
+            .expect_err("corrupt binding");
+        assert!(!format!("{error:?}").contains("invalid-sensitive-value"));
+        assert!(
+            fixture
+                .store
+                .record_remote_cpu_profile_binding(&fixture.saved, &profile())
+                .is_err()
+        );
+        assert_eq!(fixture.count(), 1);
+        assert_eq!(fixture.snapshots(), before);
+    }
+}
+
+#[test]
+fn workspace_workflow_and_job_collisions_fail_with_the_exact_schema_restored() {
+    for column in ["workflow_id", "job_id"] {
+        let fixture = Fixture::new();
+        fixture.record();
+        let runtime = fixture.saved.workspace().state().runtime.as_ref().expect("runtime");
+        let id = if column == "workflow_id" {
+            runtime.workflow_id.to_string()
+        } else {
+            runtime.job_id.to_string()
+        };
+        // Distinct unique columns can still form a conflicting OR lookup after
+        // corruption: one row owns workspace, another owns its original workflow/job.
+        corrupt(
+            &fixture,
+            &format!(
+                "UPDATE remote_provider_bindings SET {column} = '33333333-3333-4333-8333-333333333333';
+             INSERT INTO remote_provider_bindings SELECT 'foreign', session_id, generation,
+             '44444444-4444-4444-8444-444444444444', '55555555-5555-4555-8555-555555555555',
+             version, provider, subscription_id, profile_digest FROM remote_provider_bindings;
+             UPDATE remote_provider_bindings SET {column} = '{id}' WHERE workspace_local_id = 'foreign';"
+            ),
+        );
+        assert_eq!(fixture.count(), 2);
+        assert!(fixture.store.load_remote_cpu_profile_binding(&fixture.saved).is_err());
+        assert!(
+            fixture
+                .store
+                .record_remote_cpu_profile_binding(&fixture.saved, &profile())
+                .is_err()
+        );
+    }
+}
+
+#[test]
+fn legacy_schemas_return_none_without_migration_backfill_or_snapshot_changes() {
+    for version in [4, 5, 6] {
+        let fixture = Fixture::new();
+        let connection = fixture.raw();
+        connection
+            .execute_batch("DROP TABLE remote_provider_bindings")
+            .expect("legacy");
+        if version <= 5 {
+            connection
+                .execute_batch("DROP TABLE remote_network_volume_selections")
+                .expect("legacy volume");
+        }
+        if version == 4 {
+            connection
+                .execute_batch("DROP TABLE remote_first_pin_intents")
+                .expect("legacy pin");
+        }
+        connection
+            .pragma_update(None, "user_version", version)
+            .expect("version");
+        let before = fixture.snapshots();
+        let reader = CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("reader");
+        assert_eq!(
+            reader
+                .load_remote_cpu_profile_binding(&fixture.saved)
+                .expect("legacy absence"),
+            None
+        );
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .expect("version"),
+            version
+        );
+        let tables: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'remote_provider_bindings'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("absence");
+        assert_eq!(tables, 0);
+        assert_eq!(fixture.snapshots(), before);
+    }
+}
+
+#[test]
+fn read_does_not_create_a_missing_database_or_accept_a_non_cpu_binding() {
+    let fixture = Fixture::new();
+    std::fs::remove_file(fixture.store.path()).expect("remove owned synthetic database");
+    assert!(fixture.store.load_remote_cpu_profile_binding(&fixture.saved).is_err());
+    assert!(!fixture.store.path().exists());
+
+    let other = Fixture::with_target(|target| target.provider = CloudProvider::LocalDocker);
+    let runtime = other.saved.workspace().state().runtime.as_ref().expect("runtime");
+    other
+        .raw()
+        .execute(
+            "INSERT INTO remote_provider_bindings VALUES (?1, ?2, ?3, ?4, ?5, 1, 'azure', ?6, ?7)",
+            params![
+                "workspace",
+                OWNER,
+                i64::try_from(runtime.generation).expect("generation"),
+                runtime.workflow_id.to_string(),
+                runtime.job_id.to_string(),
+                SUBSCRIPTION,
+                "a".repeat(64)
+            ],
+        )
+        .expect("malformed association fixture");
+    assert!(other.store.load_remote_cpu_profile_binding(&other.saved).is_err());
+}

--- a/docs/architecture/remote-provider-bindings.md
+++ b/docs/architecture/remote-provider-bindings.md
@@ -33,11 +33,21 @@ six network-volume metadata remains validated on legacy reads.
   original profile is unavailable. It reuses the existing ownership boundary and
   avoids duplicating orchestration or introducing a new provider framework.
 
+## Immutable record/load API
+
+`RemoteCpuProfileBinding` freezes all eight approved CPU-profile fields under an
+explicit version-one domain and byte encoding; changing a field requires a
+deliberate digest-version decision. The store records it only for an exact,
+unclaimed allocation before key reservation or first-pin intent. Exact repeats
+and read-only loads remain available after setup expiry or management intent;
+neither rewrites snapshots nor consumes a creation grant. Readers validate
+bounded row contents and workspace/workflow/job collisions, not only the schema.
+The future caller must record before preparing a private key; database state
+alone cannot prove that a key file does not exist. No configured consumer is
+enabled by these APIs.
+
 ## Follow-up implementation
 
-- Add bounded, exact-allocation record/load operations and a frozen version-one
-  profile digest representation. First recording must precede key preparation
-  and provider dispatch; no late backfill or replacement is permitted.
 - Wire configured preview/consent/setup/check to this binding and the shared
   complete Azure deployment-target validator. Reject current-profile mismatch
   before credential acquisition or provider requests.


### PR DESCRIPTION
## Purpose

Add immutable CPU provider-profile record/load operations on the schema delivered in #549. This is a prerequisite for configured Azure setup and recovery in #474; it does not complete #383 or enable provider operations.

## Behavior

- Bind the exact workspace, owner, generation, workflow and job to a validated Azure subscription and versioned profile digest. The frozen encoding covers all eight current profile fields, with a literal digest regression.
- Validate the complete deployment target before recording. First recording requires an unclaimed, unexpired allocation without a saved worker, SSH reservation, first-pin or management intent. Exact repeats are idempotent; drift is refused.
- Preserve allocation/workflow snapshots and existing creation grants. Reads are non-creating, validate stored identities and bounded field contents, and distinguish absent metadata from corruption. Supported legacy schemas return no fabricated binding.
- Bindings provide consistency checks, not cryptographic authentication or provider attestation. The database cannot prove a private key file is absent; the configured caller must record the binding before key preparation.

No configured consumer, UI, cloud requests, credential access, new dependency or default changes. Seven source/test files, 801 changed source/test lines, plus the architecture note.

## Validation

- Independent local review completed; rebase onto `f4f91692` preserved the logical API patch exactly.
- Prior focused tests and both required Clippy tiers passed. Coverage uses synthetic local SQLite fixtures for immutable/idempotent recording, profile drift, late/stale recording refusal, legacy and missing-store reads, corruption and identity collisions.
- All eight final validation lanes passed on `616595a9`: formatting, maintainability, version sync, default and speech workspace tests, blocking/strict Clippy and the advisory pedantic audit. Default: 2,481 passed; speech: 2,526 passed; seven explicit ignores per configuration, no failures.

This is storage/API proof, not live Azure, UI or client-off acceptance.
