### PR TITLE
feat(repository): receive packs in named private attempts

### DIFF
--- a/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/mod.rs
@@ -1,9 +1,11 @@
 //! Bounded private pack receipt, independent of source approval and setup admission.
 
+mod named;
 mod native;
 mod observe;
 pub mod publication;
 
+pub use named::receive_named_git_base_pack;
 pub use observe::observe_git_base_pack;
 
 use super::{
@@ -156,7 +158,7 @@ pub fn receive_git_base_pack(
         .and_then(|()| staging::check_cancel(&cancelled))
         .map_err(|reason| SeedFailure { reason, residue: None })?;
     let path = staging::reserve(parent, &cancelled).map_err(|reason| SeedFailure { reason, residue: None })?;
-    receive(&path, expected, input, limits, &cancelled).map_err(|reason| SeedFailure {
+    receive(&path, expected, input, limits, &cancelled, &mut native::relocate).map_err(|reason| SeedFailure {
         reason,
         residue: Some(path),
     })
@@ -168,6 +170,7 @@ fn receive(
     input: &mut impl Read,
     limits: PackReceiveLimits,
     cancelled: &impl Fn() -> bool,
+    relocate: &mut impl FnMut(&Path, &str) -> Result<(), SeedError>,
 ) -> Result<ReceivedGitPack, SeedError> {
     let decoded = path.join("decoded");
     let selection = path.join("selection");
@@ -199,7 +202,8 @@ fn receive(
         return Err(SeedError::Object);
     }
     file.flush().map_err(|_| SeedError::Storage)?;
-    native::index(command, &decoded, summary.objects, limits.source, cancelled)?;
+    let hash = native::index(command, &decoded, summary.objects, limits.source, cancelled)?;
+    relocate(&decoded, &hash)?;
     let objects_directory = decoded.join("objects");
     native::closure(
         &selection,

--- a/crates/horizon-core/src/repository_overlay/seed/receive/named.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/named.rs
@@ -1,0 +1,286 @@
+use super::{
+    ExpectedGitPack, PackReceiveLimits, ReceivedGitPack, SeedError as Error, SeedFailure, observe::layout::reopen,
+    observe_git_base_pack, receive, staging,
+};
+use crate::repository_overlay::{
+    checkout::publication::validate_sibling_name,
+    reader::{SelectedRepositoryReader, linux::same_metadata},
+    seed::MAX_PACK_PATH_BYTES,
+};
+use rustix::fs::{Dir, Mode, OFlags, ResolveFlags, mkdirat, openat2, renameat};
+use std::{
+    fs::{File, Metadata},
+    io::Read,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const CONFINED: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_SYMLINKS)
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+
+struct Operations<'a> {
+    claim: &'a mut dyn FnMut(&File, &str) -> rustix::io::Result<()>,
+    rename: &'a mut dyn FnMut(&File, &str, &str) -> rustix::io::Result<()>,
+}
+
+/// Receive an explicit pack in one caller-named, exclusively created private attempt.
+/// This opt-in mode uses ordinary renames only inside that owned reservation; the
+/// default receiver retains its no-replace operations. Stable ancestry, exclusive
+/// same-user control and trusted native tools remain caller preconditions, not
+/// protection against concurrent same-user/privileged mutation. No filesystem is
+/// qualified by this API and no synchronization or physical durability is claimed.
+/// All existing encoded identity, EOF, decode, closure and per-child bounds apply.
+/// Blocking input/storage work remains outside native deadlines. Run off the UI thread.
+/// # Errors
+/// Invalid metadata/name/parent fail before a claim or input read. Once mkdir is
+/// attempted, every failure retains its attempted locator, which does NOT prove
+/// ownership or existence. An existing name is never adopted, even if complete.
+/// A mkdir/rename error can follow a successful operation: no retry, rollback,
+/// repair, overwrite of an existing attempt or cleanup is authorized. Only a
+/// separately requested read-only observation may inspect a retained complete tree.
+pub fn receive_named_git_base_pack(
+    parent: &Path,
+    attempt_name: &str,
+    expected: ExpectedGitPack<'_>,
+    input: &mut impl Read,
+    limits: PackReceiveLimits,
+    cancelled: impl Fn() -> bool,
+) -> Result<ReceivedGitPack, SeedFailure> {
+    receive_with(
+        parent,
+        attempt_name,
+        expected,
+        input,
+        limits,
+        &cancelled,
+        &mut Operations {
+            claim: &mut |parent, name| mkdirat(parent, name, Mode::from_raw_mode(0o700)),
+            rename: &mut |directory, source, target| renameat(directory, source, directory, target),
+        },
+    )
+}
+
+fn receive_with(
+    parent: &Path,
+    name: &str,
+    expected: ExpectedGitPack<'_>,
+    input: &mut impl Read,
+    limits: PackReceiveLimits,
+    cancelled: &impl Fn() -> bool,
+    operations: &mut Operations<'_>,
+) -> Result<ReceivedGitPack, SeedFailure> {
+    let admission = || {
+        limits.validate(expected)?;
+        staging::check_cancel(cancelled)?;
+        validate_sibling_name(name).map_err(|_| Error::UnsafeParent)?;
+        let path = parent.join(name);
+        if path.as_os_str().len() > MAX_PACK_PATH_BYTES {
+            return Err(Error::Limit);
+        }
+        let parent = staging::private_parent(parent)?;
+        staging::check_cancel(cancelled)?;
+        Ok((path, parent))
+    };
+    let (path, parent_handle) = admission().map_err(|reason| SeedFailure { reason, residue: None })?;
+    let run = || {
+        // Only a successful exclusive claim grants permission to populate this name.
+        (operations.claim)(parent_handle.root.handle(), name).map_err(|_| Error::Storage)?;
+        let reservation = Reservation {
+            root: directory(parent_handle.root.handle(), name, true)?,
+            parent: parent_handle,
+            parent_path: parent.to_path_buf(),
+            name: name.to_owned(),
+        };
+        reservation.verify()?;
+        children(&reservation.root, &[])?;
+        staging::check_cancel(cancelled)?;
+        receive(&path, expected, input, limits, cancelled, &mut |_, hash| {
+            reservation.relocate(hash, cancelled, operations.rename)
+        })?;
+        reservation.verify()?;
+        let observed = observe_git_base_pack(&path, expected, limits, cancelled)?;
+        reservation.verify()?;
+        Ok(observed)
+    };
+    run().map_err(|reason| SeedFailure {
+        reason,
+        residue: Some(path),
+    })
+}
+
+struct Reservation {
+    parent: SelectedRepositoryReader,
+    parent_path: PathBuf,
+    name: String,
+    root: File,
+}
+
+impl Reservation {
+    fn verify(&self) -> Result<(), Error> {
+        let current = staging::private_parent(&self.parent_path)?;
+        same_directory(current.root.handle(), self.parent.root.handle())?;
+        same_directory(&directory(self.parent.root.handle(), &self.name, true)?, &self.root)
+    }
+
+    fn relocate(
+        &self,
+        hash: &str,
+        cancelled: &impl Fn() -> bool,
+        rename: &mut dyn FnMut(&File, &str, &str) -> rustix::io::Result<()>,
+    ) -> Result<(), Error> {
+        self.verify()?;
+        let directory = directory(&self.root, "decoded/objects/pack", false)?;
+        let nodes = [
+            Node::open(&directory, "received.pack")?,
+            Node::open(&directory, "received.idx")?,
+        ];
+        let mut names = ["received.pack".to_owned(), "received.idx".to_owned()];
+        for (index, extension) in ["pack", "idx"].into_iter().enumerate() {
+            staging::check_cancel(cancelled)?;
+            self.verify()?;
+            same_directory(&directory_at(&self.root)?, &directory)?;
+            children(&directory, &[&names[0], &names[1]])?;
+            for (node, name) in nodes.iter().zip(&names) {
+                node.verify(&directory, name, name.starts_with("pack-"))?;
+            }
+            let target = format!("pack-{hash}.{extension}");
+            // No target is present in this exclusively held private directory. Any
+            // error is unconfirmed, including an error after the rename took effect.
+            rename(&directory, &names[index], &target).map_err(|_| Error::Storage)?;
+            names[index] = target;
+        }
+        self.verify()?;
+        same_directory(&directory_at(&self.root)?, &directory)?;
+        children(&directory, &[&names[0], &names[1]])?;
+        for (node, name) in nodes.iter().zip(&names) {
+            node.verify(&directory, name, true)?;
+        }
+        staging::check_cancel(cancelled)
+    }
+}
+
+fn directory_at(root: &File) -> Result<File, Error> {
+    directory(root, "decoded/objects/pack", false)
+}
+
+fn pin(parent: &File, name: &str) -> Result<File, Error> {
+    openat2(
+        parent,
+        name,
+        OFlags::PATH | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+        CONFINED,
+    )
+    .map(File::from)
+    .map_err(|_| Error::UnsafeParent)
+}
+
+fn directory(parent: &File, name: &str, private: bool) -> Result<File, Error> {
+    let handle = pin(parent, name)?;
+    let metadata = handle.metadata().map_err(|_| Error::Storage)?;
+    if !metadata.is_dir()
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.nlink() == 0
+        || metadata.mode() & 0o7000 != 0
+        || (private && metadata.mode() & 0o7777 != 0o700)
+    {
+        return Err(Error::UnsafeParent);
+    }
+    Ok(handle)
+}
+
+fn same_directory(left: &File, right: &File) -> Result<(), Error> {
+    let left = left.metadata().map_err(|_| Error::Storage)?;
+    let right = right.metadata().map_err(|_| Error::Storage)?;
+    if (left.dev(), left.ino(), left.uid(), left.gid(), left.mode())
+        == (right.dev(), right.ino(), right.uid(), right.gid(), right.mode())
+        && right.nlink() != 0
+    {
+        Ok(())
+    } else {
+        Err(Error::UnsafeParent)
+    }
+}
+
+fn children(directory: &File, expected: &[&str]) -> Result<(), Error> {
+    let mut names = Vec::new();
+    for entry in Dir::read_from(&reopen(directory)?).map_err(|_| Error::Storage)? {
+        let entry = entry.map_err(|_| Error::Storage)?;
+        let name = entry.file_name().to_str().map_err(|_| Error::Object)?;
+        if matches!(name, "." | "..") {
+            continue;
+        }
+        if names.len() >= expected.len() || !expected.contains(&name) {
+            return Err(Error::Object);
+        }
+        names.push(name.to_owned());
+    }
+    if names.len() == expected.len() {
+        Ok(())
+    } else {
+        Err(Error::Object)
+    }
+}
+
+struct Node {
+    handle: File,
+    metadata: Metadata,
+}
+
+impl Node {
+    fn open(directory: &File, name: &str) -> Result<Self, Error> {
+        let handle = pin(directory, name)?;
+        let metadata = handle.metadata().map_err(|_| Error::Storage)?;
+        if !metadata.is_file()
+            || metadata.nlink() != 1
+            || metadata.mode() & 0o7777 != 0o600
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+        {
+            return Err(Error::Object);
+        }
+        Ok(Self { handle, metadata })
+    }
+
+    fn verify(&self, directory: &File, name: &str, renamed: bool) -> Result<(), Error> {
+        let held = self.handle.metadata().map_err(|_| Error::Storage)?;
+        let named = Self::open(directory, name)?.metadata;
+        let stable = if renamed {
+            // A successful rename changes ctime, but must preserve every other
+            // content/identity field (atime is deliberately not an integrity field).
+            let before = &self.metadata;
+            (
+                before.dev(),
+                before.ino(),
+                before.uid(),
+                before.gid(),
+                before.mode(),
+                before.nlink(),
+                before.len(),
+                before.mtime(),
+                before.mtime_nsec(),
+            ) == (
+                held.dev(),
+                held.ino(),
+                held.uid(),
+                held.gid(),
+                held.mode(),
+                held.nlink(),
+                held.len(),
+                held.mtime(),
+                held.mtime_nsec(),
+            )
+        } else {
+            same_metadata(&self.metadata, &held) && self.metadata.gid() == held.gid()
+        };
+        if stable && same_metadata(&held, &named) && held.gid() == named.gid() {
+            Ok(())
+        } else {
+            Err(Error::Object)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/seed/receive/named/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/named/tests.rs
@@ -1,0 +1,534 @@
+use super::*;
+use crate::cloud_run::ArtifactDigest;
+use crate::repository_overlay::seed::{
+    export::{PackExportLimits, PreparedGitPack, prepare_git_base_pack},
+    prepare_git_seed,
+    tests::{Fixture, private_fixture, snapshot},
+};
+use rustix::io::Errno;
+use std::{
+    cell::Cell,
+    fs::{self, OpenOptions},
+    io::{self, Cursor, Write},
+    os::unix::fs::{OpenOptionsExt, PermissionsExt, symlink},
+};
+
+const HASH: &str = "1111111111111111111111111111111111111111";
+
+fn pack(parent: &Path) -> PreparedGitPack {
+    let fixture = Fixture::new();
+    let resolved = fixture.resolve(vec![], vec![], vec![]);
+    let seed = prepare_git_seed(parent, &resolved, &mut fixture.source(), || false).unwrap();
+    prepare_git_base_pack(parent, &seed, PackExportLimits::default(), || false).unwrap()
+}
+
+fn claim(parent: &File, name: &str) -> rustix::io::Result<()> {
+    mkdirat(parent, name, Mode::from_raw_mode(0o700))
+}
+
+fn relocate(directory: &File, source: &str, target: &str) -> rustix::io::Result<()> {
+    renameat(directory, source, directory, target)
+}
+
+struct Unread;
+impl Read for Unread {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        panic!("unexpected input consumption")
+    }
+}
+
+fn expected(digest: &ArtifactDigest) -> ExpectedGitPack<'_> {
+    ExpectedGitPack {
+        base_commit: git2::Oid::from_str(HASH).unwrap(),
+        sha256: digest,
+        encoded_bytes: 32,
+    }
+}
+
+#[test]
+fn public_named_receive_observe_and_default_receive_keep_identical_pack_semantics() {
+    let source = private_fixture();
+    let pack = pack(source.path());
+    let before = snapshot(source.path());
+    let destination = private_fixture();
+    let received = receive_named_git_base_pack(
+        destination.path(),
+        "attempt",
+        (&pack).into(),
+        &mut File::open(pack.path()).unwrap(),
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap();
+    let observed =
+        observe_git_base_pack(received.path(), (&pack).into(), PackReceiveLimits::default(), || false).unwrap();
+    let default = super::super::receive_git_base_pack(
+        destination.path(),
+        (&pack).into(),
+        &mut File::open(pack.path()).unwrap(),
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap();
+    assert_eq!(received.path(), destination.path().join("attempt"));
+    for result in [&received, &observed, &default] {
+        assert_eq!(result.base_commit(), pack.base_commit());
+        assert_eq!(result.sha256(), pack.sha256());
+        assert_eq!(result.encoded_bytes(), pack.encoded_bytes());
+        assert_eq!(result.objects(), received.objects());
+        assert!(!format!("{result:?}").contains(destination.path().to_str().unwrap()));
+    }
+    let saved = snapshot(destination.path());
+    let failure = receive_named_git_base_pack(
+        destination.path(),
+        "attempt",
+        (&pack).into(),
+        &mut Unread,
+        PackReceiveLimits::default(),
+        || false,
+    )
+    .unwrap_err();
+    assert_eq!(failure.residue(), Some(received.path()));
+    drop((received, observed, default, failure));
+    assert_eq!(snapshot(destination.path()), saved);
+    assert_eq!(snapshot(source.path()), before);
+}
+
+#[test]
+fn invalid_admission_never_claims_or_reads() {
+    let outer = private_fixture();
+    let valid = private_fixture();
+    let insecure = outer.path().join("insecure");
+    fs::create_dir(&insecure).unwrap();
+    fs::set_permissions(&insecure, fs::Permissions::from_mode(0o755)).unwrap();
+    let alias = outer.path().join("alias");
+    symlink(valid.path(), &alias).unwrap();
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    for case in 0..12 {
+        let mut parent = valid.path().to_path_buf();
+        let mut name = "attempt".to_owned();
+        let mut identity = expected(&digest);
+        let mut limits = PackReceiveLimits::default();
+        match case {
+            0 => name.clear(),
+            1 => name = "../escape".into(),
+            2 => name = "/absolute".into(),
+            3 => name = "a".repeat(256),
+            4 => parent = PathBuf::from("relative"),
+            5 => parent = outer.path().join("missing"),
+            6 => parent.clone_from(&insecure),
+            7 => parent.clone_from(&alias),
+            8 => identity.base_commit = git2::Oid::ZERO_SHA1,
+            9 => limits.encoded_bytes = 31,
+            10 => parent = PathBuf::from(format!("/{}", "x".repeat(MAX_PACK_PATH_BYTES))),
+            11 => {}
+            _ => unreachable!(),
+        }
+        let failure = receive_with(
+            &parent,
+            &name,
+            identity,
+            &mut Unread,
+            limits,
+            &|| case == 11,
+            &mut Operations {
+                claim: &mut |_, _| panic!("unexpected claim"),
+                rename: &mut |_, _, _| panic!("unexpected rename"),
+            },
+        )
+        .unwrap_err();
+        assert!(failure.residue().is_none());
+        if case == 10 {
+            assert_eq!(failure.reason, Error::Limit);
+        }
+        assert!(!format!("{failure:?} {failure}").contains(parent.to_str().unwrap()));
+    }
+    assert_eq!(fs::read_dir(valid.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn exact_candidate_path_limit_admits_only_the_boundary_before_claiming() {
+    let root = private_fixture();
+    let name = "attempt";
+    let target_parent_bytes = MAX_PACK_PATH_BYTES - 1 - name.len();
+    let mut parent = root.path().to_path_buf();
+    while parent.as_os_str().len() < target_parent_bytes {
+        let remaining = target_parent_bytes - parent.as_os_str().len();
+        // Keep every component portable and avoid leaving room for only a separator.
+        let component_bytes = if remaining == 129 {
+            126
+        } else {
+            (remaining - 1).min(127)
+        };
+        parent.push("a".repeat(component_bytes));
+    }
+    fs::create_dir_all(&parent).unwrap();
+    fs::set_permissions(&parent, fs::Permissions::from_mode(0o700)).unwrap();
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    for attempt in [name, "attemptx"] {
+        let count = Cell::new(0);
+        let candidate = parent.join(attempt);
+        let boundary = attempt == name;
+        assert_eq!(
+            candidate.as_os_str().len(),
+            MAX_PACK_PATH_BYTES + usize::from(!boundary)
+        );
+        let failure = receive_with(
+            &parent,
+            attempt,
+            expected(&digest),
+            &mut Unread,
+            PackReceiveLimits::default(),
+            &|| false,
+            &mut Operations {
+                claim: &mut |_, _| {
+                    count.set(count.get() + 1);
+                    Err(Errno::IO)
+                },
+                rename: &mut |_, _, _| panic!("no rename before a successful claim"),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(count.get(), usize::from(boundary));
+        assert_eq!(failure.reason, if boundary { Error::Storage } else { Error::Limit });
+        assert_eq!(failure.residue(), boundary.then_some(candidate.as_path()));
+    }
+    assert_eq!(fs::read_dir(parent).unwrap().count(), 0);
+}
+
+#[test]
+fn every_dispatched_claim_error_retains_only_an_attempted_locator_without_ownership() {
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    for error in [Errno::IO, Errno::NOENT, Errno::EXIST, Errno::NOSYS] {
+        for happened in [false, true] {
+            let root = private_fixture();
+            let count = Cell::new(0);
+            let failure = receive_with(
+                root.path(),
+                "attempt",
+                expected(&digest),
+                &mut Unread,
+                PackReceiveLimits::default(),
+                &|| false,
+                &mut Operations {
+                    claim: &mut |parent, name| {
+                        count.set(count.get() + 1);
+                        if happened {
+                            claim(parent, name)?;
+                        }
+                        Err(error)
+                    },
+                    rename: &mut |_, _, _| panic!("claim error cannot grant rename"),
+                },
+            )
+            .unwrap_err();
+            assert_eq!(count.get(), 1);
+            assert_eq!(failure.reason, Error::Storage);
+            assert_eq!(failure.residue(), Some(root.path().join("attempt").as_path()));
+            assert_eq!(root.path().join("attempt").exists(), happened);
+            drop(failure);
+            assert_eq!(fs::read_dir(root.path()).unwrap().count(), usize::from(happened));
+        }
+    }
+}
+
+#[test]
+fn existing_empty_partial_file_and_link_attempts_never_grant_a_receiver() {
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    for kind in 0..4 {
+        let root = private_fixture();
+        let target = root.path().join("attempt");
+        match kind {
+            0 | 1 => {
+                fs::create_dir(&target).unwrap();
+                if kind == 1 {
+                    fs::write(target.join("partial"), b"retain").unwrap();
+                }
+            }
+            2 => fs::write(&target, b"retain").unwrap(),
+            3 => symlink("missing", &target).unwrap(),
+            _ => unreachable!(),
+        }
+        let metadata = fs::symlink_metadata(&target).unwrap();
+        let failure = receive_named_git_base_pack(
+            root.path(),
+            "attempt",
+            expected(&digest),
+            &mut Unread,
+            PackReceiveLimits::default(),
+            || false,
+        )
+        .unwrap_err();
+        assert_eq!(failure.residue(), Some(target.as_path()));
+        assert!(same_metadata(&metadata, &fs::symlink_metadata(&target).unwrap()));
+        if kind == 1 {
+            assert_eq!(fs::read(target.join("partial")).unwrap(), b"retain");
+        }
+    }
+}
+
+#[test]
+fn successful_claim_followed_by_cancellation_or_parent_replacement_never_reads_input() {
+    let digest = ArtifactDigest::sha256(b"synthetic");
+    for replace in [false, true] {
+        let outer = private_fixture();
+        let root = outer.path().join("root");
+        fs::create_dir(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        let cancel = Cell::new(false);
+        let failure = receive_with(
+            &root,
+            "attempt",
+            expected(&digest),
+            &mut Unread,
+            PackReceiveLimits::default(),
+            &|| cancel.get(),
+            &mut Operations {
+                claim: &mut |parent, name| {
+                    claim(parent, name)?;
+                    if replace {
+                        fs::rename(&root, outer.path().join("retained")).unwrap();
+                        fs::create_dir(&root).unwrap();
+                        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+                    } else {
+                        cancel.set(true);
+                    }
+                    Ok(())
+                },
+                rename: &mut |_, _, _| panic!("no rename after failed claim verification"),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(failure.residue(), Some(root.join("attempt").as_path()));
+        let retained = if replace {
+            outer.path().join("retained/attempt")
+        } else {
+            root.join("attempt")
+        };
+        assert_eq!(fs::read_dir(retained).unwrap().count(), 0);
+        assert_eq!(
+            failure.reason,
+            if replace { Error::UnsafeParent } else { Error::Cancelled }
+        );
+    }
+}
+
+#[test]
+fn rename_errors_retain_partial_or_complete_names_without_replay() {
+    let source = private_fixture();
+    let pack = pack(source.path());
+    for failed_call in 1..=2 {
+        for happened in [false, true] {
+            let root = private_fixture();
+            let calls = Cell::new(0);
+            let failure = receive_with(
+                root.path(),
+                "attempt",
+                (&pack).into(),
+                &mut File::open(pack.path()).unwrap(),
+                PackReceiveLimits::default(),
+                &|| false,
+                &mut Operations {
+                    claim: &mut claim,
+                    rename: &mut |directory, source, target| {
+                        calls.set(calls.get() + 1);
+                        if calls.get() == failed_call {
+                            if happened {
+                                relocate(directory, source, target)?;
+                            }
+                            Err(Errno::IO)
+                        } else {
+                            relocate(directory, source, target)
+                        }
+                    },
+                },
+            )
+            .unwrap_err();
+            assert_eq!(failure.reason, Error::Storage);
+            assert_eq!(calls.get(), failed_call);
+            let path = failure.residue().unwrap();
+            let names: Vec<_> = fs::read_dir(path.join("decoded/objects/pack"))
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+                .collect();
+            assert_eq!(names.len(), 2);
+            assert_eq!(
+                names.iter().filter(|name| name.starts_with("pack-")).count(),
+                failed_call - 1 + usize::from(happened)
+            );
+            assert!(observe_git_base_pack(path, (&pack).into(), PackReceiveLimits::default(), || false).is_err());
+            let before = snapshot(root.path());
+            drop(failure);
+            assert_eq!(snapshot(root.path()), before);
+            assert!(
+                receive_named_git_base_pack(
+                    root.path(),
+                    "attempt",
+                    (&pack).into(),
+                    &mut Unread,
+                    PackReceiveLimits::default(),
+                    || false
+                )
+                .is_err()
+            );
+        }
+    }
+}
+
+fn pair(root: &Path) -> Reservation {
+    let parent = staging::private_parent(root).unwrap();
+    claim(parent.root.handle(), "attempt").unwrap();
+    let reservation = Reservation {
+        root: directory(parent.root.handle(), "attempt", true).unwrap(),
+        parent,
+        parent_path: root.to_path_buf(),
+        name: "attempt".into(),
+    };
+    let directory = root.join("attempt/decoded/objects/pack");
+    fs::create_dir_all(&directory).unwrap();
+    for extension in ["pack", "idx"] {
+        OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(directory.join(format!("received.{extension}")))
+            .unwrap()
+            .write_all(extension.as_bytes())
+            .unwrap();
+    }
+    reservation
+}
+
+#[test]
+fn cancellation_at_each_private_rename_boundary_retains_the_observed_phase() {
+    for after in 0..=2 {
+        let root = private_fixture();
+        let reservation = pair(root.path());
+        let calls = Cell::new(0);
+        let result = reservation.relocate(HASH, &|| calls.get() == after, &mut |directory, source, target| {
+            calls.set(calls.get() + 1);
+            relocate(directory, source, target)
+        });
+        assert_eq!(result, Err(Error::Cancelled));
+        assert_eq!(calls.get(), after);
+        assert_eq!(
+            fs::read_dir(root.path().join("attempt/decoded/objects/pack"))
+                .unwrap()
+                .count(),
+            2
+        );
+    }
+}
+
+#[test]
+fn foreign_nodes_destinations_and_changed_directory_bindings_prevent_renames() {
+    for case in 0..8 {
+        let root = private_fixture();
+        let reservation = pair(root.path());
+        let path = root.path().join("attempt/decoded/objects/pack");
+        let source = path.join("received.pack");
+        match case {
+            0 => fs::write(path.join("foreign"), b"retain").unwrap(),
+            1 => fs::write(path.join(format!("pack-{HASH}.pack")), b"retain").unwrap(),
+            2 => {
+                fs::rename(&source, root.path().join("original")).unwrap();
+                symlink(root.path().join("original"), &source).unwrap();
+            }
+            3 => fs::hard_link(&source, root.path().join("alias")).unwrap(),
+            4 => fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).unwrap(),
+            5 => {
+                fs::rename(root.path().join("attempt"), root.path().join("retained")).unwrap();
+                fs::create_dir(root.path().join("attempt")).unwrap();
+            }
+            6 => {
+                fs::rename(&path, root.path().join("retained")).unwrap();
+                symlink(root.path().join("retained"), &path).unwrap();
+            }
+            7 => fs::set_permissions(root.path().join("attempt"), fs::Permissions::from_mode(0o755)).unwrap(),
+            _ => unreachable!(),
+        }
+        assert!(
+            reservation
+                .relocate(HASH, &|| false, &mut |_, _, _| panic!("unsafe rename"))
+                .is_err()
+        );
+        if case == 1 {
+            assert_eq!(fs::read(path.join(format!("pack-{HASH}.pack"))).unwrap(), b"retain");
+        }
+    }
+}
+
+#[test]
+fn changes_after_first_rename_cannot_silently_replace_the_second_node() {
+    for case in 0..4 {
+        let root = private_fixture();
+        let reservation = pair(root.path());
+        let path = root.path().join("attempt/decoded/objects/pack");
+        let calls = Cell::new(0);
+        let result = reservation.relocate(HASH, &|| false, &mut |directory, source, target| {
+            calls.set(calls.get() + 1);
+            relocate(directory, source, target)?;
+            match case {
+                0 => fs::write(path.join("received.idx"), b"changed").unwrap(),
+                1 => fs::write(path.join(target), b"changed").unwrap(),
+                2 => fs::hard_link(path.join(target), root.path().join("alias")).unwrap(),
+                3 => fs::write(path.join(format!("pack-{HASH}.idx")), b"retain").unwrap(),
+                _ => unreachable!(),
+            }
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1);
+    }
+}
+
+#[test]
+fn streamed_digest_eof_read_errors_cancellation_and_wrong_base_keep_the_claim() {
+    struct Reader<'a>(&'a mut dyn FnMut(&mut [u8]) -> io::Result<usize>);
+    impl Read for Reader<'_> {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            self.0(buffer)
+        }
+    }
+    let source = private_fixture();
+    let pack = pack(source.path());
+    for kind in 0..6 {
+        let root = private_fixture();
+        let mut bytes = fs::read(pack.path()).unwrap();
+        match kind {
+            0 => {
+                bytes.pop();
+            }
+            1 => bytes.push(0),
+            2 => bytes[15] ^= 1,
+            _ => {}
+        }
+        let cancelled = Cell::new(false);
+        let mut cursor = Cursor::new(bytes);
+        let mut input = |buffer: &mut [u8]| {
+            if kind == 3 {
+                return Err(io::Error::other("private-marker"));
+            }
+            let result = cursor.read(buffer);
+            cancelled.set(kind == 4);
+            result
+        };
+        let mut identity = (&pack).into();
+        if kind == 5 {
+            identity = expected(pack.sha256());
+            identity.encoded_bytes = pack.encoded_bytes();
+        }
+        let failure = receive_named_git_base_pack(
+            root.path(),
+            "attempt",
+            identity,
+            &mut Reader(&mut input),
+            PackReceiveLimits::default(),
+            || cancelled.get(),
+        )
+        .unwrap_err();
+        assert_eq!(failure.residue(), Some(root.path().join("attempt").as_path()));
+        assert!(!format!("{failure:?} {failure}").contains("private-marker"));
+        assert!(!root.path().join("attempt/decoded/objects/pack/received.idx").exists());
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/seed/receive/native.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/receive/native.rs
@@ -15,7 +15,7 @@ pub(super) fn index(
     objects: u32,
     limits: PackedSourceLimits,
     cancelled: &impl Fn() -> bool,
-) -> Result<(), SeedError> {
+) -> Result<String, SeedError> {
     let mut session = Session::spawn(command, limits.object_timeout, Box::new(cancelled))?;
     session.begin_without_input();
     let hash = line(&mut session)?.ok_or(SeedError::Object)?;
@@ -34,6 +34,10 @@ pub(super) fn index(
         return Err(SeedError::Object);
     }
     fs::set_permissions(&index, fs::Permissions::from_mode(0o600)).map_err(|_| SeedError::Storage)?;
+    Ok(hash.to_owned())
+}
+
+pub(super) fn relocate(path: &Path, hash: &str) -> Result<(), SeedError> {
     for extension in ["pack", "idx"] {
         renameat_with(
             CWD,

--- a/crates/horizon-core/src/repository_overlay/seed/staging.rs
+++ b/crates/horizon-core/src/repository_overlay/seed/staging.rs
@@ -32,6 +32,18 @@ pub(super) fn prepare(
 
 pub(super) fn reserve(parent: &Path, cancelled: &impl Fn() -> bool) -> Result<std::path::PathBuf, Error> {
     check_cancel(cancelled)?;
+    let _parent = private_parent(parent)?;
+    // Stable ancestry and exclusive same-user ownership are caller preconditions.
+    // Keep immediately: a failed seed is evidence, never an automatic recursive delete.
+    tempfile::Builder::new()
+        .prefix("repository-seed-")
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir_in(parent)
+        .map(tempfile::TempDir::keep)
+        .map_err(|_| Error::Storage)
+}
+
+pub(super) fn private_parent(parent: &Path) -> Result<SelectedRepositoryReader, Error> {
     if !parent.is_absolute() {
         return Err(Error::UnsafeParent);
     }
@@ -44,14 +56,7 @@ pub(super) fn reserve(parent: &Path, cancelled: &impl Fn() -> bool) -> Result<st
     {
         return Err(Error::UnsafeParent);
     }
-    // Stable ancestry and exclusive same-user ownership are caller preconditions.
-    // Keep immediately: a failed seed is evidence, never an automatic recursive delete.
-    tempfile::Builder::new()
-        .prefix("repository-seed-")
-        .permissions(fs::Permissions::from_mode(0o700))
-        .tempdir_in(parent)
-        .map(tempfile::TempDir::keep)
-        .map_err(|_| Error::Storage)
+    Ok(reader)
 }
 
 fn populate(

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -343,6 +343,10 @@ back into large multi-purpose modules.
   encoded verification before shared read-only native index/closure checks. The
   reader's existing metadata fingerprint is reused for held/named comparisons.
   See [private pack receipt](../remote-repository-pack-receipt.md).
+  The opt-in `seed/receive/named` leaf owns caller-named exclusive attempts and
+  held-private-directory ordinary renames without changing the default receiver.
+  It reuses stream/native/observer validation and retains uncertain attempt names;
+  see [named private receipt](named-git-pack-receive.md) for ownership and proof limits.
   Its peer `publication/` subtree owns explicit qualified no-replace publication
   and distinct pre/post/uncertain rename receipts. It reuses the read-only fixed
   layout's bound handles and fingerprints for synchronization instead of adding

--- a/docs/architecture/named-git-pack-receive.md
+++ b/docs/architecture/named-git-pack-receive.md
@@ -1,0 +1,24 @@
+# Explicit named private pack receipt
+
+`receive_named_git_base_pack` is a Linux-only opt-in sibling of the existing
+receiver. The caller supplies a bounded portable attempt name under an existing
+private parent. Expected metadata, limits and parent admission precede input reads.
+One successful exclusive mkdir grants ownership; an existing name is never adopted.
+Every dispatched claim error retains the attempted locator without proving that it
+exists or belongs to this attempt. The caller must establish ownership separately.
+
+The common stream/EOF/digest, isolated strict indexing and exact shallow closure
+checks are unchanged. Only final pack/index naming differs: ordinary renames run
+once within the exclusively owned reservation using held directory/file identities
+and exact child-name checks. Errors may follow completed operations; partial names
+are retained, never retried, repaired, overwritten or cleaned. Successful receipt
+also passes the existing read-only observer; observation cannot resume a receiver.
+
+Stable ancestry and exclusive same-user control remain caller preconditions. This
+is not confinement against a malicious concurrent same-user or privileged writer.
+The default receiver, CLI/intake callers and qualified publisher remain unchanged.
+There is no implicit fallback, synchronization acknowledgement, cloud operation,
+worker enrollment or full checkpoint/recovery claim. Local fixtures and injected
+errors test operation ownership and retention, not HPS/NFS compatibility or physical
+durability; the complete selected-filesystem receive/publication path still needs
+separate live qualification. Blocking storage/input calls have no hard deadline.


### PR DESCRIPTION
## Purpose

Add an explicit Linux named private pack receiver as a prerequisite for #471.
This does not complete worker-owned checkpoints or qualify a provider filesystem.

## Behavior

- `receive_named_git_base_pack` accepts a validated caller-chosen attempt name under an existing private parent. Only successful exclusive directory creation grants permission to populate it; existing attempts are never adopted or replayed.
- Reuse existing bounded input, exact length/EOF/digest, isolated strict decoding and exact shallow-closure checks. Two ordinary renames occur only inside the owned private reservation, with held identities and exact child-name checks; successful receipt also passes the existing read-only observer.
- Retain attempted locations and partial data on failure without inferring ownership, absence or rollback. No automatic retry, repair, cleanup or overwrite of an existing attempt.
- Preserve the default receiver's no-replace operations, existing CLI/intake callers and qualified publisher. Reuse the central path bound, including native inner-path headroom.

## Validation

On exact commit `b6312d66`, all eight validation lanes passed: 2,603 default / 2,648 speech tests, with seven ignored in each lane across 26 suites. All 66 focused seed tests passed, and blocking, strict and pedantic Clippy completed without warnings.

An initial blocking lint failure in test-local declaration placement was corrected; refreshed precommit checks and the final matrix passed.

Coverage includes public named/default/observer parity, 3839/3840-byte admission boundaries, existing/foreign attempts, ambiguous claim and rename outcomes, cancellation, identity changes, corrupt/truncated/trailing input, reader errors and wrong-base rejection.

## Limits

Stable ancestry, exclusive same-user control and trusted native tools remain caller preconditions. This is not protection against a concurrent same-user or privileged writer. Local fixtures and injected errors test ownership and retention semantics, not HPS/NFS compatibility, synchronization durability or full checkpoint recovery. Blocking input/storage calls retain their existing latency limitations. No cloud, credential, worker enrollment or image publication changes.

Scope: 855 changed source/test lines across five paths, plus 28 documentation lines.
