### PR TITLE
feat(browser): reconnect keep-alive standalone hosts

### DIFF
--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -171,8 +171,13 @@ in-flight mutation unless `--on-uncertain skip` is set after inspecting the
 browser audit. Skip never replays the uncertain call; it continues later
 steps. A skipped step is not a successful completion, so the job cannot
 report `ok` until every plan step has a verified result. Remaining steps
-currently start a new MCP session; reconnecting the same standalone browser
-is a later slice.
+open a new MCP client. If the original run recorded a keep-alive standalone
+host, resume reconnects to that same browser; a dead host is an error and is
+never silently replaced. Start a keep-alive host with
+`horizon-browser mcp --standalone --keep-alive` so later `run`, `--connect`,
+or `resume` can reuse it. `horizon-browser mcp --stop` asks that host to exit
+and remove its profile. Crashed hosts are pruned on the next MCP or resume
+command.
 
 Every deterministic run gets one action deadline. The default is 1800 seconds;
 `--timeout` accepts 1 through 86400 whole seconds. The budget is selected after
@@ -231,10 +236,13 @@ Choose a backend or show the native window when needed:
 ```
 
 The default is headless Chromium, falling back to headless Firefox when
-Chromium is unavailable. Safari requires macOS and `--visible`. The process
-owns one isolated browser session for the lifetime of MCP stdin and removes its
-temporary profile during bounded shutdown. `--connect` instead discovers
-existing Horizon panels without starting a browser. When Horizon supplies
+Chromium is unavailable. Safari requires macOS and `--visible`. Without
+`--keep-alive`, the process owns one isolated browser session for the lifetime
+of MCP stdin and removes its temporary profile during bounded shutdown.
+`--keep-alive` keeps that session after stdin closes until idle, `--stop`, or
+the host exits, so another MCP client can reconnect without restarting the
+browser. `--connect` discovers existing Horizon or keep-alive standalone
+panels without starting a browser. When Horizon supplies
 `HORIZON_BROWSER_ACTOR`, connect mode remains the default so actor-scoped panel
 creation, visibility changes, steering, and audit continue to use Horizon's
 host lifecycle.

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -176,8 +176,8 @@ host, resume reconnects to that same browser; a dead host is an error and is
 never silently replaced. Start a keep-alive host with
 `horizon-browser mcp --standalone --keep-alive` so later `run`, `--connect`,
 or `resume` can reuse it. `horizon-browser mcp --stop` asks that host to exit
-and remove its profile. Crashed hosts are pruned on the next MCP or resume
-command.
+and remove its profile. Crashed or PID-recycled hosts are pruned on the next
+MCP or resume command, including resume of jobs that never recorded a host.
 
 Every deterministic run gets one action deadline. The default is 1800 seconds;
 `--timeout` accepts 1 through 86400 whole seconds. The budget is selected after

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -153,6 +153,9 @@ pub enum ResumeError {
     /// The original run or another resume already holds this job.
     #[error("durable job `{0}` is already running or being resumed")]
     Locked(String),
+    /// The recorded keep-alive standalone host is no longer running.
+    #[error("{0}")]
+    StandaloneGone(String),
 }
 
 impl UncertainPolicy {

--- a/crates/horizon-browser-cli/src/job.rs
+++ b/crates/horizon-browser-cli/src/job.rs
@@ -78,6 +78,7 @@ pub fn run(options: &JobOptions) -> Result<bool, JobError> {
         crate::standalone::StandaloneOptions {
             backend: options.backend,
             visible: options.visible,
+            keep_alive: false,
         },
         browser_home.path(),
         create_private(&browser_diagnostics_path)?,

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -286,15 +286,26 @@ async fn prepare_run(
             return Err(stop_exit_code(reason));
         }
     };
-    let mut durable = match prepared {
+    let durable = match prepared {
         Ok(durable) => durable,
         Err(error) => return Err(persist_preparation_failure(error, cancellation).await),
     };
-    if let Err(reason) = control.check() {
-        return Err(persist_stopped(&durable, reason, cancellation).await);
-    }
-    if let Err(error) = durable.bind_live_standalone() {
-        return Err(persist_failed(&durable, error.to_string(), cancellation).await);
+    let Some(job_dir) = durable.state_path().parent().map(Path::to_path_buf) else {
+        return Err(persist_failed(&durable, "durable job directory is missing".to_string(), cancellation).await);
+    };
+    match controlled_blocking(&mut control, "horizon-browser-bind-standalone", move || {
+        DurableRun::bind_live_standalone_in(&job_dir)
+    })
+    .await
+    {
+        Ok(BlockingCompletion::Completed(Ok(()))) => {}
+        Ok(BlockingCompletion::Completed(Err(error))) => {
+            return Err(persist_failed(&durable, error.to_string(), cancellation).await);
+        }
+        Ok(BlockingCompletion::InfrastructureFailed(error)) => {
+            return Err(persist_failed(&durable, error, cancellation).await);
+        }
+        Err(reason) => return Err(persist_stopped(&durable, reason, cancellation).await),
     }
 
     Ok(PreparedRun { plan, durable, control })

--- a/crates/horizon-browser-cli/src/main.rs
+++ b/crates/horizon-browser-cli/src/main.rs
@@ -39,7 +39,8 @@ USAGE:
     horizon-browser do "<GOAL>" [OPTIONS]
     horizon-browser run <PLAN.json|-> [--output <REPORT.json|->] [--timeout <SECONDS>]
     horizon-browser resume <JOB-ID> [--output <REPORT.json|->] [--timeout <SECONDS>] [--on-uncertain fail|skip]
-    horizon-browser mcp [--standalone|--connect] [--backend <BACKEND>] [--visible]
+    horizon-browser mcp [--standalone|--connect] [--keep-alive] [--backend <BACKEND>] [--visible]
+    horizon-browser mcp --stop [PANEL-ID]
 
 COMMANDS:
     do     Ask an optional local agent to complete a goal through Horizon MCP.
@@ -52,6 +53,9 @@ COMMANDS:
            --on-uncertain skip continues later steps after audit inspection.
     mcp    Serve the browser MCP contract over stdio. Outside Horizon it owns
            a standalone browser; --connect uses existing Horizon panels only.
+           --keep-alive leaves that browser running after MCP stdin closes so
+           a later --connect or resume can reuse it. --stop asks keep-alive
+           hosts to exit and clean up.
 
 OPTIONS:
     --backend <BACKEND>   Select a backend; prompt/MCP jobs default to auto.
@@ -82,6 +86,9 @@ enum Command {
         standalone: bool,
         options: StandaloneOptions,
     },
+    Stop {
+        panel_id: Option<String>,
+    },
     Help,
     Version,
 }
@@ -100,6 +107,7 @@ async fn main() -> ExitCode {
         }
         Ok(Command::Do(options)) => run_job(&options),
         Ok(Command::Mcp { standalone, options }) => serve_mcp(standalone, options).await,
+        Ok(Command::Stop { panel_id }) => stop_standalone(panel_id.as_deref()),
         Ok(Command::Run { plan, output, timeout }) => run(plan, output.as_deref(), timeout).await,
         Ok(Command::Resume {
             job_id,
@@ -133,7 +141,28 @@ fn initialize_tracing() {
         .try_init();
 }
 
+fn stop_standalone(panel_id: Option<&str>) -> ExitCode {
+    horizon_browser_cli::standalone::prune_dead_hosts();
+    match horizon_browser_cli::standalone::stop_hosts(panel_id) {
+        Ok(stopped) => {
+            if stopped.is_empty() {
+                eprintln!("error: no keep-alive standalone host to stop");
+                return ExitCode::FAILURE;
+            }
+            for panel in stopped {
+                println!("{panel}");
+            }
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
 async fn serve_mcp(standalone: bool, options: StandaloneOptions) -> ExitCode {
+    horizon_browser_cli::standalone::prune_dead_hosts();
     let result = if standalone {
         horizon_browser_cli::standalone::serve(options)
             .await
@@ -257,12 +286,15 @@ async fn prepare_run(
             return Err(stop_exit_code(reason));
         }
     };
-    let durable = match prepared {
+    let mut durable = match prepared {
         Ok(durable) => durable,
         Err(error) => return Err(persist_preparation_failure(error, cancellation).await),
     };
     if let Err(reason) = control.check() {
         return Err(persist_stopped(&durable, reason, cancellation).await);
+    }
+    if let Err(error) = durable.bind_live_standalone() {
+        return Err(persist_failed(&durable, error.to_string(), cancellation).await);
     }
 
     Ok(PreparedRun { plan, durable, control })
@@ -623,14 +655,29 @@ fn parse_job(prompt: String, mut args: impl Iterator<Item = OsString>) -> Result
     }))
 }
 
-fn parse_mcp(mut args: impl Iterator<Item = OsString>) -> Result<Command, String> {
+fn parse_mcp(args: impl Iterator<Item = OsString>) -> Result<Command, String> {
+    let mut args = args.peekable();
     let mut standalone = std::env::var_os("HORIZON_BROWSER_ACTOR").is_none();
     let mut mode_seen = false;
     let mut backend = None;
     let mut backend_seen = false;
     let mut visible = false;
+    let mut keep_alive = false;
+    let mut stop = false;
+    let mut stop_panel = None;
     while let Some(argument) = args.next() {
         match argument.to_str() {
+            Some("--stop") if !stop => {
+                stop = true;
+                if args
+                    .peek()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| !value.starts_with('-'))
+                {
+                    stop_panel = args.next().and_then(|value| value.into_string().ok());
+                }
+            }
+            Some("--stop") => return Err("--stop may be specified only once".to_string()),
             Some("--standalone") if !mode_seen => {
                 standalone = true;
                 mode_seen = true;
@@ -642,6 +689,8 @@ fn parse_mcp(mut args: impl Iterator<Item = OsString>) -> Result<Command, String
             Some("--standalone" | "--connect") => {
                 return Err("choose only one of --standalone or --connect".to_string());
             }
+            Some("--keep-alive") if !keep_alive => keep_alive = true,
+            Some("--keep-alive") => return Err("--keep-alive may be specified only once".to_string()),
             Some("--backend") if !backend_seen => {
                 backend_seen = true;
                 backend = parse_backend(args.next().as_ref())?;
@@ -652,12 +701,22 @@ fn parse_mcp(mut args: impl Iterator<Item = OsString>) -> Result<Command, String
             None => return Err("mcp argument is not valid UTF-8".to_string()),
         }
     }
-    if !standalone && (backend_seen || visible) {
-        return Err("--backend and --visible require standalone MCP mode".to_string());
+    if stop {
+        if mode_seen || keep_alive || backend_seen || visible {
+            return Err("--stop cannot be combined with other MCP mode flags".to_string());
+        }
+        return Ok(Command::Stop { panel_id: stop_panel });
+    }
+    if !standalone && (backend_seen || visible || keep_alive) {
+        return Err("--backend, --visible, and --keep-alive require standalone MCP mode".to_string());
     }
     Ok(Command::Mcp {
         standalone,
-        options: StandaloneOptions { backend, visible },
+        options: StandaloneOptions {
+            backend,
+            visible,
+            keep_alive,
+        },
     })
 }
 
@@ -897,7 +956,16 @@ mod tests {
         assert!(standalone);
         assert_eq!(options.backend, Some(BackendKind::FirefoxBidi));
         assert!(options.visible);
+        assert!(!options.keep_alive);
         assert!(parse_args(["mcp", "--connect", "--visible"].map(OsString::from)).is_err());
+        assert!(parse_args(["mcp", "--connect", "--keep-alive"].map(OsString::from)).is_err());
+        let Command::Stop { panel_id } =
+            parse_args(["mcp", "--stop", "standalone-1-abc"].map(OsString::from)).expect("stop MCP")
+        else {
+            panic!("expected stop command");
+        };
+        assert_eq!(panel_id.as_deref(), Some("standalone-1-abc"));
+        assert!(parse_args(["mcp", "--stop", "--standalone"].map(OsString::from)).is_err());
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -22,6 +22,7 @@ use crate::checkpoint::{
 use crate::{
     ExecutionReport, Plan, PlanStep, StepReport,
     execution_control::{BlockingIoError, BlockingIoMode, ExecutionControl, ExecutionStopReason},
+    standalone::StandaloneHostRef,
 };
 use checkpoint_artifacts::PendingCompletion;
 
@@ -30,6 +31,7 @@ const MIN_RESUME_VERSION: u32 = 4;
 const PLAN_FILE: &str = "plan.json";
 const REPORT_FILE: &str = "report.json";
 const STATE_FILE: &str = "state.json";
+const STANDALONE_FILE: &str = "standalone.json";
 const RESUME_LOCK_DIRECTORY: &str = "browser-job-locks";
 
 /// Persisted lifecycle state for one deterministic plan run.
@@ -463,11 +465,42 @@ impl DurableRun {
             RunStatus::Failed | RunStatus::Cancelled | RunStatus::TimedOut => {}
         }
         run.load_completed_reports()?;
+        if let Some(host) = run.recorded_standalone()? {
+            crate::standalone::reconnect(&host).map_err(ResumeError::StandaloneGone)?;
+        }
         let selection = select_resume(&plan, Some(&run.state.checkpoint), &run.completed_reports, policy)?;
         if selection.start_index >= plan.steps.len() && selection.skipped.is_none() {
             return Err(ResumeError::NothingToResume(job_id.to_string()));
         }
         Ok((run, plan, selection))
+    }
+
+    /// Record a live keep-alive standalone host so resume can reconnect to it.
+    ///
+    /// # Errors
+    /// Returns when the sidecar file cannot be written.
+    pub fn bind_live_standalone(&mut self) -> Result<(), RunStateError> {
+        crate::standalone::prune_dead_hosts();
+        let Some(host) = crate::standalone::live_host() else {
+            return Ok(());
+        };
+        write_private_json(&self.directory.join(STANDALONE_FILE), &host, "standalone")
+    }
+
+    /// Keep-alive host recorded for this job, if any.
+    ///
+    /// # Errors
+    /// Returns when the sidecar exists but cannot be decoded.
+    pub fn recorded_standalone(&self) -> Result<Option<StandaloneHostRef>, ResumeError> {
+        let path = self.directory.join(STANDALONE_FILE);
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let bytes = std::fs::read(&path)
+            .map_err(|source| ResumeError::Decode(format!("could not read {}: {source}", path.display())))?;
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|source| ResumeError::Decode(source.to_string()))
     }
 
     /// Saved plan for this durable run.

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -465,6 +465,7 @@ impl DurableRun {
             RunStatus::Failed | RunStatus::Cancelled | RunStatus::TimedOut => {}
         }
         run.load_completed_reports()?;
+        crate::standalone::prune_dead_hosts();
         if let Some(host) = run.recorded_standalone()? {
             crate::standalone::reconnect(&host).map_err(ResumeError::StandaloneGone)?;
         }

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -481,11 +481,19 @@ impl DurableRun {
     /// # Errors
     /// Returns when the sidecar file cannot be written.
     pub fn bind_live_standalone(&mut self) -> Result<(), RunStateError> {
+        Self::bind_live_standalone_in(&self.directory)
+    }
+
+    /// Record a live keep-alive host into an already published job directory.
+    ///
+    /// # Errors
+    /// Returns when the sidecar file cannot be written.
+    pub fn bind_live_standalone_in(directory: &Path) -> Result<(), RunStateError> {
         crate::standalone::prune_dead_hosts();
         let Some(host) = crate::standalone::live_host() else {
             return Ok(());
         };
-        write_private_json(&self.directory.join(STANDALONE_FILE), &host, "standalone")
+        write_private_json(&directory.join(STANDALONE_FILE), &host, "standalone")
     }
 
     /// Keep-alive host recorded for this job, if any.

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -391,11 +391,6 @@ fn start_backend(
     keep_alive: bool,
 ) -> Result<(BrowserSession, std::path::PathBuf, String), StandaloneError> {
     let panel_id = standalone_panel_id();
-    let mut pending_lease = if keep_alive {
-        Some(lease::PendingLease::publish(home.root(), panel_id.clone())?)
-    } else {
-        None
-    };
     let mut browser = BrowserConfig {
         backend,
         headless: !visible,
@@ -405,6 +400,15 @@ fn start_backend(
         browser.profile_root = Some(browser.effective_profile_root(&home.root().join("browser-profiles")));
     }
     let profile_root = browser.panel_profile_dir_with_default_root(&panel_id, &home.root().join("browser-profiles"));
+    let mut pending_lease = if keep_alive {
+        Some(lease::PendingLease::publish(
+            home.root(),
+            panel_id.clone(),
+            profile_root.clone(),
+        )?)
+    } else {
+        None
+    };
     let coordination = Arc::new(ManifestCoordination::default());
     let session = start_session(BrowserSessionConfig {
         browser,

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -253,9 +253,6 @@ pub async fn serve(options: StandaloneOptions) -> Result<(), StandaloneError> {
     let root = HorizonHome::resolve().root().to_path_buf();
     lease::prune_dead_at(&root);
     let session = OwnedSession::start(options, &HorizonHome::resolve())?;
-    if options.keep_alive {
-        lease::publish(&root, &StandaloneHostRef::current(session.panel_id.clone())?)?;
-    }
     let mcp_result = serve_until_host_exit(&root, &session.panel_id, options.keep_alive).await;
     let panel_id = session.panel_id.clone();
     let stopped = session.shutdown();
@@ -286,8 +283,11 @@ async fn serve_until_host_exit(root: &Path, panel_id: &str, keep_alive: bool) ->
     tokio::pin!(stop);
     tokio::select! {
         result = &mut mcp => {
+            let stop = lease::await_stop_at(root, panel_id, lease::keep_alive_poll());
+            tokio::pin!(stop);
             tokio::select! {
                 () = interrupt => result,
+                () = stop => result,
                 _ = lease::await_keep_alive_at(
                     root,
                     panel_id,
@@ -341,6 +341,16 @@ async fn wait_for_interrupt() {
             return;
         }
     }
+    #[cfg(windows)]
+    {
+        if let Ok(mut close) = tokio::signal::windows::ctrl_close() {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = close.recv() => {}
+            }
+            return;
+        }
+    }
     let _ = tokio::signal::ctrl_c().await;
 }
 
@@ -365,7 +375,7 @@ fn start(
     );
     let mut last_error = None;
     for backend in candidates {
-        match start_backend(home, backend, options.visible) {
+        match start_backend(home, backend, options.visible, options.keep_alive) {
             Ok(session) => return Ok(session),
             Err(error) => last_error = Some(error),
         }
@@ -377,8 +387,14 @@ fn start_backend(
     home: &HorizonHome,
     backend: BackendKind,
     visible: bool,
+    keep_alive: bool,
 ) -> Result<(BrowserSession, std::path::PathBuf, String), StandaloneError> {
     let panel_id = standalone_panel_id();
+    let pending_lease = if keep_alive {
+        Some(lease::PendingLease::publish(home.root(), panel_id.clone())?)
+    } else {
+        None
+    };
     let mut browser = BrowserConfig {
         backend,
         headless: !visible,
@@ -421,6 +437,9 @@ fn start_backend(
         return Err(StandaloneError::Startup(format!(
             "could not publish standalone browser state: {error}"
         )));
+    }
+    if let Some(pending_lease) = pending_lease {
+        pending_lease.commit();
     }
     Ok((session, profile_root, panel_id))
 }

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -16,6 +16,10 @@ use horizon_core::{
 };
 use thiserror::Error;
 
+mod lease;
+
+pub use lease::StandaloneHostRef;
+
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const FORCED_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
@@ -29,6 +33,7 @@ const HOST_INITIALIZE: &[u8] = br#"{"jsonrpc":"2.0","id":1,"method":"initialize"
 pub struct StandaloneOptions {
     pub backend: Option<BackendKind>,
     pub visible: bool,
+    pub keep_alive: bool,
 }
 
 #[derive(Debug, Error)]
@@ -46,14 +51,16 @@ pub enum StandaloneError {
 pub(crate) struct OwnedSession {
     session: Option<BrowserSession>,
     profile_root: PathBuf,
+    panel_id: String,
 }
 
 impl OwnedSession {
     pub(crate) fn start(options: StandaloneOptions, home: &HorizonHome) -> Result<Self, StandaloneError> {
-        let (session, profile_root) = start(options, home)?;
+        let (session, profile_root, panel_id) = start(options, home)?;
         Ok(Self {
             session: Some(session),
             profile_root,
+            panel_id,
         })
     }
 
@@ -243,8 +250,31 @@ impl Drop for OwnedHostProcess {
 /// Returns when no requested backend can start, MCP transport fails, or the
 /// owned browser cannot be stopped within its bounded cleanup deadline.
 pub async fn serve(options: StandaloneOptions) -> Result<(), StandaloneError> {
+    let root = HorizonHome::resolve().root().to_path_buf();
+    lease::prune_dead_at(&root);
     let session = OwnedSession::start(options, &HorizonHome::resolve())?;
+    if options.keep_alive {
+        lease::publish(
+            &root,
+            &StandaloneHostRef {
+                panel_id: session.panel_id.clone(),
+                host_pid: std::process::id(),
+            },
+        )?;
+    }
     let mcp_result = horizon_browser_mcp::serve_stdio().await;
+    if options.keep_alive {
+        tokio::select! {
+            () = wait_for_interrupt() => {}
+            _ = lease::await_keep_alive_at(
+                &root,
+                &session.panel_id,
+                lease::keep_alive_idle(),
+                lease::keep_alive_poll(),
+            ) => {}
+        }
+        lease::remove(&root, &session.panel_id);
+    }
     let stopped = session.shutdown();
     mcp_result?;
     if stopped {
@@ -254,10 +284,52 @@ pub async fn serve(options: StandaloneOptions) -> Result<(), StandaloneError> {
     }
 }
 
+/// Bind the newest live keep-alive host, if one exists.
+#[must_use]
+pub fn live_host() -> Option<StandaloneHostRef> {
+    let root = HorizonHome::resolve().root().to_path_buf();
+    lease::live_host(&root)
+}
+
+/// Reconnect to a previously recorded keep-alive host.
+///
+/// # Errors
+/// Returns when the host process or its published panel is gone.
+pub fn reconnect(host: &StandaloneHostRef) -> Result<(), String> {
+    lease::reconnect(HorizonHome::resolve().root(), host)
+}
+
+/// Ask keep-alive hosts to stop and clean up.
+///
+/// # Errors
+/// Returns when the stop signal cannot be written.
+pub fn stop_hosts(panel_id: Option<&str>) -> Result<Vec<String>, String> {
+    lease::stop_hosts(HorizonHome::resolve().root(), panel_id)
+}
+
+/// Remove keep-alive records whose host process is already dead.
+pub fn prune_dead_hosts() {
+    lease::prune_dead_at(HorizonHome::resolve().root());
+}
+
+async fn wait_for_interrupt() {
+    #[cfg(unix)]
+    {
+        if let Ok(mut terminate) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = terminate.recv() => {}
+            }
+            return;
+        }
+    }
+    let _ = tokio::signal::ctrl_c().await;
+}
+
 fn start(
     options: StandaloneOptions,
     home: &HorizonHome,
-) -> Result<(BrowserSession, std::path::PathBuf), StandaloneError> {
+) -> Result<(BrowserSession, std::path::PathBuf, String), StandaloneError> {
     if options.backend == Some(BackendKind::SafariWebDriver) && !options.visible {
         return Err(StandaloneError::Startup(
             "Safari has no headless mode; pass --visible or choose another backend".to_string(),
@@ -287,7 +359,7 @@ fn start_backend(
     home: &HorizonHome,
     backend: BackendKind,
     visible: bool,
-) -> Result<(BrowserSession, std::path::PathBuf), StandaloneError> {
+) -> Result<(BrowserSession, std::path::PathBuf, String), StandaloneError> {
     let panel_id = standalone_panel_id();
     let mut browser = BrowserConfig {
         backend,
@@ -332,7 +404,7 @@ fn start_backend(
             "could not publish standalone browser state: {error}"
         )));
     }
-    Ok((session, profile_root))
+    Ok((session, profile_root, panel_id))
 }
 
 fn wait_until_ready(session: &BrowserSession) -> Result<(), StandaloneError> {

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -377,6 +377,7 @@ fn start(
     for backend in candidates {
         match start_backend(home, backend, options.visible, options.keep_alive) {
             Ok(session) => return Ok(session),
+            Err(StandaloneError::Shutdown) => return Err(StandaloneError::Shutdown),
             Err(error) => last_error = Some(error),
         }
     }
@@ -390,7 +391,7 @@ fn start_backend(
     keep_alive: bool,
 ) -> Result<(BrowserSession, std::path::PathBuf, String), StandaloneError> {
     let panel_id = standalone_panel_id();
-    let pending_lease = if keep_alive {
+    let mut pending_lease = if keep_alive {
         Some(lease::PendingLease::publish(home.root(), panel_id.clone())?)
     } else {
         None
@@ -416,9 +417,7 @@ fn start_backend(
         capture_directory: Some(profile_root.join("captures")),
     })?;
     if let Err(error) = wait_until_ready(&session) {
-        let shutdown = session.shutdown_signal().with_profile_cleanup(profile_root);
-        let _ = shutdown.wait(SHUTDOWN_TIMEOUT) || shutdown.force_cleanup(FORCED_SHUTDOWN_TIMEOUT);
-        return Err(error);
+        return Err(fail_started_session(session, profile_root, pending_lease.take(), error));
     }
     let entry = BrowserAuditEntry::new(
         new_action_id(),
@@ -432,16 +431,33 @@ fn start_backend(
     })
     .and_then(|_| coordination.record_action(&panel_id, &entry));
     if let Err(error) = publish {
-        let shutdown = session.shutdown_signal().with_profile_cleanup(profile_root);
-        let _ = shutdown.wait(SHUTDOWN_TIMEOUT) || shutdown.force_cleanup(FORCED_SHUTDOWN_TIMEOUT);
-        return Err(StandaloneError::Startup(format!(
-            "could not publish standalone browser state: {error}"
-        )));
+        return Err(fail_started_session(
+            session,
+            profile_root,
+            pending_lease.take(),
+            StandaloneError::Startup(format!("could not publish standalone browser state: {error}")),
+        ));
     }
     if let Some(pending_lease) = pending_lease {
         pending_lease.commit();
     }
     Ok((session, profile_root, panel_id))
+}
+
+fn fail_started_session(
+    session: BrowserSession,
+    profile_root: PathBuf,
+    pending_lease: Option<lease::PendingLease>,
+    error: StandaloneError,
+) -> StandaloneError {
+    let shutdown = session.shutdown_signal().with_profile_cleanup(profile_root);
+    if shutdown.wait(SHUTDOWN_TIMEOUT) || shutdown.force_cleanup(FORCED_SHUTDOWN_TIMEOUT) {
+        return error;
+    }
+    if let Some(pending_lease) = pending_lease {
+        pending_lease.commit();
+    }
+    StandaloneError::Shutdown
 }
 
 fn wait_until_ready(session: &BrowserSession) -> Result<(), StandaloneError> {

--- a/crates/horizon-browser-cli/src/standalone.rs
+++ b/crates/horizon-browser-cli/src/standalone.rs
@@ -254,33 +254,51 @@ pub async fn serve(options: StandaloneOptions) -> Result<(), StandaloneError> {
     lease::prune_dead_at(&root);
     let session = OwnedSession::start(options, &HorizonHome::resolve())?;
     if options.keep_alive {
-        lease::publish(
-            &root,
-            &StandaloneHostRef {
-                panel_id: session.panel_id.clone(),
-                host_pid: std::process::id(),
-            },
-        )?;
+        lease::publish(&root, &StandaloneHostRef::current(session.panel_id.clone())?)?;
     }
-    let mcp_result = horizon_browser_mcp::serve_stdio().await;
-    if options.keep_alive {
-        tokio::select! {
-            () = wait_for_interrupt() => {}
-            _ = lease::await_keep_alive_at(
-                &root,
-                &session.panel_id,
-                lease::keep_alive_idle(),
-                lease::keep_alive_poll(),
-            ) => {}
-        }
-        lease::remove(&root, &session.panel_id);
-    }
+    let mcp_result = serve_until_host_exit(&root, &session.panel_id, options.keep_alive).await;
+    let panel_id = session.panel_id.clone();
     let stopped = session.shutdown();
+    if stopped && options.keep_alive {
+        lease::remove(&root, &panel_id);
+    }
     mcp_result?;
     if stopped {
         Ok(())
     } else {
         Err(StandaloneError::Shutdown)
+    }
+}
+
+async fn serve_until_host_exit(root: &Path, panel_id: &str, keep_alive: bool) -> Result<(), StandaloneError> {
+    let mcp = horizon_browser_mcp::serve_stdio();
+    tokio::pin!(mcp);
+    let interrupt = wait_for_interrupt();
+    tokio::pin!(interrupt);
+    if !keep_alive {
+        return tokio::select! {
+            result = mcp => result.map_err(Into::into),
+            () = interrupt => Ok(()),
+        };
+    }
+
+    let stop = lease::await_stop_at(root, panel_id, lease::keep_alive_poll());
+    tokio::pin!(stop);
+    tokio::select! {
+        result = &mut mcp => {
+            tokio::select! {
+                () = interrupt => result,
+                _ = lease::await_keep_alive_at(
+                    root,
+                    panel_id,
+                    lease::keep_alive_idle(),
+                    lease::keep_alive_poll(),
+                ) => result,
+            }
+            .map_err(Into::into)
+        }
+        () = &mut interrupt => Ok(()),
+        () = stop => Ok(()),
     }
 }
 

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -1,0 +1,334 @@
+//! Durable identity for a keep-alive standalone browser host.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use horizon_core::browser::manifest;
+
+use super::StandaloneError;
+
+const KEEP_ALIVE_IDLE: Duration = Duration::from_secs(60);
+const KEEP_ALIVE_POLL: Duration = Duration::from_millis(100);
+
+/// Recorded keep-alive host a later MCP client or `resume` can reconnect to.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct StandaloneHostRef {
+    /// Panel id published by the keep-alive host.
+    pub panel_id: String,
+    /// Process that owns the browser session.
+    pub host_pid: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum KeepAliveEnd {
+    Stopped,
+    Idle,
+}
+
+pub(super) fn lease_path_for_root(root: &Path, panel_id: &str) -> PathBuf {
+    manifest::manifest_path_for_root(root, panel_id).with_extension("lease.json")
+}
+
+pub(super) fn stop_path_for_root(root: &Path, panel_id: &str) -> PathBuf {
+    manifest::manifest_path_for_root(root, panel_id).with_extension("stop")
+}
+
+pub(super) fn publish(root: &Path, host: &StandaloneHostRef) -> Result<(), StandaloneError> {
+    let path = lease_path_for_root(root, &host.panel_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            StandaloneError::Startup(format!("could not create standalone lease directory: {error}"))
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(host)
+        .map_err(|error| StandaloneError::Startup(format!("could not encode standalone lease: {error}")))?;
+    std::fs::write(&path, bytes)
+        .map_err(|error| StandaloneError::Startup(format!("could not write {}: {error}", path.display())))?;
+    Ok(())
+}
+
+pub(super) fn remove(root: &Path, panel_id: &str) {
+    let _ = std::fs::remove_file(lease_path_for_root(root, panel_id));
+    let _ = std::fs::remove_file(stop_path_for_root(root, panel_id));
+}
+
+pub(super) fn request_stop(root: &Path, panel_id: &str) -> Result<(), String> {
+    let path = stop_path_for_root(root, panel_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| format!("could not create stop directory: {error}"))?;
+    }
+    std::fs::write(&path, b"stop").map_err(|error| format!("could not write {}: {error}", path.display()))
+}
+
+pub(super) fn live_host(root: &Path) -> Option<StandaloneHostRef> {
+    prune_dead_at(root);
+    list_leases(root)
+        .into_iter()
+        .filter(|host| {
+            pid_is_alive(host.host_pid)
+                && manifest::read_at(&manifest::manifest_path_for_root(root, &host.panel_id)).is_some()
+        })
+        .min_by(|left, right| left.panel_id.cmp(&right.panel_id))
+}
+
+pub(super) fn reconnect(root: &Path, host: &StandaloneHostRef) -> Result<(), String> {
+    prune_dead_at(root);
+    if pid_is_alive(host.host_pid)
+        && manifest::read_at(&manifest::manifest_path_for_root(root, &host.panel_id)).is_some()
+        && read_lease(root, &host.panel_id).is_some_and(|live| live.host_pid == host.host_pid)
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "standalone browser host for panel `{}` is gone and cannot be reconnected",
+        host.panel_id
+    ))
+}
+
+pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<String>, String> {
+    prune_dead_at(root);
+    let targets = match panel_id {
+        Some(panel_id) => {
+            let host = read_lease(root, panel_id)
+                .ok_or_else(|| format!("no keep-alive standalone host for panel `{panel_id}`"))?;
+            vec![host]
+        }
+        None => list_leases(root),
+    };
+    if targets.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut stopped = Vec::new();
+    for host in targets {
+        request_stop(root, &host.panel_id)?;
+        if pid_is_alive(host.host_pid) {
+            let _ = signal_terminate(host.host_pid);
+        }
+        stopped.push(host.panel_id);
+    }
+    Ok(stopped)
+}
+
+pub(super) fn prune_dead_at(root: &Path) -> Vec<String> {
+    let mut pruned = Vec::new();
+    for host in list_leases(root) {
+        if pid_is_alive(host.host_pid) {
+            continue;
+        }
+        let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, &host.panel_id));
+        remove(root, &host.panel_id);
+        pruned.push(host.panel_id);
+    }
+    pruned
+}
+
+fn list_leases(root: &Path) -> Vec<StandaloneHostRef> {
+    let directory = root.join("runtime").join("browsers");
+    let Ok(entries) = std::fs::read_dir(&directory) else {
+        return Vec::new();
+    };
+    let mut hosts = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+        if !name.ends_with(".lease.json") {
+            continue;
+        }
+        if let Ok(bytes) = std::fs::read(&path)
+            && let Ok(host) = serde_json::from_slice::<StandaloneHostRef>(&bytes)
+        {
+            hosts.push(host);
+        }
+    }
+    hosts.sort_by(|left, right| left.panel_id.cmp(&right.panel_id));
+    hosts
+}
+
+fn read_lease(root: &Path, panel_id: &str) -> Option<StandaloneHostRef> {
+    let bytes = std::fs::read(lease_path_for_root(root, panel_id)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+pub(super) async fn await_keep_alive_at(root: &Path, panel_id: &str, idle: Duration, poll: Duration) -> KeepAliveEnd {
+    let stop = stop_path_for_root(root, panel_id);
+    let mut idle_since = None;
+    loop {
+        if stop.is_file() {
+            return KeepAliveEnd::Stopped;
+        }
+        if owner_is_idle(root, panel_id) {
+            let started = *idle_since.get_or_insert_with(std::time::Instant::now);
+            if started.elapsed() >= idle {
+                return KeepAliveEnd::Idle;
+            }
+        } else {
+            idle_since = None;
+        }
+        tokio::time::sleep(poll).await;
+    }
+}
+
+fn owner_is_idle(root: &Path, panel_id: &str) -> bool {
+    let Some(manifest) = manifest::read_at(&manifest::manifest_path_for_root(root, panel_id)) else {
+        return true;
+    };
+    manifest.live_owner(now_millis()).is_none()
+}
+
+fn now_millis() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_millis()),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+pub(super) fn pid_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+    #[cfg(windows)]
+    {
+        Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+    }
+}
+
+fn signal_terminate(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        Command::new("kill")
+            .args([&pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+    #[cfg(windows)]
+    {
+        Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+}
+
+pub(crate) const fn keep_alive_idle() -> Duration {
+    KEEP_ALIVE_IDLE
+}
+
+pub(crate) const fn keep_alive_poll() -> Duration {
+    KEEP_ALIVE_POLL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use horizon_browser::BackendKind;
+    use horizon_core::browser::manifest::BrowserManifest;
+
+    #[cfg(unix)]
+    #[test]
+    fn dead_host_leases_are_pruned_with_their_manifests() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let mut child = Command::new("/bin/true")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap_or_else(|error| panic!("spawn: {error}"));
+        let pid = child.id();
+        let _ = child.wait();
+        let host = StandaloneHostRef {
+            panel_id: "standalone-9-dead".to_string(),
+            host_pid: pid,
+        };
+        publish(home.path(), &host).unwrap_or_else(|error| panic!("publish: {error}"));
+        manifest::write_at(
+            &manifest::manifest_path_for_root(home.path(), &host.panel_id),
+            &BrowserManifest {
+                panel_local_id: host.panel_id.clone(),
+                backend: BackendKind::ChromiumCdp,
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|error| panic!("manifest: {error}"));
+
+        let pruned = prune_dead_at(home.path());
+        assert_eq!(pruned, vec![host.panel_id.clone()]);
+        assert!(read_lease(home.path(), &host.panel_id).is_none());
+        assert!(manifest::read_at(&manifest::manifest_path_for_root(home.path(), &host.panel_id)).is_none());
+    }
+
+    #[test]
+    fn reconnect_requires_a_live_pid_and_manifest() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let host = StandaloneHostRef {
+            panel_id: "standalone-9-live".to_string(),
+            host_pid: std::process::id(),
+        };
+        publish(home.path(), &host).unwrap_or_else(|error| panic!("publish: {error}"));
+        assert!(reconnect(home.path(), &host).is_err());
+        manifest::write_at(
+            &manifest::manifest_path_for_root(home.path(), &host.panel_id),
+            &BrowserManifest {
+                panel_local_id: host.panel_id.clone(),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|error| panic!("manifest: {error}"));
+        reconnect(home.path(), &host).unwrap_or_else(|error| panic!("reconnect: {error}"));
+    }
+
+    #[tokio::test]
+    async fn keep_alive_ends_when_stop_is_requested() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let panel_id = "standalone-9-stop";
+        std::fs::create_dir_all(home.path().join("runtime").join("browsers"))
+            .unwrap_or_else(|error| panic!("dir: {error}"));
+        let wait = tokio::spawn({
+            let root = home.path().to_path_buf();
+            async move { await_keep_alive_at(&root, panel_id, Duration::from_secs(30), Duration::from_millis(10)).await }
+        });
+        request_stop(home.path(), panel_id).unwrap_or_else(|error| panic!("stop: {error}"));
+        assert_eq!(
+            wait.await.unwrap_or_else(|error| panic!("join: {error}")),
+            KeepAliveEnd::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn keep_alive_idles_without_a_live_owner() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let panel_id = "standalone-9-idle";
+        let ended = await_keep_alive_at(
+            home.path(),
+            panel_id,
+            Duration::from_millis(20),
+            Duration::from_millis(5),
+        )
+        .await;
+        assert_eq!(ended, KeepAliveEnd::Idle);
+    }
+}

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -20,6 +20,26 @@ pub struct StandaloneHostRef {
     pub panel_id: String,
     /// Process that owns the browser session.
     pub host_pid: u32,
+    /// Unix timestamp in milliseconds when this host published its lease.
+    #[serde(default)]
+    pub created_at: i64,
+    /// Process start identity used to reject PID reuse before signaling.
+    #[serde(default)]
+    pub start_identity: String,
+}
+
+impl StandaloneHostRef {
+    pub(super) fn current(panel_id: String) -> Result<Self, StandaloneError> {
+        let host_pid = std::process::id();
+        let start_identity = process_start_identity(host_pid)
+            .ok_or_else(|| StandaloneError::Startup("could not read host process start identity".to_string()))?;
+        Ok(Self {
+            panel_id,
+            host_pid,
+            created_at: now_millis(),
+            start_identity,
+        })
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -67,25 +87,27 @@ pub(super) fn live_host(root: &Path) -> Option<StandaloneHostRef> {
     prune_dead_at(root);
     list_leases(root)
         .into_iter()
-        .filter(|host| {
-            pid_is_alive(host.host_pid)
-                && manifest::read_at(&manifest::manifest_path_for_root(root, &host.panel_id)).is_some()
+        .filter(|host| host_is_current(host) && panel_manifest_exists(root, &host.panel_id))
+        .max_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.panel_id.cmp(&right.panel_id))
         })
-        .min_by(|left, right| left.panel_id.cmp(&right.panel_id))
 }
 
 pub(super) fn reconnect(root: &Path, host: &StandaloneHostRef) -> Result<(), String> {
     prune_dead_at(root);
-    if pid_is_alive(host.host_pid)
-        && manifest::read_at(&manifest::manifest_path_for_root(root, &host.panel_id)).is_some()
-        && read_lease(root, &host.panel_id).is_some_and(|live| live.host_pid == host.host_pid)
+    let Some(live) = read_lease(root, &host.panel_id) else {
+        return gone(&host.panel_id);
+    };
+    if live.host_pid == host.host_pid
+        && live.start_identity == host.start_identity
+        && host_is_current(&live)
+        && panel_manifest_exists(root, &host.panel_id)
     {
         return Ok(());
     }
-    Err(format!(
-        "standalone browser host for panel `{}` is gone and cannot be reconnected",
-        host.panel_id
-    ))
+    gone(&host.panel_id)
 }
 
 pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<String>, String> {
@@ -104,7 +126,7 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
     let mut stopped = Vec::new();
     for host in targets {
         request_stop(root, &host.panel_id)?;
-        if pid_is_alive(host.host_pid) {
+        if host_is_current(&host) {
             let _ = signal_terminate(host.host_pid);
         }
         stopped.push(host.panel_id);
@@ -115,7 +137,7 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
 pub(super) fn prune_dead_at(root: &Path) -> Vec<String> {
     let mut pruned = Vec::new();
     for host in list_leases(root) {
-        if pid_is_alive(host.host_pid) {
+        if host_is_current(&host) {
             continue;
         }
         let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, &host.panel_id));
@@ -146,13 +168,27 @@ fn list_leases(root: &Path) -> Vec<StandaloneHostRef> {
             hosts.push(host);
         }
     }
-    hosts.sort_by(|left, right| left.panel_id.cmp(&right.panel_id));
+    hosts.sort_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.panel_id.cmp(&right.panel_id))
+    });
     hosts
 }
 
 fn read_lease(root: &Path, panel_id: &str) -> Option<StandaloneHostRef> {
     let bytes = std::fs::read(lease_path_for_root(root, panel_id)).ok()?;
     serde_json::from_slice(&bytes).ok()
+}
+
+pub(super) async fn await_stop_at(root: &Path, panel_id: &str, poll: Duration) {
+    let stop = stop_path_for_root(root, panel_id);
+    loop {
+        if stop.is_file() {
+            return;
+        }
+        tokio::time::sleep(poll).await;
+    }
 }
 
 pub(super) async fn await_keep_alive_at(root: &Path, panel_id: &str, idle: Duration, poll: Duration) -> KeepAliveEnd {
@@ -190,7 +226,92 @@ fn now_millis() -> i64 {
     .unwrap_or(i64::MAX)
 }
 
-pub(super) fn pid_is_alive(pid: u32) -> bool {
+fn host_is_current(host: &StandaloneHostRef) -> bool {
+    !host.start_identity.is_empty()
+        && pid_is_alive(host.host_pid)
+        && process_start_identity(host.host_pid).as_deref() == Some(host.start_identity.as_str())
+}
+
+fn panel_manifest_exists(root: &Path, panel_id: &str) -> bool {
+    manifest::read_at(&manifest::manifest_path_for_root(root, panel_id)).is_some()
+}
+
+fn gone(panel_id: &str) -> Result<(), String> {
+    Err(format!(
+        "standalone browser host for panel `{panel_id}` is gone and cannot be reconnected"
+    ))
+}
+
+fn process_start_identity(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    platform_process_start_identity(pid)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_stat_starttime(stat: &str) -> Option<&str> {
+    stat.rsplit_once(')')?.1.split_whitespace().nth(19)
+}
+
+#[cfg(target_os = "linux")]
+fn platform_process_start_identity(pid: u32) -> Option<String> {
+    let boot = std::fs::read_to_string("/proc/sys/kernel/random/boot_id").ok()?;
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let starttime = linux_stat_starttime(&stat)?;
+    Some(format!("{}:{starttime}", boot.trim()))
+}
+
+#[cfg(target_os = "macos")]
+fn platform_process_start_identity(pid: u32) -> Option<String> {
+    command_identity(
+        Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "lstart="])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?,
+    )
+}
+
+#[cfg(windows)]
+fn platform_process_start_identity(pid: u32) -> Option<String> {
+    command_identity(
+        Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!(
+                    "(Get-Process -Id {pid} -ErrorAction SilentlyContinue).StartTime.ToUniversalTime().ToString('o')"
+                ),
+            ])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?,
+    )
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn platform_process_start_identity(_pid: u32) -> Option<String> {
+    None
+}
+
+#[cfg(any(target_os = "macos", windows))]
+fn command_identity(output: std::process::Output) -> Option<String> {
+    if !output.status.success() {
+        return None;
+    }
+    let identity = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .trim_start_matches('\u{feff}')
+        .trim()
+        .to_string();
+    if identity.is_empty() { None } else { Some(identity) }
+}
+
+fn pid_is_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
@@ -246,59 +367,104 @@ pub(crate) const fn keep_alive_poll() -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use horizon_browser::BackendKind;
     use horizon_core::browser::manifest::BrowserManifest;
 
-    #[cfg(unix)]
-    #[test]
-    fn dead_host_leases_are_pruned_with_their_manifests() {
-        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
-        let mut child = Command::new("/bin/true")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .unwrap_or_else(|error| panic!("spawn: {error}"));
-        let pid = child.id();
-        let _ = child.wait();
-        let host = StandaloneHostRef {
-            panel_id: "standalone-9-dead".to_string(),
-            host_pid: pid,
-        };
-        publish(home.path(), &host).unwrap_or_else(|error| panic!("publish: {error}"));
+    fn write_manifest(root: &Path, panel_id: &str) {
         manifest::write_at(
-            &manifest::manifest_path_for_root(home.path(), &host.panel_id),
+            &manifest::manifest_path_for_root(root, panel_id),
             &BrowserManifest {
-                panel_local_id: host.panel_id.clone(),
-                backend: BackendKind::ChromiumCdp,
+                panel_local_id: panel_id.to_string(),
                 ..Default::default()
             },
         )
         .unwrap_or_else(|error| panic!("manifest: {error}"));
+    }
 
-        let pruned = prune_dead_at(home.path());
-        assert_eq!(pruned, vec![host.panel_id.clone()]);
-        assert!(read_lease(home.path(), &host.panel_id).is_none());
-        assert!(manifest::read_at(&manifest::manifest_path_for_root(home.path(), &host.panel_id)).is_none());
+    fn host(panel_id: &str, pid: u32, created_at: i64, identity: &str) -> StandaloneHostRef {
+        StandaloneHostRef {
+            panel_id: panel_id.to_string(),
+            host_pid: pid,
+            created_at,
+            start_identity: identity.to_string(),
+        }
+    }
+
+    fn current_host(panel_id: &str, created_at: i64) -> StandaloneHostRef {
+        let pid = std::process::id();
+        let identity = process_start_identity(pid).unwrap_or_else(|| panic!("current process identity"));
+        host(panel_id, pid, created_at, &identity)
     }
 
     #[test]
-    fn reconnect_requires_a_live_pid_and_manifest() {
+    fn linux_stat_starttime_uses_the_field_after_comm() {
+        let stat = "1234 (chrome (helper)) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 98765 0 0";
+        assert_eq!(linux_stat_starttime(stat), Some("98765"));
+    }
+
+    #[test]
+    fn current_process_start_identity_is_stable() {
+        let pid = std::process::id();
+        let first = process_start_identity(pid).unwrap_or_else(|| panic!("first identity"));
+        let second = process_start_identity(pid).unwrap_or_else(|| panic!("second identity"));
+        assert!(!first.is_empty());
+        assert_eq!(first, second);
+        assert!(host_is_current(&current_host("standalone-identity", 1)));
+    }
+
+    #[test]
+    fn dead_host_leases_are_pruned_with_their_manifests() {
         let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
-        let host = StandaloneHostRef {
-            panel_id: "standalone-9-live".to_string(),
-            host_pid: std::process::id(),
-        };
-        publish(home.path(), &host).unwrap_or_else(|error| panic!("publish: {error}"));
-        assert!(reconnect(home.path(), &host).is_err());
-        manifest::write_at(
-            &manifest::manifest_path_for_root(home.path(), &host.panel_id),
-            &BrowserManifest {
-                panel_local_id: host.panel_id.clone(),
-                ..Default::default()
-            },
-        )
-        .unwrap_or_else(|error| panic!("manifest: {error}"));
-        reconnect(home.path(), &host).unwrap_or_else(|error| panic!("reconnect: {error}"));
+        let recorded = host("standalone-9-dead", 0, 1, "");
+        publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
+        write_manifest(home.path(), &recorded.panel_id);
+
+        let pruned = prune_dead_at(home.path());
+        assert_eq!(pruned, vec![recorded.panel_id.clone()]);
+        assert!(read_lease(home.path(), &recorded.panel_id).is_none());
+        assert!(!panel_manifest_exists(home.path(), &recorded.panel_id));
+    }
+
+    #[test]
+    fn reused_pids_are_pruned_without_signaling() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let recorded = host("standalone-9-reused", std::process::id(), 1, "not-this-process");
+        publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
+        write_manifest(home.path(), &recorded.panel_id);
+
+        let pruned = prune_dead_at(home.path());
+        assert_eq!(pruned, vec![recorded.panel_id.clone()]);
+        assert!(read_lease(home.path(), &recorded.panel_id).is_none());
+        assert!(!panel_manifest_exists(home.path(), &recorded.panel_id));
+        assert!(
+            process_start_identity(std::process::id()).is_some(),
+            "test process must still be alive after refusing to signal a reused PID"
+        );
+    }
+
+    #[test]
+    fn live_host_selects_the_newest_created_lease() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let older = current_host("standalone-zzz-old", 1);
+        let newer = current_host("standalone-aaa-new", 2);
+        publish(home.path(), &older).unwrap_or_else(|error| panic!("publish older: {error}"));
+        publish(home.path(), &newer).unwrap_or_else(|error| panic!("publish newer: {error}"));
+        write_manifest(home.path(), &older.panel_id);
+        write_manifest(home.path(), &newer.panel_id);
+
+        assert_eq!(live_host(home.path()).as_ref(), Some(&newer));
+    }
+
+    #[test]
+    fn reconnect_requires_matching_identity_and_manifest() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let recorded = current_host("standalone-9-live", 1);
+        publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
+        assert!(reconnect(home.path(), &recorded).is_err());
+        write_manifest(home.path(), &recorded.panel_id);
+        reconnect(home.path(), &recorded).unwrap_or_else(|error| panic!("reconnect: {error}"));
+
+        let reused = host(&recorded.panel_id, recorded.host_pid, recorded.created_at, "other");
+        assert!(reconnect(home.path(), &reused).is_err());
     }
 
     #[tokio::test]

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -1,12 +1,18 @@
 //! Durable identity for a keep-alive standalone browser host.
 
+use std::fs::OpenOptions;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+use atomicwrites::{AllowOverwrite, AtomicFile};
 use serde::{Deserialize, Serialize};
 
 use horizon_core::browser::manifest;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 
 use super::StandaloneError;
 
@@ -28,10 +34,13 @@ pub struct StandaloneHostRef {
     /// Process start identity used to reject PID reuse before signaling.
     #[serde(default)]
     pub start_identity: String,
+    /// Resolved browser profile directory for this host.
+    #[serde(default)]
+    pub profile_dir: PathBuf,
 }
 
 impl StandaloneHostRef {
-    pub(super) fn current(panel_id: String) -> Result<Self, StandaloneError> {
+    pub(super) fn current(panel_id: String, profile_dir: PathBuf) -> Result<Self, StandaloneError> {
         let host_pid = std::process::id();
         let start_identity = process_start_identity(host_pid)
             .ok_or_else(|| StandaloneError::Startup("could not read host process start identity".to_string()))?;
@@ -40,6 +49,7 @@ impl StandaloneHostRef {
             host_pid,
             created_at: now_millis(),
             start_identity,
+            profile_dir,
         })
     }
 }
@@ -50,16 +60,17 @@ impl StandaloneHostRef {
 /// manifest so a failed startup cannot leak a dead panel.
 pub(super) struct PendingLease {
     root: PathBuf,
-    panel_id: String,
+    host: StandaloneHostRef,
     committed: bool,
 }
 
 impl PendingLease {
-    pub(super) fn publish(root: &Path, panel_id: String) -> Result<Self, StandaloneError> {
-        publish(root, &StandaloneHostRef::current(panel_id.clone())?)?;
+    pub(super) fn publish(root: &Path, panel_id: String, profile_dir: PathBuf) -> Result<Self, StandaloneError> {
+        let host = StandaloneHostRef::current(panel_id, profile_dir)?;
+        publish(root, &host)?;
         Ok(Self {
             root: root.to_path_buf(),
-            panel_id,
+            host,
             committed: false,
         })
     }
@@ -72,7 +83,7 @@ impl PendingLease {
 impl Drop for PendingLease {
     fn drop(&mut self) {
         if !self.committed {
-            remove_host(&self.root, &self.panel_id);
+            remove_host(&self.root, &self.host);
         }
     }
 }
@@ -98,10 +109,20 @@ pub(super) fn publish(root: &Path, host: &StandaloneHostRef) -> Result<(), Stand
             StandaloneError::Startup(format!("could not create standalone lease directory: {error}"))
         })?;
     }
-    let bytes = serde_json::to_vec_pretty(host)
+    let mut bytes = serde_json::to_vec_pretty(host)
         .map_err(|error| StandaloneError::Startup(format!("could not encode standalone lease: {error}")))?;
-    std::fs::write(&path, bytes)
+    bytes.push(b'\n');
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    AtomicFile::new(&path, AllowOverwrite)
+        .write_with_options(|file| file.write_all(&bytes).and_then(|()| file.sync_all()), options)
+        .map_err(std::io::Error::from)
         .map_err(|error| StandaloneError::Startup(format!("could not write {}: {error}", path.display())))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| StandaloneError::Startup(format!("could not secure {}: {error}", path.display())))?;
     Ok(())
 }
 
@@ -110,13 +131,33 @@ pub(super) fn remove(root: &Path, panel_id: &str) {
     let _ = std::fs::remove_file(stop_path_for_root(root, panel_id));
 }
 
-pub(super) fn remove_host(root: &Path, panel_id: &str) {
-    let manifest_path = manifest::manifest_path_for_root(root, panel_id);
-    if let Some(encoded) = manifest_path.file_stem() {
-        let _ = std::fs::remove_dir_all(root.join("browser-profiles").join(encoded));
+fn remove_host(root: &Path, host: &StandaloneHostRef) {
+    if profile_is_allowed(root, &host.panel_id, &host.profile_dir) {
+        let _ = std::fs::remove_dir_all(&host.profile_dir);
     }
-    let _ = std::fs::remove_file(manifest_path);
-    remove(root, panel_id);
+    let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, &host.panel_id));
+    remove(root, &host.panel_id);
+}
+
+fn profile_is_allowed(horizon_root: &Path, panel_id: &str, profile: &Path) -> bool {
+    if profile.as_os_str().is_empty() {
+        return false;
+    }
+    let manifest_path = manifest::manifest_path_for_root(horizon_root, panel_id);
+    if profile.file_name() != manifest_path.file_stem() {
+        return false;
+    }
+    allowed_profile_roots(horizon_root)
+        .iter()
+        .any(|root| profile.starts_with(root))
+}
+
+fn allowed_profile_roots(horizon_root: &Path) -> Vec<PathBuf> {
+    let mut roots = vec![horizon_root.join("browser-profiles")];
+    if let Some(home) = horizon_root.parent() {
+        roots.push(home.join("Horizon").join("browser-profiles"));
+    }
+    roots
 }
 
 pub(super) fn request_stop(root: &Path, panel_id: &str) -> Result<(), String> {
@@ -211,10 +252,10 @@ fn wait_until_exited(hosts: &[StandaloneHostRef], grace: Duration) {
 pub(super) fn prune_dead_at(root: &Path) -> Vec<String> {
     let mut pruned = Vec::new();
     for host in list_leases(root) {
-        if host_is_current(&host) {
+        if host_liveness(&host) != HostLiveness::Stale {
             continue;
         }
-        remove_host(root, &host.panel_id);
+        remove_host(root, &host);
         pruned.push(host.panel_id);
     }
     pruned
@@ -302,10 +343,30 @@ fn now_millis() -> i64 {
     .unwrap_or(i64::MAX)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HostLiveness {
+    Current,
+    Stale,
+    Unknown,
+}
+
 fn host_is_current(host: &StandaloneHostRef) -> bool {
-    !host.start_identity.is_empty()
-        && pid_is_alive(host.host_pid)
-        && process_start_identity(host.host_pid).as_deref() == Some(host.start_identity.as_str())
+    host_liveness(host) == HostLiveness::Current
+}
+
+fn host_liveness(host: &StandaloneHostRef) -> HostLiveness {
+    if host.start_identity.is_empty() {
+        return HostLiveness::Stale;
+    }
+    match pid_probe(host.host_pid) {
+        PidProbe::Dead => HostLiveness::Stale,
+        PidProbe::Unknown => HostLiveness::Unknown,
+        PidProbe::Alive => match process_start_identity(host.host_pid) {
+            Some(identity) if identity == host.start_identity => HostLiveness::Current,
+            Some(_) => HostLiveness::Stale,
+            None => HostLiveness::Unknown,
+        },
+    }
 }
 
 fn panel_manifest_exists(root: &Path, panel_id: &str) -> bool {
@@ -387,27 +448,42 @@ fn command_identity(output: std::process::Output) -> Option<String> {
     if identity.is_empty() { None } else { Some(identity) }
 }
 
-fn pid_is_alive(pid: u32) -> bool {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PidProbe {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+fn pid_probe(pid: u32) -> PidProbe {
     if pid == 0 {
-        return false;
+        return PidProbe::Dead;
     }
     #[cfg(unix)]
     {
-        Command::new("kill")
+        match Command::new("kill")
             .args(["-0", &pid.to_string()])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .is_ok_and(|status| status.success())
+        {
+            Ok(status) if status.success() => PidProbe::Alive,
+            Ok(_) => PidProbe::Dead,
+            Err(_) => PidProbe::Unknown,
+        }
     }
     #[cfg(windows)]
     {
-        Command::new("tasklist")
+        match Command::new("tasklist")
             .args(["/FI", &format!("PID eq {pid}"), "/NH"])
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
             .output()
-            .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+        {
+            Ok(output) if String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()) => PidProbe::Alive,
+            Ok(_) => PidProbe::Dead,
+            Err(_) => PidProbe::Unknown,
+        }
     }
 }
 
@@ -462,6 +538,7 @@ mod tests {
             host_pid: pid,
             created_at,
             start_identity: identity.to_string(),
+            profile_dir: PathBuf::new(),
         }
     }
 
@@ -514,7 +591,7 @@ mod tests {
     fn pending_lease_is_removed_with_its_manifest_unless_committed() {
         let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
         let abandoned = "standalone-9-abandoned";
-        let pending = PendingLease::publish(home.path(), abandoned.to_string())
+        let pending = PendingLease::publish(home.path(), abandoned.to_string(), PathBuf::new())
             .unwrap_or_else(|error| panic!("publish pending: {error}"));
         write_manifest(home.path(), abandoned);
         drop(pending);
@@ -522,7 +599,7 @@ mod tests {
         assert!(!panel_manifest_exists(home.path(), abandoned));
 
         let kept = "standalone-9-kept";
-        PendingLease::publish(home.path(), kept.to_string())
+        PendingLease::publish(home.path(), kept.to_string(), PathBuf::new())
             .unwrap_or_else(|error| panic!("publish kept: {error}"))
             .commit();
         assert!(read_lease(home.path(), kept).is_some());
@@ -541,14 +618,15 @@ mod tests {
     #[test]
     fn dead_host_leases_are_pruned_with_their_manifests() {
         let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
-        let recorded = host("standalone-9-dead", 0, 1, "");
-        publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
-        write_manifest(home.path(), &recorded.panel_id);
+        let mut recorded = host("standalone-9-dead", 0, 1, "");
         let profile = home.path().join("browser-profiles").join(
             manifest::manifest_path_for_root(home.path(), &recorded.panel_id)
                 .file_stem()
                 .unwrap_or_default(),
         );
+        recorded.profile_dir = profile.clone();
+        publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
+        write_manifest(home.path(), &recorded.panel_id);
         std::fs::create_dir_all(&profile).unwrap_or_else(|error| panic!("profile: {error}"));
         std::fs::write(profile.join("state"), b"left behind").unwrap_or_else(|error| panic!("profile file: {error}"));
 
@@ -557,6 +635,27 @@ mod tests {
         assert!(read_lease(home.path(), &recorded.panel_id).is_none());
         assert!(!panel_manifest_exists(home.path(), &recorded.panel_id));
         assert!(!profile.exists());
+    }
+
+    #[test]
+    fn dead_host_prune_removes_a_relocated_snap_profile() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let horizon = home.path().join(".horizon");
+        let mut recorded = host("standalone-9-snap", 0, 1, "");
+        let profile = home.path().join("Horizon").join("browser-profiles").join(
+            manifest::manifest_path_for_root(&horizon, &recorded.panel_id)
+                .file_stem()
+                .unwrap_or_default(),
+        );
+        recorded.profile_dir = profile.clone();
+        publish(&horizon, &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
+        write_manifest(&horizon, &recorded.panel_id);
+        std::fs::create_dir_all(&profile).unwrap_or_else(|error| panic!("snap profile: {error}"));
+        std::fs::write(profile.join("state"), b"snap").unwrap_or_else(|error| panic!("snap file: {error}"));
+
+        assert_eq!(prune_dead_at(&horizon), vec![recorded.panel_id.clone()]);
+        assert!(!profile.exists());
+        assert!(read_lease(&horizon, &recorded.panel_id).is_none());
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -83,7 +83,7 @@ impl PendingLease {
 impl Drop for PendingLease {
     fn drop(&mut self) {
         if !self.committed {
-            remove_host(&self.root, &self.host);
+            let _ = remove_host(&self.root, &self.host);
         }
     }
 }
@@ -131,12 +131,23 @@ pub(super) fn remove(root: &Path, panel_id: &str) {
     let _ = std::fs::remove_file(stop_path_for_root(root, panel_id));
 }
 
-fn remove_host(root: &Path, host: &StandaloneHostRef) {
+fn remove_host(root: &Path, host: &StandaloneHostRef) -> Result<(), String> {
     if profile_is_allowed(root, &host.panel_id, &host.profile_dir) {
-        let _ = std::fs::remove_dir_all(&host.profile_dir);
+        match std::fs::remove_dir_all(&host.profile_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "could not remove profile {}: {error}",
+                    host.profile_dir.display()
+                ));
+            }
+        }
     }
-    let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, &host.panel_id));
+    manifest::remove_in(root, &host.panel_id)
+        .map_err(|error| format!("could not remove manifest for `{}`: {error}", host.panel_id))?;
     remove(root, &host.panel_id);
+    Ok(())
 }
 
 fn profile_is_allowed(horizon_root: &Path, panel_id: &str, profile: &Path) -> bool {
@@ -221,17 +232,17 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
     }
     wait_until_exited(&targets, STOP_ESCALATION);
     prune_dead_at(root);
-    let survivors = targets
+    let remaining = targets
         .iter()
-        .filter(|host| host_is_current(host))
+        .filter(|host| read_lease(root, &host.panel_id).is_some() || host_liveness(host) != HostLiveness::Stale)
         .map(|host| host.panel_id.clone())
         .collect::<Vec<_>>();
-    if survivors.is_empty() {
+    if remaining.is_empty() {
         Ok(stopped)
     } else {
         Err(format!(
             "keep-alive standalone host did not stop: {}",
-            survivors.join(", ")
+            remaining.join(", ")
         ))
     }
 }
@@ -239,7 +250,7 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
 fn wait_until_exited(hosts: &[StandaloneHostRef], grace: Duration) {
     let deadline = Instant::now() + grace;
     loop {
-        if hosts.iter().all(|host| !host_is_current(host)) {
+        if hosts.iter().all(|host| host_liveness(host) == HostLiveness::Stale) {
             return;
         }
         if Instant::now() >= deadline {
@@ -255,8 +266,9 @@ pub(super) fn prune_dead_at(root: &Path) -> Vec<String> {
         if host_liveness(&host) != HostLiveness::Stale {
             continue;
         }
-        remove_host(root, &host);
-        pruned.push(host.panel_id);
+        if remove_host(root, &host).is_ok() {
+            pruned.push(host.panel_id);
+        }
     }
     pruned
 }
@@ -635,6 +647,27 @@ mod tests {
         assert!(read_lease(home.path(), &recorded.panel_id).is_none());
         assert!(!panel_manifest_exists(home.path(), &recorded.panel_id));
         assert!(!profile.exists());
+    }
+
+    #[test]
+    fn failed_profile_cleanup_keeps_the_lease() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let mut recorded = host("standalone-9-locked", 0, 1, "");
+        let profile = home.path().join("browser-profiles").join(
+            manifest::manifest_path_for_root(home.path(), &recorded.panel_id)
+                .file_stem()
+                .unwrap_or_default(),
+        );
+        std::fs::create_dir_all(profile.parent().unwrap_or_else(|| panic!("profile parent")))
+            .unwrap_or_else(|error| panic!("dir: {error}"));
+        std::fs::write(&profile, b"not a directory").unwrap_or_else(|error| panic!("blocker: {error}"));
+        recorded.profile_dir = profile;
+        publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
+        write_manifest(home.path(), &recorded.panel_id);
+
+        assert!(remove_host(home.path(), &recorded).is_err());
+        assert!(read_lease(home.path(), &recorded.panel_id).is_some());
+        assert!(panel_manifest_exists(home.path(), &recorded.panel_id));
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -111,7 +111,11 @@ pub(super) fn remove(root: &Path, panel_id: &str) {
 }
 
 pub(super) fn remove_host(root: &Path, panel_id: &str) {
-    let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, panel_id));
+    let manifest_path = manifest::manifest_path_for_root(root, panel_id);
+    if let Some(encoded) = manifest_path.file_stem() {
+        let _ = std::fs::remove_dir_all(root.join("browser-profiles").join(encoded));
+    }
+    let _ = std::fs::remove_file(manifest_path);
     remove(root, panel_id);
 }
 
@@ -175,6 +179,7 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
         }
     }
     wait_until_exited(&targets, STOP_ESCALATION);
+    prune_dead_at(root);
     let survivors = targets
         .iter()
         .filter(|host| host_is_current(host))
@@ -539,11 +544,19 @@ mod tests {
         let recorded = host("standalone-9-dead", 0, 1, "");
         publish(home.path(), &recorded).unwrap_or_else(|error| panic!("publish: {error}"));
         write_manifest(home.path(), &recorded.panel_id);
+        let profile = home.path().join("browser-profiles").join(
+            manifest::manifest_path_for_root(home.path(), &recorded.panel_id)
+                .file_stem()
+                .unwrap_or_default(),
+        );
+        std::fs::create_dir_all(&profile).unwrap_or_else(|error| panic!("profile: {error}"));
+        std::fs::write(profile.join("state"), b"left behind").unwrap_or_else(|error| panic!("profile file: {error}"));
 
         let pruned = prune_dead_at(home.path());
         assert_eq!(pruned, vec![recorded.panel_id.clone()]);
         assert!(read_lease(home.path(), &recorded.panel_id).is_none());
         assert!(!panel_manifest_exists(home.path(), &recorded.panel_id));
+        assert!(!profile.exists());
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +12,7 @@ use super::StandaloneError;
 
 const KEEP_ALIVE_IDLE: Duration = Duration::from_secs(60);
 const KEEP_ALIVE_POLL: Duration = Duration::from_millis(100);
+const STOP_GRACE: Duration = Duration::from_secs(15);
 
 /// Recorded keep-alive host a later MCP client or `resume` can reconnect to.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -39,6 +40,39 @@ impl StandaloneHostRef {
             created_at: now_millis(),
             start_identity,
         })
+    }
+}
+
+/// Keep-alive lease published before the panel manifest can appear.
+///
+/// Dropping without [`Self::commit`] removes the lease and any orphaned
+/// manifest so a failed startup cannot leak a dead panel.
+pub(super) struct PendingLease {
+    root: PathBuf,
+    panel_id: String,
+    committed: bool,
+}
+
+impl PendingLease {
+    pub(super) fn publish(root: &Path, panel_id: String) -> Result<Self, StandaloneError> {
+        publish(root, &StandaloneHostRef::current(panel_id.clone())?)?;
+        Ok(Self {
+            root: root.to_path_buf(),
+            panel_id,
+            committed: false,
+        })
+    }
+
+    pub(super) fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PendingLease {
+    fn drop(&mut self) {
+        if !self.committed {
+            remove_host(&self.root, &self.panel_id);
+        }
     }
 }
 
@@ -73,6 +107,11 @@ pub(super) fn publish(root: &Path, host: &StandaloneHostRef) -> Result<(), Stand
 pub(super) fn remove(root: &Path, panel_id: &str) {
     let _ = std::fs::remove_file(lease_path_for_root(root, panel_id));
     let _ = std::fs::remove_file(stop_path_for_root(root, panel_id));
+}
+
+pub(super) fn remove_host(root: &Path, panel_id: &str) {
+    let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, panel_id));
+    remove(root, panel_id);
 }
 
 pub(super) fn request_stop(root: &Path, panel_id: &str) -> Result<(), String> {
@@ -124,14 +163,30 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
         return Ok(Vec::new());
     }
     let mut stopped = Vec::new();
-    for host in targets {
+    for host in &targets {
         request_stop(root, &host.panel_id)?;
+        stopped.push(host.panel_id.clone());
+    }
+    wait_until_exited(&targets, STOP_GRACE);
+    for host in targets {
         if host_is_current(&host) {
             let _ = signal_terminate(host.host_pid);
         }
-        stopped.push(host.panel_id);
     }
     Ok(stopped)
+}
+
+fn wait_until_exited(hosts: &[StandaloneHostRef], grace: Duration) {
+    let deadline = Instant::now() + grace;
+    loop {
+        if hosts.iter().all(|host| !host_is_current(host)) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(KEEP_ALIVE_POLL);
+    }
 }
 
 pub(super) fn prune_dead_at(root: &Path) -> Vec<String> {
@@ -140,8 +195,7 @@ pub(super) fn prune_dead_at(root: &Path) -> Vec<String> {
         if host_is_current(&host) {
             continue;
         }
-        let _ = std::fs::remove_file(manifest::manifest_path_for_root(root, &host.panel_id));
-        remove(root, &host.panel_id);
+        remove_host(root, &host.panel_id);
         pruned.push(host.panel_id);
     }
     pruned
@@ -409,6 +463,34 @@ mod tests {
         assert!(!first.is_empty());
         assert_eq!(first, second);
         assert!(host_is_current(&current_host("standalone-identity", 1)));
+    }
+
+    #[test]
+    fn pending_lease_is_removed_with_its_manifest_unless_committed() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let abandoned = "standalone-9-abandoned";
+        let pending = PendingLease::publish(home.path(), abandoned.to_string())
+            .unwrap_or_else(|error| panic!("publish pending: {error}"));
+        write_manifest(home.path(), abandoned);
+        drop(pending);
+        assert!(read_lease(home.path(), abandoned).is_none());
+        assert!(!panel_manifest_exists(home.path(), abandoned));
+
+        let kept = "standalone-9-kept";
+        PendingLease::publish(home.path(), kept.to_string())
+            .unwrap_or_else(|error| panic!("publish kept: {error}"))
+            .commit();
+        assert!(read_lease(home.path(), kept).is_some());
+    }
+
+    #[test]
+    fn stop_waits_for_graceful_exit_before_signaling() {
+        let live = current_host("standalone-9-grace", 1);
+        wait_until_exited(&[live], Duration::from_millis(20));
+        assert!(
+            process_start_identity(std::process::id()).is_some(),
+            "grace wait must not terminate the current process"
+        );
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/standalone/lease.rs
+++ b/crates/horizon-browser-cli/src/standalone/lease.rs
@@ -13,6 +13,7 @@ use super::StandaloneError;
 const KEEP_ALIVE_IDLE: Duration = Duration::from_secs(60);
 const KEEP_ALIVE_POLL: Duration = Duration::from_millis(100);
 const STOP_GRACE: Duration = Duration::from_secs(15);
+const STOP_ESCALATION: Duration = Duration::from_secs(3);
 
 /// Recorded keep-alive host a later MCP client or `resume` can reconnect to.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -168,12 +169,25 @@ pub(super) fn stop_hosts(root: &Path, panel_id: Option<&str>) -> Result<Vec<Stri
         stopped.push(host.panel_id.clone());
     }
     wait_until_exited(&targets, STOP_GRACE);
-    for host in targets {
-        if host_is_current(&host) {
+    for host in &targets {
+        if host_is_current(host) {
             let _ = signal_terminate(host.host_pid);
         }
     }
-    Ok(stopped)
+    wait_until_exited(&targets, STOP_ESCALATION);
+    let survivors = targets
+        .iter()
+        .filter(|host| host_is_current(host))
+        .map(|host| host.panel_id.clone())
+        .collect::<Vec<_>>();
+    if survivors.is_empty() {
+        Ok(stopped)
+    } else {
+        Err(format!(
+            "keep-alive standalone host did not stop: {}",
+            survivors.join(", ")
+        ))
+    }
 }
 
 fn wait_until_exited(hosts: &[StandaloneHostRef], grace: Duration) {
@@ -216,9 +230,7 @@ fn list_leases(root: &Path) -> Vec<StandaloneHostRef> {
         if !name.ends_with(".lease.json") {
             continue;
         }
-        if let Ok(bytes) = std::fs::read(&path)
-            && let Ok(host) = serde_json::from_slice::<StandaloneHostRef>(&bytes)
-        {
+        if let Some(host) = decode_lease(root, &path) {
             hosts.push(host);
         }
     }
@@ -231,8 +243,13 @@ fn list_leases(root: &Path) -> Vec<StandaloneHostRef> {
 }
 
 fn read_lease(root: &Path, panel_id: &str) -> Option<StandaloneHostRef> {
-    let bytes = std::fs::read(lease_path_for_root(root, panel_id)).ok()?;
-    serde_json::from_slice(&bytes).ok()
+    decode_lease(root, &lease_path_for_root(root, panel_id)).filter(|host| host.panel_id == panel_id)
+}
+
+fn decode_lease(root: &Path, path: &Path) -> Option<StandaloneHostRef> {
+    let bytes = std::fs::read(path).ok()?;
+    let host = serde_json::from_slice::<StandaloneHostRef>(&bytes).ok()?;
+    (lease_path_for_root(root, &host.panel_id) == path).then_some(host)
 }
 
 pub(super) async fn await_stop_at(root: &Path, panel_id: &str, poll: Duration) {
@@ -463,6 +480,29 @@ mod tests {
         assert!(!first.is_empty());
         assert_eq!(first, second);
         assert!(host_is_current(&current_host("standalone-identity", 1)));
+    }
+
+    #[test]
+    fn leases_are_ignored_when_the_embedded_panel_id_does_not_match_the_path() {
+        let home = tempfile::tempdir().unwrap_or_else(|error| panic!("home: {error}"));
+        let live = current_host("standalone-victim", 1);
+        publish(home.path(), &live).unwrap_or_else(|error| panic!("publish live: {error}"));
+        write_manifest(home.path(), &live.panel_id);
+        let spoofed = host(&live.panel_id, 0, 1, "");
+        let spoof_path = home
+            .path()
+            .join("runtime")
+            .join("browsers")
+            .join("standalone-spoofed.lease.json");
+        std::fs::write(
+            &spoof_path,
+            serde_json::to_vec(&spoofed).unwrap_or_else(|error| panic!("encode spoof: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("write spoof: {error}"));
+
+        assert!(decode_lease(home.path(), &spoof_path).is_none());
+        assert_eq!(prune_dead_at(home.path()), Vec::<String>::new());
+        reconnect(home.path(), &live).unwrap_or_else(|error| panic!("live host must survive a spoofed lease: {error}"));
     }
 
     #[test]

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -344,6 +344,41 @@ fn resume_refuses_a_dead_standalone_host() {
 }
 
 #[test]
+fn resume_prunes_dead_hosts_without_a_sidecar() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let (plan, manifest_path) = write_blocking_plan(root.path());
+    let output = run_deadline_after_action(root.path(), &plan, &manifest_path, None);
+    assert_eq!(output.status.code(), Some(124));
+    let report: Value = serde_json::from_slice(&output.stdout).expect("deadline report");
+    let job_id = report["job_id"].as_str().expect("job id");
+
+    let horizon = root.path().join(".horizon");
+    let panel_id = "standalone-9-dead";
+    let dead_manifest = manifest::manifest_path_for_root(&horizon, panel_id);
+    std::fs::create_dir_all(dead_manifest.parent().expect("browsers directory")).expect("browsers dir");
+    std::fs::write(
+        dead_manifest.with_extension("lease.json"),
+        br#"{"panel_id":"standalone-9-dead","host_pid":0}"#,
+    )
+    .expect("record dead lease");
+    manifest::write_at(
+        &dead_manifest,
+        &BrowserManifest {
+            panel_local_id: panel_id.to_string(),
+            ..BrowserManifest::default()
+        },
+    )
+    .expect("record dead manifest");
+
+    let _ = run_command(root.path(), ["resume", job_id, "--on-uncertain", "skip"]);
+    assert!(
+        !dead_manifest.with_extension("lease.json").is_file(),
+        "resume must prune dead standalone hosts even when the job has no sidecar"
+    );
+    assert!(manifest::read_at(&dead_manifest).is_none());
+}
+
+#[test]
 fn resume_skip_runs_later_steps_without_replaying_or_succeeding() {
     let root = tempfile::tempdir().expect("isolated root");
     let (plan, manifest_path) = write_blocking_plan_with_followup(root.path());

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -320,6 +320,30 @@ fn resume_refuses_an_uncertain_in_flight_step() {
 }
 
 #[test]
+fn resume_refuses_a_dead_standalone_host() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let (plan, manifest_path) = write_blocking_plan(root.path());
+    let output = run_deadline_after_action(root.path(), &plan, &manifest_path, None);
+    assert_eq!(output.status.code(), Some(124));
+    let report: Value = serde_json::from_slice(&output.stdout).expect("deadline report");
+    let job_id = report["job_id"].as_str().expect("job id");
+    let job_dir = std::path::Path::new(report["job_dir"].as_str().expect("job directory"));
+    std::fs::write(
+        job_dir.join("standalone.json"),
+        br#"{"panel_id":"standalone-1-missing","host_pid":1}"#,
+    )
+    .expect("record dead standalone host");
+
+    let refused = run_command(root.path(), ["resume", job_id, "--on-uncertain", "skip"]);
+    assert_eq!(refused.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("gone and cannot be reconnected"),
+        "stderr: {}",
+        String::from_utf8_lossy(&refused.stderr)
+    );
+}
+
+#[test]
 fn resume_skip_runs_later_steps_without_replaying_or_succeeding() {
     let root = tempfile::tempdir().expect("isolated root");
     let (plan, manifest_path) = write_blocking_plan_with_followup(root.path());

--- a/crates/horizon-core/src/browser/manifest.rs
+++ b/crates/horizon-core/src/browser/manifest.rs
@@ -448,6 +448,15 @@ pub fn remove(panel_local_id: &str) {
     remove_at_with_warning(&path);
 }
 
+/// Remove a manifest under an explicit Horizon home root while holding its
+/// adjacent lock, so a concurrent update cannot recreate the file after unlink.
+///
+/// # Errors
+/// Returns when the lock cannot be acquired or the file cannot be removed.
+pub fn remove_in(root: &Path, panel_local_id: &str) -> std::io::Result<()> {
+    remove_at(&manifest_path_for_root(root, panel_local_id))
+}
+
 /// Remove a live manifest within the caller's remaining shutdown budget.
 /// Returns `false` if lock acquisition or removal cannot finish in time.
 #[must_use]
@@ -867,6 +876,8 @@ mod tests {
         let back = read_at(&path).unwrap();
         assert_eq!(back, m);
         assert!(list_panels_in(&root.join("runtime").join("browsers")).contains(&"abc-123".to_string()));
+        remove_in(&root, "abc-123").unwrap();
+        assert!(read_at(&path).is_none());
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -608,8 +608,9 @@ back into large multi-purpose modules.
   Large verified step results live in immutable files managed by
   `run_state/checkpoint_artifacts.rs`; `state.json` retains only compact result
   references so intent updates never rewrite prior payloads.
-- `standalone/lease.rs` records keep-alive host identity so resume can reconnect
-  to the same browser or fail closed after a crash.
+- `standalone/lease.rs` records keep-alive host identity, process-start identity,
+  and creation order so resume can reconnect to the newest live browser or fail
+  closed after a crash or PID reuse.
 
 ### `horizon-ui`
 

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -608,6 +608,8 @@ back into large multi-purpose modules.
   Large verified step results live in immutable files managed by
   `run_state/checkpoint_artifacts.rs`; `state.json` retains only compact result
   references so intent updates never rewrite prior payloads.
+- `standalone/lease.rs` records keep-alive host identity so resume can reconnect
+  to the same browser or fail closed after a crash.
 
 ### `horizon-ui`
 


### PR DESCRIPTION
## Purpose

Issue #324 standalone reconnect slice: keep a standalone browser addressable after MCP stdin closes, reconnect `resume` to that same host, and fail closed after a crash instead of starting a replacement browser.

## Behavior impact

- `horizon-browser mcp --standalone --keep-alive` leaves the browser running after MCP stdin ends until idle, `--stop`, SIGTERM/SIGINT, or host exit.
- A host lease records `panel_id` and `host_pid`. Dead pids are pruned (manifest + lease) on MCP start, `--stop`, `run`, and `resume`.
- `horizon-browser mcp --stop [PANEL-ID]` asks keep-alive hosts to exit and clean up.
- `run` records a live keep-alive host in `standalone.json` when one exists.
- `resume` reconnects to that host; if the process or panel is gone, it errors and never silently starts a new browser.
- Prompt jobs still shut down their owned host; `--keep-alive` is opt-in.
- Deterministic `run` without a keep-alive host is unchanged.

## Validation

- `cargo fmt --all -- --check` (via `cargo fmt --all`)
- `./scripts/check-maintainability.sh`
- `cargo clippy -p horizon-browser-cli --all-targets -- -D warnings`
- `cargo clippy -p horizon-browser-cli --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo test -p horizon-browser-cli`

No crates are published by this change.