### PR TITLE
feat(remote): observe exact deletion scope

### DIFF
--- a/crates/horizon-core/src/cloud_run.rs
+++ b/crates/horizon-core/src/cloud_run.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 mod artifact_digest;
 pub mod azure;
 pub mod interactive_worker;
+pub mod interactive_worker_delete;
 pub mod interactive_worker_start;
 pub mod interactive_worker_stop;
 pub mod local_docker;

--- a/crates/horizon-core/src/cloud_run/azure/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/provider.rs
@@ -14,6 +14,7 @@ use crate::cloud_run::{
         InteractiveWorkerLifecycle, InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest,
         InteractiveWorkerStatus,
     },
+    interactive_worker_delete::{InteractiveWorkerDeleteObserver, InteractiveWorkerDeletionObservation},
 };
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
@@ -551,6 +552,19 @@ impl InteractiveWorkerProvider for AzureClient {
             Err(AzureError::UnexpectedStatus { status: 404, .. }) => Ok(InteractiveWorkerCleanup::AlreadyAbsent),
             Err(error) => Err(error),
         }
+    }
+}
+
+impl InteractiveWorkerDeleteObserver for AzureClient {
+    fn observe_worker_deletion(
+        &self,
+        worker: &InteractiveWorker,
+    ) -> Result<InteractiveWorkerDeletionObservation, Self::Error> {
+        Ok(if self.owned_handle(worker)?.is_some() {
+            InteractiveWorkerDeletionObservation::Present
+        } else {
+            InteractiveWorkerDeletionObservation::Absent
+        })
     }
 }
 

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider.rs
@@ -80,6 +80,7 @@ pub(super) enum GroupChange {
 #[derive(Default)]
 pub(super) struct Plane {
     pub(super) group: Option<AzureGroupInfo>,
+    pub(super) group_error: Option<AzureError>,
     pub(super) deployment: Option<AzureDeploymentState>,
     pub(super) vm_states: Vec<Option<AzureVmView>>,
     pub(super) fail_deployment: bool,
@@ -169,6 +170,9 @@ impl AzureManagementTransport for Fake {
     fn get_resource_group(&self, name: &str) -> Result<Option<AzureGroupInfo>, AzureError> {
         let mut plane = self.lock();
         plane.calls.push(Call::GetGroup(name.into()));
+        if let Some(error) = &plane.group_error {
+            return Err(error.clone());
+        }
         let found = plane.group.clone().filter(|group| group.name == name);
         if found.is_none() {
             plane.group = plane.appear_on_second_lookup.take();
@@ -434,6 +438,7 @@ pub(super) const MISMATCH: AzureError = AzureError::ResourceIdentityMismatch;
 
 mod creation;
 mod credential;
+mod delete_observer;
 mod instance;
 mod observation;
 mod running;

--- a/crates/horizon-core/src/cloud_run/azure/tests/provider/delete_observer.rs
+++ b/crates/horizon-core/src/cloud_run/azure/tests/provider/delete_observer.rs
@@ -1,0 +1,164 @@
+use super::*;
+use crate::cloud_run::{
+    interactive_worker::InteractiveWorkerLease,
+    interactive_worker_delete::{InteractiveWorkerDeleteObserver, InteractiveWorkerDeletionObservation as Observation},
+};
+
+fn client(s: &Scenario) -> AzureClient {
+    AzureClient::with_transport(
+        profile(),
+        s.plane.clone(),
+        |_: CloudWorkflowId, _: CloudJobId, _: &WorkerTarget, _: &str| {
+            panic!("deletion observation must not consult the creation fence")
+        },
+        |_: &AzureWorker, _: &str, _: &str| {
+            panic!("deletion observation must not obtain a host key or execute a guest command")
+        },
+    )
+    .expect("client")
+    .on_clock(s.clock.clone())
+}
+
+fn assert_one_group_read(s: &Scenario) {
+    assert_eq!(s.plane.calls(), [Call::GetGroup(s.group.clone())]);
+    assert!(s.clock.sleeps().is_empty(), "no polling or retry");
+}
+
+#[test]
+fn surviving_group_is_present_regardless_of_compute_or_deletion_state() {
+    let s = Scenario::new();
+    let client = client(&s);
+    for state in ["Succeeded", "Deleting", "Creating", "Failed", "unknown"] {
+        for power in [None, Some("running"), Some("deallocated")] {
+            s.plane.script(
+                Some(group_info(&s.group, s.tags.clone(), state)),
+                Some(deployment("Succeeded", "203.0.113.9")),
+                vec![power.map(|power| vm(power, &s.tags))],
+            );
+            assert_eq!(
+                client.observe_worker_deletion(&s.persisted()),
+                Ok(Observation::Present),
+                "{state}, {power:?}"
+            );
+            assert_one_group_read(&s);
+        }
+    }
+}
+
+#[test]
+fn only_group_absence_is_absent_and_a_read_is_not_retried() {
+    let s = Scenario::new();
+    let client = client(&s);
+    s.plane.script(None, None, vec![Some(vm("running", &s.tags))]);
+    s.plane.lock().appear_on_second_lookup = Some(owned(&s));
+    assert_eq!(client.observe_worker_deletion(&s.persisted()), Ok(Observation::Absent));
+    assert_one_group_read(&s);
+    // The observation is point-in-time, not a promise that the scope stays absent.
+    s.plane.script(Some(owned(&s)), None, vec![None]);
+    s.plane.lock().vanish_after_first_lookup = true;
+    assert_eq!(client.observe_worker_deletion(&s.persisted()), Ok(Observation::Present));
+    assert_one_group_read(&s);
+}
+
+#[test]
+fn every_owned_group_tag_is_required_and_must_match() {
+    let s = Scenario::new();
+    let client = client(&s);
+    for key in s.tags.keys() {
+        for missing in [false, true] {
+            let mut group = owned(&s);
+            if missing {
+                group.tags.remove(key);
+            } else {
+                group.tags.insert(key.clone(), "other-owner-or-target".into());
+            }
+            s.plane.script(Some(group), None, vec![None]);
+            assert_eq!(client.observe_worker_deletion(&s.persisted()), Err(MISMATCH), "{key}");
+            assert_one_group_read(&s);
+        }
+    }
+    let mut group = owned(&s);
+    group.tags.insert("unrelated-label".into(), "kept".into());
+    s.plane.script(Some(group), None, vec![None]);
+    assert_eq!(client.observe_worker_deletion(&s.persisted()), Ok(Observation::Present));
+    assert_one_group_read(&s);
+}
+
+#[test]
+fn observed_group_id_must_equal_the_saved_group_not_just_match_tags() {
+    let s = Scenario::new();
+    let client = client(&s);
+    for id in [
+        format!("/subscriptions/{OTHER_SUB}/resourceGroups/{}", s.group),
+        format!("/subscriptions/{SUB}/resourceGroups/another-group"),
+        format!("{}/providers/Microsoft.Compute/virtualMachines/worker", s.group_id),
+        String::new(),
+    ] {
+        let mut group = owned(&s);
+        group.id = id;
+        s.plane.script(Some(group), None, vec![None]);
+        assert_eq!(client.observe_worker_deletion(&s.persisted()), Err(MISMATCH));
+        assert_one_group_read(&s);
+    }
+    let mut group = owned(&s);
+    group.id.make_ascii_uppercase();
+    s.plane.script(Some(group), None, vec![None]);
+    assert_eq!(client.observe_worker_deletion(&s.persisted()), Ok(Observation::Present));
+    assert_one_group_read(&s);
+}
+
+#[test]
+fn malformed_or_foreign_saved_handles_are_rejected_before_any_lookup() {
+    let s = Scenario::new();
+    let client = client(&s);
+    let worker = s.persisted();
+    let mut foreign = worker.clone();
+    foreign.identity.provider = CloudProvider::RunPod;
+    let mut subscription = worker.clone();
+    subscription.identity.resource_id = format!("/subscriptions/{OTHER_SUB}/resourceGroups/{}", s.group);
+    let mut group = worker.clone();
+    group.identity.resource_id = format!("/subscriptions/{SUB}/resourceGroups/other");
+    let mut malformed = worker.clone();
+    malformed.identity.resource_id.push_str("?query=not-an-arm-id");
+    let mut key = worker.clone();
+    key.ssh_public_key = "ssh-rsa invalid".into();
+    let mut image = worker.clone();
+    image.target.image = "registry.example/worker:latest".into();
+    let mut timed = worker;
+    timed.target.lifetime = WorkerLifetime::TimeLimited { seconds: 60 };
+    timed.lifetime = InteractiveWorkerLifetime::TimeLimited(InteractiveWorkerLease {
+        terminate_after: "2026-01-01T00:00:00Z".into(),
+    });
+    for invalid in [foreign, subscription, group, malformed, key, image, timed] {
+        assert_eq!(
+            client.observe_worker_deletion(&invalid),
+            Err(AzureError::InvalidPersistedWorker)
+        );
+        assert!(s.plane.calls().is_empty(), "invalid handle cannot even look up absence");
+    }
+}
+
+#[test]
+fn lookup_failures_are_errors_not_absence_and_never_retry() {
+    let s = Scenario::new();
+    let client = client(&s);
+    let operation = "resource group lookup";
+    let mut failures: Vec<_> = [401, 403, 408, 429, 500, 503]
+        .into_iter()
+        .map(|status| AzureError::UnexpectedStatus { operation, status })
+        .collect();
+    failures.extend([
+        AzureError::RequestFailed { operation },
+        AzureError::InvalidResponse { operation },
+        AzureError::OperationTimedOut { operation },
+        AzureError::CredentialUnavailable {
+            reason: "synthetic refusal",
+        },
+    ]);
+    for error in failures {
+        s.plane.script(None, None, vec![None]);
+        s.plane.lock().group_error = Some(error.clone());
+        assert_eq!(client.observe_worker_deletion(&s.persisted()), Err(error));
+        assert_one_group_read(&s);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/interactive_worker_delete.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker_delete.rs
@@ -1,0 +1,32 @@
+//! Opt-in, control-plane-only observation of one exact worker's deletion scope.
+
+use super::interactive_worker::{InteractiveWorker, InteractiveWorkerProvider};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InteractiveWorkerDeletionObservation {
+    /// The exact owned deletion scope still exists, including deletion in progress.
+    /// This does not describe compute readiness, retained bytes or task state.
+    Present,
+    /// The exact deletion scope was absent at this observation. A missing child
+    /// resource alone is insufficient, and this result does not authorize replay.
+    Absent,
+}
+
+/// Optional read-only capability, separate from requesting resource deletion.
+/// Callers own durable intent, configured admission and completion recording.
+pub trait InteractiveWorkerDeleteObserver: InteractiveWorkerProvider {
+    /// Observe the complete scope of the exact persisted worker off the render thread.
+    /// Validate the handle before I/O and current ownership before reporting presence.
+    /// Use control-plane reads only: never create, delete, start, stop, reconcile,
+    /// execute guest commands, use SSH, obtain host keys or retry a mutation.
+    /// A surviving deletion scope remains present even if its compute is gone.
+    ///
+    /// # Errors
+    /// Rejects malformed or mismatched identity, uncertain metadata and failed reads.
+    /// Errors and accepted deletion responses must never be translated into absence;
+    /// diagnostics must not include provider response payloads.
+    fn observe_worker_deletion(
+        &self,
+        worker: &InteractiveWorker,
+    ) -> Result<InteractiveWorkerDeletionObservation, Self::Error>;
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -477,6 +477,11 @@ back into large multi-purpose modules.
   Persistent post-create verification failures retain the resource and consumed
   grant for explicit non-creating recovery or management. An in-flight creation
   response cannot undo another client's retained Stop through failure cleanup.
+- `cloud_run/interactive_worker_delete.rs` is an opt-in deletion-scope observer,
+  separate from issuing deletion or recording durable completion. The Azure
+  implementation reads only the exact saved resource group with owned identity
+  tags; a surviving or deleting group remains present even when its VM is absent.
+  It never uses guest commands, host-key lookup, lifecycle mutation or polling.
 - `cloud_run/interactive_worker_stop.rs` is an opt-in Stop contract, separate from
   deletion and client lifetime. The local adapter's `local_docker/stop.rs` verifies
   exact ownership and disabled automatic removal before a bounded stop, then


### PR DESCRIPTION
## Purpose

Add an optional exact-scope deletion observer for #472. This is a provider capability prerequisite, not a Delete UI or a new deletion request.

`InteractiveWorkerDeleteObserver::observe_worker_deletion` reports typed `Present` or `Absent`. The Azure implementation checks the saved handle, subscription, complete ownership tags and exact resource-group ID using one control-plane GET. A surviving group remains present even when deletion is in progress or its VM is missing. Existing deletion, readiness and Stop behavior are unchanged.

The path never creates, starts, stops, deletes, retries a mutation, claims creation, reads a host key, uses SSH or runs a guest command. Errors remain errors; accepted deletion is not reported as verified absence. Configured admission, durable intent/completion and user confirmation remain caller responsibilities. No storage retention, backup or live-cloud acceptance is claimed.

## Validation

Full exact-head local matrix passed: formatting, maintainability, version synchronization, 2,673 default tests, 2,718 speech-enabled tests, and blocking/strict/pedantic Clippy with zero warnings. Each test tier had seven ignored tests across 26 suites. The focused Azure suite passed all 73 tests, including six new deterministic observer tests.

The observer tests cover present/in-flight/absent groups, all required ownership tags, exact group and subscription identity, malformed saved handles, failed reads, and absence of other calls. No live provider, credential or native UI operations were run.

Two earlier speech runs failed unchanged browser-CLI timing assertions. Both failures were preserved; five exact-binary reruns of the first case passed, and a subsequent complete matrix passed without source changes. The earlier failure causes remain unconfirmed.
