### PR TITLE
feat(remote): configure CPU workspace setup and recovery

### DIFF
--- a/crates/horizon-core/src/remote_workspace_setup/configured.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured.rs
@@ -273,7 +273,7 @@ fn submit_with(
     if spec != prepared.state.spec || allocation.workspace().session_id() != owner {
         return Err(Error::SetupUnconfirmed);
     }
-    check_result(&store, config, &allocation, prepared.network_volume.as_ref())?;
+    check_result(&store, config, &allocation, prepared.network_volume.as_ref()).map_err(|_| Error::SetupUnconfirmed)?;
     Ok(allocation)
 }
 

--- a/crates/horizon-core/src/remote_workspace_setup/configured.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured.rs
@@ -5,6 +5,7 @@ use crate::{
     cloud_run::{
         CloudProvider, CloudWorkflowStore, GitSource, RemoteWorkspaceStoreError, StoredRemoteAllocation,
         StoredRemoteWorkspace, WorkerLifetime, WorkerTarget,
+        azure::AzureProfile,
         local_docker::LocalDockerInteractiveWorkerProvider,
         runpod::{RunPodApiKey, RunPodHostTrust, RunPodNetworkVolumeExpectation, validate_target},
     },
@@ -14,6 +15,8 @@ use crate::{
 };
 use ConfiguredWorkspaceSetupError as Error;
 use std::path::PathBuf;
+
+mod azure;
 
 /// Non-secret caller input. No defaults select an image, profile, branch, command or storage.
 pub struct RemoteWorkspaceSetupDraft {
@@ -88,6 +91,14 @@ impl PreparedRemoteWorkspaceSetup {
     pub fn retain_until_millis(&self) -> i64 {
         self.retain_until_millis
     }
+    /// Complete non-secret Azure placement, price and pull-identity configuration to
+    /// display alongside the exact target before requesting persistent billing consent.
+    #[must_use]
+    pub fn azure_profile(&self) -> Option<&AzureProfile> {
+        (self.state.spec.target.provider == CloudProvider::Azure)
+            .then(|| self.config.azure_profile(&self.state.spec.target.profile).ok())
+            .flatten()
+    }
 }
 
 /// Positive authorization for the exact displayed image and, for `RunPod`, volume.
@@ -101,6 +112,12 @@ pub enum RemoteWorkspaceSetupConsent {
     RunPodHps {
         image: String,
         volume: RunPodNetworkVolumeExpectation,
+    },
+    /// Approve the complete displayed profile and immutable image, including the
+    /// managed pull identity and declared price (not a provider quote or spending cap).
+    Azure {
+        image: String,
+        profile: AzureProfile,
     },
 }
 
@@ -197,7 +214,7 @@ pub fn submit_configured_remote_workspace(
                 prepared.network_volume.as_ref().ok_or(Error::ConsentMismatch)?,
             )
             .map_err(|_| Error::SetupUnconfirmed),
-            CloudProvider::Azure => Err(Error::UnsupportedProvider),
+            CloudProvider::Azure => azure::start(store, &identities, config, saved, prepared.retain_until_millis),
         }
     });
     drop(consent);
@@ -230,6 +247,9 @@ fn submit_with(
                 && *image == target.image
                 && prepared.network_volume.as_ref() == Some(volume)
         }
+        RemoteWorkspaceSetupConsent::Azure { image, profile } => {
+            *image == target.image && prepared.azure_profile() == Some(profile) && prepared.network_volume.is_none()
+        }
     };
     if !authorized {
         return Err(Error::ConsentMismatch);
@@ -253,14 +273,15 @@ fn submit_with(
     if spec != prepared.state.spec || allocation.workspace().session_id() != owner {
         return Err(Error::SetupUnconfirmed);
     }
-    check_result(&store, &allocation, prepared.network_volume.as_ref())?;
+    check_result(&store, config, &allocation, prepared.network_volume.as_ref())?;
     Ok(allocation)
 }
 
 /// Manually recover only the original saved setup. No key/intent repair, allocation,
 /// ensure, creation, renewal or cleanup is allowed. A dormant or interrupted pre-intent
 /// setup is reported locally. Eligible recovery may persist a pin/observation.
-/// Current profile validation cannot attest historical edits under the same name.
+/// Azure requires its immutable saved profile binding; older unbound allocations are
+/// never backfilled. Other providers' current profiles do not attest historical edits.
 /// Run off-thread; caller discards results on current session/config/selection drift.
 /// # Errors
 /// Rejects foreign homes/owners, invalid bindings, missing storage and recovery failures.
@@ -288,7 +309,7 @@ pub fn check_configured_remote_workspace_setup(
                 allocation,
             )
             .map_err(|_| Error::SetupUnconfirmed),
-            CloudProvider::Azure => Err(Error::UnsupportedProvider),
+            CloudProvider::Azure => azure::recover(store, &identities, config, allocation),
         }
     })
 }
@@ -331,6 +352,9 @@ fn check_saved_with(
     if allocation.workspace() != &saved {
         return Err(Error::ContextChanged);
     }
+    if !azure::binding_matches(store, config, &allocation)? {
+        return Ok(ConfiguredWorkspaceSetupObservation::Interrupted(saved));
+    }
     let selection = store
         .load_remote_network_volume_selection(&allocation)
         .map_err(storage)?;
@@ -366,16 +390,20 @@ fn check_saved_with(
     if result.workspace().session_id() != saved.session_id() || result.workspace().state().spec != saved.state().spec {
         return Err(Error::SetupUnconfirmed);
     }
-    check_result(&writable, &result, selection.as_ref())?;
+    check_result(&writable, config, &result, selection.as_ref())?;
     Ok(ConfiguredWorkspaceSetupObservation::Observed(result))
 }
 
 fn check_result(
     store: &CloudWorkflowStore,
+    config: &RemoteProviderConfig,
     result: &StoredRemoteAllocation,
     selection: Option<&RunPodNetworkVolumeExpectation>,
 ) -> Result<(), Error> {
     super::validate_allocation(store, result).map_err(|_| Error::SetupUnconfirmed)?;
+    if !azure::binding_matches(store, config, result)? {
+        return Err(Error::SetupUnconfirmed);
+    }
     if store
         .load_remote_network_volume_selection(result)
         .map_err(storage)?
@@ -406,7 +434,9 @@ fn validate_profile(config: &RemoteProviderConfig, target: &WorkerTarget) -> Res
                 return Err(Error::InvalidRequest);
             }
         }
-        CloudProvider::Azure => return Err(Error::UnsupportedProvider),
+        CloudProvider::Azure => {
+            azure::profile(config, target)?;
+        }
     }
     Ok(())
 }
@@ -418,7 +448,7 @@ fn validate_selection(
 ) -> Result<(), Error> {
     validate_profile(config, target)?;
     match (target.provider, selection) {
-        (CloudProvider::LocalDocker, None) => Ok(()),
+        (CloudProvider::LocalDocker | CloudProvider::Azure, None) => Ok(()),
         (CloudProvider::RunPod, Some(volume)) => {
             volume.validate().map_err(|_| Error::InvalidRequest)?;
             let profile = config

--- a/crates/horizon-core/src/remote_workspace_setup/configured/azure.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/azure.rs
@@ -1,0 +1,113 @@
+//! Azure assembly only: retain original profile provenance before key or provider work.
+use super::{Error, RemoteProviderConfig, storage};
+use crate::{
+    cloud_run::{
+        CloudProvider, CloudWorkflowStore, StoredRemoteAllocation, StoredRemoteWorkspace, WorkerTarget,
+        azure::{AzureCliCredential, AzureClient, AzureDeploymentPlan, AzureProfile},
+        interactive_worker::InteractiveWorkerProvider,
+    },
+    remote_ssh_identity::RemoteSshIdentityStore,
+};
+
+pub(super) fn profile<'a>(config: &'a RemoteProviderConfig, target: &WorkerTarget) -> Result<&'a AzureProfile, Error> {
+    let profile = config
+        .azure_profile(&target.profile)
+        .map_err(|_| Error::InvalidProfile)?;
+    AzureDeploymentPlan::validate_target(profile, target).map_err(|_| Error::InvalidProfile)?;
+    Ok(profile)
+}
+
+fn client(profile: &AzureProfile, store: &CloudWorkflowStore) -> Result<AzureClient, Error> {
+    // Both constructors are lazy. Actual token acquisition starts inside the provider's
+    // bounded ARM transport, after the shared coordinator has reserved the client key.
+    let credential = AzureCliCredential::new(profile.subscription_id.clone()).map_err(|_| Error::InvalidProfile)?;
+    AzureClient::new(profile.clone(), credential, store.clone()).map_err(|_| Error::InvalidProfile)
+}
+
+pub(super) fn start(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    config: &RemoteProviderConfig,
+    saved: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+) -> Result<StoredRemoteAllocation, Error> {
+    start_with(
+        store,
+        identities,
+        profile(config, &saved.state().spec.target)?,
+        saved,
+        retain_until_millis,
+        client,
+    )
+}
+
+fn start_with<P: InteractiveWorkerProvider>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    profile: &AzureProfile,
+    saved: &StoredRemoteWorkspace,
+    retain_until_millis: i64,
+    factory: impl FnOnce(&AzureProfile, &CloudWorkflowStore) -> Result<P, Error>,
+) -> Result<StoredRemoteAllocation, Error> {
+    AzureDeploymentPlan::validate_target(profile, &saved.state().spec.target).map_err(|_| Error::InvalidProfile)?;
+    let allocation = store
+        .allocate_remote_runtime(saved, retain_until_millis)
+        .map_err(storage)?;
+    // Failure here retains an interrupted allocation, never a key, creation claim or
+    // provider request. Do not use start_remote_workspace: it prepares a key immediately.
+    store
+        .record_remote_cpu_profile_binding(&allocation, profile)
+        .map_err(storage)?;
+    let provider = factory(profile, store)?;
+    super::super::retry_remote_workspace_setup(store, identities, &provider, &allocation)
+        .map_err(|_| Error::SetupUnconfirmed)
+}
+
+/// Missing provenance is distinguishable from corrupt or changed provenance, but
+/// neither can authorize credential access, no-handle recovery or a backfill.
+pub(super) fn binding_matches(
+    store: &CloudWorkflowStore,
+    config: &RemoteProviderConfig,
+    allocation: &StoredRemoteAllocation,
+) -> Result<bool, Error> {
+    let target = &allocation.workspace().state().spec.target;
+    if target.provider != CloudProvider::Azure {
+        return Ok(true);
+    }
+    let profile = profile(config, target)?;
+    let Some(binding) = store.load_remote_cpu_profile_binding(allocation).map_err(storage)? else {
+        return Ok(false);
+    };
+    if !binding.matches_profile(profile).map_err(|_| Error::InvalidProfile)? {
+        return Err(Error::ContextChanged);
+    }
+    Ok(true)
+}
+
+pub(super) fn recover(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    config: &RemoteProviderConfig,
+    allocation: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, Error> {
+    recover_with(store, identities, config, allocation, client)
+}
+
+fn recover_with<P: InteractiveWorkerProvider>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    config: &RemoteProviderConfig,
+    allocation: &StoredRemoteAllocation,
+    factory: impl FnOnce(&AzureProfile, &CloudWorkflowStore) -> Result<P, Error>,
+) -> Result<StoredRemoteAllocation, Error> {
+    if !binding_matches(store, config, allocation)? {
+        return Err(Error::SetupUnconfirmed);
+    }
+    let provider = factory(profile(config, &allocation.workspace().state().spec.target)?, store)?;
+    // Existing recovery recovers (never creates) the reserved key and uses inspect or
+    // reconcile without ensure. Host-key attestation may run its fixed guest command.
+    super::super::recover(store, identities, &provider, allocation).map_err(|_| Error::SetupUnconfirmed)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace_setup/configured/azure/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/azure/tests.rs
@@ -355,6 +355,66 @@ fn binding_precedes_factory_and_key_and_successful_setup_never_replays() {
 }
 
 #[test]
+fn post_start_binding_drift_is_uncertain_and_never_replays_creation() {
+    let f = Fixture::new();
+    let prepared = f.preview();
+    let locator = prepared.locator().clone();
+    let backend = Backend::new(&f, &prepared, false);
+    let result = submit_with(&f.home, &f.config, OWNER, &prepared, &f.consent(), |store, saved| {
+        let allocation = start_with(store, &f.identities(), f.profile(), saved, i64::MAX, |_, _| {
+            Ok(backend.clone())
+        })?;
+        assert_eq!(backend.counts(), [1, 1, 0, 0]);
+        // Corrupt only this fresh synthetic row after successful provider dispatch,
+        // restoring the exact immutable trigger before any public store read.
+        let raw = rusqlite::Connection::open(store.path()).expect("synthetic database");
+        let trigger: String = raw
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name='remote_provider_bindings_no_update'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("original trigger");
+        raw.execute_batch("DROP TRIGGER remote_provider_bindings_no_update")
+            .expect("admit synthetic drift");
+        assert_eq!(
+            raw.execute(
+                "UPDATE remote_provider_bindings SET profile_digest=?1",
+                ["0".repeat(64)]
+            )
+            .expect("valid different digest"),
+            1
+        );
+        raw.execute_batch(&trigger).expect("restore immutable schema");
+        assert_eq!(
+            binding_matches(store, &f.config, &allocation),
+            Err(Error::ContextChanged)
+        );
+        Ok(allocation)
+    });
+    assert_eq!(result, Err(Error::SetupUnconfirmed));
+    assert!(prepared.locator() == &locator);
+    let retained = f.load(&prepared);
+    assert!(
+        retained
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_some()
+    );
+    assert_eq!(f.start(&prepared, backend.clone()), Err(Error::SaveConflict));
+    assert!(matches!(
+        f.check(&prepared, &f.config, backend.clone()),
+        Err(Error::ContextChanged)
+    ));
+    assert_eq!(f.load(&prepared), retained);
+    assert_eq!(backend.counts(), [1, 1, 0, 0]);
+}
+
+#[test]
 fn lost_creation_response_recovers_exact_no_handle_without_ensure() {
     let f = Fixture::new();
     let prepared = f.preview();

--- a/crates/horizon-core/src/remote_workspace_setup/configured/azure/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/azure/tests.rs
@@ -1,0 +1,480 @@
+//! Synthetic provider calls exercise the real store/key/coordinator ordering, never ARM or az.
+use super::super::{
+    ConfiguredWorkspaceSetupObservation as Observation, PreparedRemoteWorkspaceSetup,
+    RemoteWorkspaceSetupConsent as Consent, RemoteWorkspaceSetupDraft, check_with, preview_configured_remote_workspace,
+    submit_configured_remote_workspace, submit_with,
+};
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{
+        GitCommitSha, GitSource, WorkerLifetime,
+        azure::{AzureDiskSku, resource_group_name},
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+            InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerRequest, InteractiveWorkerStatus,
+        },
+    },
+    remote_workspace::RemotePanelCommand,
+};
+use std::{
+    os::unix::fs::PermissionsExt,
+    sync::{Arc, Mutex},
+};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+const SUBSCRIPTION: &str = "11111111-1111-4111-8111-111111111111";
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    home: HorizonHome,
+    config: RemoteProviderConfig,
+}
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).expect("private");
+        Self {
+            home: HorizonHome::from_root(directory.path().join("home")),
+            _directory: directory,
+            config: RemoteProviderConfig {
+                azure: vec![AzureProfile {
+                    name: "cpu".into(),
+                    subscription_id: SUBSCRIPTION.into(),
+                    location: "northeurope".into(),
+                    vm_size: "Standard_D4s_v3".into(),
+                    image_pull_identity_id: format!(
+                        "/subscriptions/{SUBSCRIPTION}/resourceGroups/synthetic/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"
+                    ),
+                    declared_hourly_cost_micros: 100_000,
+                    registry_login_server: "synthetic.azurecr.io".into(),
+                    disk_sku: AzureDiskSku::StandardSsdLrs,
+                }],
+                ..Default::default()
+            },
+        }
+    }
+    fn profile(&self) -> &AzureProfile {
+        &self.config.azure[0]
+    }
+    fn draft() -> RemoteWorkspaceSetupDraft {
+        RemoteWorkspaceSetupDraft {
+            target: WorkerTarget {
+                provider: CloudProvider::Azure,
+                profile: "cpu".into(),
+                image: format!("synthetic.azurecr.io/worker@sha256:{}", "a".repeat(64)),
+                disk_gib: 20,
+                lifetime: WorkerLifetime::Persistent,
+                max_hourly_cost_micros: Some(200_000),
+            },
+            repository: GitSource {
+                repository: "example/project".into(),
+                commit: GitCommitSha::parse("b".repeat(40)).expect("commit"),
+                branch: Some("work/fixture".into()),
+            },
+            working_directory: ".".into(),
+            command: RemotePanelCommand {
+                program: "/bin/sh".into(),
+                args: vec!["-c".into(), "printf synthetic".into()],
+            },
+            panel_directory: None,
+            retain_until_millis: i64::MAX,
+            network_volume: None,
+        }
+    }
+    fn preview(&self) -> PreparedRemoteWorkspaceSetup {
+        preview_configured_remote_workspace(&self.home, &self.config, OWNER, Self::draft()).expect("preview")
+    }
+    fn consent(&self) -> Consent {
+        Consent::Azure {
+            image: Self::draft().target.image,
+            profile: self.profile().clone(),
+        }
+    }
+    fn store(&self) -> CloudWorkflowStore {
+        CloudWorkflowStore::open(&self.home).expect("store")
+    }
+    fn identities(&self) -> RemoteSshIdentityStore {
+        RemoteSshIdentityStore::new(&self.home)
+    }
+    fn load(&self, p: &PreparedRemoteWorkspaceSetup) -> StoredRemoteAllocation {
+        self.store()
+            .load_remote_allocation(OWNER, &p.locator().workspace_local_id)
+            .expect("load")
+            .expect("allocation")
+    }
+    fn start(&self, p: &PreparedRemoteWorkspaceSetup, backend: Backend) -> Result<StoredRemoteAllocation, Error> {
+        submit_with(&self.home, &self.config, OWNER, p, &self.consent(), |store, saved| {
+            start_with(
+                store,
+                &self.identities(),
+                self.profile(),
+                saved,
+                p.retain_until_millis(),
+                |profile, store| {
+                    let allocation = self.load(p);
+                    assert!(
+                        store
+                            .load_remote_cpu_profile_binding(&allocation)
+                            .expect("binding")
+                            .expect("saved before factory")
+                            .matches_profile(profile)
+                            .expect("same")
+                    );
+                    assert!(
+                        allocation
+                            .workspace()
+                            .state()
+                            .runtime
+                            .as_ref()
+                            .expect("runtime")
+                            .ssh_public_key
+                            .is_none()
+                    );
+                    assert!(!self.home.root().join("remote-ssh-identities").exists());
+                    assert_eq!(backend.counts(), [0; 4]);
+                    Ok(backend)
+                },
+            )
+        })
+    }
+    fn check(
+        &self,
+        p: &PreparedRemoteWorkspaceSetup,
+        config: &RemoteProviderConfig,
+        backend: Backend,
+    ) -> Result<Observation, Error> {
+        check_with(&self.home, config, OWNER, p.locator(), |store, allocation| {
+            recover_with(store, &self.identities(), config, allocation, |_, _| Ok(backend))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct Backend {
+    store: CloudWorkflowStore,
+    workspace: String,
+    state: Arc<Mutex<BackendState>>,
+    lose_response: bool,
+}
+#[derive(Default)]
+struct BackendState {
+    // ensure, creation claim, no-handle reconcile, handle inspect
+    calls: [usize; 4],
+    observed: Option<InteractiveWorkerStatus>,
+}
+impl Backend {
+    fn new(f: &Fixture, p: &PreparedRemoteWorkspaceSetup, lose_response: bool) -> Self {
+        Self {
+            store: f.store(),
+            workspace: p.locator().workspace_local_id.clone(),
+            state: Arc::default(),
+            lose_response,
+        }
+    }
+    fn counts(&self) -> [usize; 4] {
+        self.state.lock().expect("state").calls
+    }
+}
+impl InteractiveWorkerProvider for Backend {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::Azure
+    }
+    fn ensure_worker(&self, request: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        let allocation = self
+            .store
+            .load_remote_allocation(OWNER, &self.workspace)
+            .expect("load")
+            .expect("allocation");
+        assert_eq!(allocation.worker_request().expect("reserved"), *request);
+        assert!(
+            self.store
+                .load_remote_cpu_profile_binding(&allocation)
+                .expect("binding")
+                .is_some()
+        );
+        let mut state = self.state.lock().expect("state");
+        state.calls[0] += 1;
+        let group = resource_group_name(request.workflow_id, request.job_id);
+        assert!(
+            self.store
+                .claim_worker_creation(request.workflow_id, request.job_id, &request.target, &group)
+                .expect("fence")
+        );
+        state.calls[1] += 1;
+        let observed = InteractiveWorkerStatus {
+            worker: InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: CloudProvider::Azure,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: format!("/subscriptions/{SUBSCRIPTION}/resourceGroups/{group}"),
+                },
+                target: request.target.clone(),
+                ssh_public_key: request.ssh_public_key.clone(),
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            },
+            lifecycle: InteractiveWorkerLifecycle::Provisioning,
+            ssh: None,
+        };
+        state.observed = Some(observed.clone());
+        if self.lose_response {
+            return Err(std::io::Error::other("synthetic lost response"));
+        }
+        Ok(InteractiveWorkerEnsure::Created(observed))
+    }
+    fn reconcile_worker(
+        &self,
+        request: &InteractiveWorkerRequest,
+    ) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let mut state = self.state.lock().expect("state");
+        state.calls[2] += 1;
+        if let Some(observed) = &state.observed {
+            assert_eq!(observed.worker.ssh_public_key, request.ssh_public_key);
+        }
+        Ok(state.observed.clone())
+    }
+    fn inspect_worker(&self, worker: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        let mut state = self.state.lock().expect("state");
+        state.calls[3] += 1;
+        assert_eq!(state.observed.as_ref().expect("observation").worker, *worker);
+        Ok(state.observed.clone())
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no cleanup")
+    }
+}
+
+fn change_profile(profile: &mut AzureProfile, field: usize) {
+    match field {
+        0 => profile.name = "other".into(),
+        1 => {
+            profile.subscription_id = "22222222-2222-4222-8222-222222222222".into();
+            profile.image_pull_identity_id = profile
+                .image_pull_identity_id
+                .replace(SUBSCRIPTION, &profile.subscription_id);
+        }
+        2 => profile.location = "westeurope".into(),
+        3 => profile.vm_size = "Standard_D8s_v3".into(),
+        4 => profile.image_pull_identity_id.push('2'),
+        5 => profile.declared_hourly_cost_micros += 1,
+        6 => profile.registry_login_server = "other.azurecr.io".into(),
+        _ => profile.disk_sku = AzureDiskSku::PremiumLrs,
+    }
+}
+
+#[test]
+fn preview_discloses_complete_profile_without_creating_home() {
+    let f = Fixture::new();
+    let prepared = f.preview();
+    assert_eq!(prepared.azure_profile(), Some(f.profile()));
+    assert_eq!(prepared.spec().target, Fixture::draft().target);
+    assert!(!f.home.root().exists());
+    for mode in 0..5 {
+        let mut draft = Fixture::draft();
+        match mode {
+            0 => draft.target.disk_gib = 4096,
+            1 => draft.target.max_hourly_cost_micros = Some(1),
+            2 => draft.target.image = format!("other.azurecr.io/worker@sha256:{}", "a".repeat(64)),
+            3 => draft.target.lifetime = WorkerLifetime::TimeLimited { seconds: 900 },
+            _ => {
+                draft.network_volume = Some(crate::cloud_run::runpod::RunPodNetworkVolumeExpectation {
+                    volume_id: "synthetic-volume".into(),
+                    data_center_id: "synthetic-dc".into(),
+                    minimum_size_gb: 10,
+                });
+            }
+        }
+        assert!(preview_configured_remote_workspace(&f.home, &f.config, OWNER, draft).is_err());
+    }
+    assert!(!f.home.root().exists());
+}
+
+#[test]
+fn every_consent_or_config_field_mismatch_refuses_before_storage_or_dispatch() {
+    let f = Fixture::new();
+    for field in 0..8 {
+        let mut different = f.profile().clone();
+        change_profile(&mut different, field);
+        let prepared = f.preview();
+        let locator = prepared.locator().workspace_local_id.clone();
+        let attempt = submit_configured_remote_workspace(
+            &f.home,
+            &f.config,
+            OWNER,
+            prepared,
+            Consent::Azure {
+                image: Fixture::draft().target.image,
+                profile: different.clone(),
+            },
+        );
+        assert_eq!(attempt.result, Err(Error::ConsentMismatch));
+        assert_eq!(attempt.locator.workspace_local_id, locator);
+        let mut config = f.config.clone();
+        config.azure[0] = different;
+        assert_eq!(
+            submit_configured_remote_workspace(&f.home, &config, OWNER, f.preview(), f.consent()).result,
+            Err(Error::ContextChanged)
+        );
+    }
+    for consent in [
+        Consent::LocalDocker {
+            image: Fixture::draft().target.image,
+        },
+        Consent::Azure {
+            image: "wrong-image".into(),
+            profile: f.profile().clone(),
+        },
+    ] {
+        assert_eq!(
+            submit_configured_remote_workspace(&f.home, &f.config, OWNER, f.preview(), consent).result,
+            Err(Error::ConsentMismatch)
+        );
+    }
+    assert!(!f.home.root().exists());
+}
+
+#[test]
+fn binding_precedes_factory_and_key_and_successful_setup_never_replays() {
+    let f = Fixture::new();
+    let prepared = f.preview();
+    let backend = Backend::new(&f, &prepared, false);
+    let result = f.start(&prepared, backend.clone()).expect("setup");
+    let request = result.recovery_request().expect("request");
+    f.identities()
+        .recover(request.workflow_id, request.job_id, &request.ssh_public_key)
+        .expect("retained key");
+    assert_eq!(backend.counts(), [1, 1, 0, 0]);
+    assert_eq!(f.start(&prepared, backend.clone()), Err(Error::SaveConflict));
+    assert!(matches!(
+        f.check(&prepared, &f.config, backend.clone()),
+        Ok(Observation::Observed(_))
+    ));
+    assert_eq!(backend.counts(), [1, 1, 0, 1]);
+}
+
+#[test]
+fn lost_creation_response_recovers_exact_no_handle_without_ensure() {
+    let f = Fixture::new();
+    let prepared = f.preview();
+    let backend = Backend::new(&f, &prepared, true);
+    assert_eq!(f.start(&prepared, backend.clone()), Err(Error::SetupUnconfirmed));
+    let before = f.load(&prepared);
+    assert!(
+        before
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .worker
+            .is_none()
+    );
+    let request = before.recovery_request().expect("request");
+    let binding = f.store().load_remote_cpu_profile_binding(&before).expect("binding");
+    assert!(matches!(
+        f.check(&prepared, &f.config, backend.clone()),
+        Ok(Observation::Observed(_))
+    ));
+    let after = f.load(&prepared);
+    assert_eq!(after.recovery_request().expect("request"), request);
+    assert_eq!(
+        f.store().load_remote_cpu_profile_binding(&after).expect("binding"),
+        binding
+    );
+    assert_eq!(backend.counts(), [1, 1, 1, 0]);
+    assert!(matches!(
+        f.check(&prepared, &f.config, backend.clone()),
+        Ok(Observation::Observed(_))
+    ));
+    assert_eq!(backend.counts(), [1, 1, 1, 1]);
+}
+
+#[test]
+fn interrupted_before_key_never_repairs_and_missing_binding_never_backfills() {
+    for record_binding in [false, true] {
+        let f = Fixture::new();
+        let p = f.preview();
+        let store = f.store();
+        let saved = store.create_remote_workspace(OWNER, &p.state).expect("saved");
+        let allocation = if record_binding {
+            assert_eq!(
+                start_with::<Backend>(&store, &f.identities(), f.profile(), &saved, i64::MAX, |_, _| Err(
+                    Error::SetupUnconfirmed
+                )),
+                Err(Error::SetupUnconfirmed)
+            );
+            f.load(&p)
+        } else {
+            store.allocate_remote_runtime(&saved, i64::MAX).expect("allocate")
+        };
+        assert!(matches!(
+            check_with(&f.home, &f.config, OWNER, p.locator(), |_, _| panic!(
+                "must not dispatch"
+            )),
+            Ok(Observation::Interrupted(_))
+        ));
+        assert_eq!(
+            store
+                .load_remote_cpu_profile_binding(&allocation)
+                .expect("binding")
+                .is_some(),
+            record_binding
+        );
+        assert_eq!(f.load(&p), allocation);
+        assert!(!f.home.root().join("remote-ssh-identities").exists());
+        assert_eq!(
+            recover_with::<Backend>(&store, &f.identities(), &f.config, &allocation, |_, _| Err(
+                Error::SetupUnconfirmed
+            )),
+            Err(Error::SetupUnconfirmed)
+        );
+    }
+}
+
+#[test]
+fn changed_profiles_refuse_no_handle_recovery_before_factory_or_key_access() {
+    let f = Fixture::new();
+    let prepared = f.preview();
+    let backend = Backend::new(&f, &prepared, true);
+    assert!(f.start(&prepared, backend.clone()).is_err());
+    let allocation = f.load(&prepared);
+    for field in 0..8 {
+        let mut config = f.config.clone();
+        change_profile(&mut config.azure[0], field);
+        assert!(
+            check_with(&f.home, &config, OWNER, prepared.locator(), |_, _| panic!(
+                "must not dispatch"
+            ))
+            .is_err()
+        );
+        assert!(
+            recover_with::<Backend>(&f.store(), &f.identities(), &config, &allocation, |_, _| panic!(
+                "must not construct provider"
+            ))
+            .is_err()
+        );
+    }
+    assert_eq!(backend.counts(), [1, 1, 0, 0]);
+    assert_eq!(f.load(&prepared), allocation);
+}
+
+#[test]
+fn stale_allocation_refuses_before_recovery_factory() {
+    let f = Fixture::new();
+    let p = f.preview();
+    let store = f.store();
+    let saved = store.create_remote_workspace(OWNER, &p.state).expect("saved");
+    let allocation = store.allocate_remote_runtime(&saved, i64::MAX).expect("allocate");
+    store
+        .record_remote_cpu_profile_binding(&allocation, f.profile())
+        .expect("binding");
+    super::super::super::prepare_identity(&store, &f.identities(), &allocation).expect("reserve");
+    assert_eq!(
+        recover_with::<Backend>(&store, &f.identities(), &f.config, &allocation, |_, _| panic!(
+            "stale snapshot must not construct provider"
+        )),
+        Err(Error::StorageUnavailable)
+    );
+}

--- a/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
+++ b/crates/horizon-core/src/remote_workspace_setup/configured/tests.rs
@@ -185,6 +185,7 @@ mod linux {
                 f.preview(cloud).locator().workspace_local_id
             );
             assert!(prepared.state.runtime.is_none());
+            assert!(prepared.azure_profile().is_none());
         }
         assert!(!f.home.root().exists());
     }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -140,6 +140,9 @@ back into large multi-purpose modules.
   consumes exact image/storage consent and saves one immutable identity before
   task-free allocation. Errors retain recovery coordinates; manual checks distinguish
   dormant and interrupted records and recover only the same allocation snapshot.
+  Its `configured/azure` leaf binds the complete approved CPU profile before key
+  preparation, reuses shared setup/fence logic and refuses profile drift before
+  non-creating recovery. Credential construction is lazy; preview has no I/O.
   This leaf does not prepare Git, deliver repository credentials, start tasks or
   attest caller-supplied image/storage trust. UI confirmation remains a separate layer.
 - `remote_environment_observation.rs` produces overview-safe, point-in-time

--- a/docs/architecture/remote-provider-bindings.md
+++ b/docs/architecture/remote-provider-bindings.md
@@ -42,17 +42,32 @@ unclaimed allocation before key reservation or first-pin intent. Exact repeats
 and read-only loads remain available after setup expiry or management intent;
 neither rewrites snapshots nor consumes a creation grant. Readers validate
 bounded row contents and workspace/workflow/job collisions, not only the schema.
-The future caller must record before preparing a private key; database state
-alone cannot prove that a key file does not exist. No configured consumer is
-enabled by these APIs.
+The caller must record before preparing a private key; database state alone
+cannot prove that a key file does not exist.
+
+## Configured Azure setup
+
+The configured setup preview exposes the complete non-secret Azure profile;
+consent binds that exact profile and immutable image before saving. Its Azure
+leaf allocates through the existing store, records the immutable binding, then
+assembles the lazy CLI credential/provider with that same store's creation fence.
+The shared setup coordinator alone prepares/reserves the key and dispatches
+ensure. No second allocator, key implementation or creation fence is introduced.
+
+Manual Check requires the original binding and an unchanged complete profile
+before key or provider access, including when no worker handle was returned.
+Missing provenance remains interrupted, never backfilled. Existing recovery
+inspects or reconciles without ensure; it can retain observations and attest a
+host key through the provider's fixed guest command. Errors preserve the original
+locator and do not authorize another create, task, attachment or cleanup.
+Synthetic tests exercise this ordering; no live Azure acceptance is claimed.
 
 ## Follow-up implementation
 
-- Wire configured preview/consent/setup/check to this binding and the shared
-  complete Azure deployment-target validator. Reject current-profile mismatch
-  before credential acquisition or provider requests.
-- Prove no-handle lost-response recovery, profile/subscription drift, competing
-  controllers, missing metadata, retained SSH pins and unchanged dirty data.
+- Expose the configured API through explicit UI confirmation, without enabling
+  unsupported attachment, repository or task actions.
+- Prove live no-handle recovery, competing controllers, retained SSH pins and
+  unchanged dirty data on the exact integrated candidate.
 
 The digest is a consistency binding, not a signature or provider attestation.
 Direct malicious rewriting of the private database is not prevented by SQLite


