### PR TITLE
feat(remote): start a stopped Azure worker through the configured path

### DIFF
--- a/crates/horizon-core/src/remote_workspace/start.rs
+++ b/crates/horizon-core/src/remote_workspace/start.rs
@@ -1,6 +1,10 @@
 //! Explicit, durable Start of a stopped worker's retained compute. Reconnecting,
 //! reopening a view or restarting the application never invokes this operation.
 
+mod configured_azure;
+
+pub use configured_azure::{ConfiguredAzureStart, ConfiguredAzureStartError, start_configured_azure_environment};
+
 use crate::{
     cloud_run::{
         CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, WorkerLifetime,

--- a/crates/horizon-core/src/remote_workspace/start/configured_azure.rs
+++ b/crates/horizon-core/src/remote_workspace/start/configured_azure.rs
@@ -1,0 +1,148 @@
+//! Configured Azure Start: the same admission as the Azure Stop paths (named profile,
+//! immutable CPU profile binding, retained worker with its complete handle and public
+//! pin, no `RunPod` storage expectation), a saved Stopped record or existing Start
+//! intent, the lazy CLI credential and client only after admission, the binding
+//! rechecked around the one provider start, and the shared Start coordinator.
+
+use super::{RemoteWorkspaceStart, RemoteWorkspaceStartError, start_remote_workspace};
+use crate::{
+    cloud_run::{
+        CloudProvider, CloudWorkflowStore, StoredRemoteAllocation, azure::AzureProfile,
+        interactive_worker::InteractiveWorkerLifecycle, interactive_worker_start::InteractiveWorkerStartProvider,
+    },
+    remote_provider_config::{RemoteProviderConfig, RemoteProviderConfigError},
+    remote_workspace::{
+        RemoteEnvironmentSummary, RemoteRuntimePhase,
+        stop::{
+            ConfiguredStopConfirmationError as BindingError, RemoteWorkspaceStopError,
+            configured_azure::{Bound, RetainedAzure},
+        },
+    },
+};
+
+/// Safe overview result of one start: the saved record after the renewed observation
+/// (`Reconciling`), the provider's lifecycle, and whether the worker already ran.
+/// Reconnecting session panels re-establishes readiness; nothing resumed a task.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfiguredAzureStart {
+    pub saved: RemoteEnvironmentSummary,
+    pub lifecycle: InteractiveWorkerLifecycle,
+    pub already_running: bool,
+}
+
+/// Start the retained compute of one explicitly confirmed, saved-Stopped Azure worker.
+/// Run off the render thread after explicit confirmation. Requires the named
+/// `remote.azure` profile, the allocation's immutable CPU profile binding, the retained
+/// worker with its complete handle and complete saved public pin, and no `RunPod` storage
+/// expectation, all before the subscription-pinned CLI credential or client exists.
+/// Durable Start intent precedes the provider call through the shared coordinator; the
+/// same entry point retries an existing intent and re-posts nothing that already runs.
+/// Only the exact saved worker under its saved pin is accepted; a replacement pin is
+/// never adopted. Does not create, delete, prepare a repository, deliver credentials
+/// or replay a task; compute billing resumes at the profile's declared cost.
+/// # Errors
+/// Rejects unsupported, stale, missing or malformed selections, profile, binding, pin
+/// or storage drift, records without a saved Stop, competing management intent,
+/// unverified starts, absence and identity drift. Failures after dispatch retain
+/// intent and identity for an explicit retry.
+pub fn start_configured_azure_environment(
+    store: &CloudWorkflowStore,
+    config: &RemoteProviderConfig,
+    expected: &RemoteEnvironmentSummary,
+) -> Result<ConfiguredAzureStart, ConfiguredAzureStartError> {
+    if expected.provider != CloudProvider::Azure {
+        return Err(ConfiguredAzureStartError::UnsupportedProvider);
+    }
+    let profile = config.azure_profile(&expected.profile)?;
+    start_with(
+        store,
+        profile,
+        expected,
+        |_admitted| RetainedAzure::client(store, profile),
+        |provider, allocation| start_remote_workspace(store, provider, allocation),
+    )
+}
+
+/// Admission, then the provider, then the shared Start coordinator. A record without a
+/// saved Stop or Start intent is refused before the client exists; the saved state is
+/// rechecked after client construction; the binding and storage are rechecked inside
+/// the provider call, after intent was recorded and before the renewed observation is
+/// written; nothing fallible follows that write. `client` and `start` are injectable
+/// so tests run the real ordering without the Azure CLI or ARM.
+pub(super) fn start_with<P: InteractiveWorkerStartProvider>(
+    store: &CloudWorkflowStore,
+    profile: &AzureProfile,
+    expected: &RemoteEnvironmentSummary,
+    client: impl FnOnce(&RetainedAzure) -> Result<P, BindingError>,
+    start: impl FnOnce(&Bound<'_, P>, &StoredRemoteAllocation) -> Result<RemoteWorkspaceStart, RemoteWorkspaceStartError>,
+) -> Result<ConfiguredAzureStart, ConfiguredAzureStartError> {
+    let admitted = RetainedAzure::load(store, profile, expected)?;
+    let phase = admitted
+        .allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(BindingError::InvalidBinding)?
+        .phase;
+    if !matches!(
+        phase,
+        RemoteRuntimePhase::Stopped { .. } | RemoteRuntimePhase::Starting { .. }
+    ) {
+        return Err(RemoteWorkspaceStartError::NotStopped.into());
+    }
+    let provider = client(&admitted);
+    admitted.check_current(store, &admitted.allocation)?;
+    let bound = Bound::new(provider?, store, &admitted);
+    let result = start(&bound, &admitted.allocation);
+    if bound.drifted() {
+        // Intent is recorded and compute may have been started; the renewed
+        // observation was not written. An explicit retry resolves it.
+        return Err(RemoteWorkspaceStartError::StateChanged.into());
+    }
+    let result = result?;
+    Ok(ConfiguredAzureStart {
+        saved: result.allocation.workspace().environment_summary(),
+        lifecycle: result.lifecycle,
+        already_running: result.already_running,
+    })
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum ConfiguredAzureStartError {
+    #[error("configured Azure Start is supported only for saved-Stopped persistent Azure workers")]
+    UnsupportedProvider,
+    #[error(
+        "the configured Azure profile or retained worker, public pin, profile binding and storage binding is invalid"
+    )]
+    InvalidBinding,
+    #[error(transparent)]
+    Configuration(#[from] RemoteProviderConfigError),
+    #[error("Azure Start could not be verified; refresh saved state and retry Start explicitly")]
+    Start(#[from] RemoteWorkspaceStartError),
+}
+
+impl From<BindingError> for ConfiguredAzureStartError {
+    fn from(error: BindingError) -> Self {
+        match error {
+            BindingError::UnsupportedProvider => Self::UnsupportedProvider,
+            // The Azure credential is lazy and never consulted during admission.
+            BindingError::CredentialUnavailable | BindingError::InvalidBinding => Self::InvalidBinding,
+            BindingError::Configuration(error) => Self::Configuration(error),
+            BindingError::Stop(error) => Self::Start(match error {
+                RemoteWorkspaceStopError::MissingAllocation => RemoteWorkspaceStartError::MissingAllocation,
+                RemoteWorkspaceStopError::MissingWorker => RemoteWorkspaceStartError::MissingWorker,
+                RemoteWorkspaceStopError::MissingTrust => RemoteWorkspaceStartError::MissingTrust,
+                RemoteWorkspaceStopError::StateChanged => RemoteWorkspaceStartError::StateChanged,
+                RemoteWorkspaceStopError::ProviderMismatch => RemoteWorkspaceStartError::ProviderMismatch,
+                RemoteWorkspaceStopError::UnsupportedLifetime => RemoteWorkspaceStartError::UnsupportedLifetime,
+                RemoteWorkspaceStopError::ManagementConflict => RemoteWorkspaceStartError::ManagementConflict,
+                RemoteWorkspaceStopError::InvalidTimestamp => RemoteWorkspaceStartError::InvalidTimestamp,
+                RemoteWorkspaceStopError::StorageUnavailable
+                | RemoteWorkspaceStopError::MissingStopIntent
+                | RemoteWorkspaceStopError::ProviderUnavailable
+                | RemoteWorkspaceStopError::ResourceAbsent => RemoteWorkspaceStartError::StorageUnavailable,
+            }),
+        }
+    }
+}

--- a/crates/horizon-core/src/remote_workspace/start/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/start/tests.rs
@@ -1,3 +1,5 @@
+mod configured_azure;
+
 use super::*;
 use crate::{
     cloud_run::{

--- a/crates/horizon-core/src/remote_workspace/start/tests/configured_azure.rs
+++ b/crates/horizon-core/src/remote_workspace/start/tests/configured_azure.rs
@@ -1,0 +1,587 @@
+//! Configured Azure Start on real stores with a fake provider: admission before the
+//! client, durable intent before the one start, only the saved identity accepted, and
+//! binding drift fenced around the provider call.
+use crate::{
+    cloud_run::{
+        CloudProvider, CloudWorkflowStore, StoredRemoteAllocation, WorkerLifetime,
+        azure::{AzureDiskSku, AzureProfile, resource_group_name},
+        interactive_worker::{
+            InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity,
+            InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest,
+            InteractiveWorkerSshEndpoint, InteractiveWorkerStatus,
+        },
+        interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
+    },
+    remote_provider_config::RemoteProviderConfig,
+    remote_workspace::{
+        RemoteEnvironmentSummary, RemoteRuntimePhase, RemoteWorkspaceState,
+        start::{
+            ConfiguredAzureStartError as Rejected, RemoteWorkspaceStartError as Error, configured_azure::start_with,
+            start_configured_azure_environment, start_remote_workspace,
+        },
+        stop::{ConfiguredStopConfirmationError, configured_azure::RetainedAzure},
+    },
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::Mutex;
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+const SUBSCRIPTION: &str = "11111111-1111-4111-8111-111111111111";
+
+fn azure_profile() -> AzureProfile {
+    AzureProfile {
+        name: "cpu".into(),
+        subscription_id: SUBSCRIPTION.into(),
+        location: "northeurope".into(),
+        vm_size: "Standard_D4s_v3".into(),
+        image_pull_identity_id: format!(
+            "/subscriptions/{SUBSCRIPTION}/resourceGroups/synthetic/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"
+        ),
+        declared_hourly_cost_micros: 100_000,
+        registry_login_server: "synthetic.azurecr.io".into(),
+        disk_sku: AzureDiskSku::StandardSsdLrs,
+    }
+}
+
+fn key(byte: u8) -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+
+fn pin() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: "203.0.113.9".into(),
+        port: 2222,
+        username: "root".into(),
+        host_key: key(9),
+    }
+}
+
+/// The saved phase the fixture ends in.
+#[derive(Clone, Copy, PartialEq)]
+enum Saved {
+    Running,
+    Stopping,
+    Stopped,
+    Starting,
+}
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: CloudWorkflowStore,
+    profile: AzureProfile,
+}
+
+impl Fixture {
+    fn new(saved: Saved, binding: bool, pinned: bool) -> Self {
+        let directory = tempfile::tempdir().expect("fixture");
+        let store = CloudWorkflowStore::open_path(directory.path().join("control/store.sqlite3")).expect("store");
+        let profile = azure_profile();
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1, "spec":{
+                "workspace_local_id":"workspace", "working_directory":".", "generation":0, "panels":[],
+                "target":{"provider":"azure", "profile":"cpu", "disk_gib":20, "lifetime":"persistent",
+                    "image":format!("synthetic.azurecr.io/worker@sha256:{}", "a".repeat(64)),
+                    "max_hourly_cost_micros":200_000},
+                "repository":{"repository":"example/project", "commit":"b".repeat(40)}
+            }
+        }))
+        .expect("state");
+        let workspace = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocation = store.allocate_remote_runtime(&workspace, i64::MAX).expect("allocation");
+        if binding {
+            store
+                .record_remote_cpu_profile_binding(&allocation, &profile)
+                .expect("binding");
+        }
+        let reserved = store
+            .reserve_remote_worker_request(&allocation, &key(7))
+            .expect("public request");
+        let request = reserved.worker_request().expect("request");
+        let status = InteractiveWorkerStatus {
+            worker: worker_for(&request),
+            lifecycle: if pinned {
+                InteractiveWorkerLifecycle::Ready
+            } else {
+                InteractiveWorkerLifecycle::Provisioning
+            },
+            ssh: pinned.then(pin),
+        };
+        store
+            .record_remote_worker_recovery(&reserved, Some(&status))
+            .expect("retained public observation");
+        let fixture = Self {
+            directory,
+            store,
+            profile,
+        };
+        if saved != Saved::Running {
+            fixture
+                .store
+                .record_remote_stop_phase(
+                    &fixture.current(),
+                    RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+                )
+                .expect("intent");
+        }
+        if matches!(saved, Saved::Stopped | Saved::Starting) {
+            fixture
+                .store
+                .record_remote_stop_phase(
+                    &fixture.current(),
+                    RemoteRuntimePhase::Stopped {
+                        requested_at_millis: 1,
+                        observed_at_millis: 2,
+                    },
+                )
+                .expect("completion");
+        }
+        if saved == Saved::Starting {
+            fixture
+                .store
+                .record_remote_start_phase(
+                    &fixture.current(),
+                    RemoteRuntimePhase::Starting { requested_at_millis: 3 },
+                )
+                .expect("start intent");
+        }
+        fixture
+    }
+
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+
+    fn phase(&self) -> RemoteRuntimePhase {
+        self.current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase
+    }
+
+    fn start(&self, starter: &Starter) -> Result<super::super::ConfiguredAzureStart, Rejected> {
+        start_with(
+            &self.store,
+            &self.profile,
+            &self.current().workspace().environment_summary(),
+            |_| Ok(starter),
+            |provider, allocation| start_remote_workspace(&self.store, provider, allocation),
+        )
+    }
+}
+
+fn worker_for(request: &InteractiveWorkerRequest) -> InteractiveWorker {
+    InteractiveWorker {
+        identity: InteractiveWorkerIdentity {
+            provider: CloudProvider::Azure,
+            workflow_id: request.workflow_id,
+            job_id: request.job_id,
+            resource_id: format!(
+                "/subscriptions/{SUBSCRIPTION}/resourceGroups/{}",
+                resource_group_name(request.workflow_id, request.job_id)
+            ),
+        },
+        target: request.target.clone(),
+        ssh_public_key: request.ssh_public_key.clone(),
+        lifetime: InteractiveWorkerLifetime::Persistent,
+    }
+}
+
+type StartScript = Box<dyn Fn(&InteractiveWorker) -> Result<InteractiveWorkerStart, &'static str> + Send + Sync>;
+
+struct Starter {
+    script: StartScript,
+    calls: Mutex<usize>,
+}
+
+impl Starter {
+    fn answering(
+        script: impl Fn(&InteractiveWorker) -> Result<InteractiveWorkerStart, &'static str> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            script: Box::new(script),
+            calls: Mutex::new(0),
+        }
+    }
+
+    fn same_worker(lifecycle: InteractiveWorkerLifecycle, already_running: bool) -> Self {
+        Self::answering(move |worker| {
+            let status = InteractiveWorkerStatus {
+                worker: worker.clone(),
+                lifecycle,
+                ssh: (lifecycle == InteractiveWorkerLifecycle::Ready).then(pin),
+            };
+            Ok(if already_running {
+                InteractiveWorkerStart::AlreadyRunning(status)
+            } else {
+                InteractiveWorkerStart::Started(status)
+            })
+        })
+    }
+
+    fn calls(&self) -> usize {
+        *self.calls.lock().expect("calls")
+    }
+}
+
+impl InteractiveWorkerProvider for &Starter {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::Azure
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no create")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no inspection")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no recovery")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no delete")
+    }
+}
+
+impl InteractiveWorkerStartProvider for &Starter {
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+        assert!(worker.is_valid_for(CloudProvider::Azure));
+        *self.calls.lock().expect("calls") += 1;
+        (self.script)(worker).map_err(std::io::Error::other)
+    }
+}
+
+fn refused(fixture: &Fixture, profile: &AzureProfile, summary: Option<RemoteEnvironmentSummary>) -> Rejected {
+    let before = fixture.current();
+    let expected = summary.unwrap_or_else(|| before.workspace().environment_summary());
+    let error = start_with(
+        &fixture.store,
+        profile,
+        &expected,
+        |_: &RetainedAzure| -> Result<&Starter, ConfiguredStopConfirmationError> {
+            panic!("must not construct the client")
+        },
+        |_, _| panic!("no provider work"),
+    )
+    .expect_err("refused");
+    assert_eq!(fixture.current(), before, "nothing recorded by a refusal");
+    error
+}
+
+#[test]
+fn public_azure_start_refuses_unsupported_or_missing_named_profiles_and_records_without_a_saved_stop() {
+    let fixture = Fixture::new(Saved::Stopped, true, true);
+    let before = fixture.current();
+    for provider in [CloudProvider::LocalDocker, CloudProvider::RunPod, CloudProvider::Azure] {
+        let mut expected = before.workspace().environment_summary();
+        expected.provider = provider;
+        let result = start_configured_azure_environment(&fixture.store, &RemoteProviderConfig::default(), &expected);
+        if provider == CloudProvider::Azure {
+            assert!(matches!(result, Err(Rejected::Configuration(_))), "{result:?}");
+        } else {
+            assert_eq!(result, Err(Rejected::UnsupportedProvider));
+        }
+        assert_eq!(fixture.current(), before);
+    }
+    // A configured profile with a running record is refused by admission, so the public
+    // path proves its dispatch without ever reaching the Azure CLI.
+    let fixture = Fixture::new(Saved::Running, true, true);
+    let before = fixture.current();
+    let config = RemoteProviderConfig {
+        azure: vec![fixture.profile.clone()],
+        ..Default::default()
+    };
+    assert_eq!(
+        start_configured_azure_environment(&fixture.store, &config, &before.workspace().environment_summary()),
+        Err(Rejected::Start(Error::NotStopped))
+    );
+    assert_eq!(fixture.current(), before);
+}
+
+#[test]
+fn one_start_records_intent_before_dispatch_and_resolves_the_same_identity_to_reconciling() {
+    for (already_running, lifecycle) in [
+        (false, InteractiveWorkerLifecycle::Ready),
+        (false, InteractiveWorkerLifecycle::Provisioning),
+        (true, InteractiveWorkerLifecycle::Ready),
+    ] {
+        let fixture = Fixture::new(Saved::Stopped, true, true);
+        let before = fixture.current();
+        let store = fixture.store.clone();
+        let fake = Starter::answering(move |worker| {
+            let current = store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("read")
+                .expect("allocation");
+            let runtime = current.workspace().state().runtime.as_ref().expect("runtime");
+            assert!(matches!(runtime.phase, RemoteRuntimePhase::Starting { .. }));
+            assert_eq!(runtime.worker.as_ref(), Some(worker));
+            let status = InteractiveWorkerStatus {
+                worker: worker.clone(),
+                lifecycle,
+                ssh: (lifecycle == InteractiveWorkerLifecycle::Ready).then(pin),
+            };
+            Ok(if already_running {
+                InteractiveWorkerStart::AlreadyRunning(status)
+            } else {
+                InteractiveWorkerStart::Started(status)
+            })
+        });
+        let started = fixture.start(&fake).expect("verified start");
+        let after = fixture.current();
+        assert_eq!(started.saved, after.workspace().environment_summary());
+        assert_eq!(
+            (started.lifecycle, started.already_running),
+            (lifecycle, already_running)
+        );
+        assert_eq!(fixture.phase(), RemoteRuntimePhase::Reconciling);
+        let mut permitted = before.workspace().state().clone();
+        permitted.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Reconciling;
+        assert_eq!(after.workspace().state(), &permitted);
+        assert_eq!(after.workspace().revision(), before.workspace().revision() + 2);
+        assert_eq!(fake.calls(), 1);
+        assert_eq!(fixture.start(&fake), Err(Rejected::Start(Error::NotStopped)));
+        assert_eq!(fake.calls(), 1);
+        assert_eq!(
+            fixture.directory.path().read_dir().expect("root").count(),
+            1,
+            "only the control store, no identity"
+        );
+    }
+}
+
+#[test]
+fn admission_refuses_before_the_client_for_every_invalid_record_or_profile() {
+    let cases: [(&str, Saved, bool, bool, Rejected); 5] = [
+        (
+            "running",
+            Saved::Running,
+            true,
+            true,
+            Rejected::Start(Error::NotStopped),
+        ),
+        (
+            "stop in flight",
+            Saved::Stopping,
+            true,
+            true,
+            Rejected::Start(Error::NotStopped),
+        ),
+        (
+            "no pin",
+            Saved::Stopped,
+            true,
+            false,
+            Rejected::Start(Error::MissingTrust),
+        ),
+        ("no binding", Saved::Stopped, false, true, Rejected::InvalidBinding),
+        (
+            "no pin, no binding",
+            Saved::Stopped,
+            false,
+            false,
+            Rejected::InvalidBinding,
+        ),
+    ];
+    for (label, saved, binding, pinned, expected) in cases {
+        let fixture = Fixture::new(saved, binding, pinned);
+        assert_eq!(refused(&fixture, &fixture.profile, None), expected, "{label}");
+    }
+    let fixture = Fixture::new(Saved::Stopped, true, true);
+    let mut drifted = fixture.profile.clone();
+    drifted.vm_size = "Standard_D2s_v3".into();
+    assert_eq!(refused(&fixture, &drifted, None), Rejected::InvalidBinding);
+    let mut renamed = fixture.profile.clone();
+    renamed.name = "other".into();
+    assert_eq!(refused(&fixture, &renamed, None), Rejected::InvalidBinding);
+    let mut stale = fixture.current().workspace().environment_summary();
+    stale.panel_count += 1;
+    assert_eq!(
+        refused(&fixture, &fixture.profile, Some(stale)),
+        Rejected::Start(Error::StateChanged)
+    );
+}
+
+#[test]
+fn uncertainty_absence_and_foreign_observations_retain_intent_and_an_existing_intent_is_retried() {
+    let outcomes: [(&str, Starter, Rejected); 4] = [
+        (
+            "provider failure",
+            Starter::answering(|_| Err("private-provider-marker")),
+            Rejected::Start(Error::ProviderUnavailable),
+        ),
+        (
+            "absence",
+            Starter::answering(|_| Ok(InteractiveWorkerStart::AlreadyAbsent)),
+            Rejected::Start(Error::ResourceAbsent),
+        ),
+        (
+            "another worker",
+            Starter::answering(|worker| {
+                let mut other = worker.clone();
+                other.identity.resource_id = format!("/subscriptions/{SUBSCRIPTION}/resourceGroups/horizon-ws-other");
+                Ok(InteractiveWorkerStart::Started(InteractiveWorkerStatus {
+                    worker: other,
+                    lifecycle: InteractiveWorkerLifecycle::Ready,
+                    ssh: Some(pin()),
+                }))
+            }),
+            Rejected::Start(Error::IdentityMismatch),
+        ),
+        (
+            "replacement pin",
+            Starter::answering(|worker| {
+                Ok(InteractiveWorkerStart::Started(InteractiveWorkerStatus {
+                    worker: worker.clone(),
+                    lifecycle: InteractiveWorkerLifecycle::Ready,
+                    ssh: Some(InteractiveWorkerSshEndpoint {
+                        host_key: key(11),
+                        ..pin()
+                    }),
+                }))
+            }),
+            Rejected::Start(Error::IdentityMismatch),
+        ),
+    ];
+    for (label, starter, expected) in outcomes {
+        let fixture = Fixture::new(Saved::Stopped, true, true);
+        let before = fixture.current();
+        let error = fixture.start(&starter).expect_err(label);
+        assert_eq!(error, expected, "{label}");
+        assert!(!format!("{error:?} {error}").contains("private-provider-marker"));
+        assert!(
+            matches!(fixture.phase(), RemoteRuntimePhase::Starting { .. }),
+            "{label}"
+        );
+        let retained = fixture.current();
+        let mut permitted = before.workspace().state().clone();
+        permitted.runtime.as_mut().expect("runtime").phase = fixture.phase();
+        assert_eq!(
+            retained.workspace().state(),
+            &permitted,
+            "{label}: identity and pin unchanged"
+        );
+        assert_eq!(starter.calls(), 1);
+    }
+    // A saved Start intent is admitted again and resolved without re-posting.
+    let fixture = Fixture::new(Saved::Starting, true, true);
+    let before = fixture.current();
+    let retry = Starter::same_worker(InteractiveWorkerLifecycle::Ready, true);
+    let started = fixture.start(&retry).expect("retry");
+    assert!(started.already_running);
+    assert_eq!(fixture.phase(), RemoteRuntimePhase::Reconciling);
+    assert_eq!(started.saved.revision, before.workspace().revision() + 1);
+}
+
+#[test]
+fn drift_at_the_client_and_binding_drift_during_the_start_never_resolve_intent() {
+    // Drift while the client is built refuses dispatch, with and without a client error.
+    for failure in [false, true] {
+        let fixture = Fixture::new(Saved::Stopped, true, true);
+        let before = fixture.current();
+        let starter = Starter::same_worker(InteractiveWorkerLifecycle::Ready, false);
+        let result = start_with(
+            &fixture.store,
+            &fixture.profile,
+            &before.workspace().environment_summary(),
+            |_| {
+                let current = fixture.current();
+                let mut workflow = current.workflow().workflow().clone();
+                workflow.updated_at_millis += 1;
+                fixture
+                    .store
+                    .replace(current.workflow(), &workflow)
+                    .expect("workflow drift");
+                if failure {
+                    Err(ConfiguredStopConfirmationError::InvalidBinding)
+                } else {
+                    Ok(&starter)
+                }
+            },
+            |_, _| panic!("no dispatch after snapshot drift"),
+        );
+        assert_eq!(result, Err(Rejected::Start(Error::StateChanged)));
+        assert_eq!(fixture.current().workspace(), before.workspace());
+        assert_eq!(starter.calls(), 0);
+    }
+    // The binding changing while the provider starts leaves the intent for a retry.
+    for result in [Ok(()), Err("in-flight failure")] {
+        let fixture = Fixture::new(Saved::Stopped, true, true);
+        let path = fixture.store.path().to_path_buf();
+        let starter = Starter::answering(move |worker| {
+            drift_binding(&path);
+            result.map(|()| {
+                InteractiveWorkerStart::Started(InteractiveWorkerStatus {
+                    worker: worker.clone(),
+                    lifecycle: InteractiveWorkerLifecycle::Ready,
+                    ssh: Some(pin()),
+                })
+            })
+        });
+        assert_eq!(
+            fixture.start(&starter),
+            Err(Rejected::Start(Error::StateChanged)),
+            "{result:?}"
+        );
+        assert_eq!(starter.calls(), 1);
+        assert!(matches!(fixture.phase(), RemoteRuntimePhase::Starting { .. }));
+    }
+}
+
+/// Change the immutable binding row underneath the allocation, as only corruption or a
+/// foreign writer could; the store's own triggers are bypassed for the fixture only.
+fn drift_binding(path: &std::path::Path) {
+    let mut connection = rusqlite::Connection::open(path).expect("fixture database");
+    let transaction = connection.transaction().expect("fixture transaction");
+    let trigger: String = transaction
+        .query_row(
+            "SELECT sql FROM sqlite_schema WHERE name='remote_provider_bindings_no_update'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("trigger");
+    let digest: String = transaction
+        .query_row(
+            "SELECT profile_digest FROM remote_provider_bindings WHERE workspace_local_id='workspace'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("digest");
+    let head = &digest[..digest.len() - 1];
+    let flipped = if digest.ends_with('0') {
+        format!("{head}1")
+    } else {
+        format!("{head}0")
+    };
+    transaction
+        .execute_batch("DROP TRIGGER remote_provider_bindings_no_update")
+        .expect("fixture only");
+    transaction
+        .execute(
+            "UPDATE remote_provider_bindings SET profile_digest=?1 WHERE workspace_local_id='workspace'",
+            [&flipped],
+        )
+        .expect("binding drift");
+    transaction.execute_batch(&trigger).expect("restore exact schema");
+    transaction.commit().expect("atomic fixture");
+}
+
+#[test]
+fn a_timed_target_is_never_started() {
+    let fixture = Fixture::new(Saved::Stopped, true, true);
+    let before = fixture.current();
+    let mut summary = before.workspace().environment_summary();
+    summary.lifetime = WorkerLifetime::TimeLimited { seconds: 900 };
+    assert_eq!(
+        refused(&fixture, &fixture.profile, Some(summary)),
+        Rejected::Start(Error::StateChanged),
+        "a summary that does not match the saved persistent record is stale, not admitted"
+    );
+}

--- a/crates/horizon-core/src/remote_workspace/stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop.rs
@@ -1,7 +1,7 @@
 //! Explicit, durable Stop coordination. Client lifecycle never invokes this operation.
 
 mod configured;
-mod configured_azure;
+pub(super) mod configured_azure;
 mod configured_confirmation;
 mod configured_runpod;
 mod confirmation;

--- a/crates/horizon-core/src/remote_workspace/stop/configured_azure.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/configured_azure.rs
@@ -225,10 +225,11 @@ impl RetainedAzure {
         Ok(())
     }
 
-    /// The production observer: the CLI credential pinned to the profile's subscription
-    /// and the Azure client over it. Both are lazy; no token is requested or persisted
-    /// here, and a missing CLI login surfaces as an unverified observation. Callers
-    /// reach this only through [`azure_with`], after admission.
+    /// The shared production Azure client: the CLI credential pinned to the profile's
+    /// subscription and the client over it. Both are lazy; no token is requested or
+    /// persisted here, and a missing CLI login surfaces as an unverified operation. The
+    /// admitted Stop paths (`stop_with`, `azure_with`) and the configured Start path reach
+    /// this only after admission.
     pub(in crate::remote_workspace) fn client(
         store: &CloudWorkflowStore,
         profile: &AzureProfile,

--- a/crates/horizon-core/src/remote_workspace/stop/configured_azure.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/configured_azure.rs
@@ -16,6 +16,7 @@ use crate::{
             InteractiveWorker, InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerProvider,
             InteractiveWorkerRequest, InteractiveWorkerStatus,
         },
+        interactive_worker_start::{InteractiveWorkerStart, InteractiveWorkerStartProvider},
         interactive_worker_stop::{
             InteractiveWorkerStop, InteractiveWorkerStopExpectation, InteractiveWorkerStopObservation,
             InteractiveWorkerStopObserver, InteractiveWorkerStopProvider,
@@ -87,6 +88,20 @@ pub(super) fn stop_with<P: InteractiveWorkerStopProvider>(
     {
         return Err(ConfiguredAzureStopError::ExistingStopIntent);
     }
+    // A start in flight is resolved first (explicit Start retry, then the saved-Stop
+    // check); Stop never races it, and the refusal precedes the client.
+    if admitted
+        .allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .is_some_and(|runtime| runtime.phase.start_requested_at_millis().is_some())
+    {
+        return Err(ConfiguredAzureStopError::Stop(
+            RemoteWorkspaceStopError::ManagementConflict,
+        ));
+    }
     let provider = client(&admitted);
     admitted.check_current(store, &admitted.allocation)?;
     let bound = Bound::new(provider?, store, &admitted);
@@ -103,14 +118,14 @@ pub(super) fn stop_with<P: InteractiveWorkerStopProvider>(
 /// target within the named profile, immutable binding to that profile, no `RunPod`
 /// storage expectation, no management intent, and a retained worker whose complete
 /// Azure handle validates under the profile's subscription with a complete pin.
-pub(super) struct RetainedAzure {
-    pub(super) allocation: StoredRemoteAllocation,
+pub(in crate::remote_workspace) struct RetainedAzure {
+    pub(in crate::remote_workspace) allocation: StoredRemoteAllocation,
     request: InteractiveWorkerRequest,
     binding: RemoteCpuProfileBinding,
 }
 
 impl RetainedAzure {
-    pub(super) fn load(
+    pub(in crate::remote_workspace) fn load(
         store: &CloudWorkflowStore,
         profile: &AzureProfile,
         expected: &RemoteEnvironmentSummary,
@@ -214,7 +229,10 @@ impl RetainedAzure {
     /// and the Azure client over it. Both are lazy; no token is requested or persisted
     /// here, and a missing CLI login surfaces as an unverified observation. Callers
     /// reach this only through [`azure_with`], after admission.
-    pub(super) fn client(store: &CloudWorkflowStore, profile: &AzureProfile) -> Result<AzureClient, BindingError> {
+    pub(in crate::remote_workspace) fn client(
+        store: &CloudWorkflowStore,
+        profile: &AzureProfile,
+    ) -> Result<AzureClient, BindingError> {
         let credential =
             AzureCliCredential::new(profile.subscription_id.clone()).map_err(|_| BindingError::InvalidBinding)?;
         AzureClient::new(profile.clone(), credential, store.clone()).map_err(|_| BindingError::InvalidBinding)
@@ -223,7 +241,7 @@ impl RetainedAzure {
     /// The binding and the absence of a storage selection must still hold for the
     /// allocation as it is now; used where the coordinator has already advanced the
     /// allocation (intent recorded) and fences it with its own CAS.
-    fn check_binding(&self, store: &CloudWorkflowStore) -> Result<(), BindingError> {
+    pub(in crate::remote_workspace) fn check_binding(&self, store: &CloudWorkflowStore) -> Result<(), BindingError> {
         let current = store
             .load_remote_allocation(
                 self.allocation.workspace().session_id(),
@@ -248,7 +266,7 @@ impl RetainedAzure {
 
     /// The exact allocation, its binding and the absence of a storage selection must
     /// all still hold: any drift around the observation is a changed state, not a result.
-    pub(super) fn check_current(
+    pub(in crate::remote_workspace) fn check_current(
         &self,
         store: &CloudWorkflowStore,
         expected: &StoredRemoteAllocation,
@@ -280,7 +298,7 @@ impl RetainedAzure {
 /// answer reaches the shared coordinator, by the binding recheck admission ran, so a
 /// binding that changed while the control plane was being read or the Stop was in
 /// flight can never be completed as a retained Stop.
-pub(super) struct Bound<'a, P> {
+pub(in crate::remote_workspace) struct Bound<'a, P> {
     inner: P,
     store: &'a CloudWorkflowStore,
     admitted: &'a RetainedAzure,
@@ -288,7 +306,11 @@ pub(super) struct Bound<'a, P> {
 }
 
 impl<'a, P> Bound<'a, P> {
-    fn new(inner: P, store: &'a CloudWorkflowStore, admitted: &'a RetainedAzure) -> Self {
+    pub(in crate::remote_workspace) fn new(
+        inner: P,
+        store: &'a CloudWorkflowStore,
+        admitted: &'a RetainedAzure,
+    ) -> Self {
         Self {
             inner,
             store,
@@ -297,7 +319,7 @@ impl<'a, P> Bound<'a, P> {
         }
     }
 
-    fn drifted(&self) -> bool {
+    pub(in crate::remote_workspace) fn drifted(&self) -> bool {
         self.drifted.load(Ordering::SeqCst)
     }
 
@@ -317,7 +339,7 @@ impl<'a, P> Bound<'a, P> {
 
 /// The provider's own error, or the saved binding drifting during an observation or Stop.
 #[derive(Debug)]
-pub(super) enum BoundError<E> {
+pub(in crate::remote_workspace) enum BoundError<E> {
     Provider(E),
     Drift,
 }
@@ -377,6 +399,16 @@ impl<P: InteractiveWorkerStopProvider> InteractiveWorkerStopProvider for Bound<'
         // The coordinator has recorded intent (its own CAS fences the allocation); the
         // binding and storage must still be the admitted ones before completion.
         self.fence(stopped, self.admitted.check_binding(self.store).is_ok())
+    }
+}
+
+impl<P: InteractiveWorkerStartProvider> InteractiveWorkerStartProvider for Bound<'_, P> {
+    fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error> {
+        let started = self.inner.start_worker(worker).map_err(BoundError::Provider);
+        // Start intent is recorded (the coordinator's CAS fences the allocation); the
+        // binding and storage must still be the admitted ones before the renewed
+        // observation is written.
+        self.fence(started, self.admitted.check_binding(self.store).is_ok())
     }
 }
 

--- a/crates/horizon-core/src/remote_workspace/stop/configured_runpod.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/configured_runpod.rs
@@ -206,6 +206,12 @@ pub(super) fn stop_with(
     if runtime.phase.stop_requested_at_millis().is_some() {
         return Err(ConfiguredRunPodStopError::ExistingStopIntent);
     }
+    // A start in flight is resolved first; Stop never races it, before any credential.
+    if runtime.phase.start_requested_at_millis().is_some() {
+        return Err(ConfiguredRunPodStopError::Stop(
+            RemoteWorkspaceStopError::ManagementConflict,
+        ));
+    }
     if admitted.selection.is_none() {
         return Err(ConfiguredRunPodStopError::InvalidBinding);
     }

--- a/crates/horizon-core/src/remote_workspace/stop/tests/configured_azure_stop.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests/configured_azure_stop.rs
@@ -409,3 +409,31 @@ fn the_production_client_for_stop_is_lazy_and_unsupported_profiles_never_reach_i
     assert_eq!(fixture.current(), before);
     assert_eq!(fixture.directory.path().read_dir().expect("root").count(), 1);
 }
+
+#[test]
+fn start_intent_is_refused_before_the_client_and_never_stopped_over() {
+    let fixture = retained();
+    let fake = Stopper::answering(Ok(InteractiveWorkerStop::Stopped));
+    stop(&fixture, &fake).expect("saved Stop");
+    let stopped = fixture.current();
+    let RemoteRuntimePhase::Stopped { observed_at_millis, .. } = phase(&fixture) else {
+        panic!("stopped");
+    };
+    fixture
+        .store
+        .record_remote_start_phase(
+            &stopped,
+            RemoteRuntimePhase::Starting {
+                requested_at_millis: observed_at_millis,
+            },
+        )
+        .expect("start intent");
+    let starting = fixture.current();
+    assert_eq!(
+        refused(&fixture, &fixture.profile, None),
+        Rejected::Stop(Error::ManagementConflict),
+        "a start in flight is resolved first, before any client exists"
+    );
+    assert_eq!(fixture.current(), starting);
+    assert_eq!(fake.calls(), 1);
+}

--- a/crates/horizon-core/src/remote_workspace/stop/tests/configured_runpod.rs
+++ b/crates/horizon-core/src/remote_workspace/stop/tests/configured_runpod.rs
@@ -350,6 +350,41 @@ mod linux {
     }
 
     #[test]
+    fn start_intent_is_refused_before_credentials() {
+        let fixture = Retained::new(true, true, false);
+        fixture
+            .stop(&provider(Ok(InteractiveWorkerStop::Stopped)))
+            .expect("saved Stop");
+        let stopped = fixture.current();
+        let RemoteRuntimePhase::Stopped { observed_at_millis, .. } =
+            stopped.workspace().state().runtime.as_ref().expect("runtime").phase
+        else {
+            panic!("stopped");
+        };
+        fixture
+            .store
+            .record_remote_start_phase(
+                &stopped,
+                RemoteRuntimePhase::Starting {
+                    requested_at_millis: observed_at_millis,
+                },
+            )
+            .expect("start intent");
+        let starting = fixture.current();
+        assert_eq!(
+            stop_with(
+                &fixture.store,
+                &fixture.profile,
+                &starting.workspace().environment_summary(),
+                || panic!("credentials must remain unread"),
+                |_, _| panic!("no provider work")
+            ),
+            Err(Rejected::Stop(Error::ManagementConflict))
+        );
+        assert_eq!(fixture.current(), starting);
+    }
+
+    #[test]
     fn exact_allocation_cas_does_not_reload_a_new_workflow_before_stop() {
         let fixture = Retained::new(true, true, false);
         let before = fixture.current();


### PR DESCRIPTION
Slice 3b of the Azure lifecycle integration for #474 (claim posted there; 3a is a91bc0de). It adds the first product path that records Start intent, so it also closes the three review notes left on #576 about Stop and a record with Start intent.

## Behaviour

- **`start_configured_azure_environment`** (new `remote_workspace/start/configured_azure.rs`) reuses the Azure admission shared with the Stop paths: exact allocation and summary, valid persistent request within the named `remote.azure` profile, the allocation's immutable CPU profile binding, no RunPod storage selection, no management intent, and the retained worker's complete validated handle with its complete public pin. Only a saved `Stopped` record or one already carrying Start intent is admitted; a running record or a Stop still in flight is refused before the client exists. The subscription-pinned `AzureCliCredential` and `AzureClient` are built only after admission and the saved state is rechecked after that. The shared `start_remote_workspace` coordinator then records intent, calls the merged compute-start capability once through the admitted provider wrapper, which rechecks the binding and storage inside the call before the renewed observation is written, and accepts only the saved worker and pin. Failures, absence and identity drift retain the intent; the same entry point retries it and re-posts nothing that already runs. Compute billing resumes at the profile's declared cost; nothing prepares a repository, delivers credentials or resumes a task.
- **Start-intent fences in both configured Stop admissions.** The Azure and RunPod first-Stop paths refuse a record with Start intent as a management conflict before any credential is read or client is built, matching the core `stop_allocation` fence and the existing-intent refusal.
- The Azure admission types are shared inside the `remote_workspace` module; no shared configuration, dispatch or UI path changes. The overview Start control, its Start-intent exclusion from the Stop and check predicates, and the smoke follow as 3c; until then no overview action can record Start intent.

## Tests

`start/tests/configured_azure.rs` (real stores, fake provider): public dispatch refuses unsupported and unconfigured providers and a running record without the CLI; one start records intent before dispatch and resolves the same identity to `Reconciling` with only the phase changed (started with and without an attested endpoint, already running); admission refuses before the client for a running record, a Stop in flight, a missing pin, a missing binding, profile drift, a renamed profile and a stale summary; provider failure, absence, another worker and a replacement pin retain intent and a saved intent is retried without re-posting; drift at client construction refuses dispatch with and without a client error; binding drift during the provider start retains intent without a renewed observation. `configured_azure_stop.rs` and `configured_runpod.rs` gain the Start-intent refusal before the client or credential.

## Validation

fmt, maintainability, version sync, both harness suites, `cargo test --workspace` (default and `speech`), blocking, strict and pedantic clippy, all on the pushed head. No UI change, so no UI smoke lane applies.
