### PR TITLE
ci: keep GitHub releases draft until assets exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
           lfs: true
       - name: Verify Ubuntu dependency installer
         run: python3 -B scripts/test_install_ci_ubuntu_dependencies.py -v
+      - name: Verify GitHub release orchestration
+        run: python3 -B scripts/test_release_github.py -v
       - run: ./scripts/check-maintainability.sh
 
   clippy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [created]
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Existing Git tag or GitHub Release tag to publish
+        description: Existing Git tag to build and finalize
         required: true
         type: string
       publish_snap:
@@ -31,23 +31,24 @@ permissions:
 jobs:
   validate-release:
     name: Validate Release
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.author.login != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.validate.outputs.release_tag }}
       release_version: ${{ steps.validate.outputs.release_version }}
       release_prerelease: ${{ steps.validate.outputs.release_prerelease }}
+      release_commit: ${{ steps.pending.outputs.release_commit }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag_name }}
           fetch-depth: 0
           lfs: true
-      - name: Restore workflow scripts for manual recovery
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Use workflow scripts
         shell: bash
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.sha }}"
-          git checkout "${{ github.sha }}" -- scripts
+          git fetch --no-tags --depth=1 origin "${{ github.workflow_sha }}"
+          git checkout "${{ github.workflow_sha }}" -- scripts
 
       - name: Verify workspace versions are aligned
         run: ./scripts/check-version-sync.sh
@@ -61,19 +62,6 @@ jobs:
 
           tag_name="${{ github.event.release.tag_name || inputs.tag_name }}"
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_json="$(gh release view "$tag_name" --repo "${{ github.repository }}" --json isDraft,isPrerelease)"
-            release_draft="$(jq -r '.isDraft' <<<"$release_json")"
-            release_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
-
-            if [ "$release_draft" = "true" ]; then
-              echo "::error::GitHub Release ${tag_name} is still a draft."
-              exit 1
-            fi
-          else
-            release_prerelease="${{ github.event.release.prerelease }}"
-          fi
-
           if [[ "$tag_name" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             release_version="${BASH_REMATCH[1]}"
             tag_prerelease="false"
@@ -85,10 +73,24 @@ jobs:
             exit 1
           fi
 
-          if [[ "$release_prerelease" != "$tag_prerelease" ]]; then
-            echo "::error::GitHub Release prerelease flag does not match tag ${tag_name}."
-            exit 1
+          err_file="$(mktemp)"
+          if release_json="$(gh release view "$tag_name" --repo "${{ github.repository }}" --json isDraft,isPrerelease 2>"$err_file")"; then
+            release_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+            if [[ "$release_prerelease" != "$tag_prerelease" ]]; then
+              echo "::error::GitHub Release prerelease flag does not match tag ${tag_name}."
+              exit 1
+            fi
+          else
+            if ! grep -qiE 'release not found|HTTP[[:space:]]*404|Not Found' "$err_file"; then
+              cat "$err_file" >&2
+              exit 1
+            fi
+            if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+              echo "::error::GitHub Release ${tag_name} was not found."
+              exit 1
+            fi
           fi
+          rm -f "$err_file"
 
           repo_base_version="$(workspace_base_version)"
           tag_base_version="${release_version%%-*}"
@@ -106,6 +108,21 @@ jobs:
           echo "## Release validation" >> "$GITHUB_STEP_SUMMARY"
           echo "Tag: \`${tag_name}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "Version: \`${release_version}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - id: pending
+        name: Keep GitHub Release pending until assets exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag_name="${{ steps.validate.outputs.release_tag }}"
+          commit="$(git rev-parse "${tag_name}^{commit}")"
+          echo "release_commit=${commit}" >> "$GITHUB_OUTPUT"
+
+          ./scripts/release-github.sh ensure-pending \
+            --repo "${{ github.repository }}" \
+            --tag "$tag_name" \
+            --commit "$commit" \
+            --prerelease "${{ steps.validate.outputs.release_prerelease }}"
 
   build-artifacts:
     name: Artifacts (${{ matrix.name }})
@@ -169,12 +186,11 @@ jobs:
         with:
           ref: ${{ needs.validate-release.outputs.release_tag }}
           lfs: true
-      - name: Restore workflow scripts for manual recovery
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Use workflow scripts
         shell: bash
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.sha }}"
-          git checkout "${{ github.sha }}" -- scripts
+          git fetch --no-tags --depth=1 origin "${{ github.workflow_sha }}"
+          git checkout "${{ github.workflow_sha }}" -- scripts
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.cache_key }}
@@ -302,6 +318,11 @@ jobs:
       windows_x64_sha256: ${{ steps.checksums.outputs.windows_x64_sha256 }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            scripts
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
@@ -372,9 +393,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ needs.validate-release.outputs.release_tag }}" release-assets/* \
+          ./scripts/release-github.sh upload-assets \
             --repo "${{ github.repository }}" \
-            --clobber
+            --tag "${{ needs.validate-release.outputs.release_tag }}" \
+            --commit "${{ needs.validate-release.outputs.release_commit }}" \
+            --dir release-assets
+
+  publish-github-release:
+    name: Publish GitHub Release
+    needs: [validate-release, upload-release-assets]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            scripts
+      - name: Publish only after the required asset set is present
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/release-github.sh publish \
+            --repo "${{ github.repository }}" \
+            --tag "${{ needs.validate-release.outputs.release_tag }}" \
+            --commit "${{ needs.validate-release.outputs.release_commit }}" \
+            --prerelease "${{ needs.validate-release.outputs.release_prerelease }}"
 
   publish-surge-release-index:
     name: Publish Surge Update Storage
@@ -396,12 +439,11 @@ jobs:
         with:
           ref: ${{ needs.validate-release.outputs.release_tag }}
           lfs: true
-      - name: Restore workflow scripts for manual recovery
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Use workflow scripts
         shell: bash
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.sha }}"
-          git checkout "${{ github.sha }}" -- scripts
+          git fetch --no-tags --depth=1 origin "${{ github.workflow_sha }}"
+          git checkout "${{ github.workflow_sha }}" -- scripts
 
       - uses: actions/cache@v6
         with:
@@ -563,7 +605,7 @@ jobs:
   update-homebrew-tap:
     name: Update Homebrew Tap
     if: ${{ needs.validate-release.outputs.release_prerelease == 'false' && github.repository == 'peters/horizon' }}
-    needs: [validate-release, upload-release-assets]
+    needs: [validate-release, upload-release-assets, publish-github-release]
     runs-on: ubuntu-latest
     steps:
       - name: Validate Homebrew tap token
@@ -579,12 +621,11 @@ jobs:
         with:
           ref: ${{ needs.validate-release.outputs.release_tag }}
           lfs: true
-      - name: Restore workflow scripts for manual recovery
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Use workflow scripts
         shell: bash
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.sha }}"
-          git checkout "${{ github.sha }}" -- scripts
+          git fetch --no-tags --depth=1 origin "${{ github.workflow_sha }}"
+          git checkout "${{ github.workflow_sha }}" -- scripts
 
       - name: Checkout Homebrew tap repository
         uses: actions/checkout@v7
@@ -622,7 +663,7 @@ jobs:
   update-winget-pkgs:
     name: Update WinGet Package
     if: ${{ needs.validate-release.outputs.release_prerelease == 'false' && github.repository == 'peters/horizon' }}
-    needs: [validate-release, upload-release-assets]
+    needs: [validate-release, upload-release-assets, publish-github-release]
     runs-on: ubuntu-latest
     env:
       WINGET_PKGS_REPOSITORY: peters/winget-pkgs
@@ -654,12 +695,11 @@ jobs:
         with:
           ref: ${{ needs.validate-release.outputs.release_tag }}
           lfs: true
-      - name: Restore workflow scripts for manual recovery
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Use workflow scripts
         shell: bash
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.sha }}"
-          git checkout "${{ github.sha }}" -- scripts
+          git fetch --no-tags --depth=1 origin "${{ github.workflow_sha }}"
+          git checkout "${{ github.workflow_sha }}" -- scripts
 
       - name: Checkout WinGet fork
         uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,14 +188,14 @@ cargo clippy --workspace --all-targets --features speech -- -D warnings -W clipp
 Releases are tag-driven and documented in [`docs/release-flow.md`](docs/release-flow.md).
 
 - Use `./scripts/next-version.sh alpha`, `./scripts/next-version.sh beta`, or `./scripts/next-version.sh stable` to suggest the next tag for the current release line
-- Publish from **GitHub → Releases** using tags like `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, or `vX.Y.Z`
+- Save a **draft** GitHub Release using tags like `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, or `vX.Y.Z`; do not publish the GitHub Release by hand
 - Mark alpha and beta tags as prereleases in GitHub; leave stable tags as normal releases
-- Publishing the GitHub Release triggers CI to build and upload the release binaries
+- Saving the draft (or dispatching the Release workflow with an existing tag) triggers CI to build and upload binaries, then publish the GitHub Release
 - After a stable release, bump `Cargo.toml` to the next release line in a normal PR before cutting more prereleases
 
 ### Release Notes
 
-When cutting a new release, generate concise release notes from the commits since the last tag (`git log <prev-tag>..HEAD --oneline --no-merges`). Group into **What's new** (features) and **Fixes** (bug fixes). Keep it scannable -- one line per item, no commit hashes. Pass the notes to `gh release create --notes`.
+When cutting a new release, generate concise release notes from the commits since the last tag (`git log <prev-tag>..HEAD --oneline --no-merges`). Group into **What's new** (features) and **Fixes** (bug fixes). Keep it scannable -- one line per item, no commit hashes. Pass the notes to `gh release create --notes --draft`.
 
 ### Dependencies
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -4,8 +4,10 @@ Horizon releases are tag-driven.
 
 - `vX.Y.Z-alpha.N` and `vX.Y.Z-beta.N` are prereleases.
 - `vX.Y.Z` is a stable release.
-- Publishing a GitHub Release with one of those tags triggers the release workflow, which uploads the platform binaries to the same GitHub Release.
-- The same release workflow can also be started manually with an existing tag to recover a failed release after fixing workflow automation, without bumping the version.
+- The Git tag is the source identity. Saving a draft GitHub Release for one of those tags, or dispatching the Release workflow with an existing tag, builds the deliverables.
+- The workflow uploads and verifies the required asset set while the GitHub Release is still a draft, then publishes it. A failed build therefore stays pending instead of advertising an empty public release.
+- Interrupted uploads resume from the recorded tag commit and existing asset digests. Matching files are skipped; changed files for the same commit are replaced. The workflow never retags.
+- The same release workflow can also be started manually with an existing tag to recover a failed or incomplete release after fixing workflow automation, without bumping the version.
 - Stable releases also publish `SHA256SUMS.txt`, build Surge-managed GUI installers, publish Surge update packages to the dedicated `surge` GitHub Release tag in `peters/horizon-updates`, update the `peters/homebrew-horizon` tap, and open or update the WinGet manifest PR for `Peters.Horizon`. Snap Store publication is currently paused.
 
 ## Source Of Truth
@@ -52,22 +54,26 @@ If the stable tag for the current base version already exists, the script stops 
 5. Choose the commit you want the tag to point at.
 6. If the tag has an `-alpha.N` or `-beta.N` suffix, enable **Set as a pre-release**.
 7. If the tag is plain `vX.Y.Z`, leave **Set as a pre-release** disabled.
-8. Publish the release.
+8. **Save draft**. Do not click **Publish release**.
+
+Saving the draft creates the Git tag if needed and starts the release workflow. If a release is published before the assets exist, the workflow converts it back to a draft, builds, uploads, and publishes only after the required set is present.
 
 The release workflow validates:
 
 - the tag format
-- the GitHub prerelease checkbox matches the tag suffix
+- the GitHub prerelease checkbox matches the tag suffix when a GitHub Release already exists
 - the tag's base version matches `Cargo.toml`
+- the Git tag commit recorded on the draft
 
-If the workflow itself needs a fix after a release was already published, merge the workflow fix and run **GitHub Actions → Release → Run workflow** with the existing tag. The manual recovery path reuses the existing GitHub Release instead of requiring a bumped version tag. The manual form's `publish_snap` input is currently disabled and has no effect while Snap Store publication is paused.
+If the workflow itself needs a fix after a release was started, merge the workflow fix and run **GitHub Actions → Release → Run workflow** with the existing tag. The manual recovery path accepts a draft, an incomplete published release, or a tag with no GitHub Release yet, and it does not require a bumped version tag. The manual form's `publish_snap` input is currently disabled and has no effect while Snap Store publication is paused.
 
 Then it:
 
 - rewrites the workspace version to the exact tag version in CI
 - builds the release binaries for Linux, macOS, and Windows
 - for stable releases, stages Surge packages and GUI installers for the same platform matrix
-- uploads the raw release assets, Surge installer assets, and `SHA256SUMS.txt` to the GitHub Release you just published
+- uploads the raw release assets, Surge installer assets, and `SHA256SUMS.txt` to the draft GitHub Release, skipping assets whose digests already match
+- publishes the GitHub Release only after the required asset set is present on that draft
 - for stable releases in `peters/horizon`, publishes Surge update metadata and package artifacts to the internal `surge` GitHub Release tag in `peters/horizon-updates` using the `stable` channel
 - for stable releases in non-canonical staging repos, defaults Surge update storage to the current repository so hosted smoke can stay self-contained
 - Snap Store publication is currently paused; the `publish-snap` job and its `publish_snap` manual input remain disabled
@@ -84,12 +90,15 @@ gh release create "$TAG" \
   --target main \
   --title "$TAG" \
   --notes "Release $TAG" \
-  --prerelease
+  --prerelease \
+  --draft
 ```
 
 `--target` accepts any branch, tag, or commit SHA. For beta or stable releases from a specific commit, replace `main` with the desired ref.
 
-For a stable release, omit `--prerelease`.
+For a stable release, omit `--prerelease` and keep `--draft`. The workflow publishes the GitHub Release after the required assets are uploaded and verified.
+
+To recover an interrupted tag without creating the GitHub Release by hand, run **GitHub Actions → Release → Run workflow** and pass that tag. The workflow creates the draft if needed.
 
 ## Stable Packaging Requirements
 

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Orchestrate GitHub Release finalization for Horizon.
+# The Git tag is source identity. The published GitHub Release is the
+# completion record and must not become public until the required assets exist.
+
+usage() {
+  cat <<'EOF'
+Usage:
+  release-github.sh ensure-pending --repo <owner/name> --tag <tag> --commit <sha> --prerelease <true|false>
+  release-github.sh upload-assets --repo <owner/name> --tag <tag> --commit <sha> --dir <dir>
+  release-github.sh publish --repo <owner/name> --tag <tag> --commit <sha> --prerelease <true|false>
+EOF
+}
+
+REPO=""
+TAG=""
+COMMIT=""
+PRERELEASE=""
+ASSET_DIR=""
+WORKDIR=""
+
+COMMIT_MARKER_PREFIX='<!-- horizon-release-commit: '
+COMMIT_MARKER_SUFFIX=' -->'
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_commands() {
+  local cmd
+  for cmd in gh jq sha256sum; do
+    command -v "$cmd" >/dev/null 2>&1 || die "Required command not found: $cmd"
+  done
+}
+
+parse_bool() {
+  case "$1" in
+    true|false) printf '%s\n' "$1" ;;
+    *) die "Expected true or false, got: $1" ;;
+  esac
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo)
+        REPO="${2:-}"
+        shift 2
+        ;;
+      --tag)
+        TAG="${2:-}"
+        shift 2
+        ;;
+      --commit)
+        COMMIT="${2:-}"
+        shift 2
+        ;;
+      --prerelease)
+        PRERELEASE="$(parse_bool "${2:-}")"
+        shift 2
+        ;;
+      --dir)
+        ASSET_DIR="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        printf 'Unknown argument: %s\n\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+require_identity() {
+  [ -n "$REPO" ] || die "The --repo argument is required."
+  [ -n "$TAG" ] || die "The --tag argument is required."
+  [ -n "$COMMIT" ] || die "The --commit argument is required."
+  [[ "$COMMIT" =~ ^[0-9a-fA-F]{40,64}$ ]] || die "The --commit argument must be a full Git object name."
+}
+
+normalize_sha() {
+  tr 'A-F' 'a-f' <<<"$1"
+}
+
+file_digest() {
+  local hex
+  hex="$(sha256sum -- "$1" | awk '{ print $1 }')"
+  printf 'sha256:%s\n' "$(normalize_sha "$hex")"
+}
+
+required_asset_names() {
+  printf '%s\n' \
+    horizon-linux-x64.tar.gz \
+    horizon-osx-arm64.tar.gz \
+    horizon-osx-x64.tar.gz \
+    horizon-windows-x64.exe \
+    SHA256SUMS.txt
+  if [ "${PRERELEASE:-true}" = "false" ]; then
+    printf '%s\n' \
+      horizon-installer-linux-x64.bin \
+      horizon-installer-osx-arm64.bin \
+      horizon-installer-osx-x64.bin \
+      horizon-installer-win-x64.exe
+  fi
+}
+
+json_asset_digest() {
+  local json="$1"
+  local name="$2"
+  jq -r --arg name "$name" '.assets[]? | select(.name == $name) | .digest // empty' <<<"$json"
+}
+
+json_has_asset() {
+  local json="$1"
+  local name="$2"
+  jq -e --arg name "$name" '[.assets[]? | .name] | index($name) != null' <<<"$json" >/dev/null
+}
+
+missing_required_assets() {
+  local json="$1"
+  local name
+  while IFS= read -r name; do
+    if ! json_has_asset "$json" "$name"; then
+      printf '%s\n' "$name"
+    fi
+  done < <(required_asset_names)
+}
+
+release_is_complete() {
+  local json="$1"
+  local missing
+  missing="$(missing_required_assets "$json")"
+  [ -z "$missing" ]
+}
+
+extract_recorded_commit() {
+  local body="$1"
+  sed -n "s/.*${COMMIT_MARKER_PREFIX}\\([0-9a-fA-F]\\{40,64\\}\\)${COMMIT_MARKER_SUFFIX}.*/\\1/p" <<<"$body" | head -n 1
+}
+
+body_with_commit() {
+  local body="$1"
+  local commit
+  commit="$(normalize_sha "$2")"
+  local marker="${COMMIT_MARKER_PREFIX}${commit}${COMMIT_MARKER_SUFFIX}"
+  if grep -Fq "$COMMIT_MARKER_PREFIX" <<<"$body"; then
+    printf '%s\n' "$body"
+    return 0
+  fi
+  if [ -n "$body" ]; then
+    printf '%s\n\n%s\n' "$body" "$marker"
+  else
+    printf '%s\n' "$marker"
+  fi
+}
+
+load_release_json() {
+  local err_file status
+  err_file="$(mktemp "${WORKDIR}/err.XXXXXX")"
+  if RELEASE_JSON="$(gh release view "$TAG" --repo "$REPO" --json isDraft,isPrerelease,body,assets,tagName 2>"$err_file")"; then
+    rm -f "$err_file"
+    return 0
+  else
+    status=$?
+  fi
+  if grep -qiE 'release not found|HTTP[[:space:]]*404|Not Found' "$err_file"; then
+    rm -f "$err_file"
+    RELEASE_JSON=""
+    return 1
+  fi
+  cat "$err_file" >&2
+  rm -f "$err_file"
+  if [ "$status" -eq 1 ]; then
+    return 2
+  fi
+  return "$status"
+}
+
+assert_recorded_commit() {
+  local json="$1"
+  local body recorded
+  body="$(jq -r '.body // empty' <<<"$json")"
+  recorded="$(extract_recorded_commit "$body")"
+  if [ -z "$recorded" ]; then
+    die "GitHub Release ${TAG} is missing the recorded source commit."
+  fi
+  if [ "$(normalize_sha "$recorded")" != "$(normalize_sha "$COMMIT")" ]; then
+    die "GitHub Release ${TAG} was recorded for commit ${recorded}, not ${COMMIT}."
+  fi
+}
+
+create_pending_release() {
+  local notes_file
+  notes_file="$(mktemp "${WORKDIR}/notes.XXXXXX")"
+  body_with_commit "Release ${TAG}" "$COMMIT" >"$notes_file"
+  local args=(
+    release create "$TAG"
+    --repo "$REPO"
+    --draft
+    --verify-tag
+    --title "$TAG"
+    --target "$COMMIT"
+    --notes-file "$notes_file"
+  )
+  if [ "$PRERELEASE" = "true" ]; then
+    args+=(--prerelease)
+  fi
+  gh "${args[@]}"
+  rm -f "$notes_file"
+  printf 'Created draft GitHub Release %s for commit %s.\n' "$TAG" "$(normalize_sha "$COMMIT")"
+}
+
+sync_pending_release() {
+  local json="$1"
+  local draft body recorded notes_file
+  local need_draft=0
+  local need_notes=0
+
+  draft="$(jq -r '.isDraft' <<<"$json")"
+  body="$(jq -r '.body // empty' <<<"$json")"
+  recorded="$(extract_recorded_commit "$body")"
+
+  if grep -Fq "$COMMIT_MARKER_PREFIX" <<<"$body" && [ -z "$recorded" ]; then
+    die "GitHub Release ${TAG} has a malformed recorded source commit."
+  fi
+  if [ -n "$recorded" ] && [ "$(normalize_sha "$recorded")" != "$(normalize_sha "$COMMIT")" ]; then
+    die "GitHub Release ${TAG} was recorded for commit ${recorded}, not ${COMMIT}."
+  fi
+  if [ -z "$recorded" ]; then
+    need_notes=1
+  fi
+
+  if [ "$draft" != "true" ] && ! release_is_complete "$json"; then
+    need_draft=1
+  fi
+
+  if [ "$need_draft" -eq 0 ] && [ "$need_notes" -eq 0 ]; then
+    if [ "$draft" = "true" ]; then
+      printf 'GitHub Release %s is already a draft for commit %s.\n' "$TAG" "$(normalize_sha "$COMMIT")"
+    else
+      printf 'GitHub Release %s is already published with the required asset set.\n' "$TAG"
+    fi
+    return 0
+  fi
+
+  if [ "$need_notes" -eq 1 ]; then
+    notes_file="$(mktemp "${WORKDIR}/notes.XXXXXX")"
+    body_with_commit "$body" "$COMMIT" >"$notes_file"
+    gh release edit "$TAG" --repo "$REPO" --notes-file "$notes_file"
+    rm -f "$notes_file"
+  fi
+  if [ "$need_draft" -eq 1 ]; then
+    gh release edit "$TAG" --repo "$REPO" --draft
+  fi
+
+  if [ "$need_draft" -eq 1 ]; then
+    printf 'Converted GitHub Release %s back to a draft until the required assets exist.\n' "$TAG"
+  fi
+  if [ "$need_notes" -eq 1 ]; then
+    printf 'Recorded source commit %s on GitHub Release %s.\n' "$(normalize_sha "$COMMIT")" "$TAG"
+  fi
+}
+
+load_existing_release() {
+  local status
+  set +e
+  load_release_json
+  status=$?
+  set -e
+  case "$status" in
+    0) return 0 ;;
+    1) die "GitHub Release ${TAG} does not exist." ;;
+    *) exit "$status" ;;
+  esac
+}
+
+cmd_ensure_pending() {
+  local status
+  parse_args "$@"
+  require_identity
+  [ -n "$PRERELEASE" ] || die "The --prerelease argument is required."
+
+  set +e
+  load_release_json
+  status=$?
+  set -e
+  case "$status" in
+    0) sync_pending_release "$RELEASE_JSON" ;;
+    1) create_pending_release ;;
+    *) exit "$status" ;;
+  esac
+}
+
+sorted_asset_files() {
+  local path base
+  local checksum=""
+  local files=()
+  for path in "$ASSET_DIR"/*; do
+    [ -f "$path" ] || continue
+    base="$(basename "$path")"
+    if [ "$base" = "SHA256SUMS.txt" ]; then
+      checksum="$path"
+      continue
+    fi
+    files+=("$path")
+  done
+  if [ "${#files[@]}" -gt 0 ]; then
+    printf '%s\n' "${files[@]}" | LC_ALL=C sort
+  fi
+  if [ -n "$checksum" ]; then
+    printf '%s\n' "$checksum"
+  fi
+}
+
+replace_or_upload_asset() {
+  local json="$1"
+  local path="$2"
+  local name digest remote_digest
+  name="$(basename "$path")"
+  digest="$(file_digest "$path")"
+
+  if json_has_asset "$json" "$name"; then
+    remote_digest="$(normalize_sha "$(json_asset_digest "$json" "$name")")"
+    if [ -n "$remote_digest" ] && [ "$remote_digest" = "$(normalize_sha "$digest")" ]; then
+      printf 'Skipping %s (digest matches).\n' "$name"
+      return 0
+    fi
+    printf 'Replacing %s (digest changed for recorded commit).\n' "$name"
+    gh release delete-asset "$TAG" "$name" --repo "$REPO" --yes
+  else
+    printf 'Uploading %s.\n' "$name"
+  fi
+  gh release upload "$TAG" "$path" --repo "$REPO"
+}
+
+cmd_upload_assets() {
+  parse_args "$@"
+  require_identity
+  [ -n "$ASSET_DIR" ] || die "The --dir argument is required."
+  [ -d "$ASSET_DIR" ] || die "Asset directory not found: $ASSET_DIR"
+
+  load_existing_release
+  assert_recorded_commit "$RELEASE_JSON"
+
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    replace_or_upload_asset "$RELEASE_JSON" "$path"
+    load_existing_release
+    assert_recorded_commit "$RELEASE_JSON"
+  done < <(sorted_asset_files)
+
+  printf 'Asset upload for %s is complete without publishing.\n' "$TAG"
+}
+
+cmd_publish() {
+  parse_args "$@"
+  require_identity
+  [ -n "$PRERELEASE" ] || die "The --prerelease argument is required."
+
+  load_existing_release
+  assert_recorded_commit "$RELEASE_JSON"
+
+  local missing draft
+  missing="$(missing_required_assets "$RELEASE_JSON")"
+  if [ -n "$missing" ]; then
+    printf 'error: Refusing to publish GitHub Release %s with missing assets:\n' "$TAG" >&2
+    printf '%s\n' "$missing" >&2
+    exit 1
+  fi
+
+  draft="$(jq -r '.isDraft' <<<"$RELEASE_JSON")"
+  if [ "$draft" != "true" ]; then
+    printf 'GitHub Release %s is already published with the required asset set.\n' "$TAG"
+    return 0
+  fi
+
+  local edit_args=(release edit "$TAG" --repo "$REPO" --draft=false)
+  if [ "$PRERELEASE" = "true" ]; then
+    edit_args+=(--prerelease)
+  fi
+  gh "${edit_args[@]}"
+  printf 'Published GitHub Release %s after verifying the required asset set.\n' "$TAG"
+}
+
+main() {
+  require_commands
+  WORKDIR="$(mktemp -d)"
+  trap 'rm -rf "$WORKDIR"' EXIT
+  local command="${1:-}"
+  if [ "$#" -gt 0 ]; then
+    shift
+  fi
+  case "$command" in
+    ensure-pending) cmd_ensure_pending "$@" ;;
+    upload-assets) cmd_upload_assets "$@" ;;
+    publish) cmd_publish "$@" ;;
+    -h|--help|"")
+      usage
+      [ -n "$command" ] || exit 1
+      ;;
+    *)
+      printf 'Unknown command: %s\n\n' "$command" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -143,7 +143,9 @@ release_is_complete() {
 
 extract_recorded_commit() {
   local body="$1"
-  sed -n "s/.*${COMMIT_MARKER_PREFIX}\\([0-9a-fA-F]\\{40,64\\}\\)${COMMIT_MARKER_SUFFIX}.*/\\1/p" <<<"$body" | head -n 1
+  if [[ "$body" =~ horizon-release-commit:[\ ]([0-9a-fA-F]{40,64}) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
 }
 
 body_with_commit() {

--- a/scripts/test_release_github.py
+++ b/scripts/test_release_github.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Exercise draft-first GitHub Release orchestration without calling GitHub."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts/release-github.sh"
+COMMIT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OTHER_COMMIT = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+TAG = "v0.3.0-alpha.1"
+STABLE_TAG = "v0.3.0"
+REPO = "peters/horizon"
+PRERELEASE_ASSETS = [
+    "horizon-linux-x64.tar.gz",
+    "horizon-osx-arm64.tar.gz",
+    "horizon-osx-x64.tar.gz",
+    "horizon-windows-x64.exe",
+    "SHA256SUMS.txt",
+]
+STABLE_ASSETS = PRERELEASE_ASSETS + [
+    "horizon-installer-linux-x64.bin",
+    "horizon-installer-osx-arm64.bin",
+    "horizon-installer-osx-x64.bin",
+    "horizon-installer-win-x64.exe",
+]
+
+FAKE_GH = r'''#!/usr/bin/env python3
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+
+STATE_PATH = Path(os.environ["HORIZON_RELEASE_TEST_STATE"])
+
+
+def load_state():
+    return json.loads(STATE_PATH.read_text())
+
+
+def save_state(state):
+    STATE_PATH.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def record(state, argv):
+    state.setdefault("commands", []).append(list(argv))
+
+
+def parse_flags(args):
+    flags = {}
+    positional = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--repo":
+            flags["repo"] = args[index + 1]
+            index += 2
+        elif arg == "--title":
+            flags["title"] = args[index + 1]
+            index += 2
+        elif arg == "--target":
+            flags["target"] = args[index + 1]
+            index += 2
+        elif arg == "--notes":
+            flags["notes"] = args[index + 1]
+            index += 2
+        elif arg == "--notes-file":
+            flags["notes"] = Path(args[index + 1]).read_text()
+            index += 2
+        elif arg == "--json":
+            flags["json"] = args[index + 1]
+            index += 2
+        elif arg == "--draft":
+            flags["draft"] = True
+            index += 1
+        elif arg.startswith("--draft="):
+            flags["draft"] = arg.split("=", 1)[1].lower() == "true"
+            index += 1
+        elif arg == "--prerelease":
+            flags["prerelease"] = True
+            index += 1
+        elif arg.startswith("--prerelease="):
+            flags["prerelease"] = arg.split("=", 1)[1].lower() == "true"
+            index += 1
+        elif arg == "--verify-tag":
+            flags["verify_tag"] = True
+            index += 1
+        elif arg in {"--yes", "-y"}:
+            flags["yes"] = True
+            index += 1
+        else:
+            positional.append(arg)
+            index += 1
+    return flags, positional
+
+
+def digest_for(path):
+    return "sha256:" + hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def require_release(state, tag):
+    release = state.get("releases", {}).get(tag)
+    if release is None:
+        sys.stderr.write("release not found\n")
+        sys.exit(1)
+    return release
+
+
+def main(argv):
+    state = load_state()
+    record(state, argv[1:])
+    if argv[1:3] != ["release", "view"]:
+        pass
+    flags, positional = parse_flags(argv[3:] if argv[1] == "release" else argv[1:])
+    if argv[1] != "release":
+        sys.stderr.write("unexpected command\n")
+        save_state(state)
+        sys.exit(99)
+
+    sub = argv[2]
+    if sub == "view":
+        tag = positional[0]
+        release = require_release(state, tag)
+        save_state(state)
+        json.dump(release, sys.stdout)
+        sys.stdout.write("\n")
+        return
+    if sub == "create":
+        tag = positional[0]
+        if flags.get("verify_tag") and tag not in state.get("tags", {}):
+            sys.stderr.write(f"tag {tag} not found\n")
+            save_state(state)
+            sys.exit(1)
+        if tag in state.setdefault("releases", {}):
+            sys.stderr.write("release already exists\n")
+            save_state(state)
+            sys.exit(1)
+        state["releases"][tag] = {
+            "tagName": tag,
+            "isDraft": bool(flags.get("draft", False)),
+            "isPrerelease": bool(flags.get("prerelease", False)),
+            "isImmutable": False,
+            "body": flags.get("notes", ""),
+            "targetCommitish": flags.get("target", ""),
+            "assets": [],
+        }
+        save_state(state)
+        return
+    if sub == "edit":
+        tag = positional[0]
+        release = require_release(state, tag)
+        if "draft" in flags:
+            release["isDraft"] = flags["draft"]
+        if "prerelease" in flags:
+            release["isPrerelease"] = flags["prerelease"]
+        if "notes" in flags:
+            release["body"] = flags["notes"]
+        save_state(state)
+        return
+    if sub == "upload":
+        tag = positional[0]
+        files = positional[1:]
+        release = require_release(state, tag)
+        fail_after = int(os.environ.get("HORIZON_RELEASE_TEST_FAIL_UPLOAD_AFTER") or "0")
+        for path in files:
+            name = Path(path).name
+            state["upload_attempts"] = state.get("upload_attempts", 0) + 1
+            if fail_after and state["upload_attempts"] >= fail_after:
+                save_state(state)
+                sys.stderr.write("injected upload failure\n")
+                sys.exit(2)
+            if any(asset["name"] == name for asset in release["assets"]):
+                sys.stderr.write(f"{name} already exists\n")
+                save_state(state)
+                sys.exit(1)
+            payload = Path(path).read_bytes()
+            release["assets"].append(
+                {
+                    "name": name,
+                    "size": len(payload),
+                    "digest": digest_for(path),
+                }
+            )
+        save_state(state)
+        return
+    if sub == "delete-asset":
+        tag = positional[0]
+        name = positional[1]
+        release = require_release(state, tag)
+        release["assets"] = [asset for asset in release["assets"] if asset["name"] != name]
+        save_state(state)
+        return
+
+    sys.stderr.write(f"unsupported gh release subcommand: {sub}\n")
+    save_state(state)
+    sys.exit(99)
+
+
+if __name__ == "__main__":
+    main(sys.argv)
+'''
+
+FAKE_GIT = r'''#!/bin/bash
+printf 'unexpected git invocation: %s\n' "$*" >&2
+exit 99
+'''
+
+
+class ReleaseGithubTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory(prefix="horizon-release-github-")
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.state_path = self.root / "state.json"
+        self.assets = self.root / "assets"
+        self.assets.mkdir()
+        self.state_path.write_text(json.dumps({
+            "releases": {},
+            "tags": {TAG: COMMIT, STABLE_TAG: COMMIT},
+            "commands": [],
+            "upload_attempts": 0,
+        }))
+        gh = self.root / "gh"
+        gh.write_text(FAKE_GH)
+        gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+        git = self.root / "git"
+        git.write_text(FAKE_GIT)
+        git.chmod(git.stat().st_mode | stat.S_IEXEC)
+        self.env = os.environ.copy()
+        self.env["PATH"] = str(self.root) + os.pathsep + self.env.get("PATH", "")
+        self.env["HORIZON_RELEASE_TEST_STATE"] = str(self.state_path)
+        self.env.pop("HORIZON_RELEASE_TEST_FAIL_UPLOAD_AFTER", None)
+
+    def state(self):
+        return json.loads(self.state_path.read_text())
+
+    def commands(self):
+        return self.state()["commands"]
+
+    def release(self, tag=TAG):
+        return self.state()["releases"][tag]
+
+    def write_assets(self, names, directory=None):
+        directory = directory or self.assets
+        for name in names:
+            path = directory / name
+            path.write_bytes(f"{name}:{COMMIT}\n".encode())
+        return directory
+
+    def run_script(self, *args, expect=0):
+        result = subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            env=self.env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != expect:
+            self.fail(
+                f"exit {result.returncode} != {expect}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        return result
+
+    def ensure_pending(self, tag=TAG, commit=COMMIT, prerelease="true", expect=0):
+        return self.run_script(
+            "ensure-pending",
+            "--repo", REPO,
+            "--tag", tag,
+            "--commit", commit,
+            "--prerelease", prerelease,
+            expect=expect,
+        )
+
+    def upload_assets(self, tag=TAG, commit=COMMIT, directory=None, expect=0):
+        directory = directory or self.assets
+        return self.run_script(
+            "upload-assets",
+            "--repo", REPO,
+            "--tag", tag,
+            "--commit", commit,
+            "--dir", str(directory),
+            expect=expect,
+        )
+
+    def publish(self, tag=TAG, commit=COMMIT, prerelease="true", expect=0):
+        return self.run_script(
+            "publish",
+            "--repo", REPO,
+            "--tag", tag,
+            "--commit", commit,
+            "--prerelease", prerelease,
+            expect=expect,
+        )
+
+    def asset_names(self, tag=TAG):
+        return [asset["name"] for asset in self.release(tag)["assets"]]
+
+    def test_ensure_pending_creates_draft_for_existing_tag(self):
+        result = self.ensure_pending()
+        release = self.release()
+        self.assertTrue(release["isDraft"])
+        self.assertTrue(release["isPrerelease"])
+        self.assertIn(COMMIT, release["body"])
+        self.assertEqual(release["targetCommitish"], COMMIT)
+        self.assertIn("Created draft GitHub Release", result.stdout)
+        self.assertTrue(any(command[:2] == ["release", "create"] for command in self.commands()))
+        self.assertFalse(any("--draft=false" in command for command in self.commands()))
+
+    def test_ensure_pending_requires_existing_tag(self):
+        result = self.ensure_pending(tag="v0.9.9-alpha.1", expect=1)
+        self.assertIn("not found", result.stderr)
+        self.assertNotIn("v0.9.9-alpha.1", self.state()["releases"])
+
+    def test_ensure_pending_converts_incomplete_published_release_to_draft(self):
+        self.ensure_pending()
+        state = self.state()
+        state["releases"][TAG]["isDraft"] = False
+        self.state_path.write_text(json.dumps(state, indent=2))
+        result = self.ensure_pending()
+        self.assertTrue(self.release()["isDraft"])
+        self.assertIn("back to a draft", result.stdout)
+        self.assertTrue(
+            any(command[:2] == ["release", "edit"] and "--draft" in command for command in self.commands())
+        )
+
+    def test_ensure_pending_leaves_complete_published_release_public(self):
+        self.write_assets(PRERELEASE_ASSETS)
+        self.ensure_pending()
+        self.upload_assets()
+        self.publish()
+        self.assertFalse(self.release()["isDraft"])
+        result = self.ensure_pending()
+        self.assertFalse(self.release()["isDraft"])
+        self.assertIn("already published", result.stdout)
+
+    def test_ensure_pending_rejects_a_different_recorded_commit(self):
+        self.ensure_pending()
+        result = self.ensure_pending(commit=OTHER_COMMIT, expect=1)
+        self.assertIn(COMMIT, result.stderr)
+        self.assertIn(OTHER_COMMIT, result.stderr)
+        self.assertTrue(self.release()["isDraft"])
+
+    def test_upload_skips_matching_digest_and_replaces_changed_bytes(self):
+        self.write_assets(PRERELEASE_ASSETS)
+        self.ensure_pending()
+        self.upload_assets()
+        first_uploads = sum(1 for command in self.commands() if command[:2] == ["release", "upload"])
+        self.upload_assets()
+        second_uploads = sum(1 for command in self.commands() if command[:2] == ["release", "upload"])
+        self.assertEqual(first_uploads, len(PRERELEASE_ASSETS))
+        self.assertEqual(second_uploads, first_uploads)
+
+        changed = self.assets / "horizon-linux-x64.tar.gz"
+        changed.write_bytes(b"rebuilt-bytes\n")
+        result = self.upload_assets()
+        self.assertIn("Replacing horizon-linux-x64.tar.gz", result.stdout)
+        self.assertTrue(any(command[:2] == ["release", "delete-asset"] for command in self.commands()))
+        linux = next(asset for asset in self.release()["assets"] if asset["name"] == "horizon-linux-x64.tar.gz")
+        self.assertEqual(linux["digest"], "sha256:" + hashlib.sha256(b"rebuilt-bytes\n").hexdigest())
+        self.assertTrue(self.release()["isDraft"])
+
+    def test_failure_injection_keeps_release_pending_then_resume_publishes(self):
+        self.write_assets(PRERELEASE_ASSETS)
+        self.ensure_pending()
+        self.env["HORIZON_RELEASE_TEST_FAIL_UPLOAD_AFTER"] = "2"
+        failed = self.upload_assets(expect=2)
+        self.assertIn("injected upload failure", failed.stderr)
+        self.assertTrue(self.release()["isDraft"])
+        self.assertEqual(self.asset_names(), ["horizon-linux-x64.tar.gz"])
+        self.assertFalse(any("--draft=false" in command for command in self.commands()))
+
+        refused = self.publish(expect=1)
+        self.assertIn("Refusing to publish", refused.stderr)
+        self.assertTrue(self.release()["isDraft"])
+
+        del self.env["HORIZON_RELEASE_TEST_FAIL_UPLOAD_AFTER"]
+        resumed = self.upload_assets()
+        self.assertIn("Skipping horizon-linux-x64.tar.gz", resumed.stdout)
+        self.assertCountEqual(self.asset_names(), PRERELEASE_ASSETS)
+        published = self.publish()
+        self.assertFalse(self.release()["isDraft"])
+        self.assertIn("Published GitHub Release", published.stdout)
+        self.assertTrue(any("--draft=false" in command for command in self.commands()))
+        self.assertFalse(any(command[:1] == ["tag"] for command in self.commands()))
+
+    def test_publish_requires_stable_installers_before_going_public(self):
+        self.write_assets(PRERELEASE_ASSETS)
+        self.ensure_pending(tag=STABLE_TAG, prerelease="false")
+        self.upload_assets(tag=STABLE_TAG)
+        result = self.publish(tag=STABLE_TAG, prerelease="false", expect=1)
+        self.assertIn("horizon-installer-linux-x64.bin", result.stderr)
+        self.assertTrue(self.release(STABLE_TAG)["isDraft"])
+
+        self.write_assets(STABLE_ASSETS)
+        self.upload_assets(tag=STABLE_TAG)
+        self.publish(tag=STABLE_TAG, prerelease="false")
+        self.assertFalse(self.release(STABLE_TAG)["isDraft"])
+        self.assertCountEqual(self.asset_names(STABLE_TAG), STABLE_ASSETS)
+
+    def test_script_does_not_invoke_git(self):
+        self.write_assets(PRERELEASE_ASSETS)
+        self.ensure_pending()
+        self.upload_assets()
+        self.publish()
+        git_log = self.root / "git.log"
+        self.assertFalse(git_log.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Fixes #579. The release workflow currently starts from a **published** GitHub Release, so a failed artifact build (as with [v0.2.3](https://github.com/peters/horizon/releases/tag/v0.2.3)) leaves a public release with no binaries.

The Git tag is now the source identity. The published GitHub Release is the completion record.

## Behavior impact

- Saving a **draft** GitHub Release (or dispatching the Release workflow with an existing tag) starts the build.
- Required assets are uploaded and verified while the GitHub Release is still a draft.
- The GitHub Release is published only after that set is present.
- An incomplete published release is converted back to a draft instead of staying public and empty.
- Interrupted uploads resume from the recorded tag commit and existing asset digests: matching files are skipped, changed files for the same commit are replaced, and the workflow never retags.
- Homebrew and WinGet updates wait until the GitHub Release is published.
- Manual recovery still works and now accepts drafts, incomplete published releases, and tags with no GitHub Release yet.

Existing empty releases such as v0.2.3 are not backfilled here. Dispatching the Release workflow for that tag would recover it with this path.

## Test evidence

```text
python3 -B scripts/test_release_github.py -v
```

Includes a failure-injection case: one upload fails, the GitHub Release stays a draft, resume skips the matching asset, then publish succeeds without retagging.

Also ran `cargo fmt --all -- --check` and `./scripts/check-maintainability.sh` in this worktree.

## Docs

`docs/release-flow.md` and `AGENTS.md` now say **Save draft** rather than Publish, and the CLI example uses `--draft`.