### PR TITLE
feat(storage): add explicit named bundle publication

### DIFF
--- a/crates/horizon-core/src/repository_overlay/bundle/store/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/linux.rs
@@ -1,4 +1,5 @@
 use super::{ArtifactDigest, BundleStoreError as Error, codec};
+mod named;
 use crate::repository_overlay::reader::{
     RepositoryReadError, SelectedRepositoryReader,
     linux::{RegularFileRead, Root},
@@ -18,7 +19,8 @@ const CONFINED: ResolveFlags = ResolveFlags::BENEATH
 
 pub(super) struct Directory {
     reader: Root,
-    directory: File,
+    handle: File,
+    named: bool,
 }
 
 impl Directory {
@@ -34,13 +36,23 @@ impl Directory {
             )
             .map_err(storage_error)?,
         );
-        let result = Self { reader, directory };
+        let result = Self {
+            reader,
+            handle: directory,
+            named: false,
+        };
         result.verify()?;
         Ok(result)
     }
 
+    pub(super) fn open_named(path: &Path) -> Result<Self, Error> {
+        let mut directory = Self::open(path)?;
+        directory.named = true;
+        Ok(directory)
+    }
+
     fn verify(&self) -> Result<(), Error> {
-        let metadata = self.directory.metadata().map_err(|_| Error::UnsafeDirectory)?;
+        let metadata = self.handle.metadata().map_err(|_| Error::UnsafeDirectory)?;
         if !metadata.is_dir()
             || metadata.uid() != rustix::process::geteuid().as_raw()
             || metadata.mode() & 0o7777 != 0o700
@@ -52,6 +64,9 @@ impl Directory {
     }
 
     pub(super) fn read(&self, digest: &ArtifactDigest) -> Result<Option<RegularFileRead>, Error> {
+        if self.named {
+            return named::read(self, digest);
+        }
         self.verify()?;
         match self
             .reader
@@ -64,6 +79,9 @@ impl Directory {
     }
 
     pub(super) fn put(&self, digest: &ArtifactDigest, bytes: &[u8]) -> Result<(), Error> {
+        if self.named {
+            return named::put(self, digest, bytes);
+        }
         self.put_with_sync(digest, bytes, File::sync_all)
     }
 
@@ -84,13 +102,13 @@ impl Directory {
         match linkat(
             CWD,
             format!("/proc/self/fd/{}", file.as_raw_fd()),
-            &self.directory,
+            &self.handle,
             name(digest),
             AtFlags::SYMLINK_FOLLOW,
         ) {
             Ok(()) => {
                 sync(&file).map_err(|_| Error::WriteFailed)?;
-                sync(&self.directory).map_err(|_| Error::WriteFailed)
+                sync(&self.handle).map_err(|_| Error::WriteFailed)
             }
             Err(rustix::io::Errno::EXIST) => {
                 let record = self.read(digest)?.ok_or(Error::Missing)?;
@@ -104,7 +122,7 @@ impl Directory {
         self.verify()?;
         let file = File::from(
             openat2(
-                &self.directory,
+                &self.handle,
                 ".",
                 OFlags::TMPFILE | OFlags::RDWR | OFlags::CLOEXEC,
                 Mode::RUSR | Mode::WUSR,
@@ -133,7 +151,7 @@ impl Directory {
             return Err(Error::Conflict);
         }
         sync(&record.file).map_err(|_| Error::WriteFailed)?;
-        sync(&self.directory).map_err(|_| Error::WriteFailed)
+        sync(&self.handle).map_err(|_| Error::WriteFailed)
     }
 }
 

--- a/crates/horizon-core/src/repository_overlay/bundle/store/linux/named.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/linux/named.rs
@@ -1,0 +1,178 @@
+//! Named publication uses exclusive permanent digest slots, never reclaimable locks.
+//! Stable trusted ownership is required; this is not protection from the worker owner.
+
+use super::{ArtifactDigest, CONFINED, Directory, Error, RegularFileRead, RepositoryReadError, codec, storage_error};
+use rustix::fs::{Mode, OFlags, mkdirat, openat2, renameat};
+use std::{
+    fs::File,
+    io::{self, Write},
+    os::unix::fs::MetadataExt,
+};
+
+const PENDING: &str = "pending";
+const RECORD: &str = "record.hzov";
+const PRIVATE: Mode = Mode::RUSR.union(Mode::WUSR).union(Mode::XUSR);
+
+struct Slot(File);
+
+impl Slot {
+    fn open(parent: &Directory, digest: &ArtifactDigest) -> Result<Option<Self>, Error> {
+        parent.verify()?;
+        let file = match openat2(
+            &parent.handle,
+            digest.as_str(),
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        ) {
+            Ok(fd) => File::from(fd),
+            Err(rustix::io::Errno::NOENT) => return Ok(None),
+            Err(error) => return Err(storage_error(error)),
+        };
+        let metadata = file.metadata().map_err(|_| Error::UnsafeDirectory)?;
+        if metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o700
+            || metadata.nlink() == 0
+        {
+            return Err(Error::UnsafeDirectory);
+        }
+        Ok(Some(Self(file)))
+    }
+
+    fn verify(&self, parent: &Directory, digest: &ArtifactDigest) -> Result<(), Error> {
+        let current = Self::open(parent, digest)?.ok_or(Error::Conflict)?;
+        if !same_inode(&self.0, &current.0)? {
+            return Err(Error::Conflict);
+        }
+        Ok(())
+    }
+
+    fn read(&self, parent: &Directory, digest: &ArtifactDigest) -> Result<RegularFileRead, Error> {
+        self.verify(parent, digest)?;
+        // A partial claim, including an unexpected pending name, is not absence.
+        match openat2(
+            &self.0,
+            PENDING,
+            OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        ) {
+            Err(rustix::io::Errno::NOENT) => {}
+            _ => return Err(Error::Conflict),
+        }
+        let record = parent
+            .reader
+            .read_private_file(
+                &format!("{}/{RECORD}", digest.as_str()),
+                codec::MAX_ENCODED_BUNDLE_BYTES,
+            )
+            .map_err(|error| match error {
+                RepositoryReadError::Missing => Error::Conflict,
+                other => Error::Read(other),
+            })?;
+        self.verify(parent, digest)?;
+        Ok(record)
+    }
+
+    fn resynchronize(
+        &self,
+        parent: &Directory,
+        digest: &ArtifactDigest,
+        bytes: &[u8],
+        expected: Option<&File>,
+        sync: &mut impl FnMut(&File) -> io::Result<()>,
+    ) -> Result<(), Error> {
+        let record = self.read(parent, digest)?;
+        if record.bytes != bytes {
+            return Err(Error::Conflict);
+        }
+        if let Some(file) = expected
+            && !same_inode(file, &record.file)?
+        {
+            return Err(Error::Conflict);
+        }
+        for file in [&record.file, &self.0, &parent.handle] {
+            sync(file).map_err(|_| Error::WriteFailed)?;
+        }
+        let verified = self.read(parent, digest)?;
+        if verified.bytes != bytes || !same_inode(&record.file, &verified.file)? {
+            return Err(Error::Conflict);
+        }
+        Ok(())
+    }
+}
+
+fn same_inode(left: &File, right: &File) -> Result<bool, Error> {
+    let left = left.metadata().map_err(|_| Error::WriteFailed)?;
+    let right = right.metadata().map_err(|_| Error::WriteFailed)?;
+    Ok((left.dev(), left.ino()) == (right.dev(), right.ino()))
+}
+
+pub(super) fn read(parent: &Directory, digest: &ArtifactDigest) -> Result<Option<RegularFileRead>, Error> {
+    Slot::open(parent, digest)?
+        .map(|slot| slot.read(parent, digest))
+        .transpose()
+}
+
+pub(super) fn put(parent: &Directory, digest: &ArtifactDigest, bytes: &[u8]) -> Result<(), Error> {
+    put_with(
+        parent,
+        digest,
+        bytes,
+        File::sync_all,
+        |root, name| mkdirat(root, name, PRIVATE),
+        |slot| renameat(slot, PENDING, slot, RECORD),
+    )
+}
+
+fn put_with(
+    parent: &Directory,
+    digest: &ArtifactDigest,
+    bytes: &[u8],
+    mut sync: impl FnMut(&File) -> io::Result<()>,
+    mut claim: impl FnMut(&File, &str) -> Result<(), rustix::io::Errno>,
+    mut publish: impl FnMut(&File) -> Result<(), rustix::io::Errno>,
+) -> Result<(), Error> {
+    parent.verify()?;
+    match claim(&parent.handle, digest.as_str()) {
+        Ok(()) => {}
+        Err(rustix::io::Errno::EXIST) => {
+            return Slot::open(parent, digest)?
+                .ok_or(Error::Conflict)?
+                .resynchronize(parent, digest, bytes, None, &mut sync);
+        }
+        // An ambiguous NFS mkdir error never confers ownership of a possible slot.
+        Err(error) => return Err(storage_error(error)),
+    }
+    let slot = Slot::open(parent, digest)?.ok_or(Error::Conflict)?;
+    sync(&parent.handle).map_err(|_| Error::WriteFailed)?;
+    let mut file = File::from(
+        openat2(
+            &slot.0,
+            PENDING,
+            OFlags::CREATE | OFlags::EXCL | OFlags::RDWR | OFlags::CLOEXEC,
+            Mode::RUSR | Mode::WUSR,
+            CONFINED,
+        )
+        .map_err(storage_error)?,
+    );
+    let metadata = file.metadata().map_err(|_| Error::WriteFailed)?;
+    if !metadata.is_file()
+        || metadata.nlink() != 1
+        || metadata.mode() & 0o7777 != 0o600
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+    {
+        return Err(Error::WriteFailed);
+    }
+    file.write_all(bytes).map_err(|_| Error::WriteFailed)?;
+    sync(&file).map_err(|_| Error::WriteFailed)?;
+    slot.verify(parent, digest)?;
+    // Only this successful fresh claim owner can rename. Existing slots never
+    // take this path, so an existing complete or partial claim is not overwritten.
+    // Even an ambiguous rename error returns failure, without retrying the rename.
+    publish(&slot.0).map_err(storage_error)?;
+    slot.resynchronize(parent, digest, bytes, Some(&file), &mut sync)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/bundle/store/linux/named/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/linux/named/tests.rs
@@ -1,0 +1,316 @@
+use super::*;
+use crate::repository_overlay::bundle::store::tests::private_fixture;
+use std::{
+    fs,
+    os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt, symlink},
+    path::Path,
+    sync::Barrier,
+    thread,
+};
+
+fn claim(root: &File, name: &str) -> Result<(), rustix::io::Errno> {
+    mkdirat(root, name, PRIVATE)
+}
+
+fn publish(slot: &File) -> Result<(), rustix::io::Errno> {
+    renameat(slot, PENDING, slot, RECORD)
+}
+
+fn private_dir(path: &Path) {
+    fs::DirBuilder::new()
+        .mode(0o700)
+        .create(path)
+        .expect("private directory");
+}
+
+fn private_file(path: &Path, bytes: &[u8]) {
+    fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .expect("private file")
+        .write_all(bytes)
+        .expect("fixture bytes");
+}
+
+#[test]
+fn incomplete_claims_are_never_absence_reclaimed_or_overwritten() {
+    for pending in [None, Some(b"partial".as_slice())] {
+        let fixture = private_fixture();
+        let parent = Directory::open_named(fixture.path()).expect("root");
+        let digest = ArtifactDigest::sha256(b"fixture");
+        assert!(read(&parent, &digest).expect("true absence").is_none());
+        let slot = fixture.path().join(digest.as_str());
+        private_dir(&slot);
+        if let Some(bytes) = pending {
+            private_file(&slot.join(PENDING), bytes);
+        }
+        assert!(matches!(read(&parent, &digest), Err(Error::Conflict)));
+        assert_eq!(put(&parent, &digest, b"complete"), Err(Error::Conflict));
+        assert!(!slot.join(RECORD).exists());
+        assert_eq!(fs::read(slot.join(PENDING)).ok().as_deref(), pending);
+    }
+}
+
+#[test]
+fn each_sync_failure_preserves_partial_or_completed_claim_without_replay() {
+    for failed_sync in 1..=5 {
+        let fixture = private_fixture();
+        let parent = Directory::open_named(fixture.path()).expect("root");
+        let digest = ArtifactDigest::sha256(b"fixture");
+        let mut calls = 0;
+        assert_eq!(
+            put_with(
+                &parent,
+                &digest,
+                b"complete",
+                |file| {
+                    calls += 1;
+                    if calls == failed_sync {
+                        Err(io::Error::other("injected sync failure"))
+                    } else {
+                        file.sync_all()
+                    }
+                },
+                claim,
+                publish
+            ),
+            Err(Error::WriteFailed)
+        );
+        if failed_sync <= 2 {
+            assert_eq!(put(&parent, &digest, b"complete"), Err(Error::Conflict));
+        } else {
+            let before = read(&parent, &digest).expect("read").expect("complete");
+            let inode = before.file.metadata().expect("inode").ino();
+            put(&parent, &digest, b"complete").expect("explicit resync");
+            let after = read(&parent, &digest).expect("read").expect("complete");
+            assert_eq!(after.file.metadata().expect("inode").ino(), inode);
+            assert_eq!(after.bytes, b"complete");
+        }
+        assert_eq!(fs::read_dir(fixture.path()).expect("claims").count(), 1);
+    }
+}
+
+#[test]
+fn ambiguous_mkdir_never_confers_write_ownership() {
+    for created in [false, true] {
+        let fixture = private_fixture();
+        let parent = Directory::open_named(fixture.path()).expect("root");
+        let digest = ArtifactDigest::sha256(b"fixture");
+        assert_eq!(
+            put_with(
+                &parent,
+                &digest,
+                b"must not write",
+                File::sync_all,
+                |root, name| {
+                    if created {
+                        claim(root, name)?;
+                    }
+                    Err(rustix::io::Errno::IO)
+                },
+                |_| panic!("no publish authority")
+            ),
+            Err(Error::WriteFailed)
+        );
+        let slot = fixture.path().join(digest.as_str());
+        assert_eq!(slot.exists(), created);
+        if created {
+            assert_eq!(fs::read_dir(&slot).expect("preserved claim").count(), 0);
+            assert_eq!(put(&parent, &digest, b"retry"), Err(Error::Conflict));
+        }
+    }
+}
+
+#[test]
+fn ambiguous_rename_preserves_evidence_and_only_completed_retry_can_resync() {
+    for renamed in [false, true] {
+        let fixture = private_fixture();
+        let parent = Directory::open_named(fixture.path()).expect("root");
+        let digest = ArtifactDigest::sha256(b"fixture");
+        assert_eq!(
+            put_with(&parent, &digest, b"complete", File::sync_all, claim, |slot| {
+                if renamed {
+                    publish(slot)?;
+                }
+                Err(rustix::io::Errno::IO)
+            }),
+            Err(Error::WriteFailed)
+        );
+        let slot = fixture.path().join(digest.as_str());
+        assert_eq!(slot.join(PENDING).exists(), !renamed);
+        assert_eq!(slot.join(RECORD).exists(), renamed);
+        if renamed {
+            put(&parent, &digest, b"complete").expect("read and resync only");
+            assert_eq!(put(&parent, &digest, b"different"), Err(Error::Conflict));
+            assert_eq!(fs::read(slot.join(RECORD)).expect("unchanged"), b"complete");
+        } else {
+            assert_eq!(put(&parent, &digest, b"complete"), Err(Error::Conflict));
+            assert_eq!(fs::read(slot.join(PENDING)).expect("partial retained"), b"complete");
+        }
+    }
+}
+
+#[test]
+fn completed_idempotency_requires_every_sync_and_exact_stable_identity() {
+    let fixture = private_fixture();
+    let parent = Directory::open_named(fixture.path()).expect("root");
+    let digest = ArtifactDigest::sha256(b"fixture");
+    put(&parent, &digest, b"complete").expect("initial write");
+    for failed_sync in 1..=3 {
+        let mut calls = 0;
+        assert_eq!(
+            put_with(
+                &parent,
+                &digest,
+                b"complete",
+                |file| {
+                    calls += 1;
+                    if calls == failed_sync {
+                        Err(io::Error::other("injected sync failure"))
+                    } else {
+                        file.sync_all()
+                    }
+                },
+                claim,
+                |_| panic!("existing record never renamed")
+            ),
+            Err(Error::WriteFailed)
+        );
+        assert_eq!(
+            read(&parent, &digest).expect("read").expect("retained").bytes,
+            b"complete"
+        );
+    }
+    let slot = fixture.path().join(digest.as_str());
+    let mut swapped = false;
+    assert_eq!(
+        put_with(
+            &parent,
+            &digest,
+            b"complete",
+            |file| {
+                file.sync_all()?;
+                if !swapped {
+                    swapped = true;
+                    fs::rename(slot.join(RECORD), slot.join("retained"))?;
+                    private_file(&slot.join(RECORD), b"complete");
+                }
+                Ok(())
+            },
+            claim,
+            publish
+        ),
+        Err(Error::Conflict)
+    );
+}
+
+#[test]
+fn independent_conflicting_writers_have_one_owner_and_keep_the_winner() {
+    let fixture = private_fixture();
+    let digest = ArtifactDigest::sha256(b"same name");
+    let barrier = Barrier::new(2);
+    let results = thread::scope(|scope| {
+        let handles: Vec<_> = [b"first".as_slice(), b"second"]
+            .into_iter()
+            .map(|bytes| {
+                let root = fixture.path();
+                let digest = &digest;
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    let parent = Directory::open_named(root).expect("root");
+                    put_with(
+                        &parent,
+                        digest,
+                        bytes,
+                        File::sync_all,
+                        |root, name| {
+                            barrier.wait();
+                            claim(root, name)
+                        },
+                        publish,
+                    )
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("writer"))
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results.iter().filter(|result| **result == Err(Error::Conflict)).count(),
+        1
+    );
+    let parent = Directory::open_named(fixture.path()).expect("root");
+    let record = read(&parent, &digest).expect("read").expect("winner");
+    assert!(record.bytes == b"first" || record.bytes == b"second");
+    let slot = fixture.path().join(digest.as_str());
+    assert_eq!(fs::read_dir(slot).expect("one record").count(), 1);
+}
+
+#[test]
+fn symlink_hardlink_mode_and_slot_replacement_are_refused() {
+    for kind in ["slot-link", "record-link", "hardlink", "mode", "pending"] {
+        let fixture = private_fixture();
+        let outside = private_fixture();
+        let parent = Directory::open_named(fixture.path()).expect("root");
+        let digest = ArtifactDigest::sha256(b"fixture");
+        let slot = fixture.path().join(digest.as_str());
+        private_file(&outside.path().join(RECORD), b"untouched");
+        if kind == "slot-link" {
+            symlink(outside.path(), &slot).expect("symlink");
+        } else {
+            private_dir(&slot);
+            match kind {
+                "record-link" => symlink(outside.path().join(RECORD), slot.join(RECORD)).expect("symlink"),
+                "hardlink" => fs::hard_link(outside.path().join(RECORD), slot.join(RECORD)).expect("hardlink"),
+                _ => {
+                    private_file(&slot.join(RECORD), b"untouched");
+                    if kind == "mode" {
+                        fs::set_permissions(slot.join(RECORD), fs::Permissions::from_mode(0o644)).expect("mode");
+                    } else {
+                        private_file(&slot.join(PENDING), b"preserve partial");
+                    }
+                }
+            }
+        }
+        assert!(read(&parent, &digest).is_err());
+        assert!(put(&parent, &digest, b"replacement").is_err());
+        assert_eq!(
+            fs::read(outside.path().join(RECORD)).expect("outside retained"),
+            b"untouched"
+        );
+    }
+    let fixture = private_fixture();
+    let parent = Directory::open_named(fixture.path()).expect("root");
+    let digest = ArtifactDigest::sha256(b"fixture");
+    let slot = fixture.path().join(digest.as_str());
+    let mut calls = 0;
+    assert_eq!(
+        put_with(
+            &parent,
+            &digest,
+            b"retained",
+            |file| {
+                file.sync_all()?;
+                calls += 1;
+                if calls == 2 {
+                    fs::rename(&slot, fixture.path().join("retained"))?;
+                    private_dir(&slot);
+                }
+                Ok(())
+            },
+            claim,
+            |_| panic!("replaced slot must not publish")
+        ),
+        Err(Error::Conflict)
+    );
+    assert_eq!(fs::read_dir(slot).expect("replacement empty").count(), 0);
+    assert_eq!(
+        fs::read(fixture.path().join("retained/pending")).expect("original retained"),
+        b"retained"
+    );
+}

--- a/crates/horizon-core/src/repository_overlay/bundle/store/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/mod.rs
@@ -9,13 +9,35 @@ use std::{fmt, path::Path};
 
 /// Immutable digest-named records in an explicitly selected, existing private directory.
 /// The caller owns storage selection, authorization, capacity and retention policy.
-/// No overwrite, deletion, directory creation, inventory or permission repair is exposed.
+/// No overwrite, deletion, root creation, inventory or permission repair is exposed.
 pub struct RepositoryBundleStore {
     #[cfg(target_os = "linux")]
     directory: linux::Directory,
 }
 
 impl RepositoryBundleStore {
+    /// Select the explicit Linux named-publication layout in an existing private root.
+    /// Each digest owns a permanently claimed directory containing `record.hzov`.
+    /// Named exclusive creation and rename replace the anonymous-file requirement;
+    /// no automatic fallback or migration from the flat layout occurs. Filesystem
+    /// synchronization support is still required, not provider durability attestation.
+    /// An incomplete claim is retained and cannot be resumed or overwritten.
+    /// # Errors
+    /// Rejects unsupported platforms and inaccessible/unsafe/non-private roots.
+    pub fn open_named(root: &Path) -> Result<Self, BundleStoreError> {
+        #[cfg(target_os = "linux")]
+        {
+            Ok(Self {
+                directory: linux::Directory::open_named(root)?,
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = root;
+            Err(BundleStoreError::Unsupported)
+        }
+    }
+
     /// Pin an owned `0700` directory without following symlinked ancestors.
     /// Linux confinement and anonymous-file publication support are required for writes.
     /// # Errors
@@ -37,8 +59,10 @@ impl RepositoryBundleStore {
     /// Synchronize and atomically publish complete bytes, never replacing an existing record.
     /// Identical retries verify and synchronize the existing file and directory again.
     /// A failure can leave a complete published record; retry explicitly with the same bundle.
-    /// Run off the UI thread: bounded buffers do not bound filesystem latency. Encoding plus
-    /// a retry comparison can hold two encoding buffers alongside the caller's bundle.
+    /// In the named layout, an incomplete permanent claim remains a conflict; only
+    /// a fully published identical record can be verified and synchronized again.
+    /// Run off the UI thread: bounded buffers do not bound filesystem latency.
+    /// Verification can hold multiple bounded encoding copies alongside the caller's bundle.
     /// # Errors
     /// Rejects unsupported storage, unsafe/conflicting existing records or synchronization failure.
     pub fn put(&self, bundle: &RepositoryOverlayBundle) -> Result<ArtifactDigest, BundleStoreError> {
@@ -57,6 +81,8 @@ impl RepositoryBundleStore {
 
     /// Read one private bounded record and revalidate its encoding, payloads and exact digest.
     /// Does not establish a signature, coherent capture, storage replication or apply authority.
+    /// In the named layout, only a missing digest directory is missing; an existing
+    /// incomplete claim is a conflict, not permission to resume publication.
     /// Run off the UI thread; decoding owns a separate bounded payload copy.
     /// # Errors
     /// Rejects missing, unsafe, oversized, corrupt or wrongly named records without modifying them.

--- a/crates/horizon-core/src/repository_overlay/bundle/store/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/bundle/store/tests.rs
@@ -51,6 +51,10 @@ fn unsupported_platform_never_creates_files_or_falls_back() {
         RepositoryBundleStore::open(fixture.path()),
         Err(BundleStoreError::Unsupported)
     ));
+    assert!(matches!(
+        RepositoryBundleStore::open_named(fixture.path()),
+        Err(BundleStoreError::Unsupported)
+    ));
     let store = RepositoryBundleStore {};
     let value = bundle(b"local bytes");
     assert_eq!(store.put(&value), Err(BundleStoreError::Unsupported));
@@ -99,6 +103,59 @@ mod supported {
             .expect("private file")
             .write_all(bytes)
             .expect("fixture bytes");
+    }
+
+    #[test]
+    fn explicit_named_layout_round_trips_without_selecting_the_flat_layout() {
+        let fixture = private_fixture();
+        let named = RepositoryBundleStore::open_named(fixture.path()).expect("named store");
+        let flat = RepositoryBundleStore::open(fixture.path()).expect("unchanged flat store");
+        for payload in [b"working\0\xff".as_slice(), b"other bytes"] {
+            let value = bundle(payload);
+            let digest = named.put(&value).expect("named publication");
+            let path = fixture.path().join(digest.as_str()).join("record.hzov");
+            let before = fs::metadata(&path).expect("record identity");
+            assert_eq!(before.nlink(), 1);
+            assert_eq!(before.mode() & 0o7777, 0o600);
+            assert_eq!(named.get(&digest).expect("verified readback"), value);
+            assert_eq!(flat.get(&digest), Err(BundleStoreError::Missing));
+            let reopened = RepositoryBundleStore::open_named(fixture.path()).expect("reopen");
+            assert_eq!(reopened.put(&value).expect("idempotent resync"), digest);
+            let after = fs::metadata(&path).expect("same identity");
+            assert_eq!(
+                (before.ino(), before.mtime(), before.mtime_nsec()),
+                (after.ino(), after.mtime(), after.mtime_nsec())
+            );
+            fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("fixture corruption")
+                .write_all(b"invalid")
+                .expect("corrupt bytes");
+            assert!(reopened.get(&digest).is_err());
+            assert_eq!(reopened.put(&value), Err(BundleStoreError::Conflict));
+        }
+    }
+
+    #[test]
+    fn named_layout_keeps_the_opened_root_when_its_path_is_replaced() {
+        let fixture = private_fixture();
+        let selected = fixture.path().join("selected");
+        let retained = fixture.path().join("retained");
+        private_directory(&selected);
+        let store = RepositoryBundleStore::open_named(&selected).expect("pinned root");
+        fs::rename(&selected, &retained).expect("retain original");
+        private_directory(&selected);
+        let value = bundle(b"pinned bytes");
+        let digest = store.put(&value).expect("publish to held root");
+        assert_eq!(fs::read_dir(&selected).expect("replacement").count(), 0);
+        assert_eq!(
+            RepositoryBundleStore::open_named(&retained)
+                .expect("original")
+                .get(&digest)
+                .expect("read"),
+            value
+        );
     }
 
     #[test]

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -7,6 +7,10 @@ back into large multi-purpose modules.
 
 ### Remote worker image
 
+- `repository_overlay::bundle::store` keeps anonymous publication as its default;
+  the explicit named layout owns permanent digest slots in a focused Linux leaf.
+  Neither layout discovers data, transfers it, schedules capture or certifies
+  provider durability. See [named publication](named-bundle-publication.md).
 - Prepared task admission keeps immutable intake/setup selection and read-only
   checkout inspection in `repository_overlay::intake::setup`. The fixed
   `setup-binding` and `setup-checkout` helpers never materialize or start tasks.

--- a/docs/architecture/named-bundle-publication.md
+++ b/docs/architecture/named-bundle-publication.md
@@ -1,0 +1,33 @@
+# Explicit named bundle publication
+
+`RepositoryBundleStore::open_named` selects a separate, explicit on-disk layout
+in an existing owned `0700` root. The default `open` and anonymous-file `put`
+behavior remain unchanged; there is no fallback, migration or format detection.
+
+The named layout uses `<digest>/record.hzov`. Only a successful exclusive mkdir
+grants ownership of a new digest slot. Its sole creator writes a `0600` `pending`
+file, synchronizes it, renames it within the slot, synchronizes the record and
+both directories, and re-reads exact bytes and inode identity before success.
+The encoded bundle and digest validation are the existing bounded codec.
+
+An existing slot never grants write ownership. A complete identical record can
+only be read, compared and synchronized again. A partial claim is a conflict,
+not absence and not a reusable lock; it and its bytes remain intact. No cleanup
+or overwrite is automatic. Concurrent writers may receive a conflict while a
+claim is incomplete, and may explicitly verify the completed winner later.
+
+Ambiguous mkdir errors do not confer ownership. Any rename error is reported
+without retrying that mutation: a network filesystem may have completed the
+rename despite its error reply. A later explicit operation can acknowledge only
+the fully verified and re-synchronized completed record. Symlinked ancestors,
+cross-filesystem slot traversal, wrong ownership/private modes and hardlinked
+records are refused. Stable trusted worker ownership remains a precondition;
+this is not a defense against a malicious owner changing their own directory.
+
+The named path avoids `O_TMPFILE`, anonymous `/proc/self/fd` linking and
+`RENAME_NOREPLACE`. Existing safe reads still use Linux descriptor confinement
+and reopen held regular files through procfs. Named create/rename/fsync support
+must be verified on the selected filesystem. These API and local test results
+are **not** RunPod HPS qualification, physical power-loss durability proof,
+independent replication or provider retention/replacement acceptance. No PC
+transfer, provider operation, capture scheduler or checkpoint watermark is added.


### PR DESCRIPTION
## Purpose

Add an explicit named-publication storage prerequisite for #471. `RepositoryBundleStore::open_named` opts into a separate digest-directory layout; existing anonymous publication APIs and behavior are unchanged. There is no automatic fallback or migration.

## Behavior

- Claim each digest directory exclusively before creating a private named record, synchronizing, publishing, and verifying exact bytes and identity.
- Retain incomplete claims permanently and fail closed on ambiguous ownership or publication. No automatic overwrite, reclamation, or cleanup.
- Accept an existing completed record only after exact-content verification and resynchronization. Root creation remains the caller's responsibility.

## Validation

- Focused bundle-store tests: 25 passed, including partial claims, injected synchronization failures, ambiguous create/rename responses, completed-record resynchronization, confinement, and layout isolation.
- Blocking and strict Clippy passed after a narrow import/private-field/test-import correction; the initial lint failure is retained in local evidence.
- Exact-head full validation on `f7b31f045ba55390552273b41007a999e62d8824`: formatting, maintainability, version synchronization, default tests (2,520 passed), speech tests (2,565 passed), blocking/strict/pedantic Clippy all passed. Each test tier had zero failures and seven explicitly ignored tests.

Scope: five source/test files, 615 changed lines, plus architecture documentation. This is local storage API evidence only: not RunPod HPS qualification, physical durability, provider retention, independent backup, or delivery of the worker capture service. No UI, cloud allocation, credential transfer, or image publication.
