### PR TITLE
feat(repository): capture verified checkpoint generations

### DIFF
--- a/crates/horizon-core/src/repository_overlay/checkpoint/linux.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/linux.rs
@@ -1,0 +1,324 @@
+use super::{
+    CheckpointError as Error, CheckpointFailure, CheckpointGeneration, CheckpointRequest, GenerationManifest,
+    PackIdentity, storage::Generation,
+};
+use crate::{
+    cloud_run::{ArtifactDigest, GitCommitSha},
+    repository_overlay::{
+        OverlayPlanError,
+        bundle::{OverlayBundleError, RepositoryOverlayBundle, codec, store::RepositoryBundleStore},
+        capture::{GitCaptureError, capture_selected_revision},
+        namespace::{NamespaceError, ResolvedRepositoryOverlay, resolve_namespaces_from_source},
+        reader::RepositoryReadError,
+        seed::{
+            GitObjectInspector, GitObjectMetadata, GitObjectSource, GitObjectStream, SeedError,
+            export::{PackExportLimits, prepare_git_base_pack},
+            packed::{PackedGitObjectSource, PackedSourceLimits},
+            prepare_git_seed,
+            receive::{
+                PackReceiveLimits, observe_git_base_pack,
+                publication::{
+                    NamedPackPublication, NamedPackPublicationFailure, PackPublicationError, publish_named_git_pack,
+                },
+                receive_named_git_base_pack,
+            },
+        },
+    },
+};
+use git2::{ObjectType, Oid};
+use std::{
+    fs::File,
+    io::{Cursor, Read},
+    path::Path,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const CONTENT_BYTES: u64 = 16 * 1024 * 1024;
+const PACK_BYTES: u64 = 32 * 1024 * 1024;
+const SOURCE_BYTES: u64 = 32 * 1024 * 1024;
+const OBJECTS: usize = 2048;
+const LFS_PREFIX: &[u8] = b"version https://git-lfs.github.com/spec/v1";
+
+pub(super) fn run(
+    request: &CheckpointRequest,
+    checkout: &Path,
+    identity: &impl Fn() -> Result<(), Error>,
+    cancelled: &impl Fn() -> bool,
+) -> Result<CheckpointGeneration, CheckpointFailure> {
+    let preflight = || {
+        request.validate()?;
+        if cancelled() {
+            return Err(Error::Cancelled);
+        }
+        identity()?;
+        Generation::admit(request, checkout)
+    };
+    let parent = preflight().map_err(|reason| CheckpointFailure { reason, retained: None })?;
+    let path = request.parent.join(&request.attempt_name);
+    let execute = || {
+        let generation = Generation::claim(request, parent)?;
+        let deadline = Instant::now();
+        let stop = || cancelled() || deadline.elapsed() > Duration::from_secs(120);
+        let manifest = capture(request, checkout, identity, &generation, &stop)?;
+        let bytes = serde_json::to_vec(&manifest).map_err(|_| Error::Storage)?;
+        let digest = ArtifactDigest::sha256(&bytes);
+        generation.finish(&bytes)?;
+        identity()?;
+        if stop() {
+            return Err(Error::Cancelled);
+        }
+        Ok(CheckpointGeneration {
+            path: generation.path,
+            manifest_sha256: digest,
+            manifest,
+        })
+    };
+    execute().map_err(|reason| CheckpointFailure {
+        reason,
+        retained: Some(path),
+    })
+}
+
+fn sample(request: &CheckpointRequest, checkout: &Path) -> Result<RepositoryOverlayBundle, Error> {
+    let selected: Vec<_> = request.selected.iter().map(String::as_str).collect();
+    let bundle = capture_selected_revision(
+        checkout,
+        request.preparation.source.clone(),
+        &request.preparation.work_branch,
+        &selected,
+    )
+    .map_err(capture_error)?;
+    if bundle.file_bytes() as u64 > CONTENT_BYTES {
+        return Err(Error::Capacity);
+    }
+    if bundle.blobs().any(|blob| blob.bytes().starts_with(LFS_PREFIX)) {
+        return Err(Error::Unsupported);
+    }
+    Ok(bundle)
+}
+
+fn capture(
+    request: &CheckpointRequest,
+    checkout: &Path,
+    identity: &impl Fn() -> Result<(), Error>,
+    generation: &Generation,
+    cancelled: &impl Fn() -> bool,
+) -> Result<GenerationManifest, Error> {
+    let started_at_millis = now()?;
+    let bundle = sample(request, checkout)?;
+    let encoded = codec::encode(&bundle).map_err(|_| Error::Capacity)?;
+    if encoded.len() as u64 > CONTENT_BYTES {
+        return Err(Error::Capacity);
+    }
+    let overlay_record = ArtifactDigest::sha256(&encoded);
+    let overlay_bytes = encoded.len() as u64;
+    drop(encoded);
+    let limits = PackedSourceLimits {
+        address_space_bytes: 512 * 1024 * 1024,
+        cpu_seconds: 15,
+        object_timeout: Duration::from_secs(15),
+    };
+    let scratch = generation.path.join("scratch");
+    let mut source = Source {
+        inner: PackedGitObjectSource::new(&scratch, &checkout.join(".git/objects"), limits, cancelled)
+            .map_err(|e| seed_error(e.reason))?,
+        bytes: 0,
+        objects: 0,
+    };
+    let resolved = resolve_namespaces_from_source(&mut source, bundle, cancelled).map_err(namespace_error)?;
+    for namespace in [resolved.base(), resolved.index(), resolved.working_tree()] {
+        if namespace.entries().len() > 1024 || namespace.logical_bytes() > CONTENT_BYTES {
+            return Err(Error::Capacity);
+        }
+    }
+    let pack_identity = retain_pack(generation, &resolved, source, limits, cancelled)?;
+    let store = RepositoryBundleStore::open_named(&generation.path.join("bundles")).map_err(|_| Error::Storage)?;
+    let overlay_manifest = store.put(resolved.bundle()).map_err(|_| Error::Storage)?;
+    if store.get(&overlay_manifest).map_err(|_| Error::Storage)? != *resolved.bundle() {
+        return Err(Error::Storage);
+    }
+    generation.check()?;
+    identity()?;
+    if sample(request, checkout)? != *resolved.bundle() {
+        return Err(Error::Changed);
+    }
+    if cancelled() {
+        return Err(Error::Cancelled);
+    }
+    let verified_at_millis = now()?;
+    if verified_at_millis < started_at_millis {
+        return Err(Error::Identity);
+    }
+    let mut selected = request.selected.clone();
+    selected.sort_unstable();
+    Ok(GenerationManifest {
+        version: 1,
+        coverage: "complete current base closure plus selected dirty layers; not atomic or full workspace recovery"
+            .into(),
+        preparation: request.preparation.clone(),
+        complete_base_closure_consent: request.complete_base_closure_consent,
+        retained_volume_attested: request.retained_volume_attested,
+        selected,
+        pack: pack_identity,
+        overlay_manifest,
+        overlay_record,
+        overlay_bytes,
+        started_at_millis,
+        verified_at_millis,
+    })
+}
+
+fn retain_pack(
+    generation: &Generation,
+    resolved: &ResolvedRepositoryOverlay,
+    mut source: Source<'_>,
+    limits: PackedSourceLimits,
+    cancelled: &impl Fn() -> bool,
+) -> Result<PackIdentity, Error> {
+    let scratch = generation.path.join("scratch");
+    generation.check()?;
+    let seed = prepare_git_seed(&scratch, resolved, &mut source, cancelled).map_err(|e| seed_error(e.reason))?;
+    drop(source);
+    generation.check()?;
+    let pack = prepare_git_base_pack(
+        &scratch,
+        &seed,
+        PackExportLimits {
+            source: limits,
+            encoded_bytes: PACK_BYTES,
+        },
+        cancelled,
+    )
+    .map_err(|e| seed_error(e.reason))?;
+    generation.check()?;
+    let identity = PackIdentity {
+        base_commit: GitCommitSha::parse(pack.base_commit().to_string()).map_err(|_| Error::Identity)?,
+        sha256: pack.sha256().clone(),
+        encoded_bytes: pack.encoded_bytes(),
+    };
+    let receive_limits = PackReceiveLimits {
+        source: limits,
+        encoded_bytes: PACK_BYTES,
+    };
+    let packs = generation.path.join("packs");
+    let received = receive_named_git_base_pack(
+        &packs,
+        "incoming",
+        (&pack).into(),
+        &mut File::open(pack.path()).map_err(|_| Error::Storage)?,
+        receive_limits,
+        cancelled,
+    )
+    .map_err(|e| seed_error(e.reason))?;
+    generation.check()?;
+    let published =
+        publish_named_git_pack(&packs, received, receive_limits, cancelled).map_err(|error| match error {
+            NamedPackPublicationFailure::Retained {
+                reason: PackPublicationError::Verification(reason),
+                ..
+            }
+            | NamedPackPublicationFailure::PublishedUnsynchronized {
+                reason: PackPublicationError::Verification(reason),
+                ..
+            } => seed_error(reason),
+            _ => Error::Storage,
+        })?;
+    let received = match &published {
+        NamedPackPublication::Published(pack) => pack.pack(),
+        NamedPackPublication::Existing { pack, .. } => pack,
+    };
+    observe_git_base_pack(received.path(), received.into(), receive_limits, cancelled).map_err(seed_error)?;
+    generation.check()?;
+    Ok(identity)
+}
+
+fn now() -> Result<u64, Error> {
+    u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| Error::Identity)?
+            .as_millis(),
+    )
+    .map_err(|_| Error::Identity)
+}
+
+pub(super) fn capture_error(error: GitCaptureError) -> Error {
+    match error {
+        GitCaptureError::Changed | GitCaptureError::Read(RepositoryReadError::Changed) => Error::Changed,
+        GitCaptureError::Read(RepositoryReadError::TooLarge)
+        | GitCaptureError::Policy(
+            OverlayPlanError::ChangeLimit | OverlayPlanError::MetadataLimit | OverlayPlanError::ContentLimit,
+        )
+        | GitCaptureError::Bundle(OverlayBundleError::FileLimit | OverlayBundleError::BundleLimit) => Error::Capacity,
+        _ => Error::Unsupported,
+    }
+}
+
+pub(super) fn namespace_error(error: NamespaceError) -> Error {
+    match error {
+        NamespaceError::Limit
+        | NamespaceError::Policy(
+            OverlayPlanError::ChangeLimit | OverlayPlanError::MetadataLimit | OverlayPlanError::ContentLimit,
+        ) => Error::Capacity,
+        NamespaceError::Source(reason) => seed_error(reason),
+        _ => Error::Unsupported,
+    }
+}
+
+fn seed_error(error: SeedError) -> Error {
+    match error {
+        SeedError::Limit => Error::Capacity,
+        SeedError::Cancelled => Error::Cancelled,
+        SeedError::Storage | SeedError::Source => Error::Storage,
+        SeedError::UnsafeParent | SeedError::Object => Error::Identity,
+        SeedError::Unsupported => Error::Unsupported,
+    }
+}
+
+struct Source<'a> {
+    inner: PackedGitObjectSource<'a>,
+    bytes: u64,
+    objects: usize,
+}
+impl GitObjectInspector for Source<'_> {
+    fn inspect(&mut self, object: Oid) -> Result<GitObjectMetadata, SeedError> {
+        let metadata = self.inner.inspect(object)?;
+        if metadata.bytes > CONTENT_BYTES {
+            return Err(SeedError::Limit);
+        }
+        Ok(metadata)
+    }
+}
+impl GitObjectSource for Source<'_> {
+    fn open(&mut self, object: Oid) -> Result<GitObjectStream<'_>, SeedError> {
+        let stream = self.inner.open(object)?;
+        self.bytes = self.bytes.checked_add(stream.bytes).ok_or(SeedError::Limit)?;
+        self.objects += 1;
+        if stream.bytes > CONTENT_BYTES || self.bytes > SOURCE_BYTES || self.objects > OBJECTS {
+            return Err(SeedError::Limit);
+        }
+        let kind = stream.kind;
+        let length = stream.bytes;
+        let mut bytes = Vec::new();
+        stream
+            .reader
+            .take(length + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::ConnectionAborted => SeedError::Cancelled,
+                std::io::ErrorKind::TimedOut | std::io::ErrorKind::OutOfMemory => SeedError::Limit,
+                _ => SeedError::Source,
+            })?;
+        if bytes.len() as u64 != length {
+            return Err(SeedError::Object);
+        }
+        if kind == ObjectType::Blob && bytes.starts_with(LFS_PREFIX) {
+            return Err(SeedError::Unsupported);
+        }
+        Ok(GitObjectStream {
+            kind,
+            bytes: length,
+            reader: Box::new(Cursor::new(bytes)),
+        })
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/checkpoint/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/mod.rs
@@ -1,0 +1,178 @@
+//! One-shot base closure plus selected dirty layers, not a full workspace checkpoint.
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+mod storage;
+
+use crate::{
+    cloud_run::{ArtifactDigest, GitCommitSha},
+    repository_git::GitPreparation,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, fmt, path::PathBuf};
+
+pub const REQUEST_LIMIT: usize = 64 * 1024;
+pub const CAPACITY: u64 = 512 * 1024 * 1024;
+pub const ADMISSION_BYTES: u64 = 128 * 1024 * 1024;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointRequest {
+    pub version: u8,
+    pub preparation: GitPreparation,
+    pub selected: Vec<String>,
+    pub complete_base_closure_consent: bool,
+    pub retained_volume_attested: bool,
+    pub parent: PathBuf,
+    pub attempt_name: String,
+    pub max_retained_bytes: u64,
+}
+
+impl CheckpointRequest {
+    /// Validate explicit coverage/retention consent and bounded request shape without I/O.
+    /// # Errors
+    /// Rejects unsupported versions, identities, paths, selections and budgets.
+    pub fn validate(&self) -> Result<(), CheckpointError> {
+        use super::{
+            OverlayChange, OverlayContent, checkout::publication::validate_sibling_name, materialize::valid_path,
+        };
+        if self.version != 1
+            || !self.complete_base_closure_consent
+            || !self.retained_volume_attested
+            || self.preparation.binding().is_err()
+            || self.selected.is_empty()
+            || self.selected.len() > 128
+            || !(ADMISSION_BYTES..=CAPACITY).contains(&self.max_retained_bytes)
+            || !valid_path(&self.parent)
+            || validate_sibling_name(&self.attempt_name).is_err()
+            || self.parent.join(&self.attempt_name).as_os_str().len() > super::seed::MAX_PACK_RECEIVE_PARENT_BYTES
+        {
+            return Err(CheckpointError::Invalid);
+        }
+        let mut unique = BTreeSet::new();
+        for path in &self.selected {
+            OverlayChange::new(path.clone(), OverlayContent::Remove).map_err(|_| CheckpointError::Invalid)?;
+            if !unique.insert(path) {
+                return Err(CheckpointError::Invalid);
+            }
+        }
+        if serde_json::to_vec(self).map_err(|_| CheckpointError::Invalid)?.len() > REQUEST_LIMIT {
+            return Err(CheckpointError::Invalid);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackIdentity {
+    pub base_commit: GitCommitSha,
+    pub sha256: ArtifactDigest,
+    pub encoded_bytes: u64,
+}
+
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationManifest {
+    pub version: u8,
+    pub coverage: String,
+    pub preparation: GitPreparation,
+    pub complete_base_closure_consent: bool,
+    pub retained_volume_attested: bool,
+    pub selected: Vec<String>,
+    pub pack: PackIdentity,
+    pub overlay_manifest: ArtifactDigest,
+    pub overlay_record: ArtifactDigest,
+    pub overlay_bytes: u64,
+    pub started_at_millis: u64,
+    pub verified_at_millis: u64,
+}
+
+#[derive(Serialize)]
+pub struct CheckpointGeneration {
+    pub path: PathBuf,
+    pub manifest_sha256: ArtifactDigest,
+    pub manifest: GenerationManifest,
+}
+impl fmt::Debug for CheckpointGeneration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckpointGeneration").finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointError {
+    #[error("invalid checkpoint request or consent")]
+    Invalid,
+    #[error("checkpoint capture is unsupported")]
+    Unsupported,
+    #[error("checkpoint identity changed or is unsafe")]
+    Identity,
+    #[error("checkpoint source changed during capture")]
+    Changed,
+    #[error("checkpoint exceeds a conservative capacity bound")]
+    Capacity,
+    #[error("checkpoint storage is unconfirmed; retain the attempt")]
+    Storage,
+    #[error("checkpoint capture was cancelled")]
+    Cancelled,
+}
+
+#[derive(thiserror::Error)]
+#[error("{reason}")]
+pub struct CheckpointFailure {
+    pub reason: CheckpointError,
+    /// Attempted locator only; separately prove ownership before any future action.
+    pub retained: Option<PathBuf>,
+}
+impl fmt::Debug for CheckpointFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.reason.fmt(f)
+    }
+}
+
+/// Capture one explicitly consented generation. Existing attempts are never adopted.
+/// Stable exclusive ownership is required; blocking filesystem calls have no hard
+/// deadline. No cloud, task, cleanup, retry, restore or remote watermark mutation.
+/// # Errors
+/// All post-claim failures retain an uncertain locator, not an ownership assertion.
+pub fn checkpoint_once(
+    request: &CheckpointRequest,
+    cancelled: impl Fn() -> bool,
+) -> Result<CheckpointGeneration, CheckpointFailure> {
+    request
+        .validate()
+        .map_err(|reason| CheckpointFailure { reason, retained: None })?;
+    #[cfg(target_os = "linux")]
+    {
+        let before = request.preparation.inspect_checkout().map_err(|_| CheckpointFailure {
+            reason: CheckpointError::Identity,
+            retained: None,
+        })?;
+        linux::run(
+            request,
+            std::path::Path::new(before.path),
+            &|| {
+                if request.preparation.inspect_checkout().ok().as_ref() == Some(&before) {
+                    Ok(())
+                } else {
+                    Err(CheckpointError::Identity)
+                }
+            },
+            &cancelled,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = cancelled;
+        Err(CheckpointFailure {
+            reason: CheckpointError::Unsupported,
+            retained: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/repository_overlay/checkpoint/storage.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/storage.rs
@@ -1,6 +1,6 @@
 use super::{ADMISSION_BYTES, CheckpointError as Error, CheckpointRequest};
 use crate::repository_overlay::reader::SelectedRepositoryReader;
-use rustix::fs::{Mode, OFlags, ResolveFlags, mkdirat, openat2};
+use rustix::fs::{AtFlags, Mode, OFlags, ResolveFlags, StatxFlags, mkdirat, openat2, statx};
 use std::{
     fs::{self, File},
     io::Write,
@@ -30,6 +30,9 @@ pub(super) fn private(path: &Path) -> Result<File, Error> {
 }
 
 fn same(left: &File, right: &File) -> Result<(), Error> {
+    if mount(left)? != mount(right)? {
+        return Err(Error::Identity);
+    }
     let left = left.metadata().map_err(|_| Error::Storage)?;
     let right = right.metadata().map_err(|_| Error::Storage)?;
     if (left.dev(), left.ino(), left.uid(), left.mode()) == (right.dev(), right.ino(), right.uid(), right.mode()) {
@@ -37,6 +40,43 @@ fn same(left: &File, right: &File) -> Result<(), Error> {
     } else {
         Err(Error::Identity)
     }
+}
+
+fn mount(file: &File) -> Result<u64, Error> {
+    let stat = statx(file, "", AtFlags::EMPTY_PATH, StatxFlags::MNT_ID).map_err(|_| Error::Identity)?;
+    if stat.stx_mask & StatxFlags::MNT_ID.bits() == 0 || stat.stx_mnt_id == 0 {
+        return Err(Error::Identity);
+    }
+    Ok(stat.stx_mnt_id)
+}
+
+fn unrelated(ancestor: &File, descendant: &File) -> Result<(), Error> {
+    let ancestor = ancestor.metadata().map_err(|_| Error::Storage)?;
+    let identity = (ancestor.dev(), ancestor.ino());
+    let expected_mount = mount(descendant)?;
+    let mut current = descendant.try_clone().map_err(|_| Error::Storage)?;
+    for _ in 0..256 {
+        let meta = current.metadata().map_err(|_| Error::Storage)?;
+        if (meta.dev(), meta.ino()) == identity {
+            return Err(Error::Identity);
+        }
+        let parent = File::from(
+            openat2(
+                &current,
+                "..",
+                OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+                ResolveFlags::NO_SYMLINKS | ResolveFlags::NO_MAGICLINKS,
+            )
+            .map_err(|_| Error::Identity)?,
+        );
+        let next = parent.metadata().map_err(|_| Error::Storage)?;
+        if mount(&parent)? != expected_mount || (meta.dev(), meta.ino()) == (next.dev(), next.ino()) {
+            return Ok(());
+        }
+        current = parent;
+    }
+    Err(Error::Identity)
 }
 
 pub(super) fn usage(path: &Path, budget: u64) -> Result<u64, Error> {
@@ -86,23 +126,38 @@ impl Generation {
         let source = SelectedRepositoryReader::open(checkout).map_err(|_| Error::Identity)?;
         if parent.metadata().map_err(|_| Error::Storage)?.dev()
             != source.root.handle().metadata().map_err(|_| Error::Storage)?.dev()
+            || mount(&parent)? != mount(source.root.handle())?
         {
             return Err(Error::Identity);
         }
+        // Device equality alone admits bind-mounted aliases of the checkout.
+        unrelated(&parent, source.root.handle())?;
+        unrelated(source.root.handle(), &parent)?;
         if usage(&request.parent, request.max_retained_bytes)?
             .checked_add(ADMISSION_BYTES)
             .is_none_or(|bytes| bytes > request.max_retained_bytes)
         {
             return Err(Error::Capacity);
         }
+        same(&private(&request.parent)?, &parent)?;
+        same(
+            SelectedRepositoryReader::open(checkout)
+                .map_err(|_| Error::Identity)?
+                .root
+                .handle(),
+            source.root.handle(),
+        )?;
         Ok(parent)
     }
 
     pub fn claim(request: &CheckpointRequest, parent: File) -> Result<Self, Error> {
+        same(&private(&request.parent)?, &parent)?;
         mkdirat(&parent, request.attempt_name.as_str(), Mode::from_raw_mode(0o700)).map_err(|_| Error::Storage)?;
         let path = request.parent.join(&request.attempt_name);
         let root = private(&path)?;
-        if root.metadata().map_err(|_| Error::Storage)?.dev() != parent.metadata().map_err(|_| Error::Storage)?.dev() {
+        if root.metadata().map_err(|_| Error::Storage)?.dev() != parent.metadata().map_err(|_| Error::Storage)?.dev()
+            || mount(&root)? != mount(&parent)?
+        {
             return Err(Error::Identity);
         }
         let result = Self {
@@ -168,5 +223,29 @@ impl Generation {
             return Err(Error::Storage);
         }
         self.check()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pinned_ancestry_rejects_self_and_ancestors_but_accepts_siblings() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = File::open(fixture.path()).unwrap();
+        let child = fixture.path().join("child");
+        let sibling = fixture.path().join("sibling");
+        fs::create_dir(&child).unwrap();
+        fs::create_dir(&sibling).unwrap();
+        let child = File::open(child).unwrap();
+        let sibling = File::open(sibling).unwrap();
+        assert_eq!(mount(&root).unwrap(), mount(&child).unwrap());
+        assert_eq!(mount(&child).unwrap(), mount(&sibling).unwrap());
+        assert_eq!(unrelated(&child, &child), Err(Error::Identity));
+        assert_eq!(unrelated(&root, &child), Err(Error::Identity));
+        assert_eq!(unrelated(&root, &sibling), Err(Error::Identity));
+        assert!(unrelated(&child, &sibling).is_ok());
+        assert!(unrelated(&sibling, &child).is_ok());
     }
 }

--- a/crates/horizon-core/src/repository_overlay/checkpoint/storage.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/storage.rs
@@ -50,9 +50,10 @@ pub(super) fn usage(path: &Path, budget: u64) -> Result<u64, Error> {
             return Err(Error::Capacity);
         }
         let meta = fs::symlink_metadata(&path).map_err(|_| Error::Storage)?;
+        // The held 0700 root confines inherited descendant modes, as in the pack receiver.
         if meta.dev() != device
             || meta.uid() != rustix::process::geteuid().as_raw()
-            || meta.mode() & 0o7022 != 0
+            || meta.mode() & 0o7000 != 0
             || !(meta.is_dir() || (meta.is_file() && meta.nlink() == 1))
         {
             return Err(Error::Identity);

--- a/crates/horizon-core/src/repository_overlay/checkpoint/storage.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/storage.rs
@@ -1,0 +1,171 @@
+use super::{ADMISSION_BYTES, CheckpointError as Error, CheckpointRequest};
+use crate::repository_overlay::reader::SelectedRepositoryReader;
+use rustix::fs::{Mode, OFlags, ResolveFlags, mkdirat, openat2};
+use std::{
+    fs::{self, File},
+    io::Write,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const NODES: usize = 8192;
+const RECORD_LIMIT: usize = 128 * 1024;
+
+pub(super) struct Generation {
+    pub path: PathBuf,
+    root: File,
+    parent: File,
+    parent_path: PathBuf,
+    budget: u64,
+}
+
+pub(super) fn private(path: &Path) -> Result<File, Error> {
+    let reader = SelectedRepositoryReader::open(path).map_err(|_| Error::Identity)?;
+    let file = reader.root.handle().try_clone().map_err(|_| Error::Storage)?;
+    let meta = file.metadata().map_err(|_| Error::Storage)?;
+    if meta.uid() != rustix::process::geteuid().as_raw() || meta.mode() & 0o7777 != 0o700 || meta.nlink() == 0 {
+        return Err(Error::Identity);
+    }
+    Ok(file)
+}
+
+fn same(left: &File, right: &File) -> Result<(), Error> {
+    let left = left.metadata().map_err(|_| Error::Storage)?;
+    let right = right.metadata().map_err(|_| Error::Storage)?;
+    if (left.dev(), left.ino(), left.uid(), left.mode()) == (right.dev(), right.ino(), right.uid(), right.mode()) {
+        Ok(())
+    } else {
+        Err(Error::Identity)
+    }
+}
+
+pub(super) fn usage(path: &Path, budget: u64) -> Result<u64, Error> {
+    let root = private(path)?;
+    let device = root.metadata().map_err(|_| Error::Storage)?.dev();
+    let mut pending = vec![path.to_path_buf()];
+    let (mut count, mut bytes) = (0, 0u64);
+    while let Some(path) = pending.pop() {
+        count += 1;
+        if count > NODES {
+            return Err(Error::Capacity);
+        }
+        let meta = fs::symlink_metadata(&path).map_err(|_| Error::Storage)?;
+        if meta.dev() != device
+            || meta.uid() != rustix::process::geteuid().as_raw()
+            || meta.mode() & 0o7022 != 0
+            || !(meta.is_dir() || (meta.is_file() && meta.nlink() == 1))
+        {
+            return Err(Error::Identity);
+        }
+        bytes = bytes
+            .checked_add(meta.len().max(meta.blocks().saturating_mul(512)).max(4096))
+            .ok_or(Error::Capacity)?;
+        if bytes > budget {
+            return Err(Error::Capacity);
+        }
+        if meta.is_dir() {
+            for child in fs::read_dir(path).map_err(|_| Error::Storage)? {
+                if pending.len() + count >= NODES {
+                    return Err(Error::Capacity);
+                }
+                pending.push(child.map_err(|_| Error::Storage)?.path());
+            }
+        }
+    }
+    same(&private(path)?, &root)?;
+    Ok(bytes)
+}
+
+impl Generation {
+    pub fn admit(request: &CheckpointRequest, checkout: &Path) -> Result<File, Error> {
+        if request.parent.starts_with(checkout) || checkout.starts_with(&request.parent) {
+            return Err(Error::Identity);
+        }
+        let parent = private(&request.parent)?;
+        let source = SelectedRepositoryReader::open(checkout).map_err(|_| Error::Identity)?;
+        if parent.metadata().map_err(|_| Error::Storage)?.dev()
+            != source.root.handle().metadata().map_err(|_| Error::Storage)?.dev()
+        {
+            return Err(Error::Identity);
+        }
+        if usage(&request.parent, request.max_retained_bytes)?
+            .checked_add(ADMISSION_BYTES)
+            .is_none_or(|bytes| bytes > request.max_retained_bytes)
+        {
+            return Err(Error::Capacity);
+        }
+        Ok(parent)
+    }
+
+    pub fn claim(request: &CheckpointRequest, parent: File) -> Result<Self, Error> {
+        mkdirat(&parent, request.attempt_name.as_str(), Mode::from_raw_mode(0o700)).map_err(|_| Error::Storage)?;
+        let path = request.parent.join(&request.attempt_name);
+        let root = private(&path)?;
+        if root.metadata().map_err(|_| Error::Storage)?.dev() != parent.metadata().map_err(|_| Error::Storage)?.dev() {
+            return Err(Error::Identity);
+        }
+        let result = Self {
+            path,
+            root,
+            parent,
+            parent_path: request.parent.clone(),
+            budget: request.max_retained_bytes,
+        };
+        result.check()?;
+        for name in ["scratch", "packs", "bundles"] {
+            mkdirat(&result.root, name, Mode::from_raw_mode(0o700)).map_err(|_| Error::Storage)?;
+        }
+        Ok(result)
+    }
+
+    pub fn check(&self) -> Result<(), Error> {
+        same(&private(&self.parent_path)?, &self.parent)?;
+        same(&private(&self.path)?, &self.root)?;
+        usage(&self.parent_path, self.budget)?;
+        Ok(())
+    }
+
+    pub fn finish(&self, bytes: &[u8]) -> Result<(), Error> {
+        self.check()?;
+        if bytes.len() > RECORD_LIMIT {
+            return Err(Error::Capacity);
+        }
+        let mut file = File::from(
+            openat2(
+                &self.root,
+                "generation.json",
+                OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::from_raw_mode(0o600),
+                ResolveFlags::BENEATH | ResolveFlags::NO_SYMLINKS,
+            )
+            .map_err(|_| Error::Storage)?,
+        );
+        file.write_all(bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|_| Error::Storage)?;
+        for directory in [&self.root, &self.parent] {
+            File::from(
+                openat2(
+                    directory,
+                    ".",
+                    OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                    Mode::empty(),
+                    ResolveFlags::BENEATH,
+                )
+                .map_err(|_| Error::Storage)?,
+            )
+            .sync_all()
+            .map_err(|_| Error::Storage)?;
+        }
+        let reader = SelectedRepositoryReader::open(&self.path).map_err(|_| Error::Identity)?;
+        let record = reader
+            .root
+            .read_private_file("generation.json", RECORD_LIMIT)
+            .map_err(|_| Error::Storage)?;
+        same(&file, &record.file)?;
+        if record.bytes != bytes {
+            return Err(Error::Storage);
+        }
+        self.check()
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/checkpoint/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/tests.rs
@@ -136,8 +136,17 @@ mod linux {
     #[test]
     fn actual_generation_preserves_full_base_selected_layers_and_prior_attempts() {
         let (_root, checkout, mut request) = fixture();
+        let inherited = request.parent.join("inherited");
+        fs::create_dir(&inherited).unwrap();
+        let file = inherited.join("file");
+        fs::write(&file, b"retained").unwrap();
+        fs::set_permissions(&inherited, fs::Permissions::from_mode(0o775)).unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o664)).unwrap();
         let source = snapshot(&checkout);
         let first = super::super::linux::run(&request, &checkout, &|| Ok(()), &|| false).unwrap();
+        assert_eq!(inherited.metadata().unwrap().permissions().mode() & 0o7777, 0o775);
+        assert_eq!(file.metadata().unwrap().permissions().mode() & 0o7777, 0o664);
+        assert_eq!(fs::read(&file).unwrap(), b"retained");
         let bytes = fs::read(first.path.join("generation.json")).unwrap();
         assert_eq!(ArtifactDigest::sha256(&bytes), first.manifest_sha256);
         assert!(serde_json::from_slice::<GenerationManifest>(&bytes).unwrap() == first.manifest);
@@ -189,7 +198,7 @@ mod linux {
 
     #[test]
     fn admission_rejects_low_capacity_overlap_links_and_cancellation_without_a_claim() {
-        for case in 0..5 {
+        for case in 0..6 {
             let (root, checkout, mut request) = fixture();
             match case {
                 0 => request.max_retained_bytes = ADMISSION_BYTES,
@@ -200,6 +209,7 @@ mod linux {
                     symlink(&request.parent, &alias).unwrap();
                     request.parent = alias;
                 }
+                5 => fs::set_permissions(&request.parent, fs::Permissions::from_mode(0o770)).unwrap(),
                 _ => {}
             }
             let failure = super::super::linux::run(&request, &checkout, &|| Ok(()), &|| case == 4).unwrap_err();

--- a/crates/horizon-core/src/repository_overlay/checkpoint/tests.rs
+++ b/crates/horizon-core/src/repository_overlay/checkpoint/tests.rs
@@ -1,0 +1,253 @@
+use super::*;
+use serde_json::json;
+use std::path::Path;
+
+fn request(parent: &Path) -> CheckpointRequest {
+    serde_json::from_value(json!({"version":1,"preparation":{"version":1,"workspace_local_id":"synthetic",
+        "runtime_id":"11111111-1111-4111-8111-111111111111","source":{"repository":"synthetic/project","commit":"1".repeat(40),"branch":null},"work_branch":"work"},
+        "selected":["kept"],"complete_base_closure_consent":true,"retained_volume_attested":true,
+        "parent":parent,"attempt_name":"first","max_retained_bytes":CAPACITY})).unwrap()
+}
+
+#[test]
+fn strict_explicit_request_refuses_missing_consent_and_invalid_bounds_before_io() {
+    let root = if cfg!(windows) {
+        "C:/private/generations"
+    } else {
+        "/private/generations"
+    };
+    let valid = request(Path::new(root));
+    assert!(valid.validate().is_ok());
+    for (field, value) in [
+        ("version", json!(3)),
+        ("complete_base_closure_consent", json!(false)),
+        ("retained_volume_attested", json!(false)),
+        ("selected", json!([])),
+        ("selected", json!(["kept", "kept"])),
+        ("selected", json!(["../outside"])),
+        ("attempt_name", json!("../outside")),
+        ("max_retained_bytes", json!(CAPACITY + 1)),
+        ("max_retained_bytes", json!(0)),
+        ("parent", json!("relative")),
+    ] {
+        let mut wire = serde_json::to_value(&valid).unwrap();
+        wire[field] = value;
+        let request = serde_json::from_value(wire).unwrap();
+        let failure = checkpoint_once(&request, || panic!("invalid request reached execution")).unwrap_err();
+        assert_eq!(failure.reason, CheckpointError::Invalid);
+        assert!(failure.retained.is_none());
+    }
+    let mut wire = serde_json::to_value(valid).unwrap();
+    wire["unknown"] = json!(true);
+    assert!(serde_json::from_value::<CheckpointRequest>(wire).is_err());
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+    use crate::repository_overlay::{
+        bundle::store::RepositoryBundleStore,
+        capture::capture_selected_revision,
+        seed::receive::{ExpectedGitPack, PackReceiveLimits, observe_git_base_pack},
+    };
+    use git2::{Repository, Signature};
+    use std::{
+        cell::Cell,
+        collections::BTreeMap,
+        fs,
+        os::unix::fs::{PermissionsExt, symlink},
+        path::Path,
+    };
+
+    #[test]
+    fn typed_change_cancellation_and_capacity_are_not_unsupported_formats() {
+        use super::super::linux::{capture_error, namespace_error};
+        use crate::repository_overlay::{
+            capture::GitCaptureError as Capture, namespace::NamespaceError as Namespace,
+            reader::RepositoryReadError as Read, seed::SeedError as Seed,
+        };
+        for error in [Capture::Changed, Capture::Read(Read::Changed)] {
+            assert_eq!(capture_error(error), CheckpointError::Changed);
+        }
+        assert_eq!(capture_error(Capture::Read(Read::TooLarge)), CheckpointError::Capacity);
+        for (error, expected) in [
+            (Namespace::Limit, CheckpointError::Capacity),
+            (Namespace::Source(Seed::Limit), CheckpointError::Capacity),
+            (Namespace::Source(Seed::Cancelled), CheckpointError::Cancelled),
+            (Namespace::Source(Seed::Storage), CheckpointError::Storage),
+            (Namespace::UnsupportedNode, CheckpointError::Unsupported),
+        ] {
+            assert_eq!(namespace_error(error), expected);
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, PathBuf, CheckpointRequest) {
+        let root = tempfile::Builder::new()
+            .permissions(fs::Permissions::from_mode(0o700))
+            .tempdir()
+            .unwrap();
+        let checkout = root.path().join("checkout");
+        let parent = root.path().join("retained");
+        for path in [&checkout, &parent] {
+            fs::create_dir(path).unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let repository = Repository::init(&checkout).unwrap();
+        repository.set_head("refs/heads/work").unwrap();
+        fs::write(checkout.join("kept"), b"base").unwrap();
+        fs::write(checkout.join("unselected"), b"complete base content").unwrap();
+        let mut index = repository.index().unwrap();
+        index.add_path(Path::new("kept")).unwrap();
+        index.add_path(Path::new("unselected")).unwrap();
+        index.write().unwrap();
+        let tree = repository.find_tree(index.write_tree().unwrap()).unwrap();
+        let author = Signature::now("Fixture", "fixture@example.invalid").unwrap();
+        let commit = repository
+            .commit(Some("HEAD"), &author, &author, "Synthetic", &tree, &[])
+            .unwrap();
+        fs::write(checkout.join("kept"), b"staged").unwrap();
+        index.add_path(Path::new("kept")).unwrap();
+        index.write().unwrap();
+        fs::write(checkout.join("kept"), b"working").unwrap();
+        let mut request = request(&parent);
+        request.preparation.source.commit = GitCommitSha::parse(commit.to_string()).unwrap();
+        (root, checkout, request)
+    }
+
+    fn snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+        let mut result = BTreeMap::new();
+        let mut paths = vec![root.to_owned()];
+        while let Some(path) = paths.pop() {
+            for entry in fs::read_dir(path).unwrap() {
+                let entry = entry.unwrap();
+                if entry.file_type().unwrap().is_dir() {
+                    paths.push(entry.path());
+                } else {
+                    result.insert(
+                        entry.path().strip_prefix(root).unwrap().to_path_buf(),
+                        fs::read(entry.path()).unwrap(),
+                    );
+                }
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn actual_generation_preserves_full_base_selected_layers_and_prior_attempts() {
+        let (_root, checkout, mut request) = fixture();
+        let source = snapshot(&checkout);
+        let first = super::super::linux::run(&request, &checkout, &|| Ok(()), &|| false).unwrap();
+        let bytes = fs::read(first.path.join("generation.json")).unwrap();
+        assert_eq!(ArtifactDigest::sha256(&bytes), first.manifest_sha256);
+        assert!(serde_json::from_slice::<GenerationManifest>(&bytes).unwrap() == first.manifest);
+        let manifest = &first.manifest;
+        let pack = first
+            .path
+            .join("packs")
+            .join(manifest.pack.sha256.as_str())
+            .join("pack");
+        let expected = ExpectedGitPack {
+            base_commit: manifest.pack.base_commit.as_str().parse().unwrap(),
+            sha256: &manifest.pack.sha256,
+            encoded_bytes: manifest.pack.encoded_bytes,
+        };
+        observe_git_base_pack(&pack, expected, PackReceiveLimits::default(), || false).unwrap();
+        let repository = Repository::open_bare(pack.join("decoded")).unwrap();
+        let tree = repository.find_commit(expected.base_commit).unwrap().tree().unwrap();
+        assert_eq!(
+            repository
+                .find_blob(tree.get_name("unselected").unwrap().id())
+                .unwrap()
+                .content(),
+            b"complete base content"
+        );
+        let bundle = RepositoryBundleStore::open_named(&first.path.join("bundles"))
+            .unwrap()
+            .get(&manifest.overlay_manifest)
+            .unwrap();
+        assert_eq!(
+            bundle,
+            capture_selected_revision(&checkout, request.preparation.source.clone(), "work", &["kept"]).unwrap()
+        );
+        let retained = snapshot(&first.path);
+        assert!(super::super::linux::run(&request, &checkout, &|| Ok(()), &|| false).is_err());
+        request.attempt_name = "second".into();
+        super::super::linux::run(&request, &checkout, &|| Ok(()), &|| false).unwrap();
+        assert_eq!(snapshot(&first.path), retained);
+        assert_eq!(snapshot(&checkout), source);
+        let pack_file = pack.join("decoded/objects/pack");
+        let file = fs::read_dir(pack_file)
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .find(|p| p.extension().is_some_and(|e| e == "pack"))
+            .unwrap();
+        fs::write(file, b"corrupt").unwrap();
+        assert!(observe_git_base_pack(&pack, expected, PackReceiveLimits::default(), || false).is_err());
+        assert_eq!(fs::read(first.path.join("generation.json")).unwrap(), bytes);
+    }
+
+    #[test]
+    fn admission_rejects_low_capacity_overlap_links_and_cancellation_without_a_claim() {
+        for case in 0..5 {
+            let (root, checkout, mut request) = fixture();
+            match case {
+                0 => request.max_retained_bytes = ADMISSION_BYTES,
+                1 => request.parent = checkout.join(".git"),
+                2 => request.parent = root.path().to_path_buf(),
+                3 => {
+                    let alias = root.path().join("alias");
+                    symlink(&request.parent, &alias).unwrap();
+                    request.parent = alias;
+                }
+                _ => {}
+            }
+            let failure = super::super::linux::run(&request, &checkout, &|| Ok(()), &|| case == 4).unwrap_err();
+            assert!(failure.retained.is_none());
+            assert!(!request.parent.join("first").exists());
+        }
+    }
+
+    #[test]
+    fn unsupported_lfs_gitlinks_and_postclaim_identity_failure_keep_every_partial_stage() {
+        for case in 0..3 {
+            let (_root, checkout, request) = fixture();
+            if case == 0 {
+                fs::write(
+                    checkout.join("kept"),
+                    b"version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 1\n",
+                )
+                .unwrap();
+            }
+            if case == 1 {
+                let repo = Repository::open(&checkout).unwrap();
+                let mut index = repo.index().unwrap();
+                let mut entry = index.get_path(Path::new("kept"), 0).unwrap();
+                entry.mode = 0o160_000;
+                index.add(&entry).unwrap();
+                index.write().unwrap();
+            }
+            let checks = Cell::new(0);
+            let failure = super::super::linux::run(
+                &request,
+                &checkout,
+                &|| {
+                    checks.set(checks.get() + 1);
+                    if case == 2 && checks.get() > 1 {
+                        Err(CheckpointError::Identity)
+                    } else {
+                        Ok(())
+                    }
+                },
+                &|| false,
+            )
+            .unwrap_err();
+            let attempt = request.parent.join("first");
+            assert_eq!(failure.retained.as_deref(), Some(attempt.as_path()));
+            assert!(!attempt.join("generation.json").exists());
+            let before = snapshot(&attempt);
+            assert!(super::super::linux::run(&request, &checkout, &|| Ok(()), &|| false).is_err());
+            assert_eq!(snapshot(&attempt), before);
+        }
+    }
+}

--- a/crates/horizon-core/src/repository_overlay/mod.rs
+++ b/crates/horizon-core/src/repository_overlay/mod.rs
@@ -5,6 +5,7 @@
 pub mod bundle;
 pub mod capture;
 pub mod checkout;
+pub mod checkpoint;
 pub mod intake;
 pub mod materialize;
 pub mod namespace;

--- a/crates/horizon-repository/src/checkpoint.rs
+++ b/crates/horizon-repository/src/checkpoint.rs
@@ -18,6 +18,15 @@ struct Response {
 }
 
 pub(super) fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Write) -> ExitCode {
+    run_with(input, output, diagnostics, |request| checkpoint_once(request, || false))
+}
+
+fn run_with(
+    input: &mut impl Read,
+    output: &mut impl Write,
+    diagnostics: &mut impl Write,
+    execute: impl FnOnce(&CheckpointRequest) -> Result<CheckpointGeneration, CheckpointFailure>,
+) -> ExitCode {
     let mut bytes = Vec::new();
     let request = input
         .take(REQUEST_LIMIT as u64 + 1)
@@ -36,7 +45,7 @@ pub(super) fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &
         retained: None,
         reason: None,
     };
-    let code = match request.and_then(|request| checkpoint_once(&request, || false)) {
+    let code = match request.and_then(|request| execute(&request)) {
         Ok(generation) => {
             response.generation = Some(generation);
             0
@@ -52,3 +61,6 @@ pub(super) fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &
     };
     super::write_response(&response, code, super::protocol::RESPONSE_LIMIT, output, diagnostics)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-repository/src/checkpoint.rs
+++ b/crates/horizon-repository/src/checkpoint.rs
@@ -1,0 +1,67 @@
+use horizon_core::repository_overlay::checkpoint::{
+    CheckpointError, CheckpointGeneration, CheckpointRequest, REQUEST_LIMIT, checkpoint_once,
+};
+use serde::Serialize;
+use std::{
+    io::{Read, Write},
+    path::PathBuf,
+    process::ExitCode,
+};
+
+#[derive(Serialize)]
+struct Response {
+    version: u8,
+    status: &'static str,
+    generation: Option<CheckpointGeneration>,
+    retained: Option<PathBuf>,
+    reason: Option<CheckpointError>,
+}
+
+pub(super) fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &mut impl Write) -> ExitCode {
+    let mut bytes = Vec::new();
+    let request = input
+        .take(REQUEST_LIMIT as u64 + 1)
+        .read_to_end(&mut bytes)
+        .ok()
+        .filter(|_| bytes.len() <= REQUEST_LIMIT)
+        .and_then(|_| serde_json::from_slice::<CheckpointRequest>(&bytes).ok());
+    let (response, code) = match request {
+        Some(request) => match checkpoint_once(&request, || false) {
+            Ok(generation) => (
+                Response {
+                    version: 1,
+                    status: "verified",
+                    generation: Some(generation),
+                    retained: None,
+                    reason: None,
+                },
+                0,
+            ),
+            Err(failure) => {
+                let rejected = failure.retained.is_none()
+                    && matches!(failure.reason, CheckpointError::Invalid | CheckpointError::Unsupported);
+                (
+                    Response {
+                        version: 1,
+                        status: if rejected { "rejected" } else { "unconfirmed" },
+                        generation: None,
+                        retained: failure.retained,
+                        reason: Some(failure.reason),
+                    },
+                    if rejected { 2 } else { 1 },
+                )
+            }
+        },
+        None => (
+            Response {
+                version: 1,
+                status: "rejected",
+                generation: None,
+                retained: None,
+                reason: Some(CheckpointError::Invalid),
+            },
+            2,
+        ),
+    };
+    super::write_response(&response, code, super::protocol::RESPONSE_LIMIT, output, diagnostics)
+}

--- a/crates/horizon-repository/src/checkpoint.rs
+++ b/crates/horizon-repository/src/checkpoint.rs
@@ -1,5 +1,5 @@
 use horizon_core::repository_overlay::checkpoint::{
-    CheckpointError, CheckpointGeneration, CheckpointRequest, REQUEST_LIMIT, checkpoint_once,
+    CheckpointError, CheckpointFailure, CheckpointGeneration, CheckpointRequest, REQUEST_LIMIT, checkpoint_once,
 };
 use serde::Serialize;
 use std::{
@@ -24,44 +24,31 @@ pub(super) fn run(input: &mut impl Read, output: &mut impl Write, diagnostics: &
         .read_to_end(&mut bytes)
         .ok()
         .filter(|_| bytes.len() <= REQUEST_LIMIT)
-        .and_then(|_| serde_json::from_slice::<CheckpointRequest>(&bytes).ok());
-    let (response, code) = match request {
-        Some(request) => match checkpoint_once(&request, || false) {
-            Ok(generation) => (
-                Response {
-                    version: 1,
-                    status: "verified",
-                    generation: Some(generation),
-                    retained: None,
-                    reason: None,
-                },
-                0,
-            ),
-            Err(failure) => {
-                let rejected = failure.retained.is_none()
-                    && matches!(failure.reason, CheckpointError::Invalid | CheckpointError::Unsupported);
-                (
-                    Response {
-                        version: 1,
-                        status: if rejected { "rejected" } else { "unconfirmed" },
-                        generation: None,
-                        retained: failure.retained,
-                        reason: Some(failure.reason),
-                    },
-                    if rejected { 2 } else { 1 },
-                )
-            }
-        },
-        None => (
-            Response {
-                version: 1,
-                status: "rejected",
-                generation: None,
-                retained: None,
-                reason: Some(CheckpointError::Invalid),
-            },
-            2,
-        ),
+        .and_then(|_| serde_json::from_slice::<CheckpointRequest>(&bytes).ok())
+        .ok_or(CheckpointFailure {
+            reason: CheckpointError::Invalid,
+            retained: None,
+        });
+    let mut response = Response {
+        version: 1,
+        status: "verified",
+        generation: None,
+        retained: None,
+        reason: None,
+    };
+    let code = match request.and_then(|request| checkpoint_once(&request, || false)) {
+        Ok(generation) => {
+            response.generation = Some(generation);
+            0
+        }
+        Err(failure) => {
+            let rejected = failure.retained.is_none()
+                && matches!(failure.reason, CheckpointError::Invalid | CheckpointError::Unsupported);
+            response.status = if rejected { "rejected" } else { "unconfirmed" };
+            response.retained = failure.retained;
+            response.reason = Some(failure.reason);
+            if rejected { 2 } else { 1 }
+        }
     };
     super::write_response(&response, code, super::protocol::RESPONSE_LIMIT, output, diagnostics)
 }

--- a/crates/horizon-repository/src/checkpoint/tests.rs
+++ b/crates/horizon-repository/src/checkpoint/tests.rs
@@ -1,0 +1,173 @@
+use super::*;
+use horizon_core::cloud_run::ArtifactDigest;
+use serde_json::{Value, json};
+use std::io::{self, Cursor};
+
+fn request() -> Vec<u8> {
+    let parent = if cfg!(windows) {
+        "C:/synthetic/retained"
+    } else {
+        "/synthetic/retained"
+    };
+    serde_json::to_vec(&json!({
+        "version":1,"preparation":{"version":1,"workspace_local_id":"fixture",
+            "runtime_id":"11111111-1111-4111-8111-111111111111",
+            "source":{"repository":"fixture/repository","commit":"a".repeat(40),"branch":"work"},
+            "work_branch":"work"},
+        "selected":["source.txt"],"complete_base_closure_consent":true,"retained_volume_attested":true,
+        "parent":parent,"attempt_name":"first","max_retained_bytes":268_435_456
+    }))
+    .unwrap()
+}
+
+fn generation(request: &CheckpointRequest) -> CheckpointGeneration {
+    let digest = ArtifactDigest::sha256(b"synthetic generation");
+    let manifest = serde_json::from_value(json!({
+        "version":1,"coverage":"synthetic adapter fixture","preparation":request.preparation,
+        "complete_base_closure_consent":true,"retained_volume_attested":true,"selected":request.selected,
+        "pack":{"base_commit":request.preparation.source.commit,"sha256":digest,"encoded_bytes":7},
+        "overlay_manifest":digest,"overlay_record":digest,"overlay_bytes":5,
+        "started_at_millis":1,"verified_at_millis":2
+    }))
+    .unwrap();
+    CheckpointGeneration {
+        path: request.parent.join(&request.attempt_name),
+        manifest_sha256: digest,
+        manifest,
+    }
+}
+
+fn invoke(
+    input: &mut impl Read,
+    execute: impl FnOnce(&CheckpointRequest) -> Result<CheckpointGeneration, CheckpointFailure>,
+) -> (ExitCode, Value) {
+    let (mut output, mut diagnostics) = (Vec::new(), Vec::new());
+    let code = run_with(input, &mut output, &mut diagnostics, execute);
+    assert!(diagnostics.is_empty());
+    assert_eq!(output.last(), Some(&b'\n'));
+    (code, serde_json::from_slice(&output).unwrap())
+}
+
+struct FailedRead;
+impl Read for FailedRead {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::other("private read failure"))
+    }
+}
+
+#[test]
+fn malformed_and_failed_reads_reject_without_execution() {
+    let expected = json!({"version":1,"status":"rejected","generation":null,"retained":null,"reason":"invalid"});
+    let mut unknown: Value = serde_json::from_slice(&request()).unwrap();
+    unknown["unknown"] = json!(true);
+    for bytes in [
+        b"private malformed input".to_vec(),
+        b"{}".to_vec(),
+        Vec::new(),
+        [request(), b"{}".to_vec()].concat(),
+        serde_json::to_vec(&unknown).unwrap(),
+    ] {
+        assert_eq!(
+            invoke(&mut bytes.as_slice(), |_| panic!("decode failure dispatched")),
+            (ExitCode::from(2), expected.clone())
+        );
+    }
+    assert_eq!(
+        invoke(&mut FailedRead, |_| panic!("read failure dispatched")),
+        (ExitCode::from(2), expected)
+    );
+}
+
+#[test]
+fn exact_request_bound_dispatches_once_and_oversized_reads_stop_at_limit_plus_one() {
+    let mut bytes = request();
+    bytes.resize(REQUEST_LIMIT, b' ');
+    let (code, value) = invoke(&mut bytes.as_slice(), |decoded| {
+        assert_eq!(decoded.attempt_name, "first");
+        Err(CheckpointFailure {
+            reason: CheckpointError::Unsupported,
+            retained: None,
+        })
+    });
+    assert_eq!(code, ExitCode::from(2));
+    assert_eq!(value["reason"], "unsupported");
+    bytes.resize(REQUEST_LIMIT * 2, b' ');
+    let mut input = Cursor::new(bytes);
+    let (code, value) = invoke(&mut input, |_| panic!("oversized input dispatched"));
+    assert_eq!((code, value["reason"].as_str()), (ExitCode::from(2), Some("invalid")));
+    assert_eq!(input.position(), REQUEST_LIMIT as u64 + 1);
+}
+
+#[test]
+fn failure_mappings_preserve_retained_locators_and_never_acknowledge_a_generation() {
+    for reason in [
+        CheckpointError::Invalid,
+        CheckpointError::Unsupported,
+        CheckpointError::Identity,
+        CheckpointError::Changed,
+        CheckpointError::Capacity,
+        CheckpointError::Storage,
+        CheckpointError::Cancelled,
+    ] {
+        for retained in [None, Some(PathBuf::from("synthetic-retained/first"))] {
+            let rejected =
+                retained.is_none() && matches!(reason, CheckpointError::Invalid | CheckpointError::Unsupported);
+            let status = if rejected { "rejected" } else { "unconfirmed" };
+            let expected = json!({"version":1,"status":status,"generation":null,"retained":retained,"reason":reason});
+            let actual = invoke(&mut request().as_slice(), |_| {
+                Err(CheckpointFailure { reason, retained })
+            });
+            assert_eq!(actual, (ExitCode::from(if rejected { 2 } else { 1 }), expected));
+        }
+    }
+}
+
+#[test]
+fn verified_response_preserves_all_fields_and_output_loss_is_distinct() {
+    let bytes = request();
+    let expected = generation(&serde_json::from_slice(&bytes).unwrap());
+    let (code, response) = invoke(&mut bytes.as_slice(), |decoded| {
+        assert_eq!(
+            serde_json::to_value(decoded).unwrap(),
+            serde_json::from_slice::<Value>(&bytes).unwrap()
+        );
+        Ok(generation(decoded))
+    });
+    assert_eq!(code, ExitCode::SUCCESS);
+    assert_eq!(
+        response,
+        json!({"version":1,"status":"verified","generation":expected,"retained":null,"reason":null})
+    );
+    let mut diagnostics = Vec::new();
+    let code = run_with(
+        &mut bytes.as_slice(),
+        &mut [0; 0].as_mut_slice(),
+        &mut diagnostics,
+        |decoded| Ok(generation(decoded)),
+    );
+    assert_eq!(code, ExitCode::from(3));
+    assert!(
+        String::from_utf8(diagnostics)
+            .unwrap()
+            .contains("retain data and inspect before any retry")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn serialization_failure_emits_no_partial_response_or_private_path() {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+    let (mut output, mut diagnostics) = (Vec::new(), Vec::new());
+    let code = run_with(&mut request().as_slice(), &mut output, &mut diagnostics, |_| {
+        Err(CheckpointFailure {
+            reason: CheckpointError::Storage,
+            retained: Some(OsString::from_vec(vec![0xff]).into()),
+        })
+    });
+    assert_eq!(code, ExitCode::from(3));
+    assert!(output.is_empty());
+    assert_eq!(
+        diagnostics,
+        b"Could not write a complete response; retain data and inspect before any retry.\n"
+    );
+}

--- a/crates/horizon-repository/src/main.rs
+++ b/crates/horizon-repository/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod capture;
+mod checkpoint;
 mod git;
 mod intake;
 mod pack;
@@ -26,6 +27,7 @@ fn main() -> ExitCode {
                     | "capture-binding"
                     | "capture-plan"
                     | "capture-once"
+                    | "checkpoint-once"
                     | "setup"
                     | "setup-binding"
                     | "setup-checkout"
@@ -46,7 +48,7 @@ fn main() -> ExitCode {
     {
         let _ = writeln!(
             io::stderr().lock(),
-            "Usage: horizon-repository materialize|capture-binding|capture-plan|capture-once|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
+            "Usage: horizon-repository materialize|capture-binding|capture-plan|capture-once|checkpoint-once|setup|setup-status|setup-binding|setup-checkout|receive-overlay|overlay-status|receive-pack|pack-status|intake|intake-status|storage-status|git-prepare|git-status|git-binding|git-checkout < request"
         );
         return ExitCode::from(2);
     }
@@ -54,6 +56,7 @@ fn main() -> ExitCode {
     let mut output = io::stdout().lock();
     let mut diagnostics = io::stderr().lock();
     match command {
+        Some("checkpoint-once") => checkpoint::run(&mut input, &mut output, &mut diagnostics),
         Some("capture-binding") => capture::run(capture::Operation::Binding, &mut input, &mut output, &mut diagnostics),
         Some("capture-plan") => capture::run(capture::Operation::Plan, &mut input, &mut output, &mut diagnostics),
         Some("capture-once") => capture::run(capture::Operation::Once, &mut input, &mut output, &mut diagnostics),

--- a/docs/architecture/checkpoint-generations.md
+++ b/docs/architecture/checkpoint-generations.md
@@ -1,6 +1,6 @@
 # ADR: Worker-owned repository checkpoint generations
 
-**Status:** Proposed implementation; acceptance remains open
+**Status:** One-shot operation implemented and locally validated; broader acceptance remains open
 **Date:** 2026-09-13
 **Deciders:** Repository maintainers under the approved #383/#471 delivery scope
 
@@ -67,7 +67,7 @@ destructive deletion or `RepositoryCheckpoint` watermark advancement is implied.
 
 ## Action items
 
-- [ ] Implement and prove the exact-binary one-shot operation, refusal paths,
+- [x] Implement and prove the exact-binary one-shot operation, refusal paths,
   unchanged source/earlier generations and retained response uncertainty.
 - [ ] Add periodic consumption with separate explicit enrollment and verified
   generation readback before success; measure progress with clients disconnected.

--- a/docs/architecture/checkpoint-generations.md
+++ b/docs/architecture/checkpoint-generations.md
@@ -41,6 +41,13 @@ bounded admission and native limits are not a hard filesystem quota or a promise
 that uninterruptible I/O terminates promptly. Initial generations are self-contained;
 shared-pack reuse is a later optimization, not a correctness prerequisite.
 
+Existing destination and generation roots must remain owned private `0700`
+directories with no symlink ancestry. Confined descendants may inherit the
+caller's umask, as in the named receiver: their modes alone do not expose data
+through the verified private root. Accounting still rejects foreign ownership,
+devices, links, special nodes and set-id/sticky modes. It does not chmod retained
+data or change process-global umask; stable exclusive ownership remains required.
+
 ## Options considered
 
 | Option | Complexity and cost | Growth and maintenance |

--- a/docs/architecture/checkpoint-generations.md
+++ b/docs/architecture/checkpoint-generations.md
@@ -47,6 +47,10 @@ caller's umask, as in the named receiver: their modes alone do not expose data
 through the verified private root. Accounting still rejects foreign ownership,
 devices, links, special nodes and set-id/sticky modes. It does not chmod retained
 data or change process-global umask; stable exclusive ownership remains required.
+Admission requires the pinned checkout and destination to share a kernel mount
+identity, not merely a device, and rejects overlapping descriptor ancestry before
+claiming anything. Bind aliases and unavailable mount identity fail closed; a
+separately mounted destination is not supported by this first implementation.
 
 ## Options considered
 

--- a/docs/architecture/checkpoint-generations.md
+++ b/docs/architecture/checkpoint-generations.md
@@ -1,0 +1,70 @@
+# ADR: Worker-owned repository checkpoint generations
+
+**Status:** Proposed implementation; acceptance remains open
+**Date:** 2026-09-13
+**Deciders:** Repository maintainers under the approved #383/#471 delivery scope
+
+## Context
+
+The existing independent worker service protects selected staged and working
+bytes, including across commits. It does not retain the complete committed base
+needed to reconstruct a checkout after losing the source. Named bundle and pack
+primitives provide explicit ownership and uncertainty handling, not a complete
+checkpoint. The next outcome must connect those primitives to worker execution.
+
+## Decision
+
+Add one explicit `checkpoint-once` operation using existing core capture, seed,
+pack, named receive/publication and bundle verification. Keep byte-capture
+enrollment versions 1 and 2, their bindings and their service responses unchanged.
+Do not add a second receive-pack protocol as an intermediate requirement.
+
+The new bounded request separately consents to retaining the complete current
+base closure, including removed files and raw commit metadata. It identifies the
+prepared checkout, selected paths, an existing private same-volume destination
+outside the checkout and a caller-chosen attempt name. Attested retained storage
+is an operator assertion, not provider qualification.
+
+Only successful exclusive claim grants permission to populate a generation.
+Its private directory retains scratch, named packs and named bundles. Publish a
+create-new generation manifest only after verifying every referenced artifact.
+Bind the preparation, sampled commit/branch, declared coverage, pack digest and
+length, overlay identity and observation times. No successful response may imply
+that unselected dirty files, task state or Git parent history were captured.
+Unsupported submodules and LFS payload recovery must fail visibly, not masquerade
+as ordinary complete file recovery.
+
+Retain earlier generations and all uncertain attempts. Existing attempts are
+not adopted, overwritten, retried or cleaned up. Failure locators do not prove
+ownership. Account scratch and partial data as well as completed artifacts;
+bounded admission and native limits are not a hard filesystem quota or a promise
+that uninterruptible I/O terminates promptly. Initial generations are self-contained;
+shared-pack reuse is a later optimization, not a correctness prerequisite.
+
+## Options considered
+
+| Option | Complexity and cost | Growth and maintenance |
+| --- | --- | --- |
+| Direct one-shot generation using existing core APIs | Bounded integration; no new cloud cost | Reuses existing Rust boundaries; periodic consumption can follow |
+| Version another receive-pack CLI first | Additional protocol and tests | Does not by itself connect protection to the worker service |
+| Change periodic enrollment and restoration together | Largest immediate scope | Couples compatibility, scheduling and recovery before one-shot proof |
+
+## Trade-offs and consequences
+
+The first option gives a usable verified generation while keeping compatibility
+and failure diagnosis bounded. It is not yet periodic full-repository/task
+protection, a coherent application snapshot, independent backup or physical
+durability proof. Linux is the first implementation; existing platform support
+and CI remain intact. No provider operation, network transfer, task replay,
+destructive deletion or `RepositoryCheckpoint` watermark advancement is implied.
+
+## Action items
+
+- [ ] Implement and prove the exact-binary one-shot operation, refusal paths,
+  unchanged source/earlier generations and retained response uncertainty.
+- [ ] Add periodic consumption with separate explicit enrollment and verified
+  generation readback before success; measure progress with clients disconnected.
+- [ ] Restore a declared generation into a fresh private checkout, verifying all
+  references without overwriting the original or inferring task resumption.
+- [ ] Complete declared coverage, provider filesystem/mount qualification,
+  verified-loss recovery and final-write-freeze/Delete acceptance in #471/#475.

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -11,6 +11,11 @@ back into large multi-purpose modules.
   the explicit named layout owns permanent digest slots in a focused Linux leaf.
   Neither layout discovers data, transfers it, schedules capture or certifies
   provider durability. See [named publication](named-bundle-publication.md).
+- One-shot checkpoint generations keep explicit request/receipt types in
+  `repository_overlay::checkpoint`, bounded composition in its `linux` leaf and
+  retained-attempt accounting/publication in `storage`; the worker CLI only
+  decodes and reports. Existing byte-capture enrollment remains unchanged; see
+  [checkpoint generations](checkpoint-generations.md) for coverage and proof limits.
 - Explicit worker byte capture keeps request validation and existing core
   capture/bundle reuse in `horizon-repository::capture`; `byte-capture.py` owns
   the detached bounded-attempt loop and `byte_capture_store.py` owns private


### PR DESCRIPTION
## Purpose

Connect existing capture, pack and bundle primitives through Linux `checkpoint-once` for #471. Retain the complete current committed base plus explicitly selected dirty layers. This does not close #471 or #383.

## Behavior

- Require explicit base-closure/retention consent, prepared-checkout identity, selected paths, a private destination, a fresh attempt name and a bounded budget.
- Require pinned source/destination mount identities to match and their descriptor ancestry to be disjoint. Reject bind aliases and unavailable mount identity before creating a generation; recheck held identities before claim.
- Publish an immutable generation manifest only after verifying its base pack and selected index/working bundle, including digests, lengths, sampled commit and times.
- Preserve source files, earlier generations and uncertain attempts. Never adopt, overwrite, retry or clean existing names; an uncertain locator is not ownership proof.
- Reject unsupported selected/base LFS pointers and gitlinks visibly. Count partial and scratch data. Private roots remain mandatory while confined descendants may inherit ordinary Git permissions.
- Preserve existing byte-capture enrollment, default pack APIs and provider behavior.

## Validation

Candidate: `d40b9a08`, rebased onto current main `06e838d5` (including the Azure client-off provisioning tests).

All eight exact-head local gates passed: formatting, maintainability, version sync, default and speech-enabled workspace tests, and blocking, strict and pedantic Clippy. Default: 2,630 passed; speech: 2,675 passed; each has seven ignored tests across 26 suites. All three Clippy tiers completed without warnings. The additional Azure client-off harness suite passed all 72 tests, with pre-existing observer stream ResourceWarnings kept separate from these Rust results.

Six focused checkpoint tests pass under both umask `0002` and `0077`; all 50 repository-worker tests and both required precommit Clippy tiers pass. Five new synthetic CLI tests cover bounded/strict decoding, failed reads, every failure/retained mapping, complete verified responses, output loss and Unix serialization failure without dispatching filesystem operations.

The exact candidate binary passed all 21 isolated native checks. These cover complete current base content, selected staged/working/deleted/untracked layers, ordinary commits, source/earlier-generation preservation, lost output, corruption, LFS/gitlink refusal, capacity, identity and inherited permissions. Three new actual bind-mount cases prove checkout, metadata and ancestor aliases share the source device/inode but have different mount IDs; each refuses before claim without changing source bytes or metadata. Ordinary sibling directories on the retained mount still produce verified generations.

Independent local reviews cleared the mount correction and adapter tests. Earlier inherited-permission and test-fixture failures remain recorded, not hidden: the latter expected a null optional branch to survive canonical serialization and was corrected with a concrete branch fixture. Fresh hosted review is requested for this head; earlier-base CI is not current-base proof.

## Limits

Synthetic prepared-checkout receipts and local Linux storage are not real Prepare, provider/HPS qualification or physical durability. This is not periodic protection, fresh restore, unselected dirty coverage, Git parent history, task recovery or an atomic workspace snapshot. No protection watermark or Delete authority advances.

Stable ancestry, exclusive same-user control and trusted native tools remain required. The 512 MiB accounting cap and 128 MiB admission reserve are not physical quotas or hard filesystem deadlines. Separately mounted destinations are unsupported. No cloud allocation, credential transfer, image publication or release.

Scope: 1,261 changed source/test lines across eight paths; 86 documentation lines across two paths. Uses the user's explicit 1,500-line allowance.
