### PR TITLE
test(azure): add the client-off provisioning script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   azure-harness-tests:
     name: Azure harness tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Verify workspace preflight decisions

--- a/docs/testing/azure-client-off-acceptance.md
+++ b/docs/testing/azure-client-off-acceptance.md
@@ -82,8 +82,7 @@ credentials and identifiers stay private.
    the pre-existing resources
    (`az resource list --subscription <id> --query '[].id' -o json > resources.json`)
    for the cleanup comparison.
-2. **Provision A** (the script lands in a following slice; the contract below is what
-   it must meet): `provision-client.sh --manifest m.json --ssh-private-key key
+2. **Provision A**: `provision-client.sh --manifest m.json --ssh-private-key key
    --horizon-binary <binary from the record> --build-record client-build.json
    --ssh-source-cidr <controller address>/32 --out client.json`. Diagnostics go to
    stderr and `client.json` is the exact-A descriptor the later phases take. A's Ed25519 host key is read through

--- a/scripts/azure-client-off/README.md
+++ b/scripts/azure-client-off/README.md
@@ -33,9 +33,11 @@ labelling rules.
   the provenance the provisioning step verifies.
 - The tests run in CI (`Azure harness tests` job) next to the workspace preflight
   suite.
-- `provision-client.sh` (a following slice): creates client VM A in the manifest's
-  run-named group with the reaper tags and the run identity, and copies the exact
-  Horizon build after checking its provenance.
+- `provision-client.sh`: creates client VM A in the manifest's run-named group with
+  the reaper tags and the run identity under one 30-minute bound, every local file
+  reserved before the first cloud call and every create reconciled by reading the
+  exact resource back, and copies the exact Horizon build after checking its
+  provenance.
 - `tests/`: deterministic coverage of the manifest gates, the verdict logic, the
   cleanup authorization, the `az` client, the observer channel and the mutation
   phases, run with `python3 -B -m unittest discover -s scripts/azure-client-off/tests -v`

--- a/scripts/azure-client-off/provision-client.sh
+++ b/scripts/azure-client-off/provision-client.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# Provision disposable client VM A for the Azure client-off lane (#474 / #475).
+#
+# Creates one exact task-owned resource group and one Ubuntu VM with key-only SSH, a
+# virtual display and an isolated persistent Horizon home on the OS disk (retained
+# across deallocation), tagged for the existing spike reaper with the manifest's
+# cleanup deadline. Copies the exact Horizon Linux build by SHA. Never touches any
+# other resource, never logs in, registers a provider or installs an extension.
+#
+# Usage: provision-client.sh --manifest manifest.json --ssh-private-key key \
+#            --horizon-binary /path/to/horizon --build-record client-build.json \
+#            --ssh-source-cidr <this controller's public address>/32 --out client.json
+# Diagnostics go to stderr; the client descriptor is written to --out as standalone JSON.
+# SSH is admitted only from that source range; the VM is never open to the Internet.
+# The key is a fresh Ed25519 pair (`key` and `key.pub`); every SSH and SCP call uses it
+# explicitly with IdentitiesOnly, BatchMode and bounded connection attempts.
+# The build record comes from record-client-build.sh in the clean checkout the binary
+# was built from; the manifest's client_sha and client_binary_sha256 must match it and
+# the binary's actual digest, so a binary from another commit is refused.
+set -euo pipefail
+
+fail() { printf 'provision-client: %s\n' "$1" >&2; exit 1; }
+for tool in az jq ssh scp sha256sum timeout; do command -v "$tool" >/dev/null 2>&1 || fail "required command not found: $tool"; done
+# One absolute bound for the whole provisioning and readiness path, started before the
+# first cloud call; every step gets only what is left of it, so a hung call can never
+# hold a paid VM beyond the bound.
+# The absolute bound on the whole provisioning path: 30 minutes. Tests may shorten it
+# through the environment; the variable can never lengthen it.
+startup_seconds=${HORIZON_CLIENT_OFF_STARTUP_SECONDS:-1800}
+[[ "$startup_seconds" =~ ^[0-9]{1,4}$ ]] && [ "$startup_seconds" -ge 1 ] && [ "$startup_seconds" -le 1800 ] \
+  || fail "HORIZON_CLIENT_OFF_STARTUP_SECONDS must be an integer between 1 and 1800 (the 30-minute bound)"
+# Elapsed time comes from the shell's own counter, not the wall clock, so a clock
+# correction can neither stretch nor cut the paid-resource bound; the wall clock is used
+# only for the manifest's cleanup timestamp.
+SECONDS=0
+remaining() { echo $(( startup_seconds - SECONDS )); }
+KILL_GRACE=10
+bounded() { # bounded <step-cap-seconds> <command...>
+  local cap=$1 left budget; shift; left=$(remaining)
+  # The kill grace is taken out of what is left, so a step that ignores SIGTERM is
+  # killed before the bound, never after it: the 30-minute bound is absolute.
+  budget=$(( (left < cap ? left : cap) - KILL_GRACE ))
+  [ "$budget" -gt 0 ] || fail "the 30-minute startup bound is exhausted; the group stays tagged for the reaper, delete it by hand"
+  timeout -k "$KILL_GRACE" "$budget" "$@"
+}
+azb() { bounded 600 az "$@"; }
+# A create is sent only when, after its own bound, at least this much of the startup
+# bound is guaranteed for reading the resource back: an accepted create whose answer is
+# lost must always end journaled, never untracked because the deadline ran out.
+RECONCILE_WINDOW=${HORIZON_CLIENT_OFF_RECONCILE_SECONDS:-120}
+[[ "$RECONCILE_WINDOW" =~ ^[0-9]{1,3}$ ]] && [ "$RECONCILE_WINDOW" -ge 1 ] && [ "$RECONCILE_WINDOW" -le 120 ] \
+  || fail "HORIZON_CLIENT_OFF_RECONCILE_SECONDS must be an integer between 1 and 120 (tests may shorten the window, never lengthen it)"
+create() { # create <command...>: a mutation that leaves the reconciliation window behind it
+  local left cap; left=$(remaining)
+  cap=$(( left - KILL_GRACE - RECONCILE_WINDOW ))
+  [ "$cap" -ge 30 ] || fail "not enough of the startup bound left to create and then reconcile a resource; nothing created"
+  bounded "$(( cap < 600 ? cap : 600 ))" az "$@"
+}
+nap() { # nap <seconds>: never sleep past the bound
+  local left; left=$(remaining)
+  [ "$left" -gt 0 ] || fail "the 30-minute startup bound is exhausted; the group stays tagged for the reaper, delete it by hand"
+  sleep "$(( left < $1 ? left : $1 ))"
+}
+
+manifest= private_key= binary= record= source_cidr= out=
+while (($# > 0)); do
+  case "$1" in
+    --manifest) manifest=$2; shift 2 ;;
+    --ssh-private-key) private_key=$2; shift 2 ;;
+    --horizon-binary) binary=$2; shift 2 ;;
+    --build-record) record=$2; shift 2 ;;
+    --ssh-source-cidr) source_cidr=$2; shift 2 ;;
+    --out) out=$2; shift 2 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+[ -n "$manifest" ] && [ -n "$private_key" ] && [ -n "$binary" ] && [ -n "$record" ] && [ -n "$source_cidr" ] && [ -n "$out" ] \
+  || fail "--manifest, --ssh-private-key, --horizon-binary, --build-record, --ssh-source-cidr and --out are required"
+say() { printf 'provision-client: %s\n' "$1" >&2; }
+# Everything this run writes locally (journal, descriptor, pinned host key) names the
+# run's resources and endpoint: private to this user, whatever the caller's umask.
+umask 077
+# Every local output is reserved before the first cloud call: a descriptor path that
+# cannot be written, or a stale creation journal, must fail here, never after a paid
+# group exists without its record.
+out_dir=$(dirname "$out")
+[ -d "$out_dir" ] && [ -w "$out_dir" ] || fail "the directory for --out ($out_dir) does not exist or is not writable"
+# Every local file this run writes later is reserved now with an exclusive create, so
+# no pre-existing file or symlink at any of these paths can be followed or overwritten
+# once a paid resource exists.
+reserve() { [ ! -L "$1" ] && ( set -o noclobber; : >"$1" ) 2>/dev/null || fail "$1 already exists or cannot be reserved; each run needs a fresh directory"; }
+reserve "$out.tmp"
+reserve "$out"
+journal=created-groups.json
+for alias in "$out" "$out.tmp"; do
+  [ "$(realpath -m "$alias")" != "$(realpath -m "$journal")" ] || fail "--out must not be the creation journal ($journal)"
+done
+# Exclusive creation: two runs in one directory, or a dangling symlink, can never
+# share or overwrite the only cleanup record.
+[ ! -L "$journal" ] || fail "$journal is a symlink; each run needs a fresh directory or journal"
+( set -o noclobber; echo '[]' >"$journal" ) 2>/dev/null || fail "$journal already exists or cannot be created; each run needs a fresh directory or journal"
+reserve "$journal.tmp"
+python3 - "$source_cidr" <<'PY' || fail "--ssh-source-cidr must be a globally routable unicast IPv4 range no wider than /24"
+import ipaddress, sys
+network = ipaddress.IPv4Network(sys.argv[1], strict=True)
+# Global and unicast: multicast ranges count as global to ipaddress but can never name
+# the controller as an SSH source.
+sys.exit(0 if 24 <= network.prefixlen <= 32 and network.is_global and not network.is_multicast else 1)
+PY
+public_key=$private_key.pub
+[ -f "$private_key" ] && [ -f "$public_key" ] || fail "the private key and its .pub must both exist"
+# Only the key type and payload reach the VM; a comment or extra line never enters YAML.
+# Records, not newline characters: an unterminated second line is still a second line.
+[ "$(awk 'END { print NR }' "$public_key")" -le 1 ] || fail "the public key file must be a single line"
+client_key=$(awk 'NR==1 && $1=="ssh-ed25519" && $2 ~ /^[A-Za-z0-9+\/]{68}$/ {print $1" "$2}' "$public_key")
+[ -n "$client_key" ] || fail "the public key must be one Ed25519 key line"
+# The pair must actually be a pair: a public half that the private key cannot answer
+# for would create a VM no pinned session can ever enter.
+command -v ssh-keygen >/dev/null 2>&1 || fail "required command not found: ssh-keygen"
+# Stdin closed and a short timeout: a passphrase-protected key cannot prompt, and could
+# never be used by the BatchMode sessions later anyway.
+# A failing derivation yields an empty result here (never an exit under `set -e`), so
+# the pair check below is what reports it.
+derived=$( (timeout 15 ssh-keygen -y -P "" -f "$private_key" 2>/dev/null </dev/null || true) | awk '{print $1" "$2}')
+[ "$derived" = "$client_key" ] || fail "the .pub does not belong to the private key, or the key needs a passphrase (BatchMode cannot use it)"
+python3 -B "$(dirname "$0")/client_off.py" --manifest "$manifest" validate >/dev/null || fail "manifest is not runnable; fix it before renting"
+
+sub=$(jq -r .subscription_id "$manifest"); location=$(jq -r .location "$manifest")
+group=$(jq -r .client_group "$manifest"); size=$(jq -r .client_vm_size "$manifest")
+reserve "$group.known_hosts"
+sha=$(jq -r .client_sha "$manifest"); deadline=$(jq -r .cleanup_deadline_utc "$manifest")
+[ "$(azb group exists -n "$group" --subscription "$sub" -o tsv)" = false ] || fail "client group already exists; choose a fresh exact name"
+# The SKU must exist in the location before anything is created, or the group would be
+# journaled and paid for while the VM create fails.
+# The SKU must be offered without restrictions and be x86-64: the client binary the
+# build record describes is an x86-64 ELF, so an Arm64 SKU would only fail after a
+# paid VM exists.
+sku_state=$(azb vm list-skus -l "$location" --size "$size" --resource-type virtualMachines --subscription "$sub" \
+  --query "[?name=='$size'] | [0].[length(restrictions), capabilities[?name=='CpuArchitectureType'].value | [0]]" -o tsv 2>/dev/null \
+  | tr -s '[:space:]' ' ' | sed 's/ $//' || true)
+[ "$sku_state" = "0 x64" ] || fail "VM size $size is not an unrestricted x86-64 size in $location for this subscription (got '${sku_state:-nothing}')"
+# The run identity was drawn when the manifest was frozen and names A's group
+# (`horizon-client-<run_id>`, checked by `validate`): no other run can create or
+# delete this name, which is what makes the group-create PUT below safe. ARM's create
+# is an idempotent PUT that would overwrite a same-named group's tags, and the
+# `exists` check above is only a preflight; the name being this run's is the guarantee.
+run_id=$(jq -r .run_id "$manifest")
+[[ "$run_id" =~ ^[0-9a-f]{32}$ ]] && [ "$group" = "horizon-client-$run_id" ] || fail "manifest run_id and client_group disagree"
+binary_sha=$(sha256sum "$binary" | cut -d' ' -f1)
+# Provenance: the record's commit and digest must equal the manifest's, and the digest
+# must be the bytes about to be uploaded.
+[ "$(jq -r .client_sha "$record")" = "$sha" ] || fail "build record commit differs from the manifest's client_sha"
+[ "$(jq -r .client_binary_sha256 "$record")" = "$binary_sha" ] || fail "build record digest differs from the binary"
+[ "$(jq -r .client_binary_sha256 "$manifest")" = "$binary_sha" ] || fail "manifest client_binary_sha256 differs from the binary"
+
+cloud_init=$(mktemp)
+trap 'rm -f "$cloud_init"' EXIT
+cat >"$cloud_init" <<CLOUD
+#cloud-config
+package_update: true
+# The runtime the snap ships for the client, plus a software Vulkan driver for wgpu.
+packages: [xvfb, openbox, xdotool, x11-utils, imagemagick, openssh-client, git, tmux,
+           mesa-vulkan-drivers, libvulkan1, libegl1, libgl1, libgles2, libgbm1, libfontconfig1, libfreetype6,
+           libwayland-client0, libwayland-cursor0, libwayland-egl1, libx11-6, libx11-xcb1, libxcb1,
+           libxcb-render0, libxcb-shape0, libxcb-xfixes0, libxcursor1, libxi6, libxinerama1, libxrandr2,
+           libxkbcommon0, libxkbcommon-x11-0, xdg-utils, fonts-dejavu-core]
+users:
+  - name: horizon
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - $client_key
+write_files:
+  - path: /etc/systemd/system/horizon-display.service
+    content: |
+      [Unit]
+      Description=Virtual display for the disposable Horizon client
+      After=network.target
+      [Service]
+      User=horizon
+      ExecStart=/usr/bin/Xvfb :99 -screen 0 1600x1000x24 -nolisten tcp
+      Restart=always
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/horizon-wm.service
+    content: |
+      [Unit]
+      Description=Window manager on the disposable Horizon client's display
+      Requires=horizon-display.service
+      After=horizon-display.service
+      [Service]
+      User=horizon
+      Environment=DISPLAY=:99
+      ExecStartPre=/bin/sh -c 'for i in \$(seq 1 50); do xdpyinfo -display :99 >/dev/null 2>&1 && exit 0; sleep 0.2; done; exit 1'
+      ExecStart=/usr/bin/openbox
+      Restart=always
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, enable, --now, horizon-display.service, horizon-wm.service ]
+  - [ install, -d, -o, horizon, -g, horizon, -m, '0700', /home/horizon/.horizon-client-home, /home/horizon/horizon-client/$sha ]
+CLOUD
+
+say "creating group $group in $location (deadline $deadline)"
+# A pending ownership record goes into the journal before the create is sent: it names
+# the exact ARM ID and tag set this run is about to create, so even if the create is
+# accepted and every read afterwards is lost, cleanup can still re-attest the group
+# from ARM and delete it (a group that was never created reads as unknown and is left
+# alone). The record is replaced by ARM's own answer once the group is confirmed.
+# The window check comes before the pending record: a run that cannot create and then
+# reconcile leaves the journal empty, since nothing was sent.
+[ $(( $(remaining) - KILL_GRACE - RECONCILE_WINDOW )) -ge 30 ] \
+  || fail "not enough of the startup bound left to create and then reconcile a resource; nothing created"
+expected_tags=$(jq -n --arg d "$deadline" --arg s "$sha" --arg b "$binary_sha" --arg r "$run_id" \
+  '{issue:"475",lane:"azure-client-off",purpose:"horizon-azure-vm-spike",deadline:$d,client_sha:$s,client_binary_sha256:$b,run_id:$r}')
+jq --arg name "$group" --arg id "/subscriptions/$sub/resourceGroups/$group" --argjson tags "$expected_tags" \
+  '. + [{name: $name, id: $id, tags: $tags}]' "$journal" >"$journal.tmp" \
+  || fail "the pending ownership record could not be written; nothing created"
+mv "$journal.tmp" "$journal" || fail "the pending ownership record could not be placed; nothing created"
+reserve "$journal.tmp"
+# The create may be accepted while the CLI loses the answer: never trust the exit code
+# alone. Reconcile read-only and confirm the group only when it exists with this run's
+# tags; a group that exists with other tags is not ours and stops the run.
+create group create -n "$group" -l "$location" --subscription "$sub" \
+  --tags issue=475 lane=azure-client-off purpose=horizon-azure-vm-spike "deadline=$deadline" client_sha="$sha" client_binary_sha256="$binary_sha" run_id="$run_id" >/dev/null || true
+# Reconcile for as long as the startup bound allows: a create that ARM accepted while
+# the read path is slow must still end in a journaled group, never an untracked one.
+reconciled=false
+while [ "$(remaining)" -gt "$KILL_GRACE" ]; do
+  shown=$(azb group show -n "$group" --subscription "$sub" -o json 2>/dev/null || true)
+  if [ -n "$shown" ]; then
+    # Parsed comparison: Azure may return the tag keys in any order.
+    jq -e --arg d "$deadline" --arg s "$sha" --arg b "$binary_sha" --arg r "$run_id" \
+      '(.tags // {}) == {issue:"475",lane:"azure-client-off",purpose:"horizon-azure-vm-spike",deadline:$d,client_sha:$s,client_binary_sha256:$b,run_id:$r}' \
+      <<<"$shown" >/dev/null || fail "group $group exists but its tags are not exactly this run's; refusing to adopt it"
+    # The record must identify exactly this group: its name and its ARM ID under this subscription.
+    [ "$(jq -r '.name // empty' <<<"$shown")" = "$group" ] \
+      && [ "$(jq -r '.id // empty' <<<"$shown" | tr '[:upper:]' '[:lower:]')" = "$(printf '/subscriptions/%s/resourcegroups/%s' "$sub" "$group" | tr '[:upper:]' '[:lower:]')" ] \
+      || fail "group $group answered with an unexpected name or ARM ID; refusing to journal it"
+    reconciled=true; break
+  fi
+  nap 5
+done
+[ "$reconciled" = true ] || fail "group $group could not be confirmed after the create attempt; its pending record stays in $journal for cleanup to re-attest; check the subscription by hand before retrying"
+# Replace the pending record with the exact identity ARM reports (ID and full tag set)
+# the moment the group is confirmed.
+jq --argjson shown "$shown" --arg name "$group" \
+  'map(if .name == $name then {name: $shown.name, id: $shown.id, tags: ($shown.tags // {})} else . end)' "$journal" >"$journal.tmp" \
+  || fail "the creation journal could not be written; group $group exists (ID $(jq -r .id <<<"$shown")), its pending record stays for cleanup"
+mv "$journal.tmp" "$journal" || fail "the creation journal could not be replaced; group $group exists, its pending record stays for cleanup"
+say "creating client VM ($size), SSH admitted from $source_cidr only"
+create vm create -g "$group" -n client --subscription "$sub" --image Ubuntu2404 --size "$size" \
+  --admin-username horizon --ssh-key-values "$client_key" --public-ip-sku Standard --nsg-rule NONE \
+  --os-disk-size-gb 32 --custom-data "$cloud_init" \
+  --tags issue=475 lane=azure-client-off purpose=horizon-azure-vm-spike "deadline=$deadline" client_sha="$sha" client_binary_sha256="$binary_sha" run_id="$run_id" >/dev/null || true
+# The create is an ambiguous mutation once sent: read the exact VM back with this run's
+# tags before going on, and fail (with the group journaled) only when it is not there.
+vm_seen=false
+while [ "$(remaining)" -gt "$KILL_GRACE" ]; do
+  vm_json=$(azb vm show -g "$group" -n client --subscription "$sub" -o json 2>/dev/null || true)
+  if [ -n "$vm_json" ]; then
+    jq -e --arg d "$deadline" --arg s "$sha" --arg b "$binary_sha" --arg r "$run_id" \
+      '(.tags // {}) == {issue:"475",lane:"azure-client-off",purpose:"horizon-azure-vm-spike",deadline:$d,client_sha:$s,client_binary_sha256:$b,run_id:$r}' \
+      <<<"$vm_json" >/dev/null || fail "VM client exists in $group but its tags are not exactly this run's; refusing to adopt it"
+    vm_seen=true; break
+  fi
+  nap 10
+done
+[ "$vm_seen" = true ] || fail "the client VM could not be confirmed after the create attempt; the group is journaled for cleanup"
+azb network nsg rule create -g "$group" --nsg-name clientNSG -n ssh-from-controller --subscription "$sub" \
+  --priority 1000 --direction Inbound --access Allow --protocol Tcp --destination-port-ranges 22 \
+  --source-address-prefixes "$source_cidr" >/dev/null
+# Every identity value is read back and checked for shape; a `null`, an empty answer or
+# a value of the wrong form never reaches the pin or the descriptor.
+# The address can lag the VM while the network converges: poll it under the bound.
+host=
+while [ "$(remaining)" -gt "$KILL_GRACE" ]; do
+  host=$(azb vm show -d -g "$group" -n client --subscription "$sub" --query publicIps -o tsv 2>/dev/null || true)
+  [[ "$host" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] && break
+  nap 10
+done
+vm_id=$(jq -r '.id // empty' <<<"$vm_json")
+instance_id=$(jq -r '.vmId // empty' <<<"$vm_json")
+group_id=$(jq -r '.id // empty' <<<"$shown")
+[[ "$host" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || fail "the client VM has no usable public address (got '${host:-empty}')"
+# The IDs must be exactly the manifest-determined paths (ARM may vary their casing):
+# a `client` VM anywhere else is not this run's trust anchor.
+lower() { tr '[:upper:]' '[:lower:]' <<<"$1"; }
+expected_group_id="/subscriptions/$sub/resourcegroups/$group"
+[ "$(lower "$vm_id")" = "$(lower "$expected_group_id/providers/Microsoft.Compute/virtualMachines/client")" ] \
+  || fail "the client VM ID is not the manifest's VM under the manifest subscription (got '${vm_id:-empty}')"
+[[ "$instance_id" =~ ^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$ ]] || fail "the client VM instance identity (vmId) could not be read"
+[ "$(lower "$group_id")" = "$(lower "$expected_group_id")" ] || fail "the client group ID is not the manifest's group under the manifest subscription"
+# A's host key comes through the control plane, never from the first TCP handshake: the
+# run-command channel executes inside the exact VM, so the pin is bound to the resource.
+say "reading the client's SSH host key through the control plane"
+host_key=
+while [ "$(remaining)" -gt 0 ]; do
+  message=$(azb vm run-command invoke -g "$group" -n client --subscription "$sub" --command-id RunShellScript \
+    --scripts 'cat /etc/ssh/ssh_host_ed25519_key.pub' --query 'value[0].message' -o tsv 2>/dev/null || true)
+  # The complete answer must be exactly one Ed25519 key line (the classic run-command
+  # message wraps stdout in `[stdout]`/`[stderr]` markers, which are stripped first,
+  # and stderr must be empty); any other line makes the answer ambiguous, not a pin.
+  # The whole message must have exactly the expected shape: an optional
+  # `Enable succeeded:` line, `[stdout]`, exactly one Ed25519 key line, `[stderr]`,
+  # and nothing but blank lines anywhere else. Any other line, before, between or
+  # after the markers, is an ambiguous answer and never a pin.
+  candidate=$(printf '%s\n' "$message" | awk '
+    /^[[:space:]]*$/ { next }
+    state == 0 && /^Enable succeeded: *$/ { next }
+    state == 0 && $0 == "[stdout]" { state = 1; next }
+    state == 1 && NF >= 2 && NF <= 3 && $1 == "ssh-ed25519" && $2 ~ /^[A-Za-z0-9+\/]{68}$/ && key == "" { key = $1 " " $2; next }
+    state == 1 && $0 == "[stderr]" && key != "" { state = 2; next }
+    { bad = 1 }
+    END { if (!bad && state == 2) print key }')
+  if [ -n "$candidate" ]; then
+    host_key=$candidate; break
+  fi
+  # An answer that arrived but does not have the shape is a failure, not a retry.
+  [ -z "$(printf '%s' "$message" | tr -d '[:space:]')" ] || fail "the control plane answered with something other than exactly one Ed25519 host key line between the markers; refusing to pin an ambiguous host key"
+  nap 10
+done
+[ -n "$host_key" ] || fail "the client's Ed25519 host key could not be read through the control plane; the group stays tagged for the reaper, delete it by hand"
+# The key was read through a name-based run-command: the exact VM must still be the
+# one captured above (instance identity and tags) before its key is pinned or recorded.
+vm_after=$(azb vm show -g "$group" -n client --subscription "$sub" -o json)
+[ "$(jq -r '.vmId // empty' <<<"$vm_after")" = "$instance_id" ] && jq -e --argjson before "$(jq '.tags // {}' <<<"$vm_json")" '(.tags // {}) == $before' <<<"$vm_after" >/dev/null \
+  || fail "the client VM changed identity while its host key was read; refusing to pin"
+# OpenSSH looks a default-port host up by its bare address, not the bracketed form.
+printf '%s %s\n' "$host" "$host_key" >"$group.known_hosts"
+ssh_opts=(-F /dev/null -i "$private_key" -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=10
+          -o UserKnownHostsFile="$group.known_hosts" -o GlobalKnownHostsFile=/dev/null -o StrictHostKeyChecking=yes
+          -o ServerAliveInterval=15 -o ServerAliveCountMax=4)
+say "waiting for SSH on the client (pinned)"
+connected=false
+while [ "$(remaining)" -gt 0 ]; do
+  if bounded 60 ssh "${ssh_opts[@]}" "horizon@$host" true 2>/dev/null; then connected=true; break; fi
+  nap 5
+done
+[ "$connected" = true ] || fail "the client VM never accepted pinned SSH within the readiness bound; it stays tagged for the reaper, delete the group by hand"
+# sshd answers before cloud-init finished: wait for it, then require the display service
+# and the destination directory the runcmd stage creates. Every remote step is bounded
+# on the controller side as well.
+bounded 960 ssh "${ssh_opts[@]}" "horizon@$host" \
+  "timeout 900 cloud-init status --wait >/dev/null && systemctl is-active --quiet horizon-display.service && systemctl is-active --quiet horizon-wm.service && test -d /home/horizon/horizon-client/$sha" \
+  || fail "cloud-init did not complete with the display and window-manager services active and the client directory present"
+bounded 900 scp "${ssh_opts[@]}" "$binary" "horizon@$host:/home/horizon/horizon-client/$sha/horizon" \
+  || fail "the client binary upload did not complete within its bound"
+bounded 120 ssh "${ssh_opts[@]}" "horizon@$host" \
+  "chmod 0755 /home/horizon/horizon-client/$sha/horizon && sha256sum /home/horizon/horizon-client/$sha/horizon" \
+  | grep -q "^$binary_sha " || fail "client binary digest mismatch after upload"
+# Launch gate: the uploaded client must open a window on A's display with the installed
+# runtime and software Vulkan before A counts as ready. An ephemeral run writes nothing.
+say "launch gate: starting the client once on the virtual display"
+bounded 180 ssh "${ssh_opts[@]}" "horizon@$host" "bash -s" <<GATE || fail "the client did not open a window on the virtual display; A is not ready"
+set -eu
+export DISPLAY=:99 XDG_RUNTIME_DIR=/run/user/\$(id -u) HOME=/home/horizon/.horizon-client-home
+# A fresh client is the only Horizon on this VM; anything already running is a fault.
+! pgrep -x horizon >/dev/null || { echo "a Horizon process is already running on A" >&2; exit 1; }
+mkdir -p "\$XDG_RUNTIME_DIR" 2>/dev/null || true
+/home/horizon/horizon-client/$sha/horizon --ephemeral >/tmp/horizon-launch-gate.log 2>&1 &
+pid=\$!
+for _ in \$(seq 1 120); do
+  # Only a window owned by the process just started counts; a stale window does not.
+  if xdotool search --pid "\$pid" --name Horizon >/dev/null 2>&1; then kill "\$pid" 2>/dev/null || true; wait "\$pid" 2>/dev/null || true; exit 0; fi
+  if ! kill -0 "\$pid" 2>/dev/null; then echo "client exited before opening a window" >&2; tail -n 20 /tmp/horizon-launch-gate.log >&2; exit 1; fi
+  sleep 1
+done
+kill "\$pid" 2>/dev/null || true
+echo "no window within the gate" >&2
+exit 1
+GATE
+# The exact A: off and return attest this identity before any mutation.
+jq -n --arg group "$group" --arg group_id "$group_id" --arg vm_id "$vm_id" --arg instance "$instance_id" --arg run "$run_id" \
+  --arg host "$host" --arg sha "$sha" --arg digest "$binary_sha" --arg journal "$journal" \
+  '{client_group:$group, client_group_id:$group_id, client_vm_id:$vm_id, client_instance_id:$instance, run_id:$run, client_host:$host, client_sha:$sha, client_binary_sha256:$digest, client_home:"/home/horizon/.horizon-client-home", client_state_root:"/home/horizon/.horizon-client-home/.horizon", display:":99", created_journal:$journal}' \
+  >"$out.tmp" || fail "the client descriptor could not be written; the group is journaled for cleanup"
+mv -f "$out.tmp" "$out" || fail "the client descriptor could not be placed at $out; the group is journaled for cleanup"
+say "client descriptor written to $out"

--- a/scripts/azure-client-off/tests/test_provision.py
+++ b/scripts/azure-client-off/tests/test_provision.py
@@ -1,0 +1,314 @@
+"""Integration coverage of provision-client.sh's paid-resource paths against a fake `az`:
+lost create answers, delayed visibility, mismatched identity and a failing journal
+write. No Azure, no network; the startup bound is shortened through the environment."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from harness_fixtures import HARNESS, RUN_ID, manifest
+
+SUB = "0f0e0d0c-0b0a-4908-8706-050403020100"
+GROUP = f"horizon-client-{RUN_ID}"
+GROUP_ID = f"/subscriptions/{SUB}/resourceGroups/{GROUP}"
+
+FAKE_AZ = r'''#!/usr/bin/env bash
+# A scripted control plane: every call is logged, answers come from the scenario file.
+set -u
+dir=${FAKE_AZ_DIR:?}
+printf '%s\n' "$*" >>"$dir/calls.log"
+scenario=$(cat "$dir/scenario")
+count() { local f="$dir/count.$1"; local n=0; [ -f "$f" ] && n=$(cat "$f"); n=$((n + 1)); echo "$n" >"$f"; echo "$n"; }
+tags='{"issue":"475","lane":"azure-client-off","purpose":"horizon-azure-vm-spike","deadline":"'"$(cat "$dir/deadline")"'","client_sha":"'"$(cat "$dir/sha")"'","client_binary_sha256":"'"$(cat "$dir/digest")"'","run_id":"'"$(cat "$dir/run_id")"'"}'
+case "$*" in
+  "group exists"*) echo false ;;
+  "vm list-skus"*) case "$scenario" in arm-sku) printf '0\tArm64\n' ;; *) printf '0\tx64\n' ;; esac ;;
+  "group create"*) case "$scenario" in lost-create|stalled-read) exit 124 ;; esac; echo '{}' ;;
+  "group show"*)
+    n=$(count group_show)
+    case "$scenario" in
+      lost-create) [ "$n" -le 2 ] && exit 1 ;;
+      stalled-read) sleep 600 ;;   # ARM accepted the create; every read hangs past the bound
+      mismatched) tags='{"issue":"475","lane":"azure-client-off","run_id":"'"$(printf f%.0s {1..32})"'"}' ;;
+    esac
+    echo '{"id":"'"$(cat "$dir/group_id")"'","name":"'"$(cat "$dir/group")"'","location":"northeurope","tags":'"$tags"'}' ;;
+  "vm create"*)
+    case "$scenario" in
+      success|mismatched-vm|cased-vm-id|foreign-vm-id|lost-create) echo '{}' ;;
+      lost-vm-create) exit 124 ;;   # ARM accepted the create; the CLI lost the answer
+      *) exit 1 ;;
+    esac ;;
+  "vm show"*"--query publicIps"*)
+    case "$scenario" in success|mismatched-vm|lost-vm-create|cased-vm-id|foreign-vm-id) echo 52.174.10.9 ;; *) exit 1 ;; esac ;;
+  "vm show"*)
+    n=$(count vm_show)
+    case "$scenario" in
+      lost-vm-create) [ "$n" -le 2 ] && exit 1 ;;&
+      success|lost-vm-create) echo '{"id":"'"$(cat "$dir/group_id")"'/providers/Microsoft.Compute/virtualMachines/client","vmId":"9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d","tags":'"$tags"'}' ;;
+      cased-vm-id) echo '{"id":"'"$(cat "$dir/group_id" | tr '[:lower:]' '[:upper:]')"'/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINES/CLIENT","vmId":"9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d","tags":'"$tags"'}' ;;
+      foreign-vm-id) echo '{"id":"/subscriptions/00000000-0000-4000-8000-000000000000/resourceGroups/other/providers/Microsoft.Compute/virtualMachines/client","vmId":"9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d","tags":'"$tags"'}' ;;
+      mismatched-vm|lost-create) echo '{"id":"'"$(cat "$dir/group_id")"'/providers/Microsoft.Compute/virtualMachines/client","vmId":"9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d","tags":{"issue":"475"}}' ;;
+      *) exit 1 ;;
+    esac ;;
+  "network nsg rule create"*) echo '{}' ;;
+  "vm run-command invoke"*) printf 'Enable succeeded: \n[stdout]\n%s\n[stderr]\n' "$(cat "$dir/host_key")" ;;
+  *) echo "fake az: unscripted call: $*" >&2; exit 1 ;;
+esac
+'''
+
+FAKE_SSH = r'''#!/usr/bin/env bash
+# Stands in for the pinned sessions once A is reachable: records the pin file it was
+# given, answers the digest check with the expected digest, and swallows the gate script.
+dir=${FAKE_AZ_DIR:?}
+printf 'ssh %s\n' "$*" >>"$dir/calls.log"
+for arg in "$@"; do case "$arg" in UserKnownHostsFile=*) cp "${arg#UserKnownHostsFile=}" "$dir/pin.used" ;; esac; done
+case "$*" in
+  *sha256sum*) echo "$(cat "$dir/digest")  /home/horizon/horizon-client/$(cat "$dir/sha")/horizon" ;;
+  *"bash -s"*) cat >/dev/null ;;
+esac
+exit 0
+'''
+
+FAKE_SCP = r'''#!/usr/bin/env bash
+printf 'scp %s\n' "$*" >>"${FAKE_AZ_DIR:?}/calls.log"
+exit 0
+'''
+
+FAKE_JQ = r'''#!/usr/bin/env bash
+# Passes through to the real jq except for the creation-journal append, which fails.
+case "$*" in
+  *"--argjson shown"*) exit 1 ;;
+esac
+exec "$REAL_JQ" "$@"
+'''
+
+
+class ProvisionScriptTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.directory, ignore_errors=True)
+        self.bin = pathlib.Path(self.directory) / "bin"
+        self.bin.mkdir()
+        self.fake_dir = pathlib.Path(self.directory) / "fake"
+        self.fake_dir.mkdir()
+        (self.bin / "az").write_text(FAKE_AZ, encoding="utf-8")
+        (self.bin / "az").chmod(0o755)
+        host_key = "ssh-ed25519 " + "A" * 68
+        for name, value in (("group", GROUP), ("group_id", GROUP_ID), ("run_id", RUN_ID), ("host_key", host_key)):
+            (self.fake_dir / name).write_text(value, encoding="utf-8")
+        self.host_key = host_key
+        key = pathlib.Path(self.directory) / "key"
+        subprocess.run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key)], check=True)
+        self.key = str(key)
+        binary = pathlib.Path(self.directory) / "horizon"
+        binary.write_bytes(b"\x7fELF" + b"\x02\x01\x01" + b"\x00" * 13 + b"\x02\x00\x3e\x00" + b"\x00" * 100)
+        import hashlib
+        digest = hashlib.sha256(binary.read_bytes()).hexdigest()
+        self.binary = str(binary)
+        deadline = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=4)).replace(microsecond=0).isoformat()
+        self.manifest = manifest(client_binary_sha256=digest, cleanup_deadline_utc=deadline)
+        self.manifest["location"] = "northeurope"
+        (pathlib.Path(self.directory) / "m.json").write_text(json.dumps(self.manifest), encoding="utf-8")
+        (pathlib.Path(self.directory) / "record.json").write_text(
+            json.dumps({"client_sha": self.manifest["client_sha"], "client_binary_sha256": digest}), encoding="utf-8")
+        for name, value in (("deadline", deadline), ("sha", self.manifest["client_sha"]), ("digest", digest)):
+            (self.fake_dir / name).write_text(value, encoding="utf-8")
+
+    def run_script(self, scenario, seconds=12, fake_jq=False, fake_ssh=False, cidr="52.174.10.0/24", window=None):
+        (self.fake_dir / "scenario").write_text(scenario, encoding="utf-8")
+        # Each run starts with a fresh call log and fresh visibility counters.
+        for stale in self.fake_dir.glob("count.*"):
+            stale.unlink()
+        for stale in ("calls.log", "pin.used"):
+            (self.fake_dir / stale).unlink(missing_ok=True)
+        if fake_ssh:
+            for name, body in (("ssh", FAKE_SSH), ("scp", FAKE_SCP)):
+                (self.bin / name).write_text(body, encoding="utf-8")
+                (self.bin / name).chmod(0o755)
+        env = dict(os.environ, PATH=f"{self.bin}:{os.environ['PATH']}", FAKE_AZ_DIR=str(self.fake_dir),
+                   HORIZON_CLIENT_OFF_STARTUP_SECONDS=str(seconds), REAL_JQ=shutil.which("jq") or "jq")
+        if window is not None:
+            env["HORIZON_CLIENT_OFF_RECONCILE_SECONDS"] = str(window)
+        if fake_jq:
+            (self.bin / "jq").write_text(FAKE_JQ, encoding="utf-8")
+            (self.bin / "jq").chmod(0o755)
+        workdir = pathlib.Path(tempfile.mkdtemp(prefix=f"run-{scenario}-", dir=self.directory))
+        completed = subprocess.run(["bash", str(HARNESS / "provision-client.sh"), "--manifest", f"{self.directory}/m.json",
+                                    "--ssh-private-key", self.key, "--horizon-binary", self.binary,
+                                    "--build-record", f"{self.directory}/record.json", "--ssh-source-cidr", cidr,
+                                    "--out", str(workdir / "client.json")],
+                                   cwd=workdir, env=env, capture_output=True, text=True, timeout=int(seconds) + 90 if str(seconds).isdigit() else 60,
+                                   check=False)
+        return completed, workdir
+
+    def calls(self):
+        log = self.fake_dir / "calls.log"
+        return log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+    def test_a_lost_create_answer_is_reconciled_and_journaled_before_anything_else(self):
+        # The reconcile loop keeps the kill grace out of the bound and naps five seconds
+        # between reads, so two lost reads need well over ten seconds of bound.
+        # The scenario ends at the VM step with a foreign VM, so the suite stays short;
+        # the assertions are about the group create and its journaling.
+        completed, workdir = self.run_script("lost-create", seconds=200)
+        self.assertNotEqual(completed.returncode, 0)
+        journal = json.loads((workdir / "created-groups.json").read_text(encoding="utf-8"))
+        self.assertEqual([r["name"] for r in journal], [GROUP], "the group ARM accepted is journaled even though the create timed out")
+        self.assertEqual(journal[0]["id"], GROUP_ID)
+        self.assertEqual(journal[0]["tags"]["run_id"], RUN_ID)
+        shows = [c for c in self.calls() if c.startswith("group show")]
+        self.assertGreaterEqual(len(shows), 3, "visibility was polled until the group appeared")
+        self.assertIn("refusing to adopt it", completed.stderr)
+        # The descriptor path was reserved up front and never written: no A to hand on.
+        self.assertEqual((workdir / "client.json").stat().st_size, 0)
+
+    def test_an_accepted_group_is_journaled_even_when_every_read_after_the_create_stalls(self):
+        # The create is sent (the window is there), then every read hangs until the bound
+        # is gone: the pending record written before the create is what cleanup gets.
+        completed, workdir = self.run_script("stalled-read", seconds=70, window=20)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("pending record stays", completed.stderr)
+        journal = json.loads((workdir / "created-groups.json").read_text(encoding="utf-8"))
+        self.assertEqual([(r["name"], r["id"]) for r in journal], [(GROUP, GROUP_ID)])
+        self.assertEqual(journal[0]["tags"]["run_id"], RUN_ID)
+        from harness_fixtures import client_off
+        targets = client_off.cleanup_targets(self.manifest, [], journal)
+        self.assertEqual([r["name"] for r in targets["delete"]], [GROUP], "cleanup accepts the pending record and re-attests it")
+
+    def test_a_group_with_other_tags_is_never_adopted(self):
+        completed, workdir = self.run_script("mismatched", seconds=200)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("refusing to adopt it", completed.stderr)
+        # The pending record stays: cleanup re-attests it against ARM, where the foreign
+        # tags make it refuse the delete, so nothing of the other party's is touched.
+        journal = json.loads((workdir / "created-groups.json").read_text(encoding="utf-8"))
+        self.assertEqual([r["name"] for r in journal], [GROUP])
+        self.assertFalse(any(c.startswith("vm create") for c in self.calls()), "no VM is created in a foreign group")
+
+    def test_a_failing_journal_write_stops_the_run_and_names_the_group(self):
+        completed, workdir = self.run_script("plain", seconds=200, fake_jq=True)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("creation journal could not be written", completed.stderr)
+        self.assertIn(GROUP_ID, completed.stderr, "the operator is told exactly which group to delete by hand")
+        self.assertFalse(any(c.startswith("vm create") for c in self.calls()), "no paid VM without a creation record")
+
+    def test_the_whole_path_ends_in_a_descriptor_that_names_the_exact_client(self):
+        completed, workdir = self.run_script("success", seconds=200, fake_ssh=True)
+        self.assertEqual(completed.returncode, 0, completed.stderr[-1500:])
+        descriptor = json.loads((workdir / "client.json").read_text(encoding="utf-8"))
+        self.assertEqual((descriptor["client_group"], descriptor["client_group_id"], descriptor["run_id"], descriptor["client_host"]),
+                         (GROUP, GROUP_ID, RUN_ID, "52.174.10.9"))
+        self.assertEqual(descriptor["client_vm_id"], f"{GROUP_ID}/providers/Microsoft.Compute/virtualMachines/client")
+        self.assertEqual(descriptor["client_instance_id"], "9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d")
+        self.assertEqual(descriptor["client_sha"], self.manifest["client_sha"])
+        journal = json.loads((workdir / "created-groups.json").read_text(encoding="utf-8"))
+        self.assertEqual([r["name"] for r in journal], [GROUP], "the pending record was replaced, not duplicated")
+        self.assertEqual(journal[0]["id"], GROUP_ID)
+        # The pin the sessions used is the control-plane key for the bare address.
+        self.assertEqual((self.fake_dir / "pin.used").read_text(encoding="utf-8"), f"52.174.10.9 {self.host_key}\n")
+        calls = self.calls()
+        run_command = next(i for i, c in enumerate(calls) if c.startswith("vm run-command invoke"))
+        self.assertTrue(any(c.startswith("vm show") and "--query publicIps" not in c for c in calls[run_command + 1:]),
+                        "the VM is attested again after the host key was read")
+        self.assertTrue(any(c.startswith("scp ") for c in calls) and any("sha256sum" in c for c in calls))
+        for name in ("client.json.tmp", "created-groups.json.tmp"):
+            self.assertFalse((workdir / name).exists(), f"{name} is not left behind")
+
+    def test_a_lost_vm_create_answer_is_reconciled_and_the_create_is_never_repeated(self):
+        completed, workdir = self.run_script("lost-vm-create", seconds=240, fake_ssh=True)
+        self.assertEqual(completed.returncode, 0, completed.stderr[-1500:])
+        calls = self.calls()
+        self.assertEqual(sum(1 for c in calls if c.startswith("vm create")), 1, "an accepted create is never sent twice")
+        reads = [i for i, c in enumerate(calls) if c.startswith("vm show") and "--query publicIps" not in c]
+        create = next(i for i, c in enumerate(calls) if c.startswith("vm create"))
+        self.assertGreaterEqual(len([i for i in reads if i > create]), 3, "the VM was polled until it appeared")
+        descriptor = json.loads((workdir / "client.json").read_text(encoding="utf-8"))
+        self.assertEqual(descriptor["client_instance_id"], "9b8a7c6d-1e2f-4a3b-9c8d-7e6f5a4b3c2d")
+
+    def test_vm_and_group_ids_are_the_manifests_paths_whatever_their_casing(self):
+        completed, workdir = self.run_script("cased-vm-id", seconds=200, fake_ssh=True)
+        self.assertEqual(completed.returncode, 0, completed.stderr[-800:])
+        descriptor = json.loads((workdir / "client.json").read_text(encoding="utf-8"))
+        self.assertEqual(descriptor["client_vm_id"].casefold(), f"{GROUP_ID}/providers/Microsoft.Compute/virtualMachines/client".casefold())
+        completed, workdir = self.run_script("foreign-vm-id", seconds=200, fake_ssh=True)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("not the manifest's VM under the manifest subscription", completed.stderr)
+        self.assertEqual((workdir / "client.json").stat().st_size, 0, "no descriptor anchors a foreign VM")
+        self.assertEqual([r["name"] for r in json.loads((workdir / "created-groups.json").read_text(encoding="utf-8"))], [GROUP])
+        self.assertFalse(any(c.startswith("vm run-command") or c.startswith("ssh ") for c in self.calls()))
+
+    def test_a_vm_with_other_tags_is_never_adopted_and_the_group_stays_journaled(self):
+        completed, workdir = self.run_script("mismatched-vm", seconds=200, fake_ssh=True)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("its tags are not exactly this run's; refusing to adopt it", completed.stderr)
+        journal = json.loads((workdir / "created-groups.json").read_text(encoding="utf-8"))
+        self.assertEqual([r["name"] for r in journal], [GROUP], "the paid group stays journaled for cleanup")
+        self.assertFalse(any(c.startswith("vm run-command") or c.startswith("ssh ") for c in self.calls()),
+                         "nothing is read from or pinned on a VM that is not this run's")
+        self.assertEqual((workdir / "client.json").stat().st_size, 0)
+
+    def test_the_startup_override_can_shorten_but_never_lengthen_the_bound(self):
+        for value in ("3600", "0", "-5", "abc", "1801"):
+            with self.subTest(value=value):
+                completed, workdir = self.run_script("plain", seconds=value)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn("between 1 and 1800", completed.stderr)
+                self.assertEqual(self.calls(), [], "refused before any control-plane call")
+
+    def test_the_source_range_must_be_a_public_unicast_range(self):
+        for cidr in ("224.0.0.0/24", "10.0.0.0/24", "127.0.0.0/24", "52.174.0.0/16", "52.174.10.1/24"):
+            with self.subTest(cidr=cidr):
+                completed, workdir = self.run_script("plain", cidr=cidr)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn("globally routable unicast IPv4 range", completed.stderr)
+                self.assertEqual(self.calls(), [], "refused before any control-plane call")
+
+    def test_a_create_is_sent_only_with_a_reconciliation_window_behind_it(self):
+        # With too little of the bound left to create and then read the group back, the
+        # create is not sent at all: nothing can end up accepted and untracked.
+        completed, workdir = self.run_script("lost-create", seconds=100)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("not enough of the startup bound left to create", completed.stderr)
+        self.assertFalse(any(c.startswith("group create") for c in self.calls()))
+        self.assertEqual(json.loads((workdir / "created-groups.json").read_text(encoding="utf-8")), [])
+
+    def test_the_reconciliation_window_override_can_shorten_but_never_lengthen(self):
+        for value in ("121", "0", "x"):
+            with self.subTest(value=value):
+                completed, workdir = self.run_script("plain", seconds=200, window=value)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn("between 1 and 120", completed.stderr)
+                self.assertEqual(self.calls(), [], "refused before any control-plane call")
+
+    def test_an_arm64_sku_is_refused_before_any_create(self):
+        completed, workdir = self.run_script("arm-sku")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("not an unrestricted x86-64 size", completed.stderr)
+        self.assertFalse(any(c.startswith("group create") for c in self.calls()), "nothing was created")
+        self.assertEqual(json.loads((workdir / "created-groups.json").read_text(encoding="utf-8")), [])
+
+    def test_preflight_refuses_a_stale_journal_before_any_cloud_call(self):
+        workdir = pathlib.Path(self.directory) / "run-stale"
+        workdir.mkdir()
+        (workdir / "created-groups.json").write_text("[]", encoding="utf-8")
+        (self.fake_dir / "scenario").write_text("plain", encoding="utf-8")
+        env = dict(os.environ, PATH=f"{self.bin}:{os.environ['PATH']}", FAKE_AZ_DIR=str(self.fake_dir),
+                   HORIZON_CLIENT_OFF_STARTUP_SECONDS="12")
+        completed = subprocess.run(["bash", str(HARNESS / "provision-client.sh"), "--manifest", f"{self.directory}/m.json",
+                                    "--ssh-private-key", self.key, "--horizon-binary", self.binary,
+                                    "--build-record", f"{self.directory}/record.json", "--ssh-source-cidr", "52.174.10.0/24",
+                                    "--out", str(workdir / "client.json")],
+                                   cwd=workdir, env=env, capture_output=True, text=True, timeout=60, check=False)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("already exists", completed.stderr)
+        self.assertEqual(self.calls(), [], "nothing was asked of the control plane")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (client-off acceptance tooling for #475, fourth slice; does not complete either issue). Stacked on #562; the base moves to `main` once #562 merges.

## What

`scripts/azure-client-off/provision-client.sh` creates client VM A in the manifest's run-named group under a 30-minute bound with the kill grace inside it:

- every local file (descriptor and its temporary, the creation journal and its temporary, the pinned host-key file) reserved with an exclusive create before the first cloud call, `umask 077`, `--out` may not alias the journal;
- key pair checked with `ssh-keygen -y` (no passphrase prompt) and the VM size checked against the location with `az vm list-skus` before any create; a globally routable source range;
- the group and VM creates treated as ambiguous once sent and reconciled by reading the exact resource back with this run's tags for as long as the bound allows, the group journaled the moment it is confirmed with the expected name and ARM ID, every journal and descriptor write failing explicitly;
- the public address polled while the network converges; the host key read through the control plane and accepted only when the whole answer is exactly one Ed25519 key line between the `[stdout]`/`[stderr]` markers with an empty stderr; the VM attested again (instance identity and tag map, compared with jq) before the key is pinned; every identity value read back with a shape check;
- the exact build copied and digest-verified, and a launch gate on the virtual display.

The runbook's step 2 already describes this contract; the README entry loses its "following slice" note.

## Validation

Full local matrix green on this head: fmt, maintainability, version sync, preflight and harness tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic. `bash -n` on the script.