### PR TITLE
feat(worker): capture versioned repository bytes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,8 @@ containers/remote-worker/**
 !containers/remote-worker/github-credentials.py
 !containers/remote-worker/panel-session.py
 !containers/remote-worker/setup-launch.py
+!containers/remote-worker/byte-capture.py
+!containers/remote-worker/byte_capture_store.py
 !containers/remote-worker/tmux.conf
 !containers/remote-worker/sshd_config
 **/.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: python3 -B containers/remote-worker/test_github_credentials.py -v
       - name: Verify explicit worker token installation
         run: python3 -B containers/remote-worker/test_github_token_install.py -v
+      - name: Verify worker byte-capture guards
+        run: python3 -B -W error containers/remote-worker/test_byte_capture.py -v
       - name: Verify source allowlist and excluded-file controls
         run: python3 -B containers/remote-worker/test_repository_packaging.py --docker-host unix:///var/run/docker.sock
 

--- a/containers/remote-worker/Dockerfile
+++ b/containers/remote-worker/Dockerfile
@@ -194,6 +194,8 @@ COPY containers/remote-worker/session.sh /usr/local/bin/horizon-agent-session
 COPY containers/remote-worker/github-credentials.py /usr/local/bin/horizon-github-credential
 COPY containers/remote-worker/panel-session.py /usr/local/bin/horizon-panel-session
 COPY containers/remote-worker/setup-launch.py /usr/local/bin/horizon-setup-launch
+COPY containers/remote-worker/byte-capture.py /usr/local/bin/horizon-byte-capture
+COPY containers/remote-worker/byte_capture_store.py /usr/local/bin/byte_capture_store.py
 COPY containers/remote-worker/tmux.conf /etc/horizon/tmux.conf
 COPY containers/remote-worker/rust-path.sh /etc/profile.d/horizon-rust.sh
 COPY containers/remote-worker/sshd_config /etc/ssh/sshd_config.d/99-horizon-worker.conf
@@ -202,6 +204,7 @@ RUN chmod 0755 /usr/local/bin/horizon-worker-entrypoint /usr/local/bin/horizon-a
     /usr/local/bin/horizon-github-credential \
     /usr/local/bin/horizon-panel-session \
     /usr/local/bin/horizon-setup-launch \
+    /usr/local/bin/horizon-byte-capture \
     /usr/local/bin/horizon-worker-host-identity \
     && ln -s horizon-github-credential /usr/local/bin/gh \
     && chmod 0644 /etc/profile.d/horizon-rust.sh /etc/ssh/sshd_config.d/99-horizon-worker.conf \

--- a/containers/remote-worker/byte-capture.py
+++ b/containers/remote-worker/byte-capture.py
@@ -220,7 +220,8 @@ def status(binding):
                 bundles.close()
         observed = now()
         value['observed_at_millis'] = observed
-        value['stale'] = success is None or observed < success['verified_at_millis'] or observed - success['verified_at_millis'] > STALE_SECONDS * 1000
+        reference = success['verified_at_millis'] if success is not None else value['started_at_millis']
+        value['stale'] = reference is None or observed < reference or observed - reference > STALE_SECONDS * 1000
         # The stored word "running" is not a fresh process-liveness observation.
         value['recorded_state'] = value['state']
         if value['stale'] and value['state'] in ('running', 'degraded'):

--- a/containers/remote-worker/byte-capture.py
+++ b/containers/remote-worker/byte-capture.py
@@ -1,0 +1,261 @@
+#!/usr/bin/python3 -I
+"""Explicit worker-owned versioned byte captures; not atomic snapshots or backups."""
+
+import fcntl
+import importlib.util
+import os
+import resource
+import selectors
+import subprocess
+import sys
+import time
+
+spec = importlib.util.spec_from_file_location('capture_store', os.path.join(os.path.dirname(__file__), 'byte_capture_store.py'))
+store = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(store)
+BASE = '/workspace/.horizon-worker'
+HELPER = '/usr/local/bin/horizon-repository'
+ENV = {'PATH': '/usr/bin:/bin', 'LC_ALL': 'C'}
+INTERVAL = 10
+ATTEMPT_SECONDS = 15
+STALE_SECONDS = 30
+LABEL = 'versioned byte capture; not an atomic snapshot or independent backup'
+REASONS = ('invalid', 'unsupported', 'identity', 'capture', 'capacity', 'storage', 'changed')
+
+
+def now():
+    return time.time_ns() // 1_000_000
+
+
+def child_limits():
+    resource.setrlimit(resource.RLIMIT_AS, (2 * 1024**3, 2 * 1024**3))
+    resource.setrlimit(resource.RLIMIT_FSIZE, (160 * 1024**2, 160 * 1024**2))
+    resource.setrlimit(resource.RLIMIT_CPU, (15, 15))
+
+
+def invoke(enrollment, plan, available, cancelled=lambda: False):
+    """Bound child pipes/time. An uninterruptible filesystem can delay OS teardown."""
+    request = store.encode({'enrollment': enrollment, 'available_bytes': available})
+    store.require(len(request) <= store.LIMIT)
+    child = subprocess.Popen([HELPER, 'capture-plan' if plan else 'capture-once'],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        cwd='/', env=ENV, close_fds=True, start_new_session=True, umask=0o077, preexec_fn=child_limits)
+    output = bytearray()
+    try:
+        os.set_blocking(child.stdin.fileno(), False)
+        os.set_blocking(child.stdout.fileno(), False)
+        view = memoryview(request)
+        deadline = time.monotonic() + ATTEMPT_SECONDS
+        with selectors.DefaultSelector() as ready:
+            ready.register(child.stdin, selectors.EVENT_WRITE)
+            ready.register(child.stdout, selectors.EVENT_READ)
+            while ready.get_map():
+                store.require(time.monotonic() < deadline and not cancelled())
+                for key, _ in ready.select(0.1):
+                    if key.fileobj is child.stdin:
+                        count = os.write(child.stdin.fileno(), view)
+                        store.require(count > 0)
+                        view = view[count:]
+                        if not view:
+                            ready.unregister(child.stdin)
+                            child.stdin.close()
+                    else:
+                        data = os.read(child.stdout.fileno(), 1025 - len(output))
+                        output.extend(data)
+                        store.require(len(output) <= 1024)
+                        if not data:
+                            ready.unregister(child.stdout)
+                if child.poll() is not None and view:
+                    raise store.CaptureError('capture request handoff failed')
+        code = child.wait(timeout=max(0.01, deadline - time.monotonic()))
+        value = store.decode(output)
+        if code in (1, 2) and isinstance(value, dict) and value.get('reason') in REASONS:
+            raise store.CaptureError(value['reason'])
+        store.require(code == 0 and set(value) == {'version', 'binding', 'manifest', 'record_sha256', 'record_bytes', 'reason'}
+                      and value['version'] == 1 and value['reason'] is None and store.digest(value['binding']))
+        if plan:
+            store.require(all(value[field] is None for field in ('manifest', 'record_sha256', 'record_bytes')))
+        return value
+    finally:
+        if child.poll() is None:
+            child.kill()  # Only the exact child created above, never a saved PID.
+            try:
+                child.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass  # Do not promise a hard kill/reap bound for uninterruptible I/O.
+        child.stdin.close()
+        child.stdout.close()
+
+
+def cancelled(slot):
+    value = slot.read('cancel.json')
+    if value is None:
+        return False
+    store.require(store.decode(value) == {'cancel': True})
+    return True
+
+
+def service(binding):
+    slot = store.open_slot(BASE, binding)
+    lock = os.open('lock', os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=slot.fd)
+    bundles = receipts = None
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        enrollment = store.decode(slot.read('enrollment.json'))
+        bundles = slot.child('bundles')
+        receipts = slot.child('receipts')
+        state = {'version': 1, 'label': LABEL, 'binding': binding, 'state': 'running',
+                 'interval_seconds': INTERVAL, 'stale_after_seconds': STALE_SECONDS,
+                 'started_at_millis': now(), 'attempt_started_at_millis': None,
+                 'attempt_finished_at_millis': None, 'last_success': None, 'generation': 0, 'last_error': None}
+        while not cancelled(slot):
+            started = time.monotonic()
+            state['attempt_started_at_millis'] = now()
+            state['attempt_finished_at_millis'] = None
+            slot.write('status.json', state, replace=True)
+            try:
+                available = store.CAPACITY - bundles.usage()
+                observation = invoke(enrollment, False, available, lambda: cancelled(slot))
+                store.require(observation['binding'] == binding and not cancelled(slot))
+                bundles.verified_record(observation)
+                bundles.usage()
+                finished = now()
+                store.require(finished >= state['attempt_started_at_millis'])
+                previous_time = state['last_success']['verified_at_millis'] if state['last_success'] else None
+                store.require(previous_time is None or finished >= previous_time)
+                success = dict(observation, generation=state['generation'] + 1,
+                    capture_started_at_millis=state['attempt_started_at_millis'], verified_at_millis=finished,
+                    previous_verified_at_millis=previous_time)
+                # One immutable receipt per distinct content version; repeated bytes
+                # refresh the observed interval without accumulating new disk records.
+                name = observation['manifest'] + '.json'
+                previous = receipts.read(name)
+                if previous is None:
+                    receipts.write(name, success)
+                else:
+                    previous = store.decode(previous)
+                    store.require(all(previous[field] == observation[field] for field in observation))
+                store.require(not cancelled(slot))
+                state['generation'] = success['generation']
+                state['last_success'] = success
+                state['state'], state['last_error'] = 'running', None
+            except (OSError, ValueError, KeyError, TypeError, store.CaptureError, subprocess.SubprocessError) as error:
+                state['state'] = 'cancelled' if cancelled(slot) else 'error'
+                state['last_error'] = str(error) if isinstance(error, store.CaptureError) and str(error) in REASONS else 'unavailable'
+                if state['state'] != 'cancelled' and state['last_error'] == 'changed':
+                    state['state'] = 'degraded'  # Capture detected edits before publication; safe to sample again.
+            state['attempt_finished_at_millis'] = now()
+            # Success advances only after bundle publication AND verified readback.
+            slot.write('status.json', state, replace=True)
+            if state['state'] not in ('running', 'degraded'):
+                return
+            while time.monotonic() - started < INTERVAL and not cancelled(slot):
+                time.sleep(0.1)
+        state['state'] = 'cancelled'
+        slot.write('status.json', state, replace=True)
+    finally:
+        if bundles is not None:
+            bundles.close()
+        if receipts is not None:
+            receipts.close()
+        os.close(lock)
+        slot.close()
+
+
+def start(enrollment):
+    binding = invoke(enrollment, True, store.CAPACITY)['binding']
+    try:
+        slot = store.open_slot(BASE, binding, True)
+    except FileExistsError:
+        return status(binding)  # Existing enrollment is never automatically relaunched.
+    try:
+        slot.write('enrollment.json', enrollment)
+        slot.child('bundles', True).close()
+        slot.child('receipts', True).close()
+        # All I/O inherited from the controller is severed; no client heartbeat.
+        child = subprocess.Popen(['/usr/bin/python3', '-I', os.path.abspath(__file__), '_run', binding],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            cwd='/', env=ENV, close_fds=True, start_new_session=True, umask=0o077)
+        child.poll()
+        return {'version': 1, 'binding': binding, 'state': 'submitted', 'label': LABEL}
+    finally:
+        slot.close()
+
+
+def status(binding):
+    try:
+        slot = store.open_slot(BASE, binding)
+    except FileNotFoundError:
+        return {'version': 1, 'binding': binding, 'state': 'absent', 'label': LABEL}
+    try:
+        raw = slot.read('status.json')
+        if raw is None:
+            return {'version': 1, 'binding': binding, 'state': 'claimed_unknown', 'label': LABEL}
+        value = store.decode(raw)
+        store.require(set(value) == {'version', 'label', 'binding', 'state', 'interval_seconds',
+            'stale_after_seconds', 'started_at_millis', 'attempt_started_at_millis',
+            'attempt_finished_at_millis', 'last_success', 'generation', 'last_error'}
+            and value['version'] == 1 and value['binding'] == binding and value['label'] == LABEL
+            and value['state'] in ('running', 'degraded', 'cancelled', 'error')
+            and value['last_error'] in (None, 'unavailable') + REASONS
+            and value['interval_seconds'] == INTERVAL and value['stale_after_seconds'] == STALE_SECONDS
+            and type(value['generation']) is int and value['generation'] >= 0)
+        for field in ('started_at_millis', 'attempt_started_at_millis', 'attempt_finished_at_millis'):
+            store.require(value[field] is None or type(value[field]) is int and value[field] >= 0)
+        success = value['last_success']
+        if success is not None:
+            store.require(set(success) == {'version', 'binding', 'manifest', 'record_sha256', 'record_bytes', 'reason',
+                'generation', 'capture_started_at_millis', 'verified_at_millis', 'previous_verified_at_millis'}
+                and success['version'] == 1 and success['binding'] == binding and success['reason'] is None
+                and success['generation'] == value['generation']
+                and type(success['verified_at_millis']) is int and type(success['capture_started_at_millis']) is int
+                and 0 <= success['capture_started_at_millis'] <= success['verified_at_millis'])
+            store.require(success['previous_verified_at_millis'] is None or
+                type(success['previous_verified_at_millis']) is int and
+                0 <= success['previous_verified_at_millis'] <= success['verified_at_millis'])
+            bundles = slot.child('bundles')
+            try:
+                bundles.verified_record(success)
+            finally:
+                bundles.close()
+        observed = now()
+        value['observed_at_millis'] = observed
+        value['stale'] = success is None or observed < success['verified_at_millis'] or observed - success['verified_at_millis'] > STALE_SECONDS * 1000
+        # The stored word "running" is not a fresh process-liveness observation.
+        value['recorded_state'] = value['state']
+        if value['stale'] and value['state'] in ('running', 'degraded'):
+            value['state'] = 'stale'
+        return value
+    finally:
+        slot.close()
+
+
+def main(arguments):
+    if len(arguments) == 1 and arguments[0] == 'start':
+        raw = sys.stdin.buffer.read(store.LIMIT + 1)
+        store.require(len(raw) <= store.LIMIT)
+        return start(store.decode(raw))
+    store.require(len(arguments) == 2 and arguments[0] in ('status', 'cancel', '_run') and store.digest(arguments[1]))
+    command, binding = arguments
+    if command == '_run':
+        service(binding)
+        return None
+    if command == 'cancel':
+        slot = store.open_slot(BASE, binding)
+        try:
+            if not cancelled(slot):
+                slot.write('cancel.json', {'cancel': True})
+        finally:
+            slot.close()
+    return status(binding)
+
+
+if __name__ == '__main__':
+    try:
+        result = main(sys.argv[1:])
+        if result is not None:
+            sys.stdout.buffer.write(store.encode(result))
+            sys.stdout.buffer.flush()
+    except (OSError, ValueError, KeyError, TypeError, store.CaptureError, subprocess.SubprocessError):
+        sys.stderr.write('Byte capture unavailable; retain all data and inspect status.\n')
+        sys.exit(1)

--- a/containers/remote-worker/byte-capture.py
+++ b/containers/remote-worker/byte-capture.py
@@ -33,11 +33,12 @@ def child_limits():
     resource.setrlimit(resource.RLIMIT_CPU, (15, 15))
 
 
-def invoke(enrollment, plan, available, cancelled=lambda: False):
+def invoke(enrollment, operation, available, cancelled=lambda: False):
     """Bound child pipes/time. An uninterruptible filesystem can delay OS teardown."""
     request = store.encode({'enrollment': enrollment, 'available_bytes': available})
     store.require(len(request) <= store.LIMIT)
-    child = subprocess.Popen([HELPER, 'capture-plan' if plan else 'capture-once'],
+    store.require(operation in ('capture-binding', 'capture-plan', 'capture-once'))
+    child = subprocess.Popen([HELPER, operation],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
         cwd='/', env=ENV, close_fds=True, start_new_session=True, umask=0o077, preexec_fn=child_limits)
     output = bytearray()
@@ -73,7 +74,7 @@ def invoke(enrollment, plan, available, cancelled=lambda: False):
             raise store.CaptureError(value['reason'])
         store.require(code == 0 and set(value) == {'version', 'binding', 'manifest', 'record_sha256', 'record_bytes', 'reason'}
                       and value['version'] == 1 and value['reason'] is None and store.digest(value['binding']))
-        if plan:
+        if operation != 'capture-once':
             store.require(all(value[field] is None for field in ('manifest', 'record_sha256', 'record_bytes')))
         return value
     finally:
@@ -115,7 +116,7 @@ def service(binding):
             slot.write('status.json', state, replace=True)
             try:
                 available = store.CAPACITY - bundles.usage()
-                observation = invoke(enrollment, False, available, lambda: cancelled(slot))
+                observation = invoke(enrollment, 'capture-once', available, lambda: cancelled(slot))
                 store.require(observation['binding'] == binding and not cancelled(slot))
                 bundles.verified_record(observation)
                 bundles.usage()
@@ -163,7 +164,11 @@ def service(binding):
 
 
 def start(enrollment):
-    binding = invoke(enrollment, True, store.CAPACITY)['binding']
+    binding = invoke(enrollment, 'capture-binding', store.CAPACITY)['binding']
+    existing = status(binding)
+    if existing['state'] != 'absent':
+        return existing
+    store.require(invoke(enrollment, 'capture-plan', store.CAPACITY)['binding'] == binding)
     try:
         slot = store.open_slot(BASE, binding, True)
     except FileExistsError:

--- a/containers/remote-worker/byte_capture_store.py
+++ b/containers/remote-worker/byte_capture_store.py
@@ -1,0 +1,209 @@
+"""Private retained-volume records; never cleanup, export, or certify provider durability."""
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+
+LIMIT = 128 * 1024
+CAPACITY = 1024 * 1024 * 1024
+MAX_RECORDS = 4096
+FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+
+
+class CaptureError(Exception):
+    """Only static diagnostics are emitted across the CLI boundary."""
+
+
+def require(condition):
+    if not condition:
+        raise CaptureError('capture state is unavailable; retain all data')
+
+
+def unique(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result)
+        result[key] = value
+    return result
+
+
+def decode(data):
+    try:
+        return json.loads(data, object_pairs_hook=unique)
+    except (ValueError, RecursionError):
+        raise CaptureError('invalid capture JSON') from None
+
+
+def encode(value):
+    return json.dumps(value, separators=(',', ':'), ensure_ascii=True).encode() + b'\n'
+
+
+def digest(value):
+    return isinstance(value, str) and re.fullmatch('[0-9a-f]{64}', value) is not None
+
+
+def identity(info):
+    # Reading must not fail merely because the filesystem updates access time.
+    return tuple(getattr(info, field) for field in (
+        'st_dev', 'st_ino', 'st_mode', 'st_uid', 'st_gid', 'st_nlink',
+        'st_size', 'st_mtime_ns', 'st_ctime_ns'))
+
+
+class Directory:
+    def __init__(self, path):
+        require(os.path.isabs(path) and os.path.normpath(path) == path)
+        fd = os.open('/', FLAGS)
+        try:
+            for part in path.split('/')[1:]:
+                require(part not in ('', '.', '..'))
+                child = os.open(part, FLAGS, dir_fd=fd)
+                os.close(fd)
+                fd = child
+            self.path, self.fd = path, fd
+            self.original = os.fstat(fd)
+            self.verify()
+        except BaseException:
+            os.close(fd)
+            raise
+
+    def close(self):
+        os.close(self.fd)
+
+    def verify(self):
+        held, current = os.fstat(self.fd), os.stat(self.path, follow_symlinks=False)
+        require(stat.S_ISDIR(held.st_mode) and held.st_uid == os.geteuid()
+                and stat.S_IMODE(held.st_mode) == 0o700 and held.st_nlink > 0
+                and (held.st_dev, held.st_ino) == (current.st_dev, current.st_ino)
+                == (self.original.st_dev, self.original.st_ino))
+
+    def child(self, name, create=False):
+        require(re.fullmatch('[a-z0-9-]+', name) is not None)
+        self.verify()
+        if create:
+            os.mkdir(name, 0o700, dir_fd=self.fd)
+            os.fsync(self.fd)
+        result = Directory(self.path + '/' + name)
+        require(result.original.st_dev == self.original.st_dev)
+        self.verify()
+        return result
+
+    def read(self, name, limit=LIMIT):
+        self.verify()
+        require('/' not in name and name not in ('.', '..'))
+        try:
+            fd = os.open(name, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=self.fd)
+        except FileNotFoundError:
+            return None
+        try:
+            before = os.fstat(fd)
+            require(stat.S_ISREG(before.st_mode) and before.st_uid == os.geteuid()
+                    and stat.S_IMODE(before.st_mode) == 0o600 and before.st_nlink == 1
+                    and before.st_size <= limit)
+            data = bytearray()
+            while len(data) <= limit:
+                block = os.read(fd, min(65536, limit + 1 - len(data)))
+                if not block:
+                    break
+                data.extend(block)
+            require(len(data) <= limit and identity(before) == identity(os.fstat(fd))
+                    == identity(os.stat(name, dir_fd=self.fd, follow_symlinks=False)))
+            self.verify()
+            return bytes(data)
+        finally:
+            os.close(fd)
+
+    def write(self, name, value, replace=False):
+        data = encode(value)
+        require(len(data) <= LIMIT and '/' not in name)
+        self.verify()
+        temporary = 'pending-' + secrets.token_hex(16)
+        fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                     0o600, dir_fd=self.fd)
+        try:
+            view = memoryview(data)
+            while view:
+                written = os.write(fd, view)
+                require(written > 0)
+                view = view[written:]
+            os.fsync(fd)
+            self.verify()
+            if replace:
+                os.rename(temporary, name, src_dir_fd=self.fd, dst_dir_fd=self.fd)
+            else:
+                os.link(temporary, name, src_dir_fd=self.fd, dst_dir_fd=self.fd, follow_symlinks=False)
+                os.unlink(temporary, dir_fd=self.fd)
+            os.fsync(self.fd)
+            require(self.read(name) == data)
+        finally:
+            os.close(fd)
+            # A failed publication is retained, not blindly cleaned up or retried.
+
+    def usage(self):
+        self.verify()
+        total = 0
+        count = 0
+        with os.scandir(self.fd) as entries:
+            for count, entry in enumerate(entries, 1):
+                require(count <= MAX_RECORDS and digest(entry.name))
+                slot = self.child(entry.name)
+                try:
+                    total += slot.record_info().st_size
+                finally:
+                    slot.close()
+                require(total <= CAPACITY)
+        self.verify()
+        return CAPACITY if count == MAX_RECORDS else total
+
+    def record_info(self):
+        self.verify()
+        with os.scandir(self.fd) as entries:
+            first = next(entries, None)
+            require(first is not None and first.name == 'record.hzov' and next(entries, None) is None)
+            info = first.stat(follow_symlinks=False)
+        require(stat.S_ISREG(info.st_mode) and info.st_uid == os.geteuid()
+                and stat.S_IMODE(info.st_mode) == 0o600 and info.st_nlink == 1
+                and 0 < info.st_size <= 160 * 1024 * 1024)
+        self.verify()
+        return info
+
+    def record(self, manifest):
+        require(digest(manifest))
+        slot = self.child(manifest)
+        try:
+            before = slot.record_info()
+            data = slot.read('record.hzov', 160 * 1024 * 1024)
+            require(identity(before) == identity(slot.record_info()))
+            self.verify()
+            return data
+        finally:
+            slot.close()
+
+    def verified_record(self, observation):
+        require(digest(observation['manifest']) and digest(observation['record_sha256'])
+                and type(observation['record_bytes']) is int
+                and 0 < observation['record_bytes'] <= 160 * 1024 * 1024)
+        data = self.record(observation['manifest'])
+        require(data is not None and len(data) == observation['record_bytes']
+                and hashlib.sha256(data).hexdigest() == observation['record_sha256'])
+
+
+def open_slot(base, binding, create=False):
+    require(digest(binding))
+    worker = Directory(base)
+    try:
+        if create:
+            try:
+                os.mkdir('byte-captures', 0o700, dir_fd=worker.fd)
+                os.fsync(worker.fd)
+            except FileExistsError:
+                pass
+        captures = worker.child('byte-captures')
+        try:
+            return captures.child(binding, create)
+        finally:
+            captures.close()
+    finally:
+        worker.close()

--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -418,7 +418,9 @@ class ActualCli(unittest.TestCase):
         info = binary.stat()
         self.assertTrue(stat.S_ISREG(info.st_mode) and info.st_uid == os.geteuid() and not info.st_mode & 0o022)
         with tempfile.TemporaryDirectory(prefix='horizon-byte-capture-native-') as temporary:
-            arguments = ['/usr/bin/bwrap', '--unshare-all', '--new-session', '--die-with-parent', '--ro-bind', '/', '/',
+            arguments = ['/usr/bin/bwrap', '--unshare-all', '--new-session', '--die-with-parent', '--tmpfs', '/',
+                '--ro-bind', '/usr', '/usr', '--symlink', 'usr/bin', '/bin', '--symlink', 'usr/lib', '/lib',
+                '--symlink', 'usr/lib64', '/lib64', '--symlink', 'usr/sbin', '/sbin',
                 '--dev', '/dev', '--proc', '/proc', '--tmpfs', '/tmp', '--tmpfs', '/home', '--tmpfs', '/root',
                 '--tmpfs', '/run', '--tmpfs', '/etc', '--tmpfs', '/usr/local/bin',
                 '--bind', temporary, '/workspace', '--ro-bind', str(binary), '/usr/local/bin/horizon-repository',

--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -64,8 +64,8 @@ class PrivateFixture(unittest.TestCase):
         self.assertEqual(state['last_success']['manifest'], second['manifest'])
         self.assertEqual(len(list((Path(self.slot.path) / 'bundles').iterdir())), 2)
         self.assertEqual(len(list((Path(self.slot.path) / 'receipts').iterdir())), 2)
-        with patch.object(capture, 'invoke', return_value={'binding': BINDING}), patch.object(capture, 'status', return_value={'existing': True}), patch.object(capture.subprocess, 'Popen') as spawn:
-            self.assertEqual(capture.start({'fixture': True}), {'existing': True})
+        with patch.object(capture, 'invoke', return_value={'binding': BINDING}), patch.object(capture, 'status', return_value={'state': 'error'}), patch.object(capture.subprocess, 'Popen') as spawn:
+            self.assertEqual(capture.start({'fixture': True}), {'state': 'error'})
             spawn.assert_not_called()
 
     def test_readback_or_receipt_failure_cannot_advance_success(self):
@@ -80,6 +80,33 @@ class PrivateFixture(unittest.TestCase):
         self.assertEqual(state['generation'], 1)
         self.assertEqual(state['last_success']['manifest'], first['manifest'])
         self.assertEqual(state['state'], 'error')
+
+    def test_existing_start_observes_before_checkout_admission_but_new_start_does_not_claim(self):
+        state = self.run_service([self.observation(b'retained'), store.CaptureError('identity')])
+        state['interval_seconds'] = capture.INTERVAL
+        self.slot.write('status.json', state, True)
+        for binding in (BINDING, 'b' * 64):
+            def invoke(_, operation, __):
+                if operation == 'capture-binding':
+                    return {'binding': binding}
+                raise store.CaptureError('identity')
+            with patch.object(capture, 'invoke', side_effect=invoke), patch.object(capture.subprocess, 'Popen') as spawn:
+                if binding == BINDING:
+                    self.assertEqual(capture.start({'fixture': True})['last_success'], state['last_success'])
+                else:
+                    with self.assertRaises(store.CaptureError):
+                        capture.start({'fixture': True})
+                    self.assertFalse((Path(self.slot.path).parent / binding).exists())
+                spawn.assert_not_called()
+
+    def test_new_start_observes_exclusive_claim_race_winner_without_relaunch(self):
+        with patch.object(capture, 'invoke', return_value={'binding': BINDING}) as invoke, \
+                patch.object(capture, 'status', side_effect=[{'state': 'absent'}, {'state': 'claimed_unknown'}]), \
+                patch.object(store, 'open_slot', side_effect=FileExistsError), \
+                patch.object(capture.subprocess, 'Popen') as spawn:
+            self.assertEqual(capture.start({'fixture': True}), {'state': 'claimed_unknown'})
+            self.assertEqual([call.args[1] for call in invoke.call_args_list], ['capture-binding', 'capture-plan'])
+            spawn.assert_not_called()
 
     def test_changed_is_retried_without_advancing_success_and_recovery_clears_gap(self):
         first, second = self.observation(b'first'), self.observation(b'second')
@@ -294,10 +321,10 @@ class PrivateFixture(unittest.TestCase):
             helper.chmod(0o700)
             with patch.object(capture, 'HELPER', str(helper)), patch.object(capture, 'ATTEMPT_SECONDS', .3):
                 if accepted:
-                    self.assertEqual(capture.invoke({}, True, 0), response)
+                    self.assertEqual(capture.invoke({}, 'capture-plan', 0), response)
                 else:
                     with self.assertRaises((store.CaptureError, subprocess.SubprocessError)):
-                        capture.invoke({}, True, 0)
+                        capture.invoke({}, 'capture-plan', 0)
 
     def test_changed_binding_and_capacity_exhaustion_retain_success(self):
         first = self.observation(b'first')
@@ -335,7 +362,7 @@ def inside_proof():
     """Synthetic initial Git receipts only; actual capture/start/status code is unmodified."""
     usage = subprocess.run([capture.HELPER], capture_output=True, env=capture.ENV, timeout=5)
     store.require(usage.returncode == 2 and not usage.stdout
-                  and b'capture-plan' in usage.stderr and b'capture-once' in usage.stderr)
+                  and all(name in usage.stderr for name in (b'capture-binding', b'capture-plan', b'capture-once')))
     root = Path('/workspace')
     for directory in ('horizon', '.horizon-worker', 'horizon/repository', '.horizon-worker/git-workspace'):
         (root / directory).mkdir(mode=0o700)
@@ -435,6 +462,33 @@ def inside_proof():
             time.sleep(.1)
         store.require(refused['generation'] == second['generation']
                       and refused['last_success'] == second['last_success'])
+        for original in (checkout, claim / 'complete.json'):
+            retained = original.with_name(original.name + '.retained')
+            original.rename(retained)
+            try:
+                for replace in (False, True):
+                    if replace:
+                        if retained.is_dir():
+                            original.mkdir(mode=0o700)
+                        else:
+                            original.write_bytes(b'{}')
+                            original.chmod(0o600)
+                    observed = call('start', data=store.encode(enrollment))
+                    store.require(observed['last_success'] == refused['last_success']
+                                  and observed['started_at_millis'] == first['started_at_millis']
+                                  and store.identity(lock.stat()) == lock_identity)
+                    fresh = dict(enrollment, selected=['different.txt'])
+                    rejected = subprocess.run(command + ['start'], input=store.encode(fresh),
+                        capture_output=True, env=capture.ENV, timeout=20)
+                    store.require(rejected.returncode == 1 and not rejected.stdout
+                                  and list(captures.iterdir()) == [captures / binding])
+            finally:
+                if original.exists():
+                    if original.is_dir():
+                        original.rmdir()
+                    else:
+                        original.unlink()
+                retained.rename(original)
         print(json.dumps({'proof': 'controller exited; two verified byte versions', 'observed_interval_millis': interval}))
     finally:
         call('cancel', binding)

--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Pure guards by default; --binary PATH explicitly enables private bwrap CLI proof."""
+
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location('capture', HERE / 'byte-capture.py')
+capture = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(capture)
+store = capture.store
+BINDING = 'a' * 64
+BINARY = None
+
+
+class PrivateFixture(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix='horizon-byte-capture-test-')
+        self.root = Path(self.temporary.name)
+        self.base = self.root / 'worker'
+        self.base.mkdir(mode=0o700)
+        self.slot = store.open_slot(str(self.base), BINDING, True)
+        self.slot.write('enrollment.json', {'fixture': True})
+        for name in ('bundles', 'receipts'):
+            self.slot.child(name, True).close()
+        self.base_patch = patch.object(capture, 'BASE', str(self.base))
+        self.base_patch.start()
+
+    def tearDown(self):
+        self.base_patch.stop()
+        self.slot.close()
+        self.temporary.cleanup()
+
+    def observation(self, data):
+        digest = hashlib.sha256(data).hexdigest()
+        directory = Path(self.slot.path) / 'bundles' / digest
+        directory.mkdir(mode=0o700, exist_ok=True)
+        path = directory / 'record.hzov'
+        if not path.exists():
+            path.write_bytes(data)
+            path.chmod(0o600)
+        return {'version': 1, 'binding': BINDING, 'manifest': digest,
+                'record_sha256': digest, 'record_bytes': len(data), 'reason': None}
+
+    def run_service(self, observations):
+        with patch.object(capture, 'INTERVAL', 0), patch.object(capture, 'invoke', side_effect=observations):
+            capture.service(BINDING)
+        return store.decode(self.slot.read('status.json'))
+
+    def test_previous_versions_survive_failed_next_attempt_and_no_relaunch(self):
+        first, second = self.observation(b'first bytes'), self.observation(b'second bytes')
+        state = self.run_service([first, second, store.CaptureError('failure')])
+        self.assertEqual((state['state'], state['generation']), ('error', 2))
+        self.assertEqual(state['last_success']['manifest'], second['manifest'])
+        self.assertEqual(len(list((Path(self.slot.path) / 'bundles').iterdir())), 2)
+        self.assertEqual(len(list((Path(self.slot.path) / 'receipts').iterdir())), 2)
+        with patch.object(capture, 'invoke', return_value={'binding': BINDING}), patch.object(capture, 'status', return_value={'existing': True}), patch.object(capture.subprocess, 'Popen') as spawn:
+            self.assertEqual(capture.start({'fixture': True}), {'existing': True})
+            spawn.assert_not_called()
+
+    def test_readback_or_receipt_failure_cannot_advance_success(self):
+        first, second = self.observation(b'first'), self.observation(b'second')
+        write = store.Directory.write
+        def refuse_receipt(directory, name, value, replace=False):
+            if name == second['manifest'] + '.json':
+                raise OSError('synthetic receipt sync failure')
+            return write(directory, name, value, replace)
+        with patch.object(store.Directory, 'write', new=refuse_receipt):
+            state = self.run_service([first, second])
+        self.assertEqual(state['generation'], 1)
+        self.assertEqual(state['last_success']['manifest'], first['manifest'])
+        self.assertEqual(state['state'], 'error')
+
+    def test_changed_is_retried_without_advancing_success_and_recovery_clears_gap(self):
+        first, second = self.observation(b'first'), self.observation(b'second')
+        observed = []
+        results = iter([store.CaptureError('changed'), first, store.CaptureError('changed'), second, store.CaptureError('identity')])
+        def invoke(*_):
+            observed.append(store.decode(self.slot.read('status.json')))
+            result = next(results)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        with patch.object(capture, 'INTERVAL', 0), patch.object(capture, 'invoke', side_effect=invoke):
+            capture.service(BINDING)
+        self.assertEqual([value['state'] for value in observed], ['running', 'degraded', 'running', 'degraded', 'running'])
+        self.assertEqual([value['generation'] for value in observed], [0, 0, 1, 1, 2])
+        self.assertIsNone(observed[1]['last_success'])
+        self.assertEqual(observed[3]['last_success'], observed[2]['last_success'])
+        self.assertIsNone(observed[4]['last_error'])
+        state = store.decode(self.slot.read('status.json'))
+        self.assertEqual((state['state'], state['last_error'], state['generation']), ('error', 'identity', 2))
+
+    def test_identical_record_at_byte_or_count_capacity_is_still_verified(self):
+        value = self.observation(b'full')
+        for capacity, records in [(4, 4096), (100, 1)]:
+            with self.subTest(capacity=capacity), patch.object(store, 'CAPACITY', capacity), patch.object(store, 'MAX_RECORDS', records):
+                with patch.object(capture, 'INTERVAL', 0), patch.object(capture, 'invoke', side_effect=[value, store.CaptureError('capacity')]) as invoke:
+                    capture.service(BINDING)
+                self.assertEqual(invoke.call_args_list[0].args[2], 0)
+                state = store.decode(self.slot.read('status.json'))
+                self.assertEqual((state['generation'], state['last_error']), (1, 'capacity'))
+                self.assertEqual(state['last_success']['manifest'], value['manifest'])
+            # Separate synthetic service enrollment, not a product restart path.
+            (Path(self.slot.path) / 'lock').unlink()
+
+    def test_lost_publication_reply_retains_orphan_without_success(self):
+        value = self.observation(b'published before reply was lost')
+        state = self.run_service([store.CaptureError('storage')])
+        self.assertIsNone(state['last_success'])
+        self.assertEqual(state['generation'], 0)
+        self.assertEqual(list((Path(self.slot.path) / 'receipts').iterdir()), [])
+        bundles = self.slot.child('bundles')
+        try:
+            bundles.verified_record(value)
+            self.assertEqual(bundles.usage(), value['record_bytes'])
+        finally:
+            bundles.close()
+
+    def test_deep_json_refuses_without_disclosing_input_or_traceback(self):
+        raw = b'[' * 60000 + b'"private sentinel"' + b']' * 60000
+        with self.assertRaisesRegex(store.CaptureError, '^invalid capture JSON$'):
+            store.decode(raw)
+        result = subprocess.run([sys.executable, '-I', '-B', str(HERE / 'byte-capture.py'), 'start'], input=raw, capture_output=True, timeout=5)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, b'')
+        self.assertEqual(result.stderr, b'Byte capture unavailable; retain all data and inspect status.\n')
+
+    def test_corrupt_published_bytes_fail_without_a_watermark(self):
+        value = self.observation(b'original')
+        (Path(self.slot.path) / 'bundles' / value['manifest'] / 'record.hzov').write_bytes(b'corrupt')
+        state = self.run_service([value])
+        self.assertEqual(state['generation'], 0)
+        self.assertIsNone(state['last_success'])
+
+    def test_named_accounting_rejects_partial_foreign_and_linked_slots(self):
+        good = self.observation(b'prior verified bytes')
+        for index, kind in enumerate(('empty', 'pending', 'extra', 'symlink', 'flat')):
+            container = self.slot.child('case-' + str(index), True)
+            try:
+                root = Path(container.path)
+                digest = 'b' * 64
+                if kind == 'flat':
+                    (root / (digest + '.hzov')).write_bytes(b'foreign anonymous layout')
+                else:
+                    directory = root / digest
+                    directory.mkdir(mode=0o700)
+                    if kind == 'symlink':
+                        os.symlink(Path(self.slot.path) / 'bundles' / good['manifest'] / 'record.hzov', directory / 'record.hzov')
+                    elif kind != 'empty':
+                        name = 'pending' if kind == 'pending' else 'record.hzov'
+                        (directory / name).write_bytes(b'partial')
+                        (directory / name).chmod(0o600)
+                        if kind == 'extra':
+                            (directory / 'pending').write_bytes(b'never replay')
+                before = sorted(str(path.relative_to(root)) for path in root.rglob('*'))
+                with self.assertRaises((store.CaptureError, OSError)):
+                    container.usage()
+                with self.assertRaises((store.CaptureError, OSError)):
+                    container.record(digest)
+                self.assertEqual(sorted(str(path.relative_to(root)) for path in root.rglob('*')), before)
+            finally:
+                container.close()
+        bundles = self.slot.child('bundles')
+        try:
+            bundles.verified_record(good)
+        finally:
+            bundles.close()
+
+    def test_cancel_before_capture_never_invokes_child(self):
+        self.slot.write('cancel.json', {'cancel': True})
+        with patch.object(capture, 'invoke') as invoke:
+            capture.service(BINDING)
+            invoke.assert_not_called()
+        self.assertEqual(store.decode(self.slot.read('status.json'))['state'], 'cancelled')
+
+    def test_cancel_during_readback_preserves_prior_success(self):
+        value = self.observation(b'bytes')
+        def invoke(*_):
+            self.slot.write('cancel.json', {'cancel': True})
+            return value
+        with patch.object(capture, 'invoke', side_effect=invoke):
+            capture.service(BINDING)
+        state = store.decode(self.slot.read('status.json'))
+        self.assertEqual(state['state'], 'cancelled')
+        self.assertIsNone(state['last_success'])
+
+    def test_access_time_is_ignored_but_all_integrity_fields_are_compared(self):
+        self.slot.write('value.json', {'safe': True})
+        path = Path(self.slot.path) / 'value.json'
+        before = path.stat()
+        os.utime(path, ns=(before.st_atime_ns + 1_000_000, before.st_mtime_ns))
+        self.assertEqual(store.decode(self.slot.read('value.json')), {'safe': True})
+        fields = ('st_dev', 'st_ino', 'st_mode', 'st_uid', 'st_gid', 'st_nlink', 'st_size', 'st_mtime_ns', 'st_ctime_ns')
+        values = dict((field, getattr(before, field)) for field in fields)
+        from types import SimpleNamespace
+        for field in fields:
+            changed = dict(values, **{field: values[field] + 1})
+            self.assertNotEqual(store.identity(SimpleNamespace(**values)), store.identity(SimpleNamespace(**changed)))
+
+    def test_private_read_rejects_links_fifo_wrong_mode_and_capacity(self):
+        self.slot.write('original.json', {'safe': True})
+        root = Path(self.slot.path)
+        os.symlink(root / 'original.json', root / 'link.json')
+        os.link(root / 'original.json', root / 'hard.json')
+        os.mkfifo(root / 'fifo.json', 0o600)
+        for name in ('link.json', 'original.json', 'hard.json', 'fifo.json'):
+            with self.assertRaises((OSError, store.CaptureError)):
+                self.slot.read(name)
+        self.slot.write('mode.json', {})
+        (root / 'mode.json').chmod(0o644)
+        with self.assertRaises(store.CaptureError):
+            self.slot.read('mode.json')
+        self.observation(b'12345')
+        bundles = self.slot.child('bundles')
+        try:
+            with patch.object(store, 'CAPACITY', 4), self.assertRaises(store.CaptureError):
+                bundles.usage()
+        finally:
+            bundles.close()
+
+    def test_ancestry_swap_and_unknown_record_names_fail_closed(self):
+        root = Path(self.slot.path)
+        renamed = root.with_name('old')
+        root.rename(renamed)
+        root.mkdir(mode=0o700)
+        with self.assertRaises(store.CaptureError):
+            self.slot.read('enrollment.json')
+        root.rmdir()
+        renamed.rename(root)
+        bundles = self.slot.child('bundles')
+        try:
+            (Path(bundles.path) / 'unaccounted').write_bytes(b'x')
+            with self.assertRaises(store.CaptureError):
+                bundles.usage()
+        finally:
+            bundles.close()
+
+    def test_status_is_noncreating_and_stale_or_corrupt_never_looks_current(self):
+        self.assertEqual(capture.status('b' * 64)['state'], 'absent')
+        self.assertFalse((Path(self.slot.path).parent / ('b' * 64)).exists())
+        value = self.observation(b'content')
+        state = self.run_service([value, store.CaptureError('failure')])
+        state['interval_seconds'] = capture.INTERVAL
+        for recorded in ('running', 'degraded'):
+            state['state'] = recorded
+            self.slot.write('status.json', state, True)
+            with patch.object(capture, 'now', return_value=state['last_success']['verified_at_millis'] + 31_000):
+                self.assertEqual(capture.status(BINDING)['state'], 'stale')
+        state['private-extra'] = 'must not be emitted'
+        self.slot.write('status.json', state, True)
+        with self.assertRaises(store.CaptureError):
+            capture.status(BINDING)
+
+    def test_actual_child_exit_race_false_green_output_and_deadline(self):
+        helper = self.root / 'helper'
+        response = {'version': 1, 'binding': BINDING, 'manifest': None,
+                    'record_sha256': None, 'record_bytes': None, 'reason': None}
+        for tail, accepted in [('', True), ('sys.exit(1)', False),
+                               ('print("x"*2000)', False), ('time.sleep(5)', False)]:
+            helper.write_text('#!/usr/bin/python3\nimport sys,time\nsys.stdin.buffer.read()\nprint(' + repr(json.dumps(response)) + ')\n' + tail + '\n')
+            helper.chmod(0o700)
+            with patch.object(capture, 'HELPER', str(helper)), patch.object(capture, 'ATTEMPT_SECONDS', .3):
+                if accepted:
+                    self.assertEqual(capture.invoke({}, True, 0), response)
+                else:
+                    with self.assertRaises((store.CaptureError, subprocess.SubprocessError)):
+                        capture.invoke({}, True, 0)
+
+    def test_changed_binding_and_capacity_exhaustion_retain_success(self):
+        first = self.observation(b'first')
+        wrong = dict(self.observation(b'wrong'), binding='b' * 64)
+        state = self.run_service([first, wrong])
+        self.assertEqual(state['generation'], 1)
+        self.assertEqual(state['last_success']['manifest'], first['manifest'])
+        self.assertEqual(state['state'], 'error')
+
+
+def literal_bundle(raw, manifest):
+    """Test-only v1 decoding: recover exact selected payloads, never apply to checkout."""
+    store.require(raw[:8] == b'HZOVLY\x00\x01')
+    length = int.from_bytes(raw[8:12], 'little')
+    metadata = raw[12:12 + length]
+    store.require(hashlib.sha256(metadata).hexdigest() == manifest)
+    plan = store.decode(metadata)
+    offset = 12 + length
+    count = int.from_bytes(raw[offset:offset + 4], 'little')
+    offset += 4
+    blobs = {}
+    for _ in range(count):
+        digest = raw[offset:offset + 64].decode()
+        size = int.from_bytes(raw[offset + 64:offset + 72], 'little')
+        offset += 72
+        payload = raw[offset:offset + size]
+        offset += size
+        store.require(len(payload) == size and hashlib.sha256(payload).hexdigest() == digest and digest not in blobs)
+        blobs[digest] = payload
+    store.require(offset == len(raw))
+    return plan, blobs
+
+
+def inside_proof():
+    """Synthetic initial Git receipts only; actual capture/start/status code is unmodified."""
+    root = Path('/workspace')
+    for directory in ('horizon', '.horizon-worker', 'horizon/repository', '.horizon-worker/git-workspace'):
+        (root / directory).mkdir(mode=0o700)
+    checkout = root / 'horizon/repository'
+    environment = dict(capture.ENV, GIT_CONFIG_NOSYSTEM='1', GIT_CONFIG_GLOBAL='/dev/null',
+                       GIT_AUTHOR_NAME='Synthetic Test', GIT_AUTHOR_EMAIL='fixture@example.invalid',
+                       GIT_COMMITTER_NAME='Synthetic Test', GIT_COMMITTER_EMAIL='fixture@example.invalid')
+    def git(*arguments):
+        return subprocess.run(['/usr/bin/git', '-C', str(checkout), *arguments], env=environment,
+                              capture_output=True, check=True, timeout=10).stdout.strip().decode()
+    git('init', '-b', 'work/capture')
+    (checkout / 'selected.txt').write_bytes(b'base\n')
+    (checkout / 'deleted.txt').write_bytes(b'deleted base\n')
+    git('add', 'selected.txt', 'deleted.txt')
+    git('commit', '-m', 'synthetic base')
+    preparation = {'version': 1, 'workspace_local_id': 'fixture',
+        'runtime_id': '00000000-0000-4000-8000-000000000001',
+        'source': {'repository': 'fixture/repository', 'commit': git('rev-parse', 'HEAD'), 'branch': 'work/capture'},
+        'work_branch': 'work/capture'}
+    metadata = checkout.stat()
+    claim = root / '.horizon-worker/git-workspace'
+    for name, value in [('claim.json', preparation), ('complete.json',
+            {'request': preparation, 'device': metadata.st_dev, 'inode': metadata.st_ino})]:
+        (claim / name).write_bytes(json.dumps(value, separators=(',', ':')).encode())
+        (claim / name).chmod(0o600)
+    (checkout / 'selected.txt').write_bytes(b'staged bytes\n')
+    git('add', 'selected.txt')
+    (checkout / 'selected.txt').write_bytes(b'first working bytes\n')
+    (checkout / 'untracked.txt').write_bytes(b'untracked protected bytes\n')
+    (checkout / 'deleted.txt').unlink()
+    (checkout / '.env').write_bytes(b'synthetic not selected\n')
+    enrollment = {'version': 1, 'preparation': preparation,
+                  'selected': ['selected.txt', 'untracked.txt', 'deleted.txt'], 'retained_volume_attested': True}
+    command = ['/usr/bin/python3', '-I', '-B', '/usr/local/bin/horizon-byte-capture']
+    def call(*args, data=None):
+        result = subprocess.run(command + list(args), input=data, capture_output=True, env=capture.ENV, timeout=20)
+        store.require(result.returncode == 0 and not result.stderr)
+        return store.decode(result.stdout)
+    result = call('start', data=store.encode(enrollment))
+    binding = result['binding']
+    try:
+        def wait_generation(generation):
+            deadline = time.monotonic() + 35
+            while time.monotonic() < deadline:
+                value = call('status', binding)
+                if value.get('generation', 0) >= generation:
+                    return value
+                store.require(value['state'] not in ('error', 'cancelled'))
+                time.sleep(.1)
+            raise store.CaptureError('synthetic proof deadline')
+        first = wait_generation(1)
+        # The start/controller subprocess has exited; no handle or heartbeat remains.
+        (checkout / 'selected.txt').write_bytes(b'second working bytes\n')
+        second = wait_generation(first['generation'] + 1)
+        store.require(first['last_success']['manifest'] != second['last_success']['manifest'])
+        interval = second['last_success']['verified_at_millis'] - first['last_success']['verified_at_millis']
+        store.require(0 < interval <= 30_000)
+        slot = store.open_slot(capture.BASE, binding)
+        bundles = slot.child('bundles')
+        try:
+            for record, payload in [(first, b'first working bytes\n'), (second, b'second working bytes\n')]:
+                success = record['last_success']
+                bundles.verified_record(success)
+                raw = bundles.record(success['manifest'])
+                plan, blobs = literal_bundle(raw, success['manifest'])
+                index = {entry['path']: entry for entry in plan['index']}
+                working = {entry['path']: entry for entry in plan['working_tree']}
+                store.require(blobs[index['selected.txt']['sha256']] == b'staged bytes\n'
+                    and blobs[working['selected.txt']['sha256']] == payload
+                    and blobs[working['untracked.txt']['sha256']] == b'untracked protected bytes\n'
+                    and working['deleted.txt']['kind'] == 'remove' and b'synthetic not selected' not in raw)
+                recovered = root / ('recovered-' + str(record['generation']))
+                recovered.mkdir(mode=0o700)
+                (recovered / 'selected.txt').write_bytes(blobs[working['selected.txt']['sha256']])
+                store.require((recovered / 'selected.txt').read_bytes() == payload)
+        finally:
+            bundles.close()
+            slot.close()
+        repeat = call('start', data=store.encode(enrollment))
+        store.require(repeat['binding'] == binding and repeat['state'] != 'submitted')
+        git('commit', '-m', 'synthetic changed baseline')
+        deadline = time.monotonic() + 25
+        while True:
+            refused = call('status', binding)
+            if refused['state'] == 'error':
+                break
+            store.require(time.monotonic() < deadline)
+            time.sleep(.1)
+        store.require(refused['generation'] == second['generation']
+                      and refused['last_success'] == second['last_success'])
+        print(json.dumps({'proof': 'controller exited; two verified byte versions', 'observed_interval_millis': interval}))
+    finally:
+        call('cancel', binding)
+        deadline = time.monotonic() + 20
+        while call('status', binding).get('recorded_state') not in ('cancelled', 'error'):
+            store.require(time.monotonic() < deadline)
+            time.sleep(.1)
+
+
+class ActualCli(unittest.TestCase):
+    def test_explicit_local_namespace_controller_exit(self):
+        if BINARY is None:
+            self.skipTest('requires explicit --binary candidate after source/build review')
+        binary = Path(BINARY).resolve(strict=True)
+        info = binary.stat()
+        self.assertTrue(stat.S_ISREG(info.st_mode) and info.st_uid == os.geteuid() and not info.st_mode & 0o022)
+        with tempfile.TemporaryDirectory(prefix='horizon-byte-capture-native-') as temporary:
+            arguments = ['/usr/bin/bwrap', '--unshare-all', '--new-session', '--die-with-parent', '--ro-bind', '/', '/',
+                '--dev', '/dev', '--proc', '/proc', '--tmpfs', '/tmp', '--tmpfs', '/home', '--tmpfs', '/root',
+                '--tmpfs', '/run', '--tmpfs', '/etc', '--tmpfs', '/usr/local/bin',
+                '--bind', temporary, '/workspace', '--ro-bind', str(binary), '/usr/local/bin/horizon-repository',
+                '--ro-bind', str(HERE / 'byte-capture.py'), '/usr/local/bin/horizon-byte-capture',
+                '--ro-bind', str(HERE / 'byte_capture_store.py'), '/usr/local/bin/byte_capture_store.py',
+                '--ro-bind', str(HERE), '/proof', '/usr/bin/python3', '-I', '-B', '/proof/test_byte_capture.py', '--inside']
+            result = subprocess.run(arguments, capture_output=True, env=capture.ENV, timeout=90, umask=0o077)
+            self.assertEqual(result.returncode, 0, result.stderr.decode(errors='replace'))
+            self.assertIn(b'two verified byte versions', result.stdout)
+
+
+if __name__ == '__main__':
+    if sys.argv[1:] == ['--inside']:
+        inside_proof()
+    else:
+        if len(sys.argv) >= 3 and sys.argv[1] == '--binary':
+            BINARY = sys.argv[2]
+            del sys.argv[1:3]
+        unittest.main()

--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -262,6 +262,28 @@ class PrivateFixture(unittest.TestCase):
         with self.assertRaises(store.CaptureError):
             capture.status(BINDING)
 
+    def test_status_freshness_uses_start_until_verified_success(self):
+        state = self.run_service([self.observation(b'content'), store.CaptureError('failure')])
+        state['interval_seconds'] = capture.INTERVAL
+        success = state['last_success']
+        started = success['verified_at_millis'] - 100_000
+        for reference in ('started', 'verified', 'missing'):
+            state['started_at_millis'] = None if reference == 'missing' else started
+            state['last_success'] = success if reference == 'verified' else None
+            state['generation'] = 1 if reference == 'verified' else 0
+            timestamp = success['verified_at_millis'] if reference == 'verified' else started
+            for recorded in ('running', 'degraded', 'error', 'cancelled'):
+                state['state'] = recorded
+                self.slot.write('status.json', state, True)
+                for age in (-1, 0, 29_999, 30_000, 30_001):
+                    with self.subTest(reference=reference, recorded=recorded, age=age), patch.object(capture, 'now', return_value=timestamp + age):
+                        observed = capture.status(BINDING)
+                        stale = reference == 'missing' or age < 0 or age > 30_000
+                        self.assertEqual(observed['stale'], stale)
+                        self.assertEqual(observed['recorded_state'], recorded)
+                        self.assertEqual(observed['state'], 'stale' if stale and recorded in ('running', 'degraded') else recorded)
+                        self.assertEqual(observed['last_success'], state['last_success'])
+
     def test_actual_child_exit_race_false_green_output_and_deadline(self):
         helper = self.root / 'helper'
         response = {'version': 1, 'binding': BINDING, 'manifest': None,

--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -311,6 +311,9 @@ def literal_bundle(raw, manifest):
 
 def inside_proof():
     """Synthetic initial Git receipts only; actual capture/start/status code is unmodified."""
+    usage = subprocess.run([capture.HELPER], capture_output=True, env=capture.ENV, timeout=5)
+    store.require(usage.returncode == 2 and not usage.stdout
+                  and b'capture-plan' in usage.stderr and b'capture-once' in usage.stderr)
     root = Path('/workspace')
     for directory in ('horizon', '.horizon-worker', 'horizon/repository', '.horizon-worker/git-workspace'):
         (root / directory).mkdir(mode=0o700)
@@ -391,6 +394,15 @@ def inside_proof():
             slot.close()
         repeat = call('start', data=store.encode(enrollment))
         store.require(repeat['binding'] == binding and repeat['state'] != 'submitted')
+        captures = root / '.horizon-worker/byte-captures'
+        lock = captures / binding / 'lock'
+        lock_identity = store.identity(lock.stat())
+        enrollment['selected'].reverse()
+        reordered = call('start', data=store.encode(enrollment))
+        store.require(reordered['binding'] == binding and reordered['state'] != 'submitted'
+                      and reordered['started_at_millis'] == first['started_at_millis']
+                      and list(captures.iterdir()) == [captures / binding]
+                      and store.identity(lock.stat()) == lock_identity)
         git('commit', '-m', 'synthetic changed baseline')
         deadline = time.monotonic() + 25
         while True:

--- a/containers/remote-worker/test_repository_packaging.py
+++ b/containers/remote-worker/test_repository_packaging.py
@@ -14,7 +14,8 @@ import tempfile
 
 CRATES = ("horizon-repository", "horizon-core", "horizon-browser", "horizon-browser-protocol")
 WORKER_FILES = {"Dockerfile", "build-tmux.sh", "entrypoint.sh", "host-identity.py", "rust-path.sh",
-                "session.sh", "github-credentials.py", "panel-session.py", "setup-launch.py", "tmux.conf", "sshd_config"}
+                "session.sh", "github-credentials.py", "panel-session.py", "setup-launch.py", "byte-capture.py",
+                "byte_capture_store.py", "tmux.conf", "sshd_config"}
 AGENT_PATHS = tuple("usr/local/bin/" + tool for tool in
                     ("codex", "claude", "gemini", "opencode", "kilo", "pi", "grok")) + tuple(
     "usr/local/lib/node_modules/" + package for package in

--- a/crates/horizon-repository/src/capture/mod.rs
+++ b/crates/horizon-repository/src/capture/mod.rs
@@ -90,8 +90,15 @@ struct Response {
     reason: Option<Reason>,
 }
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) enum Operation {
+    Binding,
+    Plan,
+    Once,
+}
+
 pub(super) fn run(
-    plan: bool,
+    operation: Operation,
     input: &mut impl Read,
     output: &mut impl Write,
     diagnostics: &mut impl Write,
@@ -118,7 +125,9 @@ pub(super) fn run(
         if request.available_bytes > CAPACITY {
             return Err(Reason::Invalid);
         }
-        execute(&request, &binding, plan, &mut response)?;
+        if operation != Operation::Binding {
+            execute(&request, &binding, operation == Operation::Plan, &mut response)?;
+        }
         response.binding = Some(binding);
         Ok(())
     })()

--- a/crates/horizon-repository/src/capture/mod.rs
+++ b/crates/horizon-repository/src/capture/mod.rs
@@ -24,7 +24,7 @@ use std::{
 const REQUEST_LIMIT: u64 = 128 * 1024;
 const CAPACITY: u64 = 1024 * 1024 * 1024;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct Enrollment {
     version: u8,
@@ -47,8 +47,10 @@ impl Enrollment {
                 return Err(Reason::Invalid);
             }
         }
+        let mut canonical = self.clone();
+        canonical.selected.sort_unstable();
         let mut bytes = b"horizon-retained-byte-capture-v1\0".to_vec();
-        bytes.extend(serde_json::to_vec(self).map_err(|_| Reason::Invalid)?);
+        bytes.extend(serde_json::to_vec(&canonical).map_err(|_| Reason::Invalid)?);
         Ok(ArtifactDigest::sha256(&bytes))
     }
 }

--- a/crates/horizon-repository/src/capture/mod.rs
+++ b/crates/horizon-repository/src/capture/mod.rs
@@ -1,0 +1,257 @@
+//! Explicit retained-volume byte capture, not a coherent snapshot or recovery checkpoint.
+
+#[cfg(target_os = "linux")]
+use horizon_core::repository_overlay::{
+    bundle::{
+        RepositoryOverlayBundle, codec,
+        store::{BundleStoreError, RepositoryBundleStore},
+    },
+    capture::{GitCaptureError, capture_selected},
+    reader::RepositoryReadError,
+};
+use horizon_core::{
+    cloud_run::ArtifactDigest,
+    repository_git::GitPreparation,
+    repository_overlay::{OverlayChange, OverlayContent},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeSet,
+    io::{Read, Write},
+    process::ExitCode,
+};
+
+const REQUEST_LIMIT: u64 = 128 * 1024;
+const CAPACITY: u64 = 1024 * 1024 * 1024;
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Enrollment {
+    version: u8,
+    preparation: GitPreparation,
+    selected: Vec<String>,
+    retained_volume_attested: bool,
+}
+
+impl Enrollment {
+    fn binding(&self) -> Result<ArtifactDigest, Reason> {
+        if self.version != 1 || !self.retained_volume_attested || self.selected.is_empty() || self.selected.len() > 128
+        {
+            return Err(Reason::Invalid);
+        }
+        self.preparation.binding().map_err(|_| Reason::Invalid)?;
+        let mut unique = BTreeSet::new();
+        for path in &self.selected {
+            OverlayChange::new(path.clone(), OverlayContent::Remove).map_err(|_| Reason::Invalid)?;
+            if !unique.insert(path) {
+                return Err(Reason::Invalid);
+            }
+        }
+        let mut bytes = b"horizon-retained-byte-capture-v1\0".to_vec();
+        bytes.extend(serde_json::to_vec(self).map_err(|_| Reason::Invalid)?);
+        Ok(ArtifactDigest::sha256(&bytes))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Request {
+    enrollment: Enrollment,
+    available_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Reason {
+    Invalid,
+    #[cfg(not(target_os = "linux"))]
+    Unsupported,
+    #[cfg(target_os = "linux")]
+    Identity,
+    #[cfg(target_os = "linux")]
+    Capture,
+    #[cfg(target_os = "linux")]
+    Changed,
+    #[cfg(target_os = "linux")]
+    Capacity,
+    #[cfg(target_os = "linux")]
+    Storage,
+}
+
+#[derive(Serialize)]
+struct Response {
+    version: u8,
+    binding: Option<ArtifactDigest>,
+    manifest: Option<ArtifactDigest>,
+    record_sha256: Option<ArtifactDigest>,
+    record_bytes: Option<u64>,
+    reason: Option<Reason>,
+}
+
+pub(super) fn run(
+    plan: bool,
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+) -> ExitCode {
+    let mut response = Response {
+        version: 1,
+        binding: None,
+        manifest: None,
+        record_sha256: None,
+        record_bytes: None,
+        reason: None,
+    };
+    response.reason = (|| {
+        let mut bytes = Vec::new();
+        input
+            .take(REQUEST_LIMIT + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| Reason::Invalid)?;
+        if bytes.len() as u64 > REQUEST_LIMIT {
+            return Err(Reason::Invalid);
+        }
+        let request: Request = serde_json::from_slice(&bytes).map_err(|_| Reason::Invalid)?;
+        let binding = request.enrollment.binding()?;
+        if request.available_bytes > CAPACITY {
+            return Err(Reason::Invalid);
+        }
+        execute(&request, &binding, plan, &mut response)?;
+        response.binding = Some(binding);
+        Ok(())
+    })()
+    .err();
+    let code = match response.reason {
+        None => 0,
+        Some(Reason::Invalid) => 2,
+        #[cfg(not(target_os = "linux"))]
+        Some(Reason::Unsupported) => 2,
+        #[cfg(target_os = "linux")]
+        Some(_) => 1,
+    };
+    super::write_response(&response, code, 1024, output, diagnostics)
+}
+
+#[cfg(target_os = "linux")]
+fn execute(request: &Request, binding: &ArtifactDigest, plan: bool, response: &mut Response) -> Result<(), Reason> {
+    use std::{fs, os::unix::fs::MetadataExt};
+    let preparation = &request.enrollment.preparation;
+    let before = preparation.inspect_checkout().map_err(|_| Reason::Identity)?;
+    if plan {
+        return Ok(());
+    }
+    let root = std::path::PathBuf::from("/workspace/.horizon-worker/byte-captures")
+        .join(binding.as_str())
+        .join("bundles");
+    // Storage and capture both reject symlinked ancestry. Stable trusted ownership
+    // is required; these checks do not defend against a malicious worker owner.
+    let store = RepositoryBundleStore::open_named(&root).map_err(|_| Reason::Storage)?;
+    let destination = fs::symlink_metadata(&root).map_err(|_| Reason::Storage)?;
+    if destination.dev() != before.device {
+        return Err(Reason::Identity);
+    }
+    let selected: Vec<_> = request.enrollment.selected.iter().map(String::as_str).collect();
+    let bundle = capture_selected(std::path::Path::new(before.path), preparation.source.clone(), &selected).map_err(
+        |error| match error {
+            GitCaptureError::Changed | GitCaptureError::Read(RepositoryReadError::Changed) => Reason::Changed,
+            _ => Reason::Capture,
+        },
+    )?;
+    if preparation.inspect_checkout().map_err(|_| Reason::Identity)? != before {
+        return Err(Reason::Identity);
+    }
+    let encoded = codec::encode(&bundle).map_err(|_| Reason::Capture)?;
+    let length = encoded.len() as u64;
+    if needs_space(store.get(bundle.manifest_sha256()), &bundle)?
+        && length > request.available_bytes.min(available(&root, destination.uid())?)
+    {
+        return Err(Reason::Capacity);
+    }
+    let record_sha256 = ArtifactDigest::sha256(&encoded);
+    drop(encoded);
+    let digest = store.put(&bundle).map_err(|_| Reason::Storage)?;
+    let readback = store.get(&digest).map_err(|_| Reason::Storage)?;
+    if readback != bundle || preparation.inspect_checkout().map_err(|_| Reason::Identity)? != before {
+        return Err(Reason::Identity);
+    }
+    let after = fs::symlink_metadata(&root).map_err(|_| Reason::Storage)?;
+    if (after.dev(), after.ino()) != (destination.dev(), destination.ino()) {
+        return Err(Reason::Identity);
+    }
+    response.manifest = Some(digest);
+    response.record_sha256 = Some(record_sha256);
+    response.record_bytes = Some(length);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn needs_space(
+    existing: Result<RepositoryOverlayBundle, BundleStoreError>,
+    expected: &RepositoryOverlayBundle,
+) -> Result<bool, Reason> {
+    match existing {
+        Ok(value) if value == *expected => Ok(false),
+        Err(BundleStoreError::Missing) => Ok(true),
+        _ => Err(Reason::Storage),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn available(root: &std::path::Path, owner: u32) -> Result<u64, Reason> {
+    use std::os::unix::fs::MetadataExt;
+    let device = std::fs::symlink_metadata(root).map_err(|_| Reason::Storage)?.dev();
+    let mut total = 0u64;
+    for (index, entry) in std::fs::read_dir(root).map_err(|_| Reason::Storage)?.enumerate() {
+        if index >= 4095 {
+            return Err(Reason::Capacity);
+        }
+        let entry = entry.map_err(|_| Reason::Storage)?;
+        let name = entry.file_name();
+        let stem = name.to_str().ok_or(Reason::Storage)?;
+        if stem.len() != 64
+            || !stem
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(Reason::Storage);
+        }
+        let slot = std::fs::symlink_metadata(entry.path()).map_err(|_| Reason::Storage)?;
+        if !slot.is_dir()
+            || slot.uid() != owner
+            || slot.mode() & 0o7777 != 0o700
+            || slot.nlink() == 0
+            || slot.dev() != device
+        {
+            return Err(Reason::Storage);
+        }
+        let mut contents = std::fs::read_dir(entry.path()).map_err(|_| Reason::Storage)?;
+        let record = contents.next().ok_or(Reason::Storage)?.map_err(|_| Reason::Storage)?;
+        if record.file_name() != "record.hzov" || contents.next().is_some() {
+            return Err(Reason::Storage); // Partial claims are retained, never treated as reusable capacity.
+        }
+        let metadata = std::fs::symlink_metadata(record.path()).map_err(|_| Reason::Storage)?;
+        if !metadata.is_file()
+            || metadata.uid() != owner
+            || metadata.mode() & 0o7777 != 0o600
+            || metadata.nlink() != 1
+            || metadata.dev() != device
+            || metadata.len() == 0
+            || metadata.len() > codec::MAX_ENCODED_BUNDLE_BYTES as u64
+        {
+            return Err(Reason::Storage);
+        }
+        total = total
+            .checked_add(metadata.len())
+            .filter(|total| *total <= CAPACITY)
+            .ok_or(Reason::Capacity)?;
+    }
+    Ok(CAPACITY - total)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn execute(_: &Request, _: &ArtifactDigest, _: bool, _: &mut Response) -> Result<(), Reason> {
+    Err(Reason::Unsupported)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/capture/tests.rs
+++ b/crates/horizon-repository/src/capture/tests.rs
@@ -52,7 +52,7 @@ fn reordered_selection_keeps_identity_but_changed_paths_do_not() {
 
 #[test]
 fn rejection_is_bounded_redacted_and_never_acknowledges_capture() {
-    for plan in [false, true] {
+    for operation in [Operation::Binding, Operation::Plan, Operation::Once] {
         for bytes in [
             b"private malformed bytes".to_vec(),
             vec![b' '; usize::try_from(REQUEST_LIMIT).unwrap() + 1],
@@ -61,7 +61,7 @@ fn rejection_is_bounded_redacted_and_never_acknowledges_capture() {
         ] {
             let mut output = vec![];
             assert_eq!(
-                run(plan, &mut bytes.as_slice(), &mut output, &mut std::io::sink()),
+                run(operation, &mut bytes.as_slice(), &mut output, &mut std::io::sink()),
                 ExitCode::from(2)
             );
             let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
@@ -74,13 +74,35 @@ fn rejection_is_bounded_redacted_and_never_acknowledges_capture() {
     }
     assert_eq!(
         run(
-            true,
+            Operation::Plan,
             &mut b"{}".as_slice(),
             &mut [0; 0].as_mut_slice(),
             &mut std::io::sink()
         ),
         ExitCode::from(3)
     );
+}
+
+#[test]
+fn pure_binding_needs_no_checkout_and_never_acknowledges_capture() {
+    let request = enrollment();
+    let expected = request.binding().unwrap();
+    let input = serde_json::to_vec(&serde_json::json!({"enrollment":request,"available_bytes":0})).unwrap();
+    let mut output = vec![];
+    assert_eq!(
+        run(
+            Operation::Binding,
+            &mut input.as_slice(),
+            &mut output,
+            &mut std::io::sink()
+        ),
+        ExitCode::SUCCESS
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(value["binding"], expected.as_str());
+    for field in ["manifest", "record_sha256", "record_bytes", "reason"] {
+        assert!(value[field].is_null());
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/horizon-repository/src/capture/tests.rs
+++ b/crates/horizon-repository/src/capture/tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+fn enrollment() -> Enrollment {
+    serde_json::from_value(serde_json::json!({"version":1,
+        "preparation":{"version":1,"workspace_local_id":"fixture",
+            "runtime_id":"00000000-0000-4000-8000-000000000001",
+            "source":{"repository":"fixture/repository","commit":"a".repeat(40),"branch":"work/one"},
+            "work_branch":"work/one"},
+        "selected":["source.txt"],"retained_volume_attested":true}))
+    .unwrap()
+}
+
+#[test]
+fn binding_is_explicit_and_rejects_excluded_or_ambiguous_selection() {
+    let original = enrollment().binding().unwrap();
+    for paths in [
+        vec![],
+        vec![".env"],
+        vec![".ssh/key"],
+        vec!["../other"],
+        vec!["a", "a"],
+        vec!["node_modules/a"],
+        vec!["a"; 129],
+    ] {
+        let mut request = enrollment();
+        request.selected = paths.into_iter().map(str::to_owned).collect();
+        assert!(request.binding().is_err());
+    }
+    let mut request = enrollment();
+    request.retained_volume_attested = false;
+    assert!(request.binding().is_err());
+    request.retained_volume_attested = true;
+    request.selected.push("second.txt".to_owned());
+    assert_ne!(request.binding().unwrap(), original);
+    request = enrollment();
+    request.preparation.workspace_local_id = "another".to_owned();
+    assert_ne!(request.binding().unwrap(), original);
+}
+
+#[test]
+fn rejection_is_bounded_redacted_and_never_acknowledges_capture() {
+    for plan in [false, true] {
+        for bytes in [
+            b"private malformed bytes".to_vec(),
+            vec![b' '; usize::try_from(REQUEST_LIMIT).unwrap() + 1],
+            b"{}{}".to_vec(),
+            b"{\"enrollment\":{},\"available_bytes\":0}".to_vec(),
+        ] {
+            let mut output = vec![];
+            assert_eq!(
+                run(plan, &mut bytes.as_slice(), &mut output, &mut std::io::sink()),
+                ExitCode::from(2)
+            );
+            let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+            assert_eq!(value["reason"], "invalid");
+            for field in ["binding", "manifest", "record_sha256", "record_bytes"] {
+                assert!(value[field].is_null());
+            }
+            assert!(!String::from_utf8(output).unwrap().contains("private"));
+        }
+    }
+    assert_eq!(
+        run(
+            true,
+            &mut b"{}".as_slice(),
+            &mut [0; 0].as_mut_slice(),
+            &mut std::io::sink()
+        ),
+        ExitCode::from(3)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn encoded_existing_bundle_needs_no_new_quota_but_missing_and_invalid_are_distinct() {
+    use horizon_core::repository_overlay::{RepositoryOverlayPlan, bundle::VerifiedOverlayBlob};
+    let blob = VerifiedOverlayBlob::new(b"protected literal bytes".to_vec()).unwrap();
+    let change = OverlayChange::new(
+        "selected.txt".into(),
+        OverlayContent::File {
+            sha256: blob.sha256().clone(),
+            bytes: blob.bytes().len() as u64,
+            executable: false,
+        },
+    )
+    .unwrap();
+    let plan = RepositoryOverlayPlan::new(enrollment().preparation.source, [], [change]).unwrap();
+    let bundle = RepositoryOverlayBundle::new(plan, [blob]).unwrap();
+    let encoded = codec::encode(&bundle).unwrap();
+    let decoded = codec::decode(&encoded).unwrap();
+    assert_eq!(decoded, bundle);
+    assert!(!needs_space(Ok(decoded), &bundle).unwrap());
+    assert!(needs_space(Err(BundleStoreError::Missing), &bundle).unwrap());
+    assert!(matches!(
+        needs_space(Err(BundleStoreError::Conflict), &bundle),
+        Err(Reason::Storage)
+    ));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn named_capacity_counts_complete_slots_and_never_admits_partial_or_flat_records() {
+    use std::{
+        fs,
+        os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt},
+    };
+    struct Fixture(std::path::PathBuf);
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+    let path = std::env::temp_dir().join(format!(
+        "horizon-capture-capacity-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::DirBuilder::new().mode(0o700).create(&path).unwrap();
+    let root = Fixture(path);
+    let owner = root.0.metadata().unwrap().uid();
+    assert_eq!(available(&root.0, owner).unwrap(), CAPACITY);
+    for index in 0..8 {
+        let slot = root.0.join(format!("{index:064x}"));
+        fs::create_dir(&slot).unwrap();
+        fs::set_permissions(&slot, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(matches!(available(&root.0, owner), Err(Reason::Storage)));
+        let file = fs::File::create(slot.join("record.hzov")).unwrap();
+        file.set_permissions(fs::Permissions::from_mode(0o600)).unwrap();
+        file.set_len(CAPACITY / 8).unwrap();
+    }
+    assert_eq!(available(&root.0, owner).unwrap(), 0);
+    let flat = root.0.join(format!("{}.hzov", "a".repeat(64)));
+    fs::write(flat, b"not the selected layout").unwrap();
+    assert!(matches!(available(&root.0, owner), Err(Reason::Storage)));
+}

--- a/crates/horizon-repository/src/capture/tests.rs
+++ b/crates/horizon-repository/src/capture/tests.rs
@@ -38,6 +38,19 @@ fn binding_is_explicit_and_rejects_excluded_or_ambiguous_selection() {
 }
 
 #[test]
+fn reordered_selection_keeps_identity_but_changed_paths_do_not() {
+    let mut request = enrollment();
+    request.selected = vec!["z.txt".into(), "a.txt".into(), "source.txt".into()];
+    let original = request.binding().unwrap();
+    request.selected.reverse();
+    assert_eq!(request.binding().unwrap(), original);
+    request.selected.sort();
+    assert_eq!(request.binding().unwrap(), original);
+    request.selected[0] = "changed.txt".into();
+    assert_ne!(request.binding().unwrap(), original);
+}
+
+#[test]
 fn rejection_is_bounded_redacted_and_never_acknowledges_capture() {
     for plan in [false, true] {
         for bytes in [

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod capture;
 mod git;
 mod intake;
 mod pack;
@@ -22,6 +23,8 @@ fn main() -> ExitCode {
             command,
             Some(
                 "materialize"
+                    | "capture-plan"
+                    | "capture-once"
                     | "setup"
                     | "setup-binding"
                     | "setup-checkout"
@@ -50,6 +53,8 @@ fn main() -> ExitCode {
     let mut output = io::stdout().lock();
     let mut diagnostics = io::stderr().lock();
     match command {
+        Some("capture-plan") => capture::run(true, &mut input, &mut output, &mut diagnostics),
+        Some("capture-once") => capture::run(false, &mut input, &mut output, &mut diagnostics),
         Some("git-binding") => git::inspect(false, &mut input, &mut output, &mut diagnostics),
         Some("git-checkout") => git::inspect(true, &mut input, &mut output, &mut diagnostics),
         Some("git-prepare") => git::run(false, &mut input, &mut output, &mut diagnostics),

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> ExitCode {
             command,
             Some(
                 "materialize"
+                    | "capture-binding"
                     | "capture-plan"
                     | "capture-once"
                     | "setup"
@@ -45,7 +46,7 @@ fn main() -> ExitCode {
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|capture-plan|capture-once|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
+            "Usage: horizon-repository materialize|capture-binding|capture-plan|capture-once|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
         );
         return ExitCode::from(2);
     }
@@ -53,8 +54,9 @@ fn main() -> ExitCode {
     let mut output = io::stdout().lock();
     let mut diagnostics = io::stderr().lock();
     match command {
-        Some("capture-plan") => capture::run(true, &mut input, &mut output, &mut diagnostics),
-        Some("capture-once") => capture::run(false, &mut input, &mut output, &mut diagnostics),
+        Some("capture-binding") => capture::run(capture::Operation::Binding, &mut input, &mut output, &mut diagnostics),
+        Some("capture-plan") => capture::run(capture::Operation::Plan, &mut input, &mut output, &mut diagnostics),
+        Some("capture-once") => capture::run(capture::Operation::Once, &mut input, &mut output, &mut diagnostics),
         Some("git-binding") => git::inspect(false, &mut input, &mut output, &mut diagnostics),
         Some("git-checkout") => git::inspect(true, &mut input, &mut output, &mut diagnostics),
         Some("git-prepare") => git::run(false, &mut input, &mut output, &mut diagnostics),

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> ExitCode {
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
+            "Usage: horizon-repository materialize|capture-plan|capture-once|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
         );
         return ExitCode::from(2);
     }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -11,6 +11,12 @@ back into large multi-purpose modules.
   the explicit named layout owns permanent digest slots in a focused Linux leaf.
   Neither layout discovers data, transfers it, schedules capture or certifies
   provider durability. See [named publication](named-bundle-publication.md).
+- Explicit worker byte capture keeps request validation and existing core
+  capture/bundle reuse in `horizon-repository::capture`; `byte-capture.py` owns
+  the detached bounded-attempt loop and `byte_capture_store.py` owns private
+  records. No provider lifecycle or automatic enrollment is implied. See
+  [worker byte capture](worker-byte-capture.md) for the non-atomic protection
+  boundary and retained-volume attestation.
 - Prepared task admission keeps immutable intake/setup selection and read-only
   checkout inspection in `repository_overlay::intake::setup`. The fixed
   `setup-binding` and `setup-checkout` helpers never materialize or start tasks.

--- a/docs/architecture/worker-byte-capture.md
+++ b/docs/architecture/worker-byte-capture.md
@@ -32,6 +32,9 @@ Neither image entrypoint nor workspace setup automatically enrolls a capture.
 replaying capture, deleting data or stopping tasks. A repeated `start` observes
 an existing enrollment regardless of selected-path order and does not restart a cancelled, failed or uncertain
 service. A consumed enrollment with no status is `claimed_unknown`, not success.
+The pure `capture-binding` command derives enrollment identity without checkout
+access. Existing enrollment status is read before checkout admission; a new
+enrollment still requires `capture-plan` validation before its exclusive claim.
 
 ## Publication and limits
 

--- a/docs/architecture/worker-byte-capture.md
+++ b/docs/architecture/worker-byte-capture.md
@@ -1,0 +1,94 @@
+# Worker-owned versioned byte capture
+
+This opt-in Linux worker operation protects an explicitly selected set of dirty
+Git paths on an explicitly attested retained volume. It is **not an atomic or
+application-consistent snapshot, an independent backup, or a full repository/task
+checkpoint**. It does not advance `RepositoryCheckpoint` or authorize Delete.
+
+`horizon-byte-capture start` reads a bounded JSON enrollment from stdin:
+
+```json
+{
+  "version": 1,
+  "preparation": { "version": 1, "workspace_local_id": "example", "runtime_id": "00000000-0000-4000-8000-000000000001", "source": { "repository": "example/repository", "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "branch": "work/example" }, "work_branch": "work/example" },
+  "selected": ["src/example.rs", "notes.txt"],
+  "retained_volume_attested": true
+}
+```
+
+Use the exact existing Git preparation identity, not the illustrative values.
+The explicit attestation means the operator has selected retained storage; the
+service does not independently prove provider retention, replication, mount
+replacement or durability. The destination and checkout must be on the same
+filesystem. Selection is explicit; existing capture policy refuses excluded
+credential/configuration/cache paths, unsupported nodes and ambiguous index
+state. This policy is not a content-based secret detector: only enroll paths
+whose contents are authorized for this same-volume private capture.
+
+The launcher severs controller I/O and starts one worker-owned process. There is
+no client heartbeat, mandatory product lifetime or provider lifecycle action.
+Neither image entrypoint nor workspace setup automatically enrolls a capture.
+`status <binding>` reads only; `cancel <binding>` records cancellation without
+replaying capture, deleting data or stopping tasks. A repeated `start` observes
+an existing enrollment and does not restart a cancelled, failed or uncertain
+service. A consumed enrollment with no status is `claimed_unknown`, not success.
+
+## Publication and limits
+
+- The private destination is
+  `/workspace/.horizon-worker/byte-captures/<binding>`, outside the checkout.
+  Checkout identity is checked against its completed preparation receipt.
+- Each attempt uses the existing literal index/worktree capture and immutable
+  digest-named bundle store. File synchronization, publication, complete bundle
+  readback and encoded-byte hash verification precede success recording.
+  Publication explicitly selects the named layout: `bundles/<digest>/record.hzov`.
+  Anonymous-layout files are not imported or treated as free capacity. Incomplete
+  digest claims remain permanently retained and cause visible refusal; no reclaim
+  or publication replay is automatic. Selected-filesystem validation is still
+  required; local named publication is not HPS qualification or durability proof.
+- Bundles and first-success receipts for each distinct content version remain
+  immutable. Current status is atomically replaced and synchronized. Publication
+  or response uncertainty can leave an unacknowledged bundle; it remains counted
+  against capacity. No garbage collection or overwrite recovery is automatic.
+- The target cadence is 10 seconds. Status records capture start/end, current and
+  preceding verified-success times; the measured interval, not the timer setting,
+  determines whether the 30-second target was met. After 30 seconds without a
+  verified success, status is stale. A stored `running` state is not live process
+  proof; stale running observations are presented as stale.
+- Capture-detected concurrent edits are retryable: status becomes `degraded`,
+  preserving the prior verified success, and the next interval samples again.
+  A verified success clears degradation. Identity, unsupported-content, storage
+  and capacity errors remain terminal; no automatic enrollment restart occurs.
+- Maximum selection is 128 paths; existing limits are 64 MiB per file and
+  128 MiB distinct payload per bundle. Complete encoded records are accounted
+  separately, up to a 1 GiB per-enrollment record budget and 4,096 records.
+  Metadata consumes additional bounded space. Capacity exhaustion is visible;
+  it never deletes prior versions. New enrollments require new explicit action.
+  An already verified identical bundle needs no additional quota and is
+  resynchronized/read back even at the byte or record-count ceiling.
+- Each capture child has a 15-second watchdog, 15 CPU-second limit, 2 GiB virtual
+  memory limit and 160 MiB per-file write limit. Cancellation targets only that
+  newly created child. These bounds do not promise hard process teardown or
+  bounded filesystem latency for an uninterruptible storage operation.
+
+The initial exact commit remains the capture base. A later commit/HEAD change
+fails visibly and retains previous captures; automatic re-enrollment, Git
+history protection, submodule recursion, agent/task resumption, write freezing,
+verified-loss replacement and destructive-Delete gates are separate outcomes.
+Versioned literal captures can mix file times. Even retained storage is not
+protection against deleting that storage or every provider failure mode.
+
+## Local proof
+
+Run `python3 -B -W error containers/remote-worker/test_byte_capture.py` for pure
+guards. After exact-source review and candidate build, explicitly add
+`--binary /absolute/path/to/horizon-repository` for a network-isolated bwrap
+namespace. A private temporary directory is mounted at `/workspace`; the host
+path is not modified. The fixture constructs synthetic initial Git receipts
+(it is not a Git-setup/provider acceptance test), then uses actual worker CLI
+start/status/cancel and capture code. It proves controller process exit, two
+versions within the observed target interval, staged/unstaged/untracked/removal
+bytes, readback into fresh scratch paths, unchanged prior versions, and visible
+failure after HEAD drift. No credentials, provider resources or image upload
+are involved. Exact-head runtime results are still required; preparing this
+recipe does not claim they passed.

--- a/docs/architecture/worker-byte-capture.md
+++ b/docs/architecture/worker-byte-capture.md
@@ -30,7 +30,7 @@ no client heartbeat, mandatory product lifetime or provider lifecycle action.
 Neither image entrypoint nor workspace setup automatically enrolls a capture.
 `status <binding>` reads only; `cancel <binding>` records cancellation without
 replaying capture, deleting data or stopping tasks. A repeated `start` observes
-an existing enrollment and does not restart a cancelled, failed or uncertain
+an existing enrollment regardless of selected-path order and does not restart a cancelled, failed or uncertain
 service. A consumed enrollment with no status is `claimed_unknown`, not success.
 
 ## Publication and limits


### PR DESCRIPTION
## Purpose

Add an explicit Linux worker-owned versioned byte-capture service toward #471. It protects selected dirty Git bytes on operator-attested retained storage, independently of the controller process. This is not a full repository/task checkpoint or an independent backup.

## Behavior

- `horizon-byte-capture start` takes an explicit saved Git preparation and supported path selection. The worker captures literal staged/working/untracked/removal content into private named records outside the checkout; no automatic enrollment, network transfer or selection expansion.
- Verify publication and exact encoded-byte readback before advancing success. Retain previous versions and incomplete claims; no overwrite recovery or automatic cleanup.
- Retry capture-detected concurrent edits with visible degraded/stale status. Identity, unsupported content, storage and capacity failures stop visibly. Explicit status/cancel and repeated-Start observation never replay enrollment, including equivalent reordered path selections.
- Target a 10-second cadence, report observed success timestamps and stale gaps, and bound each child attempt. No mandatory service expiry; identical records can be verified again at full quota.

## Evidence

- Focused Rust tests: repository CLI 43, selected capture 19, bundle store 25; pure Python guards 19 and static packaging checks passed. The existing worker build-context CI job now runs the pure capture guards with the native lane explicitly skipped there.
- Local actual-CLI proof: all 20 tests passed, including two verified versions 10,047 ms apart after controller exit, literal-byte readback, exact and reordered repeated-Start observation and prior-success retention after HEAD drift. The measured interval is not an unconditional scheduling guarantee.
- The initial native fixture failed before product startup because its read-only root lacked `/workspace`. A test-only private-root correction passed; the failed intent/logs remain separate evidence.
- The first post-CI full matrix stopped on an unexplained stderr assertion in an unchanged browser-CLI speech test. Its single exact-binary diagnostic replay passed; both records are retained separately from final validation, without claiming a proven cause.
- The selection-order regression failed against the original implementation and passed after canonicalization. Fresh corrected native proof also verified one enrollment slot, unchanged service identity and complete CLI usage guidance.
- The fresh-service status regression failed before the fix and passed afterward: 60 timing/state cases cover the first-success window, the 30-second boundary, missing timestamps, clock reversal and terminal states. A status that is not yet stale does not claim a verified capture or live process.
- Repeated Start now derives its binding without checkout access and observes an existing enrollment before admission. Native tests cover missing/replaced checkout and completion receipts: retained success and service identity stay unchanged, while a new enrollment is refused without creating a slot. Exclusive-claim races observe the winner without relaunch.
- Full exact-head validation on `49dca65701913127c1103c8a9e6ac713d3adc951`: all eight gates passed; default tests 2,526 and speech tests 2,571, each with zero failures and seven ignored tests across 26 suites. Formatting, maintainability, version synchronization and all three Clippy tiers passed.

Scope: ten source/test/packaging/CI files, 1,466 changed lines, plus architecture documentation. Native proof uses a candidate CLI and copied scripts with synthetic Git preparation receipts, not a complete image or provider campaign. No HPS qualification, physical durability, atomic snapshot, replacement recovery, destructive-Delete authority, cloud allocation, credential transfer or image publication is claimed.
