### PR TITLE
test(azure): run the power wait on an injectable clock

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider.rs
@@ -15,7 +15,7 @@ use crate::cloud_run::{
         InteractiveWorkerStatus,
     },
 };
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 mod running;
 pub use running::{AzureHostKeySource, AzureRunCommandHostKeys};
@@ -74,6 +74,28 @@ pub struct AzureClient {
     transport: Box<dyn AzureManagementTransport>,
     fence: Box<dyn AzureCreationFence>,
     host_keys: Box<dyn AzureHostKeySource>,
+    clock: Box<dyn AzureClock>,
+}
+
+/// The clock the provider's bounded waits run on: production sleeps for real, tests
+/// advance a fake so the exact deadline arithmetic runs without waiting.
+pub(super) trait AzureClock: Send + Sync {
+    fn now(&self) -> std::time::Instant;
+    fn sleep(&self, duration: Duration);
+}
+
+struct SystemClock;
+
+impl AzureClock for SystemClock {
+    fn now(&self) -> std::time::Instant {
+        std::time::Instant::now()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        if !duration.is_zero() {
+            std::thread::sleep(duration);
+        }
+    }
 }
 
 /// Whether an observation must also match the current profile's VM size and location.
@@ -143,7 +165,16 @@ impl AzureClient {
             transport: Box::new(transport),
             fence: Box::new(fence),
             host_keys: Box::new(host_keys),
+            clock: Box::new(SystemClock),
         })
+    }
+
+    /// The same client on a test clock; the waits keep their production schedule and
+    /// bound, only time itself is simulated.
+    #[cfg(test)]
+    pub(super) fn on_clock(mut self, clock: impl AzureClock + 'static) -> Self {
+        self.clock = Box::new(clock);
+        self
     }
 
     /// The persisted handle, shape-checked before any I/O. Cost and placement policy are

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -4,7 +4,7 @@
 use super::super::{
     AzureError, AzureLifecycle, AzureManagementTransport, AzureRunCommand, AzureVmView, AzureWorker, WORKER_VM_NAME,
     deployment::{SSH_PORT, identity_tags},
-    transport::remaining,
+    transport::remaining_at,
 };
 use super::{AzureClient, Observation, Placement, SSH_USERNAME, vm_lifecycle};
 use crate::cloud_run::{
@@ -13,7 +13,7 @@ use crate::cloud_run::{
     interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
     interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Polling schedule for a power transition (deallocation or start) to be observed after
 /// Azure accepted it; D-series transitions commonly take one to three minutes. The last
@@ -25,10 +25,6 @@ const POWER_BOUND: Duration = Duration::from_secs(300);
 /// final observation happens this close to the deadline, which is as near as a bounded
 /// request allows (an ARM lookup normally answers in well under a second).
 const FINAL_POLL_RESERVE: Duration = Duration::from_secs(5);
-/// Polls a test may observe before the wait is treated as exhausted (tests skip the
-/// sleeps, so the absolute bound alone would spin for its whole length).
-#[cfg(test)]
-const TEST_POLLS: usize = 14;
 /// The non-billed state the worker must hold after a stop.
 const RETAINED: AzureLifecycle = AzureLifecycle::Deallocated;
 
@@ -205,15 +201,13 @@ impl AzureClient {
         target: AzureLifecycle,
     ) -> Result<Option<AzureVmView>, AzureError> {
         let group = &current.worker.resource_group;
-        let deadline = Instant::now() + POWER_BOUND;
+        let deadline = self.clock.now() + POWER_BOUND;
         let last = POWER_BACKOFF_MS[POWER_BACKOFF_MS.len() - 1];
         let schedule = POWER_BACKOFF_MS.into_iter().chain(std::iter::repeat(last));
-        #[cfg(test)]
-        let schedule = schedule.take(TEST_POLLS);
         for delay_ms in schedule {
             // Only the absolute deadline ends the wait; a transition that completes late
             // in the bound is still observed.
-            let Some(left) = remaining(deadline) else {
+            let Some(left) = remaining_at(self.clock.now(), deadline) else {
                 break;
             };
             // Never sleep into the deadline: the sleep stops a small reserve short of
@@ -221,10 +215,8 @@ impl AzureClient {
             // deadline, is the last one, so a transition that completes at the very end
             // of the bound is still observed without busy-polling.
             let sleep_for = Duration::from_millis(delay_ms).min(left.saturating_sub(FINAL_POLL_RESERVE));
-            if !cfg!(test) && !sleep_for.is_zero() {
-                std::thread::sleep(sleep_for);
-            }
-            let Some(budget) = remaining(deadline) else {
+            self.clock.sleep(sleep_for);
+            let Some(budget) = remaining_at(self.clock.now(), deadline) else {
                 break;
             };
             let final_poll = budget <= FINAL_POLL_RESERVE;
@@ -240,7 +232,7 @@ impl AzureClient {
             if live.provisioning_state == "Deleting" {
                 break;
             }
-            let Some(budget) = remaining(deadline) else {
+            let Some(budget) = remaining_at(self.clock.now(), deadline) else {
                 break;
             };
             let Some(vm) = self.transport.get_vm_within(group, WORKER_VM_NAME, budget)? else {

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -103,6 +103,8 @@ pub(super) struct Plane {
     /// How long every bounded lookup takes on the scenario's clock.
     pub(super) request_takes: Duration,
     pub(super) clock: Option<FakeClock>,
+    /// Every budget a bounded lookup was handed, in order.
+    pub(super) budgets: Vec<Duration>,
     pub(super) calls: Vec<Call>,
 }
 
@@ -133,10 +135,15 @@ impl Fake {
             !budget.is_zero() && budget <= Duration::from_secs(300),
             "a poll carries what is left of the bound: {budget:?}"
         );
-        let plane = self.lock();
+        let mut plane = self.lock();
+        plane.budgets.push(budget);
         if let Some(clock) = &plane.clock {
             clock.advance(plane.request_takes.min(budget));
         }
+    }
+
+    pub(super) fn budgets(&self) -> Vec<Duration> {
+        self.lock().budgets.clone()
     }
 
     pub(super) fn script(
@@ -150,6 +157,7 @@ impl Fake {
         plane.deployment = deployment;
         plane.vm_states = vm_states;
         plane.calls.clear();
+        plane.budgets.clear();
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -16,8 +16,46 @@ pub(super) use crate::cloud_run::{
 pub(super) use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
+
+/// Simulated time: sleeps advance it instantly and are recorded, and the plane can
+/// charge every bounded request against it, so the waits' deadline arithmetic runs
+/// exactly as in production without a real second passing.
+#[derive(Clone)]
+pub(super) struct FakeClock(Arc<Mutex<(Instant, Vec<Duration>)>>);
+
+impl Default for FakeClock {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new((Instant::now(), Vec::new()))))
+    }
+}
+
+impl FakeClock {
+    pub(super) fn advance(&self, by: Duration) {
+        self.0.lock().expect("clock").0 += by;
+    }
+
+    pub(super) fn sleeps(&self) -> Vec<Duration> {
+        self.0.lock().expect("clock").1.clone()
+    }
+
+    pub(super) fn instant(&self) -> Instant {
+        self.0.lock().expect("clock").0
+    }
+}
+
+impl super::super::provider::AzureClock for FakeClock {
+    fn now(&self) -> Instant {
+        self.0.lock().expect("clock").0
+    }
+
+    fn sleep(&self, duration: Duration) {
+        let mut clock = self.0.lock().expect("clock");
+        clock.0 += duration;
+        clock.1.push(duration);
+    }
+}
 
 /// Every management call the provider makes, in order, with its arguments.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -62,6 +100,9 @@ pub(super) struct Plane {
     /// Replaces the group once the start was posted, as a concurrent retag or deletion
     /// during the wait would.
     pub(super) group_after_start: Option<GroupChange>,
+    /// How long every bounded lookup takes on the scenario's clock.
+    pub(super) request_takes: Duration,
+    pub(super) clock: Option<FakeClock>,
     pub(super) calls: Vec<Call>,
 }
 
@@ -82,6 +123,20 @@ impl Fake {
             .into_iter()
             .filter(|call| !matches!(call, Call::GetGroup(_) | Call::GetDeployment(_) | Call::GetVm(_)))
             .collect()
+    }
+
+    /// A bounded request: it must carry what is left of the bound, and it costs the
+    /// scenario's request time on the clock (never more than its own budget, as a
+    /// bounded request would be cut off there).
+    fn charge(&self, budget: Duration) {
+        assert!(
+            !budget.is_zero() && budget <= Duration::from_secs(300),
+            "a poll carries what is left of the bound: {budget:?}"
+        );
+        let plane = self.lock();
+        if let Some(clock) = &plane.clock {
+            clock.advance(plane.request_takes.min(budget));
+        }
     }
 
     pub(super) fn script(
@@ -190,18 +245,12 @@ impl AzureManagementTransport for Fake {
     }
 
     fn get_resource_group_within(&self, name: &str, budget: Duration) -> Result<Option<AzureGroupInfo>, AzureError> {
-        assert!(
-            !budget.is_zero() && budget <= Duration::from_secs(300),
-            "a poll carries what is left of the stop bound: {budget:?}"
-        );
+        self.charge(budget);
         self.get_resource_group(name)
     }
 
     fn get_vm_within(&self, group: &str, name: &str, budget: Duration) -> Result<Option<AzureVmView>, AzureError> {
-        assert!(
-            !budget.is_zero() && budget <= Duration::from_secs(300),
-            "a poll carries what is left of the stop bound: {budget:?}"
-        );
+        self.charge(budget);
         self.get_vm(group, name)
     }
 
@@ -273,6 +322,7 @@ pub(super) fn deployment(state: &str, host: &str) -> AzureDeploymentState {
 }
 
 pub(super) struct Scenario {
+    pub(super) clock: FakeClock,
     pub(super) request: InteractiveWorkerRequest,
     pub(super) group: String,
     pub(super) group_id: String,
@@ -289,11 +339,15 @@ impl Scenario {
             ssh_public_key: ed25519_key(7, "client"),
         };
         let group = resource_group_name(request.workflow_id, request.job_id);
+        let clock = FakeClock::default();
+        let plane = Fake::default();
+        plane.lock().clock = Some(clock.clone());
         Self {
+            clock,
             group_id: format!("/subscriptions/{SUB}/resourceGroups/{group}"),
             group,
             tags: worker_tags(&request),
-            plane: Fake::default(),
+            plane,
             request,
         }
     }
@@ -322,7 +376,9 @@ impl Scenario {
             );
             host_key.clone()
         };
-        AzureClient::with_transport(profile(), self.plane.clone(), fence, keys).expect("client")
+        AzureClient::with_transport(profile(), self.plane.clone(), fence, keys)
+            .expect("client")
+            .on_clock(self.clock.clone())
     }
 
     pub(super) fn persisted(&self) -> InteractiveWorker {
@@ -362,3 +418,4 @@ mod instance;
 mod observation;
 mod running;
 mod start;
+mod wait;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/wait.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/wait.rs
@@ -119,6 +119,40 @@ fn slow_requests_spend_the_bound_and_never_get_a_budget_past_the_deadline() {
         .filter(|call| matches!(call, Call::GetVm(_)))
         .count();
     assert_eq!(vm_polls, 2, "the observation and the one poll that fit in the bound");
+    // Each bounded lookup was handed exactly what was left: the group lookup at 0 s,
+    // the VM lookup at 100 s, the group lookup at 201 s; nothing after 300 s.
+    assert_eq!(s.plane.budgets(), secs(&[300, 200, 99]));
+}
+
+#[test]
+fn every_poll_is_handed_exactly_what_is_left_of_the_bound() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    s.plane.lock().request_takes = Duration::from_millis(500);
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        states(40, "starting", &s),
+    );
+    assert_eq!(client.start_worker(&worker), Err(AzureError::StartUnverified));
+    // Two lookups per poll, each half a second: the budgets walk down from the bound by
+    // the sleeps and the request times alone, and the wait never asks past the bound.
+    let mut expected = Vec::new();
+    let mut left = BOUND;
+    for sleep in s.clock.sleeps() {
+        left = left.saturating_sub(sleep);
+        expected.push(left);
+        left = left.saturating_sub(Duration::from_millis(500));
+        expected.push(left);
+        left = left.saturating_sub(Duration::from_millis(500));
+    }
+    assert_eq!(s.plane.budgets(), expected);
+    assert!(expected.iter().all(|budget| !budget.is_zero() && *budget <= BOUND));
+    assert!(
+        *expected.last().expect("polls") <= RESERVE,
+        "the last poll runs inside the reserve"
+    );
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/wait.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/wait.rs
@@ -1,0 +1,139 @@
+//! The power wait on simulated time: the production schedule and bound run exactly, so
+//! the deadline arithmetic (the final-poll reserve, slow requests eating the bound, a
+//! transition that completes at the very end) is proven rather than skipped.
+use super::*;
+use crate::cloud_run::{
+    interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
+    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+};
+
+const BOUND: Duration = Duration::from_secs(300);
+const RESERVE: Duration = Duration::from_secs(5);
+
+fn secs(values: &[u64]) -> Vec<Duration> {
+    values.iter().map(|value| Duration::from_secs(*value)).collect()
+}
+
+/// The polls a wait makes on an instant control plane: one per schedule step until the
+/// last sleep is cut short so a final poll lands inside the reserve.
+fn expected_sleeps() -> Vec<Duration> {
+    let mut sleeps = secs(&[0, 1, 2, 4, 8, 15]);
+    sleeps.extend(secs(&[30; 8]));
+    sleeps.push(Duration::from_secs(25));
+    sleeps
+}
+
+fn states(before: usize, then: &str, s: &Scenario) -> Vec<Option<AzureVmView>> {
+    let mut states = vec![Some(vm("deallocated", &s.tags))];
+    states.extend((0..before).map(|_| Some(vm("starting", &s.tags))));
+    states.push(Some(vm(then, &s.tags)));
+    states
+}
+
+#[test]
+fn the_wait_follows_the_schedule_and_polls_once_more_inside_the_reserve() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    // Stuck in `starting` for the whole bound: every scheduled poll happens, the last
+    // one inside the reserve, and nothing is claimed.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        states(40, "starting", &s),
+    );
+    let begun = s.clock.instant();
+    assert_eq!(client.start_worker(&worker), Err(AzureError::StartUnverified));
+    assert_eq!(
+        s.clock.sleeps(),
+        expected_sleeps(),
+        "the production schedule, last sleep cut to the reserve"
+    );
+    let elapsed = s.clock.instant().saturating_duration_since(begun);
+    assert!(
+        elapsed >= BOUND.saturating_sub(RESERVE) && elapsed <= BOUND,
+        "the last poll lands inside the reserve: {elapsed:?}"
+    );
+    let polls = s
+        .plane
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::GetVm(_)))
+        .count();
+    assert_eq!(
+        polls,
+        1 + expected_sleeps().len(),
+        "one observation and one poll per sleep; an unverified start is never re-observed"
+    );
+}
+
+#[test]
+fn a_transition_that_completes_at_the_very_end_of_the_bound_is_still_observed() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let final_poll = expected_sleeps().len() - 1;
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        states(final_poll, "running", &s),
+    );
+    let started = client.start_worker(&worker).expect("start");
+    assert!(matches!(started, InteractiveWorkerStart::Started(_)), "{started:?}");
+    assert_eq!(s.clock.sleeps(), expected_sleeps());
+    // One step later is one step too late: the final poll saw `starting`, and the wait
+    // never polls past its deadline.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        states(final_poll + 1, "running", &s),
+    );
+    assert_eq!(client.start_worker(&worker), Err(AzureError::StartUnverified));
+    assert_eq!(
+        s.plane.mutations(),
+        vec![Call::Start(s.group.clone())],
+        "posted once, never re-posted"
+    );
+}
+
+#[test]
+fn slow_requests_spend_the_bound_and_never_get_a_budget_past_the_deadline() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    // Every bounded lookup takes 100 s: the first poll spends 200 s, the next sleep is
+    // one second, the following group lookup is handed the 99 s left and uses them all,
+    // and the wait ends without another request (the fake asserts every budget it gets).
+    s.plane.lock().request_takes = Duration::from_secs(100);
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", "203.0.113.9")),
+        states(1, "running", &s),
+    );
+    assert_eq!(client.start_worker(&worker), Err(AzureError::StartUnverified));
+    assert_eq!(s.clock.sleeps(), secs(&[0, 1]));
+    let vm_polls = s
+        .plane
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::GetVm(_)))
+        .count();
+    assert_eq!(vm_polls, 2, "the observation and the one poll that fit in the bound");
+}
+
+#[test]
+fn the_stop_wait_runs_on_the_same_schedule() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let final_poll = expected_sleeps().len() - 1;
+    let mut states = vec![Some(vm("running", &s.tags))];
+    states.extend((0..final_poll).map(|_| Some(vm("deallocating", &s.tags))));
+    states.push(Some(vm("deallocated", &s.tags)));
+    s.plane
+        .script(Some(owned(&s)), Some(deployment("Succeeded", "203.0.113.9")), states);
+    let begun = s.clock.instant();
+    assert_eq!(client.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    assert_eq!(s.clock.sleeps(), expected_sleeps());
+    assert!(s.clock.instant().saturating_duration_since(begun) <= BOUND);
+}

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -397,7 +397,12 @@ fn decode_json(
 
 /// Time left before an absolute deadline, or `None` once it has passed.
 pub(super) fn remaining(deadline: std::time::Instant) -> Option<Duration> {
-    let left = deadline.saturating_duration_since(std::time::Instant::now());
+    remaining_at(std::time::Instant::now(), deadline)
+}
+
+/// What is left of `deadline` at `now`, or nothing once it has passed.
+pub(super) fn remaining_at(now: std::time::Instant, deadline: std::time::Instant) -> Option<Duration> {
+    let left = deadline.saturating_duration_since(now);
     (!left.is_zero()).then_some(left)
 }
 


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (adapter test hardening; does not complete the issue).

## Why

The stop and start waits skipped their sleeps under test and stopped after a fixed number of polls, so the deadline arithmetic (final-poll reserve, last sleep cut short, slow requests eating the bound, a transition completing at the very end) was never executed by any test.

## What

- The provider takes its time from an `AzureClock`. Production uses the system clock and sleeps for real; tests install a fake that advances on every sleep and can charge each bounded request against the bound.
- The test-only poll cap and the `cfg!(test)` sleep skip are gone: the waits run their production schedule and bound in tests.
- New tests (`tests/provider/wait.rs`): the exact schedule (0, 1, 2, 4, 8, 15, then 30-second steps, the last cut to 25 s so a poll lands inside the 5-second reserve); a transition observed on that final poll is a verified start while one step later is not and the start is never re-posted; 100-second lookups end the wait after the one poll that fits, with no request handed a budget past the deadline; the stop wait runs the same schedule.

## Validation

Full local matrix green on the pre-rebase head and Azure unit tests plus pedantic clippy re-run after rebasing onto #553: fmt, maintainability, version sync, preflight tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic.