### PR TITLE
feat(remote): start an existing retained worker

### DIFF
--- a/crates/horizon-core/src/cloud_run/runpod.rs
+++ b/crates/horizon-core/src/cloud_run/runpod.rs
@@ -16,6 +16,7 @@ mod interactive;
 mod models;
 mod network_attachment;
 mod network_volume;
+mod start;
 mod stop;
 #[cfg(test)]
 mod tests;
@@ -426,6 +427,9 @@ trait Transport: Send + Sync {
     fn create(&self, request: &CreatePodRequest) -> Result<ApiPod, RunPodError>;
     fn get(&self, pod_id: &str) -> Result<Option<ApiPod>, RunPodError>;
     fn stop(&self, pod_id: &str) -> Result<(), RunPodError>;
+    fn start(&self, _pod_id: &str) -> Result<(), RunPodError> {
+        Err(RunPodError::StartUnverified)
+    }
     fn delete(&self, pod_id: &str) -> Result<RunPodCleanup, RunPodError>;
 }
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/crates/horizon-core/src/cloud_run/runpod/diagnostics.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/diagnostics.rs
@@ -84,7 +84,9 @@ fn classify(mut error: &RunPodError) -> Diagnostic {
         | RunPodError::StopRetentionUnverified
         | RunPodError::StopStateUnverified
         | RunPodError::StopResourceLost
-        | RunPodError::StopVerificationFailed => "unknown",
+        | RunPodError::StopVerificationFailed
+        | RunPodError::StartIdentityRequired
+        | RunPodError::StartUnverified => "unknown",
     };
     if let RunPodError::RequestFailed { operation }
     | RunPodError::UnexpectedStatus { operation, .. }

--- a/crates/horizon-core/src/cloud_run/runpod/host_key.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/host_key.rs
@@ -104,6 +104,20 @@ impl RunPodHostTrust {
 }
 
 impl RunPodHostKeySource for RunPodHostTrust {
+    fn retained_endpoint(&self, worker: &InteractiveWorker) -> Option<InteractiveWorkerSshEndpoint> {
+        let Mode::Retained { pod_id, lifetime, ssh } = &self.mode else {
+            return None;
+        };
+        (worker.is_valid_for(CloudProvider::RunPod)
+            && worker.identity.resource_id == *pod_id
+            && worker.identity.workflow_id == self.expected.workflow_id
+            && worker.identity.job_id == self.expected.job_id
+            && worker.target == self.expected.target
+            && worker.ssh_public_key == self.expected.ssh_public_key
+            && worker.lifetime == *lifetime)
+            .then(|| ssh.clone())
+    }
+
     fn host_key(
         &self,
         worker: &RunPodWorker,

--- a/crates/horizon-core/src/cloud_run/runpod/http.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http.rs
@@ -6,7 +6,7 @@ const GRAPHQL_URL: &str = "https://api.runpod.io/graphql";
 const CREATE_MUTATION: &str =
     "mutation CreatePod($input: PodFindAndDeployOnDemandInput!) { podFindAndDeployOnDemand(input: $input) { id } }";
 pub(super) const RESPONSE_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub(super) const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const PROPAGATION_BACKOFF_MS: [u64; 8] = [0, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000];
 const CAPACITY_ERROR_MARKERS: [&str; 8] = [
     "no longer any instances available",

--- a/crates/horizon-core/src/cloud_run/runpod/http.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/http.rs
@@ -164,6 +164,19 @@ impl Transport for RunPodHttp {
             .then_some(())
             .ok_or(RunPodError::ResourceIdentityMismatch)
     }
+    fn start(&self, pod_id: &str) -> Result<(), RunPodError> {
+        let url = format!("{}/action", Self::pod_url(pod_id)?);
+        let response = self
+            .agent
+            .post(url.as_str())
+            .header("Authorization", &self.authorization)
+            .send_json(serde_json::json!({"action": "start"}))
+            .map_err(|_| RunPodError::RequestFailed { operation: "pod Start" })?;
+        let pod: ApiPod = decode_json(response, 200, "pod Start")?;
+        (pod.id == pod_id)
+            .then_some(())
+            .ok_or(RunPodError::ResourceIdentityMismatch)
+    }
     fn delete(&self, pod_id: &str) -> Result<RunPodCleanup, RunPodError> {
         let url = Self::pod_url(pod_id)?;
         let response = self

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -23,6 +23,13 @@ use super::{
 /// worker identity and endpoint. An unauthenticated network key scan is not an
 /// attestation source.
 pub trait RunPodHostKeySource: Send + Sync {
+    /// Return only an already-retained pin for this exact worker, without I/O or
+    /// bootstrap. The default denies compute Start to initial-trust sources.
+    #[must_use]
+    fn retained_endpoint(&self, _worker: &InteractiveWorker) -> Option<InteractiveWorkerSshEndpoint> {
+        None
+    }
+
     #[must_use]
     fn host_key(
         &self,
@@ -48,9 +55,9 @@ where
 
 /// Adapts the exact GPU-worker lifecycle to the common interactive contract.
 pub struct RunPodInteractiveWorkerProvider {
-    client: RunPodClient,
-    profile: RunPodProfile,
-    host_keys: Box<dyn RunPodHostKeySource>,
+    pub(super) client: RunPodClient,
+    pub(super) profile: RunPodProfile,
+    pub(super) host_keys: Box<dyn RunPodHostKeySource>,
 }
 
 impl RunPodInteractiveWorkerProvider {
@@ -82,7 +89,7 @@ impl RunPodInteractiveWorkerProvider {
         }
     }
 
-    fn adapt_status(
+    pub(super) fn adapt_status(
         &self,
         status: RunPodWorkerStatus,
         target: &WorkerTarget,

--- a/crates/horizon-core/src/cloud_run/runpod/models.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/models.rs
@@ -210,6 +210,10 @@ pub enum RunPodError {
     StopResourceLost,
     #[error("RunPod Stop was not verified; retain identity and explicitly reconcile before retrying")]
     StopVerificationFailed,
+    #[error("RunPod Start requires a persistent worker with retained SSH trust")]
+    StartIdentityRequired,
+    #[error("RunPod Start or retained storage was not verified; retain identity and reconcile without resending")]
+    StartUnverified,
     #[error("RunPod recovered worker lease was outside the requested bound and was deleted")]
     LeaseDeadlineRejected { worker: Box<RunPodWorker> },
     #[error("RunPod recovered worker lease was outside the requested bound but cleanup failed")]

--- a/crates/horizon-core/src/cloud_run/runpod/start.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/start.rs
@@ -1,0 +1,129 @@
+//! Single-dispatch compute resume of an owned persistent Pod, never task replay.
+use super::{
+    ApiPod, InteractiveWorkerLifetime, RunPodError, RunPodInteractiveWorkerProvider, RunPodLifecycle, RunPodWorker,
+    RunPodWorkerStatus, interactive::runpod_worker, status_from_resource, stop::RetainedMount, validate_target,
+};
+use crate::cloud_run::{
+    interactive_worker::{InteractiveWorker, InteractiveWorkerSshEndpoint, InteractiveWorkerStatus},
+    interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
+};
+use std::time::Duration;
+
+// At most three observations, each with the existing 30-second HTTP bound (plus
+// one selected-volume read). Including admission and POST, at most 275 seconds
+// of provider requests/backoff; no mutation retry or unbounded polling.
+const OBSERVATION_BACKOFF_MS: [u64; 3] = [0, 1_000, 4_000];
+
+struct Snapshot {
+    status: RunPodWorkerStatus,
+    mount: RetainedMount,
+}
+
+impl RunPodInteractiveWorkerProvider {
+    fn start_status(
+        &self,
+        status: RunPodWorkerStatus,
+        worker: &InteractiveWorker,
+        pin: &InteractiveWorkerSshEndpoint,
+    ) -> Result<InteractiveWorkerStatus, RunPodError> {
+        let status = self.adapt_status(status, &worker.target, &worker.ssh_public_key);
+        if status.ssh.as_ref().is_some_and(|ssh| ssh != pin) {
+            return Err(RunPodError::ResourceIdentityMismatch);
+        }
+        Ok(status)
+    }
+
+    fn start_snapshot(
+        &self,
+        pod: &ApiPod,
+        worker: &RunPodWorker,
+        expected: &InteractiveWorker,
+        pin: &InteractiveWorkerSshEndpoint,
+    ) -> Result<Snapshot, RunPodError> {
+        let status = status_from_resource(pod, worker, Some(&expected.ssh_public_key))?;
+        let mount = self
+            .client
+            .retained_mount(pod, &self.profile)
+            .map_err(|_| RunPodError::StartUnverified)?;
+        let metadata = &pod.stop;
+        let valid = match status.lifecycle {
+            RunPodLifecycle::Exited => {
+                metadata.runtime.as_ref().is_some_and(serde_json::Value::is_null)
+                    && metadata.locked == false
+                    && metadata
+                        .actions
+                        .as_array()
+                        .is_some_and(|actions| actions.iter().any(|v| v == "start"))
+            }
+            RunPodLifecycle::Running => metadata.runtime.as_ref().is_some_and(serde_json::Value::is_object),
+            RunPodLifecycle::Provisioning => {
+                pod.status.as_deref() == Some("STARTING")
+                    && metadata.runtime.as_ref().is_some_and(serde_json::Value::is_null)
+            }
+            _ => false,
+        };
+        if !valid {
+            return Err(RunPodError::StartUnverified);
+        }
+        if let Some(ssh) = pod.ssh.as_ref().and_then(|ssh| ssh.direct.as_ref())
+            && (ssh.host != pin.host || ssh.port != pin.port || ssh.username != pin.username)
+        {
+            return Err(RunPodError::ResourceIdentityMismatch);
+        }
+        Ok(Snapshot { status, mount })
+    }
+}
+
+impl InteractiveWorkerStartProvider for RunPodInteractiveWorkerProvider {
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+        self.client.check_network_worker(worker)?;
+        let retained = runpod_worker(worker)?;
+        validate_target(&worker.target, &self.profile)?;
+        if worker.lifetime != InteractiveWorkerLifetime::Persistent {
+            return Err(RunPodError::StartIdentityRequired);
+        }
+        let pin = self
+            .host_keys
+            .retained_endpoint(worker)
+            .filter(InteractiveWorkerSshEndpoint::is_complete)
+            .ok_or(RunPodError::StartIdentityRequired)?;
+        if self.client.network_binding.is_none() && self.profile.volume_gib == 0 {
+            return Err(RunPodError::StartUnverified);
+        }
+        let Some(pod) = self.client.transport.get(&retained.pod_id)? else {
+            return Ok(InteractiveWorkerStart::AlreadyAbsent);
+        };
+        let before = self.start_snapshot(&pod, &retained, worker, &pin)?;
+        if before.status.lifecycle == RunPodLifecycle::Running {
+            return self
+                .start_status(before.status, worker, &pin)
+                .map(InteractiveWorkerStart::AlreadyRunning);
+        }
+        // A STARTING Pod is only observed. An ambiguous POST response is never
+        // authority to submit again; only independently observed state can succeed.
+        if before.status.lifecycle == RunPodLifecycle::Exited {
+            let _response = self.client.transport.start(&retained.pod_id);
+        }
+        for delay_ms in OBSERVATION_BACKOFF_MS {
+            if !cfg!(test) {
+                std::thread::sleep(Duration::from_millis(delay_ms));
+            }
+            let Some(pod) = self.client.transport.get(&retained.pod_id)? else {
+                return Err(RunPodError::StartUnverified);
+            };
+            let current = self.start_snapshot(&pod, &retained, worker, &pin)?;
+            if current.mount != before.mount {
+                return Err(RunPodError::StartUnverified);
+            }
+            if current.status.lifecycle == RunPodLifecycle::Running {
+                return self
+                    .start_status(current.status, worker, &pin)
+                    .map(InteractiveWorkerStart::Started);
+            }
+        }
+        Err(RunPodError::StartUnverified)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/cloud_run/runpod/start.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/start.rs
@@ -9,10 +9,27 @@ use crate::cloud_run::{
 };
 use std::time::Duration;
 
-// At most three observations, each with the existing 30-second HTTP bound (plus
-// one selected-volume read). Including admission and POST, at most 275 seconds
-// of provider requests/backoff; no mutation retry or unbounded polling.
-const OBSERVATION_BACKOFF_MS: [u64; 3] = [0, 1_000, 4_000];
+const TRANSITION_BOUND: Duration = Duration::from_secs(300);
+const OBSERVATION_BACKOFF_MS: [u64; 6] = [0, 1_000, 2_000, 4_000, 8_000, 15_000];
+const REPEATED_BACKOFF_MS: u64 = 30_000;
+
+trait Clock {
+    fn elapsed(&self) -> Duration;
+    fn sleep(&self, duration: Duration);
+}
+
+#[cfg(not(test))]
+struct MonotonicClock(std::time::Instant);
+
+#[cfg(not(test))]
+impl Clock for MonotonicClock {
+    fn elapsed(&self) -> Duration {
+        self.0.elapsed()
+    }
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
 
 struct Snapshot {
     status: RunPodWorkerStatus,
@@ -74,8 +91,12 @@ impl RunPodInteractiveWorkerProvider {
     }
 }
 
-impl InteractiveWorkerStartProvider for RunPodInteractiveWorkerProvider {
-    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+impl RunPodInteractiveWorkerProvider {
+    fn start_with_clock(
+        &self,
+        worker: &InteractiveWorker,
+        clock: &impl Clock,
+    ) -> Result<InteractiveWorkerStart, RunPodError> {
         self.client.check_network_worker(worker)?;
         let retained = runpod_worker(worker)?;
         validate_target(&worker.target, &self.profile)?;
@@ -94,6 +115,9 @@ impl InteractiveWorkerStartProvider for RunPodInteractiveWorkerProvider {
             return Ok(InteractiveWorkerStart::AlreadyAbsent);
         };
         let before = self.start_snapshot(&pod, &retained, worker, &pin)?;
+        if clock.elapsed() >= TRANSITION_BOUND {
+            return Err(RunPodError::StartUnverified);
+        }
         if before.status.lifecycle == RunPodLifecycle::Running {
             return self
                 .start_status(before.status, worker, &pin)
@@ -102,26 +126,68 @@ impl InteractiveWorkerStartProvider for RunPodInteractiveWorkerProvider {
         // A STARTING Pod is only observed. An ambiguous POST response is never
         // authority to submit again; only independently observed state can succeed.
         if before.status.lifecycle == RunPodLifecycle::Exited {
+            if TRANSITION_BOUND.saturating_sub(clock.elapsed()) < super::http::REQUEST_TIMEOUT {
+                return Err(RunPodError::StartUnverified);
+            }
             let _response = self.client.transport.start(&retained.pod_id);
         }
-        for delay_ms in OBSERVATION_BACKOFF_MS {
-            if !cfg!(test) {
-                std::thread::sleep(Duration::from_millis(delay_ms));
+        self.await_running(worker, &retained, &pin, &before, clock)
+    }
+
+    fn await_running(
+        &self,
+        worker: &InteractiveWorker,
+        retained: &RunPodWorker,
+        pin: &InteractiveWorkerSshEndpoint,
+        before: &Snapshot,
+        clock: &impl Clock,
+    ) -> Result<InteractiveWorkerStart, RunPodError> {
+        // Reserve the complete existing per-request timeout for both Pod and, when
+        // selected, volume reads. Never start an observation that cannot fit; the
+        // final poll follows a clipped sleep and is not repeated in a busy loop.
+        let reserve = super::http::REQUEST_TIMEOUT * if self.client.network_binding.is_some() { 2 } else { 1 };
+        let final_window = reserve + Duration::from_secs(1);
+        for delay_ms in OBSERVATION_BACKOFF_MS
+            .into_iter()
+            .chain(std::iter::repeat(REPEATED_BACKOFF_MS))
+        {
+            let remaining = TRANSITION_BOUND.saturating_sub(clock.elapsed());
+            if remaining < reserve {
+                break;
             }
+            clock.sleep(Duration::from_millis(delay_ms).min(remaining.saturating_sub(final_window)));
+            let remaining = TRANSITION_BOUND.saturating_sub(clock.elapsed());
+            if remaining < reserve {
+                break;
+            }
+            let final_poll = remaining <= final_window;
             let Some(pod) = self.client.transport.get(&retained.pod_id)? else {
                 return Err(RunPodError::StartUnverified);
             };
-            let current = self.start_snapshot(&pod, &retained, worker, &pin)?;
-            if current.mount != before.mount {
+            let current = self.start_snapshot(&pod, retained, worker, pin)?;
+            if clock.elapsed() > TRANSITION_BOUND || current.mount != before.mount {
                 return Err(RunPodError::StartUnverified);
             }
             if current.status.lifecycle == RunPodLifecycle::Running {
                 return self
-                    .start_status(current.status, worker, &pin)
+                    .start_status(current.status, worker, pin)
                     .map(InteractiveWorkerStart::Started);
+            }
+            if final_poll {
+                break;
             }
         }
         Err(RunPodError::StartUnverified)
+    }
+}
+
+impl InteractiveWorkerStartProvider for RunPodInteractiveWorkerProvider {
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+        #[cfg(not(test))]
+        let clock = MonotonicClock(std::time::Instant::now());
+        #[cfg(test)]
+        let clock = tests::TestClock::default();
+        self.start_with_clock(worker, &clock)
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/runpod/start/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/start/tests.rs
@@ -1,0 +1,493 @@
+use super::super::{
+    CreatePodRequest, RunPodApiKey, RunPodCleanup, RunPodClient, RunPodHostTrust, RunPodNetworkVolumeExpectation,
+    Transport,
+    http::RunPodHttp,
+    network_volume::ApiNetworkVolume,
+    resource_name,
+    tests::{ed25519_key, interactive_request, profile},
+};
+use super::*;
+use crate::cloud_run::interactive_worker::{InteractiveWorkerIdentity, InteractiveWorkerLifecycle};
+use crate::cloud_run::{CloudJobId, CloudProvider, CloudWorkflowId, WorkerLifetime};
+use serde_json::{Value, json};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Clone)]
+struct Fake(Arc<Mutex<State>>);
+struct State {
+    pod: Option<ApiPod>,
+    gets: VecDeque<Result<Option<ApiPod>, RunPodError>>,
+    volumes: VecDeque<Option<Value>>,
+    calls: Vec<&'static str>,
+    start_error: Option<RunPodError>,
+}
+impl Transport for Fake {
+    fn network_volume(&self, id: &str) -> Result<Option<ApiNetworkVolume>, RunPodError> {
+        assert_eq!(id, "volume_exact");
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("volume");
+        let value = state.volumes.pop_front().unwrap_or_else(|| Some(volume()));
+        Ok(value.map(|value| serde_json::from_value(value).expect("volume")))
+    }
+    fn list_by_name(&self, _: &str) -> Result<Vec<ApiPod>, RunPodError> {
+        panic!("no list")
+    }
+    fn create(&self, _: &CreatePodRequest) -> Result<ApiPod, RunPodError> {
+        panic!("no create")
+    }
+    fn delete(&self, _: &str) -> Result<RunPodCleanup, RunPodError> {
+        panic!("no delete")
+    }
+    fn stop(&self, _: &str) -> Result<(), RunPodError> {
+        panic!("no stop")
+    }
+    fn get(&self, id: &str) -> Result<Option<ApiPod>, RunPodError> {
+        assert_eq!(id, "pod_exact");
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("get");
+        state.gets.pop_front().unwrap_or_else(|| Ok(state.pod.clone()))
+    }
+    fn start(&self, id: &str) -> Result<(), RunPodError> {
+        assert_eq!(id, "pod_exact");
+        let mut state = self.0.lock().expect("state");
+        state.calls.push("start");
+        if let Some(pod) = &mut state.pod {
+            pod.status = Some("RUNNING".into());
+            pod.stop.runtime = Some(json!({"uptime":0}));
+        }
+        state.start_error.take().map_or(Ok(()), Err)
+    }
+}
+
+fn volume() -> Value {
+    json!({"id":"volume_exact","dataCenter":"EUR-NO-1","size":20,"type":"HIGH_PERFORMANCE"})
+}
+fn pin() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: "worker.example".into(),
+        port: 2200,
+        username: "root".into(),
+        host_key: ed25519_key(73),
+    }
+}
+struct Fixture {
+    worker: InteractiveWorker,
+    raw: Value,
+    fake: Fake,
+    network: bool,
+}
+impl Fixture {
+    fn new(network: bool) -> Self {
+        let mut request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+        request.target.lifetime = WorkerLifetime::Persistent;
+        let raw = json!({
+            "id":"pod_exact", "name":resource_name(request.workflow_id, request.job_id),
+            "image":request.target.image, "status":"EXITED", "cost":0,
+            "env":{"HORIZON_WORKFLOW_ID":request.workflow_id,"HORIZON_JOB_ID":request.job_id,
+                "HORIZON_CLOUD_PROTOCOL_VERSION":"1","HORIZON_WORKER_LIFETIME":"persistent",
+                "HORIZON_SSH_PUBLIC_KEY":request.ssh_public_key},
+            "ssh":{"direct":{"host":"worker.example","port":2200,"username":"root"}},
+            "mounts": if network { json!({"network":[{"volumeId":"volume_exact","path":"/workspace"}]}) }
+                      else { json!({"persistent":{"size":20,"path":"/workspace"}}) },
+            "cloud":"SECURE","dataCenterId":"EUR-NO-1","cluster":null,
+            "locked":false,"actions":["start","terminate"],"runtime":null
+        });
+        let worker = InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::RunPod,
+                workflow_id: request.workflow_id,
+                job_id: request.job_id,
+                resource_id: "pod_exact".into(),
+            },
+            target: request.target,
+            ssh_public_key: request.ssh_public_key,
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        };
+        Self {
+            worker,
+            fake: Fake(Arc::new(Mutex::new(State {
+                pod: Some(serde_json::from_value(raw.clone()).expect("pod")),
+                gets: VecDeque::new(),
+                volumes: VecDeque::new(),
+                calls: Vec::new(),
+                start_error: None,
+            }))),
+            raw,
+            network,
+        }
+    }
+    fn provider(&self) -> RunPodInteractiveWorkerProvider {
+        let client = RunPodClient::with_transport_and_fence(
+            self.fake.clone(),
+            |_, _, _: &crate::cloud_run::WorkerTarget, _: &str| panic!("no claim"),
+        );
+        let trust = RunPodHostTrust::retained(&self.worker, &pin()).expect("retained trust");
+        if self.network {
+            let request = crate::cloud_run::interactive_worker::InteractiveWorkerRequest {
+                workflow_id: self.worker.identity.workflow_id,
+                job_id: self.worker.identity.job_id,
+                target: self.worker.target.clone(),
+                ssh_public_key: self.worker.ssh_public_key.clone(),
+            };
+            RunPodInteractiveWorkerProvider::new_with_network_volume(
+                client,
+                profile(),
+                trust,
+                &request,
+                &RunPodNetworkVolumeExpectation {
+                    volume_id: "volume_exact".into(),
+                    data_center_id: "EUR-NO-1".into(),
+                    minimum_size_gb: 10,
+                },
+            )
+            .expect("network")
+        } else {
+            RunPodInteractiveWorkerProvider::new(client, profile(), trust)
+        }
+    }
+    fn set(&self, raw: Value) {
+        self.fake.0.lock().expect("state").pod = Some(serde_json::from_value(raw).expect("pod"));
+    }
+    fn calls(&self) -> Vec<&'static str> {
+        self.fake.0.lock().expect("state").calls.clone()
+    }
+    fn queued(&self, values: Vec<Option<Value>>) {
+        self.fake.0.lock().expect("state").gets = values
+            .into_iter()
+            .map(|raw| Ok(raw.map(|raw| serde_json::from_value(raw).expect("pod"))))
+            .collect();
+    }
+}
+
+#[test]
+fn starts_once_then_reopened_running_worker_is_read_only_with_original_pin() {
+    for network in [false, true] {
+        let f = Fixture::new(network);
+        let provider = f.provider();
+        let before = f.worker.clone();
+        let InteractiveWorkerStart::Started(status) = provider.start_worker(&f.worker).expect("start") else {
+            panic!("started")
+        };
+        assert_eq!(status.worker, before);
+        assert_eq!(status.lifecycle, InteractiveWorkerLifecycle::Ready);
+        assert_eq!(status.ssh, Some(pin()));
+        assert_eq!(
+            f.provider().start_worker(&f.worker),
+            Ok(InteractiveWorkerStart::AlreadyRunning(status))
+        );
+        assert_eq!(
+            f.calls(),
+            if network {
+                vec!["get", "volume", "start", "get", "volume", "get", "volume"]
+            } else {
+                vec!["get", "start", "get", "get"]
+            }
+        );
+        assert_eq!(f.worker, before);
+    }
+}
+
+#[test]
+fn invalid_saved_worker_profile_and_nonretained_trust_refuse_before_io() {
+    for changed in 0..7 {
+        let f = Fixture::new(false);
+        let mut provider = f.provider();
+        let mut worker = f.worker.clone();
+        match changed {
+            0 => worker.identity.resource_id = "../other".into(),
+            1 => worker.identity.provider = CloudProvider::Azure,
+            2 => worker.ssh_public_key.clear(),
+            3 => worker.target.profile = "other".into(),
+            4 => provider.profile.volume_gib = 0,
+            5 => {
+                let request = interactive_request(worker.identity.workflow_id, worker.identity.job_id);
+                provider.host_keys = Box::new(
+                    RunPodHostTrust::initial_task_free(&RunPodApiKey::new("synthetic").expect("key"), &request)
+                        .expect("initial"),
+                );
+            }
+            _ => {
+                worker.target.lifetime = WorkerLifetime::TimeLimited { seconds: 3600 };
+                worker.lifetime = InteractiveWorkerLifetime::TimeLimited(
+                    crate::cloud_run::interactive_worker::InteractiveWorkerLease {
+                        terminate_after: super::super::termination_deadline(3600).expect("deadline"),
+                    },
+                );
+            }
+        }
+        assert!(provider.start_worker(&worker).is_err());
+        assert!(f.calls().is_empty());
+    }
+}
+
+#[test]
+fn exact_absence_never_creates_and_post_dispatch_absence_is_unverified() {
+    let f = Fixture::new(false);
+    f.fake.0.lock().expect("state").pod = None;
+    assert_eq!(
+        f.provider().start_worker(&f.worker),
+        Ok(InteractiveWorkerStart::AlreadyAbsent)
+    );
+    assert_eq!(f.calls(), vec!["get"]);
+    let f = Fixture::new(false);
+    f.queued(vec![Some(f.raw.clone()), None]);
+    assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
+    assert_eq!(f.calls(), vec!["get", "start", "get"]);
+}
+
+#[test]
+fn stopped_state_requires_positive_runtime_capability_and_storage_proof() {
+    for changed in 0..14 {
+        let f = Fixture::new(false);
+        let mut raw = f.raw.clone();
+        match changed {
+            0 => {
+                raw.as_object_mut().expect("pod").remove("runtime");
+            }
+            1 => raw["runtime"] = json!({"uptime":1}),
+            2 => raw["actions"] = json!(["terminate"]),
+            3 => raw["locked"] = json!(true),
+            4 => raw["mounts"] = json!({}),
+            5 => raw["mounts"]["persistent"]["size"] = json!(19),
+            6 => raw["mounts"]["persistent"]["path"] = json!("/other"),
+            7 => raw["mounts"]["network"] = json!([]),
+            8 => raw["cloud"] = json!("COMMUNITY"),
+            9 => raw["cluster"] = json!({"id":"foreign"}),
+            10 => raw["status"] = json!("TERMINATED"),
+            11 => raw["status"] = json!("ERROR"),
+            12 => raw["status"] = json!("PROVISIONING"),
+            _ => raw["status"] = json!("unknown"),
+        }
+        f.set(raw);
+        assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
+        assert_eq!(f.calls(), vec!["get"]);
+    }
+}
+
+#[test]
+fn ownership_ssh_and_retained_mount_drift_on_either_side_never_succeeds() {
+    for after in [false, true] {
+        for changed in 0..10 {
+            let f = Fixture::new(false);
+            let mut raw = f.raw.clone();
+            match changed {
+                0 => raw["id"] = json!("foreign"),
+                1 => raw["name"] = json!("foreign"),
+                2 => raw["image"] = json!("other"),
+                3 => raw["env"]["HORIZON_WORKFLOW_ID"] = json!(CloudWorkflowId::new()),
+                4 => raw["env"]["HORIZON_JOB_ID"] = json!(CloudJobId::new()),
+                5 => raw["env"]["HORIZON_SSH_PUBLIC_KEY"] = json!(ed25519_key(2)),
+                6 => raw["env"]["HORIZON_TERMINATE_AFTER"] = json!("2099-01-01T00:00:00Z"),
+                7 => raw["ssh"]["direct"]["host"] = json!("replacement.example"),
+                8 => raw["ssh"]["direct"]["port"] = json!(2222),
+                _ => raw["mounts"]["persistent"]["size"] = json!(21),
+            }
+            if changed == 9 && !after {
+                continue;
+            } // A larger initial retained volume is allowed.
+            f.queued(if after {
+                vec![Some(f.raw.clone()), Some(raw)]
+            } else {
+                vec![Some(raw)]
+            });
+            assert!(f.provider().start_worker(&f.worker).is_err());
+            assert_eq!(
+                f.calls(),
+                if after {
+                    vec!["get", "start", "get"]
+                } else {
+                    vec!["get"]
+                }
+            );
+        }
+    }
+}
+
+#[test]
+fn ambiguous_start_is_observed_without_retry_and_pending_observation_is_bounded() {
+    for outcome in 0..3 {
+        let error = || match outcome {
+            0 => None,
+            1 => Some(RunPodError::RequestFailed { operation: "pod Start" }),
+            _ => Some(RunPodError::InvalidResponse { operation: "pod Start" }),
+        };
+        let f = Fixture::new(false);
+        f.fake.0.lock().expect("state").start_error = error();
+        assert!(matches!(
+            f.provider().start_worker(&f.worker),
+            Ok(InteractiveWorkerStart::Started(_))
+        ));
+        assert_eq!(f.calls(), vec!["get", "start", "get"]);
+        let f = Fixture::new(false);
+        f.fake.0.lock().expect("state").start_error = error();
+        f.queued(vec![Some(f.raw.clone()); 4]);
+        assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
+        assert_eq!(f.calls(), vec!["get", "start", "get", "get", "get"]);
+    }
+    let f = Fixture::new(false);
+    let mut starting = f.raw.clone();
+    starting["status"] = json!("STARTING");
+    let mut running = starting.clone();
+    running["status"] = json!("RUNNING");
+    running["runtime"] = json!({"uptime":0});
+    f.queued(vec![Some(starting.clone()), Some(starting), Some(running)]);
+    assert!(matches!(
+        f.provider().start_worker(&f.worker),
+        Ok(InteractiveWorkerStart::Started(_))
+    ));
+    assert_eq!(f.calls(), vec!["get", "get", "get"]);
+}
+
+#[test]
+fn missing_endpoint_stays_provisioning_and_inconsistent_running_is_rejected() {
+    let f = Fixture::new(false);
+    let mut raw = f.raw.clone();
+    raw["status"] = json!("RUNNING");
+    raw["runtime"] = json!({"uptime":0});
+    raw["ssh"] = json!({});
+    f.set(raw.clone());
+    let result = f.provider().start_worker(&f.worker).expect("running");
+    assert_eq!(
+        result.status().expect("status").lifecycle,
+        InteractiveWorkerLifecycle::Provisioning
+    );
+    assert!(result.status().expect("status").ssh.is_none());
+    assert_eq!(f.calls(), vec!["get"]);
+    raw["runtime"] = Value::Null;
+    f.set(raw);
+    assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
+}
+
+#[test]
+fn selected_volume_is_checked_before_start_and_during_every_observation() {
+    for after in [false, true] {
+        for changed in 0..4 {
+            let f = Fixture::new(true);
+            let mut value = volume();
+            match changed {
+                0 => value["id"] = json!("foreign"),
+                1 => value["type"] = json!("STANDARD"),
+                2 => value["dataCenter"] = json!("other"),
+                _ => value["size"] = json!(9),
+            }
+            f.fake.0.lock().expect("state").volumes = if after {
+                vec![Some(volume()), Some(value)]
+            } else {
+                vec![Some(value)]
+            }
+            .into();
+            assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
+            assert_eq!(
+                f.calls(),
+                if after {
+                    vec!["get", "volume", "start", "get", "volume"]
+                } else {
+                    vec!["get", "volume"]
+                }
+            );
+        }
+    }
+}
+
+#[test]
+fn network_attachment_drift_and_failed_observations_do_not_retry_start() {
+    for after in [false, true] {
+        for changed in 0..4 {
+            let f = Fixture::new(true);
+            let mut raw = f.raw.clone();
+            match changed {
+                0 => raw["mounts"]["network"][0]["volumeId"] = json!("other"),
+                1 => raw["mounts"]["network"][0]["path"] = json!("/other"),
+                2 => raw["dataCenterId"] = json!("other"),
+                _ => raw["mounts"]["persistent"] = json!({"size":20,"path":"/workspace"}),
+            }
+            f.queued(if after {
+                vec![Some(f.raw.clone()), Some(raw)]
+            } else {
+                vec![Some(raw)]
+            });
+            assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
+            assert_eq!(
+                f.calls().iter().filter(|call| **call == "start").count(),
+                usize::from(after)
+            );
+        }
+    }
+    let f = Fixture::new(false);
+    f.fake.0.lock().expect("state").gets = VecDeque::from([
+        Ok(Some(serde_json::from_value(f.raw.clone()).expect("pod"))),
+        Err(RunPodError::RequestFailed {
+            operation: "pod inspection",
+        }),
+    ]);
+    assert_eq!(
+        f.provider().start_worker(&f.worker),
+        Err(RunPodError::RequestFailed {
+            operation: "pod inspection"
+        })
+    );
+    assert_eq!(f.calls(), vec!["get", "start", "get"]);
+}
+
+#[test]
+fn http_start_uses_exact_v2_action_once_and_redacts_invalid_responses() {
+    use std::{
+        io::Read as _,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+    use ureq::{
+        Body, SendBody,
+        http::{Request, Response},
+        middleware::MiddlewareNext,
+    };
+    for (code, body) in [
+        (200, r#"{"id":"pod_exact"}"#.to_string()),
+        (200, r#"{"id":"foreign"}"#.into()),
+        (200, "private malformed response".into()),
+        (200, "x".repeat(2 * 1024 * 1024 + 1)),
+        (403, "private denied".into()),
+        (404, "private absent".into()),
+        (409, "private conflict".into()),
+        (302, "private redirect".into()),
+        (204, String::new()),
+    ] {
+        let should_succeed = code == 200 && body == r#"{"id":"pod_exact"}"#;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let count = calls.clone();
+        let agent = ureq::Agent::config_builder()
+            .middleware(move |request: Request<SendBody>, _: MiddlewareNext| {
+                count.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(request.method(), "POST");
+                assert_eq!(request.uri(), "https://api.runpod.io/v2/pods/pod_exact/action");
+                assert_eq!(request.headers()["Authorization"], "Bearer synthetic-credential");
+                let mut payload = String::new();
+                request
+                    .into_body()
+                    .into_reader()
+                    .read_to_string(&mut payload)
+                    .expect("body");
+                assert_eq!(
+                    serde_json::from_str::<Value>(&payload).expect("json"),
+                    json!({"action":"start"})
+                );
+                Ok(Response::builder()
+                    .status(code)
+                    .body(Body::builder().data(body.clone()))
+                    .expect("response"))
+            })
+            .build()
+            .new_agent();
+        let result = RunPodHttp::mock(agent).start("pod_exact");
+        assert_eq!(result.is_ok(), should_succeed);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!format!("{result:?}").contains("private"));
+        assert!(!format!("{result:?}").contains("synthetic-credential"));
+    }
+    let http = RunPodHttp::new(&RunPodApiKey::new("synthetic").expect("key"));
+    for id in ["", "../foreign", "pod/action", "pod?start=true"] {
+        assert_eq!(http.start(id), Err(RunPodError::ResourceIdentityMismatch));
+    }
+}

--- a/crates/horizon-core/src/cloud_run/runpod/start/tests.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/start/tests.rs
@@ -15,6 +15,17 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[derive(Default, Clone)]
+pub(super) struct TestClock(Arc<Mutex<Duration>>);
+impl Clock for TestClock {
+    fn elapsed(&self) -> Duration {
+        *self.0.lock().expect("clock")
+    }
+    fn sleep(&self, duration: Duration) {
+        *self.0.lock().expect("clock") += duration;
+    }
+}
+
 #[derive(Clone)]
 struct Fake(Arc<Mutex<State>>);
 struct State {
@@ -23,12 +34,15 @@ struct State {
     volumes: VecDeque<Option<Value>>,
     calls: Vec<&'static str>,
     start_error: Option<RunPodError>,
+    clock: TestClock,
+    request_duration: Duration,
 }
 impl Transport for Fake {
     fn network_volume(&self, id: &str) -> Result<Option<ApiNetworkVolume>, RunPodError> {
         assert_eq!(id, "volume_exact");
         let mut state = self.0.lock().expect("state");
         state.calls.push("volume");
+        state.clock.sleep(state.request_duration);
         let value = state.volumes.pop_front().unwrap_or_else(|| Some(volume()));
         Ok(value.map(|value| serde_json::from_value(value).expect("volume")))
     }
@@ -48,12 +62,14 @@ impl Transport for Fake {
         assert_eq!(id, "pod_exact");
         let mut state = self.0.lock().expect("state");
         state.calls.push("get");
+        state.clock.sleep(state.request_duration);
         state.gets.pop_front().unwrap_or_else(|| Ok(state.pod.clone()))
     }
     fn start(&self, id: &str) -> Result<(), RunPodError> {
         assert_eq!(id, "pod_exact");
         let mut state = self.0.lock().expect("state");
         state.calls.push("start");
+        state.clock.sleep(state.request_duration);
         if let Some(pod) = &mut state.pod {
             pod.status = Some("RUNNING".into());
             pod.stop.runtime = Some(json!({"uptime":0}));
@@ -114,6 +130,8 @@ impl Fixture {
                 volumes: VecDeque::new(),
                 calls: Vec::new(),
                 start_error: None,
+                clock: TestClock::default(),
+                request_duration: Duration::ZERO,
             }))),
             raw,
             network,
@@ -159,6 +177,11 @@ impl Fixture {
             .into_iter()
             .map(|raw| Ok(raw.map(|raw| serde_json::from_value(raw).expect("pod"))))
             .collect();
+    }
+    fn timed(&self, request_duration: Duration) -> TestClock {
+        let mut state = self.fake.0.lock().expect("state");
+        state.request_duration = request_duration;
+        state.clock.clone()
     }
 }
 
@@ -323,9 +346,10 @@ fn ambiguous_start_is_observed_without_retry_and_pending_observation_is_bounded(
         assert_eq!(f.calls(), vec!["get", "start", "get"]);
         let f = Fixture::new(false);
         f.fake.0.lock().expect("state").start_error = error();
-        f.queued(vec![Some(f.raw.clone()); 4]);
+        f.queued(vec![Some(f.raw.clone()); 100]);
         assert_eq!(f.provider().start_worker(&f.worker), Err(RunPodError::StartUnverified));
-        assert_eq!(f.calls(), vec!["get", "start", "get", "get", "get"]);
+        assert_eq!(f.calls().iter().filter(|&&call| call == "start").count(), 1);
+        assert_eq!(f.calls().iter().filter(|&&call| call == "get").count(), 15);
     }
     let f = Fixture::new(false);
     let mut starting = f.raw.clone();
@@ -339,6 +363,70 @@ fn ambiguous_start_is_observed_without_retry_and_pending_observation_is_bounded(
         Ok(InteractiveWorkerStart::Started(_))
     ));
     assert_eq!(f.calls(), vec!["get", "get", "get"]);
+}
+
+#[test]
+fn delayed_start_is_observed_beyond_five_seconds_without_resubmission() {
+    for network in [false, true] {
+        let f = Fixture::new(network);
+        let clock = f.timed(Duration::from_secs(1));
+        let mut starting = f.raw.clone();
+        starting["status"] = json!("STARTING");
+        let mut running = starting.clone();
+        running["status"] = json!("RUNNING");
+        running["runtime"] = json!({"uptime":0});
+        let mut replies = vec![Some(f.raw.clone())];
+        replies.extend(vec![Some(starting); 7]);
+        replies.push(Some(running));
+        f.queued(replies);
+        let result = f.provider().start_with_clock(&f.worker, &clock).expect("late start");
+        assert!(matches!(result, InteractiveWorkerStart::Started(_)));
+        assert!(clock.elapsed() >= Duration::from_secs(90));
+        assert!(clock.elapsed() < TRANSITION_BOUND);
+        assert_eq!(f.calls().iter().filter(|&&call| call == "start").count(), 1);
+        assert_eq!(f.calls().iter().filter(|&&call| call == "get").count(), 9);
+        if network {
+            assert_eq!(f.calls().iter().filter(|&&call| call == "volume").count(), 9);
+        }
+    }
+}
+
+#[test]
+fn pending_transition_reserves_all_reads_and_counts_request_time_in_deadline() {
+    for network in [false, true] {
+        for request_seconds in [0, 30] {
+            let f = Fixture::new(network);
+            let clock = f.timed(Duration::from_secs(request_seconds));
+            f.queued(vec![Some(f.raw.clone()); 100]);
+            assert_eq!(
+                f.provider().start_with_clock(&f.worker, &clock),
+                Err(RunPodError::StartUnverified)
+            );
+            let expected_seconds = match (network, request_seconds) {
+                (false, 0) => 269,
+                (true, 0) => 239,
+                (false, _) => 300,
+                (true, _) => 273,
+            };
+            assert_eq!(clock.elapsed(), Duration::from_secs(expected_seconds));
+            assert!(clock.elapsed() <= TRANSITION_BOUND);
+            assert_eq!(f.calls().iter().filter(|&&call| call == "start").count(), 1);
+            assert!(f.calls().iter().filter(|&&call| call == "get").count() <= 15);
+        }
+    }
+}
+
+#[test]
+fn exhausted_admission_cannot_dispatch_and_late_running_result_cannot_succeed() {
+    for (seconds, calls) in [(271, vec!["get"]), (101, vec!["get", "start", "get"])] {
+        let f = Fixture::new(false);
+        let clock = f.timed(Duration::from_secs(seconds));
+        assert_eq!(
+            f.provider().start_with_clock(&f.worker, &clock),
+            Err(RunPodError::StartUnverified)
+        );
+        assert_eq!(f.calls(), calls);
+    }
 }
 
 #[test]

--- a/crates/horizon-core/src/cloud_run/runpod/stop.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/stop.rs
@@ -15,13 +15,18 @@ use serde_json::Value;
 #[serde(default)]
 pub(super) struct StopMetadata {
     mounts: Value,
-    actions: Value,
-    locked: Value,
-    cloud: Value,
-    cluster: Value,
-    runtime: Value,
+    pub(super) actions: Value,
+    pub(super) locked: Value,
+    pub(super) cloud: Value,
+    pub(super) cluster: Value,
+    #[serde(default, deserialize_with = "present_runtime")]
+    pub(super) runtime: Option<Value>,
     #[serde(rename = "dataCenterId")]
     data_center_id: Value,
+}
+
+fn present_runtime<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Option<Value>, D::Error> {
+    Value::deserialize(deserializer).map(Some)
 }
 
 impl StopMetadata {
@@ -42,7 +47,7 @@ struct Mounts {
 
 #[derive(Debug, Eq, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct PersistentMount {
+pub(super) struct PersistentMount {
     size: u32,
     path: String,
 }
@@ -53,7 +58,7 @@ struct RetainedState {
 }
 
 #[derive(Eq, PartialEq)]
-enum RetainedMount {
+pub(super) enum RetainedMount {
     Ordinary(PersistentMount),
     SelectedNetwork,
 }
@@ -137,23 +142,9 @@ impl RunPodClient {
     ) -> Result<RetainedState, RunPodError> {
         let status = status_from_resource(pod, worker, Some(ssh_public_key))?;
         let metadata = &pod.stop;
-        if metadata.cloud != "SECURE" || !metadata.cluster.is_null() {
-            return Err(RunPodError::StopRetentionUnverified);
-        }
-        let mount = if self.network_binding.is_some() {
-            self.verify_selected_volume()?;
-            self.verify_attachment(pod)?;
-            RetainedMount::SelectedNetwork
-        } else {
-            let mounts: Mounts =
-                serde_json::from_value(metadata.mounts.clone()).map_err(|_| RunPodError::StopRetentionUnverified)?;
-            if mounts.persistent.path != "/workspace" || mounts.persistent.size < profile.volume_gib {
-                return Err(RunPodError::StopRetentionUnverified);
-            }
-            RetainedMount::Ordinary(mounts.persistent)
-        };
+        let mount = self.retained_mount(pod, profile)?;
         let stopped = match status.lifecycle {
-            RunPodLifecycle::Exited if metadata.runtime.is_null() => true,
+            RunPodLifecycle::Exited if metadata.runtime.as_ref().is_none_or(Value::is_null) => true,
             RunPodLifecycle::Provisioning | RunPodLifecycle::Running
                 if metadata.locked == false
                     && metadata
@@ -166,5 +157,24 @@ impl RunPodClient {
             _ => return Err(RunPodError::StopStateUnverified),
         };
         Ok(RetainedState { mount, stopped })
+    }
+
+    pub(super) fn retained_mount(&self, pod: &ApiPod, profile: &RunPodProfile) -> Result<RetainedMount, RunPodError> {
+        let metadata = &pod.stop;
+        if metadata.cloud != "SECURE" || !metadata.cluster.is_null() {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
+        Ok(if self.network_binding.is_some() {
+            self.verify_selected_volume()?;
+            self.verify_attachment(pod)?;
+            RetainedMount::SelectedNetwork
+        } else {
+            let mounts: Mounts =
+                serde_json::from_value(metadata.mounts.clone()).map_err(|_| RunPodError::StopRetentionUnverified)?;
+            if mounts.persistent.path != "/workspace" || mounts.persistent.size < profile.volume_gib {
+                return Err(RunPodError::StopRetentionUnverified);
+            }
+            RetainedMount::Ordinary(mounts.persistent)
+        })
     }
 }


### PR DESCRIPTION
## Purpose

Adds the retained GPU worker provider's Start capability for #473, without changing shared workspace/store or UI management paths.

## Behavior and safety

- Requires the exact saved persistent worker, matching profile/storage attachment and an existing retained SSH identity before provider mutation.
- Uses one Start action for an explicitly stopped worker. An already running worker is observed read-only; an absent worker is not recreated.
- Reconciles ambiguous Start replies through repeated bounded read-only observations, never a second Start. A monotonic five-minute operation window includes admission, dispatch, reads and backoff; complete per-request budgets are reserved before polling. Expiry retains uncertainty, not false readiness.
- Ownership, storage and SSH identity drift fail closed. Nothing creates workers, replaces pins, prepares repositories, transfers credentials or replays tasks. Existing Stop behavior is preserved.

The transport follows the [documented V2 state-transition API](https://docs.runpod.io/api-reference-v2/pods/trigger-a-pod-state-transition). Changed SSH TCP ports are deliberately refused, including after Start: authenticated endpoint refresh is a separate follow-up. No live cloud Start or client-off acceptance is claimed.

## Validation

Full validation passed in the exact candidate worktree: formatting, maintainability, version sync, default tests (2,675 passed), speech tests (2,720 passed), blocking Clippy, strict Clippy and pedantic Clippy. Both test tiers had 7 ignored tests across 26 suites; this pass used four test threads and two build jobs.

The focused suite passed 98 tests. Thirteen provider tests cover retained identity/storage admission, absence, read-only running/starting states, ambiguous replies, attachment/endpoint drift and exact HTTP handling. Simulated-clock regressions cover starts taking over 90 seconds, slow reads, final-poll limits, exhausted admission and late-result refusal without real long sleeps.

Scope: 9 source/test paths, 888 changed lines. No UI or configuration changes; no UI smoke applies.
