### PR TITLE
test(browser): assert stdin deadline admission

### DIFF
--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -438,6 +438,11 @@ fn assert_stdin_deadline_result(
     assert_eq!(state["execution_timeout_seconds"], STDIN_EXECUTION_TIMEOUT.as_secs());
     assert!(state["completed_steps"].as_u64().is_some_and(|count| count <= 1));
     let deadline = u128::from(state["deadline_at_millis"].as_u64().expect("saved deadline"));
+    let created = u128::from(state["created_at_millis"].as_u64().expect("saved creation time"));
+    assert!(
+        created + DEADLINE_ROUNDING_SLACK_MILLIS >= before_eof.as_millis() && created <= after_exit.as_millis(),
+        "saved creation {created} is outside before EOF {before_eof:?} and after exit {after_exit:?}"
+    );
     // Check timer admission, not filesystem speed; allow only millisecond rounding slack.
     let timeout_millis = STDIN_EXECUTION_TIMEOUT.as_millis();
     assert!(
@@ -445,8 +450,8 @@ fn assert_stdin_deadline_result(
         "saved deadline {deadline} predates EOF {before_eof:?} plus timeout {STDIN_EXECUTION_TIMEOUT:?}"
     );
     assert!(
-        deadline <= after_exit.as_millis() + timeout_millis,
-        "saved deadline {deadline} exceeds exit {after_exit:?} plus timeout {STDIN_EXECUTION_TIMEOUT:?}"
+        deadline <= created + timeout_millis + DEADLINE_ROUNDING_SLACK_MILLIS,
+        "saved deadline {deadline} exceeds creation {created} plus timeout {STDIN_EXECUTION_TIMEOUT:?}"
     );
     assert_eq!(
         state["job_id"].as_str(),

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -6,6 +6,8 @@ use horizon_core::browser::manifest::{self, BrowserManifest};
 use serde_json::{Value, json};
 
 const DEADLINE_TEST_TIMEOUT_SECONDS: u64 = 3;
+const STDIN_EXECUTION_TIMEOUT: Duration = Duration::from_secs(1);
+const DEADLINE_ROUNDING_SLACK_MILLIS: u128 = 1;
 
 #[test]
 fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
@@ -378,7 +380,7 @@ fn resume_skip_runs_later_steps_without_replaying_or_succeeding() {
 fn run_timeout_starts_after_stdin_plan_validation() {
     let root = tempfile::tempdir().expect("isolated root");
     let mut child = Command::new(env!("CARGO_BIN_EXE_horizon-browser"))
-        .args(["run", "-", "--timeout", "1"])
+        .args(["run", "-", "--timeout", &STDIN_EXECUTION_TIMEOUT.as_secs().to_string()])
         .env("HOME", root.path())
         .env("HORIZON_BROWSER_ACTOR", "browser-cli-test")
         .env("RUST_LOG", "off")
@@ -401,6 +403,10 @@ fn run_timeout_starts_after_stdin_plan_validation() {
     wait_for_exit(&mut child, "delayed stdin browser job");
     let output = child.wait_with_output().expect("collect delayed-plan browser job");
     let after_exit = SystemTime::now().duration_since(UNIX_EPOCH).expect("exit clock");
+    assert!(
+        after_exit >= before_eof,
+        "wall clock moved backwards: before EOF {before_eof:?}, after exit {after_exit:?}"
+    );
     assert_stdin_deadline_result(root.path(), &output, before_eof, after_exit);
 }
 
@@ -421,16 +427,27 @@ fn assert_stdin_deadline_result(
         .collect::<Result<Vec<_>, _>>()
         .expect("job entries");
     assert_eq!(jobs.len(), 1);
+    assert!(
+        jobs[0].file_type().expect("job entry type").is_dir(),
+        "single job entry must be a directory"
+    );
     let job_dir = jobs[0].path();
     let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("job state"))
         .expect("decode job state");
     assert_eq!(state["version"], 4);
-    assert_eq!(state["execution_timeout_seconds"], 1);
+    assert_eq!(state["execution_timeout_seconds"], STDIN_EXECUTION_TIMEOUT.as_secs());
     assert!(state["completed_steps"].as_u64().is_some_and(|count| count <= 1));
     let deadline = u128::from(state["deadline_at_millis"].as_u64().expect("saved deadline"));
     // Check timer admission, not filesystem speed; allow only millisecond rounding slack.
-    assert!(deadline + 1 >= before_eof.as_millis() + 1_000);
-    assert!(deadline <= after_exit.as_millis() + 1_000);
+    let timeout_millis = STDIN_EXECUTION_TIMEOUT.as_millis();
+    assert!(
+        deadline + DEADLINE_ROUNDING_SLACK_MILLIS >= before_eof.as_millis() + timeout_millis,
+        "saved deadline {deadline} predates EOF {before_eof:?} plus timeout {STDIN_EXECUTION_TIMEOUT:?}"
+    );
+    assert!(
+        deadline <= after_exit.as_millis() + timeout_millis,
+        "saved deadline {deadline} exceeds exit {after_exit:?} plus timeout {STDIN_EXECUTION_TIMEOUT:?}"
+    );
     assert_eq!(
         state["job_id"].as_str(),
         job_dir.file_name().and_then(|name| name.to_str())

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -1,6 +1,6 @@
 use std::io::{BufRead as _, BufReader, Write as _};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use horizon_core::browser::manifest::{self, BrowserManifest};
 use serde_json::{Value, json};
@@ -396,18 +396,90 @@ fn run_timeout_starts_after_stdin_plan_validation() {
     stdin
         .write_all(br#"{"version":1,"steps":[{"id":"panels","tool":"browser_list"}]}"#)
         .expect("write delayed plan");
+    let before_eof = SystemTime::now().duration_since(UNIX_EPOCH).expect("EOF clock");
     drop(stdin);
     wait_for_exit(&mut child, "delayed stdin browser job");
     let output = child.wait_with_output().expect("collect delayed-plan browser job");
+    let after_exit = SystemTime::now().duration_since(UNIX_EPOCH).expect("exit clock");
+    assert_stdin_deadline_result(root.path(), &output, before_eof, after_exit);
+}
 
+fn assert_stdin_deadline_result(
+    root: &std::path::Path,
+    output: &std::process::Output,
+    before_eof: Duration,
+    after_exit: Duration,
+) {
     assert!(
-        output.status.success(),
-        "stderr: {}",
+        matches!(output.status.code(), Some(0 | 124)),
+        "exit: {}; stderr: {}",
+        output.status,
         String::from_utf8_lossy(&output.stderr)
     );
-    let report: Value = serde_json::from_slice(&output.stdout).expect("delayed-plan report");
-    assert_eq!(report["ok"], true);
-    assert_eq!(report["completed_steps"], 1);
+    let jobs = std::fs::read_dir(root.join(".horizon/browser-jobs"))
+        .expect("delayed-plan jobs")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("job entries");
+    assert_eq!(jobs.len(), 1);
+    let job_dir = jobs[0].path();
+    let state: Value = serde_json::from_slice(&std::fs::read(job_dir.join("state.json")).expect("job state"))
+        .expect("decode job state");
+    assert_eq!(state["version"], 4);
+    assert_eq!(state["execution_timeout_seconds"], 1);
+    assert!(state["completed_steps"].as_u64().is_some_and(|count| count <= 1));
+    let deadline = u128::from(state["deadline_at_millis"].as_u64().expect("saved deadline"));
+    // Check timer admission, not filesystem speed; allow only millisecond rounding slack.
+    assert!(deadline + 1 >= before_eof.as_millis() + 1_000);
+    assert!(deadline <= after_exit.as_millis() + 1_000);
+    assert_eq!(
+        state["job_id"].as_str(),
+        job_dir.file_name().and_then(|name| name.to_str())
+    );
+    let success = output.status.success();
+    assert_eq!(state["status"], if success { "succeeded" } else { "timed_out" });
+    if success {
+        assert_eq!(state["completed_steps"], 1);
+    } else {
+        assert!(deadline <= after_exit.as_millis());
+        assert!(
+            state["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("job deadline exceeded"))
+        );
+    }
+    if state["report_file"].is_null() {
+        assert!(!success);
+        assert_eq!(state["completed_steps"], 0);
+        assert!(output.stdout.is_empty());
+        assert!(!job_dir.join("report.json").exists());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("job deadline exceeded"));
+        assert!(stderr.contains(state["job_id"].as_str().expect("saved job id")));
+    } else {
+        assert_eq!(state["report_file"], "report.json");
+        assert!(output.stderr.is_empty());
+        let report: Value = serde_json::from_slice(&output.stdout).expect("delayed-plan report");
+        let saved: Value = serde_json::from_slice(&std::fs::read(job_dir.join("report.json")).expect("saved report"))
+            .expect("decode saved report");
+        assert_eq!(saved, report);
+        assert_eq!(report["job_id"], state["job_id"]);
+        assert_eq!(report["ok"], success);
+        assert_eq!(report["completed_steps"], state["completed_steps"]);
+        assert_eq!(
+            report["steps"].as_array().map(Vec::len),
+            state["completed_steps"]
+                .as_u64()
+                .and_then(|count| usize::try_from(count).ok())
+        );
+        assert_eq!(
+            report["stop_reason"],
+            if success {
+                Value::Null
+            } else {
+                json!("deadline_exceeded")
+            }
+        );
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Purpose

Make the stdin deadline integration test verify when the one-second execution deadline is armed, instead of requiring all subsequent filesystem and MCP work to finish within one second. Related to #324; this does not close the tracker.

## Behavior

- Test-only: one file, 101 additions and 7 deletions. No production timeout, persistence, browser or remote-lifecycle changes.
- Retains the one-second timeout and 1200 ms open-stdin liveness check. A parent timestamp immediately before closing stdin is the safe lower bracket: it detects a timer armed before the held input completes, including one not polled until afterward. It does not measure the child's exact EOF observation instant.
- The upper bound uses persisted job creation time, recorded after timer admission and before execution, rather than allowing an extra timeout after process exit. Creation time itself must fit the observed run interval.
- Requires exactly one coherent saved job. Success needs the matching successful report; timeout needs consistent deadline/state/report evidence or an explicit zero-completion pre-execution timeout with identified durable state. Missing output is not accepted by itself.
- Includes an explicit backward-clock diagnostic, strict directory assertion without filtering, and named timeout/rounding constants. No timeout increase or clock clamping.

## Validation

- Reproduced the original assertion failure on unchanged binaries with a bounded 50 ms delay per child-process fsync, without changing host storage settings. The CLI returned 124 with a valid timeout report and post-input deadline.
- Final source `9e6fae8`: all 12 normal CLI integration tests and the controlled-delay stdin test passed; the latter still observed CLI exit 124 with coherent artifacts.
- Formatting, maintainability, version sync, blocking and strict Clippy passed before commit. Independent local source review includes all hosted-comment corrections.
- Final commit `9e6fae8` passed all eight validation gates: 2,667 default and 2,712 speech tests, zero failures, seven ignored in each tier, plus formatting, maintainability, version sync and blocking/strict/pedantic Clippy. Prior results remain separately retained.

The controlled reproduction demonstrates the test's disk-speed assumption, not the historical machine-pressure cause. Separate three-second report/dispatch failures are not claimed fixed. No live browser, cloud resource, GUI, credential or release action was performed.
