### PR TITLE
feat(remote): persist explicit environment deletion

### DIFF
--- a/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations.rs
@@ -3,6 +3,7 @@
 //! off the render thread; only the durable creation fence may grant provider creation.
 
 mod binding;
+mod delete;
 mod guards;
 mod recovery;
 mod request;

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/delete.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/delete.rs
@@ -1,0 +1,41 @@
+//! Dedicated Delete transitions, retaining allocation identity and its creation fence.
+
+use super::{CloudWorkflowStore, StoredRemoteAllocation, WorkspaceReplacement, binding};
+use crate::{
+    remote_environment_delete::RemoteEnvironmentDeleteError as Error,
+    remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteRuntimePhase},
+};
+use rusqlite::TransactionBehavior;
+
+impl CloudWorkflowStore {
+    pub(crate) fn record_remote_delete_phase(
+        &self,
+        expected: &StoredRemoteAllocation,
+        phase: RemoteRuntimePhase,
+    ) -> Result<StoredRemoteAllocation, Error> {
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        super::super::database::ensure_current_schema(&transaction)?;
+        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)?
+            .ok_or(Error::MissingAllocation)?;
+        let current = binding::recover(&transaction, &row)?;
+        if current != *expected {
+            return Err(Error::StateChanged);
+        }
+        let mut next = current.workspace.state().clone();
+        let runtime = next.runtime.as_mut().ok_or(Error::MissingAllocation)?;
+        if let RemoteRuntimePhase::DeleteRequested { requested_at_millis } = phase {
+            runtime.cleanup = Some(RemoteCleanupIntent {
+                reason: RemoteCleanupReason::WorkspaceRemoved,
+                requested_at_millis,
+            });
+        }
+        runtime.phase = phase;
+        let workspace = WorkspaceReplacement::for_deletion(&current.workspace, &next)?.persist(&transaction)?;
+        transaction.commit()?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: current.workflow,
+        })
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -199,6 +199,21 @@ pub(super) struct WorkspaceReplacement<'a> {
 }
 
 impl<'a> WorkspaceReplacement<'a> {
+    /// Only the deletion coordinator may enter or complete destructive intent.
+    /// Validate a phase-only transition before retaining the usual exact-snapshot CAS.
+    pub(super) fn for_deletion(
+        expected: &'a StoredRemoteWorkspace,
+        next: &'a RemoteWorkspaceState,
+    ) -> Result<Self, RemoteWorkspaceStoreError> {
+        validate_key(&expected.session_id, &expected.state.spec.workspace_local_id)?;
+        validation::validate_delete_replacement(&expected.state, next)?;
+        Ok(Self {
+            expected,
+            next,
+            snapshot: encode(&expected.session_id, next)?,
+        })
+    }
+
     pub(super) fn new(
         expected: &'a StoredRemoteWorkspace,
         next: &'a RemoteWorkspaceState,
@@ -481,6 +496,8 @@ pub enum RemoteWorkspaceStoreError {
     RuntimeRequestUnavailable,
     #[error("remote workspace has pending management intent; reconnect cannot change it")]
     RuntimeRecoveryUnavailable,
+    #[error("remote Delete intent and completion require the verified coordinator")]
+    RuntimeDeleteCoordinationRequired,
     #[error("remote Stop completion requires the verified coordinator")]
     RuntimeStopConfirmationRequired,
     #[error("remote Start intent is recorded and resolved only by the verified Start coordinator")]

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -19,6 +19,16 @@ pub(in crate::cloud_run::store) fn validate_key(session_id: &str, workspace_loca
 
 pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &RemoteWorkspaceState) -> Result<(), Error> {
     next.validate()?;
+    if previous != next
+        && [previous, next].into_iter().any(|state| {
+            state
+                .runtime
+                .as_ref()
+                .is_some_and(|runtime| runtime.phase.delete_requested_at_millis().is_some())
+        })
+    {
+        return Err(Error::RuntimeDeleteCoordinationRequired);
+    }
     if previous.spec.workspace_local_id != next.spec.workspace_local_id {
         return Err(Error::ReplacementIdentityMismatch);
     }
@@ -96,6 +106,63 @@ pub(super) fn validate_replacement(previous: &RemoteWorkspaceState, next: &Remot
         && previous.spec.generation.checked_add(1) != Some(next.spec.generation)
     {
         return Err(Error::NonMonotonicReplacement);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_delete_replacement(
+    previous: &RemoteWorkspaceState,
+    next: &RemoteWorkspaceState,
+) -> Result<(), Error> {
+    use crate::{
+        cloud_run::WorkerLifetime,
+        remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason},
+    };
+    next.validate()?;
+    let mut permitted = previous.clone();
+    let runtime = permitted
+        .runtime
+        .as_mut()
+        .ok_or(Error::RuntimeDeleteCoordinationRequired)?;
+    let next_runtime = next.runtime.as_ref().ok_or(Error::RuntimeDeleteCoordinationRequired)?;
+    if runtime.worker.is_none() || previous.spec.target.lifetime != WorkerLifetime::Persistent {
+        return Err(Error::RuntimeDeleteCoordinationRequired);
+    }
+    match (runtime.phase, next_runtime.phase) {
+        (
+            RemoteRuntimePhase::Ready
+            | RemoteRuntimePhase::Reconciling
+            | RemoteRuntimePhase::Failed
+            | RemoteRuntimePhase::Stopped { .. },
+            RemoteRuntimePhase::DeleteRequested { requested_at_millis },
+        ) if runtime.cleanup.is_none()
+            && requested_at_millis >= 0
+            && !matches!(runtime.phase, RemoteRuntimePhase::Stopped { observed_at_millis, .. }
+                    if requested_at_millis < observed_at_millis) =>
+        {
+            runtime.cleanup = Some(RemoteCleanupIntent {
+                reason: RemoteCleanupReason::WorkspaceRemoved,
+                requested_at_millis,
+            });
+        }
+        (
+            RemoteRuntimePhase::DeleteRequested { requested_at_millis },
+            RemoteRuntimePhase::DeleteRequested {
+                requested_at_millis: retained,
+            },
+        ) if requested_at_millis == retained => {}
+        (
+            RemoteRuntimePhase::DeleteRequested { requested_at_millis },
+            RemoteRuntimePhase::Deleted {
+                requested_at_millis: retained,
+                observed_at_millis,
+            },
+        ) if requested_at_millis == retained && observed_at_millis >= requested_at_millis => {}
+        _ => return Err(Error::RuntimeDeleteCoordinationRequired),
+    }
+    runtime.phase = next_runtime.phase;
+    if &permitted != next {
+        return Err(Error::ReplacementIdentityMismatch);
     }
     Ok(())
 }

--- a/crates/horizon-core/src/lib.rs
+++ b/crates/horizon-core/src/lib.rs
@@ -19,6 +19,7 @@ mod local_store;
 mod managed_install;
 mod opencode_paths;
 mod panel;
+pub mod remote_environment_delete;
 pub mod remote_environment_observation;
 pub mod remote_git_setup;
 pub mod remote_github_credential;

--- a/crates/horizon-core/src/remote_environment_delete.rs
+++ b/crates/horizon-core/src/remote_environment_delete.rs
@@ -1,0 +1,270 @@
+//! Explicit destructive intent and exact worker-absence confirmation, never client cleanup.
+
+use crate::{
+    cloud_run::{
+        CloudStoreError, CloudWorkflowStore, RemoteWorkspaceStoreError, StoredRemoteAllocation, WorkerLifetime,
+        interactive_worker::InteractiveWorker,
+        interactive_worker_delete::{InteractiveWorkerDeleteObserver, InteractiveWorkerDeletionObservation},
+    },
+    remote_workspace::RemoteRuntimePhase,
+};
+
+/// Saved state after a deletion request or its non-mutating confirmation.
+#[derive(Debug, Eq, PartialEq)]
+pub struct RemoteEnvironmentDeletion {
+    pub allocation: StoredRemoteAllocation,
+    /// Only an exact provider absence observation permits this to be true.
+    pub absence_verified: bool,
+}
+
+/// Delete the exact retained worker after an explicit destructive confirmation.
+///
+/// The caller must disclose running-task loss, unpushed-data loss and the provider's
+/// complete deletion scope. Independent network storage is not implicitly deleted.
+/// This function durably records intent before one provider call, then makes one
+/// read-only absence observation. Any ambiguous response retains intent. Checking
+/// never replays Delete; another attempt requires separately confirmed explicit retry.
+/// The allocation, original identity and creation fence survive as a tombstone.
+/// Run off the render thread; closing a view or client must never invoke this API.
+/// # Errors
+/// Refuses stale ownership, missing retained identity, unsupported lifetime, active
+/// management intent and storage errors. Provider failures are redacted and retain intent.
+pub fn delete_remote_environment<P: InteractiveWorkerDeleteObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<RemoteEnvironmentDeletion, RemoteEnvironmentDeleteError> {
+    let allocation = current(store, provider, expected)?;
+    let runtime = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?;
+    if runtime.cleanup.is_some()
+        || !matches!(
+            runtime.phase,
+            RemoteRuntimePhase::Ready
+                | RemoteRuntimePhase::Reconciling
+                | RemoteRuntimePhase::Failed
+                | RemoteRuntimePhase::Stopped { .. }
+        )
+    {
+        return Err(Error::ManagementConflict);
+    }
+    let requested_at_millis = current_millis()?;
+    let requested =
+        store.record_remote_delete_phase(&allocation, RemoteRuntimePhase::DeleteRequested { requested_at_millis })?;
+    let worker = retained_worker(&requested)?;
+    // Accepted, completed and lost replies all need an independent observation.
+    // No provider payload enters errors or durable state, and the call is not retried.
+    let _response = provider.delete_worker(worker);
+    observe(store, provider, &requested)
+}
+
+/// Check previously saved Delete intent without requesting deletion or touching SSH.
+/// A surviving resource remains pending, even if the provider says it is deleting.
+/// Confirmed tombstones are returned without further I/O; their observation is historical.
+/// # Errors
+/// Refuses missing intent, stale identity, provider errors and invalid timestamps.
+pub fn confirm_remote_environment_deletion<P: InteractiveWorkerDeleteObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<RemoteEnvironmentDeletion, RemoteEnvironmentDeleteError> {
+    let allocation = current(store, provider, expected)?;
+    let phase = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?
+        .phase;
+    match phase {
+        RemoteRuntimePhase::Deleted { .. } => Ok(RemoteEnvironmentDeletion {
+            allocation,
+            absence_verified: true,
+        }),
+        RemoteRuntimePhase::DeleteRequested { .. } => observe(store, provider, &allocation),
+        _ => Err(Error::MissingDeleteIntent),
+    }
+}
+
+/// Retry saved Delete intent only after a new explicit destructive confirmation.
+/// Uses the same disclosure and exact resource scope as [`delete_remote_environment`].
+/// First check ownership and absence without mutation: absence completes the intent
+/// without another Delete; failed observation refuses dispatch. A surviving resource
+/// permits one request after a revision-guarded durable retry admission. The original
+/// intent time and identities remain unchanged. Refresh/reconnect must never call this.
+/// Present does not prove the prior request failed: confirmation must disclose that
+/// the earlier deletion may still be in progress when another request is authorized.
+/// # Errors
+/// Refuses missing pending intent, stale identity, provider observation errors and
+/// storage conflicts. Unverified results keep intent; retry is never automatic.
+pub fn retry_remote_environment_deletion<P: InteractiveWorkerDeleteObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<RemoteEnvironmentDeletion, RemoteEnvironmentDeleteError> {
+    let allocation = current(store, provider, expected)?;
+    let phase = allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?
+        .phase;
+    if !matches!(phase, RemoteRuntimePhase::DeleteRequested { .. }) {
+        return Err(Error::MissingDeleteIntent);
+    }
+    let checked = observe(store, provider, &allocation)?;
+    if checked.absence_verified {
+        return Ok(checked);
+    }
+    // Even unchanged intent advances the revision: another caller using this same
+    // snapshot cannot dispatch a second retry. The provider revalidates ownership.
+    let admitted = store.record_remote_delete_phase(&checked.allocation, phase)?;
+    let _response = provider.delete_worker(retained_worker(&admitted)?);
+    observe(store, provider, &admitted)
+}
+
+fn current<P: InteractiveWorkerDeleteObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, Error> {
+    let allocation = store
+        .load_remote_allocation(
+            expected.workspace().session_id(),
+            &expected.workspace().state().spec.workspace_local_id,
+        )?
+        .ok_or(Error::MissingAllocation)?;
+    if allocation != *expected {
+        return Err(Error::StateChanged);
+    }
+    let worker = retained_worker(&allocation)?;
+    if !worker.is_valid_for(provider.provider()) {
+        return Err(Error::ProviderMismatch);
+    }
+    if worker.target.lifetime != WorkerLifetime::Persistent {
+        return Err(Error::UnsupportedLifetime);
+    }
+    Ok(allocation)
+}
+
+fn retained_worker(allocation: &StoredRemoteAllocation) -> Result<&InteractiveWorker, Error> {
+    allocation
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?
+        .worker
+        .as_ref()
+        .ok_or(Error::MissingWorker)
+}
+
+fn observe<P: InteractiveWorkerDeleteObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<RemoteEnvironmentDeletion, Error> {
+    let runtime = expected
+        .workspace()
+        .state()
+        .runtime
+        .as_ref()
+        .ok_or(Error::MissingAllocation)?;
+    let RemoteRuntimePhase::DeleteRequested { requested_at_millis } = runtime.phase else {
+        return Err(Error::MissingDeleteIntent);
+    };
+    if requested_at_millis > current_millis()? {
+        return Err(Error::InvalidTimestamp);
+    }
+    let observation = provider
+        .observe_worker_deletion(retained_worker(expected)?)
+        .map_err(|_| Error::ProviderUnavailable)?;
+    if observation == InteractiveWorkerDeletionObservation::Present {
+        // Even a pending result must still belong to the exact snapshot observed.
+        let allocation = current(store, provider, expected)?;
+        return Ok(RemoteEnvironmentDeletion {
+            allocation,
+            absence_verified: false,
+        });
+    }
+    let observed_at_millis = current_millis()?;
+    if observed_at_millis < requested_at_millis {
+        return Err(Error::InvalidTimestamp);
+    }
+    let allocation = store.record_remote_delete_phase(
+        expected,
+        RemoteRuntimePhase::Deleted {
+            requested_at_millis,
+            observed_at_millis,
+        },
+    )?;
+    Ok(RemoteEnvironmentDeletion {
+        allocation,
+        absence_verified: true,
+    })
+}
+
+fn current_millis() -> Result<i64, Error> {
+    i64::try_from(time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000)
+        .ok()
+        .filter(|millis| *millis >= 0)
+        .ok_or(Error::InvalidTimestamp)
+}
+
+type Error = RemoteEnvironmentDeleteError;
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteEnvironmentDeleteError {
+    #[error("no exact owned allocation is available for deletion")]
+    MissingAllocation,
+    #[error("no retained worker identity is available for deletion")]
+    MissingWorker,
+    #[error("saved environment changed; refresh before proceeding")]
+    StateChanged,
+    #[error("deletion provider does not match the saved worker")]
+    ProviderMismatch,
+    #[error("explicit environment deletion requires a persistent worker")]
+    UnsupportedLifetime,
+    #[error("existing management intent prevents a new Delete; check saved intent instead")]
+    ManagementConflict,
+    #[error("no saved explicit Delete intent is available to check")]
+    MissingDeleteIntent,
+    #[error("worker absence could not be verified; saved Delete intent and identity remain")]
+    ProviderUnavailable,
+    #[error("deletion timestamps could not be safely recorded")]
+    InvalidTimestamp,
+    #[error("owned remote deletion state could not be safely accessed")]
+    StorageUnavailable,
+}
+
+impl From<RemoteWorkspaceStoreError> for Error {
+    fn from(value: RemoteWorkspaceStoreError) -> Self {
+        match value {
+            RemoteWorkspaceStoreError::SnapshotConflict | RemoteWorkspaceStoreError::RevisionConflict { .. } => {
+                Self::StateChanged
+            }
+            RemoteWorkspaceStoreError::RuntimeDeleteCoordinationRequired => Self::ManagementConflict,
+            _ => Self::StorageUnavailable,
+        }
+    }
+}
+
+impl From<CloudStoreError> for Error {
+    fn from(_: CloudStoreError) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+impl From<rusqlite::Error> for Error {
+    fn from(_: rusqlite::Error) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_environment_delete/tests.rs
+++ b/crates/horizon-core/src/remote_environment_delete/tests.rs
@@ -1,0 +1,556 @@
+use super::*;
+use crate::{
+    cloud_run::{
+        CloudProvider,
+        interactive_worker::{
+            InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity, InteractiveWorkerLifecycle,
+            InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerStatus,
+        },
+    },
+    remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason, RemoteWorkspaceState},
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    store: CloudWorkflowStore,
+}
+
+impl Fixture {
+    fn new(stopped: bool) -> Self {
+        let root = tempfile::tempdir().expect("root");
+        let store = CloudWorkflowStore::open_path(root.path().join("control/workflows.sqlite3")).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({
+            "version":1,"spec":{"workspace_local_id":"workspace","working_directory":".",
+            "generation":0,"panels":[],"target":{"provider":"local_docker","profile":"development",
+            "disk_gib":20,"lifetime":"persistent","image":format!("example/worker@sha256:{}","a".repeat(64))},
+            "repository":{"repository":"example/project","commit":"b".repeat(40)}}
+        }))
+        .expect("state");
+        let saved = store.create_remote_workspace(OWNER, &state).expect("saved");
+        let allocation = store.allocate_remote_runtime(&saved, i64::MAX).expect("allocated");
+        let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+        blob.extend([7; 32]);
+        let key = format!("ssh-ed25519 {}", STANDARD.encode(blob));
+        let reserved = store
+            .reserve_remote_worker_request(&allocation, &key)
+            .expect("reserved");
+        let request = reserved.worker_request().expect("request");
+        let worker = InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::LocalDocker,
+                workflow_id: request.workflow_id,
+                job_id: request.job_id,
+                resource_id: "a".repeat(64),
+            },
+            target: request.target,
+            ssh_public_key: request.ssh_public_key,
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        };
+        let allocation = store
+            .record_remote_worker_recovery(
+                &reserved,
+                Some(&InteractiveWorkerStatus {
+                    worker,
+                    lifecycle: InteractiveWorkerLifecycle::Provisioning,
+                    ssh: None,
+                }),
+            )
+            .expect("observed");
+        if stopped {
+            store
+                .record_remote_stop_phase(
+                    &allocation,
+                    RemoteRuntimePhase::Stopped {
+                        requested_at_millis: 1,
+                        observed_at_millis: 2,
+                    },
+                )
+                .expect("saved Stop");
+        }
+        Self { _root: root, store }
+    }
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+    fn delete(&self, provider: &Provider) -> Result<RemoteEnvironmentDeletion, Error> {
+        delete_remote_environment(&self.store, provider, &self.current())
+    }
+}
+
+type Hook = Box<dyn Fn(&InteractiveWorker) + Send + Sync>;
+struct Provider {
+    present: AtomicBool,
+    fail_delete: bool,
+    fail_observe: bool,
+    calls: Mutex<Vec<&'static str>>,
+    on_delete: Option<Hook>,
+    on_observe: Option<Hook>,
+    kind: CloudProvider,
+}
+impl Provider {
+    fn new(present: bool) -> Self {
+        Self {
+            present: AtomicBool::new(present),
+            fail_delete: false,
+            fail_observe: false,
+            calls: Mutex::new(Vec::new()),
+            on_delete: None,
+            on_observe: None,
+            kind: CloudProvider::LocalDocker,
+        }
+    }
+    fn calls(&self) -> Vec<&'static str> {
+        self.calls.lock().expect("calls").clone()
+    }
+}
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        self.kind
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no reconcile")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no SSH readiness")
+    }
+    fn delete_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        self.calls.lock().expect("calls").push("delete");
+        if let Some(hook) = &self.on_delete {
+            hook(worker);
+        }
+        if self.fail_delete {
+            Err(std::io::Error::other("private delete payload"))
+        } else {
+            Ok(InteractiveWorkerCleanup::Deleted)
+        }
+    }
+}
+impl InteractiveWorkerDeleteObserver for Provider {
+    fn observe_worker_deletion(
+        &self,
+        worker: &InteractiveWorker,
+    ) -> Result<InteractiveWorkerDeletionObservation, Self::Error> {
+        self.calls.lock().expect("calls").push("observe");
+        if let Some(hook) = &self.on_observe {
+            hook(worker);
+        }
+        if self.fail_observe {
+            return Err(std::io::Error::other("private observation payload"));
+        }
+        Ok(if self.present.load(Ordering::SeqCst) {
+            InteractiveWorkerDeletionObservation::Present
+        } else {
+            InteractiveWorkerDeletionObservation::Absent
+        })
+    }
+}
+
+#[test]
+fn intent_precedes_single_delete_and_absence_preserves_tombstone_and_fence() {
+    for stopped in [false, true] {
+        let fixture = Fixture::new(stopped);
+        let before = fixture.current();
+        let mut other_spec = before.workspace().state().spec.clone();
+        other_spec.workspace_local_id = "unrelated".into();
+        other_spec.generation = 0;
+        let other = fixture
+            .store
+            .create_remote_workspace(OWNER, &RemoteWorkspaceState::new(other_spec).expect("other state"))
+            .expect("other workspace");
+        let store = fixture.store.clone();
+        let mut provider = Provider::new(false);
+        provider.on_delete = Some(Box::new(move |worker| {
+            let saved = store
+                .load_remote_allocation(OWNER, "workspace")
+                .expect("read")
+                .expect("saved");
+            let runtime = saved.workspace().state().runtime.as_ref().expect("runtime");
+            assert!(matches!(runtime.phase, RemoteRuntimePhase::DeleteRequested { .. }));
+            assert_eq!(runtime.worker.as_ref(), Some(worker));
+            assert_eq!(
+                runtime.cleanup.as_ref().expect("intent").reason,
+                RemoteCleanupReason::WorkspaceRemoved
+            );
+        }));
+        let result = fixture.delete(&provider).expect("deleted");
+        assert!(result.absence_verified);
+        assert_eq!(provider.calls(), ["delete", "observe"]);
+        let after = &result.allocation;
+        assert_eq!(before.workflow(), after.workflow());
+        assert_eq!(before.workspace().state().spec, after.workspace().state().spec);
+        assert_eq!(before.workspace().revision() + 2, after.workspace().revision());
+        assert_eq!(retained_worker(&before), retained_worker(after));
+        assert_eq!(fixture.current(), *after);
+        assert!(
+            fixture
+                .store
+                .claim_worker_creation(
+                    before.workflow().workflow().id,
+                    retained_worker(&before).expect("worker").identity.job_id,
+                    &before.workspace().state().spec.target,
+                    "synthetic-worker"
+                )
+                .is_err()
+        );
+        assert!(
+            fixture
+                .store
+                .list_remote_workspaces(OWNER)
+                .expect("workspaces")
+                .contains(&other)
+        );
+        assert!(
+            fixture
+                .store
+                .allocate_remote_runtime(after.workspace(), i64::MAX)
+                .is_err()
+        );
+        assert!(fixture.store.record_remote_worker_recovery(after, None).is_err());
+        let again = confirm_remote_environment_deletion(&fixture.store, &provider, after).expect("historical");
+        assert_eq!(again, result);
+        assert_eq!(provider.calls(), ["delete", "observe"]);
+        assert_eq!(fixture.delete(&provider), Err(Error::ManagementConflict));
+    }
+}
+
+#[test]
+fn accepted_or_lost_response_stays_pending_and_explicit_check_never_replays() {
+    for fail_delete in [false, true] {
+        let fixture = Fixture::new(true);
+        let mut provider = Provider::new(true);
+        provider.fail_delete = fail_delete;
+        let pending = fixture.delete(&provider).expect("pending");
+        assert!(!pending.absence_verified);
+        assert_eq!(fixture.delete(&provider), Err(Error::ManagementConflict));
+        let still =
+            confirm_remote_environment_deletion(&fixture.store, &provider, &pending.allocation).expect("present");
+        assert_eq!(still, pending);
+        provider.present.store(false, Ordering::SeqCst);
+        let complete =
+            confirm_remote_environment_deletion(&fixture.store, &provider, &pending.allocation).expect("absent");
+        assert!(complete.absence_verified);
+        assert_eq!(provider.calls(), ["delete", "observe", "observe", "observe"]);
+        assert_eq!(
+            complete.allocation.workspace().revision(),
+            pending.allocation.workspace().revision() + 1
+        );
+    }
+}
+
+#[test]
+fn separately_confirmed_retry_checks_before_one_dispatch_and_retains_identity() {
+    let fixture = Fixture::new(true);
+    let original = fixture.current();
+    assert_eq!(
+        retry_remote_environment_deletion(&fixture.store, &Provider::new(true), &original),
+        Err(Error::MissingDeleteIntent)
+    );
+    let pending = fixture.delete(&Provider::new(true)).expect("pending").allocation;
+    let store = fixture.store.clone();
+    let snapshot = pending.clone();
+    let mut provider = Provider::new(true);
+    provider.on_delete = Some(Box::new(move |_| {
+        let admitted = store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("saved");
+        assert_eq!(admitted.workspace().revision(), snapshot.workspace().revision() + 1);
+        assert_eq!(admitted.workspace().state(), snapshot.workspace().state());
+        assert_eq!(admitted.workflow(), snapshot.workflow());
+    }));
+    let retried = retry_remote_environment_deletion(&fixture.store, &provider, &pending).expect("retry");
+    assert!(!retried.absence_verified);
+    assert_eq!(provider.calls(), ["observe", "delete", "observe"]);
+    assert_eq!(retained_worker(&retried.allocation), retained_worker(&pending));
+    assert_eq!(
+        retry_remote_environment_deletion(&fixture.store, &provider, &pending),
+        Err(Error::StateChanged)
+    );
+    assert_eq!(provider.calls(), ["observe", "delete", "observe"]);
+    assert_eq!(fixture.delete(&provider), Err(Error::ManagementConflict));
+}
+
+#[test]
+fn retry_observation_absence_or_error_never_dispatches_delete() {
+    for absent in [false, true] {
+        let fixture = Fixture::new(false);
+        let pending = fixture.delete(&Provider::new(true)).expect("pending").allocation;
+        let mut provider = Provider::new(false);
+        provider.fail_observe = !absent;
+        let result = retry_remote_environment_deletion(&fixture.store, &provider, &pending);
+        if absent {
+            assert!(result.expect("absent").absence_verified);
+            assert_eq!(
+                fixture.current().workspace().revision(),
+                pending.workspace().revision() + 1
+            );
+        } else {
+            assert_eq!(result, Err(Error::ProviderUnavailable));
+            assert_eq!(fixture.current(), pending);
+        }
+        assert_eq!(provider.calls(), ["observe"]);
+    }
+}
+
+#[test]
+fn retry_observation_race_cannot_dispatch_or_rewind_confirmation() {
+    let fixture = Fixture::new(false);
+    let pending = fixture.delete(&Provider::new(true)).expect("pending").allocation;
+    let store = fixture.store.clone();
+    let snapshot = pending.clone();
+    let mut provider = Provider::new(true);
+    provider.on_observe = Some(Box::new(move |_| {
+        assert!(
+            confirm_remote_environment_deletion(&store, &Provider::new(false), &snapshot)
+                .expect("concurrent confirmation")
+                .absence_verified
+        );
+    }));
+    assert_eq!(
+        retry_remote_environment_deletion(&fixture.store, &provider, &pending),
+        Err(Error::StateChanged)
+    );
+    assert_eq!(provider.calls(), ["observe"]);
+    assert!(matches!(
+        fixture
+            .current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase,
+        RemoteRuntimePhase::Deleted { .. }
+    ));
+}
+
+#[test]
+fn competing_retry_of_same_snapshot_has_one_dispatch_even_with_a_lost_reply() {
+    let fixture = Fixture::new(false);
+    let pending = fixture.delete(&Provider::new(true)).expect("pending").allocation;
+    let store = fixture.store.clone();
+    let snapshot = pending.clone();
+    let mut winner = Provider::new(true);
+    winner.fail_delete = true;
+    let winner = std::sync::Arc::new(winner);
+    let nested = winner.clone();
+    let mut loser = Provider::new(true);
+    loser.on_observe = Some(Box::new(move |_| {
+        let result = retry_remote_environment_deletion(&store, nested.as_ref(), &snapshot).expect("retry");
+        assert!(!result.absence_verified);
+    }));
+    assert_eq!(
+        retry_remote_environment_deletion(&fixture.store, &loser, &pending),
+        Err(Error::StateChanged)
+    );
+    assert_eq!(loser.calls(), ["observe"]);
+    assert_eq!(winner.calls(), ["observe", "delete", "observe"]);
+    assert_eq!(fixture.current().workspace().state(), pending.workspace().state());
+    assert_eq!(
+        fixture.current().workspace().revision(),
+        pending.workspace().revision() + 1
+    );
+}
+
+#[test]
+fn failed_observation_retains_intent_and_redacts_provider_payload() {
+    let fixture = Fixture::new(false);
+    let mut provider = Provider::new(false);
+    provider.fail_delete = true;
+    provider.fail_observe = true;
+    let error = fixture.delete(&provider).expect_err("unverified");
+    assert_eq!(error, Error::ProviderUnavailable);
+    assert!(!format!("{error:?} {error}").contains("private"));
+    assert!(matches!(
+        fixture
+            .current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase,
+        RemoteRuntimePhase::DeleteRequested { .. }
+    ));
+    provider.fail_observe = false;
+    assert!(
+        confirm_remote_environment_deletion(&fixture.store, &provider, &fixture.current())
+            .expect("check")
+            .absence_verified
+    );
+    assert_eq!(provider.calls(), ["delete", "observe", "observe"]);
+}
+
+#[test]
+fn stale_foreign_missing_intent_and_conflicting_management_refuse_before_io() {
+    let fixture = Fixture::new(false);
+    let provider = Provider::new(false);
+    let before = fixture.current();
+    assert_eq!(
+        confirm_remote_environment_deletion(&fixture.store, &provider, &before),
+        Err(Error::MissingDeleteIntent)
+    );
+    let mut changed = before.workspace().state().clone();
+    changed.spec.working_directory = "src".into();
+    fixture
+        .store
+        .replace_remote_workspace(before.workspace(), &changed)
+        .expect("changed");
+    assert_eq!(
+        delete_remote_environment(&fixture.store, &provider, &before),
+        Err(Error::StateChanged)
+    );
+    let mut foreign = Provider::new(false);
+    foreign.kind = CloudProvider::Azure;
+    assert_eq!(fixture.delete(&foreign), Err(Error::ProviderMismatch));
+    assert!(provider.calls().is_empty());
+    assert!(foreign.calls().is_empty());
+    for reason in [
+        RemoteCleanupReason::Cancelled,
+        RemoteCleanupReason::WorkspaceRemoved,
+        RemoteCleanupReason::ApplicationExit,
+    ] {
+        let f = Fixture::new(false);
+        let saved = f.current();
+        let mut state = saved.workspace().state().clone();
+        // Legacy cleanup intent alone is enough to refuse explicit Delete, whatever its phase.
+        state.runtime.as_mut().expect("runtime").cleanup = Some(RemoteCleanupIntent {
+            reason,
+            requested_at_millis: 1,
+        });
+        f.store
+            .replace_remote_workspace(saved.workspace(), &state)
+            .expect("legacy intent");
+        assert_eq!(f.delete(&provider), Err(Error::ManagementConflict));
+    }
+    assert!(provider.calls().is_empty());
+}
+
+#[test]
+fn concurrent_confirmation_cannot_be_overwritten_or_cause_another_delete() {
+    let fixture = Fixture::new(false);
+    let store = fixture.store.clone();
+    let mut provider = Provider::new(false);
+    provider.on_delete = Some(Box::new(move |_| {
+        let pending = store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("pending");
+        let result =
+            confirm_remote_environment_deletion(&store, &Provider::new(false), &pending).expect("concurrent check");
+        assert!(result.absence_verified);
+    }));
+    assert_eq!(fixture.delete(&provider), Err(Error::StateChanged));
+    assert_eq!(provider.calls(), ["delete", "observe"]);
+    assert!(matches!(
+        fixture
+            .current()
+            .workspace()
+            .state()
+            .runtime
+            .as_ref()
+            .expect("runtime")
+            .phase,
+        RemoteRuntimePhase::Deleted { .. }
+    ));
+}
+
+#[test]
+fn generic_writes_cannot_forge_complete_rewind_or_erase_delete_intent() {
+    let fixture = Fixture::new(true);
+    let saved = fixture.current();
+    let mut forged = saved.workspace().state().clone();
+    let runtime = forged.runtime.as_mut().expect("runtime");
+    runtime.phase = RemoteRuntimePhase::DeleteRequested { requested_at_millis: 3 };
+    runtime.cleanup = Some(RemoteCleanupIntent {
+        reason: RemoteCleanupReason::WorkspaceRemoved,
+        requested_at_millis: 3,
+    });
+    assert!(
+        fixture
+            .store
+            .replace_remote_workspace(saved.workspace(), &forged)
+            .is_err()
+    );
+    let pending = fixture.delete(&Provider::new(true)).expect("pending").allocation;
+    let original = pending.workspace().state();
+    for alteration in 0..5 {
+        let mut next = original.clone();
+        match alteration {
+            0 => next.runtime = None,
+            1 => next.runtime.as_mut().expect("runtime").phase = RemoteRuntimePhase::Reconciling,
+            2 => next.runtime.as_mut().expect("runtime").cleanup = None,
+            3 => next.spec.working_directory = "different".into(),
+            _ => {
+                let runtime = next.runtime.as_mut().expect("runtime");
+                let time = runtime.phase.delete_requested_at_millis().expect("time");
+                runtime.phase = RemoteRuntimePhase::Deleted {
+                    requested_at_millis: time,
+                    observed_at_millis: time,
+                };
+            }
+        }
+        assert!(
+            fixture
+                .store
+                .replace_remote_workspace(pending.workspace(), &next)
+                .is_err()
+        );
+        assert_eq!(fixture.current(), pending);
+    }
+    assert!(
+        fixture
+            .store
+            .record_remote_stop_phase(&pending, RemoteRuntimePhase::Stopping { requested_at_millis: 1 })
+            .is_err()
+    );
+    assert!(
+        fixture
+            .store
+            .record_remote_start_phase(&pending, RemoteRuntimePhase::Reconciling)
+            .is_err()
+    );
+}
+
+#[test]
+fn malformed_tombstones_and_unsafe_time_are_rejected() {
+    let fixture = Fixture::new(true);
+    let before = fixture.current();
+    assert!(
+        fixture
+            .store
+            .record_remote_delete_phase(&before, RemoteRuntimePhase::DeleteRequested { requested_at_millis: 1 })
+            .is_err()
+    );
+    assert_eq!(fixture.current(), before);
+    let deleted = fixture.delete(&Provider::new(false)).expect("deleted").allocation;
+    let encoded = serde_json::to_value(deleted.workspace().state()).expect("encode");
+    assert_eq!(
+        serde_json::from_value::<RemoteWorkspaceState>(encoded.clone()).expect("roundtrip"),
+        *deleted.workspace().state()
+    );
+    for change in 0..4 {
+        let mut value = encoded.clone();
+        match change {
+            0 => value["runtime"]["cleanup"] = serde_json::Value::Null,
+            1 => value["runtime"]["worker"] = serde_json::Value::Null,
+            2 => value["runtime"]["cleanup"]["reason"] = serde_json::json!("application_exit"),
+            _ => value["runtime"]["phase"]["deleted"]["observed_at_millis"] = serde_json::json!(-1),
+        }
+        assert!(serde_json::from_value::<RemoteWorkspaceState>(value).is_err());
+    }
+}

--- a/crates/horizon-core/src/remote_workspace/mod.rs
+++ b/crates/horizon-core/src/remote_workspace/mod.rs
@@ -183,9 +183,28 @@ pub enum RemoteRuntimePhase {
     Starting {
         requested_at_millis: i64,
     },
+    /// Explicit destructive request, separate from legacy cleanup and client closure.
+    DeleteRequested {
+        requested_at_millis: i64,
+    },
+    /// Exact worker absence was observed; retained identity is a tombstone, not a backup.
+    Deleted {
+        requested_at_millis: i64,
+        observed_at_millis: i64,
+    },
 }
 
 impl RemoteRuntimePhase {
+    pub(crate) const fn delete_requested_at_millis(self) -> Option<i64> {
+        match self {
+            Self::DeleteRequested { requested_at_millis }
+            | Self::Deleted {
+                requested_at_millis, ..
+            } => Some(requested_at_millis),
+            _ => None,
+        }
+    }
+
     pub(crate) const fn stop_requested_at_millis(self) -> Option<i64> {
         match self {
             Self::Stopping { requested_at_millis }

--- a/crates/horizon-core/src/remote_workspace/validation.rs
+++ b/crates/horizon-core/src/remote_workspace/validation.rs
@@ -203,6 +203,18 @@ impl RemoteRuntimeGeneration {
         {
             return Err(Error::InvalidRuntime("Start intent"));
         }
+        if let Some(requested_at_millis) = self.phase.delete_requested_at_millis()
+            && (requested_at_millis < 0
+                || self.worker.is_none()
+                || self.cleanup.as_ref().is_none_or(|intent| {
+                    intent.reason != super::RemoteCleanupReason::WorkspaceRemoved
+                        || intent.requested_at_millis != requested_at_millis
+                })
+                || matches!(self.phase, RemoteRuntimePhase::Deleted { observed_at_millis, .. }
+                    if observed_at_millis < requested_at_millis))
+        {
+            return Err(Error::InvalidRuntime("Delete intent"));
+        }
         Ok(())
     }
 }

--- a/crates/horizon-ui/src/app/remote_environments/paint.rs
+++ b/crates/horizon-ui/src/app/remote_environments/paint.rs
@@ -324,6 +324,8 @@ fn phase_label(phase: Option<RemoteRuntimePhase>) -> &'static str {
         Some(RemoteRuntimePhase::Checkpointing) => "Checkpointing",
         Some(RemoteRuntimePhase::Cancelling) => "Cancelling",
         Some(RemoteRuntimePhase::Deleting) => "Deleting",
+        Some(RemoteRuntimePhase::DeleteRequested { .. }) => "Delete requested (saved)",
+        Some(RemoteRuntimePhase::Deleted { .. }) => "Worker absence verified (saved)",
         Some(RemoteRuntimePhase::Failed) => "Failed",
         Some(RemoteRuntimePhase::Stopping { .. }) => "Stop requested (saved)",
         Some(RemoteRuntimePhase::Stopped { .. }) => "Stopped (saved, not live)",

--- a/crates/horizon-ui/src/app/remote_environments/stop.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop.rs
@@ -455,11 +455,17 @@ fn check_supported(summary: &RemoteEnvironmentSummary) -> bool {
 /// Linux and Azure on every platform only for a retained persistent worker whose saved
 /// identity names the same provider and which carries neither Stop intent (existing
 /// intent is checked, never resent) nor Start intent (resolved by Start, never raced).
+/// Saved Delete intent and verified deletion exclude Stop for every provider.
 fn supported(summary: &RemoteEnvironmentSummary) -> bool {
     let Some(identity) = summary.worker_identity.as_ref() else {
         return false;
     };
-    if summary.lifetime != WorkerLifetime::Persistent {
+    if summary.lifetime != WorkerLifetime::Persistent
+        || matches!(
+            summary.saved_phase,
+            Some(RemoteRuntimePhase::DeleteRequested { .. } | RemoteRuntimePhase::Deleted { .. })
+        )
+    {
         return false;
     }
     let cloud = identity.provider == summary.provider

--- a/crates/horizon-ui/src/app/remote_environments/stop/tests.rs
+++ b/crates/horizon-ui/src/app/remote_environments/stop/tests.rs
@@ -167,6 +167,52 @@ fn retained_timed_workers_never_offer_or_prepare_stop_in_any_saved_stop_phase() 
 }
 
 #[test]
+fn saved_deletion_never_offers_prepares_or_dispatches_stop_for_any_provider() {
+    use crate::app::test_support::raw_input;
+    use crate::test_egui::DiscardTextures;
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = HorizonHome::from_root(fixture.path().join("unused"));
+    for provider in [CloudProvider::LocalDocker, CloudProvider::RunPod, CloudProvider::Azure] {
+        for phase in [
+            RemoteRuntimePhase::DeleteRequested { requested_at_millis: 1 },
+            RemoteRuntimePhase::Deleted {
+                requested_at_millis: 1,
+                observed_at_millis: 2,
+            },
+        ] {
+            let ctx = Context::default();
+            let mut expected = summary();
+            expected.provider = provider;
+            expected.worker_identity.as_mut().expect("worker").provider = provider;
+            let mut previous = StopState::default();
+            previous.prepare(&expected, &config(), &ctx);
+            assert_eq!(previous.confirmation.is_some(), supported(&expected));
+            expected.saved_phase = Some(phase);
+            assert!(!supported(&expected));
+            let mut state = StopState::default();
+            let mut action = InventoryAction::None;
+            let _ = ctx
+                .run_ui(raw_input([1100.0, 780.0], None), |ui| {
+                    show(ui, &state, &expected, true, &mut action);
+                })
+                .discard_textures();
+            assert_eq!(
+                ctx.data(|data| data.get_temp::<bool>(egui::Id::new("stop-request-enabled-test"))),
+                Some(false)
+            );
+            assert!(matches!(action, InventoryAction::None));
+            state.prepare(&expected, &config(), &ctx);
+            assert!(state.confirmation.is_none());
+            assert!(!state.start(&home, &config(), &expected, &ctx));
+            assert!(!previous.start(&home, &config(), &expected, &ctx));
+            assert!(!state.is_pending());
+            assert!(!previous.is_pending());
+            assert!(!home.root().exists());
+        }
+    }
+}
+
+#[test]
 fn cancel_selection_page_and_close_clear_only_unconfirmed_intent() {
     let fixture = tempfile::tempdir().expect("fixture");
     let home = HorizonHome::from_root(fixture.path().join("unused"));

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -482,6 +482,12 @@ back into large multi-purpose modules.
   implementation reads only the exact saved resource group with owned identity
   tags; a surviving or deleting group remains present even when its VM is absent.
   It never uses guest commands, host-key lookup, lifecycle mutation or polling.
+- `remote_environment_delete.rs` coordinates explicit Delete, separately confirmed
+  Retry and read-only confirmation over an exact owned allocation. Its dedicated store transition
+  retains worker identity and creation fences as a tombstone; generic writes
+  cannot introduce, resolve or erase the new destructive intent. Provider
+  acceptance is not absence, and independent network storage is not implicitly
+  deleted. Legacy cleanup phases remain separate from this explicit operation.
 - `cloud_run/interactive_worker_stop.rs` is an opt-in Stop contract, separate from
   deletion and client lifetime. The local adapter's `local_docker/stop.rs` verifies
   exact ownership and disabled automatic removal before a bounded stop, then


### PR DESCRIPTION
## Purpose

Persist explicit Delete intent for an exact retained remote environment, then confirm deletion only through a separate provider absence observation. Part of #472 and #383; this does not close either issue.

## Behavior

- Record intent transactionally before one provider deletion dispatch. Accepted, failed or lost replies never establish absence.
- Keep pending intent after uncertainty. Check is observation-only and cannot resubmit Delete.
- Permit a separately confirmed Retry only after a fresh exact-resource observation and revision-guarded admission. Absence finishes without another Delete; failures retain intent. Confirmation must disclose that the earlier request may still be in progress.
- Preserve allocation, worker identity and creation fence as a tombstone. Generic writes cannot forge or erase these phases; unrelated workspaces remain unchanged.
- Name the two saved states in the existing inventory and disable Stop for both. Other Stop eligibility remains unchanged. No new Delete control or automatic provider call is added here.

Provider-specific admission and destructive UI confirmation follow separately. Callers must disclose complete deletion scope, running-task loss and possible loss of unpushed work. Independent network storage is not implicitly deleted. Client closure never invokes this API.

## Validation

Exact head `34d7ba33907c854cf7b07355e96b7c8588a9a19e` passed all eight local gates: formatting, maintainability, version sync, default tests (2,722 passed), speech tests (2,767 passed), blocking Clippy, strict Clippy and advisory pedantic Clippy. Both test configurations had zero failures and seven ignored tests.

Eleven focused coordinator/store tests cover explicit Retry, stale snapshots, competing same-snapshot requests, uncertain responses and independently confirmed absence. Stop regression coverage checks all three providers and both deletion phases: disabled rendered control, no fresh confirmation and no dispatch from a stale confirmation.

Fresh isolated Linux smoke on this exact head verified both labels and disabled Stop controls at 1200×900 and 800×600, plus an ordinary retained workspace with Stop still enabled. Selection, scrolling, passive pointer/idle behavior, overview Close/reopen, Refresh and restored sizing passed. A single normal WM_DELETE_WINDOW closed the application with exit 0. Saved state, prepared files and preexisting GUI identities were unchanged; no provider or credential process ran. Screenshots were independently inspected. This synthetic UI validation is not live cloud deletion proof.

Earlier failures remain preserved: an older-head Alt-F4 close attempt timed out; a later normal-close diagnostic passed on that same older binary. The first current-head fixture attempt stopped before GUI launch because sandbox-mapped ancestor ownership was rejected by the SSH-path safety check; the unchanged test passed host-side with its network isolation retained. Precommit Clippy also caught a similar test-variable name, corrected before the final matrix. An earlier unchanged browser test failure remains of unproven cause; its timing correction is now merged in #583.

Independent local review completed. Hosted Stop-eligibility feedback is addressed by this revision; fresh hosted review and CI are required before merge. The user approved the narrow 12-source/test-file exception: 1,040 changed source/test lines, plus six maintainability-note lines.
