### PR TITLE
test(azure): close the credential, poll-schedule and disk-retention gaps

### DIFF
--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -433,6 +433,7 @@ pub(super) fn owned(s: &Scenario) -> AzureGroupInfo {
 pub(super) const MISMATCH: AzureError = AzureError::ResourceIdentityMismatch;
 
 mod creation;
+mod credential;
 mod instance;
 mod observation;
 mod running;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/credential.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/credential.rs
@@ -13,6 +13,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 const REASON: &str = "Azure CLI did not return a token";
 
+/// One entry point of the client, invoked with its own arguments.
+type Attempt<'a> = &'a dyn Fn() -> Result<(), AzureError>;
+
 fn unavailable() -> AzureError {
     AzureError::CredentialUnavailable { reason: REASON }
 }
@@ -49,26 +52,24 @@ fn every_entry_point_reports_the_credential_failure_before_any_request_or_claim(
         ssh: &pin,
         network_volume: None,
     };
-    let attempts: [(&str, Result<(), AzureError>); 7] = [
-        ("ensure", client.ensure_worker(&s.request).map(drop)),
-        ("reconcile", client.reconcile_worker(&s.request).map(drop)),
-        ("inspect", client.inspect_worker(&worker).map(drop)),
-        ("delete", client.delete_worker(&worker).map(drop)),
-        ("stop", client.stop_worker(&worker).map(drop)),
-        ("start", client.start_worker(&worker).map(drop)),
-        ("observe stop", client.observe_worker_stop(expectation).map(drop)),
+    let attempts: [(&str, Attempt); 7] = [
+        ("ensure", &|| client.ensure_worker(&s.request).map(drop)),
+        ("reconcile", &|| client.reconcile_worker(&s.request).map(drop)),
+        ("inspect", &|| client.inspect_worker(&worker).map(drop)),
+        ("delete", &|| client.delete_worker(&worker).map(drop)),
+        ("stop", &|| client.stop_worker(&worker).map(drop)),
+        ("start", &|| client.start_worker(&worker).map(drop)),
+        ("observe stop", &|| client.observe_worker_stop(expectation).map(drop)),
     ];
-    for (entry, outcome) in &attempts {
+    for (entry, attempt) in attempts {
         assert_eq!(
-            outcome,
-            &Err(unavailable()),
+            attempt(),
+            Err(unavailable()),
             "{entry} passes the credential error through"
         );
+        // The delta of this one call: exactly one token request, no retry around a
+        // failing credential and no path that skips the credential.
+        assert_eq!(asked.swap(0, Ordering::SeqCst), 1, "{entry} asks the credential once");
     }
-    assert_eq!(
-        asked.load(Ordering::SeqCst),
-        attempts.len(),
-        "one token request per entry point, no retry around a failing credential"
-    );
     assert!(format!("{}", unavailable()).contains(REASON));
 }

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/credential.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/credential.rs
@@ -1,0 +1,74 @@
+//! The production client over a credential that cannot produce a token: every entry
+//! point fails with that exact error before any request, claim or command, and the
+//! error is passed through unchanged so the caller sees why.
+use super::*;
+use crate::cloud_run::{
+    interactive_worker::InteractiveWorkerSshEndpoint,
+    interactive_worker_start::InteractiveWorkerStartProvider,
+    interactive_worker_stop::{
+        InteractiveWorkerStopExpectation, InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
+    },
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+const REASON: &str = "Azure CLI did not return a token";
+
+fn unavailable() -> AzureError {
+    AzureError::CredentialUnavailable { reason: REASON }
+}
+
+/// The production constructor with a credential that always fails and a fence that
+/// must never be consulted: without a token there is no control-plane read, and
+/// without a read nothing is ever claimed.
+fn client(asked: &Arc<AtomicUsize>) -> AzureClient {
+    let asked = Arc::clone(asked);
+    let credential = move || {
+        asked.fetch_add(1, Ordering::SeqCst);
+        Err(unavailable())
+    };
+    let fence = |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| -> Result<bool, AzureError> {
+        panic!("a creation claim without a control-plane read")
+    };
+    AzureClient::new(profile(), credential, fence).expect("client")
+}
+
+#[test]
+fn every_entry_point_reports_the_credential_failure_before_any_request_or_claim() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let asked = Arc::new(AtomicUsize::new(0));
+    let client = client(&asked);
+    let pin = InteractiveWorkerSshEndpoint {
+        host: "203.0.113.9".into(),
+        port: SSH_PORT,
+        username: SSH_USERNAME.into(),
+        host_key: host_key(),
+    };
+    let expectation = InteractiveWorkerStopExpectation {
+        worker: &worker,
+        ssh: &pin,
+        network_volume: None,
+    };
+    let attempts: [(&str, Result<(), AzureError>); 7] = [
+        ("ensure", client.ensure_worker(&s.request).map(drop)),
+        ("reconcile", client.reconcile_worker(&s.request).map(drop)),
+        ("inspect", client.inspect_worker(&worker).map(drop)),
+        ("delete", client.delete_worker(&worker).map(drop)),
+        ("stop", client.stop_worker(&worker).map(drop)),
+        ("start", client.start_worker(&worker).map(drop)),
+        ("observe stop", client.observe_worker_stop(expectation).map(drop)),
+    ];
+    for (entry, outcome) in &attempts {
+        assert_eq!(
+            outcome,
+            &Err(unavailable()),
+            "{entry} passes the credential error through"
+        );
+    }
+    assert_eq!(
+        asked.load(Ordering::SeqCst),
+        attempts.len(),
+        "one token request per entry point, no retry around a failing credential"
+    );
+    assert!(format!("{}", unavailable()).contains(REASON));
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
@@ -302,10 +302,15 @@ fn the_retained_disk_survives_a_stop_observe_start_cycle_on_the_same_instance() 
     );
     assert_eq!(client.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
     assert_eq!(s.plane.mutations(), [Call::Deallocate(s.group.clone())]);
-    // Check saved Stop: deallocated compute, the same disk, the saved address.
-    let deallocated = retained_vm(&s, "deallocated");
-    assert_eq!(disk_of(&deallocated), retained, "deallocation keeps the disk");
-    s.plane.script(Some(owned(&s)), address(), vec![Some(deallocated)]);
+    // Check saved Stop against the state the stop left behind, not a fresh script:
+    // deallocated compute, the same disk, the saved address.
+    let after_stop = s.plane.lock().vm_states.clone();
+    assert_eq!(
+        after_stop.iter().flatten().map(disk_of).collect::<Vec<_>>(),
+        std::slice::from_ref(&retained),
+        "the stop's final VM state keeps the disk on the same instance"
+    );
+    s.plane.lock().calls.clear();
     assert_eq!(observe(&s, &pin()), Ok(Observation::RetainedStopped));
     assert_read_only(&s);
     // Start: the same instance comes back with the same disk and is ready through the
@@ -316,7 +321,7 @@ fn the_retained_disk_survives_a_stop_observe_start_cycle_on_the_same_instance() 
         vec![
             Some(retained_vm(&s, "deallocated")),
             Some(retained_vm(&s, "starting")),
-            Some(running.clone()),
+            Some(running),
         ],
     );
     let started = client.start_worker(&worker).expect("start");
@@ -325,7 +330,13 @@ fn the_retained_disk_survives_a_stop_observe_start_cycle_on_the_same_instance() 
     };
     assert_eq!(status.lifecycle, Lifecycle::Ready);
     assert_eq!(s.plane.mutations(), [Call::Start(s.group.clone())]);
-    s.plane.script(Some(owned(&s)), address(), vec![Some(running)]);
+    let after_start = s.plane.lock().vm_states.clone();
+    assert_eq!(
+        after_start.iter().flatten().map(disk_of).collect::<Vec<_>>(),
+        [retained],
+        "the started instance carries the retained disk"
+    );
+    s.plane.lock().calls.clear();
     assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
     assert_read_only(&s);
     // A rebuilt worker on another instance without the retained disk is never confirmed

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/stop_observer.rs
@@ -4,9 +4,10 @@
 use super::*;
 use crate::cloud_run::{
     interactive_worker::InteractiveWorkerSshEndpoint,
+    interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
     interactive_worker_stop::{
-        InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation as Observation,
-        InteractiveWorkerStopObserver,
+        InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation as Observation,
+        InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
     },
     runpod::RunPodNetworkVolumeExpectation,
 };
@@ -268,5 +269,72 @@ fn saved_identity_and_pin_are_validated_before_and_during_the_read() {
         vec![Some(foreign_vm)],
     );
     assert_eq!(observe(&s, &pin()), Err(MISMATCH));
+    assert_read_only(&s);
+}
+
+/// The retained disk through a whole Stop, Check saved Stop, Start cycle on one
+/// instance: the plane keeps the disk attached across deallocation (the template's
+/// `Detach` delete option), the observer confirms it exactly then, and the started
+/// worker comes back on the same instance with the same disk. The observation itself
+/// issues no mutation at any point of the cycle.
+#[test]
+fn the_retained_disk_survives_a_stop_observe_start_cycle_on_the_same_instance() {
+    let s = Scenario::new();
+    let worker = s.persisted();
+    let client = s.client(false, Some(host_key()));
+    let address = || Some(deployment("Succeeded", HOST));
+    let disk_of = |view: &AzureVmView| (view.instance_id.clone(), view.data_disks.clone(), view.data_disk_count);
+    let running = retained_vm(&s, "running");
+    let retained = disk_of(&running);
+    // Running: observed only, nothing to confirm yet.
+    s.plane.script(Some(owned(&s)), address(), vec![Some(running.clone())]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
+    assert_read_only(&s);
+    // Stop: the deallocation is posted once and the disk stays attached throughout.
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![
+            Some(running.clone()),
+            Some(retained_vm(&s, "deallocating")),
+            Some(retained_vm(&s, "deallocated")),
+        ],
+    );
+    assert_eq!(client.stop_worker(&worker), Ok(InteractiveWorkerStop::Stopped));
+    assert_eq!(s.plane.mutations(), [Call::Deallocate(s.group.clone())]);
+    // Check saved Stop: deallocated compute, the same disk, the saved address.
+    let deallocated = retained_vm(&s, "deallocated");
+    assert_eq!(disk_of(&deallocated), retained, "deallocation keeps the disk");
+    s.plane.script(Some(owned(&s)), address(), vec![Some(deallocated)]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::RetainedStopped));
+    assert_read_only(&s);
+    // Start: the same instance comes back with the same disk and is ready through the
+    // attested key; the observer then reports the running worker as pending again.
+    s.plane.script(
+        Some(owned(&s)),
+        address(),
+        vec![
+            Some(retained_vm(&s, "deallocated")),
+            Some(retained_vm(&s, "starting")),
+            Some(running.clone()),
+        ],
+    );
+    let started = client.start_worker(&worker).expect("start");
+    let InteractiveWorkerStart::Started(status) = &started else {
+        panic!("the retained worker starts: {started:?}");
+    };
+    assert_eq!(status.lifecycle, Lifecycle::Ready);
+    assert_eq!(s.plane.mutations(), [Call::Start(s.group.clone())]);
+    s.plane.script(Some(owned(&s)), address(), vec![Some(running)]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
+    assert_read_only(&s);
+    // A rebuilt worker on another instance without the retained disk is never confirmed
+    // as the saved Stop: retention is proven by the disk, not by the power state.
+    let mut replaced = retained_vm(&s, "deallocated");
+    replaced.instance_id = Some("7d6c5b4a-3928-4170-a6b5-c4d3e2f1a0b9".into());
+    replaced.data_disks.clear();
+    replaced.data_disk_count = 0;
+    s.plane.script(Some(owned(&s)), address(), vec![Some(replaced)]);
+    assert_eq!(observe(&s, &pin()), Ok(Observation::Pending));
     assert_read_only(&s);
 }

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -25,7 +25,7 @@ struct Expectation {
     status: u16,
     body: String,
     request_body: Option<serde_json::Value>,
-    header: Option<(&'static str, String)>,
+    headers: Vec<(&'static str, String)>,
 }
 
 fn expect(
@@ -41,12 +41,12 @@ fn expect(
         status,
         body: body.to_string(),
         request_body,
-        header: None,
+        headers: Vec::new(),
     }
 }
 
 fn with_header(mut expectation: Expectation, name: &'static str, value: String) -> Expectation {
-    expectation.header = Some((name, value));
+    expectation.headers.push((name, value));
     expectation
 }
 
@@ -84,7 +84,7 @@ fn http_with_sleeps(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<Atomic
                 None => assert!(payload.is_empty(), "unexpected body on call {index}"),
             }
             let mut response = Response::builder().status(expectation.status);
-            if let Some((name, value)) = expectation.header {
+            for (name, value) in expectation.headers {
                 response = response.header(name, value);
             }
             Ok(response.body(Body::builder().data(expectation.body)).expect("response"))

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport.rs
@@ -51,7 +51,16 @@ fn with_header(mut expectation: Expectation, name: &'static str, value: String) 
 }
 
 fn http(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<AtomicUsize>) {
+    let (transport, calls, _) = http_with_sleeps(expectations);
+    (transport, calls)
+}
+
+/// The scripted transport plus every wait its poll loops asked for, in order; the
+/// waits are recorded instead of slept.
+fn http_with_sleeps(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<AtomicUsize>, Arc<Mutex<Vec<Duration>>>) {
     let calls = Arc::new(AtomicUsize::new(0));
+    let sleeps = Arc::new(Mutex::new(Vec::new()));
+    let recorded = Arc::clone(&sleeps);
     let count = Arc::clone(&calls);
     let queue = Arc::new(Mutex::new(expectations));
     let agent = ureq::Agent::config_builder()
@@ -83,11 +92,13 @@ fn http(expectations: Vec<Expectation>) -> (AzureArmHttp, Arc<AtomicUsize>) {
         .build()
         .new_agent();
     let credential = || AzureAccessToken::new("synthetic-token-value", Duration::from_secs(3_600));
-    (
-        AzureArmHttp::with_agent(agent, SUB, credential).expect("transport"),
-        calls,
-    )
+    let transport = AzureArmHttp::with_agent(agent, SUB, credential)
+        .expect("transport")
+        .with_sleeper(move |duration| recorded.lock().expect("sleeps").push(duration));
+    (transport, calls, sleeps)
 }
+
+mod run_command_schedule;
 
 fn group_url(name: &str) -> String {
     format!("https://management.azure.com/subscriptions/{SUB}/resourcegroups/{name}?api-version=2022-09-01")

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport/run_command_schedule.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport/run_command_schedule.rs
@@ -1,0 +1,107 @@
+//! The run-command poll schedule as it runs in production: the backoff table, ARM's
+//! `Retry-After` lengthening a step (never shortening it), the cap on one wait, and
+//! nothing slept once the operation is terminal.
+use super::*;
+
+fn accepted() -> Expectation {
+    with_header(
+        expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+        "azure-asyncoperation",
+        operation_url(),
+    )
+}
+
+fn poll(status: u16, body: &str, retry_after: Option<&str>) -> Expectation {
+    let poll = expect("GET", operation_url(), status, body, None);
+    match retry_after {
+        Some(seconds) => with_header(poll, "retry-after", seconds.into()),
+        None => poll,
+    }
+}
+
+const IN_PROGRESS: &str = r#"{"status":"InProgress"}"#;
+const DONE: &str = r#"{"status":"Succeeded","properties":{"output":{"value":[{"code":"ProvisioningState/succeeded","message":"[stdout]\nok\n[stderr]\n"}]}}}"#;
+
+#[test]
+fn polls_follow_the_backoff_table_and_retry_after_only_lengthens_a_capped_step() {
+    let (transport, calls, sleeps) = http_with_sleeps(vec![
+        accepted(),
+        // A far-future Retry-After is honoured only up to the cap.
+        poll(200, IN_PROGRESS, Some("3600")),
+        // Longer than the table step: the header wins.
+        poll(429, "throttled", Some("7")),
+        // Malformed guidance falls back to the table.
+        poll(200, IN_PROGRESS, Some("soon")),
+        // Shorter than the table step: the table wins, a header never shortens a wait.
+        poll(200, IN_PROGRESS, Some("0")),
+        // The HTTP-date form is not used by ARM's operation resources and is ignored.
+        poll(200, IN_PROGRESS, Some("Wed, 21 Oct 2026 07:28:00 GMT")),
+        poll(200, DONE, None),
+    ]);
+    assert_eq!(
+        transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+        Ok(Some("ok".into()))
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 7);
+    assert_eq!(
+        *sleeps.lock().expect("sleeps"),
+        [
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+            Duration::from_secs(7),
+            Duration::from_secs(4),
+            Duration::from_secs(8),
+            Duration::from_secs(15),
+        ],
+        "one wait before each poll, none after the terminal answer"
+    );
+}
+
+#[test]
+fn a_synchronous_answer_and_a_refused_operation_never_wait() {
+    let (transport, _, sleeps) = http_with_sleeps(vec![
+        expect(
+            "POST",
+            vm_url("/runCommand"),
+            200,
+            r#"{"value":[{"code":"ProvisioningState/succeeded","message":"[stdout]\nnow\n[stderr]\n"}]}"#,
+            Some(run_command_body()),
+        ),
+        with_header(
+            expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
+            "azure-asyncoperation",
+            format!("https://management.azure.com/subscriptions/{FOREIGN_SUB}/operations/op-2"),
+        ),
+    ]);
+    assert_eq!(
+        transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+        Ok(Some("now".into()))
+    );
+    assert_eq!(
+        transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+        Err(AzureError::InvalidResponse {
+            operation: "virtual machine run command"
+        })
+    );
+    assert!(sleeps.lock().expect("sleeps").is_empty(), "no poll, no wait");
+}
+
+#[test]
+fn the_bounded_poll_sleeps_the_whole_table_exactly_once() {
+    let (transport, _, sleeps) = http_with_sleeps(
+        std::iter::once(accepted())
+            .chain((0..9).map(|_| poll(200, IN_PROGRESS, None)))
+            .collect(),
+    );
+    assert_eq!(
+        transport.run_command(GROUP, "worker", AzureRunCommand::HostKey),
+        Err(AzureError::OperationTimedOut {
+            operation: "virtual machine run command"
+        })
+    );
+    let table: Vec<Duration> = [500, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 30_000, 30_000]
+        .into_iter()
+        .map(Duration::from_millis)
+        .collect();
+    assert_eq!(*sleeps.lock().expect("sleeps"), table);
+}

--- a/crates/horizon-core/src/cloud_run/azure/tests/transport/run_command_schedule.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/transport/run_command_schedule.rs
@@ -3,12 +3,16 @@
 //! nothing slept once the operation is terminal.
 use super::*;
 
-fn accepted() -> Expectation {
-    with_header(
+fn accepted(retry_after: Option<&str>) -> Expectation {
+    let accepted = with_header(
         expect("POST", vm_url("/runCommand"), 202, "", Some(run_command_body())),
         "azure-asyncoperation",
         operation_url(),
-    )
+    );
+    match retry_after {
+        Some(seconds) => with_header(accepted, "retry-after", seconds.into()),
+        None => accepted,
+    }
 }
 
 fn poll(status: u16, body: &str, retry_after: Option<&str>) -> Expectation {
@@ -25,7 +29,8 @@ const DONE: &str = r#"{"status":"Succeeded","properties":{"output":{"value":[{"c
 #[test]
 fn polls_follow_the_backoff_table_and_retry_after_only_lengthens_a_capped_step() {
     let (transport, calls, sleeps) = http_with_sleeps(vec![
-        accepted(),
+        // The acceptance's own guidance governs the first wait.
+        accepted(Some("3")),
         // A far-future Retry-After is honoured only up to the cap.
         poll(200, IN_PROGRESS, Some("3600")),
         // Longer than the table step: the header wins.
@@ -46,7 +51,7 @@ fn polls_follow_the_backoff_table_and_retry_after_only_lengthens_a_capped_step()
     assert_eq!(
         *sleeps.lock().expect("sleeps"),
         [
-            Duration::from_millis(500),
+            Duration::from_secs(3),
             Duration::from_secs(60),
             Duration::from_secs(7),
             Duration::from_secs(4),
@@ -89,7 +94,7 @@ fn a_synchronous_answer_and_a_refused_operation_never_wait() {
 #[test]
 fn the_bounded_poll_sleeps_the_whole_table_exactly_once() {
     let (transport, _, sleeps) = http_with_sleeps(
-        std::iter::once(accepted())
+        std::iter::once(accepted(None))
             .chain((0..9).map(|_| poll(200, IN_PROGRESS, None)))
             .collect(),
     );

--- a/crates/horizon-core/src/cloud_run/azure/transport.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport.rs
@@ -191,6 +191,9 @@ pub struct AzureArmHttp {
     agent: ureq::Agent,
     credential: Box<dyn AzureCredentialSource>,
     subscription_id: String,
+    /// How a poll loop waits between requests: real sleeps in production, recorded and
+    /// skipped in tests so the exact schedule is asserted without waiting it out.
+    sleeper: Box<dyn Fn(Duration) + Send + Sync>,
 }
 
 impl AzureArmHttp {
@@ -223,12 +226,20 @@ impl AzureArmHttp {
             agent,
             credential: Box::new(credential),
             subscription_id,
+            sleeper: Box::new(std::thread::sleep),
         })
     }
 
     #[cfg(test)]
     pub(crate) fn config(&self) -> &ureq::config::Config {
         self.agent.config()
+    }
+
+    /// The same transport with its poll waits routed through `sleeper`.
+    #[cfg(test)]
+    pub(crate) fn with_sleeper(mut self, sleeper: impl Fn(Duration) + Send + Sync + 'static) -> Self {
+        self.sleeper = Box::new(sleeper);
+        self
     }
 
     fn group_url(&self, name: &str, api_version: &str) -> Result<String, AzureError> {

--- a/crates/horizon-core/src/cloud_run/azure/transport/run_command.rs
+++ b/crates/horizon-core/src/cloud_run/azure/transport/run_command.rs
@@ -126,9 +126,7 @@ impl AzureArmHttp {
                 break;
             };
             let delay = Duration::from_millis(delay_ms).max(retry_after.unwrap_or_default());
-            if !cfg!(test) {
-                std::thread::sleep(delay.min(left));
-            }
+            (self.sleeper)(delay.min(left));
             let Some(budget) = super::remaining(deadline) else {
                 break;
             };


### PR DESCRIPTION
Part of the Azure lane for #474 (adapter tests only; no shared configuration, dispatch or UI paths).

Closes the remaining deterministic-coverage gaps from the Azure test inventory:

- **Provider-level credential failure.** `tests/provider/credential.rs` builds the production client (`AzureClient::new`) over a credential that never yields a token and a fence that panics if consulted. Every entry point (ensure, reconcile, inspect, delete, stop, start, observe saved Stop) returns `CredentialUnavailable` unchanged, asks the credential exactly once, and issues no request or claim.
- **Run-command poll schedule and the Retry-After cap.** The run-command poll loop now waits through an injectable sleeper on `AzureArmHttp` (production: `std::thread::sleep`; tests: recorded and skipped) instead of a `cfg!(test)` skip, so the schedule is asserted rather than bypassed. `tests/transport/run_command_schedule.rs` pins the backoff table, that `Retry-After` only lengthens a step (`0` and malformed or HTTP-date values fall back to the table), the 60 s cap on one wait (`3600` waits 60 s), no wait after a terminal or synchronous answer, and the whole table slept exactly once on the bounded path.
- **Disk retention across Stop, Check saved Stop, Start in the fake plane.** `stop_observer.rs` runs the full cycle on one instance: the disk stays attached through deallocation, the observer confirms RetainedStopped exactly then, the started worker returns on the same instance with the same disk, and a rebuilt instance without the retained disk is never confirmed. The observation issues no mutation at any point.

Validation: fmt, maintainability, version sync, both harness test suites, `cargo test --workspace` (default and `speech`), and the blocking, strict and pedantic clippy tiers, all run locally on the pushed head.
