### PR TITLE
test(azure): add the client-off harness core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
       - name: Verify source allowlist and excluded-file controls
         run: python3 -B containers/remote-worker/test_repository_packaging.py --docker-host unix:///var/run/docker.sock
 
+  azure-harness-tests:
+    name: Azure harness tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify workspace preflight decisions
+        run: python3 -B -m unittest discover -s scripts/azure-workspace-preflight/tests -v
+      - name: Verify client-off harness decisions
+        run: python3 -B -m unittest discover -s scripts/azure-client-off/tests -v
+
   remote-panel-sessions:
     name: Remote panel sessions
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ crates/horizon-ui/publish-assets/
 .idea/caches/
 
 profiling-output/
+
+# Python bytecode caches from the script test suites
+__pycache__/
+*.pyc

--- a/scripts/azure-client-off/README.md
+++ b/scripts/azure-client-off/README.md
@@ -15,9 +15,13 @@ the provisioning scripts follow in the next slice together with the runbook.
   apart), `az.py` (bounded `az` calls without a shell; every mutation names the exact
   resource and `--dry-run` journals instead of issuing) and `cleanup.py` (deletion
   of exactly the groups this run journaled, re-proven owned immediately before the
-  delete, and only when their tags carry a value drawn fresh for one run).
-- `client_off.py`: the command line: `validate`, `journal-group`, `cleanup`,
-  `verdict`, driven by a frozen manifest.
+  delete, and only when their tags bind them to this run: A's group carries the
+  `run_id` passed to `cleanup`, B's group carries the workflow and job identities
+  its own name is derived from).
+- `client_off.py`: the command line: `validate`, `journal-group`, `cleanup`
+  (`--run-id` from the provisioning output), `verdict`, driven by a frozen manifest.
+- The tests run in CI (`Azure harness tests` job) next to the workspace preflight
+  suite.
 - `tests/`: deterministic coverage of the manifest gates, the verdict logic, the
   cleanup authorization and the `az` client, run with
   `python3 -B -m unittest discover -s scripts/azure-client-off/tests -v`.

--- a/scripts/azure-client-off/README.md
+++ b/scripts/azure-client-off/README.md
@@ -15,11 +15,14 @@ the provisioning scripts follow in the next slice together with the runbook.
   apart), `az.py` (bounded `az` calls without a shell; every mutation names the exact
   resource and `--dry-run` journals instead of issuing) and `cleanup.py` (deletion
   of exactly the groups this run journaled, re-proven owned immediately before the
-  delete, and only when their tags bind them to this run: A's group carries the
-  `run_id` passed to `cleanup`, B's group carries the workflow and job identities
-  its own name is derived from).
-- `client_off.py`: the command line: `validate`, `journal-group`, `cleanup`
-  (`--run-id` from the provisioning output), `verdict`, driven by a frozen manifest.
+  delete, and only when their tags bind them to this run: A's group is named
+  `horizon-client-<run_id>` and carries the manifest's `run_id`, B's group is the
+  adapter's `horizon-ws-<workflow>-<job>` and carries those identities). ARM offers
+  no conditional delete for resource groups, so this rests on names no other run can
+  reuse rather than on a compare-and-delete.
+- `client_off.py`: the command line: `validate`, `journal-group`, `cleanup`,
+  `verdict`, driven by a frozen manifest that carries a `run_id` drawn when it was
+  frozen (`head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'`).
 - The tests run in CI (`Azure harness tests` job) next to the workspace preflight
   suite.
 - `tests/`: deterministic coverage of the manifest gates, the verdict logic, the

--- a/scripts/azure-client-off/README.md
+++ b/scripts/azure-client-off/README.md
@@ -1,0 +1,25 @@
+# Azure client-off harness
+
+Tooling for the Azure client-off acceptance of #474 / #475: client VM A runs the
+exact Horizon client, a separate worker B keeps a task running, and observer C (this
+controller) proves that B keeps working while A is deallocated and that A
+reconnects afterwards without a new create or a replay.
+
+This slice ships the core; the mutation phases (off, observer install, return) and
+the provisioning scripts follow in the next slice together with the runbook.
+
+- `clientoff/`: the harness modules. `manifest.py` (schema, constants, the deadline
+  arithmetic that keeps the reaper away from a live run), `verdict.py` (pure
+  evaluation of recorded observer samples: cadence, A deallocated throughout, B's
+  identity, image tag and endpoint constant, counter advancing, checkpoints judged
+  apart), `az.py` (bounded `az` calls without a shell; every mutation names the exact
+  resource and `--dry-run` journals instead of issuing) and `cleanup.py` (deletion
+  of exactly the groups this run journaled, re-proven owned immediately before the
+  delete, and only when their tags carry a value drawn fresh for one run).
+- `client_off.py`: the command line: `validate`, `journal-group`, `cleanup`,
+  `verdict`, driven by a frozen manifest.
+- `tests/`: deterministic coverage of the manifest gates, the verdict logic, the
+  cleanup authorization and the `az` client, run with
+  `python3 -B -m unittest discover -s scripts/azure-client-off/tests -v`.
+
+No `az login`, provider registration or extension install happens anywhere here.

--- a/scripts/azure-client-off/client_off.py
+++ b/scripts/azure-client-off/client_off.py
@@ -59,6 +59,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     journal.add_argument("--created", required=True, help="JSON array file to append to (created if absent)")
     cleanup = sub.add_parser("cleanup", help="delete exactly the groups this run created")
     cleanup.add_argument("--groups-before", required=True, help="JSON list of group names recorded before the run")
+    cleanup.add_argument("--run-id", required=True,
+                         help="this run's identity as drawn by provision-client.sh (client.json `run_id`, also in its log)")
     cleanup.add_argument("--created", required=True,
                          help="creation journal: JSON array of {name, id, tags} records written at creation "
                               "(provision-client.sh for A, journal-group for B)")
@@ -124,7 +126,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         result = {"passed": False, "deleted": [],
                   "findings": [f"groups-before or created unreadable: {type(error).__name__}; nothing deleted"]}
     else:
-        result = phase_cleanup(az, manifest, before, created)
+        result = phase_cleanup(az, manifest, before, created, args.run_id)
     result["az_calls"] = az.journal
     print(json.dumps(result, indent=2))
     return 0 if result.get("passed") else 1

--- a/scripts/azure-client-off/client_off.py
+++ b/scripts/azure-client-off/client_off.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Azure client-off acceptance harness for #474 / #475 (Azure lane).
+
+Topology: client VM A runs the exact Horizon client with a persistent home; a separate
+worker B is created through the product path (or, until that is wired for Azure, the
+adapter's live driver, in which case the run is an adapter-only rehearsal, never the
+product pass); observer C is this controller. The harness deallocates A only, verifies
+`PowerState/deallocated`, observes B's identity and task progress read-only for the
+declared interval, starts A only, and cleans up exactly the journaled resources.
+
+Observer C's only reach into B is a pinned SSH session with a key that sshd restricts
+(`restrict,command=`) to a forced reader of the progress and checkpoint files; the key
+is installed through the ARM run-command channel and accepted only once the forced
+reader answers a session that asked for another command.
+
+This slice ships the core: the manifest gate, the pure verdict over a recorded journal,
+the creation journal and cleanup authorization. The mutation phases (off, observer
+install, return) and the provisioning scripts follow in the next slice.
+
+Nothing here logs in, registers a provider or installs an extension. Every `az` call is
+an argument list without a shell, bounded in time. The observer never renews a lease,
+reconnects a terminal, checkpoints or replays a task. Counter progress is recorded as
+counter progress, never labelled a checkpoint.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, List, Optional
+
+# The harness is a script, run from any directory; its modules live beside it.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from clientoff.az import Az  # noqa: E402
+from clientoff.cleanup import identity_record, journal_records, phase_cleanup  # noqa: E402
+from clientoff.manifest import TOOL_VERSION, validate_manifest  # noqa: E402
+from clientoff.verdict import verdict_from_records  # noqa: E402
+
+def load_json(path: str) -> Any:
+    """A file's JSON, or a sentinel object that no validator accepts."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        return {"__unreadable__": type(error).__name__}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--manifest", required=True, help="JSON manifest frozen before renting")
+    parser.add_argument("--journal", default="client-off-journal.ndjson")
+    parser.add_argument("--dry-run", action="store_true", help="never issue a mutating az call")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("validate", help="check the manifest; nothing is called")
+    journal = sub.add_parser("journal-group", help="append a group's ARM identity and tags to the creation journal")
+    journal.add_argument("--group", required=True)
+    journal.add_argument("--created", required=True, help="JSON array file to append to (created if absent)")
+    cleanup = sub.add_parser("cleanup", help="delete exactly the groups this run created")
+    cleanup.add_argument("--groups-before", required=True, help="JSON list of group names recorded before the run")
+    cleanup.add_argument("--created", required=True,
+                         help="creation journal: JSON array of {name, id, tags} records written at creation "
+                              "(provision-client.sh for A, journal-group for B)")
+    verdict = sub.add_parser("verdict", help="evaluate a recorded journal without any provider call")
+    verdict.add_argument("--journal-in", required=True)
+    args = parser.parse_args(argv)
+    try:
+        with open(args.manifest, encoding="utf-8") as handle:
+            manifest = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        print(json.dumps({"runnable": False, "problems": [f"manifest unreadable: {type(error).__name__}"]}, indent=2))
+        return 2
+    # Only the phases that rent or keep compute alive need a future deadline.
+    problems = validate_manifest(manifest, renting=args.command in ("validate", "off", "return"), phase=args.command)
+    if problems:
+        print(json.dumps({"runnable": False, "problems": problems}, indent=2))
+        return 2
+    if args.command == "validate":
+        print(json.dumps({"runnable": True, "tool_version": TOOL_VERSION}, indent=2))
+        return 0
+    if args.command == "verdict":
+        try:
+            with open(args.journal_in, encoding="utf-8") as handle:
+                records = [json.loads(line) for line in handle if line.strip()]
+        except (OSError, json.JSONDecodeError) as error:
+            result = {"passed": False, "findings": [f"journal unreadable: {type(error).__name__}"]}
+        else:
+            result = verdict_from_records(records, manifest)
+        print(json.dumps(result, indent=2))
+        return 0 if result["passed"] else 1
+    az = Az(manifest["subscription_id"], dry_run=args.dry_run)
+    if args.command == "journal-group":
+        record = identity_record(az, args.group)
+        if record is None:
+            print(json.dumps({"passed": False, "findings": [f"group {args.group} could not be read"]}, indent=2))
+            return 1
+        existing: Any = []
+        if os.path.exists(args.created):
+            existing = load_json(args.created)
+        records = journal_records(existing)
+        if records is None:
+            print(json.dumps({"passed": False, "findings": ["created is not a JSON array of identity records"]}, indent=2))
+            return 1
+        if record["name"].casefold() in records:
+            print(json.dumps({"passed": False, "findings": [f"{record['name']} is already journaled; the journal is append-only"]}, indent=2))
+            return 1
+        existing = [*existing, record]
+        # Atomic replace: the only cleanup authorization is never left half-written.
+        temporary = f"{args.created}.tmp"
+        with open(temporary, "w", encoding="utf-8") as handle:
+            json.dump(existing, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, args.created)
+        print(json.dumps({"passed": True, "journaled": record}, indent=2))
+        return 0
+    try:
+        with open(args.groups_before, encoding="utf-8") as handle:
+            before = json.load(handle)
+        with open(args.created, encoding="utf-8") as handle:
+            created = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        result = {"passed": False, "deleted": [],
+                  "findings": [f"groups-before or created unreadable: {type(error).__name__}; nothing deleted"]}
+    else:
+        result = phase_cleanup(az, manifest, before, created)
+    result["az_calls"] = az.journal
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("passed") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/azure-client-off/client_off.py
+++ b/scripts/azure-client-off/client_off.py
@@ -59,8 +59,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     journal.add_argument("--created", required=True, help="JSON array file to append to (created if absent)")
     cleanup = sub.add_parser("cleanup", help="delete exactly the groups this run created")
     cleanup.add_argument("--groups-before", required=True, help="JSON list of group names recorded before the run")
-    cleanup.add_argument("--run-id", required=True,
-                         help="this run's identity as drawn by provision-client.sh (client.json `run_id`, also in its log)")
     cleanup.add_argument("--created", required=True,
                          help="creation journal: JSON array of {name, id, tags} records written at creation "
                               "(provision-client.sh for A, journal-group for B)")
@@ -126,7 +124,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         result = {"passed": False, "deleted": [],
                   "findings": [f"groups-before or created unreadable: {type(error).__name__}; nothing deleted"]}
     else:
-        result = phase_cleanup(az, manifest, before, created, args.run_id)
+        result = phase_cleanup(az, manifest, before, created)
     result["az_calls"] = az.journal
     print(json.dumps(result, indent=2))
     return 0 if result.get("passed") else 1

--- a/scripts/azure-client-off/clientoff/__init__.py
+++ b/scripts/azure-client-off/clientoff/__init__.py
@@ -1,0 +1,7 @@
+"""Azure client-off harness modules: manifest and pure verdict, the bounded `az` client and
+cleanup authorization. `client_off.py` is the command-line entry point."""
+from __future__ import annotations
+
+from . import az, cleanup, manifest, verdict
+
+MODULES = (manifest, verdict, az, cleanup)

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -21,7 +21,8 @@ class Az:
             return None
         try:
             completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
-        except subprocess.TimeoutExpired:
+        except (subprocess.TimeoutExpired, OSError):
+            # A missing or unexecutable `az` is an unreadable answer, like a timeout.
             return None
         if completed.returncode != 0 or not completed.stdout.strip():
             return None
@@ -38,11 +39,16 @@ class Az:
         statuses = instance_view.get("statuses") if isinstance(instance_view, dict) else None
         if not isinstance(statuses, list):
             return None
+        # Every entry must be well formed and exactly one may carry a power state: a
+        # view naming two states, or one that cannot be read, is no state at all.
+        codes = []
         for status in statuses:
             code = status.get("code") if isinstance(status, dict) else None
-            if isinstance(code, str) and code.startswith("PowerState/"):
-                return code
-        return None
+            if not isinstance(code, str):
+                return None
+            if code.startswith("PowerState/"):
+                codes.append(code)
+        return codes[0] if len(codes) == 1 else None
 
     def append_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
         """Append one `authorized_keys` line inside the worker container through the ARM

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -1,0 +1,66 @@
+"""Bounded `az` calls without a shell; every mutation names the exact resource."""
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from typing import Any, Dict, List, Optional
+from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, RUN_COMMAND_SECONDS, TAG_IMAGE_REF, WORKER_CONTAINER, utc_now
+
+
+class Az:
+    """Bounded `az` calls without a shell; every mutation names the exact resource."""
+
+    def __init__(self, subscription: str, dry_run: bool = False) -> None:
+        self.subscription, self.dry_run, self.journal = subscription, dry_run, []
+
+    def run(self, args: List[str], mutating: bool = False, timeout: int = CLI_STEP_SECONDS) -> Optional[Any]:
+        command = ["az", *args, "--subscription", self.subscription, "-o", "json"]
+        self.journal.append({"at": utc_now().isoformat(), "mutating": mutating, "args": args})
+        if self.dry_run and mutating:
+            return None
+        try:
+            completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
+        except subprocess.TimeoutExpired:
+            return None
+        if completed.returncode != 0 or not completed.stdout.strip():
+            return None
+        try:
+            return json.loads(completed.stdout)
+        except json.JSONDecodeError:
+            return None
+
+    def power_state(self, group: str, name: str) -> Optional[str]:
+        view = self.run(["vm", "get-instance-view", "-g", group, "-n", name])
+        if not isinstance(view, dict):
+            return None
+        instance_view = view.get("instanceView")
+        statuses = instance_view.get("statuses") if isinstance(instance_view, dict) else None
+        if not isinstance(statuses, list):
+            return None
+        for status in statuses:
+            code = status.get("code") if isinstance(status, dict) else None
+            if isinstance(code, str) and code.startswith("PowerState/"):
+                return code
+        return None
+
+    def append_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
+        """Append one `authorized_keys` line inside the worker container through the ARM
+        run-command channel; the line travels base64-encoded so no quoting layer can alter it."""
+        encoded = base64.b64encode((line.rstrip("\n") + "\n").encode("ascii")).decode("ascii")
+        script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && mkdir -p /root/.ssh && "
+                  f"echo {encoded} | base64 -d >> /root/.ssh/authorized_keys'")
+        return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
+                         "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
+
+    def vm_identity(self, group: str, name: str) -> Dict[str, Optional[str]]:
+        vm = self.run(["vm", "show", "-g", group, "-n", name])
+        group_info = self.run(["group", "show", "-n", group])
+        # The endpoint is read from ARM every sample and never trusted from the worker file.
+        address = self.run(["network", "public-ip", "show", "-g", group, "-n", PUBLIC_IP_NAME])
+        tags = (vm or {}).get("tags") if isinstance(vm, dict) else None
+        return {"b_group_id": (group_info or {}).get("id") if isinstance(group_info, dict) else None,
+                "b_vm_id": (vm or {}).get("id") if isinstance(vm, dict) else None,
+                "b_instance_id": (vm or {}).get("vmId") if isinstance(vm, dict) else None,
+                "b_image_ref": tags.get(TAG_IMAGE_REF) if isinstance(tags, dict) else None,
+                "b_host": (address or {}).get("ipAddress") if isinstance(address, dict) else None}

--- a/scripts/azure-client-off/clientoff/cleanup.py
+++ b/scripts/azure-client-off/clientoff/cleanup.py
@@ -31,24 +31,29 @@ def journal_records(value: Any) -> Optional[Dict[str, Dict[str, Any]]]:
     return records
 
 
-def per_run_identity(tags: Any) -> bool:
-    """Whether a tag set carries a value drawn fresh for one run: A's `run_id`, or the
-    adapter's workflow and job identities on B's group. ARM group IDs are name-based
-    and every other tag is reproducible, so only such a value distinguishes the group
-    this run created from a same-name recreation with restored tags."""
+def run_bound(record: Dict[str, Any], manifest: Dict[str, Any], run_id: str) -> bool:
+    """Whether a journaled record is bound to this run and nothing else. ARM group IDs
+    are name-based and every other tag is reproducible, so the tags must carry a value
+    drawn fresh for this run and agree with the name: A's group must carry exactly this
+    run's `run_id`; B's group must carry the adapter's workflow and job identities from
+    which its own name is derived (`horizon-ws-<workflow>-<job>`)."""
+    tags, name = record.get("tags"), str(record.get("name", ""))
     if not isinstance(tags, dict):
         return False
-    if RUN_ID_RE.fullmatch(str(tags.get("run_id", ""))):
-        return True
-    return all(UUID_RE.fullmatch(str(tags.get(key, ""))) for key in ("horizon-workflow-id", "horizon-job-id"))
+    if name.casefold() == str(manifest["client_group"]).casefold():
+        return bool(RUN_ID_RE.fullmatch(run_id)) and tags.get("run_id") == run_id
+    if name.casefold() == str(manifest["worker_group"]).casefold():
+        workflow, job = str(tags.get("horizon-workflow-id", "")), str(tags.get("horizon-job-id", ""))
+        return bool(UUID_RE.fullmatch(workflow) and UUID_RE.fullmatch(job)) and name.casefold() == f"horizon-ws-{workflow}-{job}"
+    return False
 
 
-def owned_now(az: Az, record: Dict[str, Any]) -> Optional[bool]:
+def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any], run_id: str) -> Optional[bool]:
     """Immediately before a delete: is the group still the exact resource that was
-    journaled at creation (same ARM ID, identical tag set including its per-run
-    value)? None when it cannot be read; an absent, recreated or retagged group is
-    not ours, and a record without a per-run value never authorizes a delete."""
-    if not per_run_identity(record.get("tags")):
+    journaled at creation (same ARM ID, identical tag set) and bound to this run? None
+    when it cannot be read; an absent, recreated or retagged group is not ours, and a
+    record not bound to this run never authorizes a delete, nor even a read."""
+    if not run_bound(record, manifest, run_id):
         return False
     shown = az.run(["group", "show", "-n", record["name"]])
     if not isinstance(shown, dict) or not isinstance(shown.get("tags"), dict):
@@ -66,36 +71,36 @@ def identity_record(az: Az, group: str) -> Optional[Dict[str, Any]]:
     return {"name": shown["name"], "id": shown["id"], "tags": shown["tags"]}
 
 
-def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any) -> Dict[str, Any]:
-    """Which groups may be deleted: only those this run journaled as created, and never
-    one that existed before the run. Malformed inputs refuse everything. Pure, so the
-    refusal is testable; the returned records carry the identity to re-check."""
+def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any, run_id: str) -> Dict[str, Any]:
+    """Which groups may be deleted: only those this run journaled as created, bound to
+    this run, and never one that existed before the run. Malformed inputs refuse
+    everything. Pure, so the refusal is testable; the returned records carry the
+    identity to re-check."""
     wanted = [manifest["client_group"], manifest["worker_group"]]
     before, records = group_list(before), journal_records(created)
     if before is None or records is None:
         return {"delete": [], "refused": wanted, "malformed": True}
     pre_existing = {name.casefold() for name in before}
     refused = [group for group in wanted if group.casefold() in pre_existing or group.casefold() not in records
-               or not per_run_identity(records[group.casefold()].get("tags"))]
+               or not run_bound(records[group.casefold()], manifest, run_id)]
     return {"delete": [records[group.casefold()] for group in wanted if group not in refused], "refused": refused}
 
 
-def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str]) -> Dict[str, Any]:
-    """Delete only the exact groups this run created; verify absence and untouched peers."""
-    targets = cleanup_targets(manifest, before, created)
+def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str], run_id: str) -> Dict[str, Any]:
+    """Delete only the exact groups this run created; verify absence and untouched peers.
+    A dry run walks the same authorization (the reads happen, the delete is journaled
+    and suppressed by `Az.run`) and stops before waiting for an absence it never caused."""
+    targets = cleanup_targets(manifest, before, created, run_id)
     if targets.get("malformed"):
         return {"passed": False, "deleted": [],
                 "findings": ["groups-before is not a JSON array of names or created is not a JSON array of identity records"]}
     findings = [f"refusing to delete {group}: pre-existing, not journaled as created by this run, or journaled "
-                "without a per-run identity tag" for group in targets["refused"]]
-    if az.dry_run:
-        return {"passed": False, "dry_run": True, "findings": findings, "deleted": [],
-                "would_delete": [record["name"] for record in targets["delete"]]}
+                "without this run's identity in its tags" for group in targets["refused"]]
     deleting = []
     for record in targets["delete"]:
         group = record["name"]
         # A same-named group recreated or retagged since the journal entry is not ours.
-        owned = owned_now(az, record)
+        owned = owned_now(az, record, manifest, run_id)
         if owned is None:
             findings.append(f"refusing to delete {group}: ownership could not be read")
         elif not owned:
@@ -106,6 +111,8 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
             # mutable name: a group replaced in between answers 404 instead of vanishing.
             az.run(["rest", "--method", "delete", "--url", f"{ARM}{record['id']}?api-version=2022-09-01"], mutating=True)
     targets["delete"] = deleting
+    if az.dry_run:
+        return {"passed": False, "dry_run": True, "findings": findings, "deleted": [], "would_delete": deleting}
     deadline = time.monotonic() + 1_500
     unresolved: Dict[str, str] = {}
     while time.monotonic() < deadline:

--- a/scripts/azure-client-off/clientoff/cleanup.py
+++ b/scripts/azure-client-off/clientoff/cleanup.py
@@ -1,0 +1,133 @@
+"""Cleanup authorization: delete exactly the groups this run journaled, proven owned again immediately before the delete."""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+from .az import Az
+from .manifest import ARM, GROUP_RE, RUN_ID_RE, UUID_RE, same_id
+
+
+def group_list(value: Any) -> Optional[List[str]]:
+    """An inventory is a JSON array of group names; anything else is refused."""
+    if isinstance(value, list) and all(isinstance(item, str) and GROUP_RE.fullmatch(item) for item in value):
+        return value
+    return None
+
+
+def journal_records(value: Any) -> Optional[Dict[str, Dict[str, Any]]]:
+    """The creation journal is a JSON array of {name, id, tags} records taken from ARM
+    when the group was created; anything else is refused. Keyed by case-folded name."""
+    if not isinstance(value, list):
+        return None
+    records: Dict[str, Dict[str, Any]] = {}
+    for item in value:
+        if (not isinstance(item, dict) or not isinstance(item.get("name"), str) or not GROUP_RE.fullmatch(item["name"])
+                or not isinstance(item.get("id"), str) or not item["id"] or not isinstance(item.get("tags"), dict)
+                or not all(isinstance(k, str) and isinstance(v, str) for k, v in item["tags"].items())):
+            return None
+        if item["name"].casefold() in records:
+            return None  # conflicting identities for one name: the journal is not trustworthy
+        records[item["name"].casefold()] = item
+    return records
+
+
+def per_run_identity(tags: Any) -> bool:
+    """Whether a tag set carries a value drawn fresh for one run: A's `run_id`, or the
+    adapter's workflow and job identities on B's group. ARM group IDs are name-based
+    and every other tag is reproducible, so only such a value distinguishes the group
+    this run created from a same-name recreation with restored tags."""
+    if not isinstance(tags, dict):
+        return False
+    if RUN_ID_RE.fullmatch(str(tags.get("run_id", ""))):
+        return True
+    return all(UUID_RE.fullmatch(str(tags.get(key, ""))) for key in ("horizon-workflow-id", "horizon-job-id"))
+
+
+def owned_now(az: Az, record: Dict[str, Any]) -> Optional[bool]:
+    """Immediately before a delete: is the group still the exact resource that was
+    journaled at creation (same ARM ID, identical tag set including its per-run
+    value)? None when it cannot be read; an absent, recreated or retagged group is
+    not ours, and a record without a per-run value never authorizes a delete."""
+    if not per_run_identity(record.get("tags")):
+        return False
+    shown = az.run(["group", "show", "-n", record["name"]])
+    if not isinstance(shown, dict) or not isinstance(shown.get("tags"), dict):
+        return None
+    return same_id(shown.get("id"), record["id"]) and shown["tags"] == record["tags"]
+
+
+def identity_record(az: Az, group: str) -> Optional[Dict[str, Any]]:
+    """Read a group's ARM identity and tags into a journal record."""
+    shown = az.run(["group", "show", "-n", group])
+    if not isinstance(shown, dict) or not isinstance(shown.get("id"), str) or not isinstance(shown.get("name"), str):
+        return None
+    if not isinstance(shown.get("tags"), dict):
+        return None
+    return {"name": shown["name"], "id": shown["id"], "tags": shown["tags"]}
+
+
+def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any) -> Dict[str, Any]:
+    """Which groups may be deleted: only those this run journaled as created, and never
+    one that existed before the run. Malformed inputs refuse everything. Pure, so the
+    refusal is testable; the returned records carry the identity to re-check."""
+    wanted = [manifest["client_group"], manifest["worker_group"]]
+    before, records = group_list(before), journal_records(created)
+    if before is None or records is None:
+        return {"delete": [], "refused": wanted, "malformed": True}
+    pre_existing = {name.casefold() for name in before}
+    refused = [group for group in wanted if group.casefold() in pre_existing or group.casefold() not in records
+               or not per_run_identity(records[group.casefold()].get("tags"))]
+    return {"delete": [records[group.casefold()] for group in wanted if group not in refused], "refused": refused}
+
+
+def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str]) -> Dict[str, Any]:
+    """Delete only the exact groups this run created; verify absence and untouched peers."""
+    targets = cleanup_targets(manifest, before, created)
+    if targets.get("malformed"):
+        return {"passed": False, "deleted": [],
+                "findings": ["groups-before is not a JSON array of names or created is not a JSON array of identity records"]}
+    findings = [f"refusing to delete {group}: pre-existing, not journaled as created by this run, or journaled "
+                "without a per-run identity tag" for group in targets["refused"]]
+    if az.dry_run:
+        return {"passed": False, "dry_run": True, "findings": findings, "deleted": [],
+                "would_delete": [record["name"] for record in targets["delete"]]}
+    deleting = []
+    for record in targets["delete"]:
+        group = record["name"]
+        # A same-named group recreated or retagged since the journal entry is not ours.
+        owned = owned_now(az, record)
+        if owned is None:
+            findings.append(f"refusing to delete {group}: ownership could not be read")
+        elif not owned:
+            findings.append(f"refusing to delete {group}: absent, replaced or retagged since it was journaled")
+        else:
+            deleting.append(group)
+            # Delete the exact resource ID that was journaled and re-attested, never the
+            # mutable name: a group replaced in between answers 404 instead of vanishing.
+            az.run(["rest", "--method", "delete", "--url", f"{ARM}{record['id']}?api-version=2022-09-01"], mutating=True)
+    targets["delete"] = deleting
+    deadline = time.monotonic() + 1_500
+    unresolved: Dict[str, str] = {}
+    while time.monotonic() < deadline:
+        # False is proven absence; True is presence; None (timeout, CLI error, malformed
+        # answer) is unknown and never counts as absence.
+        unresolved = {}
+        for group in targets["delete"]:
+            exists = az.run(["group", "exists", "-n", group])
+            if exists is True:
+                unresolved[group] = "present"
+            elif exists is not False:
+                unresolved[group] = "unknown"
+        if not unresolved:
+            break
+        time.sleep(15)
+    for group, state in sorted(unresolved.items()):
+        findings.append(f"group {group} {state} at the bound: absence not proven")
+    inventory = az.run(["group", "list"])
+    names = group_list([group.get("name") for group in inventory]
+                       if isinstance(inventory, list) and all(isinstance(group, dict) for group in inventory) else None)
+    if names is None:
+        findings.append("final resource-group inventory unreadable: unchanged pre-existing resources not proven")
+    elif sorted(name.casefold() for name in names) != sorted(name.casefold() for name in before):
+        findings.append("pre-existing resource groups changed during the run")
+    return {"passed": not findings, "findings": findings, "deleted": targets["delete"]}

--- a/scripts/azure-client-off/clientoff/cleanup.py
+++ b/scripts/azure-client-off/clientoff/cleanup.py
@@ -31,29 +31,31 @@ def journal_records(value: Any) -> Optional[Dict[str, Dict[str, Any]]]:
     return records
 
 
-def run_bound(record: Dict[str, Any], manifest: Dict[str, Any], run_id: str) -> bool:
+def run_bound(record: Dict[str, Any], manifest: Dict[str, Any]) -> bool:
     """Whether a journaled record is bound to this run and nothing else. ARM group IDs
-    are name-based and every other tag is reproducible, so the tags must carry a value
-    drawn fresh for this run and agree with the name: A's group must carry exactly this
-    run's `run_id`; B's group must carry the adapter's workflow and job identities from
-    which its own name is derived (`horizon-ws-<workflow>-<job>`)."""
+    are name-based and every other tag is reproducible, so the tags must carry the
+    identity the name itself is derived from: A's group (`horizon-client-<run_id>`)
+    must carry exactly the manifest's `run_id`; B's group (`horizon-ws-<workflow>-<job>`)
+    must carry the adapter's workflow and job identities."""
     tags, name = record.get("tags"), str(record.get("name", ""))
+    run_id = str(manifest.get("run_id", ""))
     if not isinstance(tags, dict):
         return False
     if name.casefold() == str(manifest["client_group"]).casefold():
-        return bool(RUN_ID_RE.fullmatch(run_id)) and tags.get("run_id") == run_id
+        return bool(RUN_ID_RE.fullmatch(run_id)) and tags.get("run_id") == run_id \
+            and name.casefold() == f"horizon-client-{run_id}"
     if name.casefold() == str(manifest["worker_group"]).casefold():
         workflow, job = str(tags.get("horizon-workflow-id", "")), str(tags.get("horizon-job-id", ""))
         return bool(UUID_RE.fullmatch(workflow) and UUID_RE.fullmatch(job)) and name.casefold() == f"horizon-ws-{workflow}-{job}"
     return False
 
 
-def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any], run_id: str) -> Optional[bool]:
+def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any]) -> Optional[bool]:
     """Immediately before a delete: is the group still the exact resource that was
     journaled at creation (same ARM ID, identical tag set) and bound to this run? None
     when it cannot be read; an absent, recreated or retagged group is not ours, and a
     record not bound to this run never authorizes a delete, nor even a read."""
-    if not run_bound(record, manifest, run_id):
+    if not run_bound(record, manifest):
         return False
     shown = az.run(["group", "show", "-n", record["name"]])
     if not isinstance(shown, dict) or not isinstance(shown.get("tags"), dict):
@@ -71,7 +73,7 @@ def identity_record(az: Az, group: str) -> Optional[Dict[str, Any]]:
     return {"name": shown["name"], "id": shown["id"], "tags": shown["tags"]}
 
 
-def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any, run_id: str) -> Dict[str, Any]:
+def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any) -> Dict[str, Any]:
     """Which groups may be deleted: only those this run journaled as created, bound to
     this run, and never one that existed before the run. Malformed inputs refuse
     everything. Pure, so the refusal is testable; the returned records carry the
@@ -82,15 +84,15 @@ def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any, run_id:
         return {"delete": [], "refused": wanted, "malformed": True}
     pre_existing = {name.casefold() for name in before}
     refused = [group for group in wanted if group.casefold() in pre_existing or group.casefold() not in records
-               or not run_bound(records[group.casefold()], manifest, run_id)]
+               or not run_bound(records[group.casefold()], manifest)]
     return {"delete": [records[group.casefold()] for group in wanted if group not in refused], "refused": refused}
 
 
-def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str], run_id: str) -> Dict[str, Any]:
+def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str]) -> Dict[str, Any]:
     """Delete only the exact groups this run created; verify absence and untouched peers.
     A dry run walks the same authorization (the reads happen, the delete is journaled
     and suppressed by `Az.run`) and stops before waiting for an absence it never caused."""
-    targets = cleanup_targets(manifest, before, created, run_id)
+    targets = cleanup_targets(manifest, before, created)
     if targets.get("malformed"):
         return {"passed": False, "deleted": [],
                 "findings": ["groups-before is not a JSON array of names or created is not a JSON array of identity records"]}
@@ -100,15 +102,18 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
     for record in targets["delete"]:
         group = record["name"]
         # A same-named group recreated or retagged since the journal entry is not ours.
-        owned = owned_now(az, record, manifest, run_id)
+        owned = owned_now(az, record, manifest)
         if owned is None:
             findings.append(f"refusing to delete {group}: ownership could not be read")
         elif not owned:
             findings.append(f"refusing to delete {group}: absent, replaced or retagged since it was journaled")
         else:
             deleting.append(group)
-            # Delete the exact resource ID that was journaled and re-attested, never the
-            # mutable name: a group replaced in between answers 404 instead of vanishing.
+            # Delete the resource ID that was journaled and re-attested a moment ago. ARM
+            # offers no conditional delete for resource groups and the ID is name-based,
+            # so the guarantee rests on the name: unique to this run, so nothing else can
+            # legitimately stand at this path in the window between the re-read and the
+            # delete reaching ARM.
             az.run(["rest", "--method", "delete", "--url", f"{ARM}{record['id']}?api-version=2022-09-01"], mutating=True)
     targets["delete"] = deleting
     if az.dry_run:

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -159,3 +159,17 @@ def routable(address: Any) -> bool:
 def same_id(left: Any, right: Any) -> bool:
     """ARM resource IDs compare case-insensitively; addresses compare exactly."""
     return isinstance(left, str) and isinstance(right, str) and left.casefold() == right.casefold()
+
+
+def client_tags(manifest: Dict[str, Any]) -> Dict[str, str]:
+    """The complete tag set provisioning writes on A's group and VM: the frozen
+    artifact's digest and the run identity the manifest (and A's group name) carry."""
+    return {"issue": "475", "lane": "azure-client-off", "purpose": "horizon-azure-vm-spike",
+            "deadline": str(manifest["cleanup_deadline_utc"]), "client_sha": str(manifest["client_sha"]),
+            "client_binary_sha256": str(manifest["client_binary_sha256"]), "run_id": str(manifest["run_id"])}
+
+
+def client_ids(manifest: Dict[str, Any]) -> Dict[str, str]:
+    """A's ARM group and VM ID paths as the manifest determines them."""
+    group = f"/subscriptions/{manifest['subscription_id']}/resourceGroups/{manifest['client_group']}"
+    return {"a_group_id": group, "a_vm_id": f"{group}/providers/Microsoft.Compute/virtualMachines/client"}

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -75,7 +75,9 @@ def required_minutes(manifest: Dict[str, Any], phase: str) -> int:
     """How many minutes past `now` the deadline must lie for `phase` to start."""
     off = manifest.get("off_minutes") if type(manifest.get("off_minutes")) is int else MIN_OFF_MINUTES  # noqa: E721
     return {"validate": PROVISION_MINUTES + off + CLEANUP_MARGIN_MINUTES, "off": off + CLEANUP_MARGIN_MINUTES,
-            "install-observer-key": off + CLEANUP_MARGIN_MINUTES, "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
+            # The install may spend its whole run-command bound before the off interval starts.
+            "install-observer-key": RUN_COMMAND_SECONDS // 60 + off + CLEANUP_MARGIN_MINUTES,
+            "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
 
 
 def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = None, renting: bool = True,

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -12,6 +12,8 @@ ARM = "https://management.azure.com"
 CLI_STEP_SECONDS = 90
 SAMPLE_SECONDS = 15
 SAMPLE_JITTER_SECONDS = 5
+# Wake-up latency tolerated between two consecutive actual observations.
+ACTUAL_GAP_ALLOWANCE_SECONDS = 1
 MIN_OFF_MINUTES = 10
 REAPER_TAGS = {"purpose": "horizon-azure-vm-spike"}
 CLIENT_VM_NAME = "client"
@@ -21,6 +23,8 @@ RUN_COMMAND_SECONDS = 600
 UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 GROUP_RE = re.compile(r"^[A-Za-z0-9_.()-]{1,90}$")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# The same rule as the workspace preflight: a lowercase Azure region name.
+REGION_RE = re.compile(r"^[a-z][a-z0-9]{1,63}$")
 DIGEST_RE = re.compile(r"^[a-z0-9]+(?:[.-][a-z0-9]+)+(?::[0-9]{1,5})?/[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*@sha256:[0-9a-f]{64}$")
 MANIFEST_FIELDS = ("subscription_id", "location", "run_id", "client_group", "client_vm_size", "client_sha",
                    "client_binary_sha256", "worker_group", "worker_image", "hourly_cost_micros", "budget_micros",
@@ -71,7 +75,7 @@ def required_minutes(manifest: Dict[str, Any], phase: str) -> int:
     """How many minutes past `now` the deadline must lie for `phase` to start."""
     off = manifest.get("off_minutes") if type(manifest.get("off_minutes")) is int else MIN_OFF_MINUTES  # noqa: E721
     return {"validate": PROVISION_MINUTES + off + CLEANUP_MARGIN_MINUTES, "off": off + CLEANUP_MARGIN_MINUTES,
-            "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
+            "install-observer-key": off + CLEANUP_MARGIN_MINUTES, "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
 
 
 def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = None, renting: bool = True,
@@ -109,8 +113,7 @@ def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = No
     text("client_sha", SHA_RE, "a full commit SHA")
     text("client_binary_sha256", SHA256_RE, "a SHA-256 digest")
     text("worker_image", DIGEST_RE, "a complete registry/repository@sha256 digest reference")
-    if not isinstance(manifest["location"], str) or not manifest["location"]:
-        problems.append("location is not a region name")
+    text("location", REGION_RE, "a lowercase Azure region name such as northeurope")
     for field in ("hourly_cost_micros", "budget_micros"):
         # bool is an int subclass in JSON decoding; only an exact integer counts.
         if type(manifest[field]) is not int or manifest[field] <= 0:  # noqa: E721
@@ -121,13 +124,13 @@ def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = No
         problems.append("cleanup_deadline_utc is not an ISO-8601 instant")
     else:
         needed = _dt.timedelta(minutes=required_minutes(manifest, phase)) if renting else _dt.timedelta(0)
-        if renting and deadline <= now:
+        if deadline - now > _dt.timedelta(hours=24):
+            problems.append("cleanup_deadline_utc is more than 24 hours away")
+        elif renting and deadline <= now:
             problems.append("cleanup_deadline_utc is not in the future")
         elif renting and deadline - now < needed:
             problems.append(f"cleanup_deadline_utc must lie at least {int(needed.total_seconds() // 60)} minutes "
                             f"ahead for the {phase} phase (provisioning bound, off interval and margins)")
-        elif deadline - now > _dt.timedelta(hours=24):
-            problems.append("cleanup_deadline_utc is more than 24 hours away")
     if type(manifest["off_minutes"]) is not int or manifest["off_minutes"] < MIN_OFF_MINUTES:  # noqa: E721
         problems.append(f"off_minutes must be at least {MIN_OFF_MINUTES}")
     if type(manifest["lease_seconds"]) is not int or manifest["lease_seconds"] < 0:  # noqa: E721

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -74,9 +74,10 @@ RETURN_MARGIN_MINUTES = 15
 def required_minutes(manifest: Dict[str, Any], phase: str) -> int:
     """How many minutes past `now` the deadline must lie for `phase` to start."""
     off = manifest.get("off_minutes") if type(manifest.get("off_minutes")) is int else MIN_OFF_MINUTES  # noqa: E721
-    return {"validate": PROVISION_MINUTES + off + CLEANUP_MARGIN_MINUTES, "off": off + CLEANUP_MARGIN_MINUTES,
+    install = RUN_COMMAND_SECONDS // 60
+    return {"validate": PROVISION_MINUTES + install + off + CLEANUP_MARGIN_MINUTES, "off": off + CLEANUP_MARGIN_MINUTES,
             # The install may spend its whole run-command bound before the off interval starts.
-            "install-observer-key": RUN_COMMAND_SECONDS // 60 + off + CLEANUP_MARGIN_MINUTES,
+            "install-observer-key": install + off + CLEANUP_MARGIN_MINUTES,
             "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
 
 

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -22,9 +22,15 @@ UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]
 GROUP_RE = re.compile(r"^[A-Za-z0-9_.()-]{1,90}$")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^[a-z0-9]+(?:[.-][a-z0-9]+)+(?::[0-9]{1,5})?/[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*@sha256:[0-9a-f]{64}$")
-MANIFEST_FIELDS = ("subscription_id", "location", "client_group", "client_vm_size", "client_sha",
+MANIFEST_FIELDS = ("subscription_id", "location", "run_id", "client_group", "client_vm_size", "client_sha",
                    "client_binary_sha256", "worker_group", "worker_image", "hourly_cost_micros", "budget_micros",
                    "cleanup_deadline_utc", "off_minutes", "lease_seconds")
+# Every group name this harness may create or delete is unique to one run: A's group is
+# named from the run identity drawn when the manifest was frozen, B's group from the
+# adapter's workflow and job identities. ARM resource IDs are name-based, so a name
+# that no other run can reuse is what makes "the exact resource" meaningful.
+CLIENT_GROUP_PREFIX = "horizon-client-"
+WORKER_GROUP_RE = re.compile(r"^horizon-ws-([0-9a-f-]{36})-([0-9a-f-]{36})$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 VM_SIZE_RE = re.compile(r"^Standard_[A-Za-z0-9_-]{2,40}$")
 # Plain components only: no `.` or `..`, so two spellings can never alias one file.
@@ -89,8 +95,15 @@ def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = No
 
     text("subscription_id", UUID_RE, "an exact UUID")
     text("client_vm_size", VM_SIZE_RE, "an Azure VM size name")
+    text("run_id", RUN_ID_RE, "a 32-hex-digit run identity drawn for this manifest")
     text("client_group", GROUP_RE, "a valid resource group name")
+    if isinstance(manifest["client_group"], str) and isinstance(manifest["run_id"], str) \
+            and manifest["client_group"] != f"{CLIENT_GROUP_PREFIX}{manifest['run_id']}":
+        problems.append(f"client_group must be {CLIENT_GROUP_PREFIX}<run_id>: a name no other run can reuse")
     text("worker_group", GROUP_RE, "a valid resource group name")
+    worker_group = WORKER_GROUP_RE.fullmatch(str(manifest["worker_group"]))
+    if not worker_group or not all(UUID_RE.fullmatch(part) for part in worker_group.groups()):
+        problems.append("worker_group must be the adapter's horizon-ws-<workflow>-<job> name")
     if same_group(manifest["client_group"], manifest["worker_group"]):
         problems.append("client and worker must live in different exact groups")
     text("client_sha", SHA_RE, "a full commit SHA")

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -1,0 +1,145 @@
+"""Manifest schema, constants and the small pure helpers every other module shares."""
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import ipaddress
+import re
+from typing import Any, Dict, List, Optional
+
+TOOL_VERSION = "0.1.0"
+ARM = "https://management.azure.com"
+CLI_STEP_SECONDS = 90
+SAMPLE_SECONDS = 15
+SAMPLE_JITTER_SECONDS = 5
+MIN_OFF_MINUTES = 10
+REAPER_TAGS = {"purpose": "horizon-azure-vm-spike"}
+CLIENT_VM_NAME = "client"
+PUBLIC_IP_NAME = "worker-pip"
+WORKER_CONTAINER = "horizon-worker"
+RUN_COMMAND_SECONDS = 600
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+GROUP_RE = re.compile(r"^[A-Za-z0-9_.()-]{1,90}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^[a-z0-9]+(?:[.-][a-z0-9]+)+(?::[0-9]{1,5})?/[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*@sha256:[0-9a-f]{64}$")
+MANIFEST_FIELDS = ("subscription_id", "location", "client_group", "client_vm_size", "client_sha",
+                   "client_binary_sha256", "worker_group", "worker_image", "hourly_cost_micros", "budget_micros",
+                   "cleanup_deadline_utc", "off_minutes", "lease_seconds")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+VM_SIZE_RE = re.compile(r"^Standard_[A-Za-z0-9_-]{2,40}$")
+# Plain components only: no `.` or `..`, so two spellings can never alias one file.
+PROGRESS_PATH_RE = re.compile(r"^/workspace(?:/(?!\.\.?(?:/|$))[A-Za-z0-9_.-]+)+$")
+PROGRESS_READ_LIMIT = 256
+TAG_IMAGE_REF = "horizon-worker-image-ref-sha256"
+HOST_KEY_RE = re.compile(r"^ssh-ed25519 [A-Za-z0-9+/]{68}$")
+RUN_ID_RE = re.compile(r"[0-9a-f]{32}")
+INSTANCE_ID_RE = re.compile(r"[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}")
+
+
+def utc_now() -> _dt.datetime:
+    return _dt.datetime.now(_dt.timezone.utc)
+
+
+def parse_utc(value: str) -> _dt.datetime:
+    """Parse an ISO-8601 instant; a value without an offset is rejected, never guessed."""
+    parsed = _dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("instant has no UTC offset")
+    return parsed.astimezone(_dt.timezone.utc)
+
+
+def same_group(left: Any, right: Any) -> bool:
+    """Azure resource-group names are case-insensitive; compare them that way."""
+    return isinstance(left, str) and isinstance(right, str) and left.casefold() == right.casefold()
+
+
+# Time the manifest deadline must still cover when a phase starts: provisioning runs
+# under a 30-minute bound, the off interval is declared, and return plus cleanup need
+# a margin. A deadline that the reaper could reach mid-run is not runnable.
+PROVISION_MINUTES = 30
+CLEANUP_MARGIN_MINUTES = 30
+RETURN_MARGIN_MINUTES = 15
+
+
+def required_minutes(manifest: Dict[str, Any], phase: str) -> int:
+    """How many minutes past `now` the deadline must lie for `phase` to start."""
+    off = manifest.get("off_minutes") if type(manifest.get("off_minutes")) is int else MIN_OFF_MINUTES  # noqa: E721
+    return {"validate": PROVISION_MINUTES + off + CLEANUP_MARGIN_MINUTES, "off": off + CLEANUP_MARGIN_MINUTES,
+            "return": RETURN_MARGIN_MINUTES}.get(phase, 0)
+
+
+def validate_manifest(manifest: Dict[str, Any], now: Optional[_dt.datetime] = None, renting: bool = True,
+                      phase: str = "validate") -> List[str]:
+    """Problems that must be fixed before anything is rented; empty means runnable.
+
+    With `renting=False` (verdict and cleanup) the deadline must still be a valid
+    instant but may lie in the past: a late cleanup is exactly the case that must run.
+    """
+    now = now or utc_now()
+    if not isinstance(manifest, dict):
+        return ["manifest is not a JSON object"]
+    problems = [f"missing {field}" for field in MANIFEST_FIELDS if field not in manifest]
+    if problems:
+        return problems
+    def text(field: str, pattern: "re.Pattern[str]", what: str, search: bool = False) -> None:
+        value = manifest[field]
+        matched = isinstance(value, str) and (pattern.search(value) if search else pattern.fullmatch(value))
+        if not matched:
+            problems.append(f"{field} is not {what}")
+
+    text("subscription_id", UUID_RE, "an exact UUID")
+    text("client_vm_size", VM_SIZE_RE, "an Azure VM size name")
+    text("client_group", GROUP_RE, "a valid resource group name")
+    text("worker_group", GROUP_RE, "a valid resource group name")
+    if same_group(manifest["client_group"], manifest["worker_group"]):
+        problems.append("client and worker must live in different exact groups")
+    text("client_sha", SHA_RE, "a full commit SHA")
+    text("client_binary_sha256", SHA256_RE, "a SHA-256 digest")
+    text("worker_image", DIGEST_RE, "a complete registry/repository@sha256 digest reference")
+    if not isinstance(manifest["location"], str) or not manifest["location"]:
+        problems.append("location is not a region name")
+    for field in ("hourly_cost_micros", "budget_micros"):
+        # bool is an int subclass in JSON decoding; only an exact integer counts.
+        if type(manifest[field]) is not int or manifest[field] <= 0:  # noqa: E721
+            problems.append(f"{field} must be a positive integer")
+    try:
+        deadline = parse_utc(str(manifest["cleanup_deadline_utc"]))
+    except ValueError:
+        problems.append("cleanup_deadline_utc is not an ISO-8601 instant")
+    else:
+        needed = _dt.timedelta(minutes=required_minutes(manifest, phase)) if renting else _dt.timedelta(0)
+        if renting and deadline <= now:
+            problems.append("cleanup_deadline_utc is not in the future")
+        elif renting and deadline - now < needed:
+            problems.append(f"cleanup_deadline_utc must lie at least {int(needed.total_seconds() // 60)} minutes "
+                            f"ahead for the {phase} phase (provisioning bound, off interval and margins)")
+        elif deadline - now > _dt.timedelta(hours=24):
+            problems.append("cleanup_deadline_utc is more than 24 hours away")
+    if type(manifest["off_minutes"]) is not int or manifest["off_minutes"] < MIN_OFF_MINUTES:  # noqa: E721
+        problems.append(f"off_minutes must be at least {MIN_OFF_MINUTES}")
+    if type(manifest["lease_seconds"]) is not int or manifest["lease_seconds"] < 0:  # noqa: E721
+        problems.append("lease_seconds must be a non-negative integer (0 when no lease applies)")
+    elif type(manifest["off_minutes"]) is int and manifest["off_minutes"] * 60 <= manifest["lease_seconds"]:  # noqa: E721
+        problems.append("off_minutes must exceed lease_seconds so the interval crosses the lease boundary")
+    return problems
+
+
+def image_ref_digest(image: str) -> str:
+    """The adapter tags each worker with the SHA-256 of its full image reference."""
+    return hashlib.sha256(image.encode()).hexdigest()
+
+
+def routable(address: Any) -> bool:
+    """Only a public, globally routable IP address can be worker B's endpoint."""
+    if not isinstance(address, str):
+        return False
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return parsed.is_global and not parsed.is_multicast
+
+
+def same_id(left: Any, right: Any) -> bool:
+    """ARM resource IDs compare case-insensitively; addresses compare exactly."""
+    return isinstance(left, str) and isinstance(right, str) and left.casefold() == right.casefold()

--- a/scripts/azure-client-off/clientoff/verdict.py
+++ b/scripts/azure-client-off/clientoff/verdict.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
-from .manifest import SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, image_ref_digest, parse_utc, routable, same_id
+from .manifest import INSTANCE_ID_RE, SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, image_ref_digest, parse_utc, routable, same_id
 
 
 def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seconds: int,
@@ -116,12 +116,35 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
     }
 
 
+def baseline_problems(baseline: Any, manifest: Dict[str, Any]) -> List[str]:
+    """The header's identity must be an Azure worker in the manifest's worker group:
+    ARM group and VM ID paths under the manifest subscription, a VM instance identity,
+    a routable address. Stable but meaningless strings never identify a worker."""
+    if not isinstance(baseline, dict):
+        return ["baseline is not an object"]
+    problems = []
+    group = f"/subscriptions/{manifest['subscription_id']}/resourceGroups/{manifest['worker_group']}"
+    if not same_id(baseline.get("b_group_id"), group):
+        problems.append("baseline group ID is not the manifest worker group under the manifest subscription")
+    if not same_id(baseline.get("b_vm_id"), f"{group}/providers/Microsoft.Compute/virtualMachines/worker"):
+        problems.append("baseline VM ID is not the worker VM in that group")
+    if not isinstance(baseline.get("b_instance_id"), str) or not INSTANCE_ID_RE.fullmatch(baseline["b_instance_id"]):
+        problems.append("baseline instance identity is not a VM instance identity")
+    if not routable(baseline.get("b_host")):
+        problems.append("baseline address is not a public IP address")
+    return problems
+
+
 def verdict_from_records(records: List[Any], manifest: Dict[str, Any]) -> Dict[str, Any]:
     """Offline verdict over a journal: the first record must be the baseline header the
-    off phase wrote, so a journal from another worker can never pass."""
+    off phase wrote, naming an Azure worker in the manifest's group, so a journal from
+    another worker, or a fabricated one, can never pass."""
     if not records or not isinstance(records[0], dict) or not isinstance(records[0].get("baseline"), dict):
         return {"passed": False, "findings": ["journal has no baseline header; not produced by the off phase"]}
     header, samples = records[0], records[1:]
+    problems = baseline_problems(header["baseline"], manifest)
+    if problems:
+        return {"passed": False, "findings": [f"baseline: {problem}" for problem in problems]}
     if header.get("worker_image") != manifest["worker_image"]:
         return {"passed": False, "findings": ["journal was recorded for a different worker image"]}
     if header.get("observed_image_ref") != image_ref_digest(manifest["worker_image"]):

--- a/scripts/azure-client-off/clientoff/verdict.py
+++ b/scripts/azure-client-off/clientoff/verdict.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
-from .manifest import INSTANCE_ID_RE, SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, image_ref_digest, parse_utc, routable, same_id
+from .manifest import (ACTUAL_GAP_ALLOWANCE_SECONDS, INSTANCE_ID_RE, SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, image_ref_digest,
+                       parse_utc, routable, same_id)
 
 
 def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seconds: int,
@@ -64,12 +65,14 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
         return {"passed": False, "findings": ["a sample was recorded before its scheduled slot"], "samples": len(samples)}
     late = sum(1 for slot, actual in zip(slots, times) if (actual - slot).total_seconds() > SAMPLE_JITTER_SECONDS)
     misses = sum(round(delta / SAMPLE_SECONDS) - 1 for delta in deltas)
-    # The actual instants must also keep the cadence on their own.
+    # The actual instants must keep the cadence on their own: A and B are observed at
+    # least every 15 s, with only wake-up latency allowed between two consecutive
+    # observations; the jitter allowance applies to the slot, never here.
     wide = sum(1 for earlier, later in zip(times, times[1:])
-               if (later - earlier).total_seconds() > SAMPLE_SECONDS + SAMPLE_JITTER_SECONDS)
+               if (later - earlier).total_seconds() > SAMPLE_SECONDS + ACTUAL_GAP_ALLOWANCE_SECONDS)
     if misses or late or wide:
         findings.append(f"cadence not met: {misses} missed {SAMPLE_SECONDS}s observations, {late} late samples, "
-                        f"{wide} gaps over {SAMPLE_SECONDS + SAMPLE_JITTER_SECONDS}s")
+                        f"{wide} gaps over {SAMPLE_SECONDS}s between consecutive observations")
     not_off = [index for index, sample in enumerate(samples) if sample.get("a_power") != "PowerState/deallocated"]
     if not_off:
         findings.append(f"client A not deallocated in {len(not_off)} samples (first at index {not_off[0]})")
@@ -145,6 +148,8 @@ def verdict_from_records(records: List[Any], manifest: Dict[str, Any]) -> Dict[s
     if not records or not isinstance(records[0], dict) or not isinstance(records[0].get("baseline"), dict):
         return {"passed": False, "findings": ["journal has no baseline header; not produced by the off phase"]}
     header, samples = records[0], records[1:]
+    if not isinstance(header.get("worker_image"), str) or not isinstance(header.get("observed_image_ref"), str):
+        return {"passed": False, "findings": ["journal header does not name the worker image and its observed tag"]}
     problems = baseline_problems(header["baseline"], manifest)
     if problems:
         return {"passed": False, "findings": [f"baseline: {problem}" for problem in problems]}

--- a/scripts/azure-client-off/clientoff/verdict.py
+++ b/scripts/azure-client-off/clientoff/verdict.py
@@ -1,0 +1,130 @@
+"""Pure verdict over recorded observer samples; no provider call is ever made here."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from .manifest import SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, image_ref_digest, parse_utc, routable, same_id
+
+
+def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seconds: int,
+                     expected_image_ref: Optional[str] = None,
+                     expected_identity: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Pure verdict over observer samples taken while A was meant to be off.
+
+    Each sample: {"at": ISO instant, "a_power": str|None, "b_group_id": str|None,
+    "b_vm_id": str|None, "b_instance_id": str|None (the VM's vmId, which a same-name
+    recreation does not keep), "b_host": str|None, "b_image_ref": str|None (the worker's
+    image-reference tag), "b_power": str|None, "progress": int|None, "checkpoint":
+    int|None}. Missing fields are misses, never passes. Counters and checkpoints are
+    judged apart. With `expected_image_ref` (the manifest's image reference) every
+    sample must carry the adapter's tag for exactly that image; with
+    `expected_identity` (the group ID, VM ID, instance identity and address recorded
+    at baseline, before A was stopped) the first sample must be that very worker.
+    """
+    findings: List[str] = []
+    if len(samples) < 2:
+        return {"passed": False, "findings": ["fewer than two samples"], "samples": len(samples)}
+    text_fields = ("a_power", "b_group_id", "b_vm_id", "b_instance_id", "b_host", "b_image_ref", "b_power")
+    if any(not isinstance(sample, dict) or any(sample.get(field) is not None and not isinstance(sample.get(field), str)
+                                                for field in text_fields) for sample in samples):
+        return {"passed": False, "findings": ["a sample has a field of the wrong shape"], "samples": len(samples)}
+    try:
+        times = [parse_utc(str(sample["at"])) for sample in samples]
+    except (KeyError, ValueError, TypeError):
+        return {"passed": False, "findings": ["a sample has a missing or invalid timestamp"], "samples": len(samples)}
+    if expected_identity is not None:
+        first = samples[0]
+        mismatched = [field for field in ("b_group_id", "b_vm_id", "b_instance_id", "b_host")
+                      if not same_id(first.get(field), expected_identity.get(field))]
+        if mismatched:
+            findings.append(f"first sample does not match the worker recorded at baseline: {mismatched}")
+    if any(later < earlier for earlier, later in zip(times, times[1:])):
+        return {"passed": False, "findings": ["sample timestamps are not monotonic"], "samples": len(samples)}
+    span = (times[-1] - times[0]).total_seconds()
+    if span < off_minutes * 60:
+        findings.append(f"observed {span:.0f}s, declared interval {off_minutes * 60}s")
+    if span <= lease_seconds:
+        findings.append(f"observed {span:.0f}s did not exceed the lease of {lease_seconds}s")
+    # Cadence: #475 wants a sample at least every 15 s, with scheduled and actual times
+    # recorded. With scheduled instants present, a sample is late when it lands more
+    # than the jitter allowance after its slot, and a jump in scheduled slots is that
+    # many missed observations; without them, the inter-sample gaps stand in.
+    # Every sample carries its scheduled instant; there is no inference from gaps.
+    scheduled = [sample.get("scheduled_at") for sample in samples]
+    if not all(isinstance(value, str) for value in scheduled):
+        return {"passed": False, "findings": ["a sample has no scheduled instant"], "samples": len(samples)}
+    try:
+        slots = [parse_utc(str(value)) for value in scheduled]
+    except ValueError:
+        return {"passed": False, "findings": ["a sample has an invalid scheduled instant"], "samples": len(samples)}
+    deltas = [(later - earlier).total_seconds() for earlier, later in zip(slots, slots[1:])]
+    # Slots are computed instants: strictly increasing exact multiples of the cadence.
+    if any(delta <= 0 or abs(delta / SAMPLE_SECONDS - round(delta / SAMPLE_SECONDS)) > 1e-6 for delta in deltas):
+        return {"passed": False, "findings": ["scheduled instants are not increasing 15-second slots"], "samples": len(samples)}
+    if any(actual < slot for slot, actual in zip(slots, times)):
+        return {"passed": False, "findings": ["a sample was recorded before its scheduled slot"], "samples": len(samples)}
+    late = sum(1 for slot, actual in zip(slots, times) if (actual - slot).total_seconds() > SAMPLE_JITTER_SECONDS)
+    misses = sum(round(delta / SAMPLE_SECONDS) - 1 for delta in deltas)
+    # The actual instants must also keep the cadence on their own.
+    wide = sum(1 for earlier, later in zip(times, times[1:])
+               if (later - earlier).total_seconds() > SAMPLE_SECONDS + SAMPLE_JITTER_SECONDS)
+    if misses or late or wide:
+        findings.append(f"cadence not met: {misses} missed {SAMPLE_SECONDS}s observations, {late} late samples, "
+                        f"{wide} gaps over {SAMPLE_SECONDS + SAMPLE_JITTER_SECONDS}s")
+    not_off = [index for index, sample in enumerate(samples) if sample.get("a_power") != "PowerState/deallocated"]
+    if not_off:
+        findings.append(f"client A not deallocated in {len(not_off)} samples (first at index {not_off[0]})")
+    def identity(sample: Dict[str, Any], field: str) -> Optional[str]:
+        value = sample.get(field)
+        return value.casefold() if isinstance(value, str) and value.strip() else None
+
+    identities = {(identity(sample, "b_group_id"), identity(sample, "b_vm_id"), identity(sample, "b_instance_id"))
+                  for sample in samples}
+    if len(identities) != 1 or any(None in pair for pair in identities):
+        findings.append("worker B identity changed or was unreadable during the interval")
+    b_states = {sample.get("b_power") for sample in samples}
+    if b_states != {"PowerState/running"}:
+        findings.append(f"worker B power states during the interval: {sorted(str(s) for s in b_states)}")
+    counters = [sample.get("progress") for sample in samples]
+    if any(type(counter) is not int for counter in counters):  # noqa: E721
+        findings.append("progress counter unreadable or not an integer in at least one sample")
+    elif any(later < earlier for earlier, later in zip(counters, counters[1:])):
+        findings.append("progress counter went backwards (task replay or a different task)")
+    elif any(later <= earlier for earlier, later in zip(counters, counters[1:])):
+        stalls = sum(1 for earlier, later in zip(counters, counters[1:]) if later <= earlier)
+        findings.append(f"progress counter did not advance between {stalls} consecutive samples")
+    hosts = {sample.get("b_host") for sample in samples}
+    if len(hosts) != 1 or not all(routable(host) for host in hosts):
+        findings.append("worker B endpoint changed, was unreadable or was not a public address during the interval")
+    if expected_image_ref is not None:
+        wanted = image_ref_digest(expected_image_ref)
+        if any(sample.get("b_image_ref") != wanted for sample in samples):
+            findings.append("worker B did not carry the manifest image's reference tag in every sample")
+    checkpoints = [sample.get("checkpoint") for sample in samples]
+    checkpoint_proof = (all(type(value) is int for value in checkpoints) and checkpoints[-1] > checkpoints[0]  # noqa: E721
+                        and all(later >= earlier for earlier, later in zip(checkpoints, checkpoints[1:])))
+    return {
+        "passed": not findings,
+        "findings": findings,
+        "samples": len(samples),
+        "observed_seconds": span,
+        "missed_samples": misses,
+        "late_samples": late,
+        "counter_progress": counters[0] if counters and counters[0] is not None else None,
+        "counter_progress_end": counters[-1] if counters and counters[-1] is not None else None,
+        # Recorded separately: counter progress is never labelled checkpoint evidence.
+        "worker_checkpoint_progress": checkpoint_proof,
+    }
+
+
+def verdict_from_records(records: List[Any], manifest: Dict[str, Any]) -> Dict[str, Any]:
+    """Offline verdict over a journal: the first record must be the baseline header the
+    off phase wrote, so a journal from another worker can never pass."""
+    if not records or not isinstance(records[0], dict) or not isinstance(records[0].get("baseline"), dict):
+        return {"passed": False, "findings": ["journal has no baseline header; not produced by the off phase"]}
+    header, samples = records[0], records[1:]
+    if header.get("worker_image") != manifest["worker_image"]:
+        return {"passed": False, "findings": ["journal was recorded for a different worker image"]}
+    if header.get("observed_image_ref") != image_ref_digest(manifest["worker_image"]):
+        return {"passed": False, "findings": ["baseline observation did not carry the manifest image's reference tag"]}
+    return evaluate_samples(samples, manifest["off_minutes"], manifest["lease_seconds"], manifest["worker_image"],
+                            header["baseline"])

--- a/scripts/azure-client-off/clientoff/verdict.py
+++ b/scripts/azure-client-off/clientoff/verdict.py
@@ -11,7 +11,7 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
                      expected_identity: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Pure verdict over observer samples taken while A was meant to be off.
 
-    Each sample: {"at": ISO instant, "a_power": str|None, "b_group_id": str|None,
+    Each sample: {"at": ISO instant, "a_power": str|None, "a_attested": bool, "b_group_id": str|None,
     "b_vm_id": str|None, "b_instance_id": str|None (the VM's vmId, which a same-name
     recreation does not keep), "b_host": str|None, "b_image_ref": str|None (the worker's
     image-reference tag), "b_power": str|None, "progress": int|None, "checkpoint":
@@ -76,6 +76,13 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
     not_off = [index for index, sample in enumerate(samples) if sample.get("a_power") != "PowerState/deallocated"]
     if not_off:
         findings.append(f"client A not deallocated in {len(not_off)} samples (first at index {not_off[0]})")
+    # Each sample carries the outcome of a full attestation of A (IDs, instance identity,
+    # complete tag set on group and VM) taken with its power state; anything but an
+    # explicit success means the VM that was off is not known to be the provisioned A.
+    unattested = [index for index, sample in enumerate(samples) if sample.get("a_attested") is not True]
+    if unattested:
+        findings.append(f"client A not attested as the provisioned resource in {len(unattested)} samples "
+                        f"(first at index {unattested[0]})")
     def identity(sample: Dict[str, Any], field: str) -> Optional[str]:
         value = sample.get(field)
         return value.casefold() if isinstance(value, str) and value.strip() else None

--- a/scripts/azure-client-off/clientoff/verdict.py
+++ b/scripts/azure-client-off/clientoff/verdict.py
@@ -2,16 +2,18 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
-from .manifest import (ACTUAL_GAP_ALLOWANCE_SECONDS, INSTANCE_ID_RE, SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, image_ref_digest,
-                       parse_utc, routable, same_id)
+from .manifest import (ACTUAL_GAP_ALLOWANCE_SECONDS, INSTANCE_ID_RE, SAMPLE_JITTER_SECONDS, SAMPLE_SECONDS, client_ids,
+                       client_tags, image_ref_digest, parse_utc, routable, same_id)
 
 
 def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seconds: int,
                      expected_image_ref: Optional[str] = None,
-                     expected_identity: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+                     expected_identity: Optional[Dict[str, Any]] = None,
+                     expected_client_tags: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """Pure verdict over observer samples taken while A was meant to be off.
 
-    Each sample: {"at": ISO instant, "a_power": str|None, "a_attested": bool, "b_group_id": str|None,
+    Each sample: {"at": ISO instant, "a_power": str|None, "a_group_id", "a_vm_id", "a_instance_id": str|None,
+    "a_tags", "a_group_tags": the tag maps ARM showed on A's VM and group, "b_group_id": str|None,
     "b_vm_id": str|None, "b_instance_id": str|None (the VM's vmId, which a same-name
     recreation does not keep), "b_host": str|None, "b_image_ref": str|None (the worker's
     image-reference tag), "b_power": str|None, "progress": int|None, "checkpoint":
@@ -24,7 +26,8 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
     findings: List[str] = []
     if len(samples) < 2:
         return {"passed": False, "findings": ["fewer than two samples"], "samples": len(samples)}
-    text_fields = ("a_power", "a_instance_id", "b_group_id", "b_vm_id", "b_instance_id", "b_host", "b_image_ref", "b_power")
+    text_fields = ("a_power", "a_group_id", "a_vm_id", "a_instance_id", "b_group_id", "b_vm_id", "b_instance_id", "b_host",
+                   "b_image_ref", "b_power")
     if any(not isinstance(sample, dict) or any(sample.get(field) is not None and not isinstance(sample.get(field), str)
                                                 for field in text_fields) for sample in samples):
         return {"passed": False, "findings": ["a sample has a field of the wrong shape"], "samples": len(samples)}
@@ -34,7 +37,8 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
         return {"passed": False, "findings": ["a sample has a missing or invalid timestamp"], "samples": len(samples)}
     if expected_identity is not None:
         first = samples[0]
-        mismatched = [field for field in ("b_group_id", "b_vm_id", "b_instance_id", "b_host", "a_instance_id")
+        mismatched = [field for field in ("b_group_id", "b_vm_id", "b_instance_id", "b_host", "a_group_id", "a_vm_id",
+                                          "a_instance_id")
                       if field in expected_identity and not same_id(first.get(field), expected_identity.get(field))]
         if mismatched:
             findings.append(f"first sample does not match the worker recorded at baseline: {mismatched}")
@@ -76,13 +80,24 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
     not_off = [index for index, sample in enumerate(samples) if sample.get("a_power") != "PowerState/deallocated"]
     if not_off:
         findings.append(f"client A not deallocated in {len(not_off)} samples (first at index {not_off[0]})")
-    # Each sample carries the outcome of a full attestation of A (IDs, instance identity,
-    # complete tag set on group and VM) taken with its power state; anything but an
-    # explicit success means the VM that was off is not known to be the provisioned A.
-    unattested = [index for index, sample in enumerate(samples) if sample.get("a_attested") is not True]
-    if unattested:
-        findings.append(f"client A not attested as the provisioned resource in {len(unattested)} samples "
-                        f"(first at index {unattested[0]})")
+    # Each sample carries the evidence of a full attestation of A taken with its power
+    # state: the ARM group and VM IDs, the instance identity and the tag maps ARM showed
+    # on the VM and the group. The verdict re-derives the attestation from that evidence
+    # against the identity recorded before the stop and the manifest's tag set; a VM
+    # retagged or replaced during the interval is a finding, never a pass.
+    if expected_client_tags is not None:
+        unattested = [index for index, sample in enumerate(samples)
+                      if sample.get("a_tags") != expected_client_tags or sample.get("a_group_tags") != expected_client_tags]
+        if unattested:
+            findings.append(f"client A did not carry exactly this run's tags in {len(unattested)} samples "
+                            f"(first at index {unattested[0]})")
+    if expected_identity is not None:
+        strayed = [index for index, sample in enumerate(samples)
+                   if any(field in expected_identity and not same_id(sample.get(field), expected_identity[field])
+                          for field in ("a_group_id", "a_vm_id", "a_instance_id"))]
+        if strayed:
+            findings.append(f"client A was not the resource recorded before the stop in {len(strayed)} samples "
+                            f"(first at index {strayed[0]})")
     def identity(sample: Dict[str, Any], field: str) -> Optional[str]:
         value = sample.get(field)
         return value.casefold() if isinstance(value, str) and value.strip() else None
@@ -91,9 +106,10 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
                   for sample in samples}
     if len(identities) != 1 or any(None in pair for pair in identities):
         findings.append("worker B identity changed or was unreadable during the interval")
-    a_identities = {identity(sample, "a_instance_id") for sample in samples}
-    if len(a_identities) != 1 or None in a_identities:
-        findings.append("client A instance identity changed or was unreadable during the interval")
+    a_identities = {(identity(sample, "a_group_id"), identity(sample, "a_vm_id"), identity(sample, "a_instance_id"))
+                    for sample in samples}
+    if len(a_identities) != 1 or any(None in triple for triple in a_identities):
+        findings.append("client A identity changed or was unreadable during the interval")
     b_states = {sample.get("b_power") for sample in samples}
     if b_states != {"PowerState/running"}:
         findings.append(f"worker B power states during the interval: {sorted(str(s) for s in b_states)}")
@@ -145,6 +161,11 @@ def baseline_problems(baseline: Any, manifest: Dict[str, Any]) -> List[str]:
         problems.append("baseline instance identity is not a VM instance identity")
     if not routable(baseline.get("b_host")):
         problems.append("baseline address is not a public IP address")
+    ids = client_ids(manifest)
+    if not same_id(baseline.get("a_group_id"), ids["a_group_id"]) or not same_id(baseline.get("a_vm_id"), ids["a_vm_id"]):
+        problems.append("baseline client IDs are not the manifest client group and VM under the manifest subscription")
+    if not isinstance(baseline.get("a_instance_id"), str) or not INSTANCE_ID_RE.fullmatch(baseline["a_instance_id"]):
+        problems.append("baseline client instance identity is not a VM instance identity")
     return problems
 
 
@@ -165,4 +186,4 @@ def verdict_from_records(records: List[Any], manifest: Dict[str, Any]) -> Dict[s
     if header.get("observed_image_ref") != image_ref_digest(manifest["worker_image"]):
         return {"passed": False, "findings": ["baseline observation did not carry the manifest image's reference tag"]}
     return evaluate_samples(samples, manifest["off_minutes"], manifest["lease_seconds"], manifest["worker_image"],
-                            header["baseline"])
+                            header["baseline"], client_tags(manifest))

--- a/scripts/azure-client-off/clientoff/verdict.py
+++ b/scripts/azure-client-off/clientoff/verdict.py
@@ -23,7 +23,7 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
     findings: List[str] = []
     if len(samples) < 2:
         return {"passed": False, "findings": ["fewer than two samples"], "samples": len(samples)}
-    text_fields = ("a_power", "b_group_id", "b_vm_id", "b_instance_id", "b_host", "b_image_ref", "b_power")
+    text_fields = ("a_power", "a_instance_id", "b_group_id", "b_vm_id", "b_instance_id", "b_host", "b_image_ref", "b_power")
     if any(not isinstance(sample, dict) or any(sample.get(field) is not None and not isinstance(sample.get(field), str)
                                                 for field in text_fields) for sample in samples):
         return {"passed": False, "findings": ["a sample has a field of the wrong shape"], "samples": len(samples)}
@@ -33,8 +33,8 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
         return {"passed": False, "findings": ["a sample has a missing or invalid timestamp"], "samples": len(samples)}
     if expected_identity is not None:
         first = samples[0]
-        mismatched = [field for field in ("b_group_id", "b_vm_id", "b_instance_id", "b_host")
-                      if not same_id(first.get(field), expected_identity.get(field))]
+        mismatched = [field for field in ("b_group_id", "b_vm_id", "b_instance_id", "b_host", "a_instance_id")
+                      if field in expected_identity and not same_id(first.get(field), expected_identity.get(field))]
         if mismatched:
             findings.append(f"first sample does not match the worker recorded at baseline: {mismatched}")
     if any(later < earlier for earlier, later in zip(times, times[1:])):
@@ -81,6 +81,9 @@ def evaluate_samples(samples: List[Dict[str, Any]], off_minutes: int, lease_seco
                   for sample in samples}
     if len(identities) != 1 or any(None in pair for pair in identities):
         findings.append("worker B identity changed or was unreadable during the interval")
+    a_identities = {identity(sample, "a_instance_id") for sample in samples}
+    if len(a_identities) != 1 or None in a_identities:
+        findings.append("client A instance identity changed or was unreadable during the interval")
     b_states = {sample.get("b_power") for sample in samples}
     if b_states != {"PowerState/running"}:
         findings.append(f"worker B power states during the interval: {sorted(str(s) for s in b_states)}")

--- a/scripts/azure-client-off/tests/harness_fixtures.py
+++ b/scripts/azure-client-off/tests/harness_fixtures.py
@@ -66,6 +66,7 @@ def samples(count, *, start=NOW, step=15, a_power="PowerState/deallocated", prog
             "scheduled_at": (start + dt.timedelta(seconds=slot * index)).isoformat(),
             "at": (start + dt.timedelta(seconds=step * index)).isoformat(),
             "a_power": a_power,
+            "a_instance_id": A_INSTANCE,
             "b_group_id": identity[0],
             "b_vm_id": identity[1],
             "b_instance_id": instance,

--- a/scripts/azure-client-off/tests/harness_fixtures.py
+++ b/scripts/azure-client-off/tests/harness_fixtures.py
@@ -30,13 +30,17 @@ RUN_ID = "0123456789abcdef0123456789abcdef"
 WORKFLOW_ID = "4c5d6e7f-8a9b-4c0d-8e1f-2a3b4c5d6e7f"
 JOB_ID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"
 ADAPTER_TAGS = {"horizon-workflow-id": WORKFLOW_ID, "horizon-job-id": JOB_ID}
+SUBSCRIPTION = "0f0e0d0c-0b0a-4908-8706-050403020100"
+B_GROUP_ID = f"/subscriptions/{SUBSCRIPTION}/resourceGroups/horizon-ws-{WORKFLOW_ID}-{JOB_ID}"
+B_VM_ID = f"{B_GROUP_ID}/providers/Microsoft.Compute/virtualMachines/worker"
 
 
 def manifest(**overrides):
     base = {
         "subscription_id": "0f0e0d0c-0b0a-4908-8706-050403020100",
         "location": "northeurope",
-        "client_group": "horizon-client-475-a",
+        "run_id": RUN_ID,
+        "client_group": f"horizon-client-{RUN_ID}",
         "client_vm_size": "Standard_B2s",
         "client_sha": "77d48a81" + "0" * 32,
         "client_binary_sha256": "b" * 64,
@@ -53,8 +57,9 @@ def manifest(**overrides):
 
 
 def samples(count, *, start=NOW, step=15, a_power="PowerState/deallocated", progress=None, checkpoint=None,
-            b_power="PowerState/running", identity=("/g/b", "/g/b/vm"), host="52.174.10.5", image=IMAGE, slot=15,
+            b_power="PowerState/running", identity=None, host="52.174.10.5", image=IMAGE, slot=15,
             instance=B_INSTANCE):
+    identity = identity or (B_GROUP_ID, B_VM_ID)
     rows = []
     for index in range(count):
         rows.append({

--- a/scripts/azure-client-off/tests/harness_fixtures.py
+++ b/scripts/azure-client-off/tests/harness_fixtures.py
@@ -33,6 +33,12 @@ ADAPTER_TAGS = {"horizon-workflow-id": WORKFLOW_ID, "horizon-job-id": JOB_ID}
 SUBSCRIPTION = "0f0e0d0c-0b0a-4908-8706-050403020100"
 B_GROUP_ID = f"/subscriptions/{SUBSCRIPTION}/resourceGroups/horizon-ws-{WORKFLOW_ID}-{JOB_ID}"
 B_VM_ID = f"{B_GROUP_ID}/providers/Microsoft.Compute/virtualMachines/worker"
+A_GROUP_ID = f"/subscriptions/{SUBSCRIPTION}/resourceGroups/horizon-client-{RUN_ID}"
+A_VM_ID = f"{A_GROUP_ID}/providers/Microsoft.Compute/virtualMachines/client"
+
+
+def client_tags():
+    return client_off.client_tags(manifest())
 
 
 def manifest(**overrides):
@@ -58,7 +64,7 @@ def manifest(**overrides):
 
 def samples(count, *, start=NOW, step=15, a_power="PowerState/deallocated", progress=None, checkpoint=None,
             b_power="PowerState/running", identity=None, host="52.174.10.5", image=IMAGE, slot=15,
-            instance=B_INSTANCE):
+            instance=B_INSTANCE, a_tags=None):
     identity = identity or (B_GROUP_ID, B_VM_ID)
     rows = []
     for index in range(count):
@@ -66,8 +72,11 @@ def samples(count, *, start=NOW, step=15, a_power="PowerState/deallocated", prog
             "scheduled_at": (start + dt.timedelta(seconds=slot * index)).isoformat(),
             "at": (start + dt.timedelta(seconds=step * index)).isoformat(),
             "a_power": a_power,
+            "a_group_id": A_GROUP_ID,
+            "a_vm_id": A_VM_ID,
             "a_instance_id": A_INSTANCE,
-            "a_attested": True,
+            "a_tags": dict(a_tags) if a_tags is not None else client_tags(),
+            "a_group_tags": dict(a_tags) if a_tags is not None else client_tags(),
             "b_group_id": identity[0],
             "b_vm_id": identity[1],
             "b_instance_id": instance,

--- a/scripts/azure-client-off/tests/harness_fixtures.py
+++ b/scripts/azure-client-off/tests/harness_fixtures.py
@@ -1,0 +1,74 @@
+"""Shared fixtures for the client-off harness tests: a flat view over the harness modules
+and the manifest, sample and record builders. No Azure, no network."""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import pathlib
+import types
+
+HARNESS = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("client_off", HARNESS / "client_off.py")
+cli = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(cli)  # puts the harness directory on sys.path for the package below
+import clientoff  # noqa: E402
+
+# One flat view over the harness for the assertions: every public name of every module
+# the harness ships, the CLI's `main` included.
+client_off = types.SimpleNamespace()
+for module in (*clientoff.MODULES, cli):
+    for name in dir(module):
+        if not name.startswith("_"):
+            setattr(client_off, name, getattr(module, name))
+
+NOW = dt.datetime(2026, 9, 12, 12, 0, tzinfo=dt.timezone.utc)
+IMAGE = "x.azurecr.io/horizon-remote-worker@sha256:" + "a" * 64
+B_INSTANCE = "3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f"
+A_INSTANCE = "9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d"
+RUN_ID = "0123456789abcdef0123456789abcdef"
+
+
+def manifest(**overrides):
+    base = {
+        "subscription_id": "0f0e0d0c-0b0a-4908-8706-050403020100",
+        "location": "northeurope",
+        "client_group": "horizon-client-475-a",
+        "client_vm_size": "Standard_B2s",
+        "client_sha": "77d48a81" + "0" * 32,
+        "client_binary_sha256": "b" * 64,
+        "worker_group": "horizon-ws-b",
+        "worker_image": IMAGE,
+        "hourly_cost_micros": 120_000,
+        "budget_micros": 2_000_000,
+        "cleanup_deadline_utc": (NOW + dt.timedelta(hours=3)).isoformat(),
+        "off_minutes": 12,
+        "lease_seconds": 600,
+    }
+    base.update(overrides)
+    return base
+
+
+def samples(count, *, start=NOW, step=15, a_power="PowerState/deallocated", progress=None, checkpoint=None,
+            b_power="PowerState/running", identity=("/g/b", "/g/b/vm"), host="52.174.10.5", image=IMAGE, slot=15,
+            instance=B_INSTANCE):
+    rows = []
+    for index in range(count):
+        rows.append({
+            "scheduled_at": (start + dt.timedelta(seconds=slot * index)).isoformat(),
+            "at": (start + dt.timedelta(seconds=step * index)).isoformat(),
+            "a_power": a_power,
+            "b_group_id": identity[0],
+            "b_vm_id": identity[1],
+            "b_instance_id": instance,
+            "b_host": host,
+            "b_image_ref": client_off.image_ref_digest(image),
+            "b_power": b_power,
+            "progress": (progress or (lambda i: i))(index),
+            "checkpoint": checkpoint(index) if checkpoint else None,
+        })
+    return rows
+
+
+def record(name, **tags):
+    return {"name": name, "id": f"/subscriptions/s/resourceGroups/{name}", "tags": tags}

--- a/scripts/azure-client-off/tests/harness_fixtures.py
+++ b/scripts/azure-client-off/tests/harness_fixtures.py
@@ -27,6 +27,9 @@ IMAGE = "x.azurecr.io/horizon-remote-worker@sha256:" + "a" * 64
 B_INSTANCE = "3f2c9a1e-5d4b-4c6a-8e7f-0a1b2c3d4e5f"
 A_INSTANCE = "9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d"
 RUN_ID = "0123456789abcdef0123456789abcdef"
+WORKFLOW_ID = "4c5d6e7f-8a9b-4c0d-8e1f-2a3b4c5d6e7f"
+JOB_ID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"
+ADAPTER_TAGS = {"horizon-workflow-id": WORKFLOW_ID, "horizon-job-id": JOB_ID}
 
 
 def manifest(**overrides):
@@ -37,7 +40,7 @@ def manifest(**overrides):
         "client_vm_size": "Standard_B2s",
         "client_sha": "77d48a81" + "0" * 32,
         "client_binary_sha256": "b" * 64,
-        "worker_group": "horizon-ws-b",
+        "worker_group": f"horizon-ws-{WORKFLOW_ID}-{JOB_ID}",
         "worker_image": IMAGE,
         "hourly_cost_micros": 120_000,
         "budget_micros": 2_000_000,

--- a/scripts/azure-client-off/tests/harness_fixtures.py
+++ b/scripts/azure-client-off/tests/harness_fixtures.py
@@ -67,6 +67,7 @@ def samples(count, *, start=NOW, step=15, a_power="PowerState/deallocated", prog
             "at": (start + dt.timedelta(seconds=step * index)).isoformat(),
             "a_power": a_power,
             "a_instance_id": A_INSTANCE,
+            "a_attested": True,
             "b_group_id": identity[0],
             "b_vm_id": identity[1],
             "b_instance_id": instance,

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -241,12 +241,20 @@ class SampleIdentityTests(unittest.TestCase):
         self.assertTrue(client_off.evaluate_samples(rows, 12, 600)["passed"])
 
     def test_first_sample_must_be_the_baseline_worker(self):
-        expected = {"b_group_id": B_GROUP_ID.upper(), "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"}
+        expected = {"b_group_id": B_GROUP_ID.upper(), "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5",
+                    "a_instance_id": A_INSTANCE}
         rows = samples(49)
         self.assertTrue(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)["passed"], "IDs compare case-insensitively")
         other = dict(expected, b_vm_id="/g/b/other")
         verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, other)
         self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), verdict)
+        other_client = dict(expected, a_instance_id=B_INSTANCE)
+        verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, other_client)
+        self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), "the VM that was off must be A")
+        rows = samples(49)
+        rows[20]["a_instance_id"] = B_INSTANCE
+        verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)
+        self.assertTrue(any("client A instance identity" in finding for finding in verdict["findings"]), verdict)
 
     def test_malformed_sample_shapes_fail_closed(self):
         rows = samples(49)

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -6,8 +6,8 @@ import datetime as dt
 import unittest
 import unittest.mock as mock
 
-from harness_fixtures import (A_INSTANCE, ADAPTER_TAGS, B_GROUP_ID, B_INSTANCE, B_VM_ID, IMAGE, JOB_ID, NOW, RUN_ID,
-                              WORKFLOW_ID, client_off, manifest, record, samples)
+from harness_fixtures import (A_GROUP_ID, A_INSTANCE, A_VM_ID, ADAPTER_TAGS, B_GROUP_ID, B_INSTANCE, B_VM_ID, IMAGE, JOB_ID, NOW,
+                              RUN_ID, WORKFLOW_ID, client_off, client_tags, manifest, record, samples)
 
 class ManifestTests(unittest.TestCase):
     def test_complete_manifest_is_runnable(self):
@@ -252,7 +252,7 @@ class SampleIdentityTests(unittest.TestCase):
 
     def test_first_sample_must_be_the_baseline_worker(self):
         expected = {"b_group_id": B_GROUP_ID.upper(), "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5",
-                    "a_instance_id": A_INSTANCE}
+                    "a_group_id": A_GROUP_ID, "a_vm_id": A_VM_ID, "a_instance_id": A_INSTANCE}
         rows = samples(49)
         self.assertTrue(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)["passed"], "IDs compare case-insensitively")
         other = dict(expected, b_vm_id="/g/b/other")
@@ -261,18 +261,20 @@ class SampleIdentityTests(unittest.TestCase):
         other_client = dict(expected, a_instance_id=B_INSTANCE)
         verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, other_client)
         self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), "the VM that was off must be A")
-        for value in (False, None, "true", 1):
-            rows = samples(49)
-            rows[20]["a_attested"] = value
-            verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)
-            self.assertTrue(any("not attested" in finding for finding in verdict["findings"]), f"{value!r}: {verdict}")
+        for field in ("a_tags", "a_group_tags"):
+            for value in (None, {}, dict(client_tags(), purpose="other"), "tags"):
+                rows = samples(49)
+                rows[20][field] = value
+                verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, expected, client_tags())
+                self.assertTrue(any("this run's tags" in finding for finding in verdict["findings"]), f"{field}={value!r}: {verdict}")
         rows = samples(49)
-        del rows[20]["a_attested"]
-        self.assertFalse(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)["passed"], "a missing attestation is a miss")
+        del rows[20]["a_tags"]
+        self.assertFalse(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected, client_tags())["passed"],
+                         "a missing tag map is a miss")
         rows = samples(49)
         rows[20]["a_instance_id"] = B_INSTANCE
         verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)
-        self.assertTrue(any("client A instance identity" in finding for finding in verdict["findings"]), verdict)
+        self.assertTrue(any("client A identity changed" in finding for finding in verdict["findings"]), verdict)
 
     def test_malformed_sample_shapes_fail_closed(self):
         rows = samples(49)
@@ -288,7 +290,8 @@ class SampleIdentityTests(unittest.TestCase):
 class OfflineVerdictTests(unittest.TestCase):
     def test_journal_needs_the_baseline_header_and_the_same_image(self):
         m = manifest()
-        header = {"baseline": {"b_group_id": B_GROUP_ID, "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"},
+        header = {"baseline": {"b_group_id": B_GROUP_ID, "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5",
+                               "a_group_id": A_GROUP_ID, "a_vm_id": A_VM_ID, "a_instance_id": A_INSTANCE},
                   "worker_image": IMAGE,
                   "observed_image_ref": client_off.image_ref_digest(IMAGE)}
         self.assertTrue(client_off.verdict_from_records([header, *samples(49)], m)["passed"])
@@ -296,14 +299,35 @@ class OfflineVerdictTests(unittest.TestCase):
         # consistently the samples repeat it, is no evidence.
         for field, value in (("b_group_id", "/g/b"), ("b_group_id", B_GROUP_ID.replace(m["subscription_id"], "0" * 36)),
                              ("b_vm_id", "/g/b/vm"), ("b_vm_id", B_VM_ID.replace("/worker", "/other")),
-                             ("b_instance_id", "stable-but-not-a-vmid"), ("b_host", "10.0.0.5")):
+                             ("b_instance_id", "stable-but-not-a-vmid"), ("b_host", "10.0.0.5"),
+                             ("a_group_id", "/g/client"), ("a_vm_id", A_VM_ID.replace("/client", "/other")),
+                             ("a_instance_id", "stable-but-not-a-vmid")):
             with self.subTest(field=field, value=value):
                 fake = dict(header, baseline=dict(header["baseline"], **{field: value}))
                 rows = samples(49, identity=(fake["baseline"]["b_group_id"], fake["baseline"]["b_vm_id"]),
                                instance=fake["baseline"]["b_instance_id"], host=fake["baseline"]["b_host"])
+                for row in rows:
+                    row.update({k: fake["baseline"][k] for k in ("a_group_id", "a_vm_id", "a_instance_id")})
                 verdict = client_off.verdict_from_records([fake, *rows], m)
                 self.assertFalse(verdict["passed"])
                 self.assertTrue(any(finding.startswith("baseline:") for finding in verdict["findings"]), verdict)
+        for missing in ("a_instance_id", "a_vm_id"):
+            with self.subTest(missing=missing):
+                partial = dict(header, baseline={k: v for k, v in header["baseline"].items() if k != missing})
+                self.assertFalse(client_off.verdict_from_records([partial, *samples(49)], m)["passed"],
+                                 "a header that does not identify A never passes")
+        # The samples' attestation evidence is re-derived offline: a retagged A fails.
+        retagged = samples(49)
+        retagged[30]["a_tags"] = dict(client_tags(), run_id="f" * 32)
+        verdict = client_off.verdict_from_records([header, *retagged], m)
+        self.assertTrue(any("exactly this run's tags" in f for f in verdict["findings"]), verdict)
+        retagged = samples(49)
+        retagged[30]["a_group_tags"] = {}
+        self.assertFalse(client_off.verdict_from_records([header, *retagged], m)["passed"])
+        strayed = samples(49)
+        strayed[30]["a_vm_id"] = A_VM_ID.replace("/client", "/other")
+        verdict = client_off.verdict_from_records([header, *strayed], m)
+        self.assertTrue(any("recorded before the stop" in f for f in verdict["findings"]), verdict)
         other_observed = dict(header, observed_image_ref="c" * 64)
         self.assertFalse(client_off.verdict_from_records([other_observed, *samples(49)], m)["passed"], "observed tag must match")
         self.assertFalse(client_off.verdict_from_records(samples(49), m)["passed"], "no header")

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -261,6 +261,14 @@ class SampleIdentityTests(unittest.TestCase):
         other_client = dict(expected, a_instance_id=B_INSTANCE)
         verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, other_client)
         self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), "the VM that was off must be A")
+        for value in (False, None, "true", 1):
+            rows = samples(49)
+            rows[20]["a_attested"] = value
+            verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)
+            self.assertTrue(any("not attested" in finding for finding in verdict["findings"]), f"{value!r}: {verdict}")
+        rows = samples(49)
+        del rows[20]["a_attested"]
+        self.assertFalse(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)["passed"], "a missing attestation is a miss")
         rows = samples(49)
         rows[20]["a_instance_id"] = B_INSTANCE
         verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -38,6 +38,13 @@ class ManifestTests(unittest.TestCase):
         enough = (NOW + dt.timedelta(minutes=client_off.required_minutes(manifest(), "validate"))).isoformat()
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=enough), NOW), [])
         self.assertEqual(client_off.validate_manifest(manifest(client_vm_size="Standard_E4-2s_v5"), NOW), [])
+        for region in ("Northern Europe", "northeurope\n", "", "NorthEurope", "north europe"):
+            with self.subTest(region=region):
+                self.assertTrue(any("region" in p for p in client_off.validate_manifest(manifest(location=region), NOW)))
+        self.assertEqual(client_off.validate_manifest(manifest(location="westus2"), NOW), [])
+        far = (NOW + dt.timedelta(hours=30)).isoformat()
+        self.assertTrue(any("24 hours" in p for p in client_off.validate_manifest(manifest(cleanup_deadline_utc=far), NOW, renting=False)),
+                        "the upper bound holds for verdict and cleanup too")
         # `$` alone would accept a trailing newline; the manifest is matched exactly.
         for field in ("worker_image", "subscription_id", "client_group", "client_sha", "client_vm_size"):
             with self.subTest(field=field):
@@ -172,11 +179,14 @@ class VerdictTests(unittest.TestCase):
             row["at"] = (NOW + dt.timedelta(seconds=15 * index + (4 if index % 2 else 0))).isoformat()
         seesaw_verdict = client_off.evaluate_samples(seesaw, 12, 600)
         self.assertEqual(seesaw_verdict["late_samples"], 0)
-        self.assertTrue(seesaw_verdict["passed"], "4 s alternating jitter keeps every actual gap within 20 s")
+        self.assertFalse(seesaw_verdict["passed"], "4 s alternating jitter opens 19-second gaps: A and B went unobserved")
+        self.assertTrue(any("gaps over 15s" in finding for finding in seesaw_verdict["findings"]), seesaw_verdict)
         for index, row in enumerate(seesaw):
-            row["at"] = (NOW + dt.timedelta(seconds=15 * index + (8 if index % 2 else 0))).isoformat()
-        verdict = client_off.evaluate_samples(seesaw, 12, 600)
-        self.assertFalse(verdict["passed"], "23-second actual gaps are a cadence finding even with contiguous slots")
+            row["at"] = (NOW + dt.timedelta(seconds=15 * index, milliseconds=(900 if index % 2 else 0))).isoformat()
+        self.assertTrue(client_off.evaluate_samples(seesaw, 12, 600)["passed"], "sub-second wake-up latency is not a gap")
+        for index, row in enumerate(seesaw):
+            row["at"] = (NOW + dt.timedelta(seconds=15 * index + index)).isoformat()
+        self.assertFalse(client_off.evaluate_samples(seesaw, 12, 600)["passed"], "16-second gaps are a cadence finding")
         early = samples(49)
         early[5]["at"] = (NOW + dt.timedelta(seconds=15 * 5 - 1)).isoformat()
         verdict = client_off.evaluate_samples(early, 12, 600)
@@ -289,6 +299,10 @@ class OfflineVerdictTests(unittest.TestCase):
         other_observed = dict(header, observed_image_ref="c" * 64)
         self.assertFalse(client_off.verdict_from_records([other_observed, *samples(49)], m)["passed"], "observed tag must match")
         self.assertFalse(client_off.verdict_from_records(samples(49), m)["passed"], "no header")
+        headless = {"baseline": header["baseline"]}
+        verdict = client_off.verdict_from_records([headless, *samples(49)], m)
+        self.assertFalse(verdict["passed"])
+        self.assertTrue(any("does not name the worker image" in f for f in verdict["findings"]), verdict)
         other_image = dict(header, worker_image="x.azurecr.io/horizon-remote-worker@sha256:" + "c" * 64)
         self.assertFalse(client_off.verdict_from_records([other_image, *samples(49)], m)["passed"])
         other_worker = dict(header, baseline=dict(header["baseline"], b_instance_id=A_INSTANCE))

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -6,7 +6,8 @@ import datetime as dt
 import unittest
 import unittest.mock as mock
 
-from harness_fixtures import A_INSTANCE, B_INSTANCE, IMAGE, NOW, RUN_ID, client_off, manifest, record, samples
+from harness_fixtures import (A_INSTANCE, ADAPTER_TAGS, B_INSTANCE, IMAGE, JOB_ID, NOW, RUN_ID, WORKFLOW_ID, client_off,
+                              manifest, record, samples)
 
 class ManifestTests(unittest.TestCase):
     def test_complete_manifest_is_runnable(self):
@@ -270,57 +271,88 @@ class OfflineVerdictTests(unittest.TestCase):
 class CleanupTests(unittest.TestCase):
     def test_only_groups_created_by_this_run_are_deleted(self):
         m = manifest()
-        adapter = {"horizon-workflow-id": "4c5d6e7f-8a9b-4c0d-8e1f-2a3b4c5d6e7f", "horizon-job-id": "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"}
-        created = [record(m["client_group"], lane="azure-client-off", run_id=RUN_ID), record(m["worker_group"], **adapter)]
-        both = client_off.cleanup_targets(m, before=["horizon-worker-registry"], created=created)
+        created = [record(m["client_group"], lane="azure-client-off", run_id=RUN_ID), record(m["worker_group"], **ADAPTER_TAGS)]
+        both = client_off.cleanup_targets(m, before=["horizon-worker-registry"], created=created, run_id=RUN_ID)
         self.assertEqual([r["name"] for r in both["delete"]], [m["client_group"], m["worker_group"]])
         self.assertEqual(both["refused"], [])
-        pre_existing = client_off.cleanup_targets(m, before=[m["worker_group"]], created=created)
+        pre_existing = client_off.cleanup_targets(m, before=[m["worker_group"]], created=created, run_id=RUN_ID)
         self.assertEqual([r["name"] for r in pre_existing["delete"]], [m["client_group"]])
         self.assertEqual(pre_existing["refused"], [m["worker_group"]], "a pre-existing group is never deleted")
-        cased = client_off.cleanup_targets(m, before=[m["worker_group"].upper()], created=created)
+        cased = client_off.cleanup_targets(m, before=[m["worker_group"].upper()], created=created, run_id=RUN_ID)
         self.assertEqual(cased["refused"], [m["worker_group"]], "group names compare case-insensitively")
-        unjournaled = client_off.cleanup_targets(m, before=[], created=created[:1])
+        unjournaled = client_off.cleanup_targets(m, before=[], created=created[:1], run_id=RUN_ID)
         self.assertEqual(unjournaled["refused"], [m["worker_group"]], "a stale manifest name is not a creation record")
-        # ARM group IDs are name-based: without a per-run value in the journaled tags a
-        # same-name recreation is indistinguishable, so such a record deletes nothing.
-        for anonymous in (record(m["worker_group"]), record(m["worker_group"], lane="azure-client-off"),
-                          record(m["worker_group"], **{"horizon-workflow-id": adapter["horizon-workflow-id"]}),
-                          record(m["worker_group"], run_id="short")):
-            with self.subTest(tags=anonymous["tags"]):
-                refused = client_off.cleanup_targets(m, before=[], created=[created[0], anonymous])
+        # ARM group IDs are name-based and every reproducible tag can be restored, so a
+        # record authorizes a delete only when its tags are bound to this run: A's group
+        # carries exactly this run's value, B's group carries the identities its own
+        # name is derived from. Anything else deletes nothing and is never even read.
+        foreign = {"horizon-workflow-id": JOB_ID, "horizon-job-id": WORKFLOW_ID}
+        for stranger in (record(m["worker_group"]), record(m["worker_group"], lane="azure-client-off"),
+                         record(m["worker_group"], **{"horizon-workflow-id": WORKFLOW_ID}), record(m["worker_group"], **foreign),
+                         record(m["worker_group"], run_id=RUN_ID), record(m["worker_group"], run_id="short")):
+            with self.subTest(tags=stranger["tags"]):
+                refused = client_off.cleanup_targets(m, before=[], created=[created[0], stranger], run_id=RUN_ID)
                 self.assertEqual(refused["refused"], [m["worker_group"]])
-                self.assertFalse(client_off.owned_now(None, anonymous), "never even read, let alone deleted")
+                self.assertFalse(client_off.owned_now(None, stranger, m, RUN_ID), "never even read, let alone deleted")
+        for other_run in ("f" * 32, "", "short"):
+            with self.subTest(run_id=other_run):
+                refused = client_off.cleanup_targets(m, before=[], created=created, run_id=other_run)
+                self.assertEqual(refused["refused"], [m["client_group"]], "A's group belongs to the run that drew its value")
         for malformed in ("horizon-client-475-a", {"horizon-client-475-a": True}, [1], ["bad/group"], None,
                           [m["client_group"]], [{"name": m["client_group"]}], [{"name": m["client_group"], "id": "", "tags": {}}],
                           [{"name": m["client_group"], "id": "/g", "tags": {"a": 1}}]):
             with self.subTest(malformed=malformed):
-                refused = client_off.cleanup_targets(m, before=[], created=malformed)
+                refused = client_off.cleanup_targets(m, before=[], created=malformed, run_id=RUN_ID)
                 self.assertEqual(refused["delete"], [], "a malformed journal authorizes nothing")
                 self.assertTrue(refused.get("malformed"))
 
     def test_ownership_before_delete_requires_the_same_id_and_identical_tags(self):
-        journaled = record("horizon-client-475-a", lane="azure-client-off", client_sha="x", run_id=RUN_ID)
+        m = manifest()
+        journaled = record(m["client_group"], lane="azure-client-off", client_sha="x", run_id=RUN_ID)
         answers = {}
 
         class FakeAz:
             def run(self, args, mutating=False, timeout=0):
                 return answers.get("show")
 
+        owned = lambda rec=journaled: client_off.owned_now(FakeAz(), rec, m, RUN_ID)  # noqa: E731
         answers["show"] = {"id": journaled["id"].upper(), "name": journaled["name"], "tags": dict(journaled["tags"])}
-        self.assertTrue(client_off.owned_now(FakeAz(), journaled), "ARM IDs compare case-insensitively")
+        self.assertTrue(owned(), "ARM IDs compare case-insensitively")
         answers["show"] = {"id": "/subscriptions/s/resourceGroups/other", "name": journaled["name"], "tags": dict(journaled["tags"])}
-        self.assertFalse(client_off.owned_now(FakeAz(), journaled), "a recreated group has a new ID")
+        self.assertFalse(owned(), "a recreated group has a new ID")
         answers["show"] = {"id": journaled["id"], "name": journaled["name"], "tags": {"lane": "azure-client-off"}}
-        self.assertFalse(client_off.owned_now(FakeAz(), journaled), "a retagged group is not ours")
+        self.assertFalse(owned(), "a retagged group is not ours")
         answers["show"] = {"id": journaled["id"], "name": journaled["name"], "tags": dict(journaled["tags"], run_id="f" * 32)}
-        self.assertFalse(client_off.owned_now(FakeAz(), journaled), "a recreation under another run value is not ours")
+        self.assertFalse(owned(), "a recreation under another run value is not ours")
         answers["show"] = {"id": journaled["id"], "name": journaled["name"], "tags": []}
-        self.assertIsNone(client_off.owned_now(FakeAz(), journaled), "a malformed tag map is unknown")
+        self.assertIsNone(owned(), "a malformed tag map is unknown")
         duplicate = client_off.journal_records([journaled, dict(journaled, id="/other")])
         self.assertIsNone(duplicate, "conflicting records for one name make the journal untrustworthy")
         answers["show"] = None
-        self.assertIsNone(client_off.owned_now(FakeAz(), journaled), "unreadable is unknown, not absence")
+        self.assertIsNone(owned(), "unreadable is unknown, not absence")
+
+    def test_dry_run_cleanup_walks_the_same_authorization_and_journals_the_delete(self):
+        m = manifest()
+        created = [record(m["client_group"], lane="azure-client-off", run_id=RUN_ID), record(m["worker_group"], **ADAPTER_TAGS)]
+        az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100", dry_run=True)
+        shown = {rec["name"]: {"id": rec["id"], "name": rec["name"], "tags": dict(rec["tags"])} for rec in created}
+        # B was retagged since it was journaled: a dry run must say so, not list it.
+        shown[m["worker_group"]]["tags"] = {}
+
+        def fake_run(args, mutating=False, timeout=0):
+            az.journal.append({"mutating": mutating, "args": args})
+            if mutating:
+                return None
+            return shown.get(args[args.index("-n") + 1]) if args[:2] == ["group", "show"] else None
+
+        with mock.patch.object(az, "run", side_effect=fake_run):
+            result = client_off.phase_cleanup(az, m, [], created, RUN_ID)
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(result["would_delete"], [m["client_group"]])
+        self.assertTrue(any("retagged" in finding for finding in result["findings"]), result)
+        proposed = [entry["args"] for entry in az.journal if entry["mutating"]]
+        self.assertEqual(len(proposed), 1)
+        self.assertIn(created[0]["id"], proposed[0][-1], "the intended delete names the journaled ARM ID")
 
 
 class AzTests(unittest.TestCase):
@@ -328,12 +360,20 @@ class AzTests(unittest.TestCase):
         az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100")
         for view in ({"instanceView": None}, {"instanceView": []}, {"instanceView": {"statuses": None}},
                      {"instanceView": {"statuses": [None, "PowerState/running"]}},
-                     {"instanceView": {"statuses": [{"code": 7}]}}, {"instanceView": {"statuses": {}}}, [], None):
+                     {"instanceView": {"statuses": [{"code": 7}]}}, {"instanceView": {"statuses": {}}}, [], None,
+                     {"instanceView": {"statuses": [{"code": "PowerState/deallocated"}, {"code": "PowerState/running"}]}},
+                     {"instanceView": {"statuses": [{"code": "PowerState/running"}, {"level": "Info"}]}}):
             with self.subTest(view=view), mock.patch.object(az, "run", return_value=view):
                 self.assertIsNone(az.power_state("g", "client"))
         with mock.patch.object(az, "run", return_value={"instanceView": {"statuses": [{"code": "PowerState/running"}]}}):
             self.assertEqual(az.power_state("g", "client"), "PowerState/running")
 
+
+    def test_a_missing_or_failing_az_is_an_unreadable_answer(self):
+        az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100")
+        for error in (FileNotFoundError("az"), PermissionError("az"), OSError("exec")):
+            with self.subTest(error=error), mock.patch.object(client_off.subprocess, "run", side_effect=error):
+                self.assertIsNone(az.run(["group", "exists", "-n", "g"]))
 
     def test_dry_run_journals_but_never_issues_a_mutation(self):
         az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100", dry_run=True)

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -6,8 +6,8 @@ import datetime as dt
 import unittest
 import unittest.mock as mock
 
-from harness_fixtures import (A_INSTANCE, ADAPTER_TAGS, B_INSTANCE, IMAGE, JOB_ID, NOW, RUN_ID, WORKFLOW_ID, client_off,
-                              manifest, record, samples)
+from harness_fixtures import (A_INSTANCE, ADAPTER_TAGS, B_GROUP_ID, B_INSTANCE, B_VM_ID, IMAGE, JOB_ID, NOW, RUN_ID,
+                              WORKFLOW_ID, client_off, manifest, record, samples)
 
 class ManifestTests(unittest.TestCase):
     def test_complete_manifest_is_runnable(self):
@@ -46,8 +46,16 @@ class ManifestTests(unittest.TestCase):
     def test_interval_must_cross_the_lease_and_groups_must_differ(self):
         problems = client_off.validate_manifest(manifest(off_minutes=10, lease_seconds=600), NOW)
         self.assertTrue(any("exceed lease_seconds" in problem for problem in problems), problems)
-        problems = client_off.validate_manifest(manifest(worker_group="horizon-client-475-a"), NOW)
+        problems = client_off.validate_manifest(manifest(worker_group=manifest()["client_group"]), NOW)
         self.assertTrue(any("different exact groups" in problem for problem in problems), problems)
+        # Every name the harness may create or delete is unique to one run.
+        for group in ("horizon-client-475-a", f"horizon-client-{'f' * 32}", f"HORIZON-CLIENT-{RUN_ID}"):
+            with self.subTest(client_group=group):
+                self.assertTrue(any("no other run can reuse" in p for p in client_off.validate_manifest(manifest(client_group=group), NOW)))
+        for group in ("horizon-ws-b", f"horizon-ws-{WORKFLOW_ID}", f"horizon-ws-{WORKFLOW_ID}-{'g' * 36}"):
+            with self.subTest(worker_group=group):
+                self.assertTrue(any("horizon-ws-<workflow>-<job>" in p for p in client_off.validate_manifest(manifest(worker_group=group), NOW)))
+        self.assertTrue(client_off.validate_manifest(manifest(run_id="short"), NOW))
         far = client_off.validate_manifest(manifest(cleanup_deadline_utc=(NOW + dt.timedelta(hours=30)).isoformat()), NOW)
         self.assertTrue(any("24 hours" in problem for problem in far), far)
 
@@ -233,7 +241,7 @@ class SampleIdentityTests(unittest.TestCase):
         self.assertTrue(client_off.evaluate_samples(rows, 12, 600)["passed"])
 
     def test_first_sample_must_be_the_baseline_worker(self):
-        expected = {"b_group_id": "/G/B", "b_vm_id": "/g/b/vm", "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"}
+        expected = {"b_group_id": B_GROUP_ID.upper(), "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"}
         rows = samples(49)
         self.assertTrue(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)["passed"], "IDs compare case-insensitively")
         other = dict(expected, b_vm_id="/g/b/other")
@@ -254,16 +262,28 @@ class SampleIdentityTests(unittest.TestCase):
 class OfflineVerdictTests(unittest.TestCase):
     def test_journal_needs_the_baseline_header_and_the_same_image(self):
         m = manifest()
-        header = {"baseline": {"b_group_id": "/g/b", "b_vm_id": "/g/b/vm", "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"},
+        header = {"baseline": {"b_group_id": B_GROUP_ID, "b_vm_id": B_VM_ID, "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"},
                   "worker_image": IMAGE,
                   "observed_image_ref": client_off.image_ref_digest(IMAGE)}
         self.assertTrue(client_off.verdict_from_records([header, *samples(49)], m)["passed"])
+        # A header naming anything but an Azure worker in the manifest's group, however
+        # consistently the samples repeat it, is no evidence.
+        for field, value in (("b_group_id", "/g/b"), ("b_group_id", B_GROUP_ID.replace(m["subscription_id"], "0" * 36)),
+                             ("b_vm_id", "/g/b/vm"), ("b_vm_id", B_VM_ID.replace("/worker", "/other")),
+                             ("b_instance_id", "stable-but-not-a-vmid"), ("b_host", "10.0.0.5")):
+            with self.subTest(field=field, value=value):
+                fake = dict(header, baseline=dict(header["baseline"], **{field: value}))
+                rows = samples(49, identity=(fake["baseline"]["b_group_id"], fake["baseline"]["b_vm_id"]),
+                               instance=fake["baseline"]["b_instance_id"], host=fake["baseline"]["b_host"])
+                verdict = client_off.verdict_from_records([fake, *rows], m)
+                self.assertFalse(verdict["passed"])
+                self.assertTrue(any(finding.startswith("baseline:") for finding in verdict["findings"]), verdict)
         other_observed = dict(header, observed_image_ref="c" * 64)
         self.assertFalse(client_off.verdict_from_records([other_observed, *samples(49)], m)["passed"], "observed tag must match")
         self.assertFalse(client_off.verdict_from_records(samples(49), m)["passed"], "no header")
         other_image = dict(header, worker_image="x.azurecr.io/horizon-remote-worker@sha256:" + "c" * 64)
         self.assertFalse(client_off.verdict_from_records([other_image, *samples(49)], m)["passed"])
-        other_worker = dict(header, baseline=dict(header["baseline"], b_vm_id="/g/b/other"))
+        other_worker = dict(header, baseline=dict(header["baseline"], b_instance_id=A_INSTANCE))
         verdict = client_off.verdict_from_records([other_worker, *samples(49)], m)
         self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), verdict)
 
@@ -272,15 +292,15 @@ class CleanupTests(unittest.TestCase):
     def test_only_groups_created_by_this_run_are_deleted(self):
         m = manifest()
         created = [record(m["client_group"], lane="azure-client-off", run_id=RUN_ID), record(m["worker_group"], **ADAPTER_TAGS)]
-        both = client_off.cleanup_targets(m, before=["horizon-worker-registry"], created=created, run_id=RUN_ID)
+        both = client_off.cleanup_targets(m, before=["horizon-worker-registry"], created=created)
         self.assertEqual([r["name"] for r in both["delete"]], [m["client_group"], m["worker_group"]])
         self.assertEqual(both["refused"], [])
-        pre_existing = client_off.cleanup_targets(m, before=[m["worker_group"]], created=created, run_id=RUN_ID)
+        pre_existing = client_off.cleanup_targets(m, before=[m["worker_group"]], created=created)
         self.assertEqual([r["name"] for r in pre_existing["delete"]], [m["client_group"]])
         self.assertEqual(pre_existing["refused"], [m["worker_group"]], "a pre-existing group is never deleted")
-        cased = client_off.cleanup_targets(m, before=[m["worker_group"].upper()], created=created, run_id=RUN_ID)
+        cased = client_off.cleanup_targets(m, before=[m["worker_group"].upper()], created=created)
         self.assertEqual(cased["refused"], [m["worker_group"]], "group names compare case-insensitively")
-        unjournaled = client_off.cleanup_targets(m, before=[], created=created[:1], run_id=RUN_ID)
+        unjournaled = client_off.cleanup_targets(m, before=[], created=created[:1])
         self.assertEqual(unjournaled["refused"], [m["worker_group"]], "a stale manifest name is not a creation record")
         # ARM group IDs are name-based and every reproducible tag can be restored, so a
         # record authorizes a delete only when its tags are bound to this run: A's group
@@ -291,18 +311,24 @@ class CleanupTests(unittest.TestCase):
                          record(m["worker_group"], **{"horizon-workflow-id": WORKFLOW_ID}), record(m["worker_group"], **foreign),
                          record(m["worker_group"], run_id=RUN_ID), record(m["worker_group"], run_id="short")):
             with self.subTest(tags=stranger["tags"]):
-                refused = client_off.cleanup_targets(m, before=[], created=[created[0], stranger], run_id=RUN_ID)
+                refused = client_off.cleanup_targets(m, before=[], created=[created[0], stranger])
                 self.assertEqual(refused["refused"], [m["worker_group"]])
-                self.assertFalse(client_off.owned_now(None, stranger, m, RUN_ID), "never even read, let alone deleted")
+                self.assertFalse(client_off.owned_now(None, stranger, m), "never even read, let alone deleted")
         for other_run in ("f" * 32, "", "short"):
             with self.subTest(run_id=other_run):
-                refused = client_off.cleanup_targets(m, before=[], created=created, run_id=other_run)
+                other = dict(m, run_id=other_run)
+                refused = client_off.cleanup_targets(other, before=[], created=created)
                 self.assertEqual(refused["refused"], [m["client_group"]], "A's group belongs to the run that drew its value")
+        # The name itself must be this run's: a same-tagged group under any other name
+        # is not the one the manifest froze.
+        renamed = dict(m, client_group="horizon-client-475-a")
+        refused = client_off.cleanup_targets(renamed, before=[], created=[record("horizon-client-475-a", run_id=RUN_ID), created[1]])
+        self.assertEqual(refused["refused"], ["horizon-client-475-a"])
         for malformed in ("horizon-client-475-a", {"horizon-client-475-a": True}, [1], ["bad/group"], None,
                           [m["client_group"]], [{"name": m["client_group"]}], [{"name": m["client_group"], "id": "", "tags": {}}],
                           [{"name": m["client_group"], "id": "/g", "tags": {"a": 1}}]):
             with self.subTest(malformed=malformed):
-                refused = client_off.cleanup_targets(m, before=[], created=malformed, run_id=RUN_ID)
+                refused = client_off.cleanup_targets(m, before=[], created=malformed)
                 self.assertEqual(refused["delete"], [], "a malformed journal authorizes nothing")
                 self.assertTrue(refused.get("malformed"))
 
@@ -315,7 +341,7 @@ class CleanupTests(unittest.TestCase):
             def run(self, args, mutating=False, timeout=0):
                 return answers.get("show")
 
-        owned = lambda rec=journaled: client_off.owned_now(FakeAz(), rec, m, RUN_ID)  # noqa: E731
+        owned = lambda rec=journaled: client_off.owned_now(FakeAz(), rec, m)  # noqa: E731
         answers["show"] = {"id": journaled["id"].upper(), "name": journaled["name"], "tags": dict(journaled["tags"])}
         self.assertTrue(owned(), "ARM IDs compare case-insensitively")
         answers["show"] = {"id": "/subscriptions/s/resourceGroups/other", "name": journaled["name"], "tags": dict(journaled["tags"])}
@@ -346,7 +372,7 @@ class CleanupTests(unittest.TestCase):
             return shown.get(args[args.index("-n") + 1]) if args[:2] == ["group", "show"] else None
 
         with mock.patch.object(az, "run", side_effect=fake_run):
-            result = client_off.phase_cleanup(az, m, [], created, RUN_ID)
+            result = client_off.phase_cleanup(az, m, [], created)
         self.assertTrue(result["dry_run"])
         self.assertEqual(result["would_delete"], [m["client_group"]])
         self.assertTrue(any("retagged" in finding for finding in result["findings"]), result)

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -33,6 +33,9 @@ class ManifestTests(unittest.TestCase):
         soon = (NOW + dt.timedelta(minutes=20)).isoformat()
         self.assertTrue(any("at least" in p for p in client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW)))
         self.assertTrue(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="off"))
+        self.assertEqual(client_off.required_minutes(manifest(), "install-observer-key"),
+                         client_off.required_minutes(manifest(), "off") + client_off.RUN_COMMAND_SECONDS // 60,
+                         "the install may spend its whole run-command bound first")
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="return"), [])
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, renting=False), [])
         enough = (NOW + dt.timedelta(minutes=client_off.required_minutes(manifest(), "validate"))).isoformat()

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -36,6 +36,9 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(client_off.required_minutes(manifest(), "install-observer-key"),
                          client_off.required_minutes(manifest(), "off") + client_off.RUN_COMMAND_SECONDS // 60,
                          "the install may spend its whole run-command bound first")
+        self.assertEqual(client_off.required_minutes(manifest(), "validate"),
+                         client_off.PROVISION_MINUTES + client_off.required_minutes(manifest(), "install-observer-key"),
+                         "renting is approved only when provisioning and then the install can both run to their bounds")
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="return"), [])
         self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, renting=False), [])
         enough = (NOW + dt.timedelta(minutes=client_off.required_minutes(manifest(), "validate"))).isoformat()

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -1,0 +1,345 @@
+"""Deterministic coverage of the harness core: manifest gates, the pure verdict, cleanup
+authorization and the bounded `az` client. No Azure, no network."""
+from __future__ import annotations
+
+import datetime as dt
+import unittest
+import unittest.mock as mock
+
+from harness_fixtures import A_INSTANCE, B_INSTANCE, IMAGE, NOW, RUN_ID, client_off, manifest, record, samples
+
+class ManifestTests(unittest.TestCase):
+    def test_complete_manifest_is_runnable(self):
+        self.assertEqual(client_off.validate_manifest(manifest(), NOW), [])
+
+    def test_every_gate_is_named(self):
+        cases = {
+            "subscription_id": ("Finter As", "exact UUID"),
+            "client_group": ("bad/group", "resource group"),
+            "client_sha": ("77d48a81", "full commit SHA"),
+            "client_vm_size": ("", "VM size"),
+            "client_binary_sha256": ("deadbeef", "SHA-256"),
+            "worker_image": ("x.azurecr.io/horizon-remote-worker:latest", "digest"),
+            "budget_micros": (0, "positive"),
+            "cleanup_deadline_utc": ((NOW - dt.timedelta(minutes=1)).isoformat(), "future"),
+            "off_minutes": (5, "at least 10"),
+        }
+        for field, (value, expected) in cases.items():
+            with self.subTest(field=field):
+                problems = client_off.validate_manifest(manifest(**{field: value}), NOW)
+                self.assertTrue(any(expected in problem for problem in problems), problems)
+        # The deadline must outlast the bounded run, not merely lie in the future.
+        soon = (NOW + dt.timedelta(minutes=20)).isoformat()
+        self.assertTrue(any("at least" in p for p in client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW)))
+        self.assertTrue(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="off"))
+        self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="return"), [])
+        self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, renting=False), [])
+        enough = (NOW + dt.timedelta(minutes=client_off.required_minutes(manifest(), "validate"))).isoformat()
+        self.assertEqual(client_off.validate_manifest(manifest(cleanup_deadline_utc=enough), NOW), [])
+        self.assertEqual(client_off.validate_manifest(manifest(client_vm_size="Standard_E4-2s_v5"), NOW), [])
+        # `$` alone would accept a trailing newline; the manifest is matched exactly.
+        for field in ("worker_image", "subscription_id", "client_group", "client_sha", "client_vm_size"):
+            with self.subTest(field=field):
+                self.assertTrue(client_off.validate_manifest(manifest(**{field: manifest()[field] + "\n"}), NOW))
+
+    def test_interval_must_cross_the_lease_and_groups_must_differ(self):
+        problems = client_off.validate_manifest(manifest(off_minutes=10, lease_seconds=600), NOW)
+        self.assertTrue(any("exceed lease_seconds" in problem for problem in problems), problems)
+        problems = client_off.validate_manifest(manifest(worker_group="horizon-client-475-a"), NOW)
+        self.assertTrue(any("different exact groups" in problem for problem in problems), problems)
+        far = client_off.validate_manifest(manifest(cleanup_deadline_utc=(NOW + dt.timedelta(hours=30)).isoformat()), NOW)
+        self.assertTrue(any("24 hours" in problem for problem in far), far)
+
+    def test_missing_fields_are_reported_before_anything_else(self):
+        problems = client_off.validate_manifest({"location": "northeurope"}, NOW)
+        self.assertTrue(problems and all(problem.startswith("missing ") for problem in problems))
+        for not_object in (None, 3, "manifest", [manifest()]):
+            with self.subTest(value=not_object):
+                self.assertEqual(client_off.validate_manifest(not_object, NOW), ["manifest is not a JSON object"])
+
+    def test_past_deadline_blocks_renting_but_not_verdict_or_cleanup(self):
+        past = manifest(cleanup_deadline_utc=(NOW - dt.timedelta(hours=1)).isoformat())
+        self.assertTrue(any("future" in problem for problem in client_off.validate_manifest(past, NOW)))
+        self.assertEqual(client_off.validate_manifest(past, NOW, renting=False), [])
+
+    def test_naive_deadlines_are_rejected_not_guessed(self):
+        problems = client_off.validate_manifest(manifest(cleanup_deadline_utc="2026-09-12T15:00:00"), NOW)
+        self.assertTrue(any("ISO-8601" in problem for problem in problems), problems)
+        with self.assertRaises(ValueError):
+            client_off.parse_utc("2026-09-12T15:00:00")
+        self.assertEqual(client_off.parse_utc("2026-09-12T15:00:00Z").tzinfo, dt.timezone.utc)
+
+
+class VerdictTests(unittest.TestCase):
+    def test_full_off_interval_with_advancing_counter_passes_without_claiming_checkpoints(self):
+        verdict = client_off.evaluate_samples(samples(49), off_minutes=12, lease_seconds=600)
+        self.assertTrue(verdict["passed"], verdict)
+        self.assertEqual(verdict["missed_samples"], 0)
+        self.assertFalse(verdict["worker_checkpoint_progress"], "counters alone are not checkpoint proof")
+
+    def test_checkpoint_progress_is_judged_separately(self):
+        verdict = client_off.evaluate_samples(samples(49, checkpoint=lambda i: i // 10), 12, 600)
+        self.assertTrue(verdict["passed"])
+        self.assertTrue(verdict["worker_checkpoint_progress"])
+        verdict = client_off.evaluate_samples(samples(49, checkpoint=lambda i: 3), 12, 600)
+        self.assertFalse(verdict["worker_checkpoint_progress"], "a constant checkpoint sequence is not progress")
+
+    def test_short_interval_or_lease_not_crossed_fails(self):
+        short = client_off.evaluate_samples(samples(20), 12, 600)
+        self.assertFalse(short["passed"])
+        self.assertTrue(any("declared interval" in finding for finding in short["findings"]), short)
+        lease = client_off.evaluate_samples(samples(49), 12, 720)
+        self.assertTrue(any("did not exceed the lease" in finding for finding in lease["findings"]), lease)
+
+    def test_client_seen_running_or_worker_identity_change_fails(self):
+        rows = samples(49)
+        rows[7]["a_power"] = "PowerState/running"
+        verdict = client_off.evaluate_samples(rows, 12, 600)
+        self.assertTrue(any("not deallocated" in finding for finding in verdict["findings"]), verdict)
+        rows = samples(49)
+        rows[30]["b_vm_id"] = "/g/b/other"
+        verdict = client_off.evaluate_samples(rows, 12, 600)
+        self.assertTrue(any("identity changed" in finding for finding in verdict["findings"]), verdict)
+        for blank in ("", "  "):
+            rows = samples(49, identity=(blank, blank), instance=blank)
+            verdict = client_off.evaluate_samples(rows, 12, 600)
+            self.assertTrue(any("identity changed or was unreadable" in finding for finding in verdict["findings"]),
+                            f"stable empty identities are missing identities: {verdict}")
+        rows = samples(49)
+        rows[30]["b_instance_id"] = A_INSTANCE
+        verdict = client_off.evaluate_samples(rows, 12, 600)
+        self.assertTrue(any("identity changed" in finding for finding in verdict["findings"]),
+                        f"a recreated B under the same IDs is a different instance: {verdict}")
+        rows = samples(49)
+        rows[3]["b_power"] = "PowerState/deallocated"
+        verdict = client_off.evaluate_samples(rows, 12, 600)
+        self.assertTrue(any("power states" in finding for finding in verdict["findings"]), verdict)
+
+    def test_stalled_or_replayed_counter_and_misses_are_findings(self):
+        stalled = client_off.evaluate_samples(samples(49, progress=lambda i: 5), 12, 600)
+        self.assertTrue(any("did not advance" in finding for finding in stalled["findings"]), stalled)
+        # A counter that stalls for most of the interval and moves once at the end is a stall.
+        late = client_off.evaluate_samples(samples(49, progress=lambda i: 0 if i < 48 else 1), 12, 600)
+        self.assertTrue(any("did not advance between 47" in finding for finding in late["findings"]), late)
+        moved_host = samples(49)
+        moved_host[20]["b_host"] = "52.174.10.6"
+        verdict = client_off.evaluate_samples(moved_host, 12, 600)
+        self.assertTrue(any("endpoint changed" in finding for finding in verdict["findings"]), verdict)
+        replayed = client_off.evaluate_samples(samples(49, progress=lambda i: i if i < 40 else i - 40), 12, 600)
+        self.assertTrue(any("backwards" in finding for finding in replayed["findings"]), replayed)
+        unreadable = samples(49)
+        unreadable[10]["progress"] = None
+        verdict = client_off.evaluate_samples(unreadable, 12, 600)
+        self.assertTrue(any("unreadable" in finding for finding in verdict["findings"]), verdict)
+        gappy = samples(25, step=30, slot=30)
+        verdict = client_off.evaluate_samples(gappy, 12, 600)
+        self.assertEqual(verdict["missed_samples"], 24, "every other 15 s slot was missed")
+        self.assertFalse(verdict["passed"])
+        late = samples(49)
+        late[7]["at"] = (NOW + dt.timedelta(seconds=15 * 7 + 9)).isoformat()
+        verdict = client_off.evaluate_samples(late, 12, 600)
+        self.assertEqual((verdict["missed_samples"], verdict["late_samples"]), (0, 1))
+        self.assertFalse(verdict["passed"], "a late sample is a cadence finding")
+        on_time = samples(49)
+        on_time[7]["at"] = (NOW + dt.timedelta(seconds=15 * 7 + 4)).isoformat()
+        self.assertEqual(client_off.evaluate_samples(on_time, 12, 600)["late_samples"], 0, "4 s of jitter is tolerated")
+        skipped = samples(49)
+        del skipped[20]
+        verdict = client_off.evaluate_samples(skipped, 12, 600)
+        self.assertEqual(verdict["missed_samples"], 1, "a skipped slot is one missed observation")
+        unscheduled = samples(49)
+        del unscheduled[3]["scheduled_at"]
+        verdict = client_off.evaluate_samples(unscheduled, 12, 600)
+        self.assertTrue(any("no scheduled instant" in finding for finding in verdict["findings"]), verdict)
+        none_scheduled = samples(49)
+        for row in none_scheduled:
+            del row["scheduled_at"]
+        self.assertFalse(client_off.evaluate_samples(none_scheduled, 12, 600)["passed"], "no fallback without a schedule")
+        stretched = samples(49, step=20, slot=20)
+        verdict = client_off.evaluate_samples(stretched, 12, 600)
+        self.assertTrue(any("15-second slots" in finding for finding in verdict["findings"]), verdict)
+        seesaw = samples(49)
+        for index, row in enumerate(seesaw):
+            row["at"] = (NOW + dt.timedelta(seconds=15 * index + (4 if index % 2 else 0))).isoformat()
+        seesaw_verdict = client_off.evaluate_samples(seesaw, 12, 600)
+        self.assertEqual(seesaw_verdict["late_samples"], 0)
+        self.assertTrue(seesaw_verdict["passed"], "4 s alternating jitter keeps every actual gap within 20 s")
+        for index, row in enumerate(seesaw):
+            row["at"] = (NOW + dt.timedelta(seconds=15 * index + (8 if index % 2 else 0))).isoformat()
+        verdict = client_off.evaluate_samples(seesaw, 12, 600)
+        self.assertFalse(verdict["passed"], "23-second actual gaps are a cadence finding even with contiguous slots")
+        early = samples(49)
+        early[5]["at"] = (NOW + dt.timedelta(seconds=15 * 5 - 1)).isoformat()
+        verdict = client_off.evaluate_samples(early, 12, 600)
+        self.assertTrue(any("before its scheduled slot" in finding for finding in verdict["findings"]), verdict)
+
+    def test_non_string_fields_and_case_variants_are_rejected(self):
+        self.assertTrue(client_off.validate_manifest(manifest(client_group=123), NOW))
+        problems = client_off.validate_manifest(manifest(client_group="Horizon-WS-B", worker_group="horizon-ws-b"), NOW)
+        self.assertTrue(any("different exact groups" in problem for problem in problems), problems)
+        self.assertTrue(client_off.validate_manifest(manifest(worker_image=["x"]), NOW))
+        for bad in ("not-an-image@sha256:" + "a" * 64, "x.azurecr.io/repo:latest", "x.azurecr.io/Repo@sha256:" + "a" * 64):
+            with self.subTest(bad=bad):
+                self.assertTrue(client_off.validate_manifest(manifest(worker_image=bad), NOW))
+        self.assertEqual(client_off.validate_manifest(manifest(worker_image="registry.example.com:5000/team/worker@sha256:" + "a" * 64), NOW), [])
+
+    def test_counters_must_be_integers(self):
+        rows = samples(49, progress=lambda i: str(i))
+        verdict = client_off.evaluate_samples(rows, 12, 600)
+        self.assertTrue(any("not an integer" in finding for finding in verdict["findings"]), verdict)
+        rows = samples(49, progress=lambda i: True)
+        self.assertFalse(client_off.evaluate_samples(rows, 12, 600)["passed"])
+        rows = samples(49, checkpoint=lambda i: str(i))
+        self.assertFalse(client_off.evaluate_samples(rows, 12, 600)["worker_checkpoint_progress"])
+
+    def test_booleans_are_not_positive_integers(self):
+        for field in ("hourly_cost_micros", "budget_micros", "off_minutes", "lease_seconds"):
+            with self.subTest(field=field):
+                self.assertTrue(client_off.validate_manifest(manifest(**{field: True}), NOW))
+
+    def test_worker_image_identity_is_checked_when_the_manifest_is_known(self):
+        rows = samples(49)
+        self.assertTrue(client_off.evaluate_samples(rows, 12, 600, IMAGE)["passed"])
+        other = "x.azurecr.io/horizon-remote-worker@sha256:" + "c" * 64
+        verdict = client_off.evaluate_samples(rows, 12, 600, other)
+        self.assertTrue(any("image" in finding for finding in verdict["findings"]), verdict)
+        rows[4]["b_image_ref"] = None
+        verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE)
+        self.assertTrue(any("image" in finding for finding in verdict["findings"]), verdict)
+
+    def test_too_few_samples_never_pass(self):
+        self.assertFalse(client_off.evaluate_samples(samples(1), 12, 600)["passed"])
+
+    def test_incomplete_evidence_is_a_failed_verdict_not_a_crash(self):
+        missing = samples(49)
+        del missing[5]["at"]
+        verdict = client_off.evaluate_samples(missing, 12, 600)
+        self.assertFalse(verdict["passed"])
+        self.assertTrue(any("timestamp" in finding for finding in verdict["findings"]), verdict)
+        naive = samples(49)
+        naive[5]["at"] = "2026-09-12T12:01:15"
+        self.assertFalse(client_off.evaluate_samples(naive, 12, 600)["passed"])
+        backwards = samples(49)
+        backwards[10]["at"], backwards[11]["at"] = backwards[11]["at"], backwards[10]["at"]
+        verdict = client_off.evaluate_samples(backwards, 12, 600)
+        self.assertTrue(any("monotonic" in finding for finding in verdict["findings"]), verdict)
+
+
+class SampleIdentityTests(unittest.TestCase):
+    def test_identity_ids_compare_case_insensitively_within_the_interval(self):
+        rows = samples(49)
+        rows[10]["b_vm_id"] = rows[10]["b_vm_id"].upper()
+        self.assertTrue(client_off.evaluate_samples(rows, 12, 600)["passed"])
+
+    def test_first_sample_must_be_the_baseline_worker(self):
+        expected = {"b_group_id": "/G/B", "b_vm_id": "/g/b/vm", "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"}
+        rows = samples(49)
+        self.assertTrue(client_off.evaluate_samples(rows, 12, 600, IMAGE, expected)["passed"], "IDs compare case-insensitively")
+        other = dict(expected, b_vm_id="/g/b/other")
+        verdict = client_off.evaluate_samples(rows, 12, 600, IMAGE, other)
+        self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), verdict)
+
+    def test_malformed_sample_shapes_fail_closed(self):
+        rows = samples(49)
+        rows[3]["b_vm_id"] = {}
+        verdict = client_off.evaluate_samples(rows, 12, 600)
+        self.assertFalse(verdict["passed"])
+        self.assertTrue(any("wrong shape" in finding for finding in verdict["findings"]), verdict)
+        rows = samples(49)
+        rows[3]["b_power"] = []
+        self.assertFalse(client_off.evaluate_samples(rows, 12, 600)["passed"])
+
+
+class OfflineVerdictTests(unittest.TestCase):
+    def test_journal_needs_the_baseline_header_and_the_same_image(self):
+        m = manifest()
+        header = {"baseline": {"b_group_id": "/g/b", "b_vm_id": "/g/b/vm", "b_instance_id": B_INSTANCE, "b_host": "52.174.10.5"},
+                  "worker_image": IMAGE,
+                  "observed_image_ref": client_off.image_ref_digest(IMAGE)}
+        self.assertTrue(client_off.verdict_from_records([header, *samples(49)], m)["passed"])
+        other_observed = dict(header, observed_image_ref="c" * 64)
+        self.assertFalse(client_off.verdict_from_records([other_observed, *samples(49)], m)["passed"], "observed tag must match")
+        self.assertFalse(client_off.verdict_from_records(samples(49), m)["passed"], "no header")
+        other_image = dict(header, worker_image="x.azurecr.io/horizon-remote-worker@sha256:" + "c" * 64)
+        self.assertFalse(client_off.verdict_from_records([other_image, *samples(49)], m)["passed"])
+        other_worker = dict(header, baseline=dict(header["baseline"], b_vm_id="/g/b/other"))
+        verdict = client_off.verdict_from_records([other_worker, *samples(49)], m)
+        self.assertTrue(any("baseline" in finding for finding in verdict["findings"]), verdict)
+
+
+class CleanupTests(unittest.TestCase):
+    def test_only_groups_created_by_this_run_are_deleted(self):
+        m = manifest()
+        adapter = {"horizon-workflow-id": "4c5d6e7f-8a9b-4c0d-8e1f-2a3b4c5d6e7f", "horizon-job-id": "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"}
+        created = [record(m["client_group"], lane="azure-client-off", run_id=RUN_ID), record(m["worker_group"], **adapter)]
+        both = client_off.cleanup_targets(m, before=["horizon-worker-registry"], created=created)
+        self.assertEqual([r["name"] for r in both["delete"]], [m["client_group"], m["worker_group"]])
+        self.assertEqual(both["refused"], [])
+        pre_existing = client_off.cleanup_targets(m, before=[m["worker_group"]], created=created)
+        self.assertEqual([r["name"] for r in pre_existing["delete"]], [m["client_group"]])
+        self.assertEqual(pre_existing["refused"], [m["worker_group"]], "a pre-existing group is never deleted")
+        cased = client_off.cleanup_targets(m, before=[m["worker_group"].upper()], created=created)
+        self.assertEqual(cased["refused"], [m["worker_group"]], "group names compare case-insensitively")
+        unjournaled = client_off.cleanup_targets(m, before=[], created=created[:1])
+        self.assertEqual(unjournaled["refused"], [m["worker_group"]], "a stale manifest name is not a creation record")
+        # ARM group IDs are name-based: without a per-run value in the journaled tags a
+        # same-name recreation is indistinguishable, so such a record deletes nothing.
+        for anonymous in (record(m["worker_group"]), record(m["worker_group"], lane="azure-client-off"),
+                          record(m["worker_group"], **{"horizon-workflow-id": adapter["horizon-workflow-id"]}),
+                          record(m["worker_group"], run_id="short")):
+            with self.subTest(tags=anonymous["tags"]):
+                refused = client_off.cleanup_targets(m, before=[], created=[created[0], anonymous])
+                self.assertEqual(refused["refused"], [m["worker_group"]])
+                self.assertFalse(client_off.owned_now(None, anonymous), "never even read, let alone deleted")
+        for malformed in ("horizon-client-475-a", {"horizon-client-475-a": True}, [1], ["bad/group"], None,
+                          [m["client_group"]], [{"name": m["client_group"]}], [{"name": m["client_group"], "id": "", "tags": {}}],
+                          [{"name": m["client_group"], "id": "/g", "tags": {"a": 1}}]):
+            with self.subTest(malformed=malformed):
+                refused = client_off.cleanup_targets(m, before=[], created=malformed)
+                self.assertEqual(refused["delete"], [], "a malformed journal authorizes nothing")
+                self.assertTrue(refused.get("malformed"))
+
+    def test_ownership_before_delete_requires_the_same_id_and_identical_tags(self):
+        journaled = record("horizon-client-475-a", lane="azure-client-off", client_sha="x", run_id=RUN_ID)
+        answers = {}
+
+        class FakeAz:
+            def run(self, args, mutating=False, timeout=0):
+                return answers.get("show")
+
+        answers["show"] = {"id": journaled["id"].upper(), "name": journaled["name"], "tags": dict(journaled["tags"])}
+        self.assertTrue(client_off.owned_now(FakeAz(), journaled), "ARM IDs compare case-insensitively")
+        answers["show"] = {"id": "/subscriptions/s/resourceGroups/other", "name": journaled["name"], "tags": dict(journaled["tags"])}
+        self.assertFalse(client_off.owned_now(FakeAz(), journaled), "a recreated group has a new ID")
+        answers["show"] = {"id": journaled["id"], "name": journaled["name"], "tags": {"lane": "azure-client-off"}}
+        self.assertFalse(client_off.owned_now(FakeAz(), journaled), "a retagged group is not ours")
+        answers["show"] = {"id": journaled["id"], "name": journaled["name"], "tags": dict(journaled["tags"], run_id="f" * 32)}
+        self.assertFalse(client_off.owned_now(FakeAz(), journaled), "a recreation under another run value is not ours")
+        answers["show"] = {"id": journaled["id"], "name": journaled["name"], "tags": []}
+        self.assertIsNone(client_off.owned_now(FakeAz(), journaled), "a malformed tag map is unknown")
+        duplicate = client_off.journal_records([journaled, dict(journaled, id="/other")])
+        self.assertIsNone(duplicate, "conflicting records for one name make the journal untrustworthy")
+        answers["show"] = None
+        self.assertIsNone(client_off.owned_now(FakeAz(), journaled), "unreadable is unknown, not absence")
+
+
+class AzTests(unittest.TestCase):
+    def test_power_state_fails_closed_on_malformed_instance_views(self):
+        az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100")
+        for view in ({"instanceView": None}, {"instanceView": []}, {"instanceView": {"statuses": None}},
+                     {"instanceView": {"statuses": [None, "PowerState/running"]}},
+                     {"instanceView": {"statuses": [{"code": 7}]}}, {"instanceView": {"statuses": {}}}, [], None):
+            with self.subTest(view=view), mock.patch.object(az, "run", return_value=view):
+                self.assertIsNone(az.power_state("g", "client"))
+        with mock.patch.object(az, "run", return_value={"instanceView": {"statuses": [{"code": "PowerState/running"}]}}):
+            self.assertEqual(az.power_state("g", "client"), "PowerState/running")
+
+
+    def test_dry_run_journals_but_never_issues_a_mutation(self):
+        az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100", dry_run=True)
+        self.assertIsNone(az.run(["vm", "deallocate", "-g", "g", "-n", "client"], mutating=True))
+        self.assertEqual([entry["mutating"] for entry in az.journal], [True])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (client-off acceptance tooling for #475, first slice; does not complete either issue).

## Why

The client-off acceptance needs tooling that can never touch the wrong resource and whose verdict is a pure function of a recorded journal. The full harness crossed the per-PR size limits during review, so it lands in two slices: this core, then the mutation phases and provisioning scripts.

## What

- `scripts/azure-client-off/clientoff/manifest.py`: manifest schema (exact matches), constants, and the deadline arithmetic (the deadline must outlast the phase about to start: provisioning bound, off interval, margins).
- `clientoff/verdict.py`: pure evaluation of observer samples: mandatory 15-second cadence, A deallocated in every sample, B's group, VM, instance identity (`vmId`), image tag and endpoint constant and matching the baseline, counter strictly advancing, checkpoints judged separately, baseline header required.
- `clientoff/az.py`: bounded `az` calls without a shell; `--dry-run` journals mutations instead of issuing them; `power_state` fails closed on malformed instance views.
- `clientoff/cleanup.py`: deletes exactly the journaled groups, by ARM ID, re-proven immediately before the delete, and only when the journaled tags carry a per-run value (A's `run_id` or the adapter's workflow and job identities), since ARM group IDs survive a same-name recreation.
- `client_off.py`: `validate`, `journal-group`, `cleanup`, `verdict`.
- Tests: 22 deterministic cases; no Azure, no network. `.gitignore` gains Python caches.

## Validation

Full local matrix green: fmt, maintainability, version sync, preflight and harness tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic.