### PR TITLE
test(azure): check the saved Stop live at every station

### DIFF
--- a/crates/horizon-core/tests/azure_live_worker.rs
+++ b/crates/horizon-core/tests/azure_live_worker.rs
@@ -47,7 +47,10 @@ use horizon_core::cloud_run::{
         InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus,
     },
     interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
-    interactive_worker_stop::{InteractiveWorkerStop, InteractiveWorkerStopProvider},
+    interactive_worker_stop::{
+        InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation,
+        InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
+    },
 };
 use std::{
     path::Path,
@@ -849,6 +852,40 @@ impl Live {
         );
     }
 
+    /// `Check saved Stop` against the live control plane: the read-only observation of
+    /// the exact saved worker and pin answers as expected, and a pin whose address is
+    /// not this worker's is an identity error rather than any observation.
+    fn check_saved_stop(
+        &self,
+        persisted: &InteractiveWorker,
+        endpoint: &InteractiveWorkerSshEndpoint,
+        expected: InteractiveWorkerStopObservation,
+        when: &str,
+    ) {
+        let observe = |ssh: &InteractiveWorkerSshEndpoint| {
+            self.client.observe_worker_stop(InteractiveWorkerStopExpectation {
+                worker: persisted,
+                ssh,
+                network_volume: None,
+            })
+        };
+        let observed = observe(endpoint).expect("observe saved stop");
+        assert_eq!(observed, expected, "check saved stop {when}");
+        if expected == InteractiveWorkerStopObservation::RetainedStopped {
+            // TEST-NET-3 is never an Azure public address: a saved pin that names
+            // another host must be refused as this worker's identity, not observed.
+            let moved = InteractiveWorkerSshEndpoint {
+                host: "203.0.113.1".into(),
+                ..endpoint.clone()
+            };
+            assert_eq!(observe(&moved), Err(AzureError::ResourceIdentityMismatch));
+        }
+        self.run.event(
+            "saved_stop_checked",
+            &format!("{when}: {observed:?} from the persisted handle and the saved pin"),
+        );
+    }
+
     /// Delete exactly the owned group and prove it is gone.
     fn delete(&self, persisted: &InteractiveWorker) {
         let started = Instant::now();
@@ -899,9 +936,33 @@ fn live_worker_create_ready_stop_delete() {
     let live = setup();
     let persisted = live.create();
     let endpoint = live.ready_and_prove_ssh(&persisted);
+    live.check_saved_stop(
+        &persisted,
+        &endpoint,
+        InteractiveWorkerStopObservation::Pending,
+        "while running",
+    );
     live.stop(&persisted);
+    live.check_saved_stop(
+        &persisted,
+        &endpoint,
+        InteractiveWorkerStopObservation::RetainedStopped,
+        "after the stop",
+    );
     live.start_and_reattach(&persisted, &endpoint);
+    live.check_saved_stop(
+        &persisted,
+        &endpoint,
+        InteractiveWorkerStopObservation::Pending,
+        "after the start",
+    );
     live.stop(&persisted);
+    live.check_saved_stop(
+        &persisted,
+        &endpoint,
+        InteractiveWorkerStopObservation::RetainedStopped,
+        "after the second stop",
+    );
     if keep() {
         live.cleanup.borrow_mut().armed = false;
         live.run
@@ -909,8 +970,14 @@ fn live_worker_create_ready_stop_delete() {
         return;
     }
     live.delete(&persisted);
+    live.check_saved_stop(
+        &persisted,
+        &endpoint,
+        InteractiveWorkerStopObservation::Absent,
+        "after the delete",
+    );
     live.run.event(
         "done",
-        "create, ready, pinned ssh, stop, start, pinned reattach with retained data, stop, delete all proven",
+        "create, ready, pinned ssh, check saved stop, stop, start, pinned reattach with retained data, stop, delete all proven",
     );
 }

--- a/docs/testing/azure-workspace-live-acceptance.md
+++ b/docs/testing/azure-workspace-live-acceptance.md
@@ -40,6 +40,12 @@ the same file run in every matrix without Azure.
 6. **Explicit Stop** deallocates and verifies `PowerState/deallocated` within its
    deadline; inspect, a repeated Stop and `ensure_worker` all report the retained
    stop without creating.
+   **Check saved Stop** (`observe_worker_stop`, the read-only observation behind the
+   shared stop confirmation) is asked at every station with the persisted handle and
+   the attested pin: `Pending` while the worker runs and again after the start,
+   `RetainedStopped` after each stop (deallocated compute, the `worker-data` disk on
+   LUN 0 with `Detach`, the saved address) and `Absent` after the delete; at each
+   retained stop a pin naming another address is refused as an identity error.
 7. **Delete exactly the owned group**, then prove absence through the adapter
    (`inspect_worker` returns nothing) and through `az group exists` in the exercised
    subscription; a repeated delete is `AlreadyAbsent`. A failure anywhere between the
@@ -213,6 +219,35 @@ same identity (address and host key) and the retained data, is idempotent on a
 running worker, and never allocates. What it does not prove: anything about
 processes that were running before the stop, which do not survive a deallocation;
 and nothing here is the saved Shell task Start, which is a separate operation.
+
+## Check saved Stop (run 18, 2026-09-13)
+
+With the Azure `InteractiveWorkerStopObserver` (the read-only observation behind the
+shared "Check saved Stop" confirmation) the driver asks `observe_worker_stop` with the
+persisted handle and the attested pin at every station of the sequence above, and at
+each retained stop also with a pin naming another address. Run 18 passed end to end,
+same fixture and settings as above:
+
+| Step | Seconds after the driver started | Observation |
+| --- | --- | --- |
+| ready with attested host key, pinned SSH | 213.9, 214.7 | |
+| check while running | 233.1 | `Pending`; nothing mutated |
+| stop verified | 249.7 | 17 s |
+| check after the stop | 251.7 | `RetainedStopped`; a pin with another address refused as an identity error |
+| `start_worker` returned `Started`, `Ready` again | 330.9, 348.8 | 79 s and 97 s after the call, same endpoint and host key |
+| check after the start | 367.4 | `Pending` |
+| second stop verified | 383.8 | 16 s |
+| check after the second stop | 385.7 | `RetainedStopped`; moved-address pin refused |
+| deleted and gone | 631.7 | 246 s |
+| check after the delete | 632.4 | `Absent` |
+
+What this proves: on the real control plane a deallocated worker carries exactly the
+retained-disk shape the observer requires (`worker-data` on LUN 0 with `Detach`, under
+the worker's own group) and the saved address, so a saved Stop is confirmed only
+there; running, starting and deleted workers are reported as pending or absent, never
+as a retained stop; and the observation issues no mutation at any station. What it
+does not prove: the shared confirmation path calling this observer for Azure, which
+is wired by the lead lane.
 
 ## What this run does not prove
 


### PR DESCRIPTION
Part of the Azure lane for #474 (live harness and runbook only; no shared paths).

The live acceptance driver (`crates/horizon-core/tests/azure_live_worker.rs`, ignored unless `HORIZON_AZURE_LIVE_*` is set) now exercises the Azure `InteractiveWorkerStopObserver` from #571 on the real control plane. At every station of the existing sequence it asks `observe_worker_stop` with the persisted handle and the attested pin: `Pending` while running and after the start, `RetainedStopped` after each stop, `Absent` after the delete. At each retained stop it also presents a pin naming another address (TEST-NET-3) and requires `ResourceIdentityMismatch`.

Run 18 (2026-09-13) passed end to end with the driver as committed here and is recorded in `docs/testing/azure-workspace-live-acceptance.md`: readiness 213.9 s, first Stop 17 s, `RetainedStopped` confirmed 2 s after the stop, start 79 s, second Stop 16 s, group gone in 246 s, `Absent` afterwards. The observer issued no mutation at any station.

What this proves and does not prove is stated in the runbook; the shared confirmation path calling this observer for Azure remains lead-owned wiring.

Validation: fmt, maintainability, version sync, both harness test suites, `cargo test --workspace` (default and `speech`), and the blocking, strict and pedantic clippy tiers, all run locally on the pushed head; the driver's five deterministic tests run in the ordinary matrix.
