### PR TITLE
fix(azure): pin the VM instance identity across waits and key reads

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider.rs
@@ -326,9 +326,14 @@ impl AzureClient {
             ..observation.worker
         };
         let ssh = match (observation.lifecycle, observation.host.as_deref()) {
-            (AzureLifecycle::Running, Some(host)) => {
-                self.attested_endpoint(&worker, host, target, ssh_public_key, placement)?
-            }
+            (AzureLifecycle::Running, Some(host)) => self.attested_endpoint(
+                &worker,
+                observation.vm.as_ref(),
+                host,
+                target,
+                ssh_public_key,
+                placement,
+            )?,
             _ => None,
         };
         let lifecycle = match observation.lifecycle {

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -2,7 +2,7 @@
 //! control plane rather than trusting whatever answers on the network address, and stop
 //! it by deallocating the VM with retained disks.
 use super::super::{
-    AzureError, AzureLifecycle, AzureManagementTransport, AzureRunCommand, AzureWorker, WORKER_VM_NAME,
+    AzureError, AzureLifecycle, AzureManagementTransport, AzureRunCommand, AzureVmView, AzureWorker, WORKER_VM_NAME,
     deployment::{SSH_PORT, identity_tags},
     transport::remaining,
 };
@@ -88,6 +88,16 @@ impl AzureHostKeySource for AzureRunCommandHostKeys {
     }
 }
 
+/// Whether `live` is the same VM instance as `baseline`: an instance identity observed
+/// once must be observed again, so a VM deleted and recreated under the same name and
+/// tags, while a wait or a key read was in flight, is never mistaken for this worker.
+pub(super) fn same_instance(baseline: Option<&AzureVmView>, live: Option<&AzureVmView>) -> bool {
+    match baseline.and_then(|vm| vm.instance_id.as_deref()) {
+        Some(pinned) => live.and_then(|vm| vm.instance_id.as_deref()) == Some(pinned),
+        None => true,
+    }
+}
+
 impl AzureClient {
     /// The SSH endpoint, only with a host key attested for this exact worker. Reading
     /// the key can take a while, so the key is paired with the address only if the
@@ -97,6 +107,7 @@ impl AzureClient {
     pub(super) fn attested_endpoint(
         &self,
         worker: &AzureWorker,
+        instance: Option<&AzureVmView>,
         host: &str,
         target: &WorkerTarget,
         ssh_public_key: &str,
@@ -113,6 +124,9 @@ impl AzureClient {
             return Err(AzureError::ResourceIdentityMismatch);
         }
         let fresh = self.observe(worker.clone(), &group, &expected, None, placement)?;
+        if !same_instance(instance, fresh.as_ref().and_then(|fresh| fresh.vm.as_ref())) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
         let unchanged = fresh
             .is_some_and(|fresh| fresh.lifecycle == AzureLifecycle::Running && fresh.host.as_deref() == Some(host));
         Ok(unchanged
@@ -180,15 +194,16 @@ impl AzureClient {
     /// Wait for the exact worker's VM to reach `target`, under an absolute deadline that
     /// covers the sleeps with each request handed only what is left of it. The wait spans
     /// minutes, so every poll re-proves the group (identity tags, recorded ID, not
-    /// deleting) and the VM (identity tags): a recreated or retagged worker at the same
-    /// path is an identity error, never this worker's transition. `None` means the
+    /// deleting) and the VM (identity tags and instance identity): a recreated or
+    /// retagged worker at the same path is an identity error, never this worker's
+    /// transition. `None` means the
     /// transition was not verified within the bound (vanished, failed, deleting, or late).
     fn await_power(
         &self,
         current: &Observation,
         expected: &std::collections::BTreeMap<String, String>,
         target: AzureLifecycle,
-    ) -> Result<Option<crate::cloud_run::azure::AzureVmView>, AzureError> {
+    ) -> Result<Option<AzureVmView>, AzureError> {
         let group = &current.worker.resource_group;
         let deadline = Instant::now() + POWER_BOUND;
         let last = POWER_BACKOFF_MS[POWER_BACKOFF_MS.len() - 1];
@@ -231,7 +246,9 @@ impl AzureClient {
             let Some(vm) = self.transport.get_vm_within(group, WORKER_VM_NAME, budget)? else {
                 break;
             };
-            if expected.iter().any(|(key, value)| vm.tags.get(key) != Some(value)) {
+            if expected.iter().any(|(key, value)| vm.tags.get(key) != Some(value))
+                || !same_instance(current.vm.as_ref(), Some(&vm))
+            {
                 return Err(AzureError::ResourceIdentityMismatch);
             }
             match vm_lifecycle(&vm) {
@@ -306,6 +323,9 @@ impl InteractiveWorkerStartProvider for AzureClient {
         let Some(fresh) = self.observe(handle, &live, &expected, None, Placement::Ignore)? else {
             return Err(AzureError::StartUnverified);
         };
+        if !same_instance(current.vm.as_ref(), fresh.vm.as_ref()) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
         // Only a worker whose VM is physically running is a started worker; anything
         // else observed after the wait (a failure, a deletion begun meanwhile, a new
         // transition, an unreadable power state) stays unverified. A running VM without

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -1,7 +1,7 @@
 pub(super) use super::super::{
     AzureClient, AzureDeploymentState, AzureError, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
     AzureRunCommand, AzureVmView, AzureWorker, SSH_USERNAME,
-    deployment::{DEPLOYMENT_NAME, SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_JOB, worker_tags},
+    deployment::{DEPLOYMENT_NAME, SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_IMAGE_REF_DIGEST, TAG_JOB, worker_tags},
     resource_group_name,
 };
 pub(super) use super::{OTHER_SUB, SUB, ed25519_key, profile, target};
@@ -249,9 +249,13 @@ pub(super) fn group_info(name: &str, tags: BTreeMap<String, String>, state: &str
     }
 }
 
+/// The instance identity every scripted VM carries unless a test replaces the instance.
+pub(super) const INSTANCE: &str = "3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f";
+
 pub(super) fn vm(power: &str, tags: &BTreeMap<String, String>) -> AzureVmView {
     AzureVmView {
         id: format!("/subscriptions/{SUB}/resourceGroups/g/providers/Microsoft.Compute/virtualMachines/worker"),
+        instance_id: Some(INSTANCE.into()),
         name: "worker".into(),
         location: "northeurope".into(),
         vm_size: "Standard_D4s_v3".into(),
@@ -354,6 +358,7 @@ pub(super) fn owned(s: &Scenario) -> AzureGroupInfo {
 pub(super) const MISMATCH: AzureError = AzureError::ResourceIdentityMismatch;
 
 mod creation;
+mod instance;
 mod observation;
 mod running;
 mod start;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/instance.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/instance.rs
@@ -1,0 +1,155 @@
+//! The VM's instance identity (`vmId`) is pinned across every wait and every key read:
+//! a VM deleted and recreated under the same name, carrying the very same tags, is a
+//! different machine and is never served, started, stopped or attested as this worker.
+use super::*;
+use crate::cloud_run::{
+    interactive_worker_start::InteractiveWorkerStartProvider,
+    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+};
+
+const OTHER_INSTANCE: &str = "9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d";
+
+/// The same name, path and tags as the scripted worker, on a different instance.
+fn recreated(power: &str, s: &Scenario) -> AzureVmView {
+    AzureVmView {
+        instance_id: Some(OTHER_INSTANCE.into()),
+        ..vm(power, &s.tags)
+    }
+}
+
+fn address() -> AzureDeploymentState {
+    deployment("Succeeded", "203.0.113.9")
+}
+
+#[test]
+fn a_recreated_vm_is_never_this_worker_starting() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    // Recreated during the wait: the poll that first sees it stops the wait.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(address()),
+        vec![
+            Some(vm("deallocated", &s.tags)),
+            Some(vm("starting", &s.tags)),
+            Some(recreated("running", &s)),
+        ],
+    );
+    assert_eq!(client.start_worker(&worker), Err(MISMATCH), "recreated during the wait");
+    // Recreated between the wait's last poll and the answer-time observation.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(address()),
+        vec![
+            Some(vm("deallocated", &s.tags)),
+            Some(vm("running", &s.tags)),
+            Some(recreated("running", &s)),
+        ],
+    );
+    assert_eq!(
+        client.start_worker(&worker),
+        Err(MISMATCH),
+        "recreated before the answer"
+    );
+    // An instance identity that disappears is as foreign as one that changes.
+    let unidentified = AzureVmView {
+        instance_id: None,
+        ..vm("running", &s.tags)
+    };
+    s.plane.script(
+        Some(owned(&s)),
+        Some(address()),
+        vec![Some(vm("deallocated", &s.tags)), Some(unidentified)],
+    );
+    assert_eq!(client.start_worker(&worker), Err(MISMATCH), "instance identity lost");
+    assert!(
+        !s.plane.calls().iter().any(|call| matches!(
+            call,
+            Call::DeleteGroup(_) | Call::CreateGroup(..) | Call::PutDeployment(..)
+        )),
+        "start never deletes or creates: {:?}",
+        s.plane.calls()
+    );
+}
+
+#[test]
+fn a_recreated_vm_is_never_this_worker_stopping_or_ready() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    s.plane.script(
+        Some(owned(&s)),
+        Some(address()),
+        vec![
+            Some(vm("running", &s.tags)),
+            Some(vm("deallocating", &s.tags)),
+            Some(recreated("deallocated", &s)),
+        ],
+    );
+    assert_eq!(
+        client.stop_worker(&worker),
+        Err(MISMATCH),
+        "a recreated VM reaching the target state is not this worker's retained stop"
+    );
+    assert_eq!(s.plane.mutations(), vec![Call::Deallocate(s.group.clone())]);
+    // The slow key read returns to a recreated VM behind the same address.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(address()),
+        vec![Some(vm("running", &s.tags)), Some(recreated("running", &s))],
+    );
+    assert_eq!(
+        client.reconcile_worker(&s.request),
+        Err(MISMATCH),
+        "the attested key never pairs with another instance's address"
+    );
+    // A worker observed without an instance identity pins nothing: the tags still rule.
+    let unidentified = |power: &str| {
+        Some(AzureVmView {
+            instance_id: None,
+            ..vm(power, &s.tags)
+        })
+    };
+    s.plane
+        .script(Some(owned(&s)), Some(address()), vec![unidentified("running")]);
+    assert_eq!(s.reconcile(Some(host_key())).lifecycle, Lifecycle::Ready);
+    s.plane
+        .script(Some(owned(&s)), Some(address()), vec![unidentified("deallocated")]);
+    assert_eq!(
+        client.stop_worker(&worker),
+        Ok(InteractiveWorkerStop::Stopped),
+        "an already deallocated VM is a retained stop"
+    );
+}
+
+#[test]
+fn another_image_under_this_workers_tags_is_refused_before_any_mutation() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let mut other_image = vm("running", &s.tags);
+    other_image.tags.insert(TAG_IMAGE_REF_DIGEST.into(), "0".repeat(64));
+    for power in ["running", "deallocated"] {
+        let mut vm = other_image.clone();
+        vm.power_state = Some(format!("PowerState/{power}"));
+        s.plane.script(Some(owned(&s)), Some(address()), vec![Some(vm)]);
+        assert_eq!(client.reconcile_worker(&s.request), Err(MISMATCH), "{power}: reconcile");
+        assert_eq!(client.inspect_worker(&worker), Err(MISMATCH), "{power}: inspect");
+        assert_eq!(client.start_worker(&worker), Err(MISMATCH), "{power}: start");
+        assert_eq!(client.stop_worker(&worker), Err(MISMATCH), "{power}: stop");
+        assert!(
+            s.plane.mutations().is_empty(),
+            "{power}: a VM running another image is never served, started or stopped: {:?}",
+            s.plane.calls()
+        );
+        // Deletion is scoped to the owned group, proven by the group's own tags: the
+        // group goes, whatever was placed inside it.
+        assert_eq!(
+            client.delete_worker(&worker),
+            Ok(InteractiveWorkerCleanup::Deleted),
+            "{power}: delete"
+        );
+        assert_eq!(s.plane.mutations(), vec![Call::DeleteGroup(s.group.clone())]);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -107,10 +107,53 @@ fn vm_url(suffix: &str) -> String {
     )
 }
 
+const VM_INSTANCE: &str = "3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f";
+
 fn vm_body(power: &str, name: &str, group: &str) -> String {
+    vm_body_with_instance(power, name, group, &format!(r#""vmId":"{VM_INSTANCE}","#))
+}
+
+fn vm_body_with_instance(power: &str, name: &str, group: &str, instance: &str) -> String {
     format!(
-        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{group}/providers/Microsoft.Compute/virtualMachines/worker","name":"{name}","location":"northeurope","tags":{{"horizon-job-id":"j"}},"properties":{{"provisioningState":"Succeeded","hardwareProfile":{{"vmSize":"Standard_D4s_v3"}},"instanceView":{{"statuses":[{{"code":"ProvisioningState/succeeded"}},{{"code":"PowerState/{power}"}}]}}}}}}"#
+        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{group}/providers/Microsoft.Compute/virtualMachines/worker","name":"{name}","location":"northeurope","tags":{{"horizon-job-id":"j"}},"properties":{{{instance}"provisioningState":"Succeeded","hardwareProfile":{{"vmSize":"Standard_D4s_v3"}},"instanceView":{{"statuses":[{{"code":"ProvisioningState/succeeded"}},{{"code":"PowerState/{power}"}}]}}}}}}"#
     )
+}
+
+#[test]
+fn virtual_machine_views_carry_only_a_well_formed_instance_identity() {
+    let expanded = format!("{}&$expand=instanceView", vm_url(""));
+    let malformed = [
+        "",
+        r#""vmId":"3F2C9A1E-5D4B-4C6A-8E7F-0A1B2C3D4E5F","#,
+        r#""vmId":"3f2c9a1e5d4b4c6a8e7f0a1b2c3d4e5f","#,
+        r#""vmId":"3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f ","#,
+        r#""vmId":7,"#,
+        r#""vmId":"../3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f","#,
+    ];
+    let mut expected = vec![expect(
+        "GET",
+        expanded.clone(),
+        200,
+        &vm_body("running", "worker", GROUP),
+        None,
+    )];
+    expected.extend(malformed.iter().map(|instance| {
+        expect(
+            "GET",
+            expanded.clone(),
+            200,
+            &vm_body_with_instance("running", "worker", GROUP, instance),
+            None,
+        )
+    }));
+    let (transport, calls) = http(expected);
+    let vm = transport.get_vm(GROUP, "worker").expect("vm").expect("present");
+    assert_eq!(vm.instance_id.as_deref(), Some(VM_INSTANCE));
+    for instance in malformed {
+        let vm = transport.get_vm(GROUP, "worker").expect("vm").expect("present");
+        assert_eq!(vm.instance_id, None, "{instance:?} is not an instance identity");
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1 + malformed.len());
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -43,6 +43,9 @@ impl AzureDeploymentState {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AzureVmView {
     pub id: String,
+    /// ARM's immutable per-instance identifier (`properties.vmId`). The resource ID is a
+    /// path and survives a delete-and-recreate under the same name; this does not.
+    pub instance_id: Option<String>,
     pub name: String,
     pub location: String,
     pub vm_size: String,
@@ -406,6 +409,15 @@ fn long_running(status: u16) -> AzureLongRunningState {
     }
 }
 
+/// `vmId` is a lowercase UUID; anything else is not an instance identity worth pinning.
+fn valid_instance_id(id: &str) -> bool {
+    id.len() == 36
+        && id.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
+        })
+}
+
 fn text(value: &serde_json::Value, pointer: &str) -> Option<String> {
     value
         .pointer(pointer)
@@ -590,6 +602,7 @@ impl AzureManagementTransport for AzureArmHttp {
             .find(|code| code.starts_with("PowerState/"));
         Ok(Some(AzureVmView {
             id,
+            instance_id: text(&value, "/properties/vmId").filter(|id| valid_instance_id(id)),
             name: observed_name,
             location: text(&value, "/location").unwrap_or_default(),
             vm_size: text(&value, "/properties/hardwareProfile/vmSize").unwrap_or_default(),

--- a/docs/testing/azure-workspace-live-acceptance.md
+++ b/docs/testing/azure-workspace-live-acceptance.md
@@ -28,7 +28,10 @@ the same file run in every matrix without Azure.
    the spike harness does.
 3. **Ready only with an attested host key.** `reconcile_worker` reports `Ready`
    only when the run-command channel returns the host key the container's SSH
-   server serves and the group, VM and address re-prove unchanged.
+   server serves and the group, VM and address re-prove unchanged. The VM re-proof
+   covers the identity tags and the instance identity (`vmId`): a VM deleted and
+   recreated under the same name and tags while the key was read, or during a stop
+   or start wait, is an identity error, never this worker.
 4. **The key is the one on the wire.** A pinned SSH session (no operator
    configuration read, `StrictHostKeyChecking=yes`, the global known-hosts file
    disabled, a `known_hosts` holding only the attested key, the generated client key)


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (adapter hardening; does not complete the issue).

## Why

An ARM resource ID is a path, so a VM deleted and recreated under the same name keeps it, and a recreation that copies the identity tags passed every re-proof the provider makes during a stop or start wait or the slow host-key read. The wait spans minutes.

## What

- `AzureVmView` carries `instance_id` from `properties.vmId`, accepted only as a lowercase UUID.
- `await_power`, the post-wait start observation and the host-key attestation require the instance observed at the start to be the one observed at the end; a changed or missing instance identity is `ResourceIdentityMismatch`. A worker observed without an instance identity pins nothing, so the tags still rule.
- New deterministic tests (`tests/provider/instance.rs`): recreated instance during the start wait, before the start answer, during the stop wait, behind the same address during the key read; lost identity; unpinned case; a VM carrying another image under this worker's tags refused on reconcile, inspect, start and stop with no mutation, while group-scoped deletion still removes the owned group. Transport test for the parser's malformed shapes.
- Live acceptance doc notes the instance pin.

## Validation

Full local matrix green: fmt, maintainability, version sync, preflight tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic.