### PR TITLE
feat(repository): publish named Git packs

### DIFF
--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/linux.rs
@@ -100,18 +100,27 @@ fn before(
     storage(&binding.parent)?;
     observe_git_base_pack(&pack.path, pack.into(), limits, cancelled)?;
     binding.layout.recheck(cancelled)?;
+    synchronize_layout(&binding.layout, cancelled, sync)?;
+    binding.verify_parent()?;
+    Ok(binding)
+}
+
+pub(super) fn synchronize_layout(
+    layout: &Layout,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
     for (point, files) in [
-        (SyncPoint::File, binding.layout.files().collect::<Vec<_>>()),
-        (SyncPoint::Directory, binding.layout.directories().rev().collect()),
+        (SyncPoint::File, layout.files().collect::<Vec<_>>()),
+        (SyncPoint::Directory, layout.directories().rev().collect()),
     ] {
         for file in files {
             staging::check_cancel(cancelled)?;
             sync(point, &reopen(file)?)?;
-            binding.layout.recheck(cancelled)?;
+            layout.recheck(cancelled)?;
         }
     }
-    binding.verify_parent()?;
-    Ok(binding)
+    Ok(())
 }
 
 fn after(
@@ -150,7 +159,7 @@ impl Binding {
     }
 }
 
-fn directory(path: &Path) -> Result<File, Error> {
+pub(super) fn directory(path: &Path) -> Result<File, Error> {
     let reader = SelectedRepositoryReader::open(path).map_err(|_| Error::Storage)?;
     let file = reader.root.handle().try_clone().map_err(|_| Error::Storage)?;
     let metadata = file.metadata().map_err(|_| Error::Storage)?;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/mod.rs
@@ -1,6 +1,7 @@
-//! Explicit qualified no-replace pack publication, not setup or source approval.
+//! Explicit pack publication policies, not setup or source approval.
 
 mod linux;
+mod named;
 
 use super::{PackReceiveLimits, ReceivedGitPack, SeedError};
 use std::{
@@ -93,6 +94,84 @@ pub fn publish_sibling_git_pack(
         &mut |_, file| file.sync_all().map_err(|_| PackPublicationError::Storage),
         &mut linux::rename,
         &linux::supported_storage,
+    )
+}
+
+/// Acknowledged named publication, or a complete existing pack reverified and
+/// synchronized without renaming. An unused incoming pack is never removed.
+#[derive(Debug)]
+pub enum NamedPackPublication {
+    Published(PublishedGitPack),
+    Existing {
+        pack: ReceivedGitPack,
+        unused_incoming: Option<ReceivedGitPack>,
+    },
+}
+
+/// Named slots are permanent claims, not reusable locks. Every variant retains
+/// its data; no failure, lost reply or dropped receipt grants cleanup or replay.
+#[derive(thiserror::Error)]
+pub enum NamedPackPublicationFailure {
+    #[error("named pack input retained without publication acknowledgement: {reason}")]
+    Retained {
+        reason: PackPublicationError,
+        pack: Box<ReceivedGitPack>,
+        /// None only when the requested destination exceeded the path bound.
+        destination: Option<PathBuf>,
+    },
+    #[error("named pack claim outcome is uncertain; no write ownership was acquired")]
+    ClaimUnconfirmed {
+        pack: Box<ReceivedGitPack>,
+        destination: PathBuf,
+    },
+    #[error("named pack rename outcome is uncertain; retain and inspect both names")]
+    RenameUnconfirmed {
+        pack: Box<ReceivedGitPack>,
+        destination: PathBuf,
+    },
+    #[error("named pack was renamed but final confirmation is incomplete: {reason}")]
+    PublishedUnsynchronized {
+        reason: PackPublicationError,
+        pack: Box<PublishedGitPack>,
+    },
+}
+
+impl fmt::Debug for NamedPackPublicationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+/// Publish to `<root>/<encoded-pack-sha256>/pack` using one exclusive permanent
+/// directory claim and ordinary rename only inside that fresh claim. Root must
+/// already be private and owned. Input must be its direct child, or exactly the
+/// complete named destination for explicit reacknowledgement. Existing slots
+/// never authorize renaming; only identical complete packs can be resynchronized.
+///
+/// Requires Linux confinement, stable exclusive input/ancestry, unchanged mounts,
+/// trusted Git/prlimit and filesystem mkdir/rename/fsync support. This explicit
+/// policy does not relax the qualified sibling publisher or receiver. Success
+/// acknowledges bounded verification/synchronization, not power-loss survival,
+/// cloud storage qualification, source approval or a complete checkpoint. No
+/// protection from hostile same-user mutation or filesystem latency is claimed.
+/// Run off the UI thread; no copy fallback, repair, task or provider action occurs.
+/// # Errors
+/// Invalid, changed, partial or foreign state, cancellation and storage failures
+/// retain the precise input/destination phase. Drop never deletes any data.
+pub fn publish_named_git_pack(
+    root: &Path,
+    pack: ReceivedGitPack,
+    limits: PackReceiveLimits,
+    cancelled: impl Fn() -> bool,
+) -> Result<NamedPackPublication, NamedPackPublicationFailure> {
+    named::publish(
+        root,
+        pack,
+        limits,
+        &cancelled,
+        &mut |_, file| file.sync_all().map_err(|_| PackPublicationError::Storage),
+        &mut named::claim,
+        &mut named::rename,
     )
 }
 

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/named.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/named.rs
@@ -1,0 +1,318 @@
+use super::super::{
+    observe::layout::{Layout, reopen},
+    observe_git_base_pack, staging,
+};
+use super::{
+    NamedPackPublication as Outcome, NamedPackPublicationFailure as Failure, PackPublicationError as Error,
+    PackReceiveLimits, PublishedGitPack, ReceivedGitPack,
+    linux::{SyncPoint, directory, synchronize_layout},
+};
+use crate::repository_overlay::seed::MAX_PACK_PATH_BYTES;
+use rustix::fs::{Dir, Mode, OFlags, ResolveFlags, mkdirat, openat2, renameat};
+use std::{
+    fs::File,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const PACK: &str = "pack";
+const PRIVATE: Mode = Mode::RUSR.union(Mode::WUSR).union(Mode::XUSR);
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+pub(super) struct Binding {
+    root: File,
+    path: PathBuf,
+    destination: PathBuf,
+    digest: String,
+    source: PathBuf,
+    layout: Layout,
+}
+
+pub(super) struct Slot(File);
+
+pub(super) fn publish(
+    root: &Path,
+    pack: ReceivedGitPack,
+    limits: PackReceiveLimits,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+    claim: &mut impl FnMut(&File, &str) -> rustix::io::Result<()>,
+    rename: &mut impl FnMut(&Binding, &Slot) -> rustix::io::Result<()>,
+) -> Result<Outcome, Failure> {
+    let destination = root
+        .as_os_str()
+        .len()
+        .checked_add(pack.sha256().as_str().len() + PACK.len() + 2)
+        .is_some_and(|length| length <= MAX_PACK_PATH_BYTES)
+        .then(|| root.join(pack.sha256().as_str()).join(PACK));
+    let binding = match Binding::open(root, &pack, destination.as_deref(), limits, cancelled) {
+        Ok(binding) => binding,
+        Err(reason) => return Err(retained(reason, pack, destination)),
+    };
+    let existing = match Slot::open(&binding) {
+        Ok(slot) => slot,
+        Err(reason) => return Err(retained(reason, pack, destination)),
+    };
+    if let Some(slot) = existing {
+        return existing_pack(&binding, &slot, pack, limits, cancelled, sync);
+    }
+    let prepared = synchronize_layout(&binding.layout, cancelled, &mut |point, file| {
+        sync(point, file)?;
+        binding.verify_input(cancelled)
+    })
+    .and_then(|()| binding.verify_input(cancelled))
+    .and_then(|()| staging::check_cancel(cancelled).map_err(Error::from));
+    if let Err(reason) = prepared {
+        return Err(retained(reason, pack, destination));
+    }
+    match claim(&binding.root, &binding.digest) {
+        Ok(()) => {}
+        Err(rustix::io::Errno::EXIST) => {
+            return match Slot::open(&binding) {
+                Ok(Some(slot)) => existing_pack(&binding, &slot, pack, limits, cancelled, sync),
+                _ => Err(retained(Error::DestinationExists, pack, destination)),
+            };
+        }
+        Err(_) => {
+            return Err(Failure::ClaimUnconfirmed {
+                pack: Box::new(pack),
+                destination: binding.destination,
+            });
+        }
+    }
+    let slot = match prepare_slot(&binding, cancelled, sync) {
+        Ok(slot) => slot,
+        Err(reason) => return Err(retained(reason, pack, destination)),
+    };
+    // This invocation alone owns this fresh, still-empty permanent slot.
+    if rename(&binding, &slot).is_err() {
+        return Err(Failure::RenameUnconfirmed {
+            pack: Box::new(pack),
+            destination: binding.destination,
+        });
+    }
+    let mut pack = pack;
+    pack.path.clone_from(&binding.destination);
+    pack.objects_directory = pack.path.join("decoded/objects");
+    let pack = PublishedGitPack(pack);
+    if let Err(reason) = finish(&binding, &slot, pack.pack(), cancelled, sync) {
+        return Err(Failure::PublishedUnsynchronized {
+            reason,
+            pack: Box::new(pack),
+        });
+    }
+    Ok(Outcome::Published(pack))
+}
+
+impl Binding {
+    fn open(
+        root: &Path,
+        pack: &ReceivedGitPack,
+        destination: Option<&Path>,
+        limits: PackReceiveLimits,
+        cancelled: &impl Fn() -> bool,
+    ) -> Result<Self, Error> {
+        staging::check_cancel(cancelled)?;
+        limits.validate(pack.into())?;
+        let destination = destination.ok_or(Error::Verification(super::SeedError::Limit))?;
+        if pack.path().as_os_str().len() > MAX_PACK_PATH_BYTES
+            || (pack.path().parent() != Some(root) && pack.path() != destination)
+        {
+            return Err(Error::Verification(super::SeedError::UnsafeParent));
+        }
+        let result = Self {
+            root: directory(root)?,
+            path: root.to_path_buf(),
+            destination: destination.to_path_buf(),
+            digest: pack.sha256().as_str().to_owned(),
+            source: pack
+                .path()
+                .strip_prefix(root)
+                .map_err(|_| Error::Storage)?
+                .to_path_buf(),
+            layout: Layout::open(pack.path(), pack.into(), cancelled)?,
+        };
+        result.verify_input(cancelled)?;
+        observe_git_base_pack(pack.path(), pack.into(), limits, cancelled)?;
+        result.verify_input(cancelled)?;
+        Ok(result)
+    }
+
+    fn verify_root(&self) -> Result<(), Error> {
+        same_inode(&self.root, &directory(&self.path)?)
+    }
+
+    fn verify_input(&self, cancelled: &impl Fn() -> bool) -> Result<(), Error> {
+        self.verify_root()?;
+        let input = File::from(
+            openat2(
+                &self.root,
+                &self.source,
+                OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                CONFINED,
+            )
+            .map_err(|_| Error::Storage)?,
+        );
+        same_inode(&input, self.layout.root())?;
+        self.layout.recheck(cancelled)?;
+        Ok(())
+    }
+}
+
+impl Slot {
+    fn open(binding: &Binding) -> Result<Option<Self>, Error> {
+        binding.verify_root()?;
+        let file = match openat2(
+            &binding.root,
+            &binding.digest,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            CONFINED,
+        ) {
+            Ok(file) => File::from(file),
+            Err(rustix::io::Errno::NOENT) => return Ok(None),
+            Err(_) => return Err(Error::DestinationExists),
+        };
+        let metadata = file.metadata().map_err(|_| Error::Storage)?;
+        if metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o700
+            || metadata.nlink() == 0
+        {
+            return Err(Error::DestinationExists);
+        }
+        Ok(Some(Self(file)))
+    }
+
+    fn verify(&self, binding: &Binding, complete: bool) -> Result<(), Error> {
+        let current = Self::open(binding)?.ok_or(Error::DestinationExists)?;
+        same_inode(&self.0, &current.0)?;
+        let mut count = 0;
+        for entry in Dir::read_from(&reopen(&self.0)?).map_err(|_| Error::Storage)? {
+            let entry = entry.map_err(|_| Error::Storage)?;
+            let name = entry.file_name().to_bytes();
+            if matches!(name, b"." | b"..") {
+                continue;
+            }
+            if !complete || name != PACK.as_bytes() || count != 0 {
+                return Err(Error::DestinationExists);
+            }
+            count += 1;
+        }
+        if count != usize::from(complete) {
+            return Err(Error::DestinationExists);
+        }
+        Ok(())
+    }
+}
+
+fn prepare_slot(
+    binding: &Binding,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<Slot, Error> {
+    let slot = Slot::open(binding)?.ok_or(Error::DestinationExists)?;
+    for (point, file) in [(SyncPoint::Directory, &slot.0), (SyncPoint::Parent, &binding.root)] {
+        binding.verify_input(cancelled)?;
+        slot.verify(binding, false)?;
+        sync(point, &reopen(file)?)?;
+    }
+    binding.verify_input(cancelled)?;
+    slot.verify(binding, false)?;
+    staging::check_cancel(cancelled)?;
+    Ok(slot)
+}
+
+fn finish(
+    binding: &Binding,
+    slot: &Slot,
+    pack: &ReceivedGitPack,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<(), Error> {
+    let layout = Layout::open(pack.path(), pack.into(), cancelled)?;
+    for (point, file) in [
+        (SyncPoint::PublishedRoot, layout.root()),
+        (SyncPoint::Directory, &slot.0),
+        (SyncPoint::Parent, &binding.root),
+    ] {
+        slot.verify(binding, true)?;
+        layout.matches_relocated(&binding.layout)?;
+        staging::check_cancel(cancelled)?;
+        sync(point, &reopen(file)?)?;
+        layout.recheck(cancelled)?;
+    }
+    slot.verify(binding, true)?;
+    layout.matches_relocated(&binding.layout)?;
+    staging::check_cancel(cancelled)?;
+    Ok(())
+}
+
+fn existing_pack(
+    binding: &Binding,
+    slot: &Slot,
+    incoming: ReceivedGitPack,
+    limits: PackReceiveLimits,
+    cancelled: &impl Fn() -> bool,
+    sync: &mut impl FnMut(SyncPoint, &File) -> Result<(), Error>,
+) -> Result<Outcome, Failure> {
+    let result = (|| {
+        slot.verify(binding, true)?;
+        let layout = Layout::open(&binding.destination, (&incoming).into(), cancelled)?;
+        let pack = observe_git_base_pack(&binding.destination, (&incoming).into(), limits, cancelled)?;
+        layout.recheck(cancelled)?;
+        synchronize_layout(&layout, cancelled, &mut |point, file| {
+            slot.verify(binding, true)?;
+            binding.verify_input(cancelled)?;
+            sync(point, file)
+        })?;
+        for (point, file) in [(SyncPoint::Directory, &slot.0), (SyncPoint::Parent, &binding.root)] {
+            staging::check_cancel(cancelled)?;
+            sync(point, &reopen(file)?)?;
+            slot.verify(binding, true)?;
+            binding.verify_input(cancelled)?;
+            layout.recheck(cancelled)?;
+        }
+        staging::check_cancel(cancelled)?;
+        Ok(pack)
+    })();
+    match result {
+        Ok(pack) => Ok(Outcome::Existing {
+            unused_incoming: (incoming.path() != pack.path()).then_some(incoming),
+            pack,
+        }),
+        Err(reason) => Err(retained(reason, incoming, Some(binding.destination.clone()))),
+    }
+}
+
+fn retained(reason: Error, pack: ReceivedGitPack, destination: Option<PathBuf>) -> Failure {
+    Failure::Retained {
+        reason,
+        pack: Box::new(pack),
+        destination,
+    }
+}
+
+fn same_inode(left: &File, right: &File) -> Result<(), Error> {
+    let left = left.metadata().map_err(|_| Error::Storage)?;
+    let right = right.metadata().map_err(|_| Error::Storage)?;
+    if (left.dev(), left.ino()) == (right.dev(), right.ino()) {
+        Ok(())
+    } else {
+        Err(Error::Storage)
+    }
+}
+
+pub(super) fn claim(root: &File, name: &str) -> rustix::io::Result<()> {
+    mkdirat(root, name, PRIVATE)
+}
+
+pub(super) fn rename(binding: &Binding, slot: &Slot) -> rustix::io::Result<()> {
+    renameat(&binding.root, &binding.source, &slot.0, PACK)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/publication/named/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/publication/named/tests.rs
@@ -1,0 +1,579 @@
+use super::super::super::observe::tests::{SnapshotNode, snapshot};
+use super::super::publish_named_git_pack;
+use super::*;
+use crate::repository_overlay::seed::{
+    export::{PackExportLimits, PreparedGitPack, prepare_git_base_pack},
+    prepare_git_seed,
+    receive::receive_git_base_pack,
+    tests::{Fixture as RepositoryFixture, private_fixture},
+};
+use std::{
+    cell::Cell,
+    collections::BTreeMap,
+    fs::{self, DirBuilder, OpenOptions},
+    io::Write,
+    os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt, symlink},
+    sync::{
+        Barrier,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+};
+
+struct Fixture {
+    _source: tempfile::TempDir,
+    pack: PreparedGitPack,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let repository = RepositoryFixture::new();
+        let source = private_fixture();
+        let resolved = repository.resolve(vec![], vec![], vec![]);
+        let seed = prepare_git_seed(source.path(), &resolved, &mut repository.source(), || false).unwrap();
+        let pack = prepare_git_base_pack(source.path(), &seed, PackExportLimits::default(), || false).unwrap();
+        Self { _source: source, pack }
+    }
+
+    fn receive(&self, root: &Path) -> ReceivedGitPack {
+        receive_git_base_pack(
+            root,
+            (&self.pack).into(),
+            &mut File::open(self.pack.path()).unwrap(),
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap()
+    }
+
+    fn destination(&self, root: &Path) -> PathBuf {
+        root.join(self.pack.sha256().as_str()).join(PACK)
+    }
+
+    fn observe(&self, root: &Path) -> ReceivedGitPack {
+        observe_git_base_pack(
+            &self.destination(root),
+            (&self.pack).into(),
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap()
+    }
+}
+
+fn private_dir(path: &Path) {
+    DirBuilder::new().mode(0o700).create(path).unwrap();
+}
+
+fn private_file(path: &Path, bytes: &[u8]) {
+    OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .unwrap()
+        .write_all(bytes)
+        .unwrap();
+}
+
+fn sync(_: SyncPoint, file: &File) -> Result<(), Error> {
+    file.sync_all().map_err(|_| Error::Storage)
+}
+
+fn store(root: &Path, pack: ReceivedGitPack) -> Result<Outcome, Failure> {
+    publish_named_git_pack(root, pack, PackReceiveLimits::default(), || false)
+}
+
+fn assert_existing(outcome: &Outcome, path: &Path, incoming: Option<&Path>) {
+    let Outcome::Existing { pack, unused_incoming } = outcome else {
+        panic!("expected existing publication")
+    };
+    assert_eq!(pack.path(), path);
+    assert_eq!(unused_incoming.as_ref().map(ReceivedGitPack::path), incoming);
+}
+
+fn tree(root: &Path) -> BTreeMap<PathBuf, SnapshotNode> {
+    snapshot(root)
+        .into_iter()
+        .filter_map(|(path, node)| {
+            let relative = path.strip_prefix(root).unwrap();
+            (!relative.as_os_str().is_empty()).then(|| (relative.to_path_buf(), node))
+        })
+        .collect()
+}
+
+#[test]
+fn public_publication_and_explicit_reacknowledgement_retain_exact_data_and_unused_input() {
+    let fixture = Fixture::new();
+    let root = private_fixture();
+    let input = fixture.receive(root.path());
+    let old = input.path().to_path_buf();
+    let original = tree(&old);
+    let inode = fs::metadata(&old).unwrap().ino();
+    let Outcome::Published(published) = store(root.path(), input).unwrap() else {
+        panic!("fresh publication")
+    };
+    assert_eq!(published.path(), fixture.destination(root.path()));
+    assert_eq!(fs::metadata(published.path()).unwrap().ino(), inode);
+    assert_eq!(tree(published.path()), original);
+    assert!(!old.exists());
+    let observed = fixture.observe(root.path());
+    assert_eq!(observed.objects(), 3);
+    let before = snapshot(root.path());
+    assert_existing(&store(root.path(), observed).unwrap(), published.path(), None);
+    assert_eq!(snapshot(root.path()), before);
+    let incoming = fixture.receive(root.path());
+    let incoming_path = incoming.path().to_path_buf();
+    let before = snapshot(root.path());
+    let existing = store(root.path(), incoming).unwrap();
+    assert_existing(&existing, published.path(), Some(&incoming_path));
+    assert_eq!(snapshot(root.path()), before);
+    drop((published, existing));
+    assert!(incoming_path.exists());
+    assert!(fixture.destination(root.path()).exists());
+}
+
+#[test]
+fn partial_foreign_corrupt_and_unsafe_existing_slots_are_not_reclaimed() {
+    let fixture = Fixture::new();
+    for kind in 0..6 {
+        let root = private_fixture();
+        let foreign = private_fixture();
+        let input = fixture.receive(root.path());
+        let destination = fixture.destination(root.path());
+        let slot = destination.parent().unwrap();
+        if kind == 5 {
+            symlink(foreign.path(), slot).unwrap();
+        } else {
+            private_dir(slot);
+        }
+        if kind == 1 {
+            private_file(&destination, b"partial");
+        }
+        if (2..=4).contains(&kind) {
+            fs::rename(fixture.receive(root.path()).path(), &destination).unwrap();
+            if kind == 2 {
+                private_file(&slot.join("foreign"), b"keep");
+            }
+            if kind == 3 {
+                let file = fs::read_dir(destination.join("decoded/objects/pack"))
+                    .unwrap()
+                    .map(|entry| entry.unwrap().path())
+                    .find(|path| path.extension().unwrap() == "pack")
+                    .unwrap();
+                let mut bytes = fs::read(&file).unwrap();
+                bytes[20] ^= 1;
+                fs::write(file, bytes).unwrap();
+            }
+            if kind == 4 {
+                fs::set_permissions(slot, fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+        let before = snapshot(root.path());
+        assert!(matches!(
+            publish(
+                root.path(),
+                input,
+                PackReceiveLimits::default(),
+                &|| false,
+                &mut sync,
+                &mut |_, _| panic!("existing slot grants no claim"),
+                &mut |_, _| panic!("no rename")
+            ),
+            Err(Failure::Retained { .. })
+        ));
+        assert_eq!(snapshot(root.path()), before);
+    }
+}
+
+#[test]
+fn sync_errors_and_cancellation_preserve_each_fresh_and_existing_phase() {
+    let fixture = Fixture::new();
+    for (existing, cancel) in [(false, false), (false, true), (true, false), (true, true)] {
+        let mut expected = vec![SyncPoint::File; 8];
+        expected.extend([SyncPoint::Directory; 11]);
+        expected.extend([SyncPoint::Directory, SyncPoint::Parent]);
+        if !existing {
+            expected.extend([SyncPoint::PublishedRoot, SyncPoint::Directory, SyncPoint::Parent]);
+        }
+        for failed in 0..=expected.len() {
+            let root = private_fixture();
+            if existing {
+                store(root.path(), fixture.receive(root.path())).unwrap();
+            }
+            let input = fixture.receive(root.path());
+            let old = input.path().to_path_buf();
+            let destination = fixture.destination(root.path());
+            let original = tree(&old);
+            let before = existing.then(|| snapshot(root.path()));
+            let stop = Cell::new(false);
+            let mut points = Vec::new();
+            let mut renames = 0;
+            let result = publish(
+                root.path(),
+                input,
+                PackReceiveLimits::default(),
+                &|| stop.get(),
+                &mut |point, file| {
+                    let index = points.len();
+                    points.push(point);
+                    if index == failed && !cancel {
+                        return Err(Error::Storage);
+                    }
+                    sync(point, file)?;
+                    if index == failed {
+                        stop.set(true);
+                    }
+                    Ok(())
+                },
+                &mut |root, name| {
+                    assert!(!existing, "no existing claim");
+                    claim(root, name)
+                },
+                &mut |binding, slot| {
+                    assert!(!existing, "no existing rename");
+                    renames += 1;
+                    rename(binding, slot)
+                },
+            );
+            assert_eq!(points, expected[..(failed + 1).min(expected.len())]);
+            let moved = !existing && failed >= 21;
+            let reason = if cancel {
+                Error::Verification(super::super::SeedError::Cancelled)
+            } else {
+                Error::Storage
+            };
+            if let Err(error) = &result {
+                assert!(!format!("{error:?} {error}").contains(root.path().to_str().unwrap()));
+            }
+            match result {
+                Ok(Outcome::Published(_)) if failed == expected.len() && !existing => {}
+                Ok(outcome) if failed == expected.len() && existing => {
+                    assert_existing(&outcome, &destination, Some(&old));
+                }
+                Err(Failure::Retained {
+                    reason: actual,
+                    pack,
+                    destination: target,
+                }) if failed < expected.len() && !moved => {
+                    assert_eq!(actual, reason);
+                    assert_eq!(pack.path(), old);
+                    assert_eq!(target.as_deref(), Some(destination.as_path()));
+                }
+                Err(Failure::PublishedUnsynchronized { reason: actual, pack }) if failed < expected.len() && moved => {
+                    assert_eq!(actual, reason);
+                    assert_eq!(pack.path(), destination);
+                }
+                _ => panic!("incorrect synchronization phase"),
+            }
+            assert_eq!(renames, usize::from(moved));
+            assert_eq!(old.exists(), !moved);
+            assert_eq!(destination.exists(), existing || moved);
+            assert_eq!(destination.parent().unwrap().exists(), existing || failed >= 19);
+            assert_eq!(tree(if moved { &destination } else { &old }), original);
+            if let Some(before) = before {
+                assert_eq!(snapshot(root.path()), before);
+            }
+        }
+    }
+}
+
+#[test]
+fn ambiguous_operations_preserve_distinct_claim_and_rename_authority() {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Operation {
+        Claim,
+        Rename,
+    }
+    let fixture = Fixture::new();
+    for (operation, changed) in [
+        (Operation::Claim, false),
+        (Operation::Claim, true),
+        (Operation::Rename, false),
+        (Operation::Rename, true),
+    ] {
+        let root = private_fixture();
+        let input = fixture.receive(root.path());
+        let old = input.path().to_path_buf();
+        let original = tree(&old);
+        let mut claims = 0;
+        let mut renames = 0;
+        let failure = publish(
+            root.path(),
+            input,
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut sync,
+            &mut |root, name| {
+                claims += 1;
+                if operation == Operation::Rename {
+                    return claim(root, name);
+                }
+                if changed {
+                    claim(root, name)?;
+                }
+                Err(rustix::io::Errno::IO)
+            },
+            &mut |binding, slot| {
+                assert!(operation == Operation::Rename, "no ownership from uncertain claim");
+                renames += 1;
+                if changed {
+                    rename(binding, slot)?;
+                }
+                Err(rustix::io::Errno::IO)
+            },
+        )
+        .unwrap_err();
+        let (pack, destination) = match failure {
+            Failure::ClaimUnconfirmed { pack, destination } if operation == Operation::Claim => (pack, destination),
+            Failure::RenameUnconfirmed { pack, destination } if operation == Operation::Rename => (pack, destination),
+            _ => panic!("incorrect uncertain phase"),
+        };
+        let moved = operation == Operation::Rename && changed;
+        let claimed = operation == Operation::Rename || changed;
+        assert_eq!(claims, 1);
+        assert_eq!(renames, usize::from(operation == Operation::Rename));
+        assert_eq!(pack.path(), old);
+        assert_eq!(destination, fixture.destination(root.path()));
+        assert_eq!(old.exists(), !moved);
+        assert_eq!(destination.exists(), moved);
+        assert_eq!(destination.parent().unwrap().exists(), claimed);
+        assert_eq!(tree(if moved { &destination } else { &old }), original);
+        if claimed {
+            let before = snapshot(root.path());
+            if moved {
+                let existing = store(root.path(), fixture.observe(root.path())).unwrap();
+                assert_existing(&existing, &destination, None);
+            } else {
+                assert!(matches!(store(root.path(), *pack), Err(Failure::Retained { .. })));
+            }
+            assert_eq!(snapshot(root.path()), before);
+        }
+    }
+}
+
+#[test]
+fn unsafe_roots_inputs_limits_and_expectations_refuse_before_claiming() {
+    let fixture = Fixture::new();
+    for case in 0..10 {
+        let outer = private_fixture();
+        let root = outer.path().join("store");
+        private_dir(&root);
+        let mut input = fixture.receive(&root);
+        let mut selected = root.clone();
+        let mut limits = PackReceiveLimits::default();
+        match case {
+            0 => fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap(),
+            1 => {
+                selected = outer.path().join("alias");
+                symlink(&root, &selected).unwrap();
+            }
+            2 => {
+                fs::rename(input.path(), root.join("retained")).unwrap();
+                symlink("retained", input.path()).unwrap();
+            }
+            3 => fs::hard_link(input.path().join("decoded/config"), outer.path().join("alias")).unwrap(),
+            4 => limits.encoded_bytes = 31,
+            5 => input.encoded_bytes += 1,
+            6 => input.base_commit = git2::Oid::ZERO_SHA1,
+            7 => selected = outer.path().join("missing"),
+            8 => selected = PathBuf::from(format!("/{}", "x".repeat(MAX_PACK_PATH_BYTES))),
+            9 => {}
+            _ => unreachable!(),
+        }
+        let before = snapshot(outer.path());
+        let failure = publish(
+            &selected,
+            input,
+            limits,
+            &|| case == 9,
+            &mut |_, _| panic!("no sync"),
+            &mut |_, _| panic!("no claim"),
+            &mut |_, _| panic!("no rename"),
+        )
+        .unwrap_err();
+        assert!(matches!(failure, Failure::Retained { .. }));
+        if case == 8 {
+            assert!(matches!(failure, Failure::Retained { destination: None, .. }));
+        }
+        if case == 9 {
+            assert!(matches!(
+                failure,
+                Failure::Retained {
+                    reason: Error::Verification(super::super::SeedError::Cancelled),
+                    ..
+                }
+            ));
+        }
+        assert_eq!(snapshot(outer.path()), before);
+    }
+}
+
+#[test]
+fn detected_source_root_slot_and_destination_replacement_cannot_be_acknowledged() {
+    let fixture = Fixture::new();
+    for case in 0..4 {
+        let outer = private_fixture();
+        let root = outer.path().join("store");
+        private_dir(&root);
+        let input = fixture.receive(&root);
+        let spare = fixture.receive(&root);
+        let old = input.path().to_path_buf();
+        let destination = fixture.destination(&root);
+        let retained = outer.path().join("retained");
+        let mut calls = 0;
+        let mut swapped = false;
+        let failure = publish(
+            &root,
+            input,
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut |point, file| {
+                sync(point, file)?;
+                if calls == [0, 0, 19, 21][case] {
+                    let selected = match case {
+                        0 => &old,
+                        1 => &root,
+                        2 => destination.parent().unwrap(),
+                        _ => &destination,
+                    };
+                    fs::rename(selected, &retained).unwrap();
+                    if matches!(case, 0 | 3) {
+                        fs::rename(spare.path(), selected).unwrap();
+                    } else {
+                        private_dir(selected);
+                    }
+                    swapped = true;
+                }
+                calls += 1;
+                Ok(())
+            },
+            &mut claim,
+            &mut rename,
+        )
+        .unwrap_err();
+        assert!(swapped);
+        assert!(retained.exists());
+        if case == 3 {
+            assert!(matches!(failure, Failure::PublishedUnsynchronized { .. }));
+        } else {
+            assert!(matches!(failure, Failure::Retained { .. }));
+        }
+    }
+}
+
+#[test]
+fn same_bytes_replaced_during_existing_resynchronization_are_not_acknowledged() {
+    let fixture = Fixture::new();
+    let root = private_fixture();
+    store(root.path(), fixture.receive(root.path())).unwrap();
+    let observed = fixture.observe(root.path());
+    let file = observed.path().join("decoded/config");
+    let bytes = fs::read(&file).unwrap();
+    let inode = fs::metadata(&file).unwrap().ino();
+    let mut swapped = false;
+    let result = publish(
+        root.path(),
+        observed,
+        PackReceiveLimits::default(),
+        &|| false,
+        &mut |point, handle| {
+            sync(point, handle)?;
+            if !swapped {
+                fs::rename(&file, root.path().join("retained-config")).unwrap();
+                private_file(&file, &bytes);
+                swapped = true;
+            }
+            Ok(())
+        },
+        &mut |_, _| panic!("no claim"),
+        &mut |_, _| panic!("no rename"),
+    );
+    assert!(swapped);
+    assert!(matches!(result, Err(Failure::Retained { .. })));
+    assert_eq!(fs::read(&file).unwrap(), bytes);
+    assert_ne!(fs::metadata(&file).unwrap().ino(), inode);
+}
+
+#[test]
+fn a_racing_partial_claim_does_not_grant_rename_authority() {
+    let fixture = Fixture::new();
+    let root = private_fixture();
+    let input = fixture.receive(root.path());
+    let old = input.path().to_path_buf();
+    let result = publish(
+        root.path(),
+        input,
+        PackReceiveLimits::default(),
+        &|| false,
+        &mut sync,
+        &mut |root, name| {
+            claim(root, name)?;
+            Err(rustix::io::Errno::EXIST)
+        },
+        &mut |_, _| panic!("a racing slot is not ours"),
+    );
+    assert!(matches!(
+        result,
+        Err(Failure::Retained {
+            reason: Error::DestinationExists,
+            ..
+        })
+    ));
+    assert!(old.exists());
+    assert!(!fixture.destination(root.path()).exists());
+}
+
+#[test]
+fn competing_publishers_rename_once_and_retain_the_unused_incoming_pack() {
+    let fixture = Fixture::new();
+    let root = private_fixture();
+    let inputs = [fixture.receive(root.path()), fixture.receive(root.path())];
+    let paths = inputs.each_ref().map(|pack| pack.path().to_path_buf());
+    let barrier = Barrier::new(2);
+    let renames = AtomicUsize::new(0);
+    let outcomes = thread::scope(|scope| {
+        let handles = inputs.map(|input| {
+            let barrier = &barrier;
+            let renames = &renames;
+            let root = root.path();
+            scope.spawn(move || {
+                publish(
+                    root,
+                    input,
+                    PackReceiveLimits::default(),
+                    &|| false,
+                    &mut sync,
+                    &mut |root, name| {
+                        barrier.wait();
+                        claim(root, name)
+                    },
+                    &mut |binding, slot| {
+                        renames.fetch_add(1, Ordering::SeqCst);
+                        rename(binding, slot)
+                    },
+                )
+            })
+        });
+        handles.map(|handle| handle.join().unwrap())
+    });
+    assert_eq!(renames.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, Ok(Outcome::Published(_))))
+            .count(),
+        1
+    );
+    assert!(outcomes.iter().all(|outcome| matches!(
+        outcome,
+        Ok(Outcome::Published(_)
+            | Outcome::Existing {
+                unused_incoming: Some(_),
+                ..
+            })
+            | Err(Failure::Retained { .. })
+    )));
+    assert_eq!(paths.iter().filter(|path| path.exists()).count(), 1);
+    fixture.observe(root.path());
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -349,6 +349,10 @@ back into large multi-purpose modules.
   another repository walker. Storage qualification and sibling-name policy remain
   shared; non-root fingerprints survive relocation unchanged. See
   [pack publication](../remote-repository-pack-publication.md).
+  Its explicit `named` leaf instead uses permanent digest-directory claims and
+  ordinary rename only for the fresh claim owner. Independent named outcomes
+  preserve uncertain operations and unused inputs; fixed-layout verification and
+  synchronization remain shared. See [named packs](named-git-pack-publication.md).
   `intake/` combines fixed retained-root initialization with pack/bundle receipt and
   noncreating observation. Its pure request/response shell keeps strict identities;
   the Linux leaf owns the create-new claim, held directory bindings and component

--- a/docs/architecture/named-git-pack-publication.md
+++ b/docs/architecture/named-git-pack-publication.md
@@ -1,0 +1,38 @@
+# Explicit named Git-pack publication
+
+Status: proposed. Date: 2026-09-13.
+
+## Context and decision
+
+Some storage does not provide the qualified sibling publisher's required
+no-replace rename behavior. An explicit, separate `publish_named_git_pack` API
+uses `<root>/<encoded-pack-sha256>/pack` in an existing private root. The default
+qualified publisher and receiver remain unchanged; there is no fallback.
+
+Only a successful exclusive mkdir grants one invocation ownership of a fresh
+permanent digest slot. It reuses the fixed-layout observer and synchronization
+sequence, persists the empty claim, then renames the verified incoming directory
+once and synchronizes the resulting pack, slot and root. Named/held identities
+are rechecked throughout; the filesystem and same-user owner must remain trusted.
+
+## Alternatives and consequences
+
+Weakening the default publisher would silently change its contract. Copying into
+an existing slot would allow partial replacement. Neither is used. Partial or
+foreign slots remain conflicts, not absence or reusable locks. Only an identical
+complete pack may be explicitly reverified and resynchronized; an unused incoming
+pack remains in the returned outcome. No rename occurs on that existing path.
+
+Separate named failures retain input and destination locators, distinguish an
+uncertain claim/rename from a known rename with incomplete synchronization, and
+never authorize cleanup, overwrite, retry or task execution. Cancellation and
+lost replies do not release claims. Directory synchronization can block outside
+native process deadlines; no latency or physical durability guarantee is added.
+
+## Follow-up boundary
+
+The receiver still uses no-replace renames for its private pack/index names.
+Named publication alone therefore does not establish end-to-end compatibility
+with a particular remote filesystem. A separately explicit receive mode may be
+needed. Complete-base export consent, checkpoint manifests, worker scheduling,
+provider qualification and real retained-data recovery proof remain separate.


### PR DESCRIPTION
Part of #471: an explicit named Git-pack publication primitive, not a complete checkpoint workflow.

## Behavior

- Adds `publish_named_git_pack` for `<private-root>/<pack-sha256>/pack`. Only an acknowledged exclusive directory claim permits one rename into that fresh slot.
- Existing complete matching packs can be explicitly reverified and synchronized without renaming; any unused incoming pack is returned intact. Partial, foreign or changed slots are refused, not reclaimed.
- Typed outcomes distinguish retained input, uncertain claim, uncertain rename, and known publication with incomplete synchronization. No failure or dropped receipt authorizes overwrite, cleanup or replay.
- Reuses fixed-layout verification and file/directory synchronization. The qualified sibling publisher and receiver retain their existing contracts.

## Validation and limits

Final exact-head validation on `fd151af1`: all eight lanes passed. Workspace tests passed 2,601 default / 2,646 speech cases, with seven ignored in each lane across 26 suites; 35 focused receive tests also passed. Blocking, strict and pedantic Clippy completed without warnings.

Synthetic Linux tests cover fresh/existing publication, every synchronization and cancellation point, ambiguous operations, unsafe paths, detected replacement and competing publishers. No provider or real retained-data proof is claimed.

This requires a stable private owned root, trusted same-user ancestry and filesystem confinement/mkdir/rename/fsync support. It does not guarantee power-loss survival, hostile same-user isolation or bounded filesystem latency. The receiver still uses no-replace renames internally: named publication alone does not establish compatibility with a remote filesystem. Source approval, checkpoint manifests, task integration and recovery acceptance remain separate.
