### PR TITLE
feat(remote): confirm retained worker Stop

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker_stop.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker_stop.rs
@@ -1,6 +1,7 @@
 //! Opt-in compute Stop capability, separate from resource deletion and attachment.
 
 use super::interactive_worker::{InteractiveWorker, InteractiveWorkerProvider};
+use super::{interactive_worker::InteractiveWorkerSshEndpoint, runpod::RunPodNetworkVolumeExpectation};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum InteractiveWorkerStop {
@@ -24,4 +25,39 @@ pub trait InteractiveWorkerStopProvider: InteractiveWorkerProvider {
     /// Rejects malformed/foreign handles, uncertain ownership or data retention, failed
     /// provider operations and unverified completion. Diagnostics must redact provider output.
     fn stop_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error>;
+}
+
+/// Saved public identity and storage selection, not new Stop or trust authority.
+#[derive(Clone, Copy)]
+pub struct InteractiveWorkerStopExpectation<'a> {
+    pub worker: &'a InteractiveWorker,
+    /// Preserved and shape-checked only; observation does not verify an SSH handshake.
+    pub ssh: &'a InteractiveWorkerSshEndpoint,
+    pub network_volume: Option<&'a RunPodNetworkVolumeExpectation>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InteractiveWorkerStopObservation {
+    /// Exact resource and selected storage remain present, with verified inactive compute.
+    /// Not a checkpoint, task result, live host-pin check or filesystem durability proof.
+    RetainedStopped,
+    /// The exact retained resource is not yet verified stopped. No mutation was attempted.
+    Pending,
+    /// The exact resource was absent. This must never be promoted to retained Stop success.
+    Absent,
+}
+
+/// Optional provider-read-only capability, deliberately separate from issuing Stop.
+pub trait InteractiveWorkerStopObserver: InteractiveWorkerProvider {
+    /// Observe one exact saved worker and storage binding off the render thread.
+    /// Validate the complete expectation before I/O, then verify retained ownership,
+    /// inactive compute and storage. Never Stop, create, restart, delete, reconcile,
+    /// use SSH, obtain host keys, or turn absence/termination into retained success.
+    /// # Errors
+    /// Rejects invalid or mismatched identity/storage, uncertain metadata and failed
+    /// observations. Diagnostics must not include provider response payloads.
+    fn observe_worker_stop(
+        &self,
+        expected: InteractiveWorkerStopExpectation<'_>,
+    ) -> Result<InteractiveWorkerStopObservation, Self::Error>;
 }

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -5,7 +5,10 @@ use super::super::{
         InteractiveWorkerLifecycle, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerSshEndpoint,
         InteractiveWorkerStatus, valid_ssh_coordinates,
     },
-    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+    interactive_worker_stop::{
+        InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation,
+        InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
+    },
 };
 use super::{
     RunPodCleanup, RunPodClient, RunPodEnsure, RunPodError, RunPodHostTrust, RunPodLifecycle,
@@ -225,6 +228,25 @@ impl InteractiveWorkerStopProvider for RunPodInteractiveWorkerProvider {
         super::validate_target(&worker.target, &self.profile)?;
         self.client
             .stop_interactive_worker(&retained, &worker.ssh_public_key, &self.profile)
+    }
+}
+
+impl InteractiveWorkerStopObserver for RunPodInteractiveWorkerProvider {
+    fn observe_worker_stop(
+        &self,
+        expected: InteractiveWorkerStopExpectation<'_>,
+    ) -> Result<InteractiveWorkerStopObservation, Self::Error> {
+        self.client.check_network_worker(expected.worker)?;
+        let retained = runpod_worker(expected.worker)?;
+        super::validate_target(&expected.worker.target, &self.profile)?;
+        if !expected.ssh.is_complete() {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        if self.client.network_binding.as_ref().map(|binding| &binding.selection) != expected.network_volume {
+            return Err(RunPodError::InvalidTarget);
+        }
+        self.client
+            .observe_interactive_worker_stop(&retained, &expected.worker.ssh_public_key, &self.profile)
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/network_attachment/tests/stop.rs
@@ -1,7 +1,13 @@
 use super::*;
 use crate::{
-    cloud_run::{CloudWorkflowStore, interactive_worker_stop::InteractiveWorkerStop},
-    remote_workspace::stop::{RemoteWorkspaceStopError, stop_remote_workspace},
+    cloud_run::{
+        CloudWorkflowStore, StoredRemoteAllocation,
+        interactive_worker_stop::{
+            InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation as Observation,
+            InteractiveWorkerStopObserver,
+        },
+    },
+    remote_workspace::stop::{RemoteWorkspaceStopError, confirm_remote_workspace_stop, stop_remote_workspace},
     remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
 };
 
@@ -379,4 +385,243 @@ fn durable_intent_selection_and_identity_survive_unverified_stop() {
     );
     assert_eq!(stopped.workflow(), pending.workflow());
     assert_calls(&fixture, &["get", "volume", "stop", "get", "volume", "get", "volume"]);
+}
+
+fn saved_pin() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: "worker.example".into(),
+        port: 2200,
+        username: "root".into(),
+        host_key: ed25519_key(73),
+    }
+}
+
+#[test]
+fn stop_observation_matches_saved_selection_before_get_and_checks_retention_without_stop() {
+    for changed in 0..4 {
+        let fixture = fixture();
+        let mut selection = fixture.selection.clone();
+        match changed {
+            0 => selection.volume_id = "foreign".into(),
+            1 => selection.data_center_id = "foreign".into(),
+            2 => selection.minimum_size_gb += 1,
+            _ => {}
+        }
+        assert_eq!(
+            fixture
+                .provider()
+                .observe_worker_stop(InteractiveWorkerStopExpectation {
+                    worker: &fixture.worker(),
+                    ssh: &saved_pin(),
+                    network_volume: (changed != 3).then_some(&selection),
+                }),
+            Err(RunPodError::InvalidTarget)
+        );
+        assert_calls(&fixture, &[]);
+    }
+    for changed in 0..6 {
+        let fixture = fixture();
+        let mut data = metadata();
+        {
+            let mut state = fixture.transport.0.lock().expect("state");
+            state.pods[0].status = Some("EXITED".into());
+            match changed {
+                1 => data["mounts"]["network"][0]["volumeId"] = json!("foreign"),
+                2 => state.volume.as_mut().expect("volume")["type"] = json!("STANDARD"),
+                3 => state.volume = None,
+                4 => state.pods[0].status = Some("TERMINATED".into()),
+                5 => data["runtime"] = json!({"uptime":1}),
+                _ => {}
+            }
+            state.pods[0].stop = serde_json::from_value(data).expect("metadata");
+        }
+        let result = fixture
+            .provider()
+            .observe_worker_stop(InteractiveWorkerStopExpectation {
+                worker: &fixture.worker(),
+                ssh: &saved_pin(),
+                network_volume: Some(&fixture.selection),
+            });
+        if changed == 0 {
+            assert_eq!(result, Ok(Observation::RetainedStopped));
+        } else {
+            assert!(result.is_err());
+        }
+        assert_calls(&fixture, &["get", "volume"]);
+    }
+}
+
+fn confirmation_fixture() -> (tempfile::TempDir, CloudWorkflowStore, StoredRemoteAllocation, Fixture) {
+    let directory = tempfile::tempdir().expect("fixture");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let fixture = Fixture::new();
+    let workspace: RemoteWorkspaceState = serde_json::from_value(json!({
+        "version":1,"spec":{"workspace_local_id":"workspace","working_directory":".","generation":0,
+            "target":fixture.request.target,"repository":{"repository":"example/project","commit":"b".repeat(40)},"panels":[]}
+    })).expect("workspace");
+    let saved = store
+        .create_remote_workspace("00000000-0000-4000-8000-000000000001", &workspace)
+        .expect("workspace");
+    let allocated = store.allocate_remote_runtime(&saved, i64::MAX).expect("allocation");
+    store
+        .record_remote_network_volume_selection(&allocated, &fixture.selection)
+        .expect("selection");
+    let reserved = store
+        .reserve_remote_worker_request(&allocated, &fixture.request.ssh_public_key)
+        .expect("request");
+    let fixture = Fixture::from_request(reserved.worker_request().expect("request"));
+    prepare(&fixture);
+    fixture.transport.0.lock().expect("state").pods[0].status = Some("EXITED".into());
+    let mut next = reserved.workspace().state().clone();
+    let runtime = next.runtime.as_mut().expect("runtime");
+    runtime.worker = Some(fixture.worker());
+    runtime.ssh = Some(saved_pin());
+    runtime.phase = RemoteRuntimePhase::Stopping { requested_at_millis: 1 };
+    store
+        .replace_remote_workspace(reserved.workspace(), &next)
+        .expect("synthetic retained intent");
+    let pending = store
+        .load_remote_allocation(saved.session_id(), "workspace")
+        .expect("read")
+        .expect("pending");
+    (directory, store, pending, fixture)
+}
+
+#[test]
+fn hps_confirmation_preserves_exact_selection_worker_and_pin() {
+    let (_directory, store, pending, fixture) = confirmation_fixture();
+    let confirmed = confirm_remote_workspace_stop(&store, &fixture.provider(), &pending).expect("confirmed");
+    assert_eq!(confirmed.observation, Observation::RetainedStopped);
+    assert_eq!(
+        store
+            .load_remote_network_volume_selection(&confirmed.allocation)
+            .expect("selection"),
+        Some(fixture.selection.clone())
+    );
+    let mut expected = pending.workspace().state().clone();
+    expected.runtime.as_mut().expect("runtime").phase = confirmed
+        .allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .expect("runtime")
+        .phase;
+    assert_eq!(confirmed.allocation.workspace().state(), &expected);
+    assert_calls(&fixture, &["get", "volume"]);
+}
+
+struct DriftingObserver {
+    provider: RunPodInteractiveWorkerProvider,
+    store: CloudWorkflowStore,
+    pin: bool,
+    during: bool,
+}
+
+impl InteractiveWorkerProvider for DriftingObserver {
+    type Error = RunPodError;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::RunPod
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no creation")
+    }
+    fn inspect_worker(
+        &self,
+        _: &InteractiveWorker,
+    ) -> Result<Option<crate::cloud_run::interactive_worker::InteractiveWorkerStatus>, Self::Error> {
+        panic!("no generic lifecycle")
+    }
+    fn reconcile_worker(
+        &self,
+        _: &InteractiveWorkerRequest,
+    ) -> Result<Option<crate::cloud_run::interactive_worker::InteractiveWorkerStatus>, Self::Error> {
+        panic!("no creation reconciliation")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no deletion")
+    }
+}
+
+impl InteractiveWorkerStopObserver for DriftingObserver {
+    fn observe_worker_stop(&self, expected: InteractiveWorkerStopExpectation<'_>) -> Result<Observation, Self::Error> {
+        let result = self.provider.observe_worker_stop(expected);
+        if self.during {
+            change_binding(&self.store, self.pin);
+        }
+        result
+    }
+}
+
+fn change_binding(store: &CloudWorkflowStore, pin: bool) {
+    // Isolate each post-read fence with valid fixture data; restore immutable selection schema.
+    let mut connection = rusqlite::Connection::open(store.path()).expect("fixture database");
+    let transaction = connection.transaction().expect("transaction");
+    if pin {
+        let snapshot: Vec<u8> = transaction
+            .query_row(
+                "SELECT snapshot FROM remote_workspaces WHERE workspace_local_id='workspace'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("snapshot");
+        let mut value: Value = serde_json::from_slice(&snapshot).expect("decode");
+        value["state"]["runtime"]["ssh"]["host_key"] = json!(ed25519_key(74));
+        transaction
+            .execute(
+                "UPDATE remote_workspaces SET snapshot=?1, revision=revision+1 WHERE workspace_local_id='workspace'",
+                [serde_json::to_vec(&value).expect("snapshot")],
+            )
+            .expect("fixture pin drift");
+    } else {
+        let trigger: String = transaction
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name='remote_network_volume_selections_no_update'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("trigger");
+        transaction
+            .execute_batch("DROP TRIGGER remote_network_volume_selections_no_update")
+            .expect("fixture only");
+        transaction.execute("UPDATE remote_network_volume_selections SET volume_id='changed-volume' WHERE workspace_local_id='workspace'", []).expect("fixture selection drift");
+        transaction.execute_batch(&trigger).expect("restore exact schema");
+    }
+    transaction.commit().expect("fixture committed");
+}
+
+#[test]
+fn saved_selection_and_pin_drift_refuse_before_query_or_after_observation_without_completion() {
+    for pin in [false, true] {
+        for during in [false, true] {
+            let (_directory, store, pending, fixture) = confirmation_fixture();
+            if !during {
+                change_binding(&store, pin);
+            }
+            let observer = DriftingObserver {
+                provider: fixture.provider(),
+                store: store.clone(),
+                pin,
+                during,
+            };
+            let error = confirm_remote_workspace_stop(&store, &observer, &pending).expect_err("drift");
+            assert_eq!(
+                error,
+                if pin || during {
+                    RemoteWorkspaceStopError::StateChanged
+                } else {
+                    RemoteWorkspaceStopError::ProviderUnavailable
+                }
+            );
+            let current = store
+                .load_remote_allocation(pending.workspace().session_id(), "workspace")
+                .expect("read")
+                .expect("current");
+            assert_eq!(
+                current.workspace().state().runtime.as_ref().expect("runtime").phase,
+                RemoteRuntimePhase::Stopping { requested_at_millis: 1 }
+            );
+            assert_calls(&fixture, if during { &["get", "volume"] } else { &[] });
+        }
+    }
 }

--- a/crates/horizon-core/src/cloud_run/runpod/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/stop.rs
@@ -6,7 +6,7 @@ use super::{
     ApiPod, InteractiveWorkerLifetime, RunPodClient, RunPodError, RunPodLifecycle, RunPodProfile, RunPodWorker,
     status_from_resource, valid_ssh_public_key,
 };
-use crate::cloud_run::interactive_worker_stop::InteractiveWorkerStop;
+use crate::cloud_run::interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopObservation};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -67,16 +67,7 @@ impl RunPodClient {
         ssh_public_key: &str,
         profile: &RunPodProfile,
     ) -> Result<InteractiveWorkerStop, RunPodError> {
-        worker.validate()?;
-        if worker.lifetime != InteractiveWorkerLifetime::Persistent {
-            return Err(RunPodError::StopUnsupportedLifetime);
-        }
-        if !valid_ssh_public_key(ssh_public_key) {
-            return Err(RunPodError::InvalidPersistedWorker);
-        }
-        if self.network_binding.is_none() && profile.volume_gib == 0 {
-            return Err(RunPodError::StopRetentionUnverified);
-        }
+        self.validate_stop_request(worker, ssh_public_key, profile)?;
         let Some(before) = self.transport.get(&worker.pod_id)? else {
             return Ok(InteractiveWorkerStop::AlreadyAbsent);
         };
@@ -99,6 +90,44 @@ impl RunPodClient {
         stopping?;
         Err(RunPodError::StopVerificationFailed)
     }
+
+    pub(super) fn observe_interactive_worker_stop(
+        &self,
+        worker: &RunPodWorker,
+        ssh_public_key: &str,
+        profile: &RunPodProfile,
+    ) -> Result<InteractiveWorkerStopObservation, RunPodError> {
+        self.validate_stop_request(worker, ssh_public_key, profile)?;
+        let Some(pod) = self.transport.get(&worker.pod_id)? else {
+            return Ok(InteractiveWorkerStopObservation::Absent);
+        };
+        let retained = self.retained_state(&pod, worker, ssh_public_key, profile)?;
+        Ok(if retained.stopped {
+            InteractiveWorkerStopObservation::RetainedStopped
+        } else {
+            InteractiveWorkerStopObservation::Pending
+        })
+    }
+
+    fn validate_stop_request(
+        &self,
+        worker: &RunPodWorker,
+        ssh_public_key: &str,
+        profile: &RunPodProfile,
+    ) -> Result<(), RunPodError> {
+        worker.validate()?;
+        if worker.lifetime != InteractiveWorkerLifetime::Persistent {
+            return Err(RunPodError::StopUnsupportedLifetime);
+        }
+        if !valid_ssh_public_key(ssh_public_key) {
+            return Err(RunPodError::InvalidPersistedWorker);
+        }
+        if self.network_binding.is_none() && profile.volume_gib == 0 {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
+        Ok(())
+    }
+
     fn retained_state(
         &self,
         pod: &ApiPod,

--- a/crates/horizon-core/src/cloud_run/runpod/tests/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/stop.rs
@@ -9,6 +9,8 @@ use crate::{
 };
 use serde_json::{Value, json};
 
+mod confirmation;
+
 struct Fixture {
     worker: InteractiveWorker,
     transport: FakeTransport,

--- a/crates/horizon-core/src/cloud_run/runpod/tests/stop/confirmation.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/tests/stop/confirmation.rs
@@ -1,0 +1,182 @@
+use super::*;
+use crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint;
+use crate::cloud_run::interactive_worker_stop::{
+    InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation as Observation, InteractiveWorkerStopObserver,
+};
+
+fn ssh() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: "worker.example".into(),
+        port: 2222,
+        username: "root".into(),
+        host_key: ed25519_key(73),
+    }
+}
+
+fn observe(fixture: &Fixture) -> Result<Observation, RunPodError> {
+    fixture
+        .provider()
+        .observe_worker_stop(InteractiveWorkerStopExpectation {
+            worker: &fixture.worker,
+            ssh: &ssh(),
+            network_volume: None,
+        })
+}
+
+#[test]
+fn observation_reads_once_for_pending_retained_stopped_absence_and_failure_without_stop() {
+    for (status, expected) in [
+        ("RUNNING", Observation::Pending),
+        ("STARTING", Observation::Pending),
+        ("PROVISIONING", Observation::Pending),
+        ("EXITED", Observation::RetainedStopped),
+    ] {
+        let fixture = Fixture::new();
+        fixture.transport.0.lock().expect("state").pods[0].status = Some(status.into());
+        assert_eq!(observe(&fixture), Ok(expected));
+        fixture.assert_calls(1, 0);
+    }
+    let fixture = Fixture::new();
+    fixture.transport.0.lock().expect("state").pods.clear();
+    assert_eq!(observe(&fixture), Ok(Observation::Absent));
+    fixture.assert_calls(1, 0);
+    let fixture = Fixture::new();
+    fixture.transport.0.lock().expect("state").scripted_gets = vec![Err(stopping_failure())];
+    assert_eq!(observe(&fixture), Err(stopping_failure()));
+    fixture.assert_calls(1, 0);
+}
+
+#[test]
+fn malformed_pin_profile_worker_and_selection_refuse_before_any_read() {
+    for changed in 0..6 {
+        let fixture = Fixture::new();
+        let mut worker = fixture.worker.clone();
+        let mut pin = ssh();
+        let selection = RunPodNetworkVolumeExpectation {
+            volume_id: "other".into(),
+            data_center_id: "other".into(),
+            minimum_size_gb: 10,
+        };
+        match changed {
+            0 => worker.identity.resource_id = "../foreign".into(),
+            1 => worker.ssh_public_key.clear(),
+            2 => worker.target.profile = "changed".into(),
+            3 => pin.host_key.clear(),
+            4 => pin.port = 0,
+            _ => {}
+        }
+        assert!(
+            fixture
+                .provider()
+                .observe_worker_stop(InteractiveWorkerStopExpectation {
+                    worker: &worker,
+                    ssh: &pin,
+                    network_volume: (changed == 5).then_some(&selection),
+                })
+                .is_err()
+        );
+        fixture.assert_calls(0, 0);
+    }
+}
+
+#[test]
+fn terminal_or_malformed_metadata_cannot_be_promoted_to_retained_success() {
+    for changed in 0..10 {
+        let fixture = Fixture::new();
+        let mut pod = fixture.pod();
+        pod.status = Some("EXITED".into());
+        let mut data = metadata();
+        match changed {
+            0 => pod.status = Some("TERMINATED".into()),
+            1 => pod.status = Some("UNKNOWN".into()),
+            2 => data["runtime"] = json!({"uptime":1}),
+            3 => data["mounts"]["persistent"]["path"] = json!("/other"),
+            4 => data["mounts"]["persistent"]["size"] = json!(19),
+            5 => data["mounts"] = json!({}),
+            6 => data["cloud"] = json!("COMMUNITY"),
+            7 => data["cluster"] = json!({"id":"foreign"}),
+            8 => {
+                pod.status = Some("RUNNING".into());
+                data["locked"] = json!(true);
+            }
+            _ => {
+                pod.status = Some("RUNNING".into());
+                data["actions"] = json!(["terminate"]);
+            }
+        }
+        pod.stop = serde_json::from_value(data).expect("metadata");
+        fixture.transport.0.lock().expect("state").pods = vec![pod];
+        assert!(observe(&fixture).is_err());
+        fixture.assert_calls(1, 0);
+    }
+}
+
+#[test]
+fn observation_refuses_exact_identity_drift_without_mutation_or_host_key_lookup() {
+    for changed in 0..6 {
+        let fixture = Fixture::new();
+        let mut pod = fixture.pod();
+        match changed {
+            0 => pod.id = "foreign".into(),
+            1 => pod.name = "foreign".into(),
+            2 => pod.image = format!("example/foreign@sha256:{}", "e".repeat(64)),
+            3 => {
+                pod.env.insert(WORKFLOW_ENV.into(), CloudWorkflowId::new().to_string());
+            }
+            4 => {
+                pod.env.insert(JOB_ENV.into(), CloudJobId::new().to_string());
+            }
+            _ => {
+                pod.env.insert(SSH_PUBLIC_KEY_ENV.into(), ed25519_key(9));
+            }
+        }
+        fixture.transport.0.lock().expect("state").scripted_gets = vec![Ok(Some(pod))];
+        assert_eq!(observe(&fixture), Err(RunPodError::ResourceIdentityMismatch));
+        fixture.assert_calls(1, 0);
+    }
+}
+
+#[test]
+fn actual_provider_confirmation_completes_delayed_stop_without_resending() {
+    let directory = tempfile::tempdir().expect("store");
+    let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+    let (allocated, fixture) = stored_fixture(&store);
+    let mut saved = allocated.workspace().state().clone();
+    saved.runtime.as_mut().expect("runtime").ssh = Some(ssh());
+    store
+        .replace_remote_workspace(allocated.workspace(), &saved)
+        .expect("saved pin");
+    let current = store
+        .load_remote_allocation(OWNER, "workspace")
+        .expect("read")
+        .expect("allocation");
+    let pending = store
+        .record_remote_stop_phase(&current, RemoteRuntimePhase::Stopping { requested_at_millis: 1 })
+        .expect("saved intent");
+    let first = crate::remote_workspace::stop::confirm_remote_workspace_stop(&store, &fixture.provider(), &pending)
+        .expect("pending read");
+    assert_eq!(first.observation, Observation::Pending);
+    assert_eq!(first.allocation, pending);
+    fixture.assert_calls(1, 0);
+    fixture.transport.0.lock().expect("state").pods[0].status = Some("EXITED".into());
+    let reopened = CloudWorkflowStore::open_path(store.path()).expect("fresh controller");
+    let confirmed =
+        crate::remote_workspace::stop::confirm_remote_workspace_stop(&reopened, &fixture.provider(), &pending)
+            .expect("retained stop");
+    assert_eq!(confirmed.observation, Observation::RetainedStopped);
+    assert!(matches!(
+        confirmed
+            .allocation
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase,
+        RemoteRuntimePhase::Stopped {
+            requested_at_millis: 1,
+            ..
+        }
+    ));
+    fixture.assert_calls(2, 0);
+}

--- a/crates/horizon-core/src/remote_workspace/stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop.rs
@@ -1,8 +1,10 @@
 //! Explicit, durable Stop coordination. Client lifecycle never invokes this operation.
 
 mod configured;
+mod confirmation;
 
 pub use configured::{ConfiguredStopError, stop_configured_remote_environment};
+pub use confirmation::{RemoteWorkspaceStopConfirmation, confirm_remote_workspace_stop};
 
 use crate::{
     cloud_run::{
@@ -89,6 +91,10 @@ pub enum RemoteWorkspaceStopError {
     MissingAllocation,
     #[error("saved environment has no exact retained worker to stop")]
     MissingWorker,
+    #[error("saved environment has no existing Stop intent to confirm")]
+    MissingStopIntent,
+    #[error("Stop observation requires an already retained complete SSH pin")]
+    MissingTrust,
     #[error("saved environment changed; refresh before explicitly retrying Stop")]
     StateChanged,
     #[error("Stop provider does not match the saved worker")]

--- a/crates/horizon-core/src/remote_workspace/stop/confirmation.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/confirmation.rs
@@ -1,0 +1,108 @@
+//! Observe an existing intent; only verified completion writes local state, never the provider.
+
+use super::{RemoteRuntimePhase, RemoteWorkspaceStopError as Error, current_millis};
+use crate::cloud_run::{
+    CloudWorkflowStore, StoredRemoteAllocation, WorkerLifetime,
+    interactive_worker_stop::{
+        InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation, InteractiveWorkerStopObserver,
+    },
+};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RemoteWorkspaceStopConfirmation {
+    /// Unchanged for pending/absent observations and already-confirmed Stop.
+    pub allocation: StoredRemoteAllocation,
+    pub observation: InteractiveWorkerStopObservation,
+}
+
+/// Confirm only an already persisted Stop intent without reissuing any provider mutation.
+/// Requires the exact complete allocation snapshot, worker and saved public host pin.
+/// The observer is provider-read-only; retained-stopped proof may CAS-write local completion.
+/// Pending, absence and errors preserve the original intent, identity and timestamps.
+/// No private key, host-key lookup, first pin, recovery, allocation or cleanup is attempted.
+/// A repeated observation of saved Stopped never rewrites its original observation time.
+/// Run off the render thread; the result is point-in-time retention, not a checkpoint,
+/// task success, live SSH trust verification, billing cessation or filesystem durability.
+/// # Errors
+/// Rejects missing intent/trust, mismatched ownership/provider, competing management,
+/// snapshot or selection drift, failed observations, unsafe clocks and storage errors.
+pub fn confirm_remote_workspace_stop<P: InteractiveWorkerStopObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    observer: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<RemoteWorkspaceStopConfirmation, Error> {
+    let allocation = current(store, expected)?;
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?;
+    let requested_at_millis = runtime
+        .phase
+        .stop_requested_at_millis()
+        .ok_or(Error::MissingStopIntent)?;
+    if runtime.cleanup.is_some() {
+        return Err(Error::ManagementConflict);
+    }
+    let worker = runtime.worker.as_ref().ok_or(Error::MissingWorker)?;
+    if !worker.is_valid_for(observer.provider()) {
+        return Err(Error::ProviderMismatch);
+    }
+    if worker.target.lifetime != WorkerLifetime::Persistent {
+        return Err(Error::UnsupportedLifetime);
+    }
+    let ssh = runtime
+        .ssh
+        .as_ref()
+        .filter(|ssh| ssh.is_complete())
+        .ok_or(Error::MissingTrust)?;
+    if requested_at_millis > current_millis()? {
+        return Err(Error::InvalidTimestamp);
+    }
+    let selection = store.load_remote_network_volume_selection(&allocation)?;
+    let observation = observer.observe_worker_stop(InteractiveWorkerStopExpectation {
+        worker,
+        ssh,
+        network_volume: selection.as_ref(),
+    });
+    current(store, &allocation)?;
+    if store.load_remote_network_volume_selection(&allocation)? != selection {
+        return Err(Error::StateChanged);
+    }
+    let observation = observation.map_err(|_| Error::ProviderUnavailable)?;
+    let confirmed = if observation == InteractiveWorkerStopObservation::RetainedStopped
+        && matches!(runtime.phase, RemoteRuntimePhase::Stopping { .. })
+    {
+        let observed_at_millis = current_millis()?;
+        if observed_at_millis < requested_at_millis {
+            return Err(Error::InvalidTimestamp);
+        }
+        store.record_remote_stop_phase(
+            &allocation,
+            RemoteRuntimePhase::Stopped {
+                requested_at_millis,
+                observed_at_millis,
+            },
+        )?
+    } else {
+        allocation
+    };
+    Ok(RemoteWorkspaceStopConfirmation {
+        allocation: confirmed,
+        observation,
+    })
+}
+
+fn current(store: &CloudWorkflowStore, expected: &StoredRemoteAllocation) -> Result<StoredRemoteAllocation, Error> {
+    let current = store
+        .load_remote_allocation(
+            expected.workspace().session_id(),
+            &expected.workspace().state().spec.workspace_local_id,
+        )?
+        .ok_or(Error::MissingAllocation)?;
+    if current != *expected {
+        return Err(Error::StateChanged);
+    }
+    Ok(current)
+}

--- a/crates/horizon-core/src/remote_workspace/stop/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests.rs
@@ -1,4 +1,5 @@
 mod configured;
+mod confirmation;
 
 use super::*;
 use crate::{

--- a/crates/horizon-core/src/remote_workspace/stop/tests/confirmation.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests/confirmation.rs
@@ -1,0 +1,248 @@
+use super::*;
+use crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint;
+use crate::cloud_run::interactive_worker_stop::{
+    InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation as Observation, InteractiveWorkerStopObserver,
+};
+
+struct Observer {
+    kind: CloudProvider,
+    result: Result<Observation, &'static str>,
+    calls: Mutex<usize>,
+    hook: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl Observer {
+    fn new(result: Result<Observation, &'static str>) -> Self {
+        Self {
+            kind: CloudProvider::LocalDocker,
+            result,
+            calls: Mutex::new(0),
+            hook: None,
+        }
+    }
+    fn calls(&self) -> usize {
+        *self.calls.lock().expect("calls")
+    }
+}
+
+impl InteractiveWorkerProvider for Observer {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("confirmation must not create")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("generic lifecycle is not retained Stop proof")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("confirmation must not reconcile creation")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("confirmation must not delete")
+    }
+}
+
+impl InteractiveWorkerStopObserver for Observer {
+    fn observe_worker_stop(&self, expected: InteractiveWorkerStopExpectation<'_>) -> Result<Observation, Self::Error> {
+        assert!(expected.ssh.is_complete());
+        assert!(expected.worker.is_valid_for(self.kind));
+        assert!(expected.network_volume.is_none());
+        *self.calls.lock().expect("calls") += 1;
+        if let Some(hook) = &self.hook {
+            hook();
+        }
+        self.result.map_err(std::io::Error::other)
+    }
+}
+
+fn retain_pin(fixture: &Fixture) {
+    let current = fixture.current();
+    let mut next = current.workspace().state().clone();
+    let runtime = next.runtime.as_mut().expect("runtime");
+    runtime.ssh = Some(InteractiveWorkerSshEndpoint {
+        host: "worker.example".into(),
+        port: 2222,
+        username: "root".into(),
+        host_key: runtime.worker.as_ref().expect("worker").ssh_public_key.clone(),
+    });
+    fixture
+        .store
+        .replace_remote_workspace(current.workspace(), &next)
+        .expect("retained public pin");
+}
+
+fn intent(fixture: &Fixture) -> StoredRemoteAllocation {
+    fixture
+        .store
+        .record_remote_stop_phase(
+            &fixture.current(),
+            RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+        )
+        .expect("existing synthetic intent, no provider Stop")
+}
+
+#[test]
+fn pending_absence_and_errors_do_not_write_or_consume_existing_intent() {
+    let fixture = Fixture::new();
+    retain_pin(&fixture);
+    let pending = intent(&fixture);
+    for outcome in [
+        Ok(Observation::Pending),
+        Ok(Observation::Absent),
+        Err("private-provider-marker"),
+    ] {
+        let observer = Observer::new(outcome);
+        let result = confirm_remote_workspace_stop(&fixture.store, &observer, &pending);
+        if let Ok(observation) = outcome {
+            let result = result.expect("point-in-time observation");
+            assert_eq!(result.observation, observation);
+            assert_eq!(result.allocation, pending);
+        } else {
+            let error = result.expect_err("unverified");
+            assert_eq!(error, Error::ProviderUnavailable);
+            assert!(!format!("{error:?} {error}").contains("private-provider-marker"));
+        }
+        assert_eq!(fixture.current(), pending);
+        assert_eq!(observer.calls(), 1);
+    }
+}
+
+#[test]
+fn delayed_confirmation_preserves_identity_and_original_times_across_fresh_store() {
+    let fixture = Fixture::new();
+    retain_pin(&fixture);
+    let pending = intent(&fixture);
+    let observer = Observer::new(Ok(Observation::RetainedStopped));
+    let reopened = CloudWorkflowStore::open_path(fixture.store.path()).expect("fresh controller");
+    let completed = confirm_remote_workspace_stop(&reopened, &observer, &pending).expect("confirmed");
+    let mut expected = pending.workspace().state().clone();
+    let phase = fixture.phase();
+    assert!(
+        matches!(phase, RemoteRuntimePhase::Stopped { requested_at_millis: 1, observed_at_millis } if observed_at_millis >= 1)
+    );
+    expected.runtime.as_mut().expect("runtime").phase = phase;
+    assert_eq!(completed.allocation.workspace().state(), &expected);
+    assert_eq!(completed.allocation.workflow(), pending.workflow());
+    assert_eq!(
+        completed.allocation.workspace().revision(),
+        pending.workspace().revision() + 1
+    );
+    for outcome in [Observation::RetainedStopped, Observation::Pending, Observation::Absent] {
+        let result = confirm_remote_workspace_stop(&reopened, &Observer::new(Ok(outcome)), &completed.allocation)
+            .expect("already-stopped observation");
+        assert_eq!(result.allocation, completed.allocation);
+        assert_eq!(result.observation, outcome);
+        assert_eq!(fixture.current(), completed.allocation);
+    }
+}
+
+#[test]
+fn missing_intent_pin_wrong_provider_and_future_request_refuse_before_observation() {
+    let fixture = Fixture::new();
+    let observer = Observer::new(Ok(Observation::RetainedStopped));
+    let untouched = fixture.current();
+    assert_eq!(
+        confirm_remote_workspace_stop(&fixture.store, &observer, &untouched),
+        Err(Error::MissingStopIntent)
+    );
+    assert_eq!(fixture.current(), untouched);
+    let pending = intent(&fixture);
+    assert_eq!(
+        confirm_remote_workspace_stop(&fixture.store, &observer, &pending),
+        Err(Error::MissingTrust)
+    );
+    assert_eq!(fixture.current(), pending);
+    retain_pin(&fixture);
+    let mut wrong = Observer::new(Ok(Observation::RetainedStopped));
+    wrong.kind = CloudProvider::RunPod;
+    assert_eq!(
+        confirm_remote_workspace_stop(&fixture.store, &wrong, &fixture.current()),
+        Err(Error::ProviderMismatch)
+    );
+    let future = Fixture::new();
+    retain_pin(&future);
+    let future_request = future
+        .store
+        .record_remote_stop_phase(
+            &future.current(),
+            RemoteRuntimePhase::Stopping {
+                requested_at_millis: i64::MAX,
+            },
+        )
+        .expect("future request");
+    assert_eq!(
+        confirm_remote_workspace_stop(&future.store, &observer, &future_request),
+        Err(Error::InvalidTimestamp)
+    );
+    assert_eq!(future.current(), future_request);
+    assert_eq!(observer.calls() + wrong.calls(), 0);
+}
+
+fn drift(store: &CloudWorkflowStore, workflow: bool) {
+    let current = store
+        .load_remote_allocation(OWNER, "workspace")
+        .expect("read")
+        .expect("allocation");
+    if workflow {
+        let mut next = current.workflow().workflow().clone();
+        next.updated_at_millis += 1;
+        store.replace(current.workflow(), &next).expect("workflow drift");
+    } else {
+        let mut next = current.workspace().state().clone();
+        next.spec.panels.clear();
+        store
+            .replace_remote_workspace(current.workspace(), &next)
+            .expect("workspace drift");
+    }
+}
+
+#[test]
+fn full_snapshot_drift_is_fenced_before_and_after_each_observation_outcome() {
+    for workflow in [false, true] {
+        for before_call in [false, true] {
+            for outcome in [
+                Ok(Observation::RetainedStopped),
+                Ok(Observation::Pending),
+                Ok(Observation::Absent),
+                Err("lost read"),
+            ] {
+                let fixture = Fixture::new();
+                retain_pin(&fixture);
+                let expected = intent(&fixture);
+                let mut observer = Observer::new(outcome);
+                if before_call {
+                    drift(&fixture.store, workflow);
+                } else {
+                    let store = fixture.store.clone();
+                    observer.hook = Some(Box::new(move || drift(&store, workflow)));
+                }
+                assert_eq!(
+                    confirm_remote_workspace_stop(&fixture.store, &observer, &expected),
+                    Err(Error::StateChanged)
+                );
+                assert_eq!(fixture.phase(), RemoteRuntimePhase::Stopping { requested_at_millis: 1 });
+                assert_eq!(observer.calls(), usize::from(!before_call));
+            }
+        }
+    }
+}
+
+#[test]
+fn time_limited_intent_cannot_be_promoted_to_retained_stop() {
+    let fixture = Fixture::with_lifetime(InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+        terminate_after: (time::OffsetDateTime::now_utc() + time::Duration::minutes(15))
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("lease"),
+    }));
+    retain_pin(&fixture);
+    let expected = intent(&fixture);
+    let observer = Observer::new(Ok(Observation::RetainedStopped));
+    assert_eq!(
+        confirm_remote_workspace_stop(&fixture.store, &observer, &expected),
+        Err(Error::UnsupportedLifetime)
+    );
+    assert_eq!(fixture.current(), expected);
+    assert_eq!(observer.calls(), 0);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -449,6 +449,11 @@ back into large multi-purpose modules.
   reasons remain distinct; saved completion is not current provider status.
   This durable entrypoint admits only persistent execution: timed creation/expiry
   cleanup needs separate coordination before it can promise retained Stop intent.
+- `remote_workspace/stop/confirmation.rs` completes only existing Stop intent,
+  using the separate provider-read-only observer and exact allocation/selection fences.
+  RunPod reuses retained-state checks without Stop, SSH or host-key lookup. Only
+  verified retention permits local completion; pending/absence preserve saved state.
+  The saved public pin is shape-checked, not live-attested; configured/UI actions are separate.
 - `remote_workspace/stop/configured.rs` admits one explicitly confirmed saved
   selection through its exact named local provider profile. It reloads the owned
   record and compares the full summary/revision before durable Stop coordination,


### PR DESCRIPTION
## Purpose

Add an explicit core API to confirm an already-persisted Stop intent without sending Stop again. This addresses the delayed-confirmation gap in #473; broader #383 acceptance remains open.

## Behavior and safety

- `confirm_remote_workspace_stop` requires the exact saved allocation, an existing Stop intent, a persistent worker, complete saved public SSH pin, and matching selected storage. It rechecks the full allocation and storage selection after the provider observation, including failed observations.
- The separate optional observer capability is implemented for RunPod. It makes one Pod read, validates exact ownership and retention using the existing checks, and verifies selected HPS metadata where applicable. It never issues Stop, create, restart, delete, recovery, SSH, or host-key lookup.
- Only retained `EXITED` compute with absent runtime and matching retained storage can advance saved `Stopping` to `Stopped` through the existing local compare-and-set. Pending and absent observations leave the allocation unchanged; absence and `TERMINATED` are not retained-Stop success. Observing an already saved `Stopped` allocation does not rewrite its timestamps.
- Saved pins are shape-checked, not verified by a live handshake. Results do not certify task success, process memory, filesystem durability, checkpoints, or billing cessation.

No configured/UI wiring, new allocation authority, credentials, dependency, schema, or default changes are included. Scope is 10 source/test files and 907 changed source/test lines, plus a short architecture note. Provider-neutral storage/capability generalization remains in #517 after #383.

## Validation

- 108 focused tests passed (23 generic Stop and 85 RunPod), including 13 new cases for delayed completion, absent/pending/error outcomes, existing-intent admission, exact snapshot/selection drift, identity/retention mismatches, and zero Stop calls in the observation path.
- Focused tests use deterministic fake provider transports and synthetic local stores, including reopen/reload cases. They do not allocate resources or establish positive live-cloud, SSH, UI, or retained-byte proof.
- Source-identical refresh onto actual main `27ef6f94`; final candidate is `b45adbd5`.
- An earlier final-base matrix attempt hit an existing browser-CLI completion assertion. Five repetitions of the unchanged retained test binary passed; the cause remains unconfirmed and no unrelated source was changed. The fresh full-matrix result below is separate evidence.
- All eight fresh exact-head gates passed: formatting, maintainability, version sync, default workspace tests (2,494 passed), speech-enabled workspace tests (2,539 passed), blocking Clippy, strict Clippy, and advisory pedantic Clippy. Each test suite had zero failures and seven explicitly ignored tests; ignored live lanes are not counted as cloud proof.
