### PR TITLE
feat(store): open existing databases without migration

### DIFF
--- a/crates/horizon-core/src/cloud_run/store.rs
+++ b/crates/horizon-core/src/cloud_run/store.rs
@@ -57,7 +57,14 @@ impl StoredWorkflow {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CloudWorkflowStore {
     path: PathBuf,
-    read_only: bool,
+    access: StoreAccess,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StoreAccess {
+    ReadWrite,
+    ReadOnly,
+    Existing(database::ExistingStoreIdentity),
 }
 
 impl CloudWorkflowStore {
@@ -78,7 +85,7 @@ impl CloudWorkflowStore {
         let path = path.into();
         let store = Self {
             path: prepare_private_store(&path)?,
-            read_only: false,
+            access: StoreAccess::ReadWrite,
         };
         let mut connection = store.connection()?;
         initialize_schema(&mut connection)?;
@@ -106,7 +113,41 @@ impl CloudWorkflowStore {
         let mut connection = database::open_read_connection(&path)?;
         let transaction = connection.transaction()?;
         ensure_current_schema(&transaction)?;
-        Ok(Self { path, read_only: true })
+        Ok(Self {
+            path,
+            access: StoreAccess::ReadOnly,
+        })
+    }
+
+    /// Open an existing current-schema store for explicit updates without creating,
+    /// migrating, repairing permissions, or changing its journal mode. Clones retain
+    /// these opening restrictions; normal domain writes still require their own admission.
+    /// Unix device/inode checks reject detected replacement before writable connections.
+    /// This assumes a stable trusted directory, not protection against concurrent same-user
+    /// path swaps. SQLite may maintain WAL bookkeeping files.
+    ///
+    /// # Errors
+    /// Rejects non-Unix platforms, missing/insecure/nonregular files, incompatible schemas,
+    /// detected file replacement and storage failures.
+    pub fn open_existing_without_migration(home: &HorizonHome) -> Result<Self, CloudStoreError> {
+        Self::open_existing_without_migration_path(home.cloud_workflow_store_path())
+    }
+
+    /// Open an explicit existing path with the same no-creation/no-migration restrictions.
+    ///
+    /// # Errors
+    /// Returns the same admission and platform errors as [`Self::open_existing_without_migration`].
+    pub fn open_existing_without_migration_path(path: impl Into<PathBuf>) -> Result<Self, CloudStoreError> {
+        let path = std::path::absolute(path.into())?;
+        #[cfg(unix)]
+        let path = database::canonical_store_path(&path)?;
+        let identity = database::ExistingStoreIdentity::capture(&path)?;
+        let store = Self {
+            path,
+            access: StoreAccess::Existing(identity),
+        };
+        drop(store.connection()?);
+        Ok(store)
     }
 
     #[must_use]
@@ -316,10 +357,10 @@ impl CloudWorkflowStore {
     }
 
     fn connection(&self) -> Result<Connection, CloudStoreError> {
-        if self.read_only {
-            database::open_read_connection(&self.path)
-        } else {
-            database::open_connection(&self.path)
+        match self.access {
+            StoreAccess::ReadWrite => database::open_connection(&self.path),
+            StoreAccess::ReadOnly => database::open_read_connection(&self.path),
+            StoreAccess::Existing(identity) => database::open_existing_connection(&self.path, identity),
         }
     }
 }
@@ -549,6 +590,10 @@ pub enum CloudStoreError {
     InsecureStoreFile,
     #[error("cloud workflow store path must not be a symbolic link")]
     SymlinkStorePath,
+    #[error("existing-only cloud workflow store updates are unsupported on this platform")]
+    ExistingStoreUnsupported,
+    #[error("existing cloud workflow store is not the validated regular file")]
+    ExistingStoreChanged,
     #[error("cloud workflow store database failed: {0}")]
     Database(#[from] rusqlite::Error),
     #[error("cloud workflow store schema {0} is not supported by this binary")]

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -168,20 +168,50 @@ pub(super) fn open_existing_connection(
     // Refuse legacy or corrupt storage before even opening a writable connection.
     let mut reader = open_read_connection(path)?;
     let transaction = reader.transaction()?;
-    let version = transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
-    if version != STORE_SCHEMA_VERSION {
-        return Err(CloudStoreError::UnsupportedSchema(version));
-    }
-    ensure_current_schema(&transaction)?;
+    validate_existing_schema(&transaction)?;
     drop(transaction);
     drop(reader);
     identity.validate(path)?;
     let mut connection = open_write_connection(path, false)?;
     let transaction = connection.transaction()?;
-    ensure_current_schema(&transaction)?;
+    validate_existing_schema(&transaction)?;
     drop(transaction);
     identity.validate(path)?;
     Ok(connection)
+}
+
+fn validate_existing_schema(connection: &Connection) -> Result<(), CloudStoreError> {
+    let version = connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
+    if version != STORE_SCHEMA_VERSION {
+        return Err(CloudStoreError::UnsupportedSchema(version));
+    }
+    ensure_current_schema(connection)?;
+    for definition in SCHEMA.split(';').chain(REMOTE_WORKSPACE_SCHEMA.split(';')) {
+        let definition = definition.trim();
+        if definition.is_empty() {
+            continue;
+        }
+        // SQLite omits this initialization-only clause from retained CREATE definitions.
+        let definition = definition.replace(" IF NOT EXISTS", "");
+        let matches: bool = connection.query_row(
+            "SELECT COUNT(*) = 1 FROM main.sqlite_schema WHERE sql = ?1",
+            [definition],
+            |row| row.get(0),
+        )?;
+        if !matches {
+            return Err(CloudStoreError::InvalidAllocationSchema);
+        }
+    }
+    let triggers: bool = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM main.sqlite_schema WHERE type = 'trigger'
+         AND tbl_name COLLATE NOCASE IN ('cloud_workflows', 'cloud_worker_creation_claims', 'remote_workspaces'))",
+        [],
+        |row| row.get(0),
+    )?;
+    if triggers {
+        return Err(CloudStoreError::InvalidAllocationSchema);
+    }
+    Ok(())
 }
 
 pub(super) fn open_read_connection(path: &Path) -> Result<Connection, CloudStoreError> {

--- a/crates/horizon-core/src/cloud_run/store/database.rs
+++ b/crates/horizon-core/src/cloud_run/store/database.rs
@@ -3,7 +3,7 @@
 #[cfg(unix)]
 use std::fs::OpenOptions;
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -108,14 +108,79 @@ const PROVIDER_BINDING_SCHEMA: [&str; 4] = [
 ];
 
 pub(super) fn open_connection(path: &Path) -> Result<Connection, CloudStoreError> {
-    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
-        | OpenFlags::SQLITE_OPEN_CREATE
-        | OpenFlags::SQLITE_OPEN_NO_MUTEX
-        | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+    open_write_connection(path, true)
+}
+
+fn open_write_connection(path: &Path, create: bool) -> Result<Connection, CloudStoreError> {
+    let mut flags =
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+    if create {
+        flags |= OpenFlags::SQLITE_OPEN_CREATE;
+    }
     let connection = Connection::open_with_flags(path, flags)?;
     connection.busy_timeout(BUSY_TIMEOUT)?;
     connection.pragma_update(None, "foreign_keys", "ON")?;
     connection.pragma_update(None, "synchronous", "FULL")?;
+    Ok(connection)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ExistingStoreIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl ExistingStoreIdentity {
+    pub(super) fn capture(path: &Path) -> Result<Self, CloudStoreError> {
+        #[cfg(unix)]
+        {
+            let metadata = validate_read_path(path)?;
+            if !metadata.file_type().is_file() {
+                return Err(CloudStoreError::ExistingStoreChanged);
+            }
+            Ok(Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            Err(CloudStoreError::ExistingStoreUnsupported)
+        }
+    }
+
+    fn validate(self, path: &Path) -> Result<(), CloudStoreError> {
+        if Self::capture(path)? != self {
+            return Err(CloudStoreError::ExistingStoreChanged);
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn open_existing_connection(
+    path: &Path,
+    identity: ExistingStoreIdentity,
+) -> Result<Connection, CloudStoreError> {
+    identity.validate(path)?;
+    // Refuse legacy or corrupt storage before even opening a writable connection.
+    let mut reader = open_read_connection(path)?;
+    let transaction = reader.transaction()?;
+    let version = transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
+    if version != STORE_SCHEMA_VERSION {
+        return Err(CloudStoreError::UnsupportedSchema(version));
+    }
+    ensure_current_schema(&transaction)?;
+    drop(transaction);
+    drop(reader);
+    identity.validate(path)?;
+    let mut connection = open_write_connection(path, false)?;
+    let transaction = connection.transaction()?;
+    ensure_current_schema(&transaction)?;
+    drop(transaction);
+    identity.validate(path)?;
     Ok(connection)
 }
 
@@ -127,7 +192,7 @@ pub(super) fn open_read_connection(path: &Path) -> Result<Connection, CloudStore
     Ok(connection)
 }
 
-fn validate_read_path(path: &Path) -> Result<(), CloudStoreError> {
+fn validate_read_path(path: &Path) -> Result<std::fs::Metadata, CloudStoreError> {
     let metadata = std::fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() {
         return Err(CloudStoreError::SymlinkStorePath);
@@ -145,7 +210,7 @@ fn validate_read_path(path: &Path) -> Result<(), CloudStoreError> {
             return Err(CloudStoreError::InsecureStoreFile);
         }
     }
-    Ok(())
+    Ok(metadata)
 }
 
 pub(super) fn initialize_schema(connection: &mut Connection) -> Result<(), CloudStoreError> {

--- a/crates/horizon-core/src/cloud_run/store/database/tests/reads.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests/reads.rs
@@ -243,3 +243,219 @@ fn read_only_open_and_single_record_reads_reject_symlink_database() {
     assert!(fixture.store.load_remote_allocation(OWNER, "workspace").is_err());
     assert_eq!(std::fs::read(retained).expect("preserved database"), before);
 }
+
+#[cfg(unix)]
+mod existing {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct DatabaseState {
+        bytes: Vec<u8>,
+        version: i64,
+        journal_mode: String,
+        rows: SavedRows,
+    }
+
+    fn state(fixture: &Fixture) -> DatabaseState {
+        let connection = open_read_connection(fixture.store.path()).expect("inspect only");
+        DatabaseState {
+            bytes: std::fs::read(fixture.store.path()).expect("database bytes"),
+            version: connection
+                .pragma_query_value(None, "user_version", |row| row.get(0))
+                .expect("version"),
+            journal_mode: connection
+                .pragma_query_value(None, "journal_mode", |row| row.get(0))
+                .expect("journal"),
+            rows: saved_bytes(&connection),
+        }
+    }
+
+    #[test]
+    fn legacy_and_future_schemas_are_refused_without_migration_or_journal_changes() {
+        for version in [4, 5, 6, STORE_SCHEMA_VERSION + 1] {
+            let fixture = fixture();
+            let writer = CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path())
+                .expect("current handle before schema drift");
+            let connection = open_connection(fixture.store.path()).expect("fixture writer");
+            if version < 7 {
+                connection
+                    .execute_batch("DROP TABLE remote_provider_bindings")
+                    .expect("legacy binding");
+            }
+            if version < 6 {
+                connection
+                    .execute_batch("DROP TABLE remote_network_volume_selections")
+                    .expect("legacy selection");
+            }
+            if version < 5 {
+                connection
+                    .execute_batch("DROP TABLE remote_first_pin_intents")
+                    .expect("legacy first pin");
+            }
+            connection
+                .pragma_update(None, "user_version", version)
+                .expect("schema fixture");
+            connection
+                .pragma_update(None, "journal_mode", "DELETE")
+                .expect("non-WAL fixture");
+            drop(connection);
+            let before = state(&fixture);
+            if version < STORE_SCHEMA_VERSION {
+                CloudWorkflowStore::open_read_only_path(fixture.store.path()).expect("genuine compatible legacy");
+            }
+            assert!(matches!(
+                CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path()),
+                Err(CloudStoreError::UnsupportedSchema(actual)) if actual == version
+            ));
+            let mut next = fixture.workflow.workflow().clone();
+            next.updated_at_millis += 1;
+            assert!(
+                matches!(writer.replace(&fixture.workflow, &next), Err(CloudStoreError::UnsupportedSchema(actual)) if actual == version)
+            );
+            assert_eq!(state(&fixture), before);
+        }
+    }
+
+    #[test]
+    fn current_schema_open_preserves_storage_and_cloned_writers_use_exact_cas() {
+        for journal in ["delete", "wal"] {
+            let fixture = fixture();
+            let connection = open_connection(fixture.store.path()).expect("fixture writer");
+            connection
+                .pragma_update(None, "journal_mode", journal)
+                .expect("journal fixture");
+            drop(connection);
+            let before = state(&fixture);
+            let writer = CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path())
+                .expect("current existing writer");
+            let writer = writer.clone();
+            assert_eq!(
+                writer.load(fixture.workflow.workflow().id).expect("read"),
+                Some(fixture.workflow.clone())
+            );
+            assert_eq!(state(&fixture), before);
+            let mut next = fixture.workflow.workflow().clone();
+            next.updated_at_millis += 1;
+            let updated = writer.replace(&fixture.workflow, &next).expect("verified exact CAS");
+            assert_eq!(updated.revision(), fixture.workflow.revision() + 1);
+            assert_eq!(updated.workflow(), &next);
+            assert_eq!(writer.load(next.id).expect("saved CAS"), Some(updated));
+            assert!(matches!(
+                writer.replace(&fixture.workflow, &next),
+                Err(CloudStoreError::RevisionConflict { .. })
+            ));
+            let after = state(&fixture);
+            assert_eq!(after.version, before.version);
+            assert_eq!(after.journal_mode, journal);
+            assert_eq!(after.rows.workspace, before.rows.workspace);
+            assert_eq!(after.rows.claims, before.rows.claims);
+        }
+    }
+
+    #[test]
+    fn missing_corrupt_and_nonregular_paths_are_not_created_or_repaired() {
+        let directory = tempfile::tempdir().expect("private directory");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("private fixture parent");
+        let home = crate::HorizonHome::from_root(directory.path().join("absent"));
+        assert!(CloudWorkflowStore::open_existing_without_migration(&home).is_err());
+        assert!(!home.root().exists());
+        let path = directory.path().join("database");
+        assert!(CloudWorkflowStore::open_existing_without_migration_path(&path).is_err());
+        assert!(!path.exists());
+        std::fs::create_dir(&path).expect("nonregular fixture");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).expect("private directory");
+        assert!(matches!(
+            CloudWorkflowStore::open_existing_without_migration_path(&path),
+            Err(CloudStoreError::ExistingStoreChanged)
+        ));
+        assert!(path.is_dir());
+        let empty = directory.path().join("empty.sqlite3");
+        std::fs::write(&empty, b"").expect("empty fixture");
+        std::fs::set_permissions(&empty, std::fs::Permissions::from_mode(0o600)).expect("private empty fixture");
+        assert!(matches!(
+            CloudWorkflowStore::open_existing_without_migration_path(&empty),
+            Err(CloudStoreError::UnsupportedSchema(0))
+        ));
+        assert_eq!(std::fs::metadata(empty).expect("unchanged empty file").len(), 0);
+        let corrupt = directory.path().join("corrupt.sqlite3");
+        std::fs::write(&corrupt, b"not a database").expect("corrupt fixture");
+        std::fs::set_permissions(&corrupt, std::fs::Permissions::from_mode(0o600)).expect("private corruption");
+        assert!(CloudWorkflowStore::open_existing_without_migration_path(&corrupt).is_err());
+        assert_eq!(std::fs::read(corrupt).expect("preserved corruption"), b"not a database");
+        let fixture = fixture();
+        let connection = open_connection(fixture.store.path()).expect("fixture writer");
+        connection
+            .execute_batch("DROP INDEX remote_runtime_allocations_job")
+            .expect("schema corruption");
+        drop(connection);
+        let before = state(&fixture);
+        assert!(matches!(
+            CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path()),
+            Err(CloudStoreError::InvalidAllocationSchema)
+        ));
+        assert_eq!(state(&fixture), before);
+    }
+
+    #[test]
+    fn existing_clones_reject_disappearance_replacement_and_symlinks_without_recreation() {
+        for replacement in ["absent", "copy", "symlink"] {
+            let fixture = fixture();
+            let path = fixture.store.path();
+            let writer = CloudWorkflowStore::open_existing_without_migration_path(path).expect("existing writer");
+            let writer = writer.clone();
+            let retained = path.with_file_name("retained.sqlite3");
+            std::fs::rename(path, &retained).expect("retain original");
+            let before = std::fs::read(&retained).expect("retained bytes");
+            match replacement {
+                "copy" => {
+                    std::fs::copy(&retained, path).expect("same-byte replacement");
+                }
+                "symlink" => std::os::unix::fs::symlink(&retained, path).expect("symlink replacement"),
+                _ => {}
+            }
+            let mut next = fixture.workflow.workflow().clone();
+            next.updated_at_millis += 1;
+            assert!(writer.replace(&fixture.workflow, &next).is_err());
+            assert_eq!(std::fs::read(&retained).expect("unchanged original"), before);
+            if replacement == "absent" {
+                assert!(!path.exists());
+            } else {
+                assert_eq!(std::fs::read(path).expect("unchanged replacement"), before);
+            }
+        }
+    }
+
+    #[test]
+    fn exposed_file_or_parent_is_refused_without_permission_repair() {
+        for parent in [false, true] {
+            let fixture = fixture();
+            let writer =
+                CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path()).expect("writer");
+            let before = std::fs::read(fixture.store.path()).expect("original");
+            let changed = if parent {
+                fixture.store.path().parent().expect("parent")
+            } else {
+                fixture.store.path()
+            };
+            let mode = if parent { 0o755 } else { 0o644 };
+            std::fs::set_permissions(changed, std::fs::Permissions::from_mode(mode)).expect("exposed fixture");
+            assert!(CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path()).is_err());
+            assert!(writer.connection().is_err());
+            assert_eq!(changed.metadata().expect("metadata").permissions().mode() & 0o777, mode);
+            assert_eq!(std::fs::read(fixture.store.path()).expect("unchanged bytes"), before);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+#[test]
+fn existing_writer_is_explicitly_unsupported_without_creating_storage() {
+    let directory = tempfile::tempdir().expect("private directory");
+    let home = crate::HorizonHome::from_root(directory.path().join("absent"));
+    assert!(matches!(
+        CloudWorkflowStore::open_existing_without_migration(&home),
+        Err(CloudStoreError::ExistingStoreUnsupported)
+    ));
+    assert!(!home.root().exists());
+}

--- a/crates/horizon-core/src/cloud_run/store/database/tests/reads.rs
+++ b/crates/horizon-core/src/cloud_run/store/database/tests/reads.rs
@@ -317,6 +317,71 @@ mod existing {
     }
 
     #[test]
+    fn base_schema_drift_is_refused_before_existing_open_or_cloned_writes() {
+        let changed_constraint = format!(
+            "DROP TABLE cloud_workflows; {}",
+            SCHEMA.replace("CHECK (revision > 0)", "CHECK (revision >= 0)")
+        );
+        for sql in [
+            "DROP INDEX remote_workspaces_session",
+            "DROP INDEX cloud_workflows_retention",
+            "DROP INDEX cloud_worker_creation_claims_workflow",
+            "DROP TABLE cloud_workflows",
+            "DROP TABLE cloud_worker_creation_claims",
+            "DROP TABLE remote_workspaces",
+            "DROP INDEX cloud_workflows_retention; CREATE INDEX cloud_workflows_retention ON cloud_workflows(updated_at_millis)",
+            "ALTER TABLE cloud_workflows RENAME COLUMN snapshot TO altered_snapshot",
+            "ALTER TABLE cloud_worker_creation_claims RENAME COLUMN resource_name TO altered_resource_name",
+            "ALTER TABLE remote_workspaces RENAME COLUMN snapshot TO altered_snapshot",
+            &changed_constraint,
+            "CREATE TRIGGER unexpected_base_write AFTER UPDATE ON ClOuD_WoRkFlOwS BEGIN DELETE FROM remote_workspaces; END",
+            "CREATE TRIGGER unexpected_base_write AFTER DELETE ON cloud_worker_creation_claims BEGIN DELETE FROM remote_workspaces; END",
+            "CREATE TRIGGER unexpected_base_write AFTER UPDATE ON remote_workspaces BEGIN DELETE FROM cloud_workflows; END",
+        ] {
+            let fixture = fixture();
+            let path = fixture.store.path();
+            let writer = CloudWorkflowStore::open_existing_without_migration_path(path)
+                .expect("current handle before drift")
+                .clone();
+            let connection = open_connection(path).expect("fixture writer");
+            connection
+                .pragma_update(None, "journal_mode", "DELETE")
+                .expect("committed byte comparison");
+            connection
+                .pragma_update(None, "foreign_keys", "OFF")
+                .expect("allow incomplete synthetic schema");
+            connection.execute_batch(sql).expect("base schema drift");
+            drop(connection);
+            let inspect = || {
+                let connection = open_read_connection(path).expect("inspect without admission");
+                let version: i64 = connection
+                    .pragma_query_value(None, "user_version", |row| row.get(0))
+                    .expect("version");
+                let journal: String = connection
+                    .pragma_query_value(None, "journal_mode", |row| row.get(0))
+                    .expect("journal");
+                (std::fs::read(path).expect("all committed bytes"), version, journal)
+            };
+            let before = inspect();
+            assert_eq!(before.1, STORE_SCHEMA_VERSION);
+            assert_eq!(before.2, "delete");
+            let admitted = CloudWorkflowStore::open_existing_without_migration_path(path);
+            assert_eq!(inspect(), before, "opening changed storage: {sql}");
+            assert!(
+                matches!(admitted, Err(CloudStoreError::InvalidAllocationSchema)),
+                "opener admitted schema drift: {sql}: {admitted:?}"
+            );
+            let mut next = fixture.workflow.workflow().clone();
+            next.updated_at_millis += 1;
+            assert!(matches!(
+                writer.replace(&fixture.workflow, &next),
+                Err(CloudStoreError::InvalidAllocationSchema)
+            ));
+            assert_eq!(inspect(), before, "cloned writer changed storage: {sql}");
+        }
+    }
+
+    #[test]
     fn current_schema_open_preserves_storage_and_cloned_writers_use_exact_cas() {
         for journal in ["delete", "wal"] {
             let fixture = fixture();
@@ -324,6 +389,12 @@ mod existing {
             connection
                 .pragma_update(None, "journal_mode", journal)
                 .expect("journal fixture");
+            connection
+                .execute(
+                    "CREATE INDEX unrelated_workflow_index ON cloud_workflows(updated_at_millis)",
+                    [],
+                )
+                .expect("unrelated index remains supported");
             drop(connection);
             let before = state(&fixture);
             let writer = CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path())

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -506,6 +506,11 @@ back into large multi-purpose modules.
   Existing-store observers use clone-preserved read-only handles, without private-path
   creation or migration. Single workspace/allocation getters always use read-only
   connections; live WAL updates remain visible without granting schema repair.
+  Explicit existing-only writers refuse creation, migration, permission repair and
+  journal-mode changes; every writable connection requires the current schema.
+  Unix device/inode checks reject detected replacement under a stable trusted directory;
+  they do not protect against concurrent same-user path swaps. This new mode refuses
+  non-Unix platforms; existing constructors and domain-specific CAS admission are unchanged.
 - `cloud_run/store/remote_workspaces.rs` owns validated, session-owned remote
   snapshot storage with exact revisions and bounded recovery. Replacement
   invariants live in its `validation.rs` leaf. These records are independent of


### PR DESCRIPTION
## Purpose

Add an explicitly non-migrating writable opener for an existing workflow store. This is the storage prerequisite for #556's saved Stop check; this PR does not change that UI or complete its review finding by itself.

## Behavior

- Add `CloudWorkflowStore::open_existing_without_migration` and its explicit-path counterpart. Admit the current schema through a read-only connection before opening a writer without SQLite's database-create flag.
- Never create directories or the database, migrate schema, repair permissions, or change journal mode. Clones retain this mode, and every writable connection revalidates the current schema. Existing domain compare-and-set checks remain responsible for authorizing updates.
- Validate the six retained base table/index definitions and reject unexpected triggers on those three base tables, in addition to the existing allocation-schema checks. Missing or altered definitions are refused; benign unrelated indexes remain supported.
- Reuse private/canonical path validation and connection settings. Unix device/inode checks reject detected file replacement before and after opening. The new mode explicitly refuses non-Unix platforms; existing constructors retain their cross-platform behavior.
- Assume a stable trusted directory: this is not protection against concurrent same-user path swaps. SQLite may maintain WAL bookkeeping files.

Scope: three source/test paths plus a short architecture note. No new dependencies, schema version, default, provider operations, or credential access.

## Validation

- Deterministic tests cover valid legacy schemas 4–6 and future/schema drift refusal; unchanged bytes, `user_version` and journal mode; DELETE/WAL current-store opening and real CAS/readback; missing/empty/corrupt/nonregular files; disappearance, same-byte replacement and symlink substitution; exposed permissions; and explicit non-Unix refusal.
- The review regression reproduced the real public opener accepting a version-7 database after `remote_workspaces_session` was dropped. The corrected opener and an existing cloned handle now refuse missing/changed base definitions and unexpected triggers before writes, preserving committed bytes, version and journal mode.
- Focused Linux store tests: 148 passed. Formatting, maintainability, version synchronization, blocking Clippy and strict Clippy passed before commit.
- Full eight-lane matrix on corrected commit `609646cc` passed: 2,517 default tests and 2,562 speech-feature tests, with 7 ignored in each tier and zero failures. Blocking, strict and pedantic Clippy passed without warnings.

The new tests use synthetic temporary stores. No UI, native-provider, cloud, credential, or retained-data proof is claimed by this prerequisite.
