### PR TITLE
feat(worker): capture selected state across commits

### DIFF
--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -532,8 +532,8 @@ def revision_proof(checkout, preparation, git, call, command):
             if value.get('last_success'):
                 plan, blobs = read(value)
                 working = {entry['path']: entry for entry in plan['working_tree']}
-                if plan['source']['commit'] == commit and blobs[working['selected.txt']['sha256']] == payload:
-                    store.require(plan['source']['branch'] == preparation['work_branch']
+                if plan['commit'] == commit and blobs[working['selected.txt']['sha256']] == payload:
+                    store.require(plan['branch'] == preparation['work_branch']
                         and set(working) == set(enrollment['selected'])
                         and working['deleted.txt']['kind'] == 'remove')
                     return value

--- a/containers/remote-worker/test_byte_capture.py
+++ b/containers/remote-worker/test_byte_capture.py
@@ -489,7 +489,85 @@ def inside_proof():
                     else:
                         original.unlink()
                 retained.rename(original)
-        print(json.dumps({'proof': 'controller exited; two verified byte versions', 'observed_interval_millis': interval}))
+    finally:
+        call('cancel', binding)
+        deadline = time.monotonic() + 20
+        while call('status', binding).get('recorded_state') not in ('cancelled', 'error'):
+            store.require(time.monotonic() < deadline)
+            time.sleep(.1)
+    revision_intervals = revision_proof(checkout, preparation, git, call, command)
+    print(json.dumps({'proof': 'controller exited; two verified byte versions',
+        'observed_interval_millis': interval, 'revision_intervals_millis': revision_intervals}))
+
+
+def revision_proof(checkout, preparation, git, call, command):
+    """Actual v2 service survives normal commits; v1 proof above remains unchanged."""
+    enrollment = {'version': 2, 'preparation': preparation,
+        'selected': ['selected.txt', 'untracked.txt', 'deleted.txt'], 'retained_volume_attested': True}
+    captures = Path(capture.BASE) / 'byte-captures'
+    before_slots = set(captures.iterdir())
+    git('checkout', '-b', 'work/other')
+    refused = subprocess.run(command + ['start'], input=store.encode(enrollment),
+        capture_output=True, env=capture.ENV, timeout=20)
+    store.require(refused.returncode == 1 and not refused.stdout and set(captures.iterdir()) == before_slots)
+    git('checkout', preparation['work_branch'])
+    started = call('start', data=store.encode(enrollment))
+    binding = started['binding']
+    store.require(started['state'] == 'submitted' and captures / binding not in before_slots)
+    def read(value):
+        slot = store.open_slot(capture.BASE, binding)
+        bundles = slot.child('bundles')
+        try:
+            success = value['last_success']
+            bundles.verified_record(success)
+            return literal_bundle(bundles.record(success['manifest']), success['manifest'])
+        finally:
+            bundles.close()
+            slot.close()
+    def wait(commit, payload):
+        deadline = time.monotonic() + 35
+        while time.monotonic() < deadline:
+            value = call('status', binding)
+            store.require(value['state'] not in ('error', 'cancelled'))
+            if value.get('last_success'):
+                plan, blobs = read(value)
+                working = {entry['path']: entry for entry in plan['working_tree']}
+                if plan['source']['commit'] == commit and blobs[working['selected.txt']['sha256']] == payload:
+                    store.require(plan['source']['branch'] == preparation['work_branch']
+                        and set(working) == set(enrollment['selected'])
+                        and working['deleted.txt']['kind'] == 'remove')
+                    return value
+            time.sleep(.1)
+        raise store.CaptureError('revision proof deadline')
+    try:
+        first = wait(git('rev-parse', 'HEAD'), b'second working bytes\n')
+        (checkout / 'selected.txt').write_bytes(b'new committed selected bytes\n')
+        git('add', 'selected.txt')
+        git('commit', '-m', 'synthetic ordinary remote commit')
+        commit = git('rev-parse', 'HEAD')
+        committed = wait(commit, b'new committed selected bytes\n')
+        plan, blobs = read(committed)
+        index = {entry['path']: entry for entry in plan['index']}
+        store.require(set(index) == set(enrollment['selected'])
+            and blobs[index['selected.txt']['sha256']] == b'new committed selected bytes\n'
+            and index['untracked.txt']['kind'] == 'remove')
+        (checkout / 'selected.txt').write_bytes(b'dirty after commit\n')
+        dirty = wait(commit, b'dirty after commit\n')
+        for previous, following in ((first, committed), (committed, dirty)):
+            store.require(previous['last_success']['manifest'] != following['last_success']['manifest'])
+            read(previous)  # Both earlier byte versions still verify after the later publication.
+        intervals = [b['last_success']['verified_at_millis'] - a['last_success']['verified_at_millis']
+                     for a, b in ((first, committed), (committed, dirty))]
+        store.require(all(0 < value <= 30_000 for value in intervals))
+        lock = captures / binding / 'lock'
+        identity = store.identity(lock.stat())
+        enrollment['selected'].reverse()
+        repeated = call('start', data=store.encode(enrollment))
+        store.require(repeated['binding'] == binding and repeated['state'] != 'submitted'
+            and repeated['started_at_millis'] == first['started_at_millis']
+            and store.identity(lock.stat()) == identity
+            and set(captures.iterdir()) == before_slots | {captures / binding})
+        return intervals
     finally:
         call('cancel', binding)
         deadline = time.monotonic() + 20
@@ -518,6 +596,9 @@ class ActualCli(unittest.TestCase):
             result = subprocess.run(arguments, capture_output=True, env=capture.ENV, timeout=90, umask=0o077)
             self.assertEqual(result.returncode, 0, result.stderr.decode(errors='replace'))
             self.assertIn(b'two verified byte versions', result.stdout)
+            proof = store.decode(result.stdout)
+            self.assertEqual(len(proof['revision_intervals_millis']), 2)
+            self.assertTrue(all(0 < value <= 30_000 for value in proof['revision_intervals_millis']))
 
 
 if __name__ == '__main__':

--- a/crates/horizon-core/src/repository_overlay/capture/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/linux.rs
@@ -52,13 +52,24 @@ pub(super) fn capture(root: &Path, source: GitSource, selected: &[&str]) -> Resu
 }
 
 pub(super) struct State {
-    reader: SelectedRepositoryReader,
-    repository: Repository,
-    base: Oid,
+    pub(super) reader: SelectedRepositoryReader,
+    pub(super) repository: Repository,
+    pub(super) base: Oid,
 }
 
 impl State {
     pub(super) fn open(root: &Path, source: &GitSource) -> Result<Self, Error> {
+        let state = Self::open_with(root, |_| {
+            Oid::from_str(source.commit.as_str()).map_err(|_| Error::BaseMismatch)
+        })?;
+        state.verify_head()?;
+        Ok(state)
+    }
+
+    pub(super) fn open_with(
+        root: &Path,
+        select_base: impl FnOnce(&Repository) -> Result<Oid, Error>,
+    ) -> Result<Self, Error> {
         let reader = SelectedRepositoryReader::open(root)?;
         let pinned = format!("/proc/self/fd/{}", reader.root.handle().as_raw_fd());
         let repository = Repository::open_ext(&pinned, RepositoryOpenFlags::NO_SEARCH, &[] as &[&str])
@@ -66,14 +77,13 @@ impl State {
         if repository.is_bare() || repository.object_format() != ObjectFormat::Sha1 {
             return Err(Error::Repository);
         }
-        let base = Oid::from_str(source.commit.as_str()).map_err(|_| Error::BaseMismatch)?;
+        let base = select_base(&repository)?;
         let state = Self {
             reader,
             repository,
             base,
         };
         state.verify_root()?;
-        state.verify_head()?;
         Ok(state)
     }
 

--- a/crates/horizon-core/src/repository_overlay/capture/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/mod.rs
@@ -57,7 +57,8 @@ pub fn capture_selected(
 /// The same platform, ownership, payload and filesystem-latency limits apply.
 /// # Errors
 /// Rejects invalid selections/source/branch, detached or unborn HEAD, unsafe nodes,
-/// unsupported index semantics and detected root/index/branch/HEAD changes.
+/// unsupported index semantics and detected root/selected-index/branch/HEAD changes.
+/// Ordinary changes to unselected index entries are outside this capture's guarantee.
 pub fn capture_selected_revision(
     root: &Path,
     mut source: GitSource,

--- a/crates/horizon-core/src/repository_overlay/capture/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/mod.rs
@@ -4,6 +4,8 @@
 mod content;
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "linux")]
+mod revision;
 
 use super::{
     MAX_CHANGES, MAX_METADATA_BYTES, OverlayPlanError,
@@ -40,6 +42,42 @@ pub fn capture_selected(
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (root, source, selection);
+        Err(GitCaptureError::Unsupported)
+    }
+}
+
+/// Capture complete literal index/worktree states for the explicit selection at
+/// the current commit of exactly `work_branch`. Unlike [`capture_selected`],
+/// unchanged selected bytes and absent nodes are included in both layers.
+/// The returned source binds the observed commit and branch; the supplied source
+/// identifies the enrolled repository, not a requirement to stay at its old commit.
+/// Only selected payloads are exported; current commit/tree metadata is read for
+/// admission. No history export, filters, remote URL reads or network I/O occurs.
+/// This is not a full repository checkpoint or an atomic multi-file snapshot.
+/// The same platform, ownership, payload and filesystem-latency limits apply.
+/// # Errors
+/// Rejects invalid selections/source/branch, detached or unborn HEAD, unsafe nodes,
+/// unsupported index semantics and detected root/index/branch/HEAD changes.
+pub fn capture_selected_revision(
+    root: &Path,
+    mut source: GitSource,
+    work_branch: &str,
+    selected: &[&str],
+) -> Result<RepositoryOverlayBundle, GitCaptureError> {
+    source.validate().map_err(|_| OverlayPlanError::InvalidSource)?;
+    source.branch = Some(work_branch.to_owned());
+    source.validate().map_err(|_| OverlayPlanError::InvalidSource)?;
+    if work_branch == "HEAD" || work_branch.len() > 1024 {
+        return Err(OverlayPlanError::InvalidSource.into());
+    }
+    let selection = validate_selection(selected)?;
+    #[cfg(target_os = "linux")]
+    {
+        revision::capture(root, source, work_branch, &selection)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (root, source, work_branch, selection);
         Err(GitCaptureError::Unsupported)
     }
 }

--- a/crates/horizon-core/src/repository_overlay/capture/revision.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/revision.rs
@@ -1,0 +1,73 @@
+use super::{
+    GitCaptureError as Error,
+    content::{Contents, GitNode},
+    linux::{State, tree_node},
+};
+use crate::{
+    cloud_run::{GitCommitSha, GitSource},
+    repository_overlay::{
+        RepositoryOverlayPlan,
+        bundle::RepositoryOverlayBundle,
+        reader::{MAX_READ_BYTES, RepositoryReadError},
+    },
+};
+use git2::{Oid, Repository};
+use std::path::Path;
+
+pub(super) fn capture(
+    root: &Path,
+    mut source: GitSource,
+    branch: &str,
+    selected: &[&str],
+) -> Result<RepositoryOverlayBundle, Error> {
+    let state = State::open_with(root, |repository| branch_head(repository, branch))?;
+    source.commit = GitCommitSha::parse(state.base.to_string()).map_err(|_| Error::InvalidObject)?;
+    let baseline = state.selected_index(selected)?;
+    let tree = state
+        .repository
+        .find_commit(state.base)
+        .and_then(|commit| commit.tree())
+        .map_err(|_| Error::GitRead)?;
+    let mut contents = Contents::default();
+    let mut index = Vec::new();
+    let mut working = Vec::new();
+    for (path, indexed) in selected.iter().zip(&baseline) {
+        // Preserve the existing base-tree ancestor refusal even for removed gitlinks.
+        tree_node(tree.clone(), path, |id| state.repository.find_tree(id))?;
+        index.push(contents.change(path, indexed.map(|node| node.read(&state.repository)).transpose()?)?);
+        let node = match state.reader.read(path, MAX_READ_BYTES) {
+            Ok(node) => Some(node),
+            Err(RepositoryReadError::Missing) => None,
+            Err(error) => return Err(error.into()),
+        };
+        working.push(contents.change(path, node)?);
+    }
+    verify(&state, branch, selected, &baseline)?;
+    contents.finish(RepositoryOverlayPlan::new(source, index, working)?)
+}
+
+pub(super) fn verify(
+    state: &State,
+    branch: &str,
+    selected: &[&str],
+    baseline: &[Option<GitNode>],
+) -> Result<(), Error> {
+    state.verify(selected, baseline).map_err(|error| match error {
+        Error::BaseMismatch => Error::Changed,
+        error => error,
+    })?;
+    if branch_head(&state.repository, branch).map_err(|_| Error::Changed)? != state.base {
+        return Err(Error::Changed);
+    }
+    Ok(())
+}
+
+pub(super) fn branch_head(repository: &Repository, branch: &str) -> Result<Oid, Error> {
+    let head = repository.head().map_err(|_| Error::BaseMismatch)?;
+    if !head.is_branch() || head.name().map_err(|_| Error::BaseMismatch)? != format!("refs/heads/{branch}") {
+        return Err(Error::BaseMismatch);
+    }
+    head.peel_to_commit()
+        .map(|commit| commit.id())
+        .map_err(|_| Error::BaseMismatch)
+}

--- a/crates/horizon-core/src/repository_overlay/capture/revision.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/revision.rs
@@ -53,7 +53,7 @@ pub(super) fn verify(
     baseline: &[Option<GitNode>],
 ) -> Result<(), Error> {
     state.verify(selected, baseline).map_err(|error| match error {
-        Error::BaseMismatch => Error::Changed,
+        Error::BaseMismatch | Error::UnsupportedIndex | Error::UnsupportedNode => Error::Changed,
         error => error,
     })?;
     if branch_head(&state.repository, branch).map_err(|_| Error::Changed)? != state.base {

--- a/crates/horizon-core/src/repository_overlay/capture/tests/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/tests/mod.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 #[cfg(target_os = "linux")]
+mod revision;
+#[cfg(target_os = "linux")]
 mod safety;
 #[cfg(target_os = "linux")]
 mod semantics;
@@ -60,11 +62,36 @@ fn metadata_budget_and_diagnostics_are_bounded_and_redacted() {
     }
 }
 
+#[test]
+fn revision_source_branch_and_selection_are_validated_before_repository_access() {
+    let missing = Path::new("/not-an-enrolled-repository");
+    for branch in ["", "HEAD", "refs/heads/../other", "work:other"] {
+        assert!(matches!(
+            capture_selected_revision(missing, source(), branch, &["file"]),
+            Err(GitCaptureError::Policy(_))
+        ));
+    }
+    let mut invalid = source();
+    invalid.repository = "https://private@example.invalid/repo".into();
+    assert_eq!(
+        capture_selected_revision(missing, invalid, "work/capture", &["file"]),
+        Err(OverlayPlanError::InvalidSource.into())
+    );
+    assert_eq!(
+        capture_selected_revision(missing, source(), "work/capture", &["same", "same"]),
+        Err(OverlayPlanError::DuplicatePath.into())
+    );
+}
+
 #[cfg(not(target_os = "linux"))]
 #[test]
 fn unsupported_platform_has_no_fallback() {
     assert_eq!(
         capture_selected(Path::new("/selected"), source(), &["file"]),
+        Err(GitCaptureError::Unsupported)
+    );
+    assert_eq!(
+        capture_selected_revision(Path::new("/selected"), source(), "work/capture", &["file"]),
         Err(GitCaptureError::Unsupported)
     );
 }

--- a/crates/horizon-core/src/repository_overlay/capture/tests/revision.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/tests/revision.rs
@@ -1,0 +1,245 @@
+use super::*;
+use crate::repository_overlay::{OverlayChange, OverlayContent, bundle::codec};
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+};
+
+fn branch(fixture: &Fixture) -> String {
+    fixture.repository.head().unwrap().shorthand().unwrap().to_owned()
+}
+
+fn file<'a>(bundle: &'a RepositoryOverlayBundle, layer: &[OverlayChange], path: &str) -> (&'a [u8], bool) {
+    let change = layer.iter().find(|change| change.path() == path).unwrap();
+    let OverlayContent::File { sha256, executable, .. } = change.content() else {
+        panic!("file expected")
+    };
+    (bundle.blob(sha256).unwrap(), *executable)
+}
+
+#[test]
+fn full_selected_layers_survive_commit_without_expanding_selection_or_changing_v1() {
+    let fixture = Fixture::new();
+    fixture.stage("selected", b"committed", 0o100_644);
+    fixture.write("selected", b"committed");
+    fixture.stage("unselected", b"private unselected bytes", 0o100_644);
+    fixture.commit();
+    let enrolled = fixture.source();
+    let branch = branch(&fixture);
+    let capture =
+        || capture_selected_revision(fixture.root(), enrolled.clone(), &branch, &["selected", "absent"]).unwrap();
+    let first = capture();
+    for layer in [first.plan().index(), first.plan().working_tree()] {
+        assert_eq!(file(&first, layer, "selected"), (&b"committed"[..], false));
+        assert!(matches!(layer[0].content(), OverlayContent::Remove));
+        assert_eq!(layer.len(), 2);
+    }
+    assert_eq!(first.blobs().len(), 1);
+    fixture.stage("selected", b"new committed bytes", 0o100_644);
+    fixture.write("selected", b"new committed bytes");
+    fixture.commit();
+    let next = capture();
+    assert_eq!(next.plan().source().commit, fixture.source().commit);
+    assert_eq!(next.plan().source().branch.as_deref(), Some(branch.as_str()));
+    assert_ne!(first.manifest_sha256(), next.manifest_sha256());
+    for layer in [next.plan().index(), next.plan().working_tree()] {
+        assert_eq!(file(&next, layer, "selected").0, b"new committed bytes");
+    }
+    assert_eq!(file(&first, first.plan().index(), "selected").0, b"committed");
+    assert_eq!(
+        capture_selected(fixture.root(), enrolled, &["selected"]),
+        Err(GitCaptureError::BaseMismatch)
+    );
+    assert_eq!(fixture.capture(&["selected"]).blobs().len(), 0);
+    let encoded = codec::encode(&next).unwrap();
+    assert!(
+        !encoded
+            .windows(b"private unselected bytes".len())
+            .any(|bytes| bytes == b"private unselected bytes")
+    );
+    assert_eq!(codec::decode(&encoded).unwrap(), next);
+}
+
+#[test]
+fn literal_modes_links_untracked_removal_and_lfs_pointer_remain_independent() {
+    let fixture = Fixture::new();
+    let pointer = b"version https://git-lfs.github.com/spec/v1\noid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nsize 8\n";
+    fixture.stage("asset", pointer, 0o100_644);
+    fixture.write("asset", b"hydrated");
+    fixture.stage("gone", b"committed gone", 0o100_644);
+    fixture.stage("link", b"asset", 0o120_000);
+    fixture.commit();
+    fixture.write("untracked", b"literal\0\xff");
+    symlink("untracked", fixture.root().join("link")).unwrap();
+    fs::set_permissions(fixture.root().join("asset"), fs::Permissions::from_mode(0o755)).unwrap();
+    let mut config = fixture.repository.config().unwrap();
+    config.set_str("filter.synthetic.clean", "false").unwrap();
+    config.set_bool("filter.synthetic.required", true).unwrap();
+    fixture.write(".gitattributes", b"asset filter=synthetic\n");
+    let bundle = capture_selected_revision(
+        fixture.root(),
+        fixture.source(),
+        &branch(&fixture),
+        &["asset", "gone", "link", "untracked"],
+    )
+    .unwrap();
+    assert_eq!(file(&bundle, bundle.plan().index(), "asset"), (&pointer[..], false));
+    assert_eq!(
+        file(&bundle, bundle.plan().working_tree(), "asset"),
+        (&b"hydrated"[..], true)
+    );
+    assert_eq!(
+        file(&bundle, bundle.plan().working_tree(), "untracked").0,
+        b"literal\0\xff"
+    );
+    assert!(matches!(bundle.plan().index()[3].content(), OverlayContent::Remove));
+    assert!(matches!(
+        bundle.plan().working_tree()[1].content(),
+        OverlayContent::Remove
+    ));
+    assert!(matches!(bundle.plan().index()[2].content(), OverlayContent::Symlink { target } if target == "asset"));
+    assert!(
+        matches!(bundle.plan().working_tree()[2].content(), OverlayContent::Symlink { target } if target == "untracked")
+    );
+}
+
+#[test]
+fn wrong_detached_unborn_and_redirected_worktrees_are_refused() {
+    let fixture = Fixture::new();
+    let source = fixture.source();
+    let branch = branch(&fixture);
+    assert_eq!(
+        capture_selected_revision(fixture.root(), source.clone(), "other", &[]),
+        Err(GitCaptureError::BaseMismatch)
+    );
+    fixture
+        .repository
+        .set_head_detached(fixture.repository.head().unwrap().target().unwrap())
+        .unwrap();
+    assert_eq!(
+        capture_selected_revision(fixture.root(), source.clone(), &branch, &[]),
+        Err(GitCaptureError::BaseMismatch)
+    );
+    fixture.repository.set_head("refs/heads/unborn").unwrap();
+    assert_eq!(
+        capture_selected_revision(fixture.root(), source.clone(), "unborn", &[]),
+        Err(GitCaptureError::BaseMismatch)
+    );
+    fixture.repository.set_head(&format!("refs/heads/{branch}")).unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    fixture
+        .repository
+        .config()
+        .unwrap()
+        .set_str("core.worktree", outside.path().to_str().unwrap())
+        .unwrap();
+    assert_eq!(
+        capture_selected_revision(fixture.root(), source, &branch, &[]),
+        Err(GitCaptureError::Repository)
+    );
+    assert_eq!(fs::read_dir(outside.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn moving_head_index_or_symbolic_branch_during_attempt_is_retryable_changed() {
+    for movement in ["commit", "index", "branch", "detached"] {
+        let fixture = Fixture::new();
+        fixture.stage("file", b"before", 0o100_644);
+        let branch = branch(&fixture);
+        let state = linux::State::open_with(fixture.root(), |repo| {
+            super::super::revision::branch_head(repo, &branch)
+        })
+        .unwrap();
+        let baseline = state.selected_index(&["file"]).unwrap();
+        match movement {
+            "commit" => fixture.commit(),
+            "index" => fixture.stage("file", b"after", 0o100_644),
+            "branch" => {
+                let commit = fixture.repository.find_commit(state.base).unwrap();
+                fixture.repository.branch("other", &commit, false).unwrap();
+                fixture.repository.set_head("refs/heads/other").unwrap();
+            }
+            _ => fixture.repository.set_head_detached(state.base).unwrap(),
+        }
+        assert_eq!(
+            super::super::revision::verify(&state, &branch, &["file"], &baseline),
+            Err(GitCaptureError::Changed),
+            "{movement}"
+        );
+    }
+}
+
+#[test]
+fn exclusions_removed_gitlink_ancestry_and_oversize_files_still_fail_closed() {
+    let fixture = Fixture::new();
+    let branch = branch(&fixture);
+    for selected in [
+        vec![".env"],
+        vec![".git/config"],
+        vec!["../escape"],
+        vec!["same", "same"],
+    ] {
+        assert!(matches!(
+            capture_selected_revision(fixture.root(), fixture.source(), &branch, &selected),
+            Err(GitCaptureError::Policy(_))
+        ));
+    }
+    fixture.stage("module", b"placeholder", 0o160_000);
+    let mut index = fixture.repository.index().unwrap();
+    let mut entry = index.get_path(Path::new("module"), 0).unwrap();
+    entry.id = fixture.repository.head().unwrap().target().unwrap();
+    index.add(&entry).unwrap();
+    index.write().unwrap();
+    fixture.commit();
+    index.remove_path(Path::new("module")).unwrap();
+    index.write().unwrap();
+    fixture.write("module/file", b"not selected repository");
+    assert_eq!(
+        capture_selected_revision(fixture.root(), fixture.source(), &branch, &["module/file"]),
+        Err(GitCaptureError::UnsupportedNode)
+    );
+    fixture.write("huge", b"");
+    fs::File::options()
+        .write(true)
+        .open(fixture.root().join("huge"))
+        .unwrap()
+        .set_len(u64::try_from(crate::repository_overlay::reader::MAX_READ_BYTES).unwrap() + 1)
+        .unwrap();
+    assert!(matches!(
+        capture_selected_revision(fixture.root(), fixture.source(), &branch, &["huge"]),
+        Err(GitCaptureError::Read(RepositoryReadError::TooLarge))
+    ));
+}
+
+#[test]
+fn revision_keeps_unsupported_index_and_working_node_refusals() {
+    let fixture = Fixture::new();
+    fixture.stage("file", b"staged", 0o100_644);
+    let branch = branch(&fixture);
+    for flags in [
+        git2::IndexEntryExtendedFlag::SKIP_WORKTREE,
+        git2::IndexEntryExtendedFlag::INTENT_TO_ADD,
+    ] {
+        let mut index = fixture.repository.index().unwrap();
+        let mut entry = index.get_path(Path::new("file"), 0).unwrap();
+        entry.flags_extended = flags.bits();
+        index.add(&entry).unwrap();
+        index.write().unwrap();
+        assert_eq!(
+            capture_selected_revision(fixture.root(), fixture.source(), &branch, &["file"]),
+            Err(GitCaptureError::UnsupportedIndex)
+        );
+    }
+    let mut index = fixture.repository.index().unwrap();
+    index.clear().unwrap();
+    index.write().unwrap();
+    fixture.write("parent/file", b"outside literal selection");
+    symlink("parent", fixture.root().join("linked")).unwrap();
+    fs::hard_link(fixture.root().join("parent/file"), fixture.root().join("hard")).unwrap();
+    for path in ["linked/file", "hard", "parent"] {
+        assert!(matches!(
+            capture_selected_revision(fixture.root(), fixture.source(), &branch, &[path]),
+            Err(GitCaptureError::Read(_))
+        ));
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/capture/tests/revision.rs
+++ b/crates/horizon-core/src/repository_overlay/capture/tests/revision.rs
@@ -170,6 +170,69 @@ fn moving_head_index_or_symbolic_branch_during_attempt_is_retryable_changed() {
 }
 
 #[test]
+fn unsupported_index_movement_is_retryable_only_after_valid_admission() {
+    for movement in ["skip", "intent", "gitlink"] {
+        let fixture = Fixture::new();
+        fixture.stage("file", b"before", 0o100_644);
+        let branch = branch(&fixture);
+        let state = linux::State::open_with(fixture.root(), |repo| {
+            super::super::revision::branch_head(repo, &branch)
+        })
+        .unwrap();
+        let baseline = state.selected_index(&["file"]).unwrap();
+        let mut index = fixture.repository.index().unwrap();
+        let mut entry = index.get_path(Path::new("file"), 0).unwrap();
+        let initial_error = if movement == "gitlink" {
+            entry.mode = 0o160_000;
+            entry.id = state.base;
+            GitCaptureError::UnsupportedNode
+        } else {
+            entry.flags_extended = if movement == "skip" {
+                git2::IndexEntryExtendedFlag::SKIP_WORKTREE.bits()
+            } else {
+                git2::IndexEntryExtendedFlag::INTENT_TO_ADD.bits()
+            };
+            GitCaptureError::UnsupportedIndex
+        };
+        index.add(&entry).unwrap();
+        index.write().unwrap();
+        assert_eq!(
+            super::super::revision::verify(&state, &branch, &["file"], &baseline),
+            Err(GitCaptureError::Changed),
+            "{movement}"
+        );
+        assert_eq!(
+            capture_selected_revision(fixture.root(), fixture.source(), &branch, &["file"]),
+            Err(initial_error),
+            "{movement}"
+        );
+    }
+}
+
+#[test]
+fn ordinary_unselected_index_movement_does_not_expand_selected_capture() {
+    let fixture = Fixture::new();
+    fixture.stage("file", b"selected", 0o100_644);
+    fixture.write("file", b"selected");
+    let branch = branch(&fixture);
+    let before = capture_selected_revision(fixture.root(), fixture.source(), &branch, &["file"]).unwrap();
+    let state = linux::State::open_with(fixture.root(), |repo| {
+        super::super::revision::branch_head(repo, &branch)
+    })
+    .unwrap();
+    let baseline = state.selected_index(&["file"]).unwrap();
+    fixture.stage("unselected", b"unselected private bytes", 0o100_644);
+    assert_eq!(
+        super::super::revision::verify(&state, &branch, &["file"], &baseline),
+        Ok(())
+    );
+    assert_eq!(
+        capture_selected_revision(fixture.root(), fixture.source(), &branch, &["file"]),
+        Ok(before)
+    );
+}
+
+#[test]
 fn exclusions_removed_gitlink_ancestry_and_oversize_files_still_fail_closed() {
     let fixture = Fixture::new();
     let branch = branch(&fixture);

--- a/crates/horizon-repository/src/capture/mod.rs
+++ b/crates/horizon-repository/src/capture/mod.rs
@@ -6,7 +6,7 @@ use horizon_core::repository_overlay::{
         RepositoryOverlayBundle, codec,
         store::{BundleStoreError, RepositoryBundleStore},
     },
-    capture::{GitCaptureError, capture_selected},
+    capture::{GitCaptureError, capture_selected, capture_selected_revision},
     reader::RepositoryReadError,
 };
 use horizon_core::{
@@ -35,7 +35,10 @@ struct Enrollment {
 
 impl Enrollment {
     fn binding(&self) -> Result<ArtifactDigest, Reason> {
-        if self.version != 1 || !self.retained_volume_attested || self.selected.is_empty() || self.selected.len() > 128
+        if !matches!(self.version, 1 | 2)
+            || !self.retained_volume_attested
+            || self.selected.is_empty()
+            || self.selected.len() > 128
         {
             return Err(Reason::Invalid);
         }
@@ -149,6 +152,12 @@ fn execute(request: &Request, binding: &ArtifactDigest, plan: bool, response: &m
     let preparation = &request.enrollment.preparation;
     let before = preparation.inspect_checkout().map_err(|_| Reason::Identity)?;
     if plan {
+        if request.enrollment.version == 2 {
+            capture_enrollment(&request.enrollment, std::path::Path::new(before.path))?;
+            if preparation.inspect_checkout().map_err(|_| Reason::Identity)? != before {
+                return Err(Reason::Identity);
+            }
+        }
         return Ok(());
     }
     let root = std::path::PathBuf::from("/workspace/.horizon-worker/byte-captures")
@@ -161,13 +170,7 @@ fn execute(request: &Request, binding: &ArtifactDigest, plan: bool, response: &m
     if destination.dev() != before.device {
         return Err(Reason::Identity);
     }
-    let selected: Vec<_> = request.enrollment.selected.iter().map(String::as_str).collect();
-    let bundle = capture_selected(std::path::Path::new(before.path), preparation.source.clone(), &selected).map_err(
-        |error| match error {
-            GitCaptureError::Changed | GitCaptureError::Read(RepositoryReadError::Changed) => Reason::Changed,
-            _ => Reason::Capture,
-        },
-    )?;
+    let bundle = capture_enrollment(&request.enrollment, std::path::Path::new(before.path))?;
     if preparation.inspect_checkout().map_err(|_| Reason::Identity)? != before {
         return Err(Reason::Identity);
     }
@@ -193,6 +196,26 @@ fn execute(request: &Request, binding: &ArtifactDigest, plan: bool, response: &m
     response.record_sha256 = Some(record_sha256);
     response.record_bytes = Some(length);
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn capture_enrollment(enrollment: &Enrollment, checkout: &std::path::Path) -> Result<RepositoryOverlayBundle, Reason> {
+    let preparation = &enrollment.preparation;
+    let selected: Vec<_> = enrollment.selected.iter().map(String::as_str).collect();
+    let captured = if enrollment.version == 2 {
+        capture_selected_revision(
+            checkout,
+            preparation.source.clone(),
+            &preparation.work_branch,
+            &selected,
+        )
+    } else {
+        capture_selected(checkout, preparation.source.clone(), &selected)
+    };
+    captured.map_err(|error| match error {
+        GitCaptureError::Changed | GitCaptureError::Read(RepositoryReadError::Changed) => Reason::Changed,
+        _ => Reason::Capture,
+    })
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/horizon-repository/src/capture/tests.rs
+++ b/crates/horizon-repository/src/capture/tests.rs
@@ -51,6 +51,27 @@ fn reordered_selection_keeps_identity_but_changed_paths_do_not() {
 }
 
 #[test]
+fn revision_mode_is_opt_in_with_distinct_canonical_identity_and_unchanged_v1_bytes() {
+    let mut request = enrollment();
+    let original = request.binding().unwrap();
+    let mut legacy = b"horizon-retained-byte-capture-v1\0".to_vec();
+    legacy.extend(serde_json::to_vec(&request).unwrap());
+    assert_eq!(original, ArtifactDigest::sha256(&legacy));
+    request.version = 2;
+    let revision = request.binding().unwrap();
+    assert_ne!(revision, original);
+    request.selected.push("second.txt".into());
+    let selected = request.binding().unwrap();
+    request.selected.reverse();
+    assert_eq!(request.binding().unwrap(), selected);
+    assert_ne!(selected, revision);
+    for version in [0, 3, 255] {
+        request.version = version;
+        assert!(request.binding().is_err());
+    }
+}
+
+#[test]
 fn rejection_is_bounded_redacted_and_never_acknowledges_capture() {
     for operation in [Operation::Binding, Operation::Plan, Operation::Once] {
         for bytes in [
@@ -100,6 +121,29 @@ fn pure_binding_needs_no_checkout_and_never_acknowledges_capture() {
     );
     let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
     assert_eq!(value["binding"], expected.as_str());
+    for field in ["manifest", "record_sha256", "record_bytes", "reason"] {
+        assert!(value[field].is_null());
+    }
+}
+
+#[test]
+fn revision_binding_command_preserves_no_filesystem_or_capture_acknowledgement() {
+    let mut enrollment = enrollment();
+    enrollment.version = 2;
+    let binding = enrollment.binding().unwrap();
+    let input = serde_json::to_vec(&serde_json::json!({"enrollment": enrollment, "available_bytes": 0})).unwrap();
+    let mut output = Vec::new();
+    assert_eq!(
+        run(
+            Operation::Binding,
+            &mut input.as_slice(),
+            &mut output,
+            &mut std::io::sink()
+        ),
+        ExitCode::SUCCESS
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(value["binding"], binding.as_str());
     for field in ["manifest", "record_sha256", "record_bytes", "reason"] {
         assert!(value[field].is_null());
     }

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -17,6 +17,10 @@ back into large multi-purpose modules.
   records. No provider lifecycle or automatic enrollment is implied. See
   [worker byte capture](worker-byte-capture.md) for the non-atomic protection
   boundary and retained-volume attestation.
+- `repository_overlay::capture::revision` adds explicit complete selected layers
+  at an observed work-branch commit, reusing pinned readers and bundle limits.
+  Enrollment version 2 opts in; the fixed-base delta API and version 1 remain
+  unchanged. This leaf does not export Git history or advance a checkpoint.
 - Prepared task admission keeps immutable intake/setup selection and read-only
   checkout inspection in `repository_overlay::intake::setup`. The fixed
   `setup-binding` and `setup-checkout` helpers never materialize or start tasks.

--- a/docs/architecture/worker-byte-capture.md
+++ b/docs/architecture/worker-byte-capture.md
@@ -85,8 +85,10 @@ Its manifest binds the observed current commit and work branch. This is not an
 export of other tracked files, Git history or all objects reachable from HEAD.
 LFS pointers and hydrated selected bytes remain literal; no filter is invoked.
 A new enrollment validates this bounded read-only capture before claiming a
-slot. During capture, detected branch/HEAD/index movement is retryable `changed`;
-a wrong, detached or unborn branch at admission is a terminal refusal. The next
+slot. During capture, detected branch/HEAD/selected-index movement, including
+newly unsupported index states after valid admission, is retryable `changed`.
+Ordinary edits to unselected index entries are outside this detection guarantee.
+A wrong, detached or unborn branch or unsupported index at admission is a terminal refusal. The next
 attempt can observe a later commit on the enrolled branch without re-enrollment.
 Version 2 has a distinct canonical binding; existing version-1 enrollments,
 receipts and retry/observation behavior are not migrated or reinterpreted.

--- a/docs/architecture/worker-byte-capture.md
+++ b/docs/architecture/worker-byte-capture.md
@@ -1,6 +1,6 @@
 # Worker-owned versioned byte capture
 
-This opt-in Linux worker operation protects an explicitly selected set of dirty
+This opt-in Linux worker operation protects an explicitly selected set of
 Git paths on an explicitly attested retained volume. It is **not an atomic or
 application-consistent snapshot, an independent backup, or a full repository/task
 checkpoint**. It does not advance `RepositoryCheckpoint` or authorize Delete.
@@ -74,9 +74,24 @@ enrollment still requires `capture-plan` validation before its exclusive claim.
   newly created child. These bounds do not promise hard process teardown or
   bounded filesystem latency for an uninterruptible storage operation.
 
-The initial exact commit remains the capture base. A later commit/HEAD change
-fails visibly and retains previous captures; automatic re-enrollment, Git
-history protection, submodule recursion, agent/task resumption, write freezing,
+Enrollment **version 1** keeps the initial exact commit as its capture base. A
+later commit/HEAD change fails visibly and retains previous captures.
+
+Opt in to **version 2** in a new enrollment to keep selected bytes protected
+across ordinary commits on the exact enrolled `work_branch`. Each version-2
+bundle contains the complete literal index and working-tree state of **every
+selected path**, including unchanged committed bytes and explicit absent nodes.
+Its manifest binds the observed current commit and work branch. This is not an
+export of other tracked files, Git history or all objects reachable from HEAD.
+LFS pointers and hydrated selected bytes remain literal; no filter is invoked.
+A new enrollment validates this bounded read-only capture before claiming a
+slot. During capture, detected branch/HEAD/index movement is retryable `changed`;
+a wrong, detached or unborn branch at admission is a terminal refusal. The next
+attempt can observe a later commit on the enrolled branch without re-enrollment.
+Version 2 has a distinct canonical binding; existing version-1 enrollments,
+receipts and retry/observation behavior are not migrated or reinterpreted.
+
+Automatic re-enrollment, Git history protection, submodule recursion, agent/task resumption, write freezing,
 verified-loss replacement and destructive-Delete gates are separate outcomes.
 Versioned literal captures can mix file times. Even retained storage is not
 protection against deleting that storage or every provider failure mode.
@@ -92,6 +107,10 @@ path is not modified. The fixture constructs synthetic initial Git receipts
 start/status/cancel and capture code. It proves controller process exit, two
 versions within the observed target interval, staged/unstaged/untracked/removal
 bytes, readback into fresh scratch paths, unchanged prior versions, and visible
-failure after HEAD drift. No credentials, provider resources or image upload
+failure after HEAD drift for version 1. The version-2 lane then proves refusal
+before claiming on a wrong branch, continued capture across a normal commit,
+retained committed selected bytes followed by new dirty bytes, two observed
+intervals within 30 seconds, earlier readback and no relaunch on repeated Start.
+No credentials, provider resources or image upload
 are involved. Exact-head runtime results are still required; preparing this
 recipe does not claim they passed.


### PR DESCRIPTION
## Purpose

Advance #471 with an explicit version-2 worker byte-capture enrollment that keeps
selected files protected across ordinary commits on the enrolled work branch.

## Behavior

- Capture both complete selected index and working-tree layers, including
  unchanged committed bytes and absent nodes; bind each manifest to the observed
  exact commit and branch. Never expand selection to unselected history or files.
- Preserve version-1 canonical identities, fixed-base delta behavior, retained
  observations and one-shot enrollment. Version 2 is opt-in with a distinct binding.
- Refuse a new version-2 enrollment on an unsupported branch/checkout before
  claiming a slot. Detected in-attempt branch/HEAD/selected-index movement is
  retryable, including newly unsupported index states after valid admission.
  Ordinary unselected index edits are outside this detection guarantee.
- Reuse the detached worker loop, bounded child execution, named bundle storage,
  verified readback, stale-state reporting and explicit cancellation unchanged.

This is selected-byte protection on explicitly attested retained storage, **not**
a full repository/task checkpoint, atomic snapshot, independent backup, Git
history export or provider durability qualification. No automatic enrollment,
PC transfer, cloud resources, credentials, filters or image publication is added.

## Validation

- Independent local review completed. Focused tests: 45 CLI, 28 core capture and
  25 bundle-store tests passed; 19 Python guards passed with the actual CLI lane
  explicitly skipped in the pure run. Packaging, format, maintainability, version
  synchronization, blocking and strict Clippy passed.
- The initial compile exposed a Git API Result/Option mismatch; its log is
  retained and the corrected precommit run passed.
- The first native run stopped on a fixture-only nested-manifest lookup; the
  existing wire format is flat. That failed run and the later corrected pass are
  retained separately.
- Review corrections have a genuine failing-then-passing regression for final
  unsupported index movement, initial-refusal coverage for skip/intent/gitlink,
  and unchanged selected output after ordinary unselected index edits.
- Fresh corrected-source native run: all 20 tests passed, no skips. It preserves
  the version-1 proof and verifies wrong-branch no-claim, controller-off ordinary
  commit, later dirty bytes, 10,056/10,039 ms measured version-2 intervals, prior
  readback and no relaunch. Earlier native and CI results are not relabeled.
- Final exact-head full validation matrix passed on `3660e0f4`: default 2,574
  and speech 2,619 tests passed, each with zero failures and seven ignored tests
  across 26 suites; format, maintainability, version synchronization, blocking,
  strict and advisory pedantic Clippy all passed.

Scope: 635 changed source/test lines across eight files, plus architecture notes.
