### PR TITLE
feat(azure): observe a saved Stop without mutating the worker

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure.rs
+++ b/crates/horizon-core/src/cloud_run/azure.rs
@@ -21,7 +21,7 @@ pub use credential::{AzureAccessToken, AzureCliCredential, AzureCredentialSource
 pub use deployment::AzureDeploymentPlan;
 pub use provider::{AzureClient, AzureCreationFence, AzureHostKeySource, AzureRunCommandHostKeys, SSH_USERNAME};
 pub use transport::{
-    AzureArmHttp, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
+    AzureArmHttp, AzureDataDisk, AzureDeploymentState, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
     AzureRunCommand, AzureVmView,
 };
 
@@ -37,6 +37,8 @@ pub(crate) const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
 pub const RESOURCE_GROUP_PREFIX: &str = "horizon-ws-";
 /// Constant VM name inside a worker's resource group; the group carries the identity.
 pub const WORKER_VM_NAME: &str = "worker";
+/// The retained data disk the deployment creates beside the VM (`<vm>-data`).
+pub const DATA_DISK_NAME: &str = "worker-data";
 
 /// Operator-declared placement for Azure CPU workers. Prices are declared, not
 /// discovered: ARM does not return an hourly rate for a VM, so the cost limit in a

--- a/crates/horizon-core/src/cloud_run/azure/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/deployment.rs
@@ -4,7 +4,7 @@
 //! and cloud-init that logs in to the registry with that identity and starts the
 //! digest-pinned worker image. Everything is derived from validated inputs; nothing
 //! operator-controlled is interpolated into YAML or shell.
-use super::{AzureError, AzureProfile, COMPUTE_API_VERSION, WORKER_VM_NAME, resource_group_name};
+use super::{AzureError, AzureProfile, COMPUTE_API_VERSION, DATA_DISK_NAME, WORKER_VM_NAME, resource_group_name};
 
 /// Network and disk resource API versions used inside the template.
 const NETWORK_API_VERSION: &str = "2023-11-01";
@@ -324,7 +324,9 @@ fn template() -> serde_json::Value {
             "nsg": "[concat(parameters('vmName'), '-nsg')]", "vnet": "[concat(parameters('vmName'), '-vnet')]",
             "pip": "[concat(parameters('vmName'), '-pip')]",
             "nic": "[concat(parameters('vmName'), '-nic')]",
-            "data": "[concat(parameters('vmName'), '-data')]",
+            // One name for creation and observation: the observer verifies the retained
+            // disk against the same constant.
+            "data": DATA_DISK_NAME,
         },
         "resources": [
             with(common("Microsoft.Network/networkSecurityGroups", NETWORK_API_VERSION, "[variables('nsg')]"), serde_json::json!({

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -307,20 +307,21 @@ impl InteractiveWorkerStopObserver for AzureClient {
         let Some(current) = self.observe(handle.clone(), &group, &tags, None, Placement::Ignore)? else {
             return Ok(InteractiveWorkerStopObservation::Absent);
         };
+        // The static address is retained with the group, whatever the compute is doing:
+        // a present, different address means the saved endpoint no longer names this
+        // worker, in every state. Without a current deployment address (deployment
+        // absent, still in flight, unusable) the snapshot is uncertain and stays pending.
+        if current.host.as_deref().is_some_and(|host| host != expected.ssh.host) {
+            return Err(AzureError::ResourceIdentityMismatch);
+        }
         match current.lifecycle {
             AzureLifecycle::Failed => Err(AzureError::StopUnverified),
             AzureLifecycle::Deallocated => {
                 let Some(vm) = current.vm.as_ref() else {
                     return Ok(InteractiveWorkerStopObservation::Pending);
                 };
-                // The static address is retained with the group. Without a current
-                // deployment address (deployment absent, still in flight, unusable) the
-                // snapshot is uncertain and stays pending; a different address means
-                // the saved endpoint no longer names this worker.
-                match current.host.as_deref() {
-                    None => return Ok(InteractiveWorkerStopObservation::Pending),
-                    Some(host) if host != expected.ssh.host => return Err(AzureError::ResourceIdentityMismatch),
-                    Some(_) => {}
+                if current.host.is_none() {
+                    return Ok(InteractiveWorkerStopObservation::Pending);
                 }
                 Ok(if retained_data_disk(vm, &handle.group_id) {
                     InteractiveWorkerStopObservation::RetainedStopped

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -2,7 +2,8 @@
 //! control plane rather than trusting whatever answers on the network address, and stop
 //! it by deallocating the VM with retained disks.
 use super::super::{
-    AzureError, AzureLifecycle, AzureManagementTransport, AzureRunCommand, AzureVmView, AzureWorker, WORKER_VM_NAME,
+    AzureError, AzureLifecycle, AzureManagementTransport, AzureRunCommand, AzureVmView, AzureWorker, DATA_DISK_NAME,
+    WORKER_VM_NAME,
     deployment::{SSH_PORT, identity_tags},
     transport::remaining_at,
 };
@@ -11,7 +12,10 @@ use crate::cloud_run::{
     WorkerTarget,
     interactive_worker::{InteractiveWorker, InteractiveWorkerSshEndpoint, valid_ssh_public_key},
     interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
-    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+    interactive_worker_stop::{
+        InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation,
+        InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
+    },
 };
 use std::time::Duration;
 
@@ -251,6 +255,73 @@ impl AzureClient {
             }
         }
         Ok(None)
+    }
+}
+
+/// The retained data disk the deployment attaches: exactly one, at LUN 0, kept when the
+/// VM is deleted, and living in the worker's own group under its fixed name.
+fn retained_data_disk(vm: &AzureVmView, group_id: &str) -> bool {
+    let expected = format!("{group_id}/providers/Microsoft.Compute/disks/{DATA_DISK_NAME}");
+    match vm.data_disks.as_slice() {
+        [disk] => disk.lun == Some(0) && disk.delete_option == "Detach" && disk.id.eq_ignore_ascii_case(&expected),
+        _ => false,
+    }
+}
+
+impl InteractiveWorkerStopObserver for AzureClient {
+    /// One read-only observation of the exact saved worker: the persisted handle and the
+    /// saved endpoint are validated before any request; then the owned group and VM are
+    /// re-proved (identity tags, recorded IDs) and the VM's power state and storage
+    /// profile are read once. `RetainedStopped` needs all of: compute deallocated (a
+    /// halted-but-allocated guest is still billed and is not it), the single retained
+    /// data disk attached at LUN 0 with `Detach` semantics under its own name, and the
+    /// saved address still the one the deployment reports. Absence of the owned group is
+    /// `Absent`; a failed deployment is an error; everything else is `Pending`. Nothing
+    /// is stopped, started, created, deleted, repaired or connected to.
+    fn observe_worker_stop(
+        &self,
+        expected: InteractiveWorkerStopExpectation<'_>,
+    ) -> Result<InteractiveWorkerStopObservation, Self::Error> {
+        if expected.network_volume.is_some() {
+            // Network volumes are a RunPod binding; an Azure worker keeps its own disk.
+            return Err(AzureError::InvalidTarget);
+        }
+        if !expected.ssh.is_complete()
+            || expected.ssh.port != SSH_PORT
+            || expected.ssh.username != SSH_USERNAME
+            || expected.ssh.host.parse::<std::net::IpAddr>().is_err()
+        {
+            return Err(AzureError::InvalidPersistedWorker);
+        }
+        let Some((handle, group, tags)) = self.owned_handle(expected.worker)? else {
+            return Ok(InteractiveWorkerStopObservation::Absent);
+        };
+        let Some(current) = self.observe(handle.clone(), &group, &tags, None, Placement::Ignore)? else {
+            return Ok(InteractiveWorkerStopObservation::Absent);
+        };
+        match current.lifecycle {
+            AzureLifecycle::Failed => Err(AzureError::StopUnverified),
+            AzureLifecycle::Deallocated => {
+                let Some(vm) = current.vm.as_ref() else {
+                    return Ok(InteractiveWorkerStopObservation::Pending);
+                };
+                if current.host.as_deref() != Some(expected.ssh.host.as_str()) {
+                    // The static address is retained with the group; a different one
+                    // means the saved endpoint no longer names this worker.
+                    return Err(AzureError::ResourceIdentityMismatch);
+                }
+                Ok(if retained_data_disk(vm, &handle.group_id) {
+                    InteractiveWorkerStopObservation::RetainedStopped
+                } else {
+                    InteractiveWorkerStopObservation::Pending
+                })
+            }
+            AzureLifecycle::Transitioning
+            | AzureLifecycle::Running
+            | AzureLifecycle::StoppedAllocated
+            | AzureLifecycle::Deleting
+            | AzureLifecycle::Unknown => Ok(InteractiveWorkerStopObservation::Pending),
+        }
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/azure/provider/running.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider/running.rs
@@ -258,12 +258,19 @@ impl AzureClient {
     }
 }
 
-/// The retained data disk the deployment attaches: exactly one, at LUN 0, kept when the
-/// VM is deleted, and living in the worker's own group under its fixed name.
+/// The retained data disk the deployment attaches: exactly one data-disk entry in the
+/// storage profile, fully represented, at LUN 0, kept when the VM is deleted, and
+/// living in the worker's own group under its fixed name. Any entry the view could not
+/// represent is storage nobody vouched for.
 fn retained_data_disk(vm: &AzureVmView, group_id: &str) -> bool {
     let expected = format!("{group_id}/providers/Microsoft.Compute/disks/{DATA_DISK_NAME}");
     match vm.data_disks.as_slice() {
-        [disk] => disk.lun == Some(0) && disk.delete_option == "Detach" && disk.id.eq_ignore_ascii_case(&expected),
+        [disk] => {
+            vm.data_disk_count == 1
+                && disk.lun == Some(0)
+                && disk.delete_option == "Detach"
+                && disk.id.eq_ignore_ascii_case(&expected)
+        }
         _ => false,
     }
 }
@@ -274,9 +281,10 @@ impl InteractiveWorkerStopObserver for AzureClient {
     /// re-proved (identity tags, recorded IDs) and the VM's power state and storage
     /// profile are read once. `RetainedStopped` needs all of: compute deallocated (a
     /// halted-but-allocated guest is still billed and is not it), the single retained
-    /// data disk attached at LUN 0 with `Detach` semantics under its own name, and the
-    /// saved address still the one the deployment reports. Absence of the owned group is
-    /// `Absent`; a failed deployment is an error; everything else is `Pending`. Nothing
+    /// data disk attached at LUN 0 with `Detach` semantics under its own name (and no
+    /// storage entry the view cannot represent), and the saved address still the one the
+    /// deployment reports. Absence of the owned group is `Absent`; a failed deployment is
+    /// an error; a missing deployment address and everything else is `Pending`. Nothing
     /// is stopped, started, created, deleted, repaired or connected to.
     fn observe_worker_stop(
         &self,
@@ -305,10 +313,14 @@ impl InteractiveWorkerStopObserver for AzureClient {
                 let Some(vm) = current.vm.as_ref() else {
                     return Ok(InteractiveWorkerStopObservation::Pending);
                 };
-                if current.host.as_deref() != Some(expected.ssh.host.as_str()) {
-                    // The static address is retained with the group; a different one
-                    // means the saved endpoint no longer names this worker.
-                    return Err(AzureError::ResourceIdentityMismatch);
+                // The static address is retained with the group. Without a current
+                // deployment address (deployment absent, still in flight, unusable) the
+                // snapshot is uncertain and stays pending; a different address means
+                // the saved endpoint no longer names this worker.
+                match current.host.as_deref() {
+                    None => return Ok(InteractiveWorkerStopObservation::Pending),
+                    Some(host) if host != expected.ssh.host => return Err(AzureError::ResourceIdentityMismatch),
+                    Some(_) => {}
                 }
                 Ok(if retained_data_disk(vm, &handle.group_id) {
                     InteractiveWorkerStopObservation::RetainedStopped

--- a/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/deployment.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    AzureDeploymentPlan, AzureError, RESOURCE_GROUP_PREFIX,
+    AzureDeploymentPlan, AzureError, DATA_DISK_NAME, RESOURCE_GROUP_PREFIX, WORKER_VM_NAME,
     deployment::{
         SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_DISK_GIB, TAG_IMAGE_DIGEST, TAG_IMAGE_REF_DIGEST, TAG_JOB, TAG_LIFETIME,
         TAG_PROFILE, TAG_PROTOCOL, TAG_WORKFLOW, client_key_digest, worker_tags,
@@ -96,6 +96,23 @@ fn plan_derives_identity_parameters_and_tags_from_validated_inputs() {
             .values()
             .all(|value| value.len() <= 256 && !value.chars().any(char::is_control))
     );
+}
+
+#[test]
+fn the_retained_disk_is_named_once_for_creation_and_observation() {
+    let plan = AzureDeploymentPlan::new(&profile(), &request("")).expect("plan");
+    assert_eq!(
+        plan.template.pointer("/variables/data").and_then(|v| v.as_str()),
+        Some(DATA_DISK_NAME)
+    );
+    assert_eq!(DATA_DISK_NAME, format!("{WORKER_VM_NAME}-data"));
+    let disk = plan.template["resources"]
+        .as_array()
+        .expect("resources")
+        .iter()
+        .find(|r| r["type"] == "Microsoft.Compute/disks")
+        .expect("disk resource");
+    assert_eq!(disk["name"], "[variables('data')]");
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -320,6 +320,7 @@ pub(super) fn vm(power: &str, tags: &BTreeMap<String, String>) -> AzureVmView {
         power_state: Some(format!("PowerState/{power}")),
         tags: tags.clone(),
         data_disks: vec![retained_disk()],
+        data_disk_count: 1,
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -1,6 +1,6 @@
 pub(super) use super::super::{
-    AzureClient, AzureDeploymentState, AzureError, AzureGroupInfo, AzureLongRunningState, AzureManagementTransport,
-    AzureRunCommand, AzureVmView, AzureWorker, SSH_USERNAME,
+    AzureClient, AzureDataDisk, AzureDeploymentState, AzureError, AzureGroupInfo, AzureLongRunningState,
+    AzureManagementTransport, AzureRunCommand, AzureVmView, AzureWorker, SSH_USERNAME,
     deployment::{DEPLOYMENT_NAME, SSH_PORT, TAG_CLIENT_KEY_DIGEST, TAG_IMAGE_REF_DIGEST, TAG_JOB, worker_tags},
     resource_group_name,
 };
@@ -319,6 +319,16 @@ pub(super) fn vm(power: &str, tags: &BTreeMap<String, String>) -> AzureVmView {
         provisioning_state: "Succeeded".into(),
         power_state: Some(format!("PowerState/{power}")),
         tags: tags.clone(),
+        data_disks: vec![retained_disk()],
+    }
+}
+
+/// The retained data disk as the deployment attaches it.
+pub(super) fn retained_disk() -> AzureDataDisk {
+    AzureDataDisk {
+        id: format!("/subscriptions/{SUB}/resourceGroups/g/providers/Microsoft.Compute/disks/worker-data"),
+        lun: Some(0),
+        delete_option: "Detach".into(),
     }
 }
 
@@ -426,4 +436,5 @@ mod instance;
 mod observation;
 mod running;
 mod start;
+mod stop_observer;
 mod wait;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
@@ -142,11 +142,29 @@ fn absence_stays_absence_and_uncertain_storage_stays_pending() {
     ];
     for (label, disks) in doubtful {
         let mut view = retained_vm(&s, "deallocated");
+        view.data_disk_count = disks.len();
         view.data_disks = disks;
         s.plane
             .script(Some(owned(&s)), Some(deployment("Succeeded", HOST)), vec![Some(view)]);
         assert_eq!(observe(&s, &pin()), Ok(Observation::Pending), "{label}");
     }
+    // A storage entry the view could not represent (no managed-disk ID) is storage
+    // nobody vouched for: the count says two, the list says one.
+    let mut view = retained_vm(&s, "deallocated");
+    view.data_disk_count = 2;
+    s.plane
+        .script(Some(owned(&s)), Some(deployment("Succeeded", HOST)), vec![Some(view)]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending), "unrepresented entry");
+    // No current deployment address (in flight or unusable): uncertain, so pending, not
+    // a mismatch.
+    for state in [deployment("Running", HOST), deployment("Succeeded", "10.0.0.5")] {
+        s.plane
+            .script(Some(owned(&s)), Some(state), vec![Some(retained_vm(&s, "deallocated"))]);
+        assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
+    }
+    s.plane
+        .script(Some(owned(&s)), None, vec![Some(retained_vm(&s, "deallocated"))]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending), "no deployment at all");
     // The disk ID compares case-insensitively, as every ARM path does.
     let mut view = retained_vm(&s, "deallocated");
     view.data_disks[0].id = view.data_disks[0].id.to_uppercase();

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
@@ -1,0 +1,235 @@
+//! `Check saved Stop`: one read-only observation of the exact saved worker. Retained
+//! Stop needs deallocated compute, the retained data disk and the saved address; absence
+//! is absence, everything uncertain is pending, and nothing is ever mutated.
+use super::*;
+use crate::cloud_run::{
+    interactive_worker::InteractiveWorkerSshEndpoint,
+    interactive_worker_stop::{
+        InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation as Observation,
+        InteractiveWorkerStopObserver,
+    },
+    runpod::RunPodNetworkVolumeExpectation,
+};
+
+const HOST: &str = "203.0.113.9";
+
+fn pin() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: HOST.into(),
+        port: SSH_PORT,
+        username: SSH_USERNAME.into(),
+        host_key: host_key(),
+    }
+}
+
+/// The scripted VM with the retained disk under the scenario's own group.
+fn retained_vm(s: &Scenario, power: &str) -> AzureVmView {
+    let mut view = vm(power, &s.tags);
+    view.data_disks = vec![AzureDataDisk {
+        id: format!("{}/providers/Microsoft.Compute/disks/worker-data", s.group_id),
+        ..retained_disk()
+    }];
+    view
+}
+
+fn observe(s: &Scenario, pin: &InteractiveWorkerSshEndpoint) -> Result<Observation, AzureError> {
+    let worker = s.persisted();
+    s.client(false, Some(host_key()))
+        .observe_worker_stop(InteractiveWorkerStopExpectation {
+            worker: &worker,
+            ssh: pin,
+            network_volume: None,
+        })
+}
+
+fn assert_read_only(s: &Scenario) {
+    assert!(
+        s.plane.mutations().is_empty() && !s.plane.calls().iter().any(|call| matches!(call, Call::Run(..))),
+        "an observation never mutates, runs a command or connects: {:?}",
+        s.plane.calls()
+    );
+}
+
+#[test]
+fn only_deallocated_compute_with_the_retained_disk_and_address_is_retained_stopped() {
+    let s = Scenario::new();
+    let cases = [
+        ("deallocated", Ok(Observation::RetainedStopped)),
+        ("running", Ok(Observation::Pending)),
+        ("starting", Ok(Observation::Pending)),
+        ("deallocating", Ok(Observation::Pending)),
+        // Guest halted but compute still allocated and billed: not a retained stop.
+        ("stopped", Ok(Observation::Pending)),
+        ("unknown", Ok(Observation::Pending)),
+    ];
+    for (power, expected) in cases {
+        s.plane.script(
+            Some(owned(&s)),
+            Some(deployment("Succeeded", HOST)),
+            vec![Some(retained_vm(&s, power))],
+        );
+        assert_eq!(observe(&s, &pin()), expected, "{power}");
+        assert_read_only(&s);
+    }
+    // A failed deployment cannot vouch for retention: an error, never a state.
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Failed", HOST)),
+        vec![Some(retained_vm(&s, "deallocated"))],
+    );
+    assert_eq!(observe(&s, &pin()), Err(AzureError::StopUnverified));
+    // A group being deleted is not retained storage.
+    s.plane.script(
+        Some(group_info(&s.group, s.tags.clone(), "Deleting")),
+        Some(deployment("Succeeded", HOST)),
+        vec![Some(retained_vm(&s, "deallocated"))],
+    );
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
+    assert_read_only(&s);
+}
+
+#[test]
+fn absence_stays_absence_and_uncertain_storage_stays_pending() {
+    let s = Scenario::new();
+    s.plane.script(None, None, vec![None]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Absent), "no owned group");
+    // The group is there but the VM is not (deployment still provisioning): pending.
+    s.plane
+        .script(Some(owned(&s)), Some(deployment("Running", HOST)), vec![None]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
+    // Storage that cannot be recognised as the retained disk is never promoted.
+    let other_group =
+        format!("/subscriptions/{SUB}/resourceGroups/other/providers/Microsoft.Compute/disks/worker-data");
+    let retained = retained_vm(&s, "deallocated").data_disks.remove(0);
+    let doubtful: Vec<(&str, Vec<AzureDataDisk>)> = vec![
+        ("no disk", vec![]),
+        ("two disks", vec![retained.clone(), retained.clone()]),
+        (
+            "deleted with the VM",
+            vec![AzureDataDisk {
+                delete_option: "Delete".into(),
+                ..retained.clone()
+            }],
+        ),
+        (
+            "other LUN",
+            vec![AzureDataDisk {
+                lun: Some(1),
+                ..retained.clone()
+            }],
+        ),
+        (
+            "no LUN",
+            vec![AzureDataDisk {
+                lun: None,
+                ..retained.clone()
+            }],
+        ),
+        (
+            "other name",
+            vec![AzureDataDisk {
+                id: retained.id.replace("worker-data", "scratch"),
+                ..retained.clone()
+            }],
+        ),
+        (
+            "other group",
+            vec![AzureDataDisk {
+                id: other_group,
+                ..retained.clone()
+            }],
+        ),
+    ];
+    for (label, disks) in doubtful {
+        let mut view = retained_vm(&s, "deallocated");
+        view.data_disks = disks;
+        s.plane
+            .script(Some(owned(&s)), Some(deployment("Succeeded", HOST)), vec![Some(view)]);
+        assert_eq!(observe(&s, &pin()), Ok(Observation::Pending), "{label}");
+    }
+    // The disk ID compares case-insensitively, as every ARM path does.
+    let mut view = retained_vm(&s, "deallocated");
+    view.data_disks[0].id = view.data_disks[0].id.to_uppercase();
+    s.plane
+        .script(Some(owned(&s)), Some(deployment("Succeeded", HOST)), vec![Some(view)]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::RetainedStopped));
+    assert_read_only(&s);
+}
+
+#[test]
+fn saved_identity_and_pin_are_validated_before_and_during_the_read() {
+    let s = Scenario::new();
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", HOST)),
+        vec![Some(retained_vm(&s, "deallocated"))],
+    );
+    // Malformed or foreign expectations never reach the control plane.
+    let mut wrong_port = pin();
+    wrong_port.port = 22;
+    let mut wrong_user = pin();
+    wrong_user.username = "horizon".into();
+    let mut wrong_host = pin();
+    wrong_host.host = "worker.example".into();
+    let mut wrong_key = pin();
+    wrong_key.host_key = "ssh-rsa AAAA".into();
+    for (label, broken) in [
+        ("port", wrong_port),
+        ("user", wrong_user),
+        ("host", wrong_host),
+        ("key", wrong_key),
+    ] {
+        s.plane.lock().calls.clear();
+        assert_eq!(observe(&s, &broken), Err(AzureError::InvalidPersistedWorker), "{label}");
+        assert!(s.plane.calls().is_empty(), "{label}: refused before any request");
+    }
+    let worker = s.persisted();
+    let volume = RunPodNetworkVolumeExpectation {
+        volume_id: "vol".into(),
+        data_center_id: "dc".into(),
+        minimum_size_gb: 10,
+    };
+    assert_eq!(
+        s.client(false, Some(host_key()))
+            .observe_worker_stop(InteractiveWorkerStopExpectation {
+                worker: &worker,
+                ssh: &pin(),
+                network_volume: Some(&volume),
+            }),
+        Err(AzureError::InvalidTarget),
+        "a network volume is a RunPod binding"
+    );
+    let mut foreign = worker.clone();
+    foreign.identity.resource_id = format!("/subscriptions/{OTHER_SUB}/resourceGroups/{}", s.group);
+    assert_eq!(
+        s.client(false, Some(host_key()))
+            .observe_worker_stop(InteractiveWorkerStopExpectation {
+                worker: &foreign,
+                ssh: &pin(),
+                network_volume: None,
+            }),
+        Err(AzureError::InvalidPersistedWorker)
+    );
+    // The saved address must still be the one the deployment reports.
+    let mut moved = pin();
+    moved.host = "203.0.113.10".into();
+    assert_eq!(observe(&s, &moved), Err(AzureError::ResourceIdentityMismatch));
+    // A retagged group or VM at the same path is not this worker.
+    let mut retagged = s.tags.clone();
+    retagged.insert(TAG_JOB.into(), CloudJobId::new().to_string());
+    s.plane.script(
+        Some(group_info(&s.group, retagged.clone(), "Succeeded")),
+        Some(deployment("Succeeded", HOST)),
+        vec![Some(retained_vm(&s, "deallocated"))],
+    );
+    assert_eq!(observe(&s, &pin()), Err(MISMATCH));
+    let mut foreign_vm = retained_vm(&s, "deallocated");
+    foreign_vm.tags = retagged;
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", HOST)),
+        vec![Some(foreign_vm)],
+    );
+    assert_eq!(observe(&s, &pin()), Err(MISMATCH));
+    assert_read_only(&s);
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
@@ -228,10 +228,29 @@ fn saved_identity_and_pin_are_validated_before_and_during_the_read() {
             }),
         Err(AzureError::InvalidPersistedWorker)
     );
-    // The saved address must still be the one the deployment reports.
+    // The saved address must still be the one the deployment reports, whatever the
+    // compute is doing: a moved address on a running or transitioning worker is a
+    // mismatch too, never something to keep retrying against.
     let mut moved = pin();
     moved.host = "203.0.113.10".into();
     assert_eq!(observe(&s, &moved), Err(AzureError::ResourceIdentityMismatch));
+    for power in ["running", "starting", "stopped"] {
+        s.plane.script(
+            Some(owned(&s)),
+            Some(deployment("Succeeded", HOST)),
+            vec![Some(retained_vm(&s, power))],
+        );
+        assert_eq!(
+            observe(&s, &moved),
+            Err(AzureError::ResourceIdentityMismatch),
+            "{power}"
+        );
+    }
+    s.plane.script(
+        Some(owned(&s)),
+        Some(deployment("Succeeded", HOST)),
+        vec![Some(retained_vm(&s, "deallocated"))],
+    );
     // A retagged group or VM at the same path is not this worker.
     let mut retagged = s.tags.clone();
     retagged.insert(TAG_JOB.into(), CloudJobId::new().to_string());

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -467,8 +467,9 @@ fn virtual_machine_views_verify_the_returned_identity() {
         ("Succeeded", Some("PowerState/running"))
     );
     assert_eq!(vm.tags.get("horizon-job-id").map(String::as_str), Some("j"));
-    // Only data disks with a managed-disk ID are listed; the OS disk never is.
-    assert_eq!(vm.data_disks.len(), 1);
+    // Only data disks with a managed-disk ID are represented, the OS disk never is, and
+    // the count keeps every entry so an unrepresented one is never silently dropped.
+    assert_eq!((vm.data_disks.len(), vm.data_disk_count), (1, 2));
     assert_eq!(
         (vm.data_disks[0].lun, vm.data_disks[0].delete_option.as_str()),
         (Some(0), "Detach")

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -115,7 +115,7 @@ fn vm_body(power: &str, name: &str, group: &str) -> String {
 
 fn vm_body_with_instance(power: &str, name: &str, group: &str, instance: &str) -> String {
     format!(
-        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{group}/providers/Microsoft.Compute/virtualMachines/worker","name":"{name}","location":"northeurope","tags":{{"horizon-job-id":"j"}},"properties":{{{instance}"provisioningState":"Succeeded","hardwareProfile":{{"vmSize":"Standard_D4s_v3"}},"instanceView":{{"statuses":[{{"code":"ProvisioningState/succeeded"}},{{"code":"PowerState/{power}"}}]}}}}}}"#
+        r#"{{"id":"/subscriptions/{SUB}/resourceGroups/{group}/providers/Microsoft.Compute/virtualMachines/worker","name":"{name}","location":"northeurope","tags":{{"horizon-job-id":"j"}},"properties":{{{instance}"provisioningState":"Succeeded","hardwareProfile":{{"vmSize":"Standard_D4s_v3"}},"storageProfile":{{"osDisk":{{"deleteOption":"Delete"}},"dataDisks":[{{"lun":0,"deleteOption":"Detach","managedDisk":{{"id":"/subscriptions/{SUB}/resourceGroups/{group}/providers/Microsoft.Compute/disks/worker-data"}}}},{{"lun":1,"managedDisk":{{}}}}]}},"instanceView":{{"statuses":[{{"code":"ProvisioningState/succeeded"}},{{"code":"PowerState/{power}"}}]}}}}}}"#
     )
 }
 
@@ -467,6 +467,13 @@ fn virtual_machine_views_verify_the_returned_identity() {
         ("Succeeded", Some("PowerState/running"))
     );
     assert_eq!(vm.tags.get("horizon-job-id").map(String::as_str), Some("j"));
+    // Only data disks with a managed-disk ID are listed; the OS disk never is.
+    assert_eq!(vm.data_disks.len(), 1);
+    assert_eq!(
+        (vm.data_disks[0].lun, vm.data_disks[0].delete_option.as_str()),
+        (Some(0), "Detach")
+    );
+    assert!(vm.data_disks[0].id.ends_with("/disks/worker-data"));
     assert_eq!(
         transport.get_vm(GROUP, "worker"),
         Err(AzureError::ResourceIdentityMismatch),

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -52,8 +52,12 @@ pub struct AzureVmView {
     pub provisioning_state: String,
     pub power_state: Option<String>,
     pub tags: BTreeMap<String, String>,
-    /// The managed data disks attached to the VM, as the storage profile lists them.
+    /// The managed data disks attached to the VM, as far as the storage profile lists
+    /// them in a form this view represents (a managed-disk ID at least).
     pub data_disks: Vec<AzureDataDisk>,
+    /// Every data-disk entry in the storage profile, represented or not: a count above
+    /// `data_disks.len()` means storage this view cannot vouch for.
+    pub data_disk_count: usize,
 }
 
 /// One attached managed data disk: its ARM ID, logical unit and what happens to it when
@@ -609,6 +613,11 @@ impl AzureManagementTransport for AzureArmHttp {
         {
             return Err(AzureError::ResourceIdentityMismatch);
         }
+        let data_disk_entries: Vec<serde_json::Value> = value
+            .pointer("/properties/storageProfile/dataDisks")
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_default();
         let power_state = value
             .pointer("/properties/instanceView/statuses")
             .and_then(serde_json::Value::as_array)
@@ -625,11 +634,8 @@ impl AzureManagementTransport for AzureArmHttp {
             provisioning_state: text(&value, "/properties/provisioningState").unwrap_or_default(),
             power_state,
             tags: tags(&value),
-            data_disks: value
-                .pointer("/properties/storageProfile/dataDisks")
-                .and_then(serde_json::Value::as_array)
-                .into_iter()
-                .flatten()
+            data_disks: data_disk_entries
+                .iter()
                 .filter_map(|disk| {
                     Some(AzureDataDisk {
                         id: text(disk, "/managedDisk/id")?,
@@ -638,6 +644,7 @@ impl AzureManagementTransport for AzureArmHttp {
                     })
                 })
                 .collect(),
+            data_disk_count: data_disk_entries.len(),
         }))
     }
 

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -52,6 +52,17 @@ pub struct AzureVmView {
     pub provisioning_state: String,
     pub power_state: Option<String>,
     pub tags: BTreeMap<String, String>,
+    /// The managed data disks attached to the VM, as the storage profile lists them.
+    pub data_disks: Vec<AzureDataDisk>,
+}
+
+/// One attached managed data disk: its ARM ID, logical unit and what happens to it when
+/// the VM is deleted (`Detach` keeps it, `Delete` removes it with the VM).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AzureDataDisk {
+    pub id: String,
+    pub lun: Option<u64>,
+    pub delete_option: String,
 }
 
 /// Outcome of a request that ARM may complete asynchronously.
@@ -614,6 +625,19 @@ impl AzureManagementTransport for AzureArmHttp {
             provisioning_state: text(&value, "/properties/provisioningState").unwrap_or_default(),
             power_state,
             tags: tags(&value),
+            data_disks: value
+                .pointer("/properties/storageProfile/dataDisks")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|disk| {
+                    Some(AzureDataDisk {
+                        id: text(disk, "/managedDisk/id")?,
+                        lun: disk.pointer("/lun").and_then(serde_json::Value::as_u64),
+                        delete_option: text(disk, "/deleteOption").unwrap_or_default(),
+                    })
+                })
+                .collect(),
         }))
     }
 


### PR DESCRIPTION
Part of the Azure workspace lane for #474 (does not complete the issue). Delivers the Azure-only dependency the lead identified for **Check saved Stop**: the provider implements `InteractiveWorkerStopObserver`; configured admission and management UI wiring stay lead-owned.

## What

- `AzureClient` implements `InteractiveWorkerStopObserver::observe_worker_stop`, observe-only. Before any request it validates the saved endpoint (complete Ed25519 pin, port 2222, user `root`, an IP address) and rejects a RunPod network-volume expectation (`InvalidTarget`). It then re-proves the owned group and VM exactly as the other paths do (identity tags, recorded IDs, persistent lifetime) and reads the VM once.
- Mapping: `RetainedStopped` only for deallocated compute with the single retained data disk attached at LUN 0, `deleteOption: Detach`, under `worker-data` in the worker's own group, and the saved address still the deployment's; owned group absent → `Absent`; failed deployment → `StopUnverified`; running, transitioning, allocated-but-halted (`PowerState/stopped`), unknown or a group being deleted → `Pending`; a different address, a retagged group or VM → `ResourceIdentityMismatch`.
- No Stop, Start, create, delete, run-command, SSH, host-key acquisition or identity repair; the tests assert the fake plane saw no mutation and no run-command.
- `AzureVmView` gains `data_disks` (managed-disk ID, LUN, delete option) parsed from the storage profile; only entries with a managed-disk ID are listed.
- Tests: `tests/provider/stop_observer.rs` (state table, absence, seven storage shapes that stay pending, case-insensitive disk ID, malformed pins refused before any request, network volume refused, foreign handle, moved address, retagged group and VM) and a transport parse test.

## Validation

Full local matrix green: fmt, maintainability, version sync, preflight and client-off harness tests, `cargo test --workspace` (default and `speech`), clippy blocking, strict and pedantic.