### PR TITLE
fix(panel-chrome): truncate attention badge summaries by char, not byte

### DIFF
--- a/crates/horizon-ui/src/app/panel_chrome.rs
+++ b/crates/horizon-ui/src/app/panel_chrome.rs
@@ -5,7 +5,7 @@ use crate::theme;
 
 use super::RenameEditAction;
 use super::speech::MicState;
-use super::util::{format_compact_count, short_session_id, usize_to_f32};
+use super::util::{format_compact_count, short_session_id, truncate_chars, usize_to_f32};
 
 #[derive(Clone, Copy)]
 pub(super) struct PanelChrome<'a> {
@@ -635,14 +635,7 @@ fn attention_badge_geometry(
     let color = attention_severity_color(*severity);
     let icon = attention_severity_icon(*severity);
 
-    // Truncate the summary for display.
-    let display_text = if summary.len() > 30 {
-        let mut truncated = summary[..29].to_string();
-        truncated.push('\u{2026}');
-        truncated
-    } else {
-        summary.to_string()
-    };
+    let display_text = attention_badge_summary(summary);
     let badge_text = format!("{icon} {display_text}");
     let font = egui::FontId::proportional(10.0);
 
@@ -665,6 +658,17 @@ fn attention_badge_geometry(
 /// it — long summaries measure wider than the fixed titlebar reserve.
 fn session_badge_clears_attention_badge(session_badge: Rect, attention_left: f32) -> bool {
     session_badge.max.x <= attention_left
+}
+
+/// Character budget for attention badge summaries, ellipsis included; keeps
+/// the badge within the fixed titlebar reserve.
+const ATTENTION_SUMMARY_MAX_CHARS: usize = 30;
+
+/// Character-based truncation for the attention badge summary. Summaries come
+/// from arbitrary agent output, so the cut must never be byte-indexed: a
+/// multi-byte character straddling the cut point would panic.
+fn attention_badge_summary(summary: &str) -> String {
+    truncate_chars(summary, ATTENTION_SUMMARY_MAX_CHARS).into_owned()
 }
 
 #[profiling::function]
@@ -823,10 +827,11 @@ mod tests {
     use egui::{Color32, Pos2, Rect};
 
     use super::{
-        AgentStatus, PanelChrome, SESSION_BADGE_MIN_TITLE_SPACE, SESSION_BADGE_TITLE_GAP, SESSION_BADGE_WIDTH,
-        WORKING_BADGE_GAP, badges_left_boundary, focus_ring_stroke, panel_border_stroke, panel_fill, panel_title_color,
-        panel_title_content_rect, panel_titlebar_fill, session_badge_clears_attention_badge, session_badge_rect,
-        title_focus_indicator_rect, title_right_boundary, working_indicator_reserve, working_indicator_width,
+        ATTENTION_SUMMARY_MAX_CHARS, AgentStatus, PanelChrome, SESSION_BADGE_MIN_TITLE_SPACE, SESSION_BADGE_TITLE_GAP,
+        SESSION_BADGE_WIDTH, WORKING_BADGE_GAP, attention_badge_summary, badges_left_boundary, focus_ring_stroke,
+        panel_border_stroke, panel_fill, panel_title_color, panel_title_content_rect, panel_titlebar_fill,
+        session_badge_clears_attention_badge, session_badge_rect, title_focus_indicator_rect, title_right_boundary,
+        working_indicator_reserve, working_indicator_width,
     };
 
     /// The boundary math is exact constant arithmetic, so an epsilon of one
@@ -1046,5 +1051,49 @@ mod tests {
         assert!(titlebar_rect.contains(indicator.max - indicator.size() * 0.01));
         assert!(indicator.width() > 0.0);
         assert!(indicator.height() > 0.0);
+    }
+
+    // Regression: the badge summary used to be cut with `summary[..29]` after
+    // a byte-length check, which panics whenever a multi-byte character
+    // straddles byte 29 (e.g. Norwegian or emoji content near the boundary).
+    #[test]
+    fn attention_summary_truncates_by_chars_when_bytes_exceed_the_budget() {
+        // 28 ASCII chars + 3 two-byte æ = 31 chars / 34 bytes; the old byte
+        // slice [..29] landed inside the first æ.
+        let summary = format!("{}æææ", "a".repeat(28));
+
+        let truncated = attention_badge_summary(&summary);
+
+        assert_eq!(truncated, format!("{}æ…", "a".repeat(28)));
+        assert_eq!(truncated.chars().count(), ATTENTION_SUMMARY_MAX_CHARS);
+    }
+
+    #[test]
+    fn attention_summary_survives_emoji_at_the_cut() {
+        // 27 ASCII chars + 4-byte emoji + 6 chars = 34 chars / 37 bytes; the
+        // old byte slice [..29] landed inside the emoji.
+        let summary = format!("{}🔥{}", "a".repeat(27), "b".repeat(6));
+
+        let truncated = attention_badge_summary(&summary);
+
+        assert_eq!(truncated, format!("{}🔥b…", "a".repeat(27)));
+        assert_eq!(truncated.chars().count(), ATTENTION_SUMMARY_MAX_CHARS);
+    }
+
+    #[test]
+    fn attention_summary_keeps_exactly_budgeted_multibyte_text() {
+        // 30 chars but 60 bytes: the old byte-length check truncated (and
+        // panicked); the char budget fits the whole summary.
+        let summary = "æ".repeat(ATTENTION_SUMMARY_MAX_CHARS);
+
+        assert_eq!(attention_badge_summary(&summary), summary);
+    }
+
+    #[test]
+    fn attention_summary_matches_old_ascii_behavior() {
+        assert_eq!(attention_badge_summary("Disk almost full"), "Disk almost full");
+        assert_eq!(attention_badge_summary(&"a".repeat(30)), "a".repeat(30));
+        assert_eq!(attention_badge_summary(&"a".repeat(31)), format!("{}…", "a".repeat(29)));
+        assert_eq!(attention_badge_summary(&"æ".repeat(40)), format!("{}…", "æ".repeat(29)));
     }
 }


### PR DESCRIPTION
## Purpose

Fixes **#271 item 1** — the byte-indexed slice panic in the attention badge summary.

`attention_badge_geometry` (panel titlebar chrome) guarded on `summary.len() > 30`
(**bytes**) then sliced `summary[..29]` (**bytes**). Any attention summary with a
multi-byte character straddling byte 29 — e.g. Norwegian or emoji content near
that offset — made the slice panic on the UI thread and crash Horizon.

## Behavior impact

- Badge summaries are now cut by **characters** via the existing
  char-based `truncate_chars` helper: 30-char budget, ellipsis included.
- ASCII behavior is unchanged (31+ chars → 29 chars + `…`).
- Multibyte summaries that fit in 30 chars but exceed 30 **bytes** (e.g. 30×`æ`
  = 60 bytes) are now shown in full instead of being truncated — and the old
  code panicked on most of those.

## Test evidence

- 4 new unit regression tests on the truncation function, including the exact
  panic vectors (2-byte char at the cut, 4-byte emoji at the cut, 60-byte/30-char
  text, ASCII parity). **Verified against the pre-fix code by temporarily
  reverting the implementation: all 4 tests panic at `summary[..29]` on the old
  implementation and pass on the new one.**
- Full pre-push matrix green in this worktree: fmt, maintainability,
  `cargo test --workspace` (+ `--features speech`), blocking/strict/pedantic
  clippy.
- Live UI smoke (debug binary, ephemeral workspace, task-owned Xvfb `:97` +
  openbox, isolated temp HOME/config, `HORIZON` unset, exact-PID scoped):
  - Sent `HORIZON_NOTIFY:attention:<28×a>æææ` (34 bytes — old `[..29]` split the
    first æ) and `<27×a>🔥bbbbbb` (old slice split the emoji) through the
    probe panel PTY: app alive at every checkpoint, no panic in the log, feed
    rendered the full multibyte messages.
  - Agent-kind panel with an agent-style prompt line painted the live titlebar
    badge (“⚠ Ready for input”) and survived a live resize — badge paint path
    exercised end-to-end.
  - Baseline launch + shrink/restore screenshots clean.

## Notes

- Pre-existing observation (out of scope): `agent-notify` attention items on
  non-agent panels are resolved in the same frame they're created
  (`update_attention`'s `attention.is_none() && has_open` branch), so shell-panel
  notifications never reach the titlebar badge — only the feed. The unit tests
  therefore carry the badge-path regression proof.
- Items 2–5 of #271 follow as separate focused PRs.