### PR TITLE
feat(remote): refresh retained SSH coordinates

### DIFF
--- a/crates/horizon-core/src/cloud_run/interactive_worker_start.rs
+++ b/crates/horizon-core/src/cloud_run/interactive_worker_start.rs
@@ -45,3 +45,31 @@ pub trait InteractiveWorkerStartProvider: InteractiveWorkerProvider {
     /// unverified rather than guessing. Diagnostics must redact provider output.
     fn start_worker(&self, worker: &InteractiveWorker) -> Result<InteractiveWorkerStart, Self::Error>;
 }
+
+/// Provider coordinates are candidates, never an attestation or authority to connect.
+/// The storage fingerprint compares two observations, not contents or durability.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InteractiveWorkerEndpointCandidate {
+    pub worker: InteractiveWorker,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub storage_fingerprint: super::ArtifactDigest,
+    pub network_volume: Option<super::runpod::RunPodNetworkVolumeExpectation>,
+}
+
+/// Optional read-only coordinate discovery, separate from compute Start. Currently
+/// implemented for retained `RunPod` workers; never calls initial host-key bootstrap.
+pub trait InteractiveWorkerEndpointObserver: InteractiveWorkerProvider {
+    /// Validate exact ownership, retained storage and the caller's original saved pin
+    /// before returning a running worker's candidate coordinates. Each call must be
+    /// bounded and GET-only. Absence or uncertain storage/readiness is an error.
+    /// # Errors
+    /// Rejects missing retained trust, foreign identity, absent/unready resources and
+    /// unverifiable storage. The caller must still prove original-key possession.
+    fn observe_endpoint_candidate(
+        &self,
+        worker: &InteractiveWorker,
+        saved: &super::interactive_worker::InteractiveWorkerSshEndpoint,
+    ) -> Result<InteractiveWorkerEndpointCandidate, Self::Error>;
+}

--- a/crates/horizon-core/src/cloud_run/runpod/interactive.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive.rs
@@ -1,3 +1,5 @@
+mod endpoint;
+
 use super::super::{
     CloudProvider, WorkerTarget,
     interactive_worker::{

--- a/crates/horizon-core/src/cloud_run/runpod/interactive/endpoint.rs
+++ b/crates/horizon-core/src/cloud_run/runpod/interactive/endpoint.rs
@@ -1,0 +1,303 @@
+//! GET-only retained coordinates. Authentication and persistence belong to the caller.
+
+use super::{RunPodInteractiveWorkerProvider, runpod_worker};
+use crate::cloud_run::{
+    ArtifactDigest,
+    interactive_worker::{InteractiveWorker, InteractiveWorkerLifetime, InteractiveWorkerSshEndpoint},
+    interactive_worker_start::{InteractiveWorkerEndpointCandidate, InteractiveWorkerEndpointObserver},
+    runpod::{RunPodError, RunPodLifecycle, status_from_resource, validate_target},
+};
+
+impl InteractiveWorkerEndpointObserver for RunPodInteractiveWorkerProvider {
+    fn observe_endpoint_candidate(
+        &self,
+        worker: &InteractiveWorker,
+        saved: &InteractiveWorkerSshEndpoint,
+    ) -> Result<InteractiveWorkerEndpointCandidate, RunPodError> {
+        self.client.check_network_worker(worker)?;
+        let retained = runpod_worker(worker)?;
+        validate_target(&worker.target, &self.profile)?;
+        if worker.lifetime != InteractiveWorkerLifetime::Persistent
+            || !saved.is_complete()
+            || self.host_keys.retained_endpoint(worker).as_ref() != Some(saved)
+        {
+            return Err(RunPodError::StartIdentityRequired);
+        }
+        if self.client.network_binding.is_none() && self.profile.volume_gib == 0 {
+            return Err(RunPodError::StopRetentionUnverified);
+        }
+        let pod = self
+            .client
+            .transport
+            .get(&retained.pod_id)?
+            .ok_or(RunPodError::StartUnverified)?;
+        let status = status_from_resource(&pod, &retained, Some(&worker.ssh_public_key))?;
+        if status.lifecycle != RunPodLifecycle::Running
+            || !pod.stop.runtime.as_ref().is_some_and(serde_json::Value::is_object)
+        {
+            return Err(RunPodError::StartUnverified);
+        }
+        self.client.retained_mount(&pod, &self.profile)?;
+        let direct = pod
+            .ssh
+            .as_ref()
+            .and_then(|ssh| ssh.direct.as_ref())
+            .ok_or(RunPodError::StartUnverified)?;
+        let mut candidate_pin = saved.clone();
+        candidate_pin.host.clone_from(&direct.host);
+        candidate_pin.port = direct.port;
+        if direct.username != saved.username || !candidate_pin.is_complete() {
+            return Err(RunPodError::ResourceIdentityMismatch);
+        }
+        let mounts = serde_json::to_vec(pod.stop.mounts()).map_err(|_| RunPodError::StopRetentionUnverified)?;
+        Ok(InteractiveWorkerEndpointCandidate {
+            worker: worker.clone(),
+            host: direct.host.clone(),
+            port: direct.port,
+            username: direct.username.clone(),
+            storage_fingerprint: ArtifactDigest::sha256(&mounts),
+            network_volume: self
+                .client
+                .network_binding
+                .as_ref()
+                .map(|binding| binding.selection.clone()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_run::{
+        CloudJobId, CloudWorkflowId, WorkerLifetime,
+        interactive_worker::InteractiveWorkerIdentity,
+        runpod::{
+            ApiPod, CreatePodRequest, RunPodCleanup, RunPodClient, RunPodHostTrust, RunPodNetworkVolumeExpectation,
+            Transport,
+            network_volume::ApiNetworkVolume,
+            resource_name,
+            tests::{ed25519_key, interactive_request, profile},
+        },
+    };
+    use serde_json::{Value, json};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct Fake(Arc<Mutex<State>>);
+    struct State {
+        pod: Option<Value>,
+        volume: Option<Value>,
+        calls: Vec<&'static str>,
+    }
+    impl Transport for Fake {
+        fn get(&self, _: &str) -> Result<Option<ApiPod>, RunPodError> {
+            let mut state = self.0.lock().expect("state");
+            state.calls.push("get");
+            Ok(state.pod.clone().map(|raw| serde_json::from_value(raw).expect("pod")))
+        }
+        fn network_volume(&self, _: &str) -> Result<Option<ApiNetworkVolume>, RunPodError> {
+            let mut state = self.0.lock().expect("state");
+            state.calls.push("volume");
+            Ok(state
+                .volume
+                .clone()
+                .map(|raw| serde_json::from_value(raw).expect("volume")))
+        }
+        fn list_by_name(&self, _: &str) -> Result<Vec<ApiPod>, RunPodError> {
+            panic!("no list")
+        }
+        fn create(&self, _: &CreatePodRequest) -> Result<ApiPod, RunPodError> {
+            panic!("no create")
+        }
+        fn delete(&self, _: &str) -> Result<RunPodCleanup, RunPodError> {
+            panic!("no delete")
+        }
+        fn start(&self, _: &str) -> Result<(), RunPodError> {
+            panic!("no start")
+        }
+        fn stop(&self, _: &str) -> Result<(), RunPodError> {
+            panic!("no stop")
+        }
+    }
+
+    struct Fixture {
+        fake: Fake,
+        worker: InteractiveWorker,
+        saved: InteractiveWorkerSshEndpoint,
+        selection: RunPodNetworkVolumeExpectation,
+    }
+    impl Fixture {
+        fn new(network: bool) -> Self {
+            let mut request = interactive_request(CloudWorkflowId::new(), CloudJobId::new());
+            request.target.lifetime = WorkerLifetime::Persistent;
+            let raw = json!({"id":"pod_exact", "name":resource_name(request.workflow_id,request.job_id),
+                "image":request.target.image,"status":"RUNNING","cost":0,
+                "env":{"HORIZON_WORKFLOW_ID":request.workflow_id,"HORIZON_JOB_ID":request.job_id,
+                "HORIZON_CLOUD_PROTOCOL_VERSION":"1","HORIZON_WORKER_LIFETIME":"persistent",
+                "HORIZON_SSH_PUBLIC_KEY":request.ssh_public_key},
+                "ssh":{"direct":{"host":"new.example","port":2300,"username":"root"}},
+                "mounts":if network {json!({"network":[{"volumeId":"volume_exact","path":"/workspace"}]})}
+                    else {json!({"persistent":{"size":20,"path":"/workspace"}})},
+                "cloud":"SECURE","cluster":null,"dataCenterId":"EUR-NO-1","runtime":{"uptime":1}});
+            let worker = InteractiveWorker {
+                identity: InteractiveWorkerIdentity {
+                    provider: crate::cloud_run::CloudProvider::RunPod,
+                    workflow_id: request.workflow_id,
+                    job_id: request.job_id,
+                    resource_id: "pod_exact".into(),
+                },
+                target: request.target,
+                ssh_public_key: request.ssh_public_key,
+                lifetime: InteractiveWorkerLifetime::Persistent,
+            };
+            Self {
+                fake: Fake(Arc::new(Mutex::new(State {
+                    pod: Some(raw),
+                    volume: Some(json!({"id":"volume_exact",
+                "dataCenter":"EUR-NO-1","size":20,"type":"HIGH_PERFORMANCE"})),
+                    calls: vec![],
+                }))),
+                worker,
+                saved: InteractiveWorkerSshEndpoint {
+                    host: "old.example".into(),
+                    port: 2200,
+                    username: "root".into(),
+                    host_key: ed25519_key(73),
+                },
+                selection: RunPodNetworkVolumeExpectation {
+                    volume_id: "volume_exact".into(),
+                    data_center_id: "EUR-NO-1".into(),
+                    minimum_size_gb: 20,
+                },
+            }
+        }
+        fn provider(&self, network: bool) -> RunPodInteractiveWorkerProvider {
+            let client = RunPodClient::with_transport_and_fence(
+                self.fake.clone(),
+                |_, _, _: &crate::cloud_run::WorkerTarget, _: &str| panic!("no claim"),
+            );
+            let trust = RunPodHostTrust::retained(&self.worker, &self.saved).expect("trust");
+            if network {
+                let request = crate::cloud_run::interactive_worker::InteractiveWorkerRequest {
+                    workflow_id: self.worker.identity.workflow_id,
+                    job_id: self.worker.identity.job_id,
+                    target: self.worker.target.clone(),
+                    ssh_public_key: self.worker.ssh_public_key.clone(),
+                };
+                RunPodInteractiveWorkerProvider::new_with_network_volume(
+                    client,
+                    profile(),
+                    trust,
+                    &request,
+                    &self.selection,
+                )
+                .expect("bound")
+            } else {
+                RunPodInteractiveWorkerProvider::new(client, profile(), trust)
+            }
+        }
+    }
+
+    #[test]
+    fn changed_coordinates_are_only_untrusted_get_results_with_retained_storage() {
+        for network in [false, true] {
+            let fixture = Fixture::new(network);
+            let candidate = fixture
+                .provider(network)
+                .observe_endpoint_candidate(&fixture.worker, &fixture.saved)
+                .expect("candidate");
+            assert_eq!(candidate.worker, fixture.worker);
+            assert_eq!(
+                (candidate.host.as_str(), candidate.port, candidate.username.as_str()),
+                ("new.example", 2300, "root")
+            );
+            assert_eq!(candidate.network_volume, network.then_some(fixture.selection));
+            assert_eq!(
+                fixture.fake.0.lock().expect("state").calls,
+                if network { vec!["get", "volume"] } else { vec!["get"] }
+            );
+        }
+    }
+
+    #[test]
+    fn incomplete_or_different_retained_pin_refuses_before_io() {
+        let fixture = Fixture::new(false);
+        for field in 0..4 {
+            let mut changed = fixture.saved.clone();
+            match field {
+                0 => changed.port += 1,
+                1 => changed.host = "elsewhere.example".into(),
+                2 => changed.host_key = ed25519_key(74),
+                _ => changed.username = "other".into(),
+            }
+            assert!(
+                fixture
+                    .provider(false)
+                    .observe_endpoint_candidate(&fixture.worker, &changed)
+                    .is_err()
+            );
+        }
+        let client = RunPodClient::with_transport_and_fence(
+            fixture.fake.clone(),
+            |_, _, _: &crate::cloud_run::WorkerTarget, _: &str| panic!("no claim"),
+        );
+        let provider = RunPodInteractiveWorkerProvider::new(
+            client,
+            profile(),
+            |_: &crate::cloud_run::runpod::RunPodWorker, _: &crate::cloud_run::runpod::RunPodSshEndpoint, _: &str| {
+                panic!("no bootstrap")
+            },
+        );
+        assert!(
+            provider
+                .observe_endpoint_candidate(&fixture.worker, &fixture.saved)
+                .is_err()
+        );
+        assert!(fixture.fake.0.lock().expect("state").calls.is_empty());
+    }
+
+    #[test]
+    fn absent_unready_foreign_and_unretained_snapshots_never_produce_coordinates() {
+        for field in 0..11 {
+            let fixture = Fixture::new(false);
+            {
+                let mut state = fixture.fake.0.lock().expect("state");
+                let raw = state.pod.as_mut().expect("pod");
+                match field {
+                    0 => {
+                        state.pod = None;
+                    }
+                    1 => raw["id"] = json!("other"),
+                    2 => raw["status"] = json!("STARTING"),
+                    3 => raw["runtime"] = Value::Null,
+                    4 => {
+                        raw.as_object_mut().expect("object").remove("runtime");
+                    }
+                    5 => raw["env"]["HORIZON_SSH_PUBLIC_KEY"] = json!(ed25519_key(74)),
+                    6 => raw["mounts"]["persistent"]["path"] = json!("/tmp"),
+                    7 => raw["cloud"] = json!("COMMUNITY"),
+                    8 => raw["ssh"]["direct"]["username"] = json!("other"),
+                    9 => raw["ssh"]["direct"]["port"] = json!(0),
+                    _ => raw["image"] = json!("other/worker:latest"),
+                }
+            }
+            assert!(
+                fixture
+                    .provider(false)
+                    .observe_endpoint_candidate(&fixture.worker, &fixture.saved)
+                    .is_err(),
+                "case {field}"
+            );
+            assert_eq!(fixture.fake.0.lock().expect("state").calls, ["get"]);
+        }
+        let fixture = Fixture::new(true);
+        fixture.fake.0.lock().expect("state").volume = None;
+        assert!(
+            fixture
+                .provider(true)
+                .observe_endpoint_candidate(&fixture.worker, &fixture.saved)
+                .is_err()
+        );
+        assert_eq!(fixture.fake.0.lock().expect("state").calls, ["get", "volume"]);
+    }
+}

--- a/crates/horizon-core/src/cloud_run/store/remote_allocations/stop.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_allocations/stop.rs
@@ -7,6 +7,43 @@ use crate::remote_workspace::{
 use rusqlite::TransactionBehavior;
 
 impl CloudWorkflowStore {
+    /// Only the authenticated refresh coordinator supplies these coordinates, after
+    /// original-key proof and a matching provider re-observation. No phase is changed.
+    pub(crate) fn record_remote_endpoint_refresh(
+        &self,
+        expected: &StoredRemoteAllocation,
+        endpoint: &crate::cloud_run::interactive_worker::InteractiveWorkerSshEndpoint,
+    ) -> Result<StoredRemoteAllocation, crate::remote_workspace::start::RemoteEndpointRefreshError> {
+        use crate::remote_workspace::start::RemoteEndpointRefreshError as RefreshError;
+        let mut connection = self.connection().map_err(|_| RefreshError::StorageUnavailable)?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|_| RefreshError::StorageUnavailable)?;
+        super::super::database::ensure_current_schema(&transaction).map_err(|_| RefreshError::StorageUnavailable)?;
+        let row = binding::load_workspace(&transaction, &expected.workspace.state().spec.workspace_local_id)
+            .map_err(|_| RefreshError::StorageUnavailable)?
+            .ok_or(RefreshError::StateChanged)?;
+        let current = binding::recover(&transaction, &row).map_err(|_| RefreshError::StorageUnavailable)?;
+        if current != *expected {
+            return Err(RefreshError::StateChanged);
+        }
+        let mut next = current.workspace.state().clone();
+        next.runtime.as_mut().ok_or(RefreshError::IdentityUnavailable)?.ssh = Some(endpoint.clone());
+        let replacement = WorkspaceReplacement::for_endpoint_refresh(&current.workspace, &next)
+            .map_err(|_| RefreshError::ObservationChanged)?;
+        if next == *current.workspace.state() {
+            return Ok(current);
+        }
+        let workspace = replacement
+            .persist(&transaction)
+            .map_err(|_| RefreshError::StorageUnavailable)?;
+        transaction.commit().map_err(|_| RefreshError::StorageUnavailable)?;
+        Ok(StoredRemoteAllocation {
+            workspace,
+            workflow: current.workflow,
+        })
+    }
+
     pub(crate) fn record_remote_stop_phase(
         &self,
         expected: &StoredRemoteAllocation,

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces.rs
@@ -199,6 +199,19 @@ pub(super) struct WorkspaceReplacement<'a> {
 }
 
 impl<'a> WorkspaceReplacement<'a> {
+    pub(super) fn for_endpoint_refresh(
+        expected: &'a StoredRemoteWorkspace,
+        next: &'a RemoteWorkspaceState,
+    ) -> Result<Self, RemoteWorkspaceStoreError> {
+        validate_key(&expected.session_id, &expected.state.spec.workspace_local_id)?;
+        validation::validate_endpoint_refresh(&expected.state, next)?;
+        Ok(Self {
+            expected,
+            next,
+            snapshot: encode(&expected.session_id, next)?,
+        })
+    }
+
     /// Only the deletion coordinator may enter or complete destructive intent.
     /// Validate a phase-only transition before retaining the usual exact-snapshot CAS.
     pub(super) fn for_deletion(

--- a/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
+++ b/crates/horizon-core/src/cloud_run/store/remote_workspaces/validation.rs
@@ -167,6 +167,46 @@ pub(super) fn validate_delete_replacement(
     Ok(())
 }
 
+pub(super) fn validate_endpoint_refresh(
+    previous: &RemoteWorkspaceState,
+    next: &RemoteWorkspaceState,
+) -> Result<(), Error> {
+    use crate::{
+        cloud_run::{CloudProvider, WorkerLifetime},
+        remote_workspace::start::endpoint::refresh_phase_allowed,
+    };
+    next.validate()?;
+    if !refresh_phase_allowed(previous)
+        || previous.spec.target.provider != CloudProvider::RunPod
+        || previous.spec.target.lifetime != WorkerLifetime::Persistent
+    {
+        return Err(Error::ReplacementIdentityMismatch);
+    }
+    let mut permitted = previous.clone();
+    let runtime = permitted.runtime.as_mut().ok_or(Error::ReplacementIdentityMismatch)?;
+    if runtime.worker.is_none() {
+        return Err(Error::ReplacementIdentityMismatch);
+    }
+    let saved = runtime
+        .ssh
+        .as_mut()
+        .filter(|ssh| ssh.is_complete())
+        .ok_or(Error::ReplacementIdentityMismatch)?;
+    let observed = next
+        .runtime
+        .as_ref()
+        .and_then(|runtime| runtime.ssh.as_ref())
+        .filter(|ssh| ssh.is_complete())
+        .ok_or(Error::ReplacementIdentityMismatch)?;
+    saved.host.clone_from(&observed.host);
+    saved.port = observed.port;
+    // Everything but transport coordinates is immutable, including phase and both keys.
+    if permitted != *next {
+        return Err(Error::ReplacementIdentityMismatch);
+    }
+    Ok(())
+}
+
 /// A saved Stopped record may take explicit Start intent requested at or after the
 /// retention observation; no other phase follows a saved Stop.
 fn starts_after_stop(previous: RemoteRuntimePhase, next: RemoteRuntimePhase) -> bool {

--- a/crates/horizon-core/src/remote_worker_ssh.rs
+++ b/crates/horizon-core/src/remote_worker_ssh.rs
@@ -15,6 +15,22 @@ use std::{path::Path, process::Command, sync::Arc};
 
 pub(crate) const HOST_ALIAS: &str = "horizon-retained-worker";
 
+/// Proves the original saved host key and client identity at candidate coordinates.
+/// An open socket or a timeout is not success; the fixed no-op must exit successfully.
+pub(crate) fn prove_endpoint(
+    identity: &RemoteSshIdentity,
+    endpoint: &InteractiveWorkerSshEndpoint,
+) -> Result<(), query::Error> {
+    let trust = known_hosts(identity, endpoint).map_err(|_| query::Error::QueryFailed)?;
+    let command = command_for(identity.private_key_path(), trust.path(), endpoint, Operation::Probe)
+        .map_err(|_| query::Error::QueryFailed)?;
+    let output = query::run(command, &[], std::time::Duration::from_secs(10), 1)?;
+    if !output.is_empty() {
+        return Err(query::Error::QueryFailed);
+    }
+    Ok(())
+}
+
 pub(crate) fn prepared_command(
     identity: &Path,
     known_hosts: &Path,
@@ -67,6 +83,7 @@ pub(crate) fn prepared_github_install(
 
 #[derive(Clone, Copy)]
 enum Operation<'a> {
+    Probe,
     Request,
     PackStatus,
     Intake,
@@ -88,7 +105,8 @@ fn command_for(
     }
     let mut command = Command::new("ssh");
     let terminal_mode = match operation {
-        Operation::Request
+        Operation::Probe
+        | Operation::Request
         | Operation::PackStatus
         | Operation::Intake
         | Operation::IntakeStatus
@@ -142,6 +160,7 @@ fn command_for(
         &endpoint.host,
     ]);
     command.arg(match operation {
+        Operation::Probe => "/usr/bin/true".into(),
         Operation::Request => "/usr/local/bin/horizon-panel-session request".into(),
         Operation::PackStatus => "/usr/local/bin/horizon-repository pack-status".into(),
         Operation::Intake => "/usr/local/bin/horizon-repository intake".into(),
@@ -237,6 +256,14 @@ mod tests {
         let identity = Path::new("/private/client key");
         let trust = Path::new("/private/known hosts");
         let baseline = prepared_command(identity, trust, &endpoint).expect("query");
+        let probe = command_for(identity, trust, &endpoint, Operation::Probe).expect("probe");
+        let mut probe_args: Vec<_> = baseline.get_args().map(std::ffi::OsStr::to_os_string).collect();
+        *probe_args.last_mut().expect("command") = "/usr/bin/true".into();
+        assert_eq!(probe.get_args().collect::<Vec<_>>(), probe_args);
+        assert_eq!(
+            probe.get_envs().collect::<Vec<_>>(),
+            baseline.get_envs().collect::<Vec<_>>()
+        );
         let storage = prepared_storage_status(identity, trust, &endpoint).expect("storage query");
         let mut expected: Vec<_> = baseline.get_args().map(std::ffi::OsStr::to_os_string).collect();
         *expected.last_mut().expect("fixed command") = "/usr/local/bin/horizon-repository storage-status".into();

--- a/crates/horizon-core/src/remote_workspace/start.rs
+++ b/crates/horizon-core/src/remote_workspace/start.rs
@@ -2,8 +2,10 @@
 //! reopening a view or restarting the application never invokes this operation.
 
 mod configured_azure;
+pub(crate) mod endpoint;
 
 pub use configured_azure::{ConfiguredAzureStart, ConfiguredAzureStartError, start_configured_azure_environment};
+pub use endpoint::{RemoteEndpointRefreshError, refresh_remote_worker_endpoint};
 
 use crate::{
     cloud_run::{

--- a/crates/horizon-core/src/remote_workspace/start/endpoint.rs
+++ b/crates/horizon-core/src/remote_workspace/start/endpoint.rs
@@ -1,0 +1,187 @@
+//! Explicit authenticated coordinate refresh, never compute or task Start.
+
+use crate::{
+    cloud_run::{
+        CloudProvider, CloudWorkflowStore, StoredRemoteAllocation, WorkerLifetime,
+        interactive_worker::{InteractiveWorker, InteractiveWorkerSshEndpoint},
+        interactive_worker_start::{InteractiveWorkerEndpointCandidate, InteractiveWorkerEndpointObserver},
+        runpod::RunPodNetworkVolumeExpectation,
+    },
+    remote_ssh_identity::{RemoteSshIdentity, RemoteSshIdentityStore},
+    remote_workspace::{RemoteRuntimePhase, RemoteWorkspaceState},
+};
+
+/// Refresh only the host/port of one exact retained `RunPod` connection after explicit
+/// user action. Uses the existing private identity and original host key to execute
+/// only `/usr/bin/true`, then independently re-observes ownership/storage/coordinates
+/// before an exact-snapshot CAS. No initial trust, new keys, provider mutation,
+/// repository credentials, task replay or phase transition occurs. Start intent and
+/// its original timestamp remain; Start/recovery are separate explicit operations.
+/// Run off the render thread. Provider reads use their existing request bounds; SSH
+/// pipe I/O is bounded to ten seconds (spawn/reap retain the query helper's OS limits).
+/// # Errors
+/// Refuses unsupported platforms/providers, absent identity, management conflicts,
+/// stale snapshots, changed storage, failed authentication and failed reads.
+pub fn refresh_remote_worker_endpoint<P: InteractiveWorkerEndpointObserver + ?Sized>(
+    store: &CloudWorkflowStore,
+    identities: &RemoteSshIdentityStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+) -> Result<StoredRemoteAllocation, RemoteEndpointRefreshError> {
+    if !cfg!(target_os = "linux") {
+        return Err(Error::Unsupported);
+    }
+    refresh_with(
+        store,
+        provider,
+        expected,
+        |worker| {
+            identities
+                .recover(
+                    worker.identity.workflow_id,
+                    worker.identity.job_id,
+                    &worker.ssh_public_key,
+                )
+                .map_err(|_| Error::IdentityUnavailable)
+        },
+        prove_connection,
+    )
+}
+
+fn prove_connection(identity: &RemoteSshIdentity, endpoint: &InteractiveWorkerSshEndpoint) -> Result<(), Error> {
+    #[cfg(target_os = "linux")]
+    {
+        crate::remote_worker_ssh::prove_endpoint(identity, endpoint).map_err(|_| Error::AuthenticationFailed)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (identity, endpoint);
+        Err(Error::Unsupported)
+    }
+}
+
+pub(crate) fn refresh_phase_allowed(state: &RemoteWorkspaceState) -> bool {
+    state.runtime.as_ref().is_some_and(|runtime| {
+        runtime.cleanup.is_none()
+            && matches!(
+                runtime.phase,
+                RemoteRuntimePhase::Ready
+                    | RemoteRuntimePhase::Reconciling
+                    | RemoteRuntimePhase::Stopped { .. }
+                    | RemoteRuntimePhase::Starting { .. }
+            )
+    })
+}
+
+fn current(store: &CloudWorkflowStore, expected: &StoredRemoteAllocation) -> Result<(), Error> {
+    let actual = store
+        .load_remote_allocation(
+            expected.workspace().session_id(),
+            &expected.workspace().state().spec.workspace_local_id,
+        )
+        .map_err(|_| Error::StorageUnavailable)?;
+    if actual.as_ref() != Some(expected) {
+        return Err(Error::StateChanged);
+    }
+    Ok(())
+}
+
+fn selection(
+    store: &CloudWorkflowStore,
+    expected: &StoredRemoteAllocation,
+) -> Result<Option<RunPodNetworkVolumeExpectation>, Error> {
+    store
+        .load_remote_network_volume_selection(expected)
+        .map_err(|_| Error::StorageUnavailable)
+}
+
+fn refresh_with<P: InteractiveWorkerEndpointObserver + ?Sized, I>(
+    store: &CloudWorkflowStore,
+    provider: &P,
+    expected: &StoredRemoteAllocation,
+    recover: impl FnOnce(&InteractiveWorker) -> Result<I, Error>,
+    probe: impl FnOnce(&I, &InteractiveWorkerSshEndpoint) -> Result<(), Error>,
+) -> Result<StoredRemoteAllocation, Error> {
+    current(store, expected)?;
+    let state = expected.workspace().state();
+    if !refresh_phase_allowed(state) {
+        return Err(Error::ManagementConflict);
+    }
+    let runtime = state.runtime.as_ref().ok_or(Error::IdentityUnavailable)?;
+    let worker = runtime.worker.as_ref().ok_or(Error::IdentityUnavailable)?;
+    let saved = runtime
+        .ssh
+        .as_ref()
+        .filter(|ssh| ssh.is_complete())
+        .ok_or(Error::IdentityUnavailable)?;
+    if provider.provider() != CloudProvider::RunPod
+        || !worker.is_valid_for(CloudProvider::RunPod)
+        || worker.target.lifetime != WorkerLifetime::Persistent
+    {
+        return Err(Error::Unsupported);
+    }
+    let volume = selection(store, expected)?;
+    let identity = recover(worker)?;
+    current(store, expected)?;
+    let before = provider
+        .observe_endpoint_candidate(worker, saved)
+        .map_err(|_| Error::ObservationFailed)?;
+    let candidate = bind_candidate(&before, worker, saved, volume.as_ref())?;
+    current(store, expected)?;
+    probe(&identity, &candidate)?;
+    current(store, expected)?;
+    let after = provider
+        .observe_endpoint_candidate(worker, saved)
+        .map_err(|_| Error::ObservationFailed)?;
+    if before != after || selection(store, expected)? != volume {
+        return Err(Error::ObservationChanged);
+    }
+    current(store, expected)?;
+    store.record_remote_endpoint_refresh(expected, &candidate)
+}
+
+fn bind_candidate(
+    candidate: &InteractiveWorkerEndpointCandidate,
+    worker: &InteractiveWorker,
+    saved: &InteractiveWorkerSshEndpoint,
+    volume: Option<&RunPodNetworkVolumeExpectation>,
+) -> Result<InteractiveWorkerSshEndpoint, Error> {
+    if candidate.worker != *worker
+        || candidate.username != saved.username
+        || candidate.network_volume.as_ref() != volume
+    {
+        return Err(Error::ObservationChanged);
+    }
+    let mut endpoint = saved.clone();
+    endpoint.host.clone_from(&candidate.host);
+    endpoint.port = candidate.port;
+    if !endpoint.is_complete() {
+        return Err(Error::ObservationChanged);
+    }
+    Ok(endpoint)
+}
+
+type Error = RemoteEndpointRefreshError;
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RemoteEndpointRefreshError {
+    #[error("connection refresh requires a retained persistent RunPod worker on Linux")]
+    Unsupported,
+    #[error("existing SSH identity or retained public pin is unavailable; no replacement was generated")]
+    IdentityUnavailable,
+    #[error("saved environment changed; refresh the selection before proceeding")]
+    StateChanged,
+    #[error("active management or cleanup prevents connection refresh")]
+    ManagementConflict,
+    #[error("retained worker coordinates or storage could not be observed")]
+    ObservationFailed,
+    #[error("observed worker identity, storage or coordinates changed")]
+    ObservationChanged,
+    #[error("original SSH identity could not be authenticated at the observed coordinates")]
+    AuthenticationFailed,
+    #[error("saved connection could not be safely accessed")]
+    StorageUnavailable,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/horizon-core/src/remote_workspace/start/endpoint/tests.rs
+++ b/crates/horizon-core/src/remote_workspace/start/endpoint/tests.rs
@@ -1,0 +1,527 @@
+use super::*;
+use crate::{
+    HorizonHome,
+    cloud_run::{
+        ArtifactDigest,
+        interactive_worker::{
+            InteractiveWorkerCleanup, InteractiveWorkerEnsure, InteractiveWorkerIdentity, InteractiveWorkerLifecycle,
+            InteractiveWorkerLifetime, InteractiveWorkerProvider, InteractiveWorkerRequest, InteractiveWorkerStatus,
+        },
+    },
+    remote_workspace::{RemoteCleanupIntent, RemoteCleanupReason},
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use std::{
+    collections::VecDeque,
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+const OWNER: &str = "00000000-0000-4000-8000-000000000001";
+
+fn key(byte: u8) -> String {
+    let mut blob = b"\0\0\0\x0bssh-ed25519\0\0\0\x20".to_vec();
+    blob.extend([byte; 32]);
+    format!("ssh-ed25519 {}", STANDARD.encode(blob))
+}
+fn pin() -> InteractiveWorkerSshEndpoint {
+    InteractiveWorkerSshEndpoint {
+        host: "old.example".into(),
+        port: 2200,
+        username: "root".into(),
+        host_key: key(9),
+    }
+}
+struct Fixture {
+    root: tempfile::TempDir,
+    store: CloudWorkflowStore,
+}
+impl Fixture {
+    fn new(phase: RemoteRuntimePhase, network: bool) -> Self {
+        let root = tempfile::tempdir().expect("fixture");
+        let store = CloudWorkflowStore::open_path(root.path().join("control/store.sqlite3")).expect("store");
+        let state: RemoteWorkspaceState = serde_json::from_value(serde_json::json!({"version":1,"spec":{
+            "workspace_local_id":"workspace","working_directory":".","generation":0,"panels":[],
+            "target":{"provider":"run_pod","profile":"development","disk_gib":20,"lifetime":"persistent",
+                "image":format!("example/worker@sha256:{}","a".repeat(64))},
+            "repository":{"repository":"example/project","commit":"b".repeat(40)}}}))
+        .expect("state");
+        let saved = store.create_remote_workspace(OWNER, &state).expect("workspace");
+        let allocated = store.allocate_remote_runtime(&saved, i64::MAX).expect("allocation");
+        if network {
+            store
+                .record_remote_network_volume_selection(&allocated, &volume())
+                .expect("selected volume");
+        }
+        let reserved = store
+            .reserve_remote_worker_request(&allocated, &key(7))
+            .expect("reserved");
+        let request = reserved.worker_request().expect("request");
+        let worker = InteractiveWorker {
+            identity: InteractiveWorkerIdentity {
+                provider: CloudProvider::RunPod,
+                workflow_id: request.workflow_id,
+                job_id: request.job_id,
+                resource_id: "pod_exact".into(),
+            },
+            target: request.target,
+            ssh_public_key: request.ssh_public_key,
+            lifetime: InteractiveWorkerLifetime::Persistent,
+        };
+        let observed = store
+            .record_remote_worker_recovery(
+                &reserved,
+                Some(&InteractiveWorkerStatus {
+                    worker,
+                    lifecycle: InteractiveWorkerLifecycle::Ready,
+                    ssh: Some(pin()),
+                }),
+            )
+            .expect("observed");
+        match phase {
+            RemoteRuntimePhase::Starting { .. } | RemoteRuntimePhase::Stopped { .. } => {
+                let stopped = store
+                    .record_remote_stop_phase(
+                        &observed,
+                        RemoteRuntimePhase::Stopped {
+                            requested_at_millis: 1,
+                            observed_at_millis: 2,
+                        },
+                    )
+                    .expect("stopped");
+                if matches!(phase, RemoteRuntimePhase::Starting { .. }) {
+                    store.record_remote_start_phase(&stopped, phase).expect("starting");
+                }
+            }
+            _ => {
+                let mut next = observed.workspace().state().clone();
+                let runtime = next.runtime.as_mut().expect("runtime");
+                runtime.phase = phase;
+                if matches!(phase, RemoteRuntimePhase::Cancelling | RemoteRuntimePhase::Deleting) {
+                    runtime.cleanup = Some(RemoteCleanupIntent {
+                        reason: RemoteCleanupReason::Cancelled,
+                        requested_at_millis: 1,
+                    });
+                }
+                store
+                    .replace_remote_workspace(observed.workspace(), &next)
+                    .expect("phase");
+            }
+        }
+        Self { root, store }
+    }
+    fn current(&self) -> StoredRemoteAllocation {
+        self.store
+            .load_remote_allocation(OWNER, "workspace")
+            .expect("load")
+            .expect("allocation")
+    }
+    fn candidate(&self) -> InteractiveWorkerEndpointCandidate {
+        InteractiveWorkerEndpointCandidate {
+            worker: self
+                .current()
+                .workspace()
+                .state()
+                .runtime
+                .as_ref()
+                .expect("runtime")
+                .worker
+                .clone()
+                .expect("worker"),
+            host: "new.example".into(),
+            port: 2300,
+            username: "root".into(),
+            storage_fingerprint: ArtifactDigest::sha256(b"mount"),
+            network_volume: selection(&self.store, &self.current()).expect("selection"),
+        }
+    }
+}
+fn volume() -> RunPodNetworkVolumeExpectation {
+    RunPodNetworkVolumeExpectation {
+        volume_id: "volume_exact".into(),
+        data_center_id: "EUR-NO-1".into(),
+        minimum_size_gb: 20,
+    }
+}
+struct Provider {
+    script: Mutex<VecDeque<Result<InteractiveWorkerEndpointCandidate, &'static str>>>,
+    calls: AtomicUsize,
+}
+impl Provider {
+    fn new(candidate: InteractiveWorkerEndpointCandidate) -> Self {
+        Self {
+            script: Mutex::new(VecDeque::from([Ok(candidate.clone()), Ok(candidate)])),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+impl InteractiveWorkerProvider for Provider {
+    type Error = std::io::Error;
+    fn provider(&self) -> CloudProvider {
+        CloudProvider::RunPod
+    }
+    fn ensure_worker(&self, _: &InteractiveWorkerRequest) -> Result<InteractiveWorkerEnsure, Self::Error> {
+        panic!("no create")
+    }
+    fn reconcile_worker(&self, _: &InteractiveWorkerRequest) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no reconcile")
+    }
+    fn inspect_worker(&self, _: &InteractiveWorker) -> Result<Option<InteractiveWorkerStatus>, Self::Error> {
+        panic!("no original endpoint read")
+    }
+    fn delete_worker(&self, _: &InteractiveWorker) -> Result<InteractiveWorkerCleanup, Self::Error> {
+        panic!("no delete")
+    }
+}
+impl InteractiveWorkerEndpointObserver for Provider {
+    fn observe_endpoint_candidate(
+        &self,
+        _: &InteractiveWorker,
+        saved: &InteractiveWorkerSshEndpoint,
+    ) -> Result<InteractiveWorkerEndpointCandidate, Self::Error> {
+        assert_eq!(saved, &pin());
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.script
+            .lock()
+            .expect("script")
+            .pop_front()
+            .expect("bounded reads")
+            .map_err(std::io::Error::other)
+    }
+}
+
+#[test]
+fn authenticated_coordinates_preserve_phase_identity_fence_and_both_keys() {
+    for phase in [
+        RemoteRuntimePhase::Reconciling,
+        RemoteRuntimePhase::Ready,
+        RemoteRuntimePhase::Stopped {
+            requested_at_millis: 1,
+            observed_at_millis: 2,
+        },
+        RemoteRuntimePhase::Starting { requested_at_millis: 3 },
+    ] {
+        for network in [false, true] {
+            let f = Fixture::new(phase, network);
+            let original = f.current();
+            let provider = Provider::new(f.candidate());
+            let saved = refresh_with(
+                &f.store,
+                &provider,
+                &original,
+                |worker| {
+                    assert_eq!(worker.ssh_public_key, key(7));
+                    Ok(())
+                },
+                |(), endpoint| {
+                    assert_eq!(endpoint.host_key, key(9));
+                    assert_eq!(endpoint.username, "root");
+                    assert_eq!((endpoint.host.as_str(), endpoint.port), ("new.example", 2300));
+                    Ok(())
+                },
+            )
+            .expect("refresh");
+            let mut permitted = original.workspace().state().clone();
+            let ssh = permitted.runtime.as_mut().expect("runtime").ssh.as_mut().expect("ssh");
+            ssh.host = "new.example".into();
+            ssh.port = 2300;
+            assert_eq!(saved.workspace().state(), &permitted);
+            assert_eq!(saved.workspace().revision(), original.workspace().revision() + 1);
+            assert_eq!(saved.workflow(), original.workflow());
+            assert_eq!(selection(&f.store, &saved).expect("selection"), network.then(volume));
+            assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+            assert!(
+                f.store
+                    .replace_remote_workspace(saved.workspace(), original.workspace().state())
+                    .is_err()
+            );
+        }
+    }
+}
+
+#[test]
+fn wrong_identity_or_failed_authentication_never_changes_saved_coordinates() {
+    let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+    let original = f.current();
+    let provider = Provider::new(f.candidate());
+    assert_eq!(
+        refresh_with(
+            &f.store,
+            &provider,
+            &original,
+            |_| Err::<(), _>(Error::IdentityUnavailable),
+            |(), _| panic!("no probe")
+        ),
+        Err(Error::IdentityUnavailable)
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        refresh_with(
+            &f.store,
+            &provider,
+            &original,
+            |_| Ok(()),
+            |(), _| Err(Error::AuthenticationFailed)
+        ),
+        Err(Error::AuthenticationFailed)
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(f.current(), original);
+    let home = HorizonHome::from_root(f.root.path().join("missing-home"));
+    assert!(
+        refresh_remote_worker_endpoint(&f.store, &RemoteSshIdentityStore::new(&home), &provider, &original).is_err()
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert!(!home.root().exists());
+}
+
+#[test]
+fn unchanged_coordinates_are_authenticated_without_advancing_revision() {
+    let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+    let original = f.current();
+    let mut candidate = f.candidate();
+    candidate.host = pin().host;
+    candidate.port = pin().port;
+    let provider = Provider::new(candidate);
+    let probes = AtomicUsize::new(0);
+    let result = refresh_with(
+        &f.store,
+        &provider,
+        &original,
+        |_| Ok(()),
+        |(), endpoint| {
+            assert_eq!(endpoint, &pin());
+            probes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        },
+    )
+    .expect("authenticated unchanged endpoint");
+    assert_eq!(result, original);
+    assert_eq!(probes.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn selection_changes_during_identity_recovery_refuse_provider_io() {
+    let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+    let original = f.current();
+    let provider = Provider::new(f.candidate());
+    let result = refresh_with(
+        &f.store,
+        &provider,
+        &original,
+        |_| {
+            let mut edited = original.workspace().state().clone();
+            edited.spec.working_directory = "changed".into();
+            f.store
+                .replace_remote_workspace(original.workspace(), &edited)
+                .expect("edit");
+            Ok(())
+        },
+        |(), _| panic!("no authentication after drift"),
+    );
+    assert_eq!(result, Err(Error::StateChanged));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn first_observation_mismatch_refuses_probe_and_second_read_drift_refuses_cas() {
+    for later in [false, true] {
+        for field in 0..7 {
+            let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+            let original = f.current();
+            let provider = Provider::new(f.candidate());
+            let mut changed = f.candidate();
+            match field {
+                0 => changed.worker.identity.resource_id = "foreign".into(),
+                1 => changed.username = "other".into(),
+                2 => changed.network_volume = Some(volume()),
+                3 => changed.port = 0,
+                4 => changed.host = "bad host".into(),
+                5 => changed.port = 2400,
+                _ => changed.storage_fingerprint = ArtifactDigest::sha256(b"different"),
+            }
+            // Valid coordinate/storage changes are allowed in the first candidate,
+            // but not across the authenticated re-observation.
+            if !later && field >= 5 {
+                continue;
+            }
+            provider.script.lock().expect("script")[usize::from(later)] = Ok(changed);
+            let probes = AtomicUsize::new(0);
+            assert!(
+                refresh_with(
+                    &f.store,
+                    &provider,
+                    &original,
+                    |_| Ok(()),
+                    |(), _| {
+                        probes.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                )
+                .is_err()
+            );
+            assert_eq!(probes.load(Ordering::SeqCst), usize::from(later));
+            assert_eq!(f.current(), original);
+        }
+    }
+}
+
+#[test]
+fn lost_observation_and_same_snapshot_competing_refresh_do_not_overwrite() {
+    let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+    let original = f.current();
+    for later in [false, true] {
+        let provider = Provider::new(f.candidate());
+        provider.script.lock().expect("script")[usize::from(later)] = Err("private provider output");
+        assert_eq!(
+            refresh_with(&f.store, &provider, &original, |_| Ok(()), |(), _| Ok(())),
+            Err(Error::ObservationFailed)
+        );
+        assert_eq!(f.current(), original);
+    }
+    let outer = Provider::new(f.candidate());
+    let inner = Provider::new(f.candidate());
+    let result = refresh_with(
+        &f.store,
+        &outer,
+        &original,
+        |_| Ok(()),
+        |(), _| {
+            refresh_with(&f.store, &inner, &original, |_| Ok(()), |(), _| Ok(())).expect("winner");
+            Ok(())
+        },
+    );
+    assert_eq!(result, Err(Error::StateChanged));
+    assert_eq!(outer.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(f.current().workspace().revision(), original.workspace().revision() + 1);
+}
+
+#[test]
+fn management_conflicts_and_late_stop_or_delete_win_before_persistence() {
+    for phase in [
+        RemoteRuntimePhase::Materializing,
+        RemoteRuntimePhase::Checkpointing,
+        RemoteRuntimePhase::Cancelling,
+        RemoteRuntimePhase::Deleting,
+        RemoteRuntimePhase::Stopping { requested_at_millis: 1 },
+    ] {
+        let f = Fixture::new(phase, false);
+        let provider = Provider::new(f.candidate());
+        assert_eq!(
+            refresh_with(
+                &f.store,
+                &provider,
+                &f.current(),
+                |_| panic!("no identity"),
+                |(): &(), _| panic!("no probe")
+            ),
+            Err(Error::ManagementConflict)
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+    for delete in [false, true] {
+        let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+        let original = f.current();
+        let provider = Provider::new(f.candidate());
+        assert_eq!(
+            refresh_with(
+                &f.store,
+                &provider,
+                &original,
+                |_| Ok(()),
+                |(), _| {
+                    if delete {
+                        f.store
+                            .record_remote_delete_phase(
+                                &original,
+                                RemoteRuntimePhase::DeleteRequested { requested_at_millis: 3 },
+                            )
+                            .expect("delete");
+                    } else {
+                        f.store
+                            .record_remote_stop_phase(
+                                &original,
+                                RemoteRuntimePhase::Stopping { requested_at_millis: 3 },
+                            )
+                            .expect("stop");
+                    }
+                    Ok(())
+                }
+            ),
+            Err(Error::StateChanged)
+        );
+        let pending = f.current();
+        assert_eq!(
+            pending
+                .workspace()
+                .state()
+                .runtime
+                .as_ref()
+                .expect("runtime")
+                .ssh
+                .as_ref(),
+            Some(&pin())
+        );
+        assert!(f.store.record_remote_endpoint_refresh(&pending, &pin()).is_err());
+        assert_eq!(
+            refresh_with(
+                &f.store,
+                &provider,
+                &pending,
+                |_| panic!("no identity"),
+                |(): &(), _| panic!("no probe")
+            ),
+            Err(Error::ManagementConflict)
+        );
+    }
+}
+
+#[test]
+fn dedicated_store_write_rejects_key_username_changes_and_stale_generic_writes() {
+    let f = Fixture::new(RemoteRuntimePhase::Reconciling, false);
+    let original = f.current();
+    for field in 0..3 {
+        let mut changed = pin();
+        match field {
+            0 => changed.host_key = key(8),
+            1 => changed.username = "other".into(),
+            _ => changed.port = 0,
+        }
+        assert!(f.store.record_remote_endpoint_refresh(&original, &changed).is_err());
+        assert_eq!(f.current(), original);
+    }
+    let mut changed = original.workspace().state().clone();
+    changed
+        .runtime
+        .as_mut()
+        .expect("runtime")
+        .ssh
+        .as_mut()
+        .expect("ssh")
+        .port = 2300;
+    assert!(
+        f.store
+            .replace_remote_workspace(original.workspace(), &changed)
+            .is_err()
+    );
+    let mut edited = original.workspace().state().clone();
+    edited.spec.working_directory = "src".into();
+    f.store
+        .replace_remote_workspace(original.workspace(), &edited)
+        .expect("edit");
+    let provider = Provider::new(f.candidate());
+    assert_eq!(
+        refresh_with(
+            &f.store,
+            &provider,
+            &original,
+            |_| panic!("no identity"),
+            |(): &(), _| panic!("no probe")
+        ),
+        Err(Error::StateChanged)
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -5,6 +5,12 @@ back into large multi-purpose modules.
 
 ## Module Boundaries
 
+- Explicit retained connection refresh lives in `remote_workspace::start::endpoint`:
+  existing-identity admission, fixed authenticated SSH no-op, provider re-observation
+  and a coordinate-only CAS. `runpod::interactive::endpoint` supplies GET-only
+  candidates; neither leaf starts compute/tasks or changes keys/management phase.
+  Generic replacements keep full SSH identity immutable, including after Delete.
+
 ### Remote worker image
 
 - `repository_overlay::bundle::store` keeps anonymous publication as its default;


### PR DESCRIPTION
## Purpose

Add an explicit core API for refreshing the host/port of an existing retained worker connection after its provider-reported coordinates change.

Part of #473 and #383.

## Behavior and safety

- Read the exact saved worker and immutable storage selection, recovering the existing client identity before provider observation.
- Validate provider ownership and retained storage, authenticate at the candidate coordinates using the original saved host key and the fixed `/usr/bin/true` probe, then re-observe before committing.
- Use an exact-snapshot, coordinate-only compare-and-swap. Preserve worker identity, host/client keys, username, management phase and intent timestamps; reject competing Stop/Delete or changed snapshots.
- No allocation, compute Start, key discovery/rotation, repository credentials, task replay or UI wiring. The real adapter is Linux-only; this is a prerequisite API, not automatic reconnect behavior.

## Validation

- 29 focused endpoint/provider/SSH tests passed, covering ordinary and network-volume retention, authentication refusal, immutable selection, concurrent management/refresh, stale storage-selection conflict classification and hardened SSH command construction.
- Precommit formatting, maintainability, version consistency, blocking and strict Clippy passed on the reviewed corrections.
- Final exact-head matrix passed on `d7b429ae20d77fb8c85bd850c1f64a984ec9ff99`: formatting, maintainability, version consistency, default tests (2,734 passed, 7 ignored), speech tests (2,779 passed, 7 ignored), and blocking, strict and pedantic Clippy. Each test tier completed 26 suites; all lint tiers reported no warnings.
- Temporary test fixtures used a private tmpfs `TMPDIR`; source, build cache and logs remained on disk. Two earlier disk-fixture matrices failed unchanged browser CLI timing assertions and remain recorded as failures. A bounded diagnostic observed threads waiting for a filesystem journal commit during one delayed exit, but did not establish the cause of the earlier missing-action stall. The tmpfs control does not alter test assertions or deadlines and is not disk-durability proof or a browser timing fix.
- Synthetic tests only: no live provider request, cloud resources, credentials or native GUI operation for this API-only change.

Scope: 1,205 changed source/test lines across 10 paths, plus focused maintainability documentation. Review corrections preserve snapshot conflicts as `StateChanged`, keep the discovery contract with the refresh coordinator, and isolate persistence in its own allocation-store leaf. Existing compute Start/Stop modules and merged Delete safeguards are retained.

Closes no broader reconnect or worker-lifecycle acceptance item.