### PR DESCRIPTION
## Purpose

Connect configured CPU workspace preview, consent, task-free creation and original-identity recovery to the immutable profile binding delivered in #549/#550. This advances #474 without adding UI or claiming cloud/client-off acceptance.

## Behavior

- Preview validates the complete named Azure profile and deployment target without acquiring credentials. Explicit consent binds the original profile and image.
- First setup saves the immutable subscription/profile binding before preparing a private key, taking a creation claim or calling the provider. Provider construction is lazy; existing shared setup and identity guards remain in force.
- Manual Check requires the original saved binding and rejects missing, corrupt or changed provenance before provider recovery. It does not allocate a replacement, repair a key, renew a creation grant or backfill metadata. Eligible recovery can persist observations or the first host pin, so the whole operation is not read-only.
- Post-start verification failures are explicitly uncertain. A binding mismatch discovered after successful provider creation cannot be reported as a definite pre-creation refusal; the original allocation remains recoverable and repeat submission cannot replay creation.

Four source/test paths, 698 changed source/test lines, plus architecture documentation. No new dependencies, defaults, public images, credential transfer or live resource allocation.

## Validation

- Independent local review completed, including the narrow post-start classification correction.
- 61 focused tests and blocking/strict Clippy passed. The new regression failed before the correction and passed afterward; it uses successful injected creation followed by synthetic binding drift, then verifies retained identity, no replay and refusal before a recovery backend call.
- Deterministic tests cover profile/consent drift, binding-before-key ordering, one-shot creation, lost-response recovery, missing provenance and exact retained identities. They do not access real credentials or ARM endpoints.
- Full eight-gate matrix passed on exact `4164078980f05f333bfd982d35a619575c9f93aa`: formatting, maintainability, version checks, default tests (2,489 passed), speech tests (2,534 passed), blocking, strict and pedantic Clippy. Each test tier retained seven existing ignored tests; neither had a failure.

Validation history is preserved: v1 was deliberately stopped to apply the correction; v2 encountered the unchanged browser CLI stdin/deadline timing assertion. A fresh complete v3 passed on the same corrected head, including that CLI test in both tiers; no browser code or test was changed by this PR. Neither earlier run is claimed as a passing matrix.

Azure UI and #547's separate client-off acceptance harness remain independent follow-up work. No native Azure, credential-transfer or live-cloud acceptance is claimed here.
