### PR TITLE
test(azure): observer-key lifecycle, bounded cleanup and build record

### DIFF
--- a/docs/testing/azure-client-off-acceptance.md
+++ b/docs/testing/azure-client-off-acceptance.md
@@ -68,16 +68,17 @@ credentials and identifiers stay private.
 ## Procedure
 
 1. **Prepare locally** (Linux controller with GNU `timeout`). In a fully clean
-   checkout at `client_sha` run `record-client-build.sh --out client-build.json` (lands
-   in the slice after this one): it
+   checkout at `client_sha` run `record-client-build.sh --out client-build.json`: it
    refuses modified or untracked files, builds the `horizon` binary for
    `x86_64-unknown-linux-gnu` from that tree, refuses anything that is not an ELF
    x86-64 binary, and records HEAD together with the digest of the binary it just
    produced, so the digest can only belong to that commit; confirm the worker image digest is pullable by the pull identity; generate
    a fresh Ed25519 key pair for A (`key`, `key.pub`); record the pre-existing resource
    groups in the manifest subscription as JSON
-   (`az group list --subscription <id> --query '[].name' -o json > groups.json`) for
-   the cleanup comparison.
+   (`az group list --subscription <id> --query '[].name' -o json > groups.json`) and
+   the pre-existing resources
+   (`az resource list --subscription <id> --query '[].id' -o json > resources.json`)
+   for the cleanup comparison.
 2. **Provision A** (the script lands in a following slice; the contract below is what
    it must meet): `provision-client.sh --manifest m.json --ssh-private-key key
    --horizon-binary <binary from the record> --build-record client-build.json
@@ -134,9 +135,8 @@ credentials and identifiers stay private.
    components, so no two spellings can name one file), and the identity
    recorded now, before A is stopped: `group_id`, `vm_id`, `instance_id` (the VM's
    `vmId`, which a same-name recreation does not keep) and `host` as ARM reports them.
-   Then install the observer key as a restricted key (`install-observer-key`, which
-   lands in the slice after this one together with `observer-key-line` and
-   `remove-observer-key`). The worker image authorises `HORIZON_SSH_PUBLIC_KEY` as an
+   Then install the observer key as a restricted key: `client_off.py --manifest m.json
+   install-observer-key --worker worker.json --public-key observer.pub`. The worker image authorises `HORIZON_SSH_PUBLIC_KEY` as an
    unrestricted root key, so a plain key would not be a read-only channel; the
    harness instead appends one `authorized_keys` line of the form
    `restrict,command="<reader>" ssh-ed25519 ...` inside the worker container through
@@ -145,8 +145,16 @@ credentials and identifiers stay private.
    user rc; the forced reader (its source and arguments travel base64-encoded, so no
    quoting layer can alter them) opens the two paths component by component with
    `O_NOFOLLOW` below `/workspace`, returns a capped prefix of regular files only and
-   prints one JSON object, whatever command the client asked for. The off phase
-   requires this channel to answer before A is touched. The line lives in the running
+   prints one JSON object naming the paths it was installed for, whatever command
+   the client asked for; the off phase and every sample require those echoed paths to
+   be exactly the descriptor's, so a stale or foreign observer line can never supply
+   another task's counter. The off phase
+   requires this channel to answer before A is touched. The install step probes first
+   and appends nothing unless B explicitly refuses the key (an answer means it is
+   already installed; anything else leaves the state unknown and appends nothing);
+   afterwards it requires the forced reader to answer a session that requested `id`,
+   and refuses the key otherwise. `observer-key-line` prints the same line for
+   inspection or for an image that installs it itself. The line lives in the running
    container only: the worker entrypoint rewrites `authorized_keys` on every container
    start. A first-class observer account in the worker image is lead-owned and would
    replace this step.
@@ -187,8 +195,9 @@ credentials and identifiers stay private.
    power state and public address as ARM reports them, and the counter and
    checkpoint sequence through one restricted, pinned session to that address only
    (any answer other than the forced reader's JSON object is an unreadable sample).
-   B's identity is read again after its state and reading; if it changed in
-   between, the sample keeps the identity it named but no state or reading. Each
+   B's identity is read again after its state and reading (ARM IDs compared
+   case-insensitively, instance identity, image tag and endpoint exactly); if it
+   changed in between, the sample keeps the identity it named but no state or reading. Each
    sample's instant is taken at its start, so acquisition latency never makes it late. The journal is one JSON line per sample and its
    path must be unused.
 5. **Return**: `client_off.py --manifest m.json return --client client.json`. Bound
@@ -213,14 +222,22 @@ credentials and identifiers stay private.
 7. **Worker lifecycle** is a different assertion, already covered by the adapter's
    live driver (Stop, explicit start, pinned reattach). Do not Stop or start B during
    the off interval.
-8. **Remove the observer key** (lands in the slice after this one): once the return
-   and the reconnect check on A are done and before the run is reported finished, the
-   observer's `authorized_keys` line is removed from B through the run-command
-   channel and the removal is proven by B refusing the key. Until that slice lands, a
-   run must not be reported finished while the observer key is authorized on a B
-   that outlives it.
+8. **Remove the observer key**: `client_off.py --manifest m.json remove-observer-key
+   --worker worker.json --public-key observer.pub`, once the return and the reconnect
+   check on A are done and before the run is reported finished. B may outlive the
+   run (a product worker is left in place by cleanup), and the run's observer private
+   key must not keep a reading channel into it. The phase attests B, removes exactly
+   the observer's `authorized_keys` line inside the worker container through the ARM
+   run-command channel (matched whole and literally; a read error leaves the file
+   untouched), re-attests B, and passes only once B explicitly refuses the observer
+   key under the pinned host key (an answer means it is still authorized; a transport
+   failure or a reader answering with nothing proves nothing and the removal stays
+   unproven); like cleanup it also runs after the manifest deadline. A worker restart drops the line as well (the entrypoint rewrites
+   the file), but the run does not rely on that.
 9. **Cleanup**: `client_off.py --manifest m.json cleanup --groups-before groups.json
-   --created created-groups.json`. Deletes only the manifest groups that this run
+   --resources-before resources.json --created created-groups.json`. Runs under one
+   20-minute bound (every ARM call is handed what is left of it; the manifest margin
+   is the return phase plus this bound). Deletes only the manifest groups that this run
    journaled as created and that did not exist before the run (anything else is
    refused and reported; the journal holds each group's ARM ID and full tag set from
    creation), re-reads each group immediately before its delete and refuses one whose
@@ -230,8 +247,10 @@ credentials and identifiers stay private.
    group must be `horizon-client-<run_id>` carrying the manifest's `run_id`, and B's group must carry the
    adapter's `horizon-workflow-id` and `horizon-job-id` from which its own name is
    derived; anything else is refused before it is even read. It then waits for
-   proven absence (an unreadable answer is unknown, never absence) and compares the
-   remaining groups with the list from step 1.
+   proven absence (an unreadable answer is unknown, never absence) and proves the
+   peers untouched: every resource outside the deleted groups must be exactly the set
+   recorded in step 1 (a vanished peer resource, or a group recreated under its old
+   name, is a finding), and the remaining group names must match the list from step 1.
 
 ## Labelling
 

--- a/docs/testing/azure-client-off-acceptance.md
+++ b/docs/testing/azure-client-off-acceptance.md
@@ -57,7 +57,8 @@ minutes), the off-phase setup at its bounds (eleven bounded ARM reads
 for the client, worker and identity-bracketed state attestations, the observer
 probe, and the deallocation with its poll, which share one 10-minute bound; about
 29 minutes), the off interval and everything that must still follow it: the return
-phase's own setup and the cleanup window (about 37 minutes); `off` and `install-observer-key`: their share of the
+phase's own setup and the cleanup window (about 42 minutes: 22 for the return at its
+bounds and the 20-minute cleanup bound); `off` and `install-observer-key`: their share of the
 same sum; `return`: its own setup at its bounds (seven bounded reads and the start
 with its poll, about 22 minutes) plus the cleanup window it must leave intact), so the
 reaper can never reach a group mid-run; the phases arm their runtime deadline from

--- a/docs/testing/azure-client-off-acceptance.md
+++ b/docs/testing/azure-client-off-acceptance.md
@@ -50,8 +50,10 @@ the binary digest, a digest image reference, positive price and budget (the exam
 values above are a `Standard_B2s` list price and a two-currency-unit budget; replace
 them with the current price and your bound), a deadline within 24 hours carrying an
 explicit UTC offset and, for the phases that rent or keep compute alive, far enough
-ahead to outlast them (`validate`: the 30-minute provisioning bound, the 10-minute
-observer install bound, the off-phase setup at its bounds (eleven bounded ARM reads
+ahead to outlast them (`validate`: the 30-minute provisioning bound, the observer
+install at its bounds (eight bounded reads, key derivation and probe before the
+10-minute run-command bound, four reads and a probe to reconcile after it; about 27
+minutes), the off-phase setup at its bounds (eleven bounded ARM reads
 for the client, worker and identity-bracketed state attestations, the observer
 probe, and the deallocation with its poll, which share one 10-minute bound; about
 29 minutes), the off interval and everything that must still follow it: the return
@@ -141,7 +143,12 @@ credentials and identifiers stay private.
    harness instead appends one `authorized_keys` line of the form
    `restrict,command="<reader>" ssh-ed25519 ...` inside the worker container through
    the ARM run-command channel, after the same identity, image-tag and running gates
-   the off phase applies. `restrict` disables pty, port, agent and X11 forwarding and
+   the off phase applies. The install reserves the whole off phase after itself, hands
+   every probe what is left of its bound, appends only while the run-command bound
+   and its reconciliation still fit, and edits `authorized_keys` through an editor
+   that opens `/root/.ssh` and the file relative to a verified directory descriptor
+   with `O_NOFOLLOW`, so no planted symlink can redirect a root write. `restrict`
+   disables pty, port, agent and X11 forwarding and
    user rc; the forced reader (its source and arguments travel base64-encoded, so no
    quoting layer can alter them) opens the two paths component by component with
    `O_NOFOLLOW` below `/workspace`, returns a capped prefix of regular files only and

--- a/docs/testing/azure-client-off-acceptance.md
+++ b/docs/testing/azure-client-off-acceptance.md
@@ -51,9 +51,9 @@ values above are a `Standard_B2s` list price and a two-currency-unit budget; rep
 them with the current price and your bound), a deadline within 24 hours carrying an
 explicit UTC offset and, for the phases that rent or keep compute alive, far enough
 ahead to outlast them (`validate`: the 30-minute provisioning bound, the observer
-install at its bounds (eight bounded reads, key derivation and probe before the
-10-minute run-command bound, four reads and a probe to reconcile after it; about 27
-minutes), the off-phase setup at its bounds (eleven bounded ARM reads
+install at its bounds (fifteen bounded reads, the key derivation and one bracketed
+probe before the 10-minute run-command bound, seven reads and a probe to reconcile
+after it; about 47 minutes), the off-phase setup at its bounds (eleven bounded ARM reads
 for the client, worker and identity-bracketed state attestations, the observer
 probe, and the deallocation with its poll, which share one 10-minute bound; about
 29 minutes), the off interval and everything that must still follow it: the return

--- a/scripts/azure-client-off/README.md
+++ b/scripts/azure-client-off/README.md
@@ -9,29 +9,30 @@ labelling rules.
   evaluation of recorded observer samples; the offline verdict also checks that the
   journal's baseline names an Azure worker in the manifest's group), `az.py` (bounded
   `az` calls without a shell; every mutation names the exact resource and `--dry-run`
-  journals instead of issuing), `observer.py` (worker descriptor gates and the pinned,
-  channel-aware read; the forced reader and its authorized_keys line join it in the
-  next slice), `phases.py`
-  (attestation of the exact A and B from ARM, off, return; the observer-key install
-  and removal join it in the next slice) and
-  `cleanup.py` (deletion of exactly the journaled groups, re-proven owned immediately
-  before the delete and only when name and tags bind them to this run: A's group is
-  `horizon-client-<run_id>` carrying the manifest's `run_id`, B's group is the
-  adapter's `horizon-ws-<workflow>-<job>` carrying those identities; ARM offers no
-  conditional delete for resource groups, so this rests on names no other run can
-  reuse rather than on a compare-and-delete).
-- `client_off.py`: the command line: `validate`, `journal-group`, `off`, `return`,
-  `cleanup`, `verdict` (the observer-key lifecycle, `observer-key-line`,
-  `install-observer-key` and `remove-observer-key`, lands in the next slice),
-  driven by a frozen manifest that carries a `run_id` drawn when it was frozen
+  journals instead of issuing), `observer.py` (worker descriptor gates, the forced
+  reader behind the restricted observer key and the pinned read), `phases.py`
+  (attestation of the exact A and B from ARM, off, observer-key install and removal,
+  return) and `cleanup.py` (deletion of exactly the journaled groups, re-proven owned
+  immediately before the delete and only when name and tags bind them to this run:
+  A's group is `horizon-client-<run_id>` carrying the manifest's `run_id`, B's group
+  is the adapter's `horizon-ws-<workflow>-<job>` carrying those identities; ARM
+  offers no conditional delete for resource groups, so this rests on names no other
+  run can reuse rather than on a compare-and-delete; untouched peers are proven from
+  a resource inventory recorded before the run, and the whole phase runs under one
+  20-minute bound).
+- `client_off.py`: the command line: `validate`, `observer-key-line`,
+  `install-observer-key`, `journal-group`, `off`, `return`, `remove-observer-key`,
+  `cleanup` (`--groups-before` and `--resources-before`, the group names and ARM
+  resource IDs recorded before the run), `verdict`, driven by a frozen manifest that
+  carries a `run_id` drawn when it was frozen
   (`head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'`); `--dry-run` never issues
   a mutating call and returns the journaled plan instead of waiting for a state it
   never caused.
+- `record-client-build.sh`: run in a fully clean checkout; builds the client from that
+  tree for x86-64 Linux and records HEAD with the digest of the binary it produced,
+  the provenance the provisioning step verifies.
 - The tests run in CI (`Azure harness tests` job) next to the workspace preflight
   suite.
-- `record-client-build.sh` (next slice): builds the client from a fully clean checkout
-  and records HEAD with the digest of the binary it produced, the provenance the
-  provisioning step verifies.
 - `provision-client.sh` (a following slice): creates client VM A in the manifest's
   run-named group with the reaper tags and the run identity, and copies the exact
   Horizon build after checking its provenance.

--- a/scripts/azure-client-off/client_off.py
+++ b/scripts/azure-client-off/client_off.py
@@ -32,7 +32,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from clientoff.az import Az  # noqa: E402
 from clientoff.cleanup import identity_record, journal_records, phase_cleanup  # noqa: E402
 from clientoff.manifest import TOOL_VERSION, validate_manifest  # noqa: E402
-from clientoff.phases import phase_off, phase_return  # noqa: E402
+from clientoff.observer import observer_authorized_line  # noqa: E402
+from clientoff.phases import phase_install_observer, phase_off, phase_remove_observer, phase_return  # noqa: E402
 from clientoff.verdict import verdict_from_records  # noqa: E402
 
 def load_json(path: str) -> Any:
@@ -51,6 +52,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--dry-run", action="store_true", help="never issue a mutating az call")
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("validate", help="check the manifest; nothing is called")
+    line = sub.add_parser("observer-key-line", help="print the restricted authorized_keys line for the observer key")
+    line.add_argument("--public-key", required=True, help="the observer's Ed25519 public key file")
+    line.add_argument("--progress-path", required=True)
+    line.add_argument("--checkpoint-path")
     journal = sub.add_parser("journal-group", help="append a group's ARM identity and tags to the creation journal")
     journal.add_argument("--group", required=True)
     journal.add_argument("--created", required=True, help="JSON array file to append to (created if absent)")
@@ -59,10 +64,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     off.add_argument("--worker", required=True,
                      help="JSON with vm_name, port, host_key, observer_key_path (the restricted key), progress_path, "
                           "optional checkpoint_path, and the baseline identity group_id, vm_id, host")
+    install = sub.add_parser("install-observer-key", help="install the restricted observer key on B via run-command")
+    install.add_argument("--worker", required=True, help="the same worker JSON the off phase reads")
+    install.add_argument("--public-key", required=True, help="the observer's Ed25519 public key file")
+    remove = sub.add_parser("remove-observer-key", help="remove the observer key from B once the run is over")
+    remove.add_argument("--worker", required=True, help="the same worker JSON the off phase reads")
+    remove.add_argument("--public-key", required=True, help="the observer's Ed25519 public key file")
     ret = sub.add_parser("return", help="start A only and require running")
     ret.add_argument("--client", required=True, help="provision-client.sh output JSON (exact A identity)")
     cleanup = sub.add_parser("cleanup", help="delete exactly the groups this run created")
     cleanup.add_argument("--groups-before", required=True, help="JSON list of group names recorded before the run")
+    cleanup.add_argument("--resources-before", required=True,
+                         help="JSON list of ARM resource IDs recorded before the run (az resource list --query '[].id')")
     cleanup.add_argument("--created", required=True,
                          help="creation journal: JSON array of {name, id, tags} records written at creation "
                               "(provision-client.sh for A, journal-group for B)")
@@ -85,6 +98,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
     if args.command == "validate":
         print(json.dumps({"runnable": True, "tool_version": TOOL_VERSION}, indent=2))
+        return 0
+    if args.command == "observer-key-line":
+        try:
+            with open(args.public_key, encoding="utf-8") as handle:
+                public_key = handle.read().strip().split("\n")[0]
+            print(observer_authorized_line(" ".join(public_key.split()[:2]), args.progress_path, args.checkpoint_path))
+        except (OSError, ValueError, IndexError) as error:
+            print(json.dumps({"passed": False, "findings": [f"observer key line: {error}"]}, indent=2))
+            return 2
         return 0
     if args.command == "verdict":
         try:
@@ -124,7 +146,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0
     if args.command in ("off", "return"):
         client = load_json(args.client)
-    if args.command == "off":
+    if args.command == "install-observer-key":
+        result = phase_install_observer(az, manifest, load_json(args.worker), args.public_key,
+                                        os.path.dirname(os.path.abspath(args.journal)) or ".")
+    elif args.command == "remove-observer-key":
+        result = phase_remove_observer(az, manifest, load_json(args.worker), args.public_key,
+                                       os.path.dirname(os.path.abspath(args.journal)) or ".")
+    elif args.command == "off":
         worker = load_json(args.worker)
         result = phase_off(az, manifest, worker, client, args.journal)
     elif args.command == "return":
@@ -135,11 +163,13 @@ def main(argv: Optional[List[str]] = None) -> int:
                 before = json.load(handle)
             with open(args.created, encoding="utf-8") as handle:
                 created = json.load(handle)
+            with open(args.resources_before, encoding="utf-8") as handle:
+                resources_before = json.load(handle)
         except (OSError, json.JSONDecodeError) as error:
             result = {"passed": False, "deleted": [],
-                      "findings": [f"groups-before or created unreadable: {type(error).__name__}; nothing deleted"]}
+                      "findings": [f"groups-before, created or resources-before unreadable: {type(error).__name__}; nothing deleted"]}
         else:
-            result = phase_cleanup(az, manifest, before, created)
+            result = phase_cleanup(az, manifest, before, created, resources_before)
     result["az_calls"] = az.journal
     print(json.dumps(result, indent=2))
     return 0 if result.get("passed") else 1

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -9,6 +9,48 @@ from typing import Any, Dict, List, Optional
 from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, RUN_COMMAND_SECONDS, TAG_IMAGE_REF, WORKER_CONTAINER, utc_now
 
 
+AUTHORIZED_KEYS_EDITOR = """import base64, os, stat, sys, tempfile
+action, line = sys.argv[1], base64.b64decode(sys.argv[2]).decode("ascii")
+flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+os.umask(0o077)
+try:
+    root = os.open("/root", flags)
+    try:
+        os.mkdir(".ssh", 0o700, dir_fd=root)
+    except FileExistsError:
+        pass
+    ssh = os.open(".ssh", flags, dir_fd=root)
+    os.close(root)
+    if action == "append":
+        fd = os.open("authorized_keys", os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW, 0o600, dir_fd=ssh)
+        try:
+            os.write(fd, (line + "\\n").encode("ascii"))
+        finally:
+            os.close(fd)
+    else:
+        try:
+            fd = os.open("authorized_keys", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=ssh)
+        except FileNotFoundError:
+            sys.exit(0)
+        with os.fdopen(fd, "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                sys.exit(3)
+            kept = [entry for entry in handle.read().split(b"\\n") if entry != line.encode("ascii")]
+        name = ".authorized_keys." + base64.b16encode(os.urandom(6)).decode("ascii")
+        tmp = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=ssh)
+        try:
+            os.write(tmp, b"\\n".join(kept))
+            os.fsync(tmp)
+        finally:
+            os.close(tmp)
+        os.replace(name, "authorized_keys", src_dir_fd=ssh, dst_dir_fd=ssh)
+    os.close(ssh)
+except OSError as error:
+    sys.stderr.write("authorized_keys editor: %s\\n" % error)
+    sys.exit(2)
+"""
+
+
 class Az:
     """Bounded `az` calls without a shell; every mutation names the exact resource."""
 
@@ -66,32 +108,26 @@ class Az:
                 codes.append(code)
         return codes[0] if len(codes) == 1 else None
 
-    def append_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
-        """Append one `authorized_keys` line inside the worker container through the ARM
-        run-command channel; the line travels base64-encoded so no quoting layer can alter it."""
-        encoded = base64.b64encode((line.rstrip("\n") + "\n").encode("ascii")).decode("ascii")
-        script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && mkdir -p /root/.ssh && "
-                  f"echo {encoded} | base64 -d >> /root/.ssh/authorized_keys'")
+    def edit_container_authorized_keys(self, group: str, name: str, line: str, action: str) -> Optional[Any]:
+        """Append or remove exactly one `authorized_keys` line inside the worker container
+        through the ARM run-command channel. The editor runs as python3 in the container,
+        opens `/root/.ssh` with `O_DIRECTORY|O_NOFOLLOW` and the key file (and its
+        temporary) relative to that directory descriptor with `O_NOFOLLOW`, so a planted
+        symlink at either path can never redirect a root write; a removal filters into a
+        temporary created next to the file and renames it over the original atomically.
+        Program and line travel base64-encoded so no quoting layer can alter them."""
+        encoded_program = base64.b64encode(AUTHORIZED_KEYS_EDITOR.encode("ascii")).decode("ascii")
+        encoded_line = base64.b64encode(line.rstrip("\n").encode("ascii")).decode("ascii")
+        script = (f"docker exec {WORKER_CONTAINER} sh -c 'echo {encoded_program} | base64 -d | "
+                  f"python3 - {action} {encoded_line}'")
         return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
                          "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
 
+    def append_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
+        return self.edit_container_authorized_keys(group, name, line, "append")
+
     def remove_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
-        """Remove every `authorized_keys` line equal to `line` inside the worker container
-        through the ARM run-command channel; the line travels base64-encoded and is
-        matched whole and literally, so nothing else in the file is touched."""
-        encoded = base64.b64encode(line.rstrip("\n").encode("ascii")).decode("ascii")
-        keys = "/root/.ssh/authorized_keys"
-        # The filtered copy goes to a unique same-directory temporary created by mktemp
-        # (never a predictable path a planted symlink could redirect); grep exits 1 when
-        # no line remains (still a success here) and 2 on an error, in which case the
-        # temporary is removed and the original file is left exactly as it was; the
-        # rename replaces the file atomically.
-        script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && k=$(echo {encoded} | base64 -d) && "
-                  f"t=$(mktemp /root/.ssh/.authorized_keys.XXXXXX) && "
-                  f"{{ grep -vxF \"$k\" {keys} > \"$t\"; rc=$?; [ $rc -le 1 ] || {{ rm -f \"$t\"; exit $rc; }}; }} && "
-                  f"mv -f \"$t\" {keys}'")
-        return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
-                         "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
+        return self.edit_container_authorized_keys(group, name, line, "remove")
 
     def vm_identity(self, group: str, name: str) -> Dict[str, Optional[str]]:
         vm = self.run(["vm", "show", "-g", group, "-n", name])

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -23,16 +23,18 @@ class Az:
         """Seconds left until the phase deadline, or None when no deadline is set."""
         return None if self.deadline is None else self.deadline - time.monotonic()
 
-    def run(self, args: List[str], mutating: bool = False, timeout: int = CLI_STEP_SECONDS) -> Optional[Any]:
+    def run(self, args: List[str], mutating: bool = False, timeout: float = CLI_STEP_SECONDS) -> Optional[Any]:
         command = ["az", *args, "--subscription", self.subscription, "-o", "json"]
         self.journal.append({"at": utc_now().isoformat(), "mutating": mutating, "args": args})
         if self.dry_run and mutating:
             return None
+        if timeout < 1:
+            return None  # no budget left for this call: it is not made
         left = self.left()
         if left is not None:
             if left < 1:
                 return None  # past the phase deadline: nothing more is asked of ARM
-            timeout = max(1, min(timeout, int(left)))
+            timeout = min(timeout, left)
         try:
             completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
         except (subprocess.TimeoutExpired, OSError):
@@ -79,12 +81,15 @@ class Az:
         matched whole and literally, so nothing else in the file is touched."""
         encoded = base64.b64encode(line.rstrip("\n").encode("ascii")).decode("ascii")
         keys = "/root/.ssh/authorized_keys"
-        # grep exits 1 when no line remains (still a success here) and 2 on an error, in
-        # which case the original file is left exactly as it was; the filtered file
-        # replaces it atomically, so no interruption can leave a truncated key file.
+        # The filtered copy goes to a unique same-directory temporary created by mktemp
+        # (never a predictable path a planted symlink could redirect); grep exits 1 when
+        # no line remains (still a success here) and 2 on an error, in which case the
+        # temporary is removed and the original file is left exactly as it was; the
+        # rename replaces the file atomically.
         script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && k=$(echo {encoded} | base64 -d) && "
-                  f"grep -vxF \"$k\" {keys} > {keys}.tmp; rc=$?; [ $rc -le 1 ] || {{ rm -f {keys}.tmp; exit $rc; }}; "
-                  f"mv -f {keys}.tmp {keys}'")
+                  f"t=$(mktemp /root/.ssh/.authorized_keys.XXXXXX) && "
+                  f"{{ grep -vxF \"$k\" {keys} > \"$t\"; rc=$?; [ $rc -le 1 ] || {{ rm -f \"$t\"; exit $rc; }}; }} && "
+                  f"mv -f \"$t\" {keys}'")
         return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
                          "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
 

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -1,11 +1,12 @@
 """Bounded `az` calls without a shell; every mutation names the exact resource."""
 from __future__ import annotations
 
+import base64
 import json
 import subprocess
 import time
 from typing import Any, Dict, List, Optional
-from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, TAG_IMAGE_REF, utc_now
+from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, RUN_COMMAND_SECONDS, TAG_IMAGE_REF, WORKER_CONTAINER, utc_now
 
 
 class Az:
@@ -62,6 +63,30 @@ class Az:
             if code.startswith("PowerState/"):
                 codes.append(code)
         return codes[0] if len(codes) == 1 else None
+
+    def append_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
+        """Append one `authorized_keys` line inside the worker container through the ARM
+        run-command channel; the line travels base64-encoded so no quoting layer can alter it."""
+        encoded = base64.b64encode((line.rstrip("\n") + "\n").encode("ascii")).decode("ascii")
+        script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && mkdir -p /root/.ssh && "
+                  f"echo {encoded} | base64 -d >> /root/.ssh/authorized_keys'")
+        return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
+                         "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
+
+    def remove_container_authorized_key(self, group: str, name: str, line: str) -> Optional[Any]:
+        """Remove every `authorized_keys` line equal to `line` inside the worker container
+        through the ARM run-command channel; the line travels base64-encoded and is
+        matched whole and literally, so nothing else in the file is touched."""
+        encoded = base64.b64encode(line.rstrip("\n").encode("ascii")).decode("ascii")
+        keys = "/root/.ssh/authorized_keys"
+        # grep exits 1 when no line remains (still a success here) and 2 on an error, in
+        # which case the original file is left exactly as it was; the filtered file
+        # replaces it atomically, so no interruption can leave a truncated key file.
+        script = (f"docker exec {WORKER_CONTAINER} sh -c 'umask 077 && k=$(echo {encoded} | base64 -d) && "
+                  f"grep -vxF \"$k\" {keys} > {keys}.tmp; rc=$?; [ $rc -le 1 ] || {{ rm -f {keys}.tmp; exit $rc; }}; "
+                  f"mv -f {keys}.tmp {keys}'")
+        return self.run(["vm", "run-command", "invoke", "-g", group, "-n", name, "--command-id", "RunShellScript",
+                         "--scripts", script], mutating=True, timeout=RUN_COMMAND_SECONDS)
 
     def vm_identity(self, group: str, name: str) -> Dict[str, Optional[str]]:
         vm = self.run(["vm", "show", "-g", group, "-n", name])

--- a/scripts/azure-client-off/clientoff/az.py
+++ b/scripts/azure-client-off/clientoff/az.py
@@ -9,10 +9,19 @@ from typing import Any, Dict, List, Optional
 from .manifest import CLI_STEP_SECONDS, PUBLIC_IP_NAME, RUN_COMMAND_SECONDS, TAG_IMAGE_REF, WORKER_CONTAINER, utc_now
 
 
-AUTHORIZED_KEYS_EDITOR = """import base64, os, stat, sys, tempfile
+AUTHORIZED_KEYS_EDITOR = """import base64, os, stat, sys
 action, line = sys.argv[1], base64.b64decode(sys.argv[2]).decode("ascii")
 flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
 os.umask(0o077)
+
+
+def write_all(fd, data):
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        view = view[written:]
+
+
 try:
     root = os.open("/root", flags)
     try:
@@ -21,29 +30,34 @@ try:
         pass
     ssh = os.open(".ssh", flags, dir_fd=root)
     os.close(root)
-    if action == "append":
-        fd = os.open("authorized_keys", os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW, 0o600, dir_fd=ssh)
-        try:
-            os.write(fd, (line + "\\n").encode("ascii"))
-        finally:
-            os.close(fd)
-    else:
-        try:
-            fd = os.open("authorized_keys", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=ssh)
-        except FileNotFoundError:
-            sys.exit(0)
+    # The existing file is read through a descriptor that follows no symlink and is
+    # accepted only as a plain regular file with a single link: a FIFO or device would
+    # block or divert the write, a hard link would reach another file.
+    entries = []
+    try:
+        fd = os.open("authorized_keys", os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=ssh)
+    except FileNotFoundError:
+        fd = None
+    if fd is not None:
         with os.fdopen(fd, "rb") as handle:
-            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+            info = os.fstat(handle.fileno())
+            if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
                 sys.exit(3)
-            kept = [entry for entry in handle.read().split(b"\\n") if entry != line.encode("ascii")]
-        name = ".authorized_keys." + base64.b16encode(os.urandom(6)).decode("ascii")
-        tmp = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=ssh)
-        try:
-            os.write(tmp, b"\\n".join(kept))
-            os.fsync(tmp)
-        finally:
-            os.close(tmp)
-        os.replace(name, "authorized_keys", src_dir_fd=ssh, dst_dir_fd=ssh)
+            entries = [entry for entry in handle.read().split(b"\\n") if entry]
+    if action == "append":
+        entries.append(line.encode("ascii"))
+    else:
+        entries = [entry for entry in entries if entry != line.encode("ascii")]
+    # Both edits go through a fresh same-directory temporary written in full, synced,
+    # and renamed over the key file atomically, so no partial or in-place write exists.
+    name = ".authorized_keys." + base64.b16encode(os.urandom(6)).decode("ascii")
+    tmp = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=ssh)
+    try:
+        write_all(tmp, b"\\n".join(entries) + (b"\\n" if entries else b""))
+        os.fsync(tmp)
+    finally:
+        os.close(tmp)
+    os.replace(name, "authorized_keys", src_dir_fd=ssh, dst_dir_fd=ssh)
     os.close(ssh)
 except OSError as error:
     sys.stderr.write("authorized_keys editor: %s\\n" % error)
@@ -111,11 +125,12 @@ class Az:
     def edit_container_authorized_keys(self, group: str, name: str, line: str, action: str) -> Optional[Any]:
         """Append or remove exactly one `authorized_keys` line inside the worker container
         through the ARM run-command channel. The editor runs as python3 in the container,
-        opens `/root/.ssh` with `O_DIRECTORY|O_NOFOLLOW` and the key file (and its
-        temporary) relative to that directory descriptor with `O_NOFOLLOW`, so a planted
-        symlink at either path can never redirect a root write; a removal filters into a
-        temporary created next to the file and renames it over the original atomically.
-        Program and line travel base64-encoded so no quoting layer can alter them."""
+        opens `/root/.ssh` with `O_DIRECTORY|O_NOFOLLOW` and the key file relative to that
+        directory descriptor with `O_NOFOLLOW`, accepts it only as a single-link regular
+        file (no symlink, hard link, FIFO or device can divert or block a root write), and
+        writes both edits in full to a fresh same-directory temporary that replaces the
+        file atomically. Program and line travel base64-encoded so no quoting layer can
+        alter them."""
         encoded_program = base64.b64encode(AUTHORIZED_KEYS_EDITOR.encode("ascii")).decode("ascii")
         encoded_line = base64.b64encode(line.rstrip("\n").encode("ascii")).decode("ascii")
         script = (f"docker exec {WORKER_CONTAINER} sh -c 'echo {encoded_program} | base64 -d | "

--- a/scripts/azure-client-off/clientoff/cleanup.py
+++ b/scripts/azure-client-off/clientoff/cleanup.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import time
 from typing import Any, Dict, List, Optional
 from .az import Az
-from .manifest import ARM, GROUP_RE, RUN_ID_RE, UUID_RE, same_id
+from .manifest import ARM, CLEANUP_BOUND_SECONDS, CLI_STEP_SECONDS, GROUP_RE, RUN_ID_RE, UUID_RE, same_id
 
 
 def group_list(value: Any) -> Optional[List[str]]:
@@ -50,14 +50,35 @@ def run_bound(record: Dict[str, Any], manifest: Dict[str, Any]) -> bool:
     return False
 
 
-def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any]) -> Optional[bool]:
+def resource_ids(value: Any) -> Optional[List[str]]:
+    """A recorded or live resource inventory: a JSON array of ARM resource IDs (or of
+    objects carrying `id`), or None when malformed."""
+    if not isinstance(value, list):
+        return None
+    ids = []
+    for item in value:
+        item = item.get("id") if isinstance(item, dict) else item
+        if not isinstance(item, str) or not item.casefold().startswith("/subscriptions/"):
+            return None
+        ids.append(item)
+    return ids
+
+
+def outside(ids: List[str], groups: List[str]) -> List[str]:
+    """The resource IDs that do not live in any of `groups` (case-insensitively)."""
+    prefixes = [f"/resourcegroups/{group.casefold()}/" for group in groups]
+    return sorted(identifier.casefold() for identifier in ids
+                  if not any(prefix in identifier.casefold() for prefix in prefixes))
+
+
+def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any], timeout: int = CLI_STEP_SECONDS) -> Optional[bool]:
     """Immediately before a delete: is the group still the exact resource that was
     journaled at creation (same ARM ID, identical tag set) and bound to this run? None
     when it cannot be read; an absent, recreated or retagged group is not ours, and a
     record not bound to this run never authorizes a delete, nor even a read."""
     if not run_bound(record, manifest):
         return False
-    shown = az.run(["group", "show", "-n", record["name"]])
+    shown = az.run(["group", "show", "-n", record["name"]], timeout=timeout)
     if not isinstance(shown, dict) or not isinstance(shown.get("tags"), dict):
         return None
     return same_id(shown.get("id"), record["id"]) and shown["tags"] == record["tags"]
@@ -88,21 +109,35 @@ def cleanup_targets(manifest: Dict[str, Any], before: Any, created: Any) -> Dict
     return {"delete": [records[group.casefold()] for group in wanted if group not in refused], "refused": refused}
 
 
-def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str]) -> Dict[str, Any]:
+def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: List[str],
+                  resources_before: Any = None, bound_seconds: int = CLEANUP_BOUND_SECONDS) -> Dict[str, Any]:
     """Delete only the exact groups this run created; verify absence and untouched peers.
-    A dry run walks the same authorization (the reads happen, the delete is journaled
-    and suppressed by `Az.run`) and stops before waiting for an absence it never caused."""
+    The whole phase runs under one absolute bound: every ARM call is handed what is
+    left of it and no poll sleeps across it. A dry run walks the same authorization
+    (the reads happen, the delete is journaled and suppressed by `Az.run`) and stops
+    before waiting for an absence it never caused. Untouched peers are proven from a
+    resource inventory recorded before the run, not from group names alone."""
+    deadline = time.monotonic() + bound_seconds
+
+    def budget() -> int:
+        return max(1, min(CLI_STEP_SECONDS, int(deadline - time.monotonic())))
+
     targets = cleanup_targets(manifest, before, created)
-    if targets.get("malformed"):
+    recorded = resource_ids(resources_before)
+    if targets.get("malformed") or recorded is None:
         return {"passed": False, "deleted": [],
-                "findings": ["groups-before is not a JSON array of names or created is not a JSON array of identity records"]}
+                "findings": ["groups-before is not a JSON array of names, created is not a JSON array of identity records, "
+                             "or resources-before is not a JSON array of ARM resource IDs"]}
     findings = [f"refusing to delete {group}: pre-existing, not journaled as created by this run, or journaled "
                 "without this run's identity in its tags" for group in targets["refused"]]
     deleting = []
     for record in targets["delete"]:
         group = record["name"]
+        if time.monotonic() >= deadline:
+            findings.append(f"cleanup bound reached before {group} was re-attested; not deleted")
+            continue
         # A same-named group recreated or retagged since the journal entry is not ours.
-        owned = owned_now(az, record, manifest)
+        owned = owned_now(az, record, manifest, timeout=budget())
         if owned is None:
             findings.append(f"refusing to delete {group}: ownership could not be read")
         elif not owned:
@@ -114,32 +149,41 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
             # so the guarantee rests on the name: unique to this run, so nothing else can
             # legitimately stand at this path in the window between the re-read and the
             # delete reaching ARM.
-            az.run(["rest", "--method", "delete", "--url", f"{ARM}{record['id']}?api-version=2022-09-01"], mutating=True)
+            az.run(["rest", "--method", "delete", "--url", f"{ARM}{record['id']}?api-version=2022-09-01"], mutating=True,
+                   timeout=budget())
     targets["delete"] = deleting
     if az.dry_run:
         return {"passed": False, "dry_run": True, "findings": findings, "deleted": [], "would_delete": deleting}
-    deadline = time.monotonic() + 1_500
     unresolved: Dict[str, str] = {}
-    while time.monotonic() < deadline:
+    while True:
         # False is proven absence; True is presence; None (timeout, CLI error, malformed
         # answer) is unknown and never counts as absence.
         unresolved = {}
         for group in targets["delete"]:
-            exists = az.run(["group", "exists", "-n", group])
+            exists = az.run(["group", "exists", "-n", group], timeout=budget()) if time.monotonic() < deadline else None
             if exists is True:
                 unresolved[group] = "present"
             elif exists is not False:
                 unresolved[group] = "unknown"
-        if not unresolved:
+        left = deadline - time.monotonic()
+        if not unresolved or left <= 0:
             break
-        time.sleep(15)
+        time.sleep(min(15.0, left))
     for group, state in sorted(unresolved.items()):
         findings.append(f"group {group} {state} at the bound: absence not proven")
-    inventory = az.run(["group", "list"])
-    names = group_list([group.get("name") for group in inventory]
-                       if isinstance(inventory, list) and all(isinstance(group, dict) for group in inventory) else None)
+    # Untouched peers: every resource that existed before the run outside the deleted
+    # groups must still exist, and nothing outside them may have appeared or gone. A
+    # group recreated under its old name shows up as changed resource IDs inside it.
+    inventory = resource_ids(az.run(["resource", "list"], timeout=budget())) if time.monotonic() < deadline else None
+    if inventory is None:
+        findings.append("final resource inventory unreadable: unchanged pre-existing resources not proven")
+    elif outside(inventory, deleting) != outside(recorded, deleting):
+        findings.append("resources outside the deleted groups changed during the run")
+    groups_now = az.run(["group", "list"], timeout=budget()) if time.monotonic() < deadline else None
+    names = group_list([group.get("name") for group in groups_now]
+                       if isinstance(groups_now, list) and all(isinstance(group, dict) for group in groups_now) else None)
     if names is None:
-        findings.append("final resource-group inventory unreadable: unchanged pre-existing resources not proven")
+        findings.append("final resource-group inventory unreadable: unchanged pre-existing groups not proven")
     elif sorted(name.casefold() for name in names) != sorted(name.casefold() for name in before):
         findings.append("pre-existing resource groups changed during the run")
     return {"passed": not findings, "findings": findings, "deleted": targets["delete"]}

--- a/scripts/azure-client-off/clientoff/cleanup.py
+++ b/scripts/azure-client-off/clientoff/cleanup.py
@@ -71,7 +71,7 @@ def outside(ids: List[str], groups: List[str]) -> List[str]:
                   if not any(prefix in identifier.casefold() for prefix in prefixes))
 
 
-def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any], timeout: int = CLI_STEP_SECONDS) -> Optional[bool]:
+def owned_now(az: Az, record: Dict[str, Any], manifest: Dict[str, Any], timeout: float = CLI_STEP_SECONDS) -> Optional[bool]:
     """Immediately before a delete: is the group still the exact resource that was
     journaled at creation (same ARM ID, identical tag set) and bound to this run? None
     when it cannot be read; an absent, recreated or retagged group is not ours, and a
@@ -119,8 +119,9 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
     resource inventory recorded before the run, not from group names alone."""
     deadline = time.monotonic() + bound_seconds
 
-    def budget() -> int:
-        return max(1, min(CLI_STEP_SECONDS, int(deadline - time.monotonic())))
+    def budget() -> float:
+        """What is left of the bound for one call, never rounded up past it."""
+        return min(float(CLI_STEP_SECONDS), deadline - time.monotonic())
 
     targets = cleanup_targets(manifest, before, created)
     recorded = resource_ids(resources_before)
@@ -133,11 +134,16 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
     deleting = []
     for record in targets["delete"]:
         group = record["name"]
-        if time.monotonic() >= deadline:
+        if budget() < 1:
             findings.append(f"cleanup bound reached before {group} was re-attested; not deleted")
             continue
         # A same-named group recreated or retagged since the journal entry is not ours.
         owned = owned_now(az, record, manifest, timeout=budget())
+        # Re-checked right before the mutation: an ownership read that exhausted the bound
+        # never turns into a delete issued past it.
+        if owned and budget() < 1:
+            findings.append(f"cleanup bound reached before {group} could be deleted; not deleted")
+            continue
         if owned is None:
             findings.append(f"refusing to delete {group}: ownership could not be read")
         elif not owned:
@@ -160,7 +166,7 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
         # answer) is unknown and never counts as absence.
         unresolved = {}
         for group in targets["delete"]:
-            exists = az.run(["group", "exists", "-n", group], timeout=budget()) if time.monotonic() < deadline else None
+            exists = az.run(["group", "exists", "-n", group], timeout=budget()) if budget() >= 1 else None
             if exists is True:
                 unresolved[group] = "present"
             elif exists is not False:
@@ -174,12 +180,12 @@ def phase_cleanup(az: Az, manifest: Dict[str, Any], before: List[str], created: 
     # Untouched peers: every resource that existed before the run outside the deleted
     # groups must still exist, and nothing outside them may have appeared or gone. A
     # group recreated under its old name shows up as changed resource IDs inside it.
-    inventory = resource_ids(az.run(["resource", "list"], timeout=budget())) if time.monotonic() < deadline else None
+    inventory = resource_ids(az.run(["resource", "list"], timeout=budget())) if budget() >= 1 else None
     if inventory is None:
         findings.append("final resource inventory unreadable: unchanged pre-existing resources not proven")
     elif outside(inventory, deleting) != outside(recorded, deleting):
         findings.append("resources outside the deleted groups changed during the run")
-    groups_now = az.run(["group", "list"], timeout=budget()) if time.monotonic() < deadline else None
+    groups_now = az.run(["group", "list"], timeout=budget()) if budget() >= 1 else None
     names = group_list([group.get("name") for group in groups_now]
                        if isinstance(groups_now, list) and all(isinstance(group, dict) for group in groups_now) else None)
     if names is None:

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -87,11 +87,13 @@ OFF_SETUP_MINUTES = (11 * CLI_STEP_SECONDS + 30 + 600) // 60 + 2
 RETURN_SETUP_MINUTES = (7 * CLI_STEP_SECONDS + 600) // 60 + 2
 # What the return phase must leave untouched after itself: the cleanup window.
 RETURN_RESERVE_MINUTES = CLEANUP_MARGIN_MINUTES - RETURN_MARGIN_MINUTES
-# Work the install phase does before and after its run-command append, at its bounds:
-# eight bounded ARM reads (two worker attestations before the append), the key
-# derivation and the probe before; four reads and a probe to reconcile after.
-INSTALL_SETUP_MINUTES = (8 * CLI_STEP_SECONDS + 30 + 30) // 60 + 2
-INSTALL_RECONCILE_SECONDS = 4 * CLI_STEP_SECONDS + 30
+# Work the install phase does before and after its run-command append, at its bounds.
+# A bracketed probe costs seven bounded ARM reads (identity before, attestation after)
+# plus the observation. Before the append: two worker attestations (four reads each),
+# the key derivation and one bracketed probe; after it: one bracketed probe.
+PROBE_READS = 7
+INSTALL_SETUP_MINUTES = ((8 + PROBE_READS) * CLI_STEP_SECONDS + 30 + 30) // 60 + 2
+INSTALL_RECONCILE_SECONDS = PROBE_READS * CLI_STEP_SECONDS + 30
 # What must remain after the off interval: the whole return phase (its setup at its
 # bounds) and the cleanup window it leaves; the off phase may deallocate A only when
 # the return can still complete.

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -67,8 +67,13 @@ def same_group(left: Any, right: Any) -> bool:
 # under a 30-minute bound, the off interval is declared, and return plus cleanup need
 # a margin. A deadline that the reaper could reach mid-run is not runnable.
 PROVISION_MINUTES = 30
-CLEANUP_MARGIN_MINUTES = 30
+# The whole cleanup phase (ownership re-reads, deletes, absence polls, inventory) runs
+# under one absolute bound; the margin a manifest must reserve after the off interval
+# is the return phase plus that bound, so the reaper deadline can never fall inside
+# either.
+CLEANUP_BOUND_SECONDS = 1_200
 RETURN_MARGIN_MINUTES = 15
+CLEANUP_MARGIN_MINUTES = RETURN_MARGIN_MINUTES + CLEANUP_BOUND_SECONDS // 60
 
 
 # Work the off phase does before its sampling interval starts, at its bounds: eleven

--- a/scripts/azure-client-off/clientoff/manifest.py
+++ b/scripts/azure-client-off/clientoff/manifest.py
@@ -87,6 +87,11 @@ OFF_SETUP_MINUTES = (11 * CLI_STEP_SECONDS + 30 + 600) // 60 + 2
 RETURN_SETUP_MINUTES = (7 * CLI_STEP_SECONDS + 600) // 60 + 2
 # What the return phase must leave untouched after itself: the cleanup window.
 RETURN_RESERVE_MINUTES = CLEANUP_MARGIN_MINUTES - RETURN_MARGIN_MINUTES
+# Work the install phase does before and after its run-command append, at its bounds:
+# eight bounded ARM reads (two worker attestations before the append), the key
+# derivation and the probe before; four reads and a probe to reconcile after.
+INSTALL_SETUP_MINUTES = (8 * CLI_STEP_SECONDS + 30 + 30) // 60 + 2
+INSTALL_RECONCILE_SECONDS = 4 * CLI_STEP_SECONDS + 30
 # What must remain after the off interval: the whole return phase (its setup at its
 # bounds) and the cleanup window it leaves; the off phase may deallocate A only when
 # the return can still complete.
@@ -98,10 +103,11 @@ def required_minutes(manifest: Dict[str, Any], phase: str) -> int:
     phases arm their runtime deadline from these same numbers, so a manifest that
     validates can always run its phase to the end of the declared work."""
     off = manifest.get("off_minutes") if type(manifest.get("off_minutes")) is int else MIN_OFF_MINUTES  # noqa: E721
-    install = RUN_COMMAND_SECONDS // 60
+    install = INSTALL_SETUP_MINUTES + RUN_COMMAND_SECONDS // 60 + INSTALL_RECONCILE_SECONDS // 60 + 1
     return {"validate": PROVISION_MINUTES + install + OFF_SETUP_MINUTES + off + AFTER_OFF_MINUTES,
             "off": OFF_SETUP_MINUTES + off + AFTER_OFF_MINUTES,
-            # The install may spend its whole run-command bound before the off interval starts.
+            # The install: its setup, the run-command bound and its reconciliation, before
+            # the whole off phase.
             "install-observer-key": install + OFF_SETUP_MINUTES + off + AFTER_OFF_MINUTES,
             # The return needs its own setup and keeps the cleanup window intact after it.
             "return": RETURN_SETUP_MINUTES + RETURN_RESERVE_MINUTES}.get(phase, 0)

--- a/scripts/azure-client-off/clientoff/observer.py
+++ b/scripts/azure-client-off/clientoff/observer.py
@@ -1,6 +1,7 @@
 """Observer C's only reach into worker B: the descriptor gates, the forced reader installed behind a restricted key, and the pinned read."""
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
@@ -50,6 +51,96 @@ def validate_worker(worker: Any) -> List[str]:
     return problems
 
 
+READER_SOURCE = """import json, os, stat, sys
+paths = json.loads(sys.argv[1])
+root = sys.argv[2]
+limit = int(sys.argv[3])
+
+
+def read(path):
+    if path is None:
+        return None
+    fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        parts = path[len(root):].strip("/").split("/")
+        for index, part in enumerate(parts):
+            last = index == len(parts) - 1
+            # Non-blocking on the last component: a FIFO planted at the path would
+            # otherwise block the open before the type check; a regular file is unaffected.
+            flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NOCTTY | (os.O_NONBLOCK if last else os.O_DIRECTORY)
+            next_fd = os.open(part, flags, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            return None
+        data = os.read(fd, limit + 1)
+        if len(data) > limit:
+            return None
+        return data.decode("ascii", "replace"), (info.st_dev, info.st_ino)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
+answers = {name: read(path) for name, path in paths.items()}
+progress, checkpoint = answers.get("progress"), answers.get("checkpoint")
+# A checkpoint file that is the counter file under another name (a hard link) is
+# counter progress, never checkpoint proof.
+if progress and checkpoint and progress[1] == checkpoint[1]:
+    checkpoint = None
+sys.stdout.write(json.dumps({"progress": progress[0] if progress else None,
+                             "checkpoint": checkpoint[0] if checkpoint else None,
+                             "paths": paths}))
+"""
+
+
+def reader_command(progress_path: str, checkpoint_path: Optional[str], root: str = "/workspace") -> str:
+    """The forced command for the observer key on B: a python reader that opens each
+    path component with `O_NOFOLLOW` below `root`, reads a capped prefix of regular
+    files only and prints one JSON object. Source and arguments travel base64-encoded,
+    so the command holds no quotes and sshd/shell quoting cannot alter it; whatever
+    command the client sends is ignored by sshd because of the forced command.
+    """
+    for path in (progress_path, checkpoint_path):
+        if path is not None and (not path.startswith(root + "/") or any(part in (".", "..") for part in path.split("/"))):
+            raise ValueError(f"observer paths must lie below {root}")
+    paths = json.dumps({"progress": progress_path, "checkpoint": checkpoint_path})
+    source = base64.b64encode(READER_SOURCE.encode("ascii")).decode("ascii")
+    argument = base64.b64encode(paths.encode("ascii")).decode("ascii")
+    return (f"python3 -c \"$(echo {source} | base64 -d)\" \"$(echo {argument} | base64 -d)\" "
+            f"{root} {PROGRESS_READ_LIMIT}")
+
+
+def observer_authorized_line(public_key: str, progress_path: str, checkpoint_path: Optional[str]) -> str:
+    """The `authorized_keys` line that makes the observer key a read-only channel:
+    `restrict` (no pty, port/agent/X11 forwarding or user rc) plus the forced reader.
+    Double quotes inside the command are escaped the one way sshd dequotes them."""
+    if not HOST_KEY_RE.fullmatch(public_key.strip()) or not PROGRESS_PATH_RE.fullmatch(progress_path):
+        raise ValueError("observer key must be one Ed25519 line and the path must lie under /workspace")
+    if checkpoint_path is not None and (not PROGRESS_PATH_RE.fullmatch(checkpoint_path) or checkpoint_path == progress_path):
+        raise ValueError("checkpoint path must be a separate plain path under /workspace")
+    command = reader_command(progress_path, checkpoint_path).replace('"', '\\"')
+    return f'restrict,command="{command}" {public_key.strip()}'
+
+
+def derived_public_key(private_key_path: str) -> Optional[str]:
+    """The public half of an Ed25519 private key, derived with `ssh-keygen -y` under a
+    bound; None when it cannot be derived."""
+    try:
+        # No stdin and an empty passphrase: a protected key fails here instead of
+        # prompting, and could never serve the BatchMode observer sessions anyway.
+        completed = subprocess.run(["ssh-keygen", "-y", "-P", "", "-f", private_key_path], capture_output=True, text=True,
+                                   timeout=30, check=False, stdin=subprocess.DEVNULL)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    key = " ".join(completed.stdout.strip().split("\n")[0].split()[:2])
+    return key if HOST_KEY_RE.fullmatch(key) else None
+
+
 def parse_counter(text: Any) -> Optional[int]:
     """Exactly one non-negative decimal integer, or nothing."""
     if not isinstance(text, str) or not re.fullmatch(r"\s*[0-9]{1,18}\s*", text):
@@ -81,7 +172,7 @@ def read_observations(host: str, port: int, host_key: str, key_path: str, direct
     precisely so that their refusal proves the option set, not merely the forced
     command.
     """
-    nothing: Dict[str, Any] = {"progress": None, "checkpoint": None, "channel": "unavailable"}
+    nothing: Dict[str, Any] = {"progress": None, "checkpoint": None, "channel": "unavailable", "paths": None}
     if not HOST_KEY_RE.fullmatch(host_key) or not routable(host) or budget_seconds < OBSERVATION_MIN_SECONDS:
         return nothing
     budget_seconds = min(float(OBSERVATION_SECONDS), budget_seconds)
@@ -104,7 +195,7 @@ def read_observations(host: str, port: int, host_key: str, key_path: str, direct
 
 
 def _observe(host: str, port: int, key_path: str, known_hosts: str, budget_seconds: float) -> Dict[str, Any]:
-    nothing: Dict[str, Any] = {"progress": None, "checkpoint": None, "channel": "unavailable"}
+    nothing: Dict[str, Any] = {"progress": None, "checkpoint": None, "channel": "unavailable", "paths": None}
     # A command is sent on purpose: with the restricted key the server must ignore it,
     # which the JSON answer (and never this command's output) proves on every sample.
     # `-tt` forces a pty request: under `restrict` sshd denies it ("PTY allocation
@@ -160,7 +251,8 @@ def _observe(host: str, port: int, key_path: str, known_hosts: str, budget_secon
         answer = json.loads(output.decode("ascii").replace("\r", ""))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return nothing
-    if not isinstance(answer, dict) or set(answer) != {"progress", "checkpoint"}:
+    if not isinstance(answer, dict) or set(answer) != {"progress", "checkpoint", "paths"} \
+            or not isinstance(answer["paths"], dict) or set(answer["paths"]) != {"progress", "checkpoint"}:
         return nothing  # the forced reader did not answer: the key is not restricted as required
     # `restrict` denies both the pty and the port forward; sshd offers no way to read
     # an authorized_keys option set from the client, so the denied capabilities are the
@@ -168,4 +260,4 @@ def _observe(host: str, port: int, key_path: str, known_hosts: str, budget_secon
     restricted = "PTY allocation request failed" in diagnostics and "remote port forwarding failed" in diagnostics
     channel = "answered" if restricted else "unrestricted"
     return {"progress": parse_counter(answer.get("progress")), "checkpoint": parse_counter(answer.get("checkpoint")),
-            "channel": channel}
+            "channel": channel, "paths": answer["paths"]}

--- a/scripts/azure-client-off/clientoff/observer.py
+++ b/scripts/azure-client-off/clientoff/observer.py
@@ -125,14 +125,16 @@ def observer_authorized_line(public_key: str, progress_path: str, checkpoint_pat
     return f'restrict,command="{command}" {public_key.strip()}'
 
 
-def derived_public_key(private_key_path: str) -> Optional[str]:
+def derived_public_key(private_key_path: str, budget_seconds: float = 30) -> Optional[str]:
     """The public half of an Ed25519 private key, derived with `ssh-keygen -y` under a
-    bound; None when it cannot be derived."""
+    bound; None when it cannot be derived (or no budget is left to derive it)."""
+    if budget_seconds < 1:
+        return None
     try:
         # No stdin and an empty passphrase: a protected key fails here instead of
         # prompting, and could never serve the BatchMode observer sessions anyway.
         completed = subprocess.run(["ssh-keygen", "-y", "-P", "", "-f", private_key_path], capture_output=True, text=True,
-                                   timeout=30, check=False, stdin=subprocess.DEVNULL)
+                                   timeout=min(30, budget_seconds), check=False, stdin=subprocess.DEVNULL)
     except (OSError, subprocess.TimeoutExpired):
         return None
     if completed.returncode != 0:
@@ -181,7 +183,9 @@ def read_observations(host: str, port: int, host_key: str, key_path: str, direct
     try:
         with tempfile.NamedTemporaryFile("w", dir=directory, prefix="observer_known_hosts.", suffix=".tmp",
                                          delete=False, encoding="utf-8") as handle:
-            handle.write(f"[{host}]:{port} {host_key}\n")
+            # OpenSSH looks a default-port host up by its bare address; the bracketed
+            # form is for any other port.
+            handle.write((f"{host} {host_key}\n" if port == 22 else f"[{host}]:{port} {host_key}\n"))
             known_hosts = handle.name
     except OSError:
         return nothing

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -8,7 +8,7 @@ import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from .az import Az
 from .manifest import (AFTER_OFF_MINUTES, CLI_STEP_SECONDS, CLIENT_VM_NAME, INSTANCE_ID_RE, OFF_SETUP_MINUTES,
-                       RETURN_RESERVE_MINUTES, required_minutes,
+                       INSTALL_RECONCILE_SECONDS, RETURN_RESERVE_MINUTES, RUN_COMMAND_SECONDS, required_minutes,
                        RUN_ID_RE, SAMPLE_SECONDS, client_tags, image_ref_digest, parse_utc, routable, same_group, same_id,
                        utc_now)
 from .observer import (OBSERVATION_MIN_SECONDS, OBSERVATION_SECONDS, derived_public_key, observer_authorized_line,
@@ -422,6 +422,11 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
         az.append_container_authorized_key(manifest["worker_group"], worker["vm_name"], line)
         return {"passed": False, "dry_run": True, "installed": False,
                 "findings": ["dry run: the restricted observer line would be appended on B now"], "plan": az.journal}
+    # Right before the mutation, with the remaining budget as it is now: the run-command
+    # bound and the reconciliation after it must both fit, or nothing is appended.
+    if az.left() is not None and az.left() < RUN_COMMAND_SECONDS + INSTALL_RECONCILE_SECONDS:
+        return {"passed": False, "installed": False,
+                "findings": ["the append and its reconciliation no longer fit before the phase deadline; nothing installed"]}
     if az.append_container_authorized_key(manifest["worker_group"], worker["vm_name"], line) is None:
         # The append may have run before its answer was lost: the reader is the truth.
         # A retry after an unproven append would stack a second line, so the state is

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -11,7 +11,8 @@ from .manifest import (AFTER_OFF_MINUTES, CLI_STEP_SECONDS, CLIENT_VM_NAME, INST
                        RETURN_RESERVE_MINUTES,
                        RUN_ID_RE, SAMPLE_SECONDS, client_tags, image_ref_digest, parse_utc, routable, same_group, same_id,
                        utc_now)
-from .observer import OBSERVATION_MIN_SECONDS, OBSERVATION_SECONDS, read_observations, validate_worker
+from .observer import (OBSERVATION_MIN_SECONDS, OBSERVATION_SECONDS, derived_public_key, observer_authorized_line,
+                       read_observations, validate_worker)
 from .verdict import evaluate_samples
 
 
@@ -53,6 +54,15 @@ def arm_phase_deadline(az: Az, manifest: Dict[str, Any], reserve_minutes: int) -
     return None
 
 
+def observed_paths_match(observed: Dict[str, Any], worker: Dict[str, Any]) -> bool:
+    """The forced reader echoes the paths it was installed for; they must be exactly the
+    descriptor's, so a stale or foreign observer line can never supply another task's
+    counter as this worker's."""
+    paths = observed.get("paths")
+    return isinstance(paths, dict) and paths.get("progress") == worker["progress_path"] \
+        and paths.get("checkpoint") == worker.get("checkpoint_path")
+
+
 def observation_budget(az: Az) -> float:
     """What an observation may take now: its own bound, or less when the phase deadline
     is nearer; below the observation minimum the caller must not start one."""
@@ -88,6 +98,22 @@ def observe_client(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
     return evidence, None
 
 
+def same_evidence(before: Dict[str, Any], after: Dict[str, Any]) -> bool:
+    """Two reads of A describe the same resource when their ARM IDs agree (ARM may
+    change the casing of a path between reads), the instance identity is identical and
+    the tag maps are exactly equal."""
+    return (same_id(before.get("a_group_id"), after.get("a_group_id")) and same_id(before.get("a_vm_id"), after.get("a_vm_id"))
+            and before.get("a_instance_id") == after.get("a_instance_id") and before.get("a_tags") == after.get("a_tags")
+            and before.get("a_group_tags") == after.get("a_group_tags"))
+
+
+def same_worker(before: Dict[str, Optional[str]], after: Dict[str, Optional[str]]) -> bool:
+    """Two identity reads of B describe the same worker when the ARM IDs agree
+    case-insensitively and the instance identity, image tag and endpoint are exact."""
+    return (same_id(before.get("b_group_id"), after.get("b_group_id")) and same_id(before.get("b_vm_id"), after.get("b_vm_id"))
+            and all(before.get(key) == after.get(key) for key in ("b_instance_id", "b_image_ref", "b_host")))
+
+
 def bound_client_state(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
                        timeout: int = CLI_STEP_SECONDS) -> Tuple[Dict[str, Any], Optional[str], Optional[str]]:
     """A's power state bound to one attested identity: the identity is attested before
@@ -101,7 +127,7 @@ def bound_client_state(az: Az, manifest: Dict[str, Any], client: Dict[str, Any],
     after, problem_after = observe_client(az, manifest, client, timeout)
     if problem_after:
         return before, None, problem_after
-    if before != after:
+    if not same_evidence(before, after):
         return before, None, "client A changed identity around the state read"
     return before, state, None
 
@@ -211,6 +237,9 @@ def phase_off(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], client: 
     if probe.get("channel") != "answered" or probe.get("progress") is None:
         return {"passed": False, "findings": ["observer key is not a working restricted read channel on B, or the counter "
                                               "is not readable yet; nothing stopped"]}
+    if not observed_paths_match(probe, worker):
+        return {"passed": False, "findings": ["the forced reader on B names other paths than the worker descriptor: a stale or "
+                                              "foreign observer line; nothing stopped"]}
     # The client must actually be on, and must still be the exact A in the same read
     # that precedes the mutation: ARM offers no conditional power operation, so the
     # attestation is repeated immediately before the call and on every poll after it,
@@ -295,7 +324,8 @@ def phase_off(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], client: 
         # tag, endpoint) is the same before and after them; a replacement or repointed
         # endpoint in between leaves an unattested sample, never a stale identity next to
         # a replacement's state.
-        if az.vm_identity(manifest["worker_group"], worker["vm_name"]) != identity or observed.get("channel") != "answered":
+        if (not same_worker(identity, az.vm_identity(manifest["worker_group"], worker["vm_name"]))
+                or observed.get("channel") != "answered" or not observed_paths_match(observed, worker)):
             # A replaced B, or a channel that is not the restricted reader any more
             # (refused, unavailable, or answering with a pty granted), leaves an
             # unreadable sample: its state and reading are never evidence.
@@ -334,6 +364,121 @@ def phase_off(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], client: 
         time.sleep(max(0.0, next_slot - time.monotonic()))
     return evaluate_samples(samples, manifest["off_minutes"], manifest["lease_seconds"], manifest["worker_image"],
                             expected_identity, client_tags(manifest))
+
+
+def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], public_key_path: str,
+                           directory: str, reader: Optional[Callable[..., Dict[str, Optional[int]]]] = None) -> Dict[str, Any]:
+    """Install the observer key on B as a restricted, forced-command key through the
+    control plane, before anything is switched off. The key is accepted only once the
+    forced reader answers a session that asked for a different command."""
+    reader = reader or read_observations
+    problems = validate_worker(worker)
+    if problems:
+        return {"passed": False, "findings": problems}
+    # Bound to the manifest deadline minus what must still follow: the off interval,
+    # the return phase and the cleanup window.
+    problem = arm_phase_deadline(az, manifest, int(manifest["off_minutes"]) + AFTER_OFF_MINUTES)
+    if problem:
+        return {"passed": False, "installed": False, "findings": [f"{problem}; nothing installed"]}
+    try:
+        with open(public_key_path, encoding="utf-8") as handle:
+            public_key = " ".join(handle.read().strip().split("\n")[0].split()[:2])
+        line = observer_authorized_line(public_key, worker["progress_path"], worker.get("checkpoint_path"))
+    except (OSError, ValueError, IndexError) as error:
+        return {"passed": False, "findings": [f"observer key line: {error}"]}
+    # The same identity, image and running gates as the off phase, read from ARM now,
+    # before anything is concluded or appended: a stale descriptor never reaches, or
+    # reports on, another VM.
+    _, problem = attest_worker(az, manifest, worker)
+    if problem:
+        return {"passed": False, "installed": False, "findings": [f"{problem}; nothing installed"]}
+    # The public half must be the observer private key's: otherwise a foreign key would
+    # be appended to B before the probe could notice.
+    if derived_public_key(worker["observer_key_path"]) != public_key:
+        return {"passed": False, "installed": False, "findings": ["the public key is not the observer private key's; nothing installed"]}
+    before = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
+    if before.get("channel") == "answered":
+        return {"passed": True, "installed": False, "findings": ["observer key already answers through the forced reader"]}
+    if before.get("channel") != "refused":
+        # Neither an answer nor an explicit refusal: whether the key is present is not
+        # known, and an append on top of an unknown state could stack a second line.
+        return {"passed": False, "installed": "unknown",
+                "findings": ["B neither refused nor answered the observer key before the install; nothing appended"]}
+    # Re-attested in the same breath as the mutation (run-command has no identity
+    # precondition), and again afterwards so the key is known to sit on the exact B.
+    _, problem = attest_worker(az, manifest, worker)
+    if problem:
+        return {"passed": False, "installed": False, "findings": [f"{problem}; nothing installed"]}
+    if az.dry_run:
+        az.append_container_authorized_key(manifest["worker_group"], worker["vm_name"], line)
+        return {"passed": False, "dry_run": True, "installed": False,
+                "findings": ["dry run: the restricted observer line would be appended on B now"], "plan": az.journal}
+    if az.append_container_authorized_key(manifest["worker_group"], worker["vm_name"], line) is None:
+        # The append may have run before its answer was lost: the reader is the truth.
+        # A retry after an unproven append would stack a second line, so the state is
+        # reported as it is proven, never as "nothing changed".
+        _, problem = attest_worker(az, manifest, worker)
+        after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
+        if problem is None and after.get("channel") == "answered":
+            return {"passed": True, "installed": True, "progress": after.get("progress"), "checkpoint": after.get("checkpoint"),
+                    "findings": ["run-command lost its answer, but the exact B's forced reader answers: the key is installed"]}
+        return {"passed": False, "installed": "unknown",
+                "findings": ["run-command did not confirm the append and the forced reader does not answer; inspect "
+                             "/root/.ssh/authorized_keys on B before retrying, a retry could append a second line"]}
+    _, problem = attest_worker(az, manifest, worker)
+    if problem:
+        return {"passed": False, "installed": True, "findings": [f"{problem} after the append; do not use this key as observer C"]}
+    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
+    if after.get("channel") != "answered":
+        return {"passed": False, "installed": True,
+                "findings": ["the forced reader did not answer after the append; do not use this key as observer C"]}
+    # The key is installed whatever the file holds right now; an unreadable counter is
+    # the off phase's finding, not this one's.
+    return {"passed": True, "installed": True, "progress": after.get("progress"), "checkpoint": after.get("checkpoint")}
+
+
+def phase_remove_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], public_key_path: str,
+                          directory: str, reader: Optional[Callable[..., Dict[str, Optional[int]]]] = None) -> Dict[str, Any]:
+    """Remove the observer key from B once the acceptance is over: the run's private key
+    must not keep a reading channel into a worker that outlives the run. Removal is
+    reconciled: it passes only once the forced reader no longer answers."""
+    reader = reader or read_observations
+    problems = validate_worker(worker)
+    if problems:
+        return {"passed": False, "findings": problems}
+    try:
+        with open(public_key_path, encoding="utf-8") as handle:
+            public_key = " ".join(handle.read().strip().split("\n")[0].split()[:2])
+        line = observer_authorized_line(public_key, worker["progress_path"], worker.get("checkpoint_path"))
+    except (OSError, ValueError, IndexError) as error:
+        return {"passed": False, "findings": [f"observer key line: {error}"]}
+    # Only the observer's own line may be removed: a foreign public key would name
+    # somebody else's line.
+    if derived_public_key(worker["observer_key_path"]) != public_key:
+        return {"passed": False, "removed": False, "findings": ["the public key is not the observer private key's; nothing removed"]}
+    _, problem = attest_worker(az, manifest, worker)
+    if problem:
+        return {"passed": False, "removed": False, "findings": [f"{problem}; nothing removed"]}
+    if az.dry_run:
+        az.remove_container_authorized_key(manifest["worker_group"], worker["vm_name"], line)
+        return {"passed": False, "dry_run": True, "removed": False,
+                "findings": ["dry run: the observer line would be removed from B now"], "plan": az.journal}
+    az.remove_container_authorized_key(manifest["worker_group"], worker["vm_name"], line)
+    # Whatever the run-command answered, the server is the truth: the key is gone only
+    # when the exact B explicitly refuses it under the pinned host key. An answer means
+    # it is still authorized; anything else (transport, timeout, a reader that answers
+    # with nothing) proves nothing and the removal stays unproven.
+    _, problem = attest_worker(az, manifest, worker)
+    if problem:
+        return {"passed": False, "removed": "unknown", "findings": [f"{problem} after the removal; removal unproven"]}
+    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
+    if after.get("channel") == "refused":
+        return {"passed": True, "removed": True, "findings": []}
+    if after.get("channel") == "answered":
+        return {"passed": False, "removed": False,
+                "findings": ["B still accepts the observer key after the removal; it is still authorized"]}
+    return {"passed": False, "removed": "unknown",
+            "findings": ["B neither refused nor answered the observer key after the removal; removal unproven, retry"]}
 
 
 def phase_return(az: Az, manifest: Dict[str, Any], client: Dict[str, Any]) -> Dict[str, Any]:

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -488,8 +488,14 @@ def phase_remove_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, An
     _, problem = attest_worker(az, manifest, worker)
     if problem:
         return {"passed": False, "removed": "unknown", "findings": [f"{problem} after the removal; removal unproven"]}
+    # The refusal counts only when B's identity is the same before and after the probe:
+    # a refusal from a replacement proves nothing about the baseline B.
+    before_probe = az.vm_identity(manifest["worker_group"], worker["vm_name"])
     after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
                    observation_budget(az))
+    if not same_worker(before_probe, az.vm_identity(manifest["worker_group"], worker["vm_name"])):
+        return {"passed": False, "removed": "unknown",
+                "findings": ["worker B changed identity around the refusal probe; removal unproven"]}
     if after.get("channel") == "refused":
         return {"passed": True, "removed": True, "findings": []}
     if after.get("channel") == "answered":

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -8,7 +8,7 @@ import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from .az import Az
 from .manifest import (AFTER_OFF_MINUTES, CLI_STEP_SECONDS, CLIENT_VM_NAME, INSTANCE_ID_RE, OFF_SETUP_MINUTES,
-                       RETURN_RESERVE_MINUTES,
+                       RETURN_RESERVE_MINUTES, required_minutes,
                        RUN_ID_RE, SAMPLE_SECONDS, client_tags, image_ref_digest, parse_utc, routable, same_group, same_id,
                        utc_now)
 from .observer import (OBSERVATION_MIN_SECONDS, OBSERVATION_SECONDS, derived_public_key, observer_authorized_line,
@@ -375,9 +375,11 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
     problems = validate_worker(worker)
     if problems:
         return {"passed": False, "findings": problems}
-    # Bound to the manifest deadline minus what must still follow: the off interval,
-    # the return phase and the cleanup window.
-    problem = arm_phase_deadline(az, manifest, int(manifest["off_minutes"]) + AFTER_OFF_MINUTES)
+    # Bound to the manifest deadline minus everything the off phase needs after this
+    # one (its own setup, the interval, the return and the cleanup window), so the
+    # install can never consume the off phase's allowance; its own setup fits in the
+    # run-command bound the manifest reserves for it.
+    problem = arm_phase_deadline(az, manifest, required_minutes(manifest, "off"))
     if problem:
         return {"passed": False, "installed": False, "findings": [f"{problem}; nothing installed"]}
     try:
@@ -394,10 +396,17 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
         return {"passed": False, "installed": False, "findings": [f"{problem}; nothing installed"]}
     # The public half must be the observer private key's: otherwise a foreign key would
     # be appended to B before the probe could notice.
-    if derived_public_key(worker["observer_key_path"]) != public_key:
+    if derived_public_key(worker["observer_key_path"], observation_budget(az)) != public_key:
         return {"passed": False, "installed": False, "findings": ["the public key is not the observer private key's; nothing installed"]}
-    before = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
+    if observation_budget(az) < OBSERVATION_MIN_SECONDS:
+        return {"passed": False, "installed": False, "findings": ["phase deadline too near for the observer probe; nothing installed"]}
+    before = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                    observation_budget(az))
     if before.get("channel") == "answered":
+        if not observed_paths_match(before, worker):
+            return {"passed": False, "installed": False,
+                    "findings": ["B already accepts this key with a forced reader for other paths: a stale or foreign "
+                                 "observer line; remove it before installing"]}
         return {"passed": True, "installed": False, "findings": ["observer key already answers through the forced reader"]}
     if before.get("channel") != "refused":
         # Neither an answer nor an explicit refusal: whether the key is present is not
@@ -418,8 +427,9 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
         # A retry after an unproven append would stack a second line, so the state is
         # reported as it is proven, never as "nothing changed".
         _, problem = attest_worker(az, manifest, worker)
-        after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
-        if problem is None and after.get("channel") == "answered":
+        after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                       observation_budget(az))
+        if problem is None and after.get("channel") == "answered" and observed_paths_match(after, worker):
             return {"passed": True, "installed": True, "progress": after.get("progress"), "checkpoint": after.get("checkpoint"),
                     "findings": ["run-command lost its answer, but the exact B's forced reader answers: the key is installed"]}
         return {"passed": False, "installed": "unknown",
@@ -428,10 +438,12 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
     _, problem = attest_worker(az, manifest, worker)
     if problem:
         return {"passed": False, "installed": True, "findings": [f"{problem} after the append; do not use this key as observer C"]}
-    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
-    if after.get("channel") != "answered":
+    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                   observation_budget(az))
+    if after.get("channel") != "answered" or not observed_paths_match(after, worker):
         return {"passed": False, "installed": True,
-                "findings": ["the forced reader did not answer after the append; do not use this key as observer C"]}
+                "findings": ["the forced reader did not answer for the descriptor's paths after the append; do not use "
+                             "this key as observer C"]}
     # The key is installed whatever the file holds right now; an unreadable counter is
     # the off phase's finding, not this one's.
     return {"passed": True, "installed": True, "progress": after.get("progress"), "checkpoint": after.get("checkpoint")}
@@ -454,7 +466,7 @@ def phase_remove_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, An
         return {"passed": False, "findings": [f"observer key line: {error}"]}
     # Only the observer's own line may be removed: a foreign public key would name
     # somebody else's line.
-    if derived_public_key(worker["observer_key_path"]) != public_key:
+    if derived_public_key(worker["observer_key_path"], observation_budget(az)) != public_key:
         return {"passed": False, "removed": False, "findings": ["the public key is not the observer private key's; nothing removed"]}
     _, problem = attest_worker(az, manifest, worker)
     if problem:
@@ -471,7 +483,8 @@ def phase_remove_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, An
     _, problem = attest_worker(az, manifest, worker)
     if problem:
         return {"passed": False, "removed": "unknown", "findings": [f"{problem} after the removal; removal unproven"]}
-    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory)
+    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                   observation_budget(az))
     if after.get("channel") == "refused":
         return {"passed": True, "removed": True, "findings": []}
     if after.get("channel") == "answered":

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -375,8 +375,10 @@ def probe_worker(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], direc
     before = az.vm_identity(manifest["worker_group"], worker["vm_name"])
     answer = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
                     observation_budget(az))
-    _, problem = attest_worker(az, manifest, worker)
-    if problem or not same_worker(before, az.vm_identity(manifest["worker_group"], worker["vm_name"])):
+    # The attestation after the probe reads B's identity itself; that read is the
+    # second half of the bracket (seven bounded ARM calls per probe in all).
+    after, problem = attest_worker(az, manifest, worker)
+    if problem or not same_worker(before, after):
         return {"progress": None, "checkpoint": None, "channel": "unavailable", "paths": None}
     return answer
 
@@ -452,11 +454,14 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
         return {"passed": False, "installed": "unknown",
                 "findings": ["run-command did not confirm the append and the forced reader does not answer; inspect "
                              "/root/.ssh/authorized_keys on B before retrying, a retry could append a second line"]}
+    # A run-command answer only says ARM ran something; whether the guest edit took is
+    # proven by the reader alone, so anything short of an answer for the descriptor's
+    # paths leaves the installation unknown, never installed.
     after = probe_worker(az, manifest, worker, directory, reader)
     if after.get("channel") != "answered" or not observed_paths_match(after, worker):
-        return {"passed": False, "installed": True,
-                "findings": ["the forced reader did not answer for the descriptor's paths after the append; do not use "
-                             "this key as observer C"]}
+        return {"passed": False, "installed": "unknown",
+                "findings": ["the forced reader did not answer for the descriptor's paths after the append; inspect "
+                             "/root/.ssh/authorized_keys on B before retrying, a retry could append a second line"]}
     # The key is installed whatever the file holds right now; an unreadable counter is
     # the off phase's finding, not this one's.
     return {"passed": True, "installed": True, "progress": after.get("progress"), "checkpoint": after.get("checkpoint")}

--- a/scripts/azure-client-off/clientoff/phases.py
+++ b/scripts/azure-client-off/clientoff/phases.py
@@ -366,6 +366,21 @@ def phase_off(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], client: 
                             expected_identity, client_tags(manifest))
 
 
+def probe_worker(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], directory: str,
+                 reader: Callable[..., Dict[str, Any]]) -> Dict[str, Any]:
+    """One observer probe of B bracketed by two identity reads: the answer counts only
+    when B's identity (ARM IDs, instance, image tag, endpoint) is the same before and
+    after it and B is attested after it, so an answer from a replaced or repointed VM is
+    reported as unavailable, never trusted."""
+    before = az.vm_identity(manifest["worker_group"], worker["vm_name"])
+    answer = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
+                    observation_budget(az))
+    _, problem = attest_worker(az, manifest, worker)
+    if problem or not same_worker(before, az.vm_identity(manifest["worker_group"], worker["vm_name"])):
+        return {"progress": None, "checkpoint": None, "channel": "unavailable", "paths": None}
+    return answer
+
+
 def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, Any], public_key_path: str,
                            directory: str, reader: Optional[Callable[..., Dict[str, Optional[int]]]] = None) -> Dict[str, Any]:
     """Install the observer key on B as a restricted, forced-command key through the
@@ -400,8 +415,7 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
         return {"passed": False, "installed": False, "findings": ["the public key is not the observer private key's; nothing installed"]}
     if observation_budget(az) < OBSERVATION_MIN_SECONDS:
         return {"passed": False, "installed": False, "findings": ["phase deadline too near for the observer probe; nothing installed"]}
-    before = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
-                    observation_budget(az))
+    before = probe_worker(az, manifest, worker, directory, reader)
     if before.get("channel") == "answered":
         if not observed_paths_match(before, worker):
             return {"passed": False, "installed": False,
@@ -431,20 +445,14 @@ def phase_install_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, A
         # The append may have run before its answer was lost: the reader is the truth.
         # A retry after an unproven append would stack a second line, so the state is
         # reported as it is proven, never as "nothing changed".
-        _, problem = attest_worker(az, manifest, worker)
-        after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
-                       observation_budget(az))
-        if problem is None and after.get("channel") == "answered" and observed_paths_match(after, worker):
+        after = probe_worker(az, manifest, worker, directory, reader)
+        if after.get("channel") == "answered" and observed_paths_match(after, worker):
             return {"passed": True, "installed": True, "progress": after.get("progress"), "checkpoint": after.get("checkpoint"),
                     "findings": ["run-command lost its answer, but the exact B's forced reader answers: the key is installed"]}
         return {"passed": False, "installed": "unknown",
                 "findings": ["run-command did not confirm the append and the forced reader does not answer; inspect "
                              "/root/.ssh/authorized_keys on B before retrying, a retry could append a second line"]}
-    _, problem = attest_worker(az, manifest, worker)
-    if problem:
-        return {"passed": False, "installed": True, "findings": [f"{problem} after the append; do not use this key as observer C"]}
-    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
-                   observation_budget(az))
+    after = probe_worker(az, manifest, worker, directory, reader)
     if after.get("channel") != "answered" or not observed_paths_match(after, worker):
         return {"passed": False, "installed": True,
                 "findings": ["the forced reader did not answer for the descriptor's paths after the append; do not use "
@@ -488,14 +496,9 @@ def phase_remove_observer(az: Az, manifest: Dict[str, Any], worker: Dict[str, An
     _, problem = attest_worker(az, manifest, worker)
     if problem:
         return {"passed": False, "removed": "unknown", "findings": [f"{problem} after the removal; removal unproven"]}
-    # The refusal counts only when B's identity is the same before and after the probe:
-    # a refusal from a replacement proves nothing about the baseline B.
-    before_probe = az.vm_identity(manifest["worker_group"], worker["vm_name"])
-    after = reader(worker["host"], worker["port"], worker["host_key"], worker["observer_key_path"], directory,
-                   observation_budget(az))
-    if not same_worker(before_probe, az.vm_identity(manifest["worker_group"], worker["vm_name"])):
-        return {"passed": False, "removed": "unknown",
-                "findings": ["worker B changed identity around the refusal probe; removal unproven"]}
+    # The refusal counts only when B's identity is the same before and after the probe
+    # and B is attested after it: a refusal from a replacement proves nothing.
+    after = probe_worker(az, manifest, worker, directory, reader)
     if after.get("channel") == "refused":
         return {"passed": True, "removed": True, "findings": []}
     if after.get("channel") == "answered":

--- a/scripts/azure-client-off/record-client-build.sh
+++ b/scripts/azure-client-off/record-client-build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build the Horizon client for client VM A and record its provenance in one step.
+#
+# Run inside a fully clean checkout (no modified or untracked files) at the frozen
+# candidate commit:
+#   record-client-build.sh --out client-build.json [--target-dir <dir>]
+# It captures HEAD, runs the release build of the `horizon` binary from that exact tree,
+# hashes the binary it just produced and writes commit, digest and path together, so
+# the digest can only belong to that commit. provision-client.sh verifies the record
+# against the manifest and the bytes it uploads.
+set -euo pipefail
+
+fail() { printf 'record-client-build: %s\n' "$1" >&2; exit 1; }
+out= target_dir=
+while (($# > 0)); do
+  case "$1" in
+    --out) out=$2; shift 2 ;;
+    --target-dir) target_dir=$2; shift 2 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+[ -n "$out" ] || fail "--out is required"
+for tool in git cargo jq sha256sum realpath; do command -v "$tool" >/dev/null 2>&1 || fail "required command not found: $tool"; done
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "run this inside the checkout to build from"
+toplevel=$(git rev-parse --show-toplevel)
+target_dir=$(realpath -m "${target_dir:-$toplevel/target}")
+# The build output is the only thing allowed to differ from the commit, and only at the
+# checkout's own target/ or outside the checkout: anywhere else inside it, Cargo's
+# output would read as an unclean tree after the build.
+case "$target_dir" in
+  "$toplevel"/target) ;;
+  "$toplevel"/*) fail "--target-dir must be the checkout's target/ or lie outside the checkout" ;;
+esac
+# Modified, untracked and ignored files alike make the tree something other than the
+# commit (the UI build prefers an ignored publish-assets directory when present); only
+# the build output directory itself is exempt.
+clean() { [ -z "$(git status --porcelain --ignored | grep -v -E '^!! target/$')" ]; }
+clean || fail "the checkout is not clean (modified, untracked or ignored files besides target/); a frozen candidate is one commit"
+sha=$(git rev-parse HEAD)
+# Built for the client VM's platform explicitly, whatever the controller runs.
+CARGO_TARGET_DIR=$target_dir cargo build --release -p horizon-ui --bin horizon --target x86_64-unknown-linux-gnu
+binary=$target_dir/x86_64-unknown-linux-gnu/release/horizon
+[ -f "$binary" ] || fail "the build produced no binary at $binary"
+# The tree must still be the same commit after the build.
+[ "$(git rev-parse HEAD)" = "$sha" ] && clean || fail "the checkout changed during the build"
+# Client VM A is Ubuntu x86-64: only an ELF64 x86-64 binary can run there.
+[ "$(od -An -tx1 -N4 "$binary" | tr -d ' \n')" = "7f454c46" ] || fail "the binary is not an ELF file; build the Linux x86-64 client"
+[ "$(od -An -tx1 -j18 -N2 "$binary" | tr -d ' \n')" = "3e00" ] || fail "the binary is not x86-64; build the Linux x86-64 client"
+digest=$(sha256sum "$binary" | cut -d' ' -f1)
+jq -n --arg sha "$sha" --arg digest "$digest" --arg binary "$binary" --arg built "$(date -u +%FT%TZ)" \
+  '{client_sha:$sha, client_binary_sha256:$digest, binary:$binary, built_at_utc:$built}' >"$out"
+echo "built and recorded $sha $digest"

--- a/scripts/azure-client-off/record-client-build.sh
+++ b/scripts/azure-client-off/record-client-build.sh
@@ -37,10 +37,14 @@ esac
 clean() { [ -z "$(git status --porcelain --ignored | grep -v -E '^!! target/$')" ]; }
 clean || fail "the checkout is not clean (modified, untracked or ignored files besides target/); a frozen candidate is one commit"
 sha=$(git rev-parse HEAD)
-# Built for the client VM's platform explicitly, whatever the controller runs.
-CARGO_TARGET_DIR=$target_dir cargo build --release -p horizon-ui --bin horizon --target x86_64-unknown-linux-gnu
+# Built for the client VM's platform explicitly, whatever the controller runs. The
+# previous artifact is removed first, so the bytes hashed below can only have been
+# produced by this invocation (a stale or tampered executable that Cargo considered
+# fresh would otherwise be recorded against HEAD).
 binary=$target_dir/x86_64-unknown-linux-gnu/release/horizon
-[ -f "$binary" ] || fail "the build produced no binary at $binary"
+rm -f "$binary"
+CARGO_TARGET_DIR=$target_dir cargo build --release -p horizon-ui --bin horizon --target x86_64-unknown-linux-gnu
+[ -f "$binary" ] && [ ! -L "$binary" ] || fail "the build produced no regular binary at $binary"
 # The tree must still be the same commit after the build.
 [ "$(git rev-parse HEAD)" = "$sha" ] && clean || fail "the checkout changed during the build"
 # Client VM A is Ubuntu x86-64: only an ELF64 x86-64 binary can run there.

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -506,9 +506,14 @@ class CleanupVerificationTests(unittest.TestCase):
             az, budgets = self.plane(m, created, present_after=(m["worker_group"],), resources_after=[{"id": peer}],
                                      groups_after=["horizon-worker-registry"])
             started = time.monotonic()
-            result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources, bound_seconds=1)
-            self.assertLess(time.monotonic() - started, 5)
+            result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources, bound_seconds=3)
+            self.assertLess(time.monotonic() - started, 6)
             self.assertTrue(any("absence not proven" in f for f in result["findings"]), result)
+            self.assertTrue(all(0 < b <= client_off.CLI_STEP_SECONDS for b in budgets), "fractional budgets, never rounded up")
+            # With no budget at all, nothing is read and nothing is deleted.
+            az, budgets = self.plane(m, created, resources_after=[{"id": peer}], groups_after=["horizon-worker-registry"])
+            result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources, bound_seconds=0)
+            self.assertEqual((result["deleted"], budgets), ([], []))
         self.assertEqual(client_off.CLEANUP_MARGIN_MINUTES,
                          client_off.RETURN_MARGIN_MINUTES + client_off.CLEANUP_BOUND_SECONDS // 60,
                          "the manifest reserves the return phase plus the whole cleanup bound")

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -3,6 +3,7 @@ authorization and the bounded `az` client. No Azure, no network."""
 from __future__ import annotations
 
 import datetime as dt
+import time
 import unittest
 import unittest.mock as mock
 
@@ -442,13 +443,75 @@ class CleanupTests(unittest.TestCase):
             return shown.get(args[args.index("-n") + 1]) if args[:2] == ["group", "show"] else None
 
         with mock.patch.object(az, "run", side_effect=fake_run):
-            result = client_off.phase_cleanup(az, m, [], created)
+            result = client_off.phase_cleanup(az, m, [], created, resources_before=[])
         self.assertTrue(result["dry_run"])
         self.assertEqual(result["would_delete"], [m["client_group"]])
         self.assertTrue(any("retagged" in finding for finding in result["findings"]), result)
         proposed = [entry["args"] for entry in az.journal if entry["mutating"]]
         self.assertEqual(len(proposed), 1)
         self.assertIn(created[0]["id"], proposed[0][-1], "the intended delete names the journaled ARM ID")
+
+
+class CleanupVerificationTests(unittest.TestCase):
+    """Absence and untouched peers are proven under one bound from a recorded inventory."""
+
+    def plane(self, m, created, *, present_after=(), resources_after=None, groups_after=None):
+        shown = {rec["name"]: {"id": rec["id"], "name": rec["name"], "tags": dict(rec["tags"])} for rec in created}
+        az = client_off.Az("0f0e0d0c-0b0a-4908-8706-050403020100")
+        budgets = []
+
+        def run(args, mutating=False, timeout=0):
+            budgets.append(timeout)
+            az.journal.append({"mutating": mutating, "args": args})
+            if mutating:
+                return {}
+            if args[:2] == ["group", "show"]:
+                return shown.get(args[args.index("-n") + 1])
+            if args[:2] == ["group", "exists"]:
+                return args[args.index("-n") + 1] in present_after
+            if args[:2] == ["resource", "list"]:
+                return resources_after
+            if args[:2] == ["group", "list"]:
+                return [{"name": name} for name in (groups_after or [])]
+            return None
+
+        az.run = run
+        return az, budgets
+
+    def test_peers_are_compared_as_resources_and_the_phase_keeps_its_bound(self):
+        m = manifest()
+        created = [record(m["client_group"], lane="azure-client-off", run_id=RUN_ID), record(m["worker_group"], **ADAPTER_TAGS)]
+        peer = "/subscriptions/s/resourceGroups/horizon-worker-registry/providers/Microsoft.ContainerRegistry/registries/r"
+        inside = f"/subscriptions/s/resourceGroups/{m['client_group']}/providers/Microsoft.Compute/virtualMachines/client"
+        before_resources = [peer, inside]
+        with mock.patch.object(client_off.time, "sleep", lambda seconds: None):
+            az, budgets = self.plane(m, created, resources_after=[{"id": peer.upper()}], groups_after=["horizon-worker-registry"])
+            result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources)
+            self.assertTrue(result["passed"], result)
+            self.assertTrue(all(1 <= b <= client_off.CLI_STEP_SECONDS for b in budgets), budgets)
+            # A peer resource that vanished, or one that appeared, is a finding even though
+            # the group names still match.
+            for after in ([], [{"id": peer}, {"id": peer + "2"}]):
+                az, _ = self.plane(m, created, resources_after=after, groups_after=["horizon-worker-registry"])
+                result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources)
+                self.assertTrue(any("resources outside the deleted groups changed" in f for f in result["findings"]), result)
+            az, _ = self.plane(m, created, resources_after=None, groups_after=["horizon-worker-registry"])
+            result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources)
+            self.assertTrue(any("inventory unreadable" in f for f in result["findings"]), result)
+            for malformed in (None, "ids", ["not-an-arm-id"], [{"name": "x"}]):
+                az, _ = self.plane(m, created, resources_after=[{"id": peer}])
+                result = client_off.phase_cleanup(az, m, [], created, malformed)
+                self.assertEqual(result["deleted"], [], f"{malformed!r}: a malformed inventory authorizes nothing")
+            # A group still present at the bound: the phase ends at the bound, not later.
+            az, budgets = self.plane(m, created, present_after=(m["worker_group"],), resources_after=[{"id": peer}],
+                                     groups_after=["horizon-worker-registry"])
+            started = time.monotonic()
+            result = client_off.phase_cleanup(az, m, ["horizon-worker-registry"], created, before_resources, bound_seconds=1)
+            self.assertLess(time.monotonic() - started, 5)
+            self.assertTrue(any("absence not proven" in f for f in result["findings"]), result)
+        self.assertEqual(client_off.CLEANUP_MARGIN_MINUTES,
+                         client_off.RETURN_MARGIN_MINUTES + client_off.CLEANUP_BOUND_SECONDS // 60,
+                         "the manifest reserves the return phase plus the whole cleanup bound")
 
 
 class AzTests(unittest.TestCase):

--- a/scripts/azure-client-off/tests/test_core.py
+++ b/scripts/azure-client-off/tests/test_core.py
@@ -34,9 +34,11 @@ class ManifestTests(unittest.TestCase):
         soon = (NOW + dt.timedelta(minutes=20)).isoformat()
         self.assertTrue(any("at least" in p for p in client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW)))
         self.assertTrue(client_off.validate_manifest(manifest(cleanup_deadline_utc=soon), NOW, phase="off"))
+        install = (client_off.INSTALL_SETUP_MINUTES + client_off.RUN_COMMAND_SECONDS // 60
+                   + client_off.INSTALL_RECONCILE_SECONDS // 60 + 1)
         self.assertEqual(client_off.required_minutes(manifest(), "install-observer-key"),
-                         client_off.required_minutes(manifest(), "off") + client_off.RUN_COMMAND_SECONDS // 60,
-                         "the install may spend its whole run-command bound first")
+                         client_off.required_minutes(manifest(), "off") + install,
+                         "the install: its setup, the run-command bound and its reconciliation, then the whole off phase")
         self.assertEqual(client_off.required_minutes(manifest(), "validate"),
                          client_off.PROVISION_MINUTES + client_off.required_minutes(manifest(), "install-observer-key"),
                          "renting is approved only when provisioning and then the install can both run to their bounds")

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -827,6 +827,22 @@ class OffPhaseTests(unittest.TestCase):
             os.symlink(f"{root}/real_keys", keys)
             self.assertEqual(run("append").returncode, 2)
             self.assertEqual(pathlib.Path(f"{root}/real_keys").read_text(encoding="utf-8").count("\n"), 1, "the target was not written")
+            # A hard link or a FIFO at the key path is refused as well; the other file is untouched.
+            os.unlink(keys)
+            os.link(f"{root}/real_keys", keys)
+            self.assertEqual(run("append").returncode, 3)
+            self.assertEqual(pathlib.Path(f"{root}/real_keys").read_text(encoding="utf-8").count("\n"), 1)
+            os.unlink(keys)
+            os.mkfifo(keys)
+            self.assertEqual(run("append").returncode, 3, "a FIFO never blocks the editor")
+            os.unlink(keys)
+            # Appending to a missing file creates it; a long line is written in full.
+            long_line = line + " " + "x" * 50_000
+            long_encoded = base64.b64encode(long_line.encode("ascii")).decode("ascii")
+            self.assertEqual(subprocess.run([sys.executable, "-", "append", long_encoded], input=program, text=True,
+                                            capture_output=True, check=False).returncode, 0)
+            self.assertEqual(keys.read_text(encoding="utf-8"), long_line + "\n")
+            self.assertEqual(oct(keys.stat().st_mode)[-3:], "600")
 
     def test_remove_observer_key_is_reconciled_by_the_reader(self):
         for answers, passed, removed in (([{"progress": None, "checkpoint": None, "channel": "refused"}], True, True),

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -746,7 +746,7 @@ class OffPhaseTests(unittest.TestCase):
         # (answers, append result, flip after which probe, expected passed/installed)
         cases = ((iter([answered]), {}, 1, (False, "unknown")),          # "already installed" from a replaced B
                  (iter([refused, answered]), None, 2, (False, "unknown")),  # lost answer settled from a replaced B
-                 (iter([refused, answered]), {}, 2, (False, True)))         # post-append proof from a replaced B
+                 (iter([refused, answered]), {}, 2, (False, "unknown")))    # post-append proof from a replaced B: unproven
         for answers, append_result, flip_after, expected in cases:
             with self.subTest(expected=expected):
                 m, az, calls = self.plane()

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -3,10 +3,12 @@ happen, in which order, on which resource, and what the restricted reader accept
 Azure, no network."""
 from __future__ import annotations
 
+import base64
 import datetime as dt
 import json
 import os
 import pathlib
+import subprocess
 import tempfile
 import time
 import unittest
@@ -91,24 +93,29 @@ class ObserverChannelTests(unittest.TestCase):
             return client_off.read_observations("52.174.10.5", 2222, self.HOST_KEY, "/dev/null", directory)
 
     def test_only_the_forced_readers_json_answer_counts(self):
-        nothing = {"progress": None, "checkpoint": None, "channel": "unavailable"}
-        self.assertEqual(self.observe(b'{"progress": "42\\n", "checkpoint": " 7 "}'),
-                         {"progress": 42, "checkpoint": 7, "channel": "answered"})
-        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}'),
-                         {"progress": 42, "checkpoint": None, "channel": "answered"})
-        self.assertEqual(self.observe(b'{"progress": null, "checkpoint": null}'),
-                         {"progress": None, "checkpoint": None, "channel": "answered"},
+        nothing = {"progress": None, "checkpoint": None, "channel": "unavailable", "paths": None}
+        paths = b'"paths": {"progress": "/workspace/live/progress", "checkpoint": null}'
+        echoed = {"progress": "/workspace/live/progress", "checkpoint": None}
+        self.assertEqual(self.observe(b'{"progress": "42\\n", "checkpoint": " 7 ", ' + paths + b'}'),
+                         {"progress": 42, "checkpoint": 7, "channel": "answered", "paths": echoed})
+        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null, ' + paths + b'}'),
+                         {"progress": 42, "checkpoint": None, "channel": "answered", "paths": echoed})
+        self.assertEqual(self.observe(b'{"progress": null, "checkpoint": null, ' + paths + b'}'),
+                         {"progress": None, "checkpoint": None, "channel": "answered", "paths": echoed},
                          "an authorized key whose files are missing is still an authorized key")
+        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}')["channel"], "unavailable",
+                         "a reader that does not echo its paths is not the forced reader")
         # The forced reader answered but the pty was granted: a `command=` line without
         # `restrict`, which is not the read-only channel the acceptance needs.
-        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}', diagnostics=b""),
-                         {"progress": 42, "checkpoint": None, "channel": "unrestricted"})
-        self.assertEqual(self.observe(b'{"progress": "42",\r\n "checkpoint": null}\r\n', diagnostics=b""),
-                         {"progress": 42, "checkpoint": None, "channel": "unrestricted"}, "a pty's CRLF is not a parse failure")
+        self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null, ' + paths + b'}', diagnostics=b""),
+                         {"progress": 42, "checkpoint": None, "channel": "unrestricted", "paths": echoed})
+        self.assertEqual(self.observe(b'{"progress": "42",\r\n "checkpoint": null, ' + paths + b'}\r\n', diagnostics=b""),
+                         {"progress": 42, "checkpoint": None, "channel": "unrestricted", "paths": echoed},
+                         "a pty's CRLF is not a parse failure")
         for partial in (b"PTY allocation request failed on channel 0\r\n",
                         b"Warning: remote port forwarding failed for listen port 47331\r\n"):
             with self.subTest(partial=partial):
-                self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null}', diagnostics=partial)["channel"],
+                self.assertEqual(self.observe(b'{"progress": "42", "checkpoint": null, ' + paths + b'}', diagnostics=partial)["channel"],
                                  "unrestricted", "one denied capability is not `restrict`: both must be denied")
         refused = b"root@52.174.10.5: Permission denied (publickey).\n"
         self.assertEqual(self.observe(b"", 255, refused), dict(nothing, channel="refused"))
@@ -120,10 +127,10 @@ class ObserverChannelTests(unittest.TestCase):
                                  "only an explicit publickey refusal under the pin is a refusal")
         # The forced reader answered, but the counter is not exactly one integer: the
         # key is authorized and the sample is unreadable.
-        for payload in (b'{"progress": "1\\n2\\n", "checkpoint": null}', b'{"progress": "-3", "checkpoint": null}',
-                        b'{"progress": "4x", "checkpoint": null}', b'{"progress": "' + b"1" * 19 + b'", "checkpoint": null}'):
+        for payload in (b'{"progress": "1\\n2\\n", "checkpoint": null, ', b'{"progress": "-3", "checkpoint": null, ',
+                        b'{"progress": "4x", "checkpoint": null, ', b'{"progress": "' + b"1" * 19 + b'", "checkpoint": null, '):
             with self.subTest(payload=payload[:40]):
-                self.assertEqual(self.observe(payload), dict(nothing, channel="answered"))
+                self.assertEqual(self.observe(payload + paths + b'}'), dict(nothing, channel="answered", paths=echoed))
         # Not the forced reader's answer at all: nothing is known.
         for payload in (b"uid=0(root) gid=0(root)\n",  # the sent command ran: the key is not restricted
                         b'{"progress": "42"}', b'{"progress": "42", "checkpoint": null, "shell": "sh"}', b"", b"\xff",
@@ -134,6 +141,64 @@ class ObserverChannelTests(unittest.TestCase):
                          nothing, "a pin with a newline is never written")
         self.assertEqual(client_off.read_observations("203.0.113.5", 2222, self.HOST_KEY, "/dev/null", "/tmp"), nothing,
                          "an unroutable endpoint is never dialled")
+
+    def test_forced_reader_reads_regular_files_below_the_root_only(self):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(f"{root}/task")
+            pathlib.Path(f"{root}/task/progress").write_text("42\n", encoding="utf-8")
+            pathlib.Path(f"{root}/secret").write_text("no\n", encoding="utf-8")
+            os.symlink(f"{root}/secret", f"{root}/task/link")
+            os.symlink(f"{root}", f"{root}/task/dirlink")
+            pathlib.Path(f"{root}/task/padded").write_text("42" + " " * client_off.PROGRESS_READ_LIMIT + "x\n",
+                                                            encoding="utf-8")
+            pathlib.Path(f"{root}/task/full").write_text("4" * client_off.PROGRESS_READ_LIMIT, encoding="utf-8")
+            os.link(f"{root}/task/progress", f"{root}/task/hardlink")
+            command = client_off.reader_command(f"{root}/task/progress", f"{root}/task/hardlink", root=root)
+            completed = subprocess.run(["sh", "-c", command], capture_output=True, text=True, check=False)
+            self.assertEqual(json.loads(completed.stdout)["checkpoint"], None,
+                             "a checkpoint that is the counter file under another name is never checkpoint proof")
+            cases = {f"{root}/task/progress": "42\n", f"{root}/task/link": None, f"{root}/task": None,
+                     f"{root}/task/dirlink/secret": None, f"{root}/task/missing": None,
+                     # Over the cap is never "exactly one integer", whatever the prefix looks like.
+                     f"{root}/task/padded": None, f"{root}/task/full": "4" * client_off.PROGRESS_READ_LIMIT}
+            for path, expected in cases.items():
+                with self.subTest(path=path):
+                    command = client_off.reader_command(path, None, root=root)
+                    self.assertNotIn("'", command, "the forced command must survive every quoting layer")
+                    completed = subprocess.run(["sh", "-c", command], capture_output=True, text=True, check=False)
+                    self.assertEqual(completed.returncode, 0, completed.stderr)
+                    answer = json.loads(completed.stdout)
+                    self.assertEqual((answer["progress"], answer["checkpoint"]), (expected, None))
+                    self.assertEqual(answer["paths"], {"progress": path, "checkpoint": None}, "the reader echoes its paths")
+            with self.assertRaises(ValueError):
+                client_off.reader_command(f"{root}/../etc/passwd", None, root=root)
+            with self.assertRaises(ValueError):
+                client_off.reader_command("/etc/passwd", None, root=root)
+
+    def test_authorized_line_restricts_the_key_and_survives_sshd_dequoting(self):
+        line = client_off.observer_authorized_line(self.HOST_KEY, "/workspace/live/progress", "/workspace/live/ckpt")
+        self.assertTrue(line.startswith('restrict,command="'))
+        self.assertTrue(line.endswith(" " + self.HOST_KEY))
+        self.assertNotIn("\n", line)
+        quoted = line[len("restrict,command="):]
+        # sshd's auth-options dequote: only a backslash before a double quote is an escape.
+        dequoted, index = "", 1
+        while index < len(quoted):
+            if quoted[index] == "\\" and quoted[index + 1] == '"':
+                index += 1
+            elif quoted[index] == '"':
+                break
+            dequoted += quoted[index]
+            index += 1
+        self.assertEqual(dequoted, client_off.reader_command("/workspace/live/progress", "/workspace/live/ckpt"))
+        self.assertIn(f" {client_off.PROGRESS_READ_LIMIT}", dequoted)
+        for key, progress, checkpoint in (("ssh-rsa AAAA", "/workspace/p", None), (self.HOST_KEY, "/etc/passwd", None),
+                                          (self.HOST_KEY, "/workspace/p", "/workspace/p"),
+                                          (self.HOST_KEY + " comment", "/workspace/p", None),
+                                          (self.HOST_KEY, "/workspace/p", "/workspace/../p")):
+            with self.subTest(key=key, progress=progress, checkpoint=checkpoint):
+                with self.assertRaises(ValueError):
+                    client_off.observer_authorized_line(key, progress, checkpoint)
 
 
 class ClientIdentityTests(unittest.TestCase):
@@ -253,7 +318,7 @@ class OffPhaseTests(unittest.TestCase):
         counter = iter(range(1, 10_000))
         journal = pathlib.Path(directory) / "journal.ndjson"
         return client_off.phase_off(az, m, worker, client, str(journal), sample_seconds=1, interval_seconds=seconds,
-                                    reader=lambda *args: {"progress": next(counter), "checkpoint": None, "channel": "answered"})
+                                    reader=lambda *args: {"progress": next(counter), "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}})
 
     def mutations(self, calls):
         return [c[1][:2] for c in calls if c[0] == "mutate"]
@@ -288,7 +353,7 @@ class OffPhaseTests(unittest.TestCase):
             "client already off": dict(plane={"a_power": "PowerState/deallocated"}),
             "observer channel unavailable": dict(reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "unavailable"}),
             "observer key refused": dict(reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"}),
-            "observer key not restricted": dict(reader=lambda *args: {"progress": 3, "checkpoint": None, "channel": "unrestricted"}),
+            "observer key not restricted": dict(reader=lambda *args: {"progress": 3, "checkpoint": None, "channel": "unrestricted", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}),
         }
         for label, case in cases.items():
             with self.subTest(label=label):
@@ -493,7 +558,7 @@ class OffPhaseTests(unittest.TestCase):
 
         def reader(*args):
             budgets.append(args[5] if len(args) > 5 else None)
-            return {"progress": len(budgets), "checkpoint": None, "channel": "answered"}
+            return {"progress": len(budgets), "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}
 
         with tempfile.TemporaryDirectory() as directory:
             client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1, interval_seconds=0.2,
@@ -516,8 +581,8 @@ class OffPhaseTests(unittest.TestCase):
     def test_a_sample_from_a_channel_that_is_not_the_restricted_reader_is_unreadable(self):
         m, az, calls = self.plane()
         worker, client = self.descriptors(m)
-        answers = iter([{"progress": 1, "checkpoint": None, "channel": "answered"}])  # the gate probe
-        later = {"progress": 9, "checkpoint": None, "channel": "unrestricted"}
+        answers = iter([{"progress": 1, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}])  # the gate probe
+        later = {"progress": 9, "checkpoint": None, "channel": "unrestricted", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}
         with tempfile.TemporaryDirectory() as directory:
             client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson", sample_seconds=1, interval_seconds=0.2,
                                  reader=lambda *args: next(answers, later))
@@ -530,7 +595,7 @@ class OffPhaseTests(unittest.TestCase):
         worker, client = self.descriptors(m)
         with tempfile.TemporaryDirectory() as directory:
             result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson",
-                                          reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered"})
+                                          reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}})
             self.assertFalse(os.path.exists(f"{directory}/j.ndjson"), "no header is left behind")
         self.assertTrue(result["dry_run"])
 
@@ -596,11 +661,180 @@ class OffPhaseTests(unittest.TestCase):
         started = time.monotonic()
         with tempfile.TemporaryDirectory() as directory:
             result = client_off.phase_off(az, m, worker, client, f"{directory}/j.ndjson",
-                                          reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered"})
+                                          reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}})
         self.assertLess(time.monotonic() - started, 5, "a dry run returns without polling for a state it never caused")
         self.assertFalse(result["passed"])
         self.assertTrue(result["dry_run"])
         self.assertEqual(self.mutations(calls), [("vm", "deallocate")], "the intended call is journaled, not issued")
+
+    def test_install_appends_the_restricted_line_through_run_command_and_proves_it(self):
+        m, az, calls = self.plane()
+        worker, _ = self.descriptors(m)
+        answers = iter([{"progress": None, "checkpoint": None, "channel": "refused"}, {"progress": 3, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}])
+        az.append_container_authorized_key = lambda group, name, line: client_off.Az.append_container_authorized_key(
+            az, group, name, line)
+        with tempfile.TemporaryDirectory() as directory:
+            private, public, public_key = self.observer_pair(directory)
+            result = client_off.phase_install_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                       reader=lambda *args: next(answers))
+        self.assertEqual(result, {"passed": True, "installed": True, "progress": 3, "checkpoint": None})
+        invoke = [c[1] for c in calls if c[0] == "mutate"]
+        self.assertEqual([c[:3] for c in invoke], [("vm", "run-command", "invoke")])
+        self.assertIn(m["worker_group"], invoke[0])
+        script = invoke[0][invoke[0].index("--scripts") + 1]
+        self.assertIn("docker exec horizon-worker", script)
+        self.assertIn(">> /root/.ssh/authorized_keys", script)
+        encoded = script.split("echo ")[1].split(" |")[0]
+        line = base64.b64decode(encoded).decode("ascii")
+        self.assertEqual(line, client_off.observer_authorized_line(public_key, worker["progress_path"], None) + "\n")
+        # The worker is attested immediately before the append and again after it.
+        mutation_index = next(i for i, c in enumerate(calls) if c[0] == "mutate")
+        shows = [i for i, c in enumerate(calls) if c[0] == "read" and c[1][:2] == ("vm", "show") and m["worker_group"] in c[1]]
+        self.assertTrue(any(i < mutation_index for i in shows) and any(i > mutation_index for i in shows), calls)
+
+    def test_install_reports_an_unanswered_append_by_what_the_reader_proves(self):
+        for answers, installed, passed in (([{"progress": None, "checkpoint": None, "channel": "refused"}, {"progress": 5, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}], True, True),
+                                           ([{"progress": None, "checkpoint": None, "channel": "refused"}, {"progress": None, "checkpoint": None, "channel": "refused"}], "unknown", False)):
+            with self.subTest(installed=installed):
+                m, az, calls = self.plane()
+                worker, _ = self.descriptors(m)
+                az.append_container_authorized_key = lambda group, name, line: None  # answer lost, not a dry run
+                del calls[:]
+                replies = iter(answers)
+                with tempfile.TemporaryDirectory() as directory:
+                    private, public, _ = self.observer_pair(directory)
+                    result = client_off.phase_install_observer(az, m, dict(worker, observer_key_path=private), public,
+                                                               directory, reader=lambda *args: next(replies))
+                self.assertEqual((result["passed"], result["installed"]), (passed, installed), result)
+                if not passed:
+                    self.assertIn("retry could append a second line", result["findings"][0])
+                shows = [c for c in calls if c[1][:2] == ("vm", "show") and m["worker_group"] in c[1]]
+                self.assertGreaterEqual(len(shows), 2, "B is attested before the append and again before the reader is believed")
+        m, az, calls = self.plane(b_vm_id="/g/b/other")
+        worker, _ = self.descriptors(m)
+        az.append_container_authorized_key = lambda group, name, line: None
+        with tempfile.TemporaryDirectory() as directory:
+            private, public, _ = self.observer_pair(directory)
+            result = client_off.phase_install_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                       reader=lambda *args: {"progress": 5, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}})
+        self.assertFalse(result["passed"], "a reader answering from a replaced B proves nothing")
+        m, az, calls = self.plane()
+        worker, _ = self.descriptors(m)
+        az.dry_run = True
+        az.append_container_authorized_key = lambda group, name, line: client_off.Az.append_container_authorized_key(
+            az, group, name, line)
+        with tempfile.TemporaryDirectory() as directory:
+            private, public, _ = self.observer_pair(directory)
+            result = client_off.phase_install_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                       reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
+        self.assertTrue(result["dry_run"] and not result["installed"] and not result["passed"], result)
+        self.assertEqual([c[1][:3] for c in calls if c[0] == "mutate"], [("vm", "run-command", "invoke")], "journaled, not issued")
+
+    def test_install_refuses_a_public_key_that_is_not_the_observer_private_keys(self):
+        m, az, calls = self.plane()
+        worker, _ = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            private, _, _ = self.observer_pair(directory)
+            other = pathlib.Path(directory) / "other.pub"
+            other.write_text("ssh-ed25519 " + "B" * 68 + " other\n", encoding="utf-8")
+            result = client_off.phase_install_observer(az, m, dict(worker, observer_key_path=private), str(other), directory,
+                                                       reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
+        self.assertFalse(result["passed"])
+        self.assertIn("not the observer private key's", result["findings"][0])
+        self.assertEqual(self.mutations(calls), [], "a foreign key is never appended")
+
+    def test_install_applies_the_off_phase_identity_gates_before_the_append(self):
+        with tempfile.TemporaryDirectory() as directory:
+            public = pathlib.Path(directory) / "observer.pub"
+            public.write_text("ssh-ed25519 " + "B" * 68 + "\n", encoding="utf-8")
+            cases = {"replaced worker": dict(plane={"b_vm_id": "/g/b/other"}),
+                     "other image": dict(plane={"image": "x.azurecr.io/horizon-remote-worker@sha256:" + "c" * 64}),
+                     "worker not running": dict(plane={"b_power": "PowerState/deallocated"}),
+                     "stale address": dict(worker_patch={"host": "52.174.10.6"})}
+            for label, case in cases.items():
+                with self.subTest(label=label):
+                    m, az, calls = self.plane(**case.get("plane", {}))
+                    worker, _ = self.descriptors(m)
+                    worker.update(case.get("worker_patch", {}))
+                    result = client_off.phase_install_observer(az, m, worker, str(public), directory,
+                                                               reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
+                    self.assertFalse(result["passed"], label)
+                    self.assertEqual(self.mutations(calls), [], f"{label}: never a run-command on another VM")
+
+    def test_install_never_appends_when_the_key_already_answers_or_the_gates_fail(self):
+        with tempfile.TemporaryDirectory() as directory:
+            private, public, _ = self.observer_pair(directory)
+            m, az, calls = self.plane()
+            worker, _ = self.descriptors(m)
+            worker["observer_key_path"] = private
+            result = client_off.phase_install_observer(az, m, worker, str(public), directory,
+                                                       reader=lambda *args: {"progress": 1, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}})
+            self.assertTrue(result["passed"] and not result["installed"])
+            self.assertEqual(self.mutations(calls), [])
+            # A probe that neither answers nor refuses authorizes nothing: an append on top
+            # of an unknown state could stack a second line.
+            for unknown in ({"progress": None, "checkpoint": None, "channel": "unavailable"},
+                            {"progress": None, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}):
+                result = client_off.phase_install_observer(az, m, worker, str(public), directory, reader=lambda *args: unknown)
+                self.assertEqual(self.mutations(calls), [], unknown)
+                if unknown["channel"] == "unavailable":
+                    self.assertEqual((result["passed"], result["installed"]), (False, "unknown"), result)
+                else:
+                    self.assertTrue(result["passed"] and not result["installed"], "an answer with missing files is still installed")
+            result = client_off.phase_install_observer(az, m, dict(worker, host_key="ssh-rsa AAAA"), str(public), directory,
+                                                       reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
+            self.assertFalse(result["passed"])
+            self.assertEqual(self.mutations(calls), [])
+
+    def observer_pair(self, directory):
+        """A real Ed25519 pair for observer C, so the pair check runs for real."""
+        private = pathlib.Path(directory) / "observer"
+        subprocess.run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "observer@c", "-f", str(private)], check=True)
+        public_key = " ".join(private.with_suffix(".pub").read_text(encoding="utf-8").split()[:2])
+        return str(private), str(private.with_suffix(".pub")), public_key
+
+    def test_remove_observer_key_is_reconciled_by_the_reader(self):
+        for answers, passed, removed in (([{"progress": None, "checkpoint": None, "channel": "refused"}], True, True),
+                                         ([{"progress": 4, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}], False, False),
+                                         ([{"progress": None, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}], False, False),
+                                         ([{"progress": None, "checkpoint": None, "channel": "unavailable"}], False, "unknown")):
+            with self.subTest(channel=answers[0]["channel"]):
+                m, az, calls = self.plane()
+                worker, _ = self.descriptors(m)
+                az.remove_container_authorized_key = lambda group, name, line: client_off.Az.remove_container_authorized_key(
+                    az, group, name, line)
+                replies = iter(answers)
+                with tempfile.TemporaryDirectory() as directory:
+                    private, public, public_key = self.observer_pair(directory)
+                    result = client_off.phase_remove_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                              reader=lambda *args: next(replies))
+                self.assertEqual((result["passed"], result["removed"]), (passed, removed), result)
+                invoke = [c[1] for c in calls if c[0] == "mutate"]
+                self.assertEqual([c[:3] for c in invoke], [("vm", "run-command", "invoke")])
+                script = invoke[0][invoke[0].index("--scripts") + 1]
+                self.assertIn("grep -vxF", script)
+                self.assertIn("[ $rc -le 1 ] ||", script, "a grep error leaves the file untouched")
+                encoded = script.split("echo ")[1].split(" |")[0]
+                self.assertEqual(base64.b64decode(encoded).decode("ascii"),
+                                 client_off.observer_authorized_line(public_key, worker["progress_path"], None))
+        m, az, calls = self.plane(b_vm_id="/g/b/other")
+        worker, _ = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            private, public, _ = self.observer_pair(directory)
+            result = client_off.phase_remove_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                      reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
+        self.assertFalse(result["passed"])
+        self.assertEqual(self.mutations(calls), [], "a replaced worker is never touched")
+        m, az, calls = self.plane()
+        worker, _ = self.descriptors(m)
+        with tempfile.TemporaryDirectory() as directory:
+            private, _, _ = self.observer_pair(directory)
+            other = pathlib.Path(directory) / "other.pub"
+            other.write_text("ssh-ed25519 " + "B" * 68 + " other\n", encoding="utf-8")
+            result = client_off.phase_remove_observer(az, m, dict(worker, observer_key_path=private), str(other), directory,
+                                                      reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
+        self.assertFalse(result["passed"])
+        self.assertEqual(self.mutations(calls), [], "somebody else's line is never removed")
 
     def test_return_requires_a_deallocated_client(self):
         m, az, calls = self.plane(a_power="PowerState/running")

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -737,6 +737,41 @@ class OffPhaseTests(unittest.TestCase):
         self.assertTrue(result["dry_run"] and not result["installed"] and not result["passed"], result)
         self.assertEqual([c[1][:3] for c in calls if c[0] == "mutate"], [("vm", "run-command", "invoke")], "journaled, not issued")
 
+    def test_every_install_probe_is_bracketed_by_worker_identity_reads(self):
+        # B's instance flips once the probe has run: the "already installed" answer, the
+        # lost-answer recovery and the post-append proof all fall back to unproven.
+        answered = {"progress": 2, "checkpoint": None, "channel": "answered",
+                    "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}
+        refused = {"progress": None, "checkpoint": None, "channel": "refused", "paths": None}
+        # (answers, append result, flip after which probe, expected passed/installed)
+        cases = ((iter([answered]), {}, 1, (False, "unknown")),          # "already installed" from a replaced B
+                 (iter([refused, answered]), None, 2, (False, "unknown")),  # lost answer settled from a replaced B
+                 (iter([refused, answered]), {}, 2, (False, True)))         # post-append proof from a replaced B
+        for answers, append_result, flip_after, expected in cases:
+            with self.subTest(expected=expected):
+                m, az, calls = self.plane()
+                worker, _ = self.descriptors(m)
+                az.append_container_authorized_key = lambda group, name, line, result=append_result: result
+                original = az.run
+                state = {"probed": 0}
+
+                def flipping(args, mutating=False, timeout=0, original=original, state=state, m=m, flip_after=flip_after):
+                    answer = original(args, mutating, timeout)
+                    if args[:2] == ["vm", "show"] and m["worker_group"] in args and state["probed"] >= flip_after:
+                        answer = dict(answer, vmId=A_INSTANCE)
+                    return answer
+
+                def reader(*args, answers=answers, state=state):
+                    state["probed"] += 1
+                    return next(answers)
+
+                az.run = flipping
+                with tempfile.TemporaryDirectory() as directory:
+                    private, public, _ = self.observer_pair(directory)
+                    result = client_off.phase_install_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                               reader=reader)
+                self.assertEqual((result["passed"], result["installed"]), expected, result)
+
     def test_install_refuses_a_public_key_that_is_not_the_observer_private_keys(self):
         m, az, calls = self.plane()
         worker, _ = self.descriptors(m)

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -878,6 +878,29 @@ class OffPhaseTests(unittest.TestCase):
                                                       reader=lambda *args: {"progress": None, "checkpoint": None, "channel": "refused"})
         self.assertFalse(result["passed"])
         self.assertEqual(self.mutations(calls), [], "a replaced worker is never touched")
+        # A refusal from a B that changed identity during the probe proves nothing.
+        m, az, calls = self.plane()
+        worker, _ = self.descriptors(m)
+        az.remove_container_authorized_key = lambda group, name, line: {}
+        original = az.run
+        state = {"probed": False}
+
+        def flipping(args, mutating=False, timeout=0):
+            answer = original(args, mutating, timeout)
+            if args[:2] == ["vm", "show"] and m["worker_group"] in args and state["probed"]:
+                answer = dict(answer, vmId=A_INSTANCE)
+            return answer
+
+        def refusing(*args):
+            state["probed"] = True
+            return {"progress": None, "checkpoint": None, "channel": "refused"}
+
+        az.run = flipping
+        with tempfile.TemporaryDirectory() as directory:
+            private, public, _ = self.observer_pair(directory)
+            result = client_off.phase_remove_observer(az, m, dict(worker, observer_key_path=private), public, directory,
+                                                      reader=refusing)
+        self.assertEqual((result["passed"], result["removed"]), (False, "unknown"), result)
         m, az, calls = self.plane()
         worker, _ = self.descriptors(m)
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/azure-client-off/tests/test_phases.py
+++ b/scripts/azure-client-off/tests/test_phases.py
@@ -9,6 +9,7 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -671,6 +672,8 @@ class OffPhaseTests(unittest.TestCase):
         m, az, calls = self.plane()
         worker, _ = self.descriptors(m)
         answers = iter([{"progress": None, "checkpoint": None, "channel": "refused"}, {"progress": 3, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}])
+        az.edit_container_authorized_keys = lambda group, name, line, action: client_off.Az.edit_container_authorized_keys(
+            az, group, name, line, action)
         az.append_container_authorized_key = lambda group, name, line: client_off.Az.append_container_authorized_key(
             az, group, name, line)
         with tempfile.TemporaryDirectory() as directory:
@@ -683,10 +686,12 @@ class OffPhaseTests(unittest.TestCase):
         self.assertIn(m["worker_group"], invoke[0])
         script = invoke[0][invoke[0].index("--scripts") + 1]
         self.assertIn("docker exec horizon-worker", script)
-        self.assertIn(">> /root/.ssh/authorized_keys", script)
-        encoded = script.split("echo ")[1].split(" |")[0]
-        line = base64.b64decode(encoded).decode("ascii")
-        self.assertEqual(line, client_off.observer_authorized_line(public_key, worker["progress_path"], None) + "\n")
+        self.assertIn("python3 - append ", script, "the editor runs in the container, relative to a verified /root/.ssh")
+        line = base64.b64decode(script.rsplit(" ", 1)[1].rstrip("'")).decode("ascii")
+        self.assertEqual(line, client_off.observer_authorized_line(public_key, worker["progress_path"], None))
+        program = base64.b64decode(script.split("echo ")[1].split(" |")[0]).decode("ascii")
+        self.assertIn("O_NOFOLLOW", program)
+        self.assertIn("dir_fd=ssh", program)
         # The worker is attested immediately before the append and again after it.
         mutation_index = next(i for i, c in enumerate(calls) if c[0] == "mutate")
         shows = [i for i, c in enumerate(calls) if c[0] == "read" and c[1][:2] == ("vm", "show") and m["worker_group"] in c[1]]
@@ -721,6 +726,8 @@ class OffPhaseTests(unittest.TestCase):
         m, az, calls = self.plane()
         worker, _ = self.descriptors(m)
         az.dry_run = True
+        az.edit_container_authorized_keys = lambda group, name, line, action: client_off.Az.edit_container_authorized_keys(
+            az, group, name, line, action)
         az.append_container_authorized_key = lambda group, name, line: client_off.Az.append_container_authorized_key(
             az, group, name, line)
         with tempfile.TemporaryDirectory() as directory:
@@ -793,6 +800,34 @@ class OffPhaseTests(unittest.TestCase):
         public_key = " ".join(private.with_suffix(".pub").read_text(encoding="utf-8").split()[:2])
         return str(private), str(private.with_suffix(".pub")), public_key
 
+    def test_the_key_editor_appends_and_removes_relative_to_a_verified_directory(self):
+        line = client_off.observer_authorized_line("ssh-ed25519 " + "A" * 68, "/workspace/live/progress", None)
+        encoded = base64.b64encode(line.encode("ascii")).decode("ascii")
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(f"{root}/.ssh", mode=0o700)
+            program = client_off.AUTHORIZED_KEYS_EDITOR.replace('os.open("/root", flags)', f'os.open("{root}", flags)')
+            keys = pathlib.Path(root) / ".ssh" / "authorized_keys"
+            keys.write_text("ssh-ed25519 " + "B" * 68 + " client\n", encoding="utf-8")
+
+            def run(action):
+                return subprocess.run([sys.executable, "-", action, encoded], input=program, text=True, capture_output=True, check=False)
+
+            self.assertEqual(run("append").returncode, 0)
+            self.assertEqual(keys.read_text(encoding="utf-8").splitlines()[1], line)
+            self.assertEqual(run("remove").returncode, 0)
+            self.assertEqual(keys.read_text(encoding="utf-8"), "ssh-ed25519 " + "B" * 68 + " client\n", "only the observer line went")
+            self.assertEqual(sorted(os.listdir(f"{root}/.ssh")), ["authorized_keys"], "no temporary left behind")
+            # A symlinked .ssh, or a symlinked key file, is never followed.
+            os.rename(f"{root}/.ssh", f"{root}/elsewhere")
+            os.symlink(f"{root}/elsewhere", f"{root}/.ssh")
+            self.assertEqual(run("append").returncode, 2)
+            os.unlink(f"{root}/.ssh")
+            os.rename(f"{root}/elsewhere", f"{root}/.ssh")
+            os.rename(keys, f"{root}/real_keys")
+            os.symlink(f"{root}/real_keys", keys)
+            self.assertEqual(run("append").returncode, 2)
+            self.assertEqual(pathlib.Path(f"{root}/real_keys").read_text(encoding="utf-8").count("\n"), 1, "the target was not written")
+
     def test_remove_observer_key_is_reconciled_by_the_reader(self):
         for answers, passed, removed in (([{"progress": None, "checkpoint": None, "channel": "refused"}], True, True),
                                          ([{"progress": 4, "checkpoint": None, "channel": "answered", "paths": {"progress": "/workspace/live/progress", "checkpoint": None}}], False, False),
@@ -801,6 +836,8 @@ class OffPhaseTests(unittest.TestCase):
             with self.subTest(channel=answers[0]["channel"]):
                 m, az, calls = self.plane()
                 worker, _ = self.descriptors(m)
+                az.edit_container_authorized_keys = lambda group, name, line, action: client_off.Az.edit_container_authorized_keys(
+                    az, group, name, line, action)
                 az.remove_container_authorized_key = lambda group, name, line: client_off.Az.remove_container_authorized_key(
                     az, group, name, line)
                 replies = iter(answers)
@@ -812,11 +849,11 @@ class OffPhaseTests(unittest.TestCase):
                 invoke = [c[1] for c in calls if c[0] == "mutate"]
                 self.assertEqual([c[:3] for c in invoke], [("vm", "run-command", "invoke")])
                 script = invoke[0][invoke[0].index("--scripts") + 1]
-                self.assertIn("grep -vxF", script)
-                self.assertIn("[ $rc -le 1 ] ||", script, "a grep error leaves the file untouched")
-                encoded = script.split("echo ")[1].split(" |")[0]
-                self.assertEqual(base64.b64decode(encoded).decode("ascii"),
+                self.assertIn("python3 - remove ", script)
+                self.assertEqual(base64.b64decode(script.rsplit(" ", 1)[1].rstrip("'")).decode("ascii"),
                                  client_off.observer_authorized_line(public_key, worker["progress_path"], None))
+                program = base64.b64decode(script.split("echo ")[1].split(" |")[0]).decode("ascii")
+                self.assertIn("os.replace(name, \"authorized_keys\", src_dir_fd=ssh, dst_dir_fd=ssh)", program)
         m, az, calls = self.plane(b_vm_id="/g/b/other")
         worker, _ = self.descriptors(m)
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (client-off acceptance tooling for #475, third slice; does not complete either issue). Builds on the merged core (#557) and phases (#547).

## What

- `clientoff/observer.py`: the forced reader (source and arguments base64-encoded; `O_NOFOLLOW` component walk below `/workspace`, non-blocking final open, capped read of regular files, a hard-linked checkpoint treated as no checkpoint) and its `restrict,command=` authorized_keys line; the reader echoes the paths it was installed for. `derived_public_key` for key-pair checks.
- `clientoff/phases.py`: `install-observer-key` (key pair check, bound to the manifest deadline, append only after B explicitly refuses the key, B re-attested around the append, reader-reconciled; a lost run-command answer is settled by the reader on the re-attested B), `remove-observer-key` (same gates; passes only when the re-attested B refuses the key again). The off gate and every sample require the reader's echoed paths to be the descriptor's. The A and B identity brackets compare ARM IDs case-insensitively.
- `clientoff/az.py`: run-command append and atomic, error-safe removal of one authorized_keys line.
- `clientoff/cleanup.py`, `clientoff/manifest.py`: cleanup under one 20-minute bound the manifest margin is derived from, every ARM call handed what is left; untouched peers proven from a resource inventory recorded before the run (`--resources-before`).
- `record-client-build.sh`: clean-tree candidate record (commit and binary digest, x86-64 Linux build).
- Runbook and README updated; 56 deterministic harness tests, including a real generated observer key pair for the pair checks.

## Carried from the #547 review

The three findings Copilot left suppressed on #547's final head are addressed here: the reader-to-descriptor path binding, and case-insensitive ARM ID comparison in both identity brackets.

## Validation

Full local matrix green on this head: fmt, maintainability, version sync, preflight and harness tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic.