### PR TITLE
feat(remote): start a stopped worker's retained compute durably

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/recovery.rs
@@ -32,6 +32,7 @@ impl StoredRemoteAllocation {
         let runtime = self.workspace.state().runtime.as_ref().ok_or(Error::UnboundRuntime)?;
         if runtime.cleanup.is_some()
             || runtime.phase.stop_requested_at_millis().is_some()
+            || runtime.phase.start_requested_at_millis().is_some()
             || matches!(
                 runtime.phase,
                 RemoteRuntimePhase::Cancelling | RemoteRuntimePhase::Deleting

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/stop.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/stop.rs
@@ -1,7 +1,9 @@
-//! Exact-snapshot Stop-intent transitions; provider operations remain outside storage.
+//! Exact-snapshot Stop and Start intent transitions; provider operations remain outside storage.
 
 use super::{CloudWorkflowStore, RemoteRuntimePhase, StoredRemoteAllocation, WorkspaceReplacement, binding};
-use crate::remote_workspace::stop::RemoteWorkspaceStopError as Error;
+use crate::remote_workspace::{
+    start::RemoteWorkspaceStartError as StartError, stop::RemoteWorkspaceStopError as Error,
+};
 use rusqlite::TransactionBehavior;
 
 impl CloudWorkflowStore {
@@ -26,6 +28,56 @@ impl CloudWorkflowStore {
         let runtime = next.runtime.as_mut().ok_or(Error::MissingAllocation)?;
         if runtime.cleanup.is_some() || runtime.worker.is_none() {
             return Err(Error::ManagementConflict);
+        }
+        runtime.phase = phase;
+        if next == *current.workspace.state() {
+            return Ok(current);
+        }
+        let workspace = WorkspaceReplacement::new(&current.workspace, &next)?.persist(&transaction)?;
+        transaction.commit()?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: current.workflow,
+        })
+    }
+
+    /// Record explicit Start intent over a saved Stopped record, keep it across a retry,
+    /// or resolve it into a renewed observation (`Reconciling`) once the same worker was
+    /// observed again. Every write is a CAS against the exact allocation snapshot; the
+    /// retained worker and pin are never changed here.
+    pub(crate) fn record_remote_start_phase(
+        &self,
+        expected: &StoredRemoteAllocation,
+        phase: RemoteRuntimePhase,
+    ) -> Result<StoredRemoteAllocation, StartError> {
+        if phase.start_requested_at_millis().is_none() && phase != RemoteRuntimePhase::Reconciling {
+            return Err(StartError::ManagementConflict);
+        }
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        super::super::database::ensure_current_schema(&transaction)?;
+        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)?
+            .ok_or(StartError::MissingAllocation)?;
+        let current = binding::recover(&transaction, &row)?;
+        if current != *expected {
+            return Err(StartError::StateChanged);
+        }
+        let mut next = current.workspace.state().clone();
+        let runtime = next.runtime.as_mut().ok_or(StartError::MissingAllocation)?;
+        if runtime.cleanup.is_some() || runtime.worker.is_none() || runtime.ssh.is_none() {
+            return Err(StartError::ManagementConflict);
+        }
+        let permitted = match (runtime.phase, phase) {
+            (
+                RemoteRuntimePhase::Stopped { observed_at_millis, .. },
+                RemoteRuntimePhase::Starting { requested_at_millis },
+            ) => requested_at_millis >= observed_at_millis,
+            (RemoteRuntimePhase::Starting { .. }, RemoteRuntimePhase::Starting { .. }) => runtime.phase == phase,
+            (RemoteRuntimePhase::Starting { .. }, RemoteRuntimePhase::Reconciling) => true,
+            _ => false,
+        };
+        if !permitted {
+            return Err(StartError::NotStopped);
         }
         runtime.phase = phase;
         if next == *current.workspace.state() {

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -154,11 +154,19 @@ impl CloudWorkflowStore {
         next: &RemoteWorkspaceState,
     ) -> Result<StoredRemoteWorkspace, RemoteWorkspaceStoreError> {
         let replacement = WorkspaceReplacement::new(expected, next)?;
-        if next.runtime.as_ref().is_some_and(|runtime| {
-            matches!(runtime.phase, RemoteRuntimePhase::Stopped { .. })
-                && expected.state.runtime.as_ref().map(|previous| previous.phase) != Some(runtime.phase)
-        }) {
+        let previous_phase = expected.state.runtime.as_ref().map(|previous| previous.phase);
+        let next_phase = next.runtime.as_ref().map(|runtime| runtime.phase);
+        if next_phase
+            .is_some_and(|phase| matches!(phase, RemoteRuntimePhase::Stopped { .. }) && previous_phase != Some(phase))
+        {
             return Err(RemoteWorkspaceStoreError::RuntimeStopConfirmationRequired);
+        }
+        // Start intent is introduced and resolved only by the verified Start coordinator.
+        if next_phase.is_some_and(|phase| phase.start_requested_at_millis().is_some() && previous_phase != Some(phase))
+            || previous_phase
+                .is_some_and(|phase| phase.start_requested_at_millis().is_some() && next_phase != Some(phase))
+        {
+            return Err(RemoteWorkspaceStoreError::RuntimeStartCoordinationRequired);
         }
         if expected.state.runtime.is_none() && next.runtime.is_some() {
             return Err(RemoteWorkspaceStoreError::RuntimeAllocationRequired);
@@ -475,6 +483,8 @@ pub enum RemoteWorkspaceStoreError {
     RuntimeRecoveryUnavailable,
     #[error("remote Stop completion requires the verified coordinator")]
     RuntimeStopConfirmationRequired,
+    #[error("remote Start intent is recorded and resolved only by the verified Start coordinator")]
+    RuntimeStartCoordinationRequired,
     #[error("remote worker observation does not match the saved request or pinned identity")]
     InvalidWorkerObservation,
     #[error("remote allocation setup cannot create; non-creating recovery is required")]

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -48,11 +48,24 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
     {
         return Err(Error::NonMonotonicReplacement);
     }
+    // Stop intent is never erased, retargeted or rewound; a saved Stopped record changes
+    // only into explicit Start intent requested no earlier than its observation.
     if let Some(runtime) = &previous.runtime
         && let Some(requested_at_millis) = runtime.phase.stop_requested_at_millis()
         && next.runtime.as_ref().is_none_or(|next_runtime| {
-            next_runtime.phase.stop_requested_at_millis() != Some(requested_at_millis)
-                || (matches!(runtime.phase, RemoteRuntimePhase::Stopped { .. }) && next_runtime.phase != runtime.phase)
+            !starts_after_stop(runtime.phase, next_runtime.phase)
+                && (next_runtime.phase.stop_requested_at_millis() != Some(requested_at_millis)
+                    || (matches!(runtime.phase, RemoteRuntimePhase::Stopped { .. })
+                        && next_runtime.phase != runtime.phase))
+        })
+    {
+        return Err(Error::NonMonotonicReplacement);
+    }
+    // Start intent resolves only into the same intent or a renewed observation.
+    if let Some(runtime) = &previous.runtime
+        && runtime.phase.start_requested_at_millis().is_some()
+        && next.runtime.as_ref().is_none_or(|next_runtime| {
+            next_runtime.phase != runtime.phase && next_runtime.phase != RemoteRuntimePhase::Reconciling
         })
     {
         return Err(Error::NonMonotonicReplacement);
@@ -85,4 +98,16 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
         return Err(Error::NonMonotonicReplacement);
     }
     Ok(())
+}
+
+/// A saved Stopped record may take explicit Start intent requested at or after the
+/// retention observation; no other phase follows a saved Stop.
+fn starts_after_stop(previous: RemoteRuntimePhase, next: RemoteRuntimePhase) -> bool {
+    matches!(
+        (previous, next),
+        (
+            RemoteRuntimePhase::Stopped { observed_at_millis, .. },
+            RemoteRuntimePhase::Starting { requested_at_millis },
+        ) if requested_at_millis >= observed_at_millis
+    )
 }

--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -2,6 +2,7 @@
 //! The data model is independent of provider, persistence I/O, and UI implementations.
 //! Snapshot validation is not permission to attach: fresh provider observation and lease checks remain required.
 
+pub mod start;
 pub mod stop;
 mod summary;
 #[cfg(test)]
@@ -176,6 +177,12 @@ pub enum RemoteRuntimePhase {
         requested_at_millis: i64,
         observed_at_millis: i64,
     },
+    /// Explicit Start intent for a stopped worker's retained compute, never inferred
+    /// from reconnecting, reopening a view or restarting the application. It resolves
+    /// to `Reconciling` once the same worker was observed again; nothing resumes a task.
+    Starting {
+        requested_at_millis: i64,
+    },
 }
 
 impl RemoteRuntimePhase {
@@ -185,6 +192,13 @@ impl RemoteRuntimePhase {
             | Self::Stopped {
                 requested_at_millis, ..
             } => Some(requested_at_millis),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn start_requested_at_millis(self) -> Option<i64> {
+        match self {
+            Self::Starting { requested_at_millis } => Some(requested_at_millis),
             _ => None,
         }
     }

--- a/crates/horizon-core/src/remote_workspace/start.rs
+++ b/crates/horizon-core/src/remote_workspace/start.rs
@@ -1,0 +1,164 @@
+//! Explicit, durable Start of a stopped worker's retained compute. Reconnecting,
+//! reopening a view or restarting the application never invokes this operation.
+
+use crate::{
+    cloud_run::{
+        CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, WorkerLifetime,
+        interactive_worker::InteractiveWorkerLifecycle,
+        interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
+    },
+    remote_workspace::RemoteRuntimePhase,
+};
+
+/// The record after a verified start: the same worker under the same saved identity,
+/// now `Reconciling`. Reconnecting session panels re-establishes readiness; nothing
+/// here resumed a task, and in-memory work did not survive the stop.
+#[derive(Debug, Eq, PartialEq)]
+pub struct RemoteWorkspaceStart {
+    pub allocation: StoredRemoteAllocation,
+    /// The provider's lifecycle after the start (`Ready` only with an attested endpoint).
+    pub lifecycle: InteractiveWorkerLifecycle,
+    /// The exact worker was already running; nothing was started or re-posted.
+    pub already_running: bool,
+}
+
+/// Record explicit Start intent over a saved Stopped record, start only the retained
+/// worker's compute, then record the renewed observation. Requires the exact current
+/// allocation snapshot with a retained persistent worker and a complete saved pin.
+/// The provider must never allocate or replace an absent worker; the observed worker and
+/// any observed endpoint must equal the saved ones, so a replacement pin is never adopted.
+/// Provider failure, absence and identity drift retain the intent and identity for an
+/// explicit retry, which reuses the original request time and re-posts nothing that is
+/// already running. Stop and recovery refuse a record with Start intent until it resolves.
+/// Run off the render thread, only after explicit confirmation.
+/// # Errors
+/// Rejects stale ownership, records without a saved Stop, missing worker or pin,
+/// provider mismatch, competing management intent, unverified starts, absence, identity
+/// drift, unsafe clocks and storage failures. Errors redact provider payloads.
+pub fn start_remote_workspace<P: InteractiveWorkerStartProvider + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<RemoteWorkspaceStart, RemoteWorkspaceStartError> {
+    use RemoteWorkspaceStartError as Error;
+    let allocation = store
+        .load_remote_allocation(
+            expected.workspace().session_id(),
+            &expected.workspace().state().spec.workspace_local_id,
+        )?
+        .ok_or(Error::MissingAllocation)?;
+    if allocation != *expected {
+        return Err(Error::StateChanged);
+    }
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?;
+    let worker = runtime.worker.as_ref().ok_or(Error::MissingWorker)?;
+    if !worker.is_valid_for(provider.provider()) {
+        return Err(Error::ProviderMismatch);
+    }
+    if worker.target.lifetime != WorkerLifetime::Persistent {
+        return Err(Error::UnsupportedLifetime);
+    }
+    if runtime.cleanup.is_some() {
+        return Err(Error::ManagementConflict);
+    }
+    let ssh = runtime
+        .ssh
+        .as_ref()
+        .filter(|ssh| ssh.is_complete())
+        .ok_or(Error::MissingTrust)?;
+    let now_millis = current_millis()?;
+    let requested_at_millis = match runtime.phase {
+        RemoteRuntimePhase::Stopped { .. } => now_millis,
+        RemoteRuntimePhase::Starting { requested_at_millis } => requested_at_millis,
+        _ => return Err(Error::NotStopped),
+    };
+    if requested_at_millis > now_millis {
+        return Err(Error::InvalidTimestamp);
+    }
+    let starting =
+        store.record_remote_start_phase(&allocation, RemoteRuntimePhase::Starting { requested_at_millis })?;
+    let (status, already_running) = match provider.start_worker(worker).map_err(|_| Error::ProviderUnavailable)? {
+        InteractiveWorkerStart::AlreadyAbsent => return Err(Error::ResourceAbsent),
+        InteractiveWorkerStart::Started(status) => (status, false),
+        InteractiveWorkerStart::AlreadyRunning(status) => (status, true),
+    };
+    // Only the exact saved worker under its saved trust counts as started: another
+    // identity, or an endpoint that differs from the saved pin, is never adopted.
+    if status.worker != *worker || status.ssh.as_ref().is_some_and(|observed| observed != ssh) {
+        return Err(Error::IdentityMismatch);
+    }
+    let allocation = store.record_remote_start_phase(&starting, RemoteRuntimePhase::Reconciling)?;
+    Ok(RemoteWorkspaceStart {
+        allocation,
+        lifecycle: status.lifecycle,
+        already_running,
+    })
+}
+
+fn current_millis() -> Result<i64, RemoteWorkspaceStartError> {
+    i64::try_from(time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000)
+        .ok()
+        .filter(|millis| *millis >= 0)
+        .ok_or(RemoteWorkspaceStartError::InvalidTimestamp)
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteWorkspaceStartError {
+    #[error("no current owned allocation is available to start")]
+    MissingAllocation,
+    #[error("saved environment has no exact retained worker to start")]
+    MissingWorker,
+    #[error("Start requires an already retained complete SSH pin")]
+    MissingTrust,
+    #[error("only a saved Stopped environment, or one with Start intent, can be started")]
+    NotStopped,
+    #[error("saved environment changed; refresh before explicitly retrying Start")]
+    StateChanged,
+    #[error("Start provider does not match the saved worker")]
+    ProviderMismatch,
+    #[error("explicit Start requires a persistent execution policy")]
+    UnsupportedLifetime,
+    #[error("existing management intent does not permit this Start request")]
+    ManagementConflict,
+    #[error("worker Start could not be verified; saved intent and identity remain retained")]
+    ProviderUnavailable,
+    #[error("worker is absent; nothing was allocated or replaced, and saved intent remains")]
+    ResourceAbsent,
+    #[error("the started worker or its endpoint does not match the saved identity; saved intent remains")]
+    IdentityMismatch,
+    #[error("Start timestamp could not be safely recorded")]
+    InvalidTimestamp,
+    #[error("owned remote Start state could not be safely accessed")]
+    StorageUnavailable,
+}
+
+impl From<RemoteWorkspaceStoreError> for RemoteWorkspaceStartError {
+    fn from(error: RemoteWorkspaceStoreError) -> Self {
+        match error {
+            RemoteWorkspaceStoreError::RevisionConflict { .. } | RemoteWorkspaceStoreError::SnapshotConflict => {
+                Self::StateChanged
+            }
+            _ => Self::StorageUnavailable,
+        }
+    }
+}
+
+impl From<CloudStoreError> for RemoteWorkspaceStartError {
+    fn from(_: CloudStoreError) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+impl From<rusqlite::Error> for RemoteWorkspaceStartError {
+    fn from(_: rusqlite::Error) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace/start/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/start/tests.rs
@@ -1,0 +1,550 @@
+use super::*;
+use crate::{
+    cloud_run::{
+        CloudProvider,
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+            InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest,
+            InteractiveWorkerSshEndpoint, InteractiveWorkerStatus,
+        },
+        interactive_worker_stop::{
+            InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation,
+            InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
+        },
+    },
+    remote_workspace::{
+        RemoteCleanupIntent, RemoteCleanupReason, RemoteWorkspaceState,
+        stop::{RemoteWorkspaceStopError, confirm_remote_workspace_stop, stop_remote_workspace},
+    },
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::Mutex;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+type Error = RemoteWorkspaceStartError;
+
+fn key(byte: u8) -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
+fn pin() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: "203.0.113.9".into(),
+        port: 2222,
+        username: "root".into(),
+        host_key: key(9),
+    }
+}
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+}
+
+impl Fixture {
+    /// A retained persistent worker with an optional complete pin, driven to a saved
+    /// Stopped record through the real Stop coordinator.
+    fn stopped(pinned: bool) -> Self {
+        let fixture = Self::retained(pinned);
+        stop_remote_workspace(&fixture.store, &Provider::stopping(), fixture.current().workspace()).expect("stopped");
+        assert!(matches!(fixture.phase(), RemoteRuntimePhase::Stopped { .. }));
+        fixture
+    }
+
+    fn retained(pinned: bool) -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/workflows.sqlite3")).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1, "spec":{
+                "workspace_local_id":"workspace", "working_directory":".", "generation":0, "panels":[],
+                "target":{"provider":"local_docker", "profile":"development", "disk_gib":20,
+                    "lifetime":"persistent", "image":format!("example/worker@sha256:{}", "a".repeat(64))},
+                "repository":{"repository":"example/project", "commit":"b".repeat(40)}
+            }
+        }))
+        .expect("state");
+        let saved = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&saved, i64::MAX).expect("allocation");
+        let reserved = store
+            .reserve_remote_worker_request(&allocation, &key(7))
+            .expect("public request");
+        let request = reserved.worker_request().expect("request");
+        let status = InteractiveWorkerStatus {
+            worker: worker_for(&request),
+            lifecycle: if pinned {
+                InteractiveWorkerLifecycle::Ready
+            } else {
+                InteractiveWorkerLifecycle::Provisioning
+            },
+            ssh: pinned.then(pin),
+        };
+        store
+            .record_remote_worker_recovery(&reserved, Some(&status))
+            .expect("retained public observation");
+        Self { directory, store }
+    }
+
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn phase(&self) -> RemoteRuntimePhase {
+        self.current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase
+    }
+
+    fn start(&self, provider: &Provider) -> Result<RemoteWorkspaceStart, Error> {
+        start_remote_workspace(&self.store, provider, &self.current())
+    }
+}
+
+fn worker_for(request: &InteractiveWorkerRequest) -> InteractiveWorker {
+    InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: CloudProvider::LocalDocker,
+            workflow_id: request.workflow_id,
+            job_id: request.job_id,
+            resource_id: "a".repeat(64),
+        },
+        target: request.target.clone(),
+        ssh_public_key: request.ssh_public_key.clone(),
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    }
+}
+
+type StartHook = Box<dyn Fn(&InteractiveWorker) + Send + Sync>;
+type StartScript = Box<dyn Fn(&InteractiveWorker) -> Result<InteractiveWorkerStart, &'static str> + Send + Sync>;
+
+/// Answers a start with a scripted result built from the worker it was asked about.
+struct Provider {
+    kind: CloudProvider,
+    start: Option<StartScript>,
+    stop: Result<InteractiveWorkerStop, &'static str>,
+    calls: Mutex<[usize; 2]>,
+    on_start: Option<StartHook>,
+}
+
+impl Provider {
+    fn stopping() -> Self {
+        Self {
+            kind: CloudProvider::LocalDocker,
+            start: None,
+            stop: Ok(InteractiveWorkerStop::Stopped),
+            calls: Mutex::new([0; 2]),
+            on_start: None,
+        }
+    }
+
+    fn starting(
+        start: impl Fn(&InteractiveWorker) -> Result<InteractiveWorkerStart, &'static str> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            kind: CloudProvider::LocalDocker,
+            start: Some(Box::new(start)),
+            stop: Err("no stop"),
+            calls: Mutex::new([0; 2]),
+            on_start: None,
+        }
+    }
+
+    fn started(
+        worker: &InteractiveWorker,
+        lifecycle: InteractiveWorkerLifecycle,
+        ssh: Option<InteractiveWorkerSshEndpoint>,
+    ) -> InteractiveWorkerStart {
+        InteractiveWorkerStart::Started(InteractiveWorkerStatus {
+            worker: worker.clone(),
+            lifecycle,
+            ssh,
+        })
+    }
+
+    fn counts(&self) -> [usize; 2] {
+        *self.calls.lock().expect("counts")
+    }
+}
+
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no creation")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no generic inspection")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no setup recovery")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no deletion")
+    }
+}
+
+impl InteractiveWorkerStopProvider for Provider {
+    fn stop_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerStop, Self::Error> {
+        self.calls.lock().expect("calls")[1] += 1;
+        self.stop.map_err(std::io::Error::other)
+    }
+}
+
+impl InteractiveWorkerStopObserver for Provider {
+    fn observe_worker_stop(
+        &self,
+        _: InteractiveWorkerStopExpectation<'_>,
+    ) -> Result<InteractiveWorkerStopObservation, Self::Error> {
+        panic!("no observation reaches a record without Stop intent")
+    }
+}
+
+impl InteractiveWorkerStartProvider for Provider {
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+        self.calls.lock().expect("calls")[0] += 1;
+        if let Some(hook) = &self.on_start {
+            hook(worker);
+        }
+        let start = self.start.as_ref().expect("a start was scripted");
+        start(worker).map_err(std::io::Error::other)
+    }
+}
+
+#[test]
+fn start_records_intent_before_dispatch_then_reconciling_with_the_same_identity() {
+    for (already_running, lifecycle) in [
+        (false, InteractiveWorkerLifecycle::Ready),
+        (false, InteractiveWorkerLifecycle::Provisioning),
+        (true, InteractiveWorkerLifecycle::Ready),
+    ] {
+        let fixture = Fixture::stopped(true);
+        let before = fixture.current();
+        let store = fixture.store.clone();
+        let mut provider = Provider::starting(move |worker| {
+            let status = InteractiveWorkerStatus {
+                worker: worker.clone(),
+                lifecycle,
+                ssh: (lifecycle == InteractiveWorkerLifecycle::Ready).then(pin),
+            };
+            Ok(if already_running {
+                InteractiveWorkerStart::AlreadyRunning(status)
+            } else {
+                InteractiveWorkerStart::Started(status)
+            })
+        });
+        provider.on_start = Some(Box::new(move |worker| {
+            let current = store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("read")
+                .expect("allocation");
+            let runtime = current.workspace().state().runtime.as_ref().expect("runtime");
+            assert!(
+                matches!(runtime.phase, RemoteRuntimePhase::Starting { .. }),
+                "intent is durable before the provider is asked"
+            );
+            assert_eq!(runtime.worker.as_ref(), Some(worker));
+        }));
+        let started = fixture.start(&provider).expect("verified start");
+        let after = fixture.current();
+        assert_eq!(started.allocation, after);
+        assert_eq!(
+            (started.lifecycle, started.already_running),
+            (lifecycle, already_running)
+        );
+        assert_eq!(fixture.phase(), RemoteRuntimePhase::Reconciling);
+        let mut permitted = before.workspace().state().clone();
+        permitted.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Reconciling;
+        assert_eq!(after.workspace().state(), &permitted, "only the phase changed");
+        assert_eq!(after.workflow(), before.workflow());
+        assert_eq!(after.workspace().revision(), before.workspace().revision() + 2);
+        assert_eq!(provider.counts(), [1, 0]);
+        // A record without a saved Stop is never started again.
+        assert_eq!(fixture.start(&provider), Err(Error::NotStopped));
+        assert_eq!(fixture.current(), after);
+        assert_eq!(provider.counts(), [1, 0]);
+    }
+}
+
+#[test]
+fn uncertainty_absence_and_foreign_observations_retain_start_intent_for_an_explicit_retry() {
+    let moved_pin = || InteractiveWorkerSshEndpoint {
+        host: "203.0.113.10".into(),
+        ..pin()
+    };
+    let rekeyed_pin = || InteractiveWorkerSshEndpoint {
+        host_key: key(11),
+        ..pin()
+    };
+    let outcomes: [(&str, Provider, Error); 5] = [
+        (
+            "provider failure",
+            Provider::starting(|_| Err("private-provider-marker")),
+            Error::ProviderUnavailable,
+        ),
+        (
+            "absence",
+            Provider::starting(|_| Ok(InteractiveWorkerStart::AlreadyAbsent)),
+            Error::ResourceAbsent,
+        ),
+        (
+            "another worker",
+            Provider::starting(|worker| {
+                let mut other = worker.clone();
+                other.identity.resource_id = "b".repeat(64);
+                Ok(Provider::started(
+                    &other,
+                    InteractiveWorkerLifecycle::Ready,
+                    Some(pin()),
+                ))
+            }),
+            Error::IdentityMismatch,
+        ),
+        (
+            "moved address",
+            Provider::starting(move |worker| {
+                Ok(Provider::started(
+                    worker,
+                    InteractiveWorkerLifecycle::Ready,
+                    Some(moved_pin()),
+                ))
+            }),
+            Error::IdentityMismatch,
+        ),
+        (
+            "replacement host key",
+            Provider::starting(move |worker| {
+                Ok(Provider::started(
+                    worker,
+                    InteractiveWorkerLifecycle::Ready,
+                    Some(rekeyed_pin()),
+                ))
+            }),
+            Error::IdentityMismatch,
+        ),
+    ];
+    for (label, provider, expected) in outcomes {
+        let fixture = Fixture::stopped(true);
+        let before = fixture.current();
+        let error = fixture.start(&provider).expect_err(label);
+        assert_eq!(error, expected, "{label}");
+        assert!(!format!("{error:?} {error}").contains("private-provider-marker"));
+        let retained = fixture.current();
+        let RemoteRuntimePhase::Starting { requested_at_millis } = fixture.phase() else {
+            panic!("{label}: intent is retained: {:?}", fixture.phase());
+        };
+        let mut permitted = before.workspace().state().clone();
+        permitted.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Starting { requested_at_millis };
+        assert_eq!(
+            retained.workspace().state(),
+            &permitted,
+            "{label}: identity and pin unchanged"
+        );
+        assert_eq!(retained.workspace().revision(), before.workspace().revision() + 1);
+        assert_eq!(provider.counts(), [1, 0]);
+        // An explicit retry from a fresh client reuses the original request and posts
+        // nothing that already runs.
+        let reopened =
+            CloudWorkflowStore::open_existing_without_migration_path(fixture.store.path()).expect("fresh client");
+        let retry = Provider::starting(|worker| {
+            Ok(InteractiveWorkerStart::AlreadyRunning(InteractiveWorkerStatus {
+                worker: worker.clone(),
+                lifecycle: InteractiveWorkerLifecycle::Ready,
+                ssh: Some(pin()),
+            }))
+        });
+        let started = start_remote_workspace(&reopened, &retry, &retained).expect("retry");
+        assert!(started.already_running);
+        assert_eq!(fixture.phase(), RemoteRuntimePhase::Reconciling);
+        assert_eq!(
+            started.allocation.workspace().revision(),
+            retained.workspace().revision() + 1
+        );
+        assert_eq!(
+            fixture.directory.path().read_dir().expect("fixture root").count(),
+            1,
+            "only the control store"
+        );
+    }
+}
+
+#[test]
+fn only_a_saved_stop_with_a_retained_pinned_worker_is_started_and_admission_precedes_dispatch() {
+    let never = || Provider::starting(|_| panic!("no provider work"));
+    // No saved Stop: a retained running record and a Stop still in flight.
+    let fixture = Fixture::retained(true);
+    assert_eq!(fixture.start(&never()), Err(Error::NotStopped));
+    let fixture = Fixture::retained(true);
+    let mut uncertain = Provider::stopping();
+    uncertain.stop = Err("uncertain");
+    assert_eq!(
+        stop_remote_workspace(&fixture.store, &uncertain, fixture.current().workspace()),
+        Err(RemoteWorkspaceStopError::ProviderUnavailable)
+    );
+    assert!(matches!(fixture.phase(), RemoteRuntimePhase::Stopping { .. }));
+    assert_eq!(fixture.start(&never()), Err(Error::NotStopped));
+    // No complete pin: the saved Stop exists, but there is no trust to compare against.
+    let fixture = Fixture::stopped(false);
+    assert_eq!(fixture.start(&never()), Err(Error::MissingTrust));
+    // Wrong provider, stale snapshot and a foreign owner.
+    let fixture = Fixture::stopped(true);
+    let before = fixture.current();
+    let mut foreign = never();
+    foreign.kind = CloudProvider::RunPod;
+    assert_eq!(fixture.start(&foreign), Err(Error::ProviderMismatch));
+    let mut workflow = before.workflow().workflow().clone();
+    workflow.updated_at_millis += 1;
+    fixture
+        .store
+        .replace(before.workflow(), &workflow)
+        .expect("workflow drift");
+    assert_eq!(
+        start_remote_workspace(&fixture.store, &never(), &before),
+        Err(Error::StateChanged)
+    );
+    assert!(
+        matches!(fixture.phase(), RemoteRuntimePhase::Stopped { .. }),
+        "no intent was recorded by any refusal"
+    );
+}
+
+#[test]
+fn generic_writes_stop_recovery_and_checks_cannot_touch_start_intent() {
+    let fixture = Fixture::stopped(true);
+    let stopped = fixture.current();
+    let observed_at = match fixture.phase() {
+        RemoteRuntimePhase::Stopped { observed_at_millis, .. } => observed_at_millis,
+        other => panic!("{other:?}"),
+    };
+    // A generic writer cannot introduce Start intent over a saved Stop.
+    let mut next = stopped.workspace().state().clone();
+    next.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Starting {
+        requested_at_millis: observed_at,
+    };
+    assert!(matches!(
+        fixture.store.replace_remote_workspace(stopped.workspace(), &next),
+        Err(RemoteWorkspaceStoreError::RuntimeStartCoordinationRequired)
+    ));
+    // Nor may the coordinator's writer rewind before the retention observation.
+    assert_eq!(
+        fixture
+            .store
+            .record_remote_start_phase(
+                &stopped,
+                RemoteRuntimePhase::Starting {
+                    requested_at_millis: observed_at - 1
+                }
+            )
+            .err(),
+        Some(Error::NotStopped)
+    );
+    assert_eq!(fixture.current(), stopped);
+    // With intent recorded, generic writes cannot erase, resolve or retarget it, Stop
+    // refuses, recovery refuses, and the saved-Stop check sees no Stop intent.
+    let _ = fixture.start(&Provider::starting(|_| Err("uncertain")));
+    let starting = fixture.current();
+    let RemoteRuntimePhase::Starting { requested_at_millis } = fixture.phase() else {
+        panic!("intent");
+    };
+    for replacement in [
+        None,
+        Some(RemoteRuntimePhase::Reconciling),
+        Some(RemoteRuntimePhase::Ready),
+        Some(RemoteRuntimePhase::Stopping {
+            requested_at_millis: requested_at_millis + 1,
+        }),
+        Some(RemoteRuntimePhase::Starting {
+            requested_at_millis: requested_at_millis + 1,
+        }),
+        Some(RemoteRuntimePhase::Stopped {
+            requested_at_millis,
+            observed_at_millis: requested_at_millis,
+        }),
+    ] {
+        let mut next = starting.workspace().state().clone();
+        if let Some(phase) = replacement {
+            next.runtime.as_mut().expect("runtime").phase = phase;
+        } else {
+            next.runtime = None;
+        }
+        assert!(
+            fixture
+                .store
+                .replace_remote_workspace(starting.workspace(), &next)
+                .is_err(),
+            "{replacement:?}"
+        );
+        assert_eq!(fixture.current(), starting);
+    }
+    assert_eq!(
+        stop_remote_workspace(&fixture.store, &Provider::stopping(), starting.workspace()),
+        Err(RemoteWorkspaceStopError::ManagementConflict)
+    );
+    assert_eq!(
+        confirm_remote_workspace_stop(&fixture.store, &Provider::stopping(), &starting),
+        Err(RemoteWorkspaceStopError::MissingStopIntent)
+    );
+    assert!(matches!(
+        fixture.store.record_remote_worker_recovery(&starting, None),
+        Err(RemoteWorkspaceStoreError::RuntimeRecoveryUnavailable)
+    ));
+    assert_eq!(fixture.current(), starting);
+    // Management intent cannot be added over Start intent either.
+    let mut next = starting.workspace().state().clone();
+    next.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 1,
+    });
+    assert!(
+        fixture
+            .store
+            .replace_remote_workspace(starting.workspace(), &next)
+            .is_err()
+    );
+    assert_eq!(fixture.current(), starting);
+}
+
+#[test]
+fn start_phase_serialization_round_trips_and_rejects_malformed_intent() {
+    let fixture = Fixture::stopped(true);
+    let mut state = fixture.current().workspace().state().clone();
+    state.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Starting { requested_at_millis: 1 };
+    let json = serde_json::to_value(&state).expect("encode");
+    assert_eq!(
+        json["runtime"]["phase"],
+        serde_json::json!({"starting":{"requested_at_millis":1}})
+    );
+    assert_eq!(
+        serde_json::from_value::<RemoteWorkspaceState>(json.clone()).expect("round trip"),
+        state
+    );
+    for phase in [
+        serde_json::json!({"starting":{"requested_at_millis":-1}}),
+        serde_json::json!({"starting":{}}),
+        serde_json::json!({"starting":{"requested_at_millis":1,"unexpected":"private-marker"}}),
+    ] {
+        let mut encoded = json.clone();
+        encoded["runtime"]["phase"] = phase;
+        assert!(serde_json::from_value::<RemoteWorkspaceState>(encoded).is_err());
+    }
+    state.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::Cancelled,
+        requested_at_millis: 1,
+    });
+    assert!(state.validate().is_err(), "Start intent excludes management intent");
+    state.runtime.as_mut().expect("runtime").cleanup = None;
+    state.runtime.as_mut().expect("runtime").ssh = None;
+    assert!(state.validate().is_err(), "Start intent requires the saved pin");
+    state.runtime.as_mut().expect("runtime").ssh = Some(pin());
+    state.runtime.as_mut().expect("runtime").worker = None;
+    assert!(state.validate().is_err(), "Start intent requires the retained worker");
+}

--- a/crates/horizon-core/src/remote_workspace/stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop.rs
@@ -68,7 +68,8 @@ fn stop_allocation<P: InteractiveWorkerStopProvider + ?Sized>(
     if worker.target.lifetime != WorkerLifetime::Persistent {
         return Err(Error::UnsupportedLifetime);
     }
-    if runtime.cleanup.is_some() {
+    // Pending management or Start intent is resolved first; Stop never races a start.
+    if runtime.cleanup.is_some() || runtime.phase.start_requested_at_millis().is_some() {
         return Err(Error::ManagementConflict);
     }
     let now_millis = current_millis()?;

--- a/crates/horizon-core/src/remote_workspace/validation.rs
+++ b/crates/horizon-core/src/remote_workspace/validation.rs
@@ -154,6 +154,7 @@ impl RemoteRuntimeGeneration {
                 return Err(Error::InvalidRuntime("worker identity"));
             }
         } else if self.phase.stop_requested_at_millis().is_some()
+            || self.phase.start_requested_at_millis().is_some()
             || matches!(
                 self.phase,
                 RemoteRuntimePhase::Materializing
@@ -196,6 +197,11 @@ impl RemoteRuntimeGeneration {
                     if observed_at_millis < requested_at_millis))
         {
             return Err(Error::InvalidRuntime("Stop intent"));
+        }
+        if let Some(requested_at_millis) = self.phase.start_requested_at_millis()
+            && (requested_at_millis < 0 || self.cleanup.is_some() || self.ssh.is_none())
+        {
+            return Err(Error::InvalidRuntime("Start intent"));
         }
         Ok(())
     }

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -327,5 +327,6 @@ fn phase_label(phase: Option<RemoteRuntimePhase>) -> &'static str {
         Some(RemoteRuntimePhase::Failed) => "Failed",
         Some(RemoteRuntimePhase::Stopping { .. }) => "Stop requested (saved)",
         Some(RemoteRuntimePhase::Stopped { .. }) => "Stopped (saved, not live)",
+        Some(RemoteRuntimePhase::Starting { .. }) => "Start requested (saved)",
     }
 }


### PR DESCRIPTION
Slice 3a of the Azure lifecycle integration for #474 (claim and addendum posted there before the first edit; slices 1 and 2 are 83150a1b and 56a43d58). This is the provider-neutral core of explicit Start; the Azure configured Start admission and the overview control follow as 3b.

## Behaviour

- **`Starting { requested_at_millis }` runtime phase.** Durable explicit Start intent for a stopped worker's retained compute, the counterpart of `Stopping`. Validation requires the retained worker and the saved pin and excludes management intent; serialization follows the existing tagged form. The overview labels it "Start requested (saved)" (the only UI change, required by the exhaustive label match).
- **Store transition.** `record_remote_start_phase` (beside the Stop-intent writer) is the only writer of Start intent: `Stopped -> Starting` only with a request time at or after the retention observation, `Starting -> Starting` idempotent, `Starting -> Reconciling` on a renewed observation, every step a CAS against the exact allocation. The generic replacement guard keeps refusing to erase, retarget or rewind Stop intent and now lets a saved Stopped record change only into that Start intent; Start intent resolves only into itself or `Reconciling`; `replace_remote_workspace` refuses to introduce or resolve Start intent (`RuntimeStartCoordinationRequired`). Recovery refuses a record with Start intent, exactly as it refuses Stop intent.
- **`start_remote_workspace`.** Requires the exact current allocation with a retained persistent worker for the provider and a complete saved pin; only a saved `Stopped` record or one already carrying Start intent is admitted. It records intent, calls the merged compute-start capability once, and accepts only the exact saved worker: the observed worker must equal the saved one and any observed endpoint must equal the saved pin, so a replacement pin is never adopted. Then it records `Reconciling`; the existing reconnect path re-establishes readiness and nothing is labelled resumed. Provider failure, absence and identity drift retain the intent and identity; an explicit retry reuses the original request time and, per the capability's contract, re-posts nothing that already runs. `stop_allocation` refuses a record with Start intent, so Stop never races a start.

## Tests (`remote_workspace/start/tests.rs`, real stores, fake provider)

Intent is durable before the provider is asked, then `Reconciling` with only the phase changed and revision +2, for a started worker with and without an attested endpoint and for an already-running one; a record without a saved Stop is never started. Provider failure, absence, another worker, a moved address and a replacement host key each retain the intent and identity, and a retry from a fresh client resolves it without re-posting. Admission refuses a running record, a Stop still in flight, a missing pin, a foreign provider and a stale snapshot, all before dispatch and without recording intent. Generic writes cannot introduce Start intent over a saved Stop, the coordinator's writer cannot rewind before the retention observation, and with intent recorded generic writes cannot erase, resolve or retarget it, management intent cannot be added, Stop refuses, recovery refuses, and the saved-Stop check sees no Stop intent. Serialization round-trips and rejects malformed intent.

## Validation

fmt, maintainability, version sync, both harness suites, `cargo test --workspace` (default and `speech`), blocking, strict and pedantic clippy, all on the pushed head. No UI control changed, so no UI smoke lane applies to this slice; the label arm is covered by the existing overview tests.
